### PR TITLE
POSDAO: fix snapshotting and remove temporary code

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:118
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/7 has no local return
-lib/explorer/staking/stake_snapshotting.ex:216
+lib/explorer/staking/stake_snapshotting.ex:207

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3732](https://github.com/poanetwork/blockscout/pull/3732) - POSDAO: fix snapshotting and remove temporary code
 - [#3731](https://github.com/poanetwork/blockscout/pull/3731) - Handle bad gateway at pending transactions fetcher
 - [#3730](https://github.com/poanetwork/blockscout/pull/3730) - Set default period for average block time counter refresh interval
 - [#3729](https://github.com/poanetwork/blockscout/pull/3729) - Token on-demand balance fetcher: handle nil balance


### PR DESCRIPTION
## Motivation

This PR removes some code temporarily added in https://github.com/poanetwork/blockscout/pull/3712 and adds a fix for `Explorer.Staking.ContractState` module which makes the module restart snapshotting procedure if there were `ChangedMiningAddress` or `ChangedStakingAddress` event emitted. The re-snapshotting is required to re-fill `snapshotted_*` fields in `staking_pools` and `staking_pools_delegators` tables after pool's address is changed.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
