### PR TITLE
Add ERC-1155 support for token transfers and token balances

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helpers.ex
@@ -32,6 +32,10 @@ defmodule BlockScoutWeb.Tokens.Helpers do
     {:ok, CurrencyHelpers.format_according_to_decimals(amount, decimals)}
   end
 
+  defp do_token_transfer_amount(%Token{type: "ERC-1155", decimals: decimals}, amount, _token_id) do
+    {:ok, CurrencyHelpers.format_according_to_decimals(amount, decimals)}
+  end
+
   defp do_token_transfer_amount(%Token{type: "ERC-721"}, _amount, _token_id) do
     {:ok, :erc721_instance}
   end

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -67,6 +67,8 @@ defmodule Explorer.Chain.TokenTransfer do
   @typep paging_options :: {:paging_options, PagingOptions.t()}
 
   @constant "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  @erc1155_single_transfer_signature "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
+  @erc1155_batch_transfer_signature "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb"
 
   @transfer_function_signature "0xa9059cbb"
 
@@ -133,6 +135,10 @@ defmodule Explorer.Chain.TokenTransfer do
   `first_topic` field.
   """
   def constant, do: @constant
+
+  def erc1155_single_transfer_signature, do: @erc1155_single_transfer_signature
+
+  def erc1155_batch_transfer_signature, do: @erc1155_batch_transfer_signature
 
   @doc """
   ERC 20's transfer(address,uint256) function signature

--- a/apps/explorer/priv/repo/migrations/20200214152058_add_token_id_to_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20200214152058_add_token_id_to_token_balances.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Migrations.AddTokenIdToTokenBalances do
+  use Ecto.Migration
+
+  def change do
+    alter table(:address_token_balances) do
+      add(:token_id, :numeric, precision: 78, scale: 0, null: true)
+      add(:token_type, :string, null: true)
+    end
+
+    create(index(:address_token_balances, [:token_id]))
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -29,7 +29,9 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
         block_number: block_number,
         token_contract_address_hash: token_contract_address_hash,
         value: value,
-        value_fetched_at: value_fetched_at
+        value_fetched_at: value_fetched_at,
+        token_id: 11,
+        token_type: "ERC-20"
       }
 
       assert {:ok,
@@ -69,7 +71,9 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
         block_number: block_number,
         token_contract_address_hash: token_contract_address_hash,
         value: nil,
-        value_fetched_at: value_fetched_at
+        value_fetched_at: value_fetched_at,
+        token_id: 11,
+        token_type: "ERC-20"
       }
 
       assert {:ok,

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -384,17 +384,20 @@ defmodule Explorer.Chain.ImportTest do
             %{
               address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
               token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
-              block_number: "37"
+              block_number: "37",
+              token_type: "ERC-20"
             },
             %{
               address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
               token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
-              block_number: "37"
+              block_number: "37",
+              token_type: "ERC-20"
             },
             %{
               address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
               token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
-              block_number: "37"
+              block_number: "37",
+              token_type: "ERC-20"
             }
           ],
           timeout: 5
@@ -1483,8 +1486,8 @@ defmodule Explorer.Chain.ImportTest do
                  },
                  address_coin_balances: %{
                    params: [
-                     %{address_hash: miner_hash, block_number: block_number, value: nil},
-                     %{address_hash: uncle_miner_hash, block_number: block_number, value: nil}
+                     %{address_hash: miner_hash, block_number: block_number, value: nil, token_type: "ERC-20"},
+                     %{address_hash: uncle_miner_hash, block_number: block_number, value: nil, token_type: "ERC-20"}
                    ],
                    timeout: 1
                  },
@@ -2050,7 +2053,8 @@ defmodule Explorer.Chain.ImportTest do
                        address_hash: address_hash,
                        token_contract_address_hash: token_contract_address_hash,
                        block_number: block_number,
-                       value: value_after
+                       value: value_after,
+                       token_type: "ERC-20"
                      }
                    ]
                  },

--- a/apps/explorer/test/explorer/token/balance_reader_test.exs
+++ b/apps/explorer/test/explorer/token/balance_reader_test.exs
@@ -32,7 +32,8 @@ defmodule Explorer.Token.BalanceReaderTest do
           %{
             token_contract_address_hash: token_contract_address_hash,
             address_hash: address_hash,
-            block_number: block_number
+            block_number: block_number,
+            token_type: "ERC-20"
           }
         ])
 
