### PR TITLE
Add Fuse Network to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ _Additional runtime options:_
 
 ### Projects Utilizing BlockScout
 * [Oasis Labs](https://blockexplorer.oasiscloud.io/)
+* [Fuse Network](https://explorer.fuse.io/)
 
 ### Configuring Ethereum Classic and other EVM Chains
 **Note: Most of these modifications will be consolidated into a single file in the future.**


### PR DESCRIPTION
## Motivation

Support our partners by adding them to the BlockScout Readme. In this update, Fuse Network (https://explorer.fuse.io/) was added.

## Changelog

- Add https://explorer.fuse.io/ to the Readme

