### PR TITLE
Handle Nethermind trace nil type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#3462](https://github.com/poanetwork/blockscout/pull/3462) - Display price for bridged tokens
 
 ### Fixes
+- [#3527](https://github.com/poanetwork/blockscout/pull/3527) - Handle Nethermind trace nil type
 - [#3525](https://github.com/poanetwork/blockscout/pull/3525) - Address token balance on demand fetcher
 - [#3514](https://github.com/poanetwork/blockscout/pull/3514) - Read contract: fix internal server error
 - [#3513](https://github.com/poanetwork/blockscout/pull/3513) - Fix input data processing for method call (array type of data)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
@@ -202,38 +202,18 @@ defmodule EthereumJSONRPC.Parity.Trace do
 
   """
 
-  def elixir_to_params(%{"type" => "call" = type} = elixir) do
-    %{
-      "action" => %{
-        "callType" => call_type,
-        "to" => to_address_hash,
-        "from" => from_address_hash,
-        "input" => input,
-        "gas" => gas,
-        "value" => value
-      },
-      "blockNumber" => block_number,
-      "transactionIndex" => transaction_index,
-      "transactionHash" => transaction_hash,
-      "index" => index,
-      "traceAddress" => trace_address
-    } = elixir
+  def elixir_to_params(%{"type" => "call"} = elixir) do
+    elixir_to_call_params(elixir)
+  end
 
-    %{
-      block_number: block_number,
-      transaction_hash: transaction_hash,
-      transaction_index: transaction_index,
-      index: index,
-      trace_address: trace_address,
-      type: type,
-      call_type: call_type,
-      from_address_hash: from_address_hash,
-      to_address_hash: to_address_hash,
-      gas: gas,
-      input: input,
-      value: value
-    }
-    |> put_call_error_or_result(elixir)
+  # In Nethermind client if error exists, type could be nil in cases:
+  # sender not specified
+  # gas limit below intrinsic gas
+  # block gas limit exceeded
+  # insufficient sender balance
+  # wrong transaction nonce
+  def elixir_to_params(%{"type" => nil, "error" => _error} = elixir) do
+    elixir_to_call_params(elixir)
   end
 
   def elixir_to_params(%{"type" => "create" = type} = elixir) do
@@ -286,6 +266,40 @@ defmodule EthereumJSONRPC.Parity.Trace do
       value: value,
       transaction_index: transaction_index
     }
+  end
+
+  defp elixir_to_call_params(%{"type" => type} = elixir) do
+    %{
+      "action" => %{
+        "callType" => call_type,
+        "to" => to_address_hash,
+        "from" => from_address_hash,
+        "input" => input,
+        "gas" => gas,
+        "value" => value
+      },
+      "blockNumber" => block_number,
+      "transactionIndex" => transaction_index,
+      "transactionHash" => transaction_hash,
+      "index" => index,
+      "traceAddress" => trace_address
+    } = elixir
+
+    %{
+      block_number: block_number,
+      transaction_hash: transaction_hash,
+      transaction_index: transaction_index,
+      index: index,
+      trace_address: trace_address,
+      type: type,
+      call_type: call_type,
+      from_address_hash: from_address_hash,
+      to_address_hash: to_address_hash,
+      gas: gas,
+      input: input,
+      value: value
+    }
+    |> put_call_error_or_result(elixir)
   end
 
   @doc """

--- a/apps/explorer/priv/repo/migrations/20201218103424_internal_txs_allow_nil_type.exs
+++ b/apps/explorer/priv/repo/migrations/20201218103424_internal_txs_allow_nil_type.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.InternalTxsAllowNilType do
+  use Ecto.Migration
+
+  def up do
+    alter table(:internal_transactions) do
+      modify(:type, :string, null: true)
+    end
+  end
+
+  def down do
+    alter table(:internal_transactions) do
+      modify(:type, :string, null: false)
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/poanetwork/blockscout/issues/3519

## Motivation

As noted by Nethermind team, Nethermind client can return null type from trace request of a transaction when an error is present in cases:
- sender not specified
- gas limit below intrinsic gas
- block gas limit exceeded
- insufficient sender balance
- wrong transaction nonce

Blockscout should handle the response from trace request with null type returned

## Changelog

- Add missing `elixir_to_params` function clause with nil type
- Allow nil values for type in DB

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