@@ -51,7 +52,8 @@ defmodule Explorer.Token.BalanceReaderTest do
           %{
             token_contract_address_hash: token_contract_address_hash,
             address_hash: address_hash,
-            block_number: block_number
+            block_number: block_number,
+            token_type: "ERC-20"
           }
         ])
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -571,7 +571,8 @@ defmodule Explorer.Factory do
       token_contract_address_hash: insert(:token).contract_address_hash,
       block_number: block_number(),
       value: Enum.random(1..100_000),
-      value_fetched_at: DateTime.utc_now()
+      value_fetched_at: DateTime.utc_now(),
+      token_type: "ERC-20"
     }
   end
 

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -26,6 +26,8 @@ defmodule Indexer.TokenBalances do
   * `token_contract_address_hash` - The contract address that represents the Token in the blockchain.
   * `address_hash` - The address_hash that we want to know the balance.
   * `block_number` - The block number that the address_hash has the balance.
+  * `token_type` - type of the token that balance belongs to
+  * `token_id` - token id for ERC-1155 tokens
   """
   def fetch_token_balances_from_blockchain([]), do: {:ok, []}
 

--- a/apps/indexer/lib/indexer/transform/address_token_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_token_balances.ex
@@ -16,14 +16,25 @@ defmodule Indexer.Transform.AddressTokenBalances do
                                  block_number: block_number,
                                  from_address_hash: from_address_hash,
                                  to_address_hash: to_address_hash,
-                                 token_contract_address_hash: token_contract_address_hash
-                               },
+                                 token_contract_address_hash: token_contract_address_hash,
+                                 token_id: token_id,
+                                 token_type: token_type
+                               } = params,
                                acc
                                when is_integer(block_number) and is_binary(from_address_hash) and
                                       is_binary(to_address_hash) and is_binary(token_contract_address_hash) ->
-      acc
-      |> add_token_balance_address(from_address_hash, token_contract_address_hash, block_number)
-      |> add_token_balance_address(to_address_hash, token_contract_address_hash, block_number)
+      if params[:token_ids] && token_type == "ERC-1155" do
+        params[:token_ids]
+        |> Enum.reduce(acc, fn id, sub_acc ->
+          sub_acc
+          |> add_token_balance_address(from_address_hash, token_contract_address_hash, id, token_type, block_number)
+          |> add_token_balance_address(to_address_hash, token_contract_address_hash, id, token_type, block_number)
+        end)
+      else
+        acc
+        |> add_token_balance_address(from_address_hash, token_contract_address_hash, token_id, token_type, block_number)
+        |> add_token_balance_address(to_address_hash, token_contract_address_hash, token_id, token_type, block_number)
+      end
     end)
   end
 
@@ -31,13 +42,15 @@ defmodule Indexer.Transform.AddressTokenBalances do
     Enum.filter(token_transfers_params, &do_filter_burn_address/1)
   end
 
-  defp add_token_balance_address(map_set, unquote(@burn_address), _, _), do: map_set
+  defp add_token_balance_address(map_set, unquote(@burn_address), _, _, _, _), do: map_set
 
-  defp add_token_balance_address(map_set, address, token_contract_address, block_number) do
+  defp add_token_balance_address(map_set, address, token_contract_address, token_id, token_type, block_number) do
     MapSet.put(map_set, %{
       address_hash: address,
       token_contract_address_hash: token_contract_address,
-      block_number: block_number
+      block_number: block_number,
+      token_id: token_id,
+      token_type: token_type
     })
   end
 

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -14,13 +14,32 @@ defmodule Indexer.Transform.TokenTransfers do
   def parse(logs) do
     initial_acc = %{tokens: [], token_transfers: []}
 
-    logs
-    |> Enum.filter(&(&1.first_topic == unquote(TokenTransfer.constant())))
-    |> Enum.reduce(initial_acc, &do_parse/2)
+    erc20_and_erc721_token_transfers =
+      logs
+      |> Enum.filter(&(&1.first_topic == unquote(TokenTransfer.constant())))
+      |> Enum.reduce(initial_acc, &do_parse/2)
+
+    erc1155_token_transfers =
+      logs
+      |> Enum.filter(fn log ->
+        log.first_topic == TokenTransfer.erc1155_single_transfer_signature() ||
+          log.first_topic == TokenTransfer.erc1155_batch_transfer_signature()
+      end)
+      |> Enum.reduce(initial_acc, &do_parse(&1, &2, :erc1155))
+
+    %{
+      tokens: erc1155_token_transfers.tokens ++ erc20_and_erc721_token_transfers.tokens,
+      token_transfers: erc1155_token_transfers.token_transfers ++ erc20_and_erc721_token_transfers.token_transfers
+    }
   end
 
-  defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc) do
-    {token, token_transfer} = parse_params(log)
+  defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc, type \\ :erc20_erc721) do
+    {token, token_transfer} =
+      if type != :erc1155 do
+        parse_params(log)
+      else
+        parse_erc1155_params(log)
+      end
 
     %{
       tokens: [token | tokens],
@@ -46,6 +65,7 @@ defmodule Indexer.Transform.TokenTransfers do
       to_address_hash: truncate_address_hash(log.third_topic),
       token_contract_address_hash: log.address_hash,
       transaction_hash: log.transaction_hash,
+      token_id: nil,
       token_type: "ERC-20"
     }
 
@@ -83,7 +103,14 @@ defmodule Indexer.Transform.TokenTransfers do
   end
 
   # ERC-721 token transfer with info in data field instead of in log topics
-  defp parse_params(%{second_topic: nil, third_topic: nil, fourth_topic: nil, data: data} = log)
+  defp parse_params(
+         %{
+           second_topic: nil,
+           third_topic: nil,
+           fourth_topic: nil,
+           data: data
+         } = log
+       )
        when not is_nil(data) do
     [from_address_hash, to_address_hash, token_id] = decode_data(data, [:address, :address, {:uint, 256}])
 
@@ -102,6 +129,62 @@ defmodule Indexer.Transform.TokenTransfers do
     token = %{
       contract_address_hash: log.address_hash,
       type: "ERC-721"
+    }
+
+    {token, token_transfer}
+  end
+
+  def parse_erc1155_params(
+        %{
+          first_topic: unquote(TokenTransfer.erc1155_batch_transfer_signature()),
+          third_topic: third_topic,
+          fourth_topic: fourth_topic,
+          data: data
+        } = log
+      ) do
+    [token_ids, values] = decode_data(data, [{:array, {:uint, 256}}, {:array, {:uint, 256}}])
+
+    token_transfer = %{
+      block_number: log.block_number,
+      block_hash: log.block_hash,
+      log_index: log.index,
+      from_address_hash: truncate_address_hash(third_topic),
+      to_address_hash: truncate_address_hash(fourth_topic),
+      token_contract_address_hash: log.address_hash,
+      transaction_hash: log.transaction_hash,
+      token_type: "ERC-1155",
+      token_ids: token_ids,
+      token_id: nil,
+      values: values
+    }
+
+    token = %{
+      contract_address_hash: log.address_hash,
+      type: "ERC-1155"
+    }
+
+    {token, token_transfer}
+  end
+
+  def parse_erc1155_params(%{third_topic: third_topic, fourth_topic: fourth_topic, data: data} = log) do
+    [token_id, value] = decode_data(data, [{:uint, 256}, {:uint, 256}])
+
+    token_transfer = %{
+      amount: value,
+      block_number: log.block_number,
+      block_hash: log.block_hash,
+      log_index: log.index,
+      from_address_hash: truncate_address_hash(third_topic),
+      to_address_hash: truncate_address_hash(fourth_topic),
+      token_contract_address_hash: log.address_hash,
+      transaction_hash: log.transaction_hash,
+      token_type: "ERC-1155",
+      token_id: token_id
+    }
+
+    token = %{
+      contract_address_hash: log.address_hash,
+      type: "ERC-1155"
     }
 
     {token, token_transfer}

--- a/apps/indexer/test/indexer/fetcher/token_balance_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_balance_test.exs
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
       insert(:token_balance, value_fetched_at: DateTime.utc_now())
 
       assert TokenBalance.init([], &[&1 | &2], nil) == [
-               {address_hash_bytes, token_contract_address_hash_bytes, block_number, 0}
+               {address_hash_bytes, token_contract_address_hash_bytes, 1000, "ERC-20", nil, 0}
              ]
     end
   end
@@ -58,7 +58,7 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
       )
 
       assert TokenBalance.run(
-               [{address_hash_bytes, token_contract_address_hash_bytes, block_number, 0}],
+               [{address_hash_bytes, token_contract_address_hash_bytes, block_number, "ERC-20", nil, 0}],
                nil
              ) == :ok
 
@@ -96,6 +96,8 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
         {
           token_balance_a.address_hash.bytes,
           token_balance_a.token_contract_address_hash.bytes,
+          "ERC-20",
+          nil,
           token_balance_a.block_number,
           # this token balance must be ignored
           max_retries
@@ -103,6 +105,8 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
         {
           token_balance_b.address_hash.bytes,
           token_balance_b.token_contract_address_hash.bytes,
+          "ERC-20",
+          nil,
           token_balance_b.block_number,
           # this token balance still have to be retried
           max_retries - 2
@@ -136,8 +140,8 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
 
       assert TokenBalance.run(
                [
-                 {address_hash_bytes, token_contract_address_hash_bytes, block_number, 0},
-                 {address_hash_bytes, token_contract_address_hash_bytes, block_number, 0}
+                 {address_hash_bytes, token_contract_address_hash_bytes, block_number, "ERC-20", nil, 0},
+                 {address_hash_bytes, token_contract_address_hash_bytes, block_number, "ERC-20", nil, 0}
                ],
                nil
              ) == :ok
@@ -177,7 +181,9 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
         %{
           address_hash: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
           block_number: 19999,
-          token_contract_address_hash: to_string(contract.contract_address_hash)
+          token_contract_address_hash: to_string(contract.contract_address_hash),
+          token_type: "ERC-20",
+          token_id: nil
         }
       ]
 
@@ -195,12 +201,16 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
         %{
           address_hash: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
           block_number: 19999,
-          token_contract_address_hash: to_string(contract.contract_address_hash)
+          token_contract_address_hash: to_string(contract.contract_address_hash),
+          token_id: 11,
+          token_type: "ERC-20"
         },
         %{
           address_hash: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
           block_number: 19999,
-          token_contract_address_hash: to_string(contract2.contract_address_hash)
+          token_contract_address_hash: to_string(contract2.contract_address_hash),
+          token_id: 11,
+          token_type: "ERC-20"
         }
       ]
 

--- a/apps/indexer/test/indexer/token_balances_test.exs
+++ b/apps/indexer/test/indexer/token_balances_test.exs
@@ -29,7 +29,9 @@ defmodule Indexer.TokenBalancesTest do
       data = %{
         token_contract_address_hash: Hash.to_string(token.contract_address_hash),
         address_hash: address_hash_string,
-        block_number: 1_000
+        block_number: 1_000,
+        token_id: 11,
+        token_type: "ERC-20"
       }
 
       get_balance_from_blockchain()
@@ -54,7 +56,9 @@ defmodule Indexer.TokenBalancesTest do
           address_hash: to_string(address.hash),
           block_number: 1_000,
           token_contract_address_hash: to_string(token.contract_address_hash),
-          retries_count: 1
+          retries_count: 1,
+          token_id: 11,
+          token_type: "ERC-20"
         }
       ]
 

--- a/apps/indexer/test/indexer/transform/address_token_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_token_balances_test.exs
@@ -24,7 +24,9 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
         block_number: block_number,
         from_address_hash: from_address_hash,
         to_address_hash: to_address_hash,
-        token_contract_address_hash: token_contract_address_hash
+        token_contract_address_hash: token_contract_address_hash,
+        token_id: nil,
+        token_type: "ERC-20"
       }
 
       params_set = AddressTokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
@@ -46,7 +48,8 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
         from_address_hash: from_address_hash,
         to_address_hash: to_address_hash,
         token_contract_address_hash: token_contract_address_hash,
-        token_type: "ERC-721"
+        token_type: "ERC-721",
+        token_id: nil
       }
 
       params_set = AddressTokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
@@ -56,7 +59,9 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
                  %{
                    address_hash: "0x5b8410f67eb8040bb1cd1e8a4ff9d5f6ce678a15",
                    block_number: 1,
-                   token_contract_address_hash: "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc"
+                   token_contract_address_hash: "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc",
+                   token_id: nil,
+                   token_type: "ERC-721"
                  }
                ])
     end

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -74,6 +74,7 @@ defmodule Indexer.Transform.TokenTransfersTest do
             block_hash: log_3.block_hash
           },
           %{
+            token_id: nil,
             amount: Decimal.new(17_000_000_000_000_000_000),
             block_number: log_1.block_number,
             log_index: log_1.index,
@@ -129,6 +130,87 @@ defmodule Indexer.Transform.TokenTransfersTest do
       }
 
       assert TokenTransfers.parse([log]) == expected
+    end
+
+    test "parses erc1155 token transfer" do
+      log = %{
+        address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+        block_number: 8_683_457,
+        data:
+          "0x1000000000000c520000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+        first_topic: "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62",
+        secon_topic: "0x0000000000000000000000009c978f4cfa1fe13406bcc05baf26a35716f881dd",
+        third_topic: "0x0000000000000000000000009c978f4cfa1fe13406bcc05baf26a35716f881dd",
+        fourth_topic: "0x0000000000000000000000009c978f4cfa1fe13406bcc05baf26a35716f881dd",
+        index: 2,
+        transaction_hash: "0x6d2dd62c178e55a13b65601f227c4ffdd8aa4e3bcb1f24731363b4f7619e92c8",
+        block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+        type: "mined"
+      }
+
+      assert TokenTransfers.parse([log]) == %{
+               token_transfers: [
+                 %{
+                   amount: 1,
+                   block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+                   block_number: 8_683_457,
+                   from_address_hash: "0x9c978f4cfa1fe13406bcc05baf26a35716f881dd",
+                   log_index: 2,
+                   to_address_hash: "0x9c978f4cfa1fe13406bcc05baf26a35716f881dd",
+                   token_contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+                   token_id:
+                     7_237_005_577_332_282_011_952_059_972_634_123_378_909_214_838_582_411_639_295_170_840_059_424_276_480,
+                   token_type: "ERC-1155",
+                   transaction_hash: "0x6d2dd62c178e55a13b65601f227c4ffdd8aa4e3bcb1f24731363b4f7619e92c8"
+                 }
+               ],
+               tokens: [
+                 %{
+                   contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+                   type: "ERC-1155"
+                 }
+               ]
+             }
+    end
+
+    test "parses erc1155 batch token transfer" do
+      log = %{
+        address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+        block_number: 8_683_457,
+        data:
+          "0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000001388",
+        first_topic: "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb",
+        secon_topic: "0x0000000000000000000000006c943470780461b00783ad530a53913bd2c104d3",
+        third_topic: "0x0000000000000000000000006c943470780461b00783ad530a53913bd2c104d3",
+        fourth_topic: "0x0000000000000000000000006c943470780461b00783ad530a53913bd2c104d3",
+        index: 2,
+        transaction_hash: "0x6d2dd62c178e55a13b65601f227c4ffdd8aa4e3bcb1f24731363b4f7619e92c8",
+        block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+        type: "mined"
+      }
+
+      assert TokenTransfers.parse([log]) == %{
+               token_transfers: [
+                 %{
+                   block_hash: "0x79594150677f083756a37eee7b97ed99ab071f502104332cb3835bac345711ca",
+                   block_number: 8_683_457,
+                   from_address_hash: "0x6c943470780461b00783ad530a53913bd2c104d3",
+                   log_index: 2,
+                   to_address_hash: "0x6c943470780461b00783ad530a53913bd2c104d3",
+                   token_contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+                   token_ids: [680_564_733_841_876_926_926_749_214_863_536_422_912],
+                   token_type: "ERC-1155",
+                   transaction_hash: "0x6d2dd62c178e55a13b65601f227c4ffdd8aa4e3bcb1f24731363b4f7619e92c8",
+                   values: [5000]
+                 }
+               ],
+               tokens: [
+                 %{
+                   contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+                   type: "ERC-1155"
+                 }
+               ]
+             }
     end
 
     test "logs error with unrecognized token transfer format" do

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -198,18 +198,14 @@ defmodule Indexer.Transform.TokenTransfersTest do
                    log_index: 2,
                    to_address_hash: "0x6c943470780461b00783ad530a53913bd2c104d3",
                    token_contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
+                   token_id: nil,
                    token_ids: [680_564_733_841_876_926_926_749_214_863_536_422_912],
                    token_type: "ERC-1155",
                    transaction_hash: "0x6d2dd62c178e55a13b65601f227c4ffdd8aa4e3bcb1f24731363b4f7619e92c8",
                    values: [5000]
                  }
                ],
-               tokens: [
-                 %{
-                   contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",
-                   type: "ERC-1155"
-                 }
-               ]
+               tokens: [%{contract_address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb", type: "ERC-1155"}]
              }
     end
 


### PR DESCRIPTION
Resolves https://github.com/poanetwork/blockscout/issues/2355

## Motivation

Blockscout doesn't support ERC-1155 tokens (https://github.com/ethereum/eips/issues/1155)

## Changelog

- [x] Support for ERC-1155 for token balances
- [ ] Support for ERC-1155 for token transfers to show in the UI