### PR TITLE
reduce uncle rewards

### DIFF
--- a/apps/indexer/lib/indexer/block/reward/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/reward/fetcher.ex
@@ -206,13 +206,13 @@ defmodule Indexer.Block.Reward.Fetcher do
         if address_type == :uncle do
           reward =
             Enum.reduce(beneficiaries_params, %Wei{value: 0}, fn %{
-                                                      address_type: address_type,
-                                                      address_hash: address_hash,
-                                                      block_hash: block_hash
-                                                    } = current_beneficiary,
-                                                    reward_acc ->
+                                                                   address_type: address_type,
+                                                                   address_hash: address_hash,
+                                                                   block_hash: block_hash
+                                                                 } = current_beneficiary,
+                                                                 reward_acc ->
               if address_type == beneficiary.address_type && address_hash == beneficiary.address_hash &&
-                block_hash == beneficiary.block_hash do
+                   block_hash == beneficiary.block_hash do
                 {:ok, minted} = Wei.cast(current_beneficiary.reward)
 
                 Wei.sum(reward_acc, minted)


### PR DESCRIPTION
part of https://github.com/poanetwork/blockscout/issues/1416

## Motivation

Another cause for the issue was that some accounts receive multiple uncle rewards. For example, 
```

%{address_hash: "0xea674fdde714fd979de3edf0f56aa9716b898ec8", address_type: :uncle, block_hash: "0xd47a8c9d432543a5f7e1c72fb31768ef8fe0d7ceb1243b62aa9741c281c28f68", block_number: 7014745, reward: "0x1f399b1438a10000"}, %{address_hash: "0xea674fdde714fd979de3edf0f56aa9716b898ec8", address_type: :uncle, block_hash: "0xd47a8c9d432543a5f7e1c72fb31768ef8fe0d7ceb1243b62aa9741c281c28f68", block_number: 7014745, reward: "0x246ddf9797668000"}
```

## Changelog

- reduce uncle rewards