### PR TITLE
Fix inventory pagination where condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Fixes
 - [#3350](https://github.com/poanetwork/blockscout/pull/3350) - Fix tokens list pagination
 - [#3347](https://github.com/poanetwork/blockscout/pull/3347) - Contract interaction: fix encoding of bytes output
-- [#3346](https://github.com/poanetwork/blockscout/pull/3346) - Fix inventory tab pagination
+- [#3346](https://github.com/poanetwork/blockscout/pull/3346), [#3351](https://github.com/poanetwork/blockscout/pull/3351) - Fix inventory tab pagination
 - [#3344](https://github.com/poanetwork/blockscout/pull/3344) - Fix logs search on address page
 - [#3342](https://github.com/poanetwork/blockscout/pull/3342) - Fix mobile styles for contract code tab
 - [#3341](https://github.com/poanetwork/blockscout/pull/3341) - Change Solc binary downloader path to official primary supported path

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -205,7 +205,7 @@ defmodule Explorer.Chain.TokenTransfer do
   def page_token_transfer(query, %PagingOptions{key: nil}), do: query
 
   def page_token_transfer(query, %PagingOptions{key: {token_id}}) do
-    where(query, [token_transfer], token_transfer.token_id > ^token_id)
+    where(query, [tt], tt.token_id < ^token_id)
   end
 
   def page_token_transfer(query, %PagingOptions{key: {block_number, log_index}}) do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4658,7 +4658,7 @@ defmodule Explorer.ChainTest do
           transaction: transaction,
           token_contract_address: token_contract_address,
           token: token,
-          token_id: 11
+          token_id: 29
         )
 
       second_page =
@@ -4669,7 +4669,7 @@ defmodule Explorer.ChainTest do
           transaction: transaction,
           token_contract_address: token_contract_address,
           token: token,
-          token_id: 29
+          token_id: 11
         )
 
       paging_options = %PagingOptions{key: {first_page.token_id}, page_size: 1}


### PR DESCRIPTION
## Motivation

Current *where* condition in the query is looking for tokens with token id greater than specified. It should be in the opposite direction since we display the highest token id on the first page.

## Changelog

Change *where* condition to find tokens with id less than specified.

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
