### PR TITLE
Token balance on demand fetcher memory leak fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3735](https://github.com/blockscout/blockscout/pull/3735) - Token balance on demand fetcher memory leak fix
 - [#3732](https://github.com/poanetwork/blockscout/pull/3732) - POSDAO: fix snapshotting and remove temporary code
 - [#3731](https://github.com/poanetwork/blockscout/pull/3731) - Handle bad gateway at pending transactions fetcher
 - [#3730](https://github.com/poanetwork/blockscout/pull/3730) - Set default period for average block time counter refresh interval

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -94,7 +94,7 @@ const elements = {
       return { balanceCard: $el.html(), balance: parseFloat($el.find('.current-balance-in-wei').attr('data-wei-value')) }
     },
     render ($el, state, oldState) {
-      if (oldState.balance === state.balance) return
+      if (oldState.balance === state.balance || isNaN(state.balance)) return
       $el.empty().append(state.balanceCard)
       loadTokenBalance(state.fetchedCoinBalanceBlockNumber)
       updateAllCalculatedUsdValues()

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.AddressTokenBalanceController do
   import BlockScoutWeb.AddressView, only: [from_address_hash: 1]
   alias BlockScoutWeb.AccessHelpers
   alias Explorer.{Chain, CustomContractsHelpers, Market}
+  alias Explorer.Chain.Address
   alias Indexer.Fetcher.TokenBalanceOnDemand
 
   def index(conn, %{"address_id" => address_hash_string} = params) do
@@ -57,7 +58,7 @@ defmodule BlockScoutWeb.AddressTokenBalanceController do
           |> put_status(200)
           |> put_layout(false)
           |> render("_token_balances.html",
-            address_hash: address_hash,
+            address_hash: Address.checksum(address_hash),
             token_balances: token_balances_with_price,
             circles_total_balance: circles_total_balance
           )
@@ -67,7 +68,7 @@ defmodule BlockScoutWeb.AddressTokenBalanceController do
           |> put_status(200)
           |> put_layout(false)
           |> render("_token_balances.html",
-            address_hash: address_hash,
+            address_hash: Address.checksum(address_hash),
             token_balances: [],
             circles_total_balance: Decimal.new(0)
           )

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
@@ -22,7 +22,7 @@
       <p
         class="address-current-balance"
         data-token-balance-dropdown
-        data-api_path="<%= AccessHelpers.get_path(@conn, :address_token_balance_path, :index, @address.hash) %>"
+        data-api_path="<%= AccessHelpers.get_path(@conn, :address_token_balance_path, :index, Address.checksum(@address.hash)) %>"
       >
           <span data-loading class="mb-0">
             <span class="loading-spinner-small mr-2">

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -6,7 +6,6 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
 
   @latest_balance_stale_threshold :timer.hours(24)
 
-  use GenServer
   use Indexer.Fetcher
 
   alias Explorer.Chain
@@ -31,30 +30,6 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
     end
   end
 
-  ## Callbacks
-
-  def child_spec([json_rpc_named_arguments, server_opts]) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [json_rpc_named_arguments, server_opts]},
-      type: :worker
-    }
-  end
-
-  def start_link(json_rpc_named_arguments, server_opts) do
-    GenServer.start_link(__MODULE__, json_rpc_named_arguments, server_opts)
-  end
-
-  def init(json_rpc_named_arguments) do
-    {:ok, %{json_rpc_named_arguments: json_rpc_named_arguments}}
-  end
-
-  def handle_cast({:fetch_and_update, block_number, address_hash, current_token_balances}, state) do
-    fetch_and_update(block_number, address_hash, current_token_balances, state.json_rpc_named_arguments)
-
-    {:noreply, state}
-  end
-
   ## Implementation
 
   defp do_trigger_fetch(address_hash, current_token_balances, latest_block_number, stale_balance_window)
@@ -64,7 +39,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
       |> Enum.filter(fn current_token_balance -> current_token_balance.block_number < stale_balance_window end)
 
     if Enum.count(stale_current_token_balances) > 0 do
-      GenServer.cast(__MODULE__, {:fetch_and_update, latest_block_number, address_hash, stale_current_token_balances})
+      fetch_and_update(latest_block_number, address_hash, stale_current_token_balances)
     else
       :current
     end
@@ -72,7 +47,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
     :ok
   end
 
-  defp fetch_and_update(block_number, address_hash, stale_current_token_balances, _json_rpc_named_arguments) do
+  defp fetch_and_update(block_number, address_hash, stale_current_token_balances) do
     current_token_balances_update_params =
       stale_current_token_balances
       |> Enum.map(fn stale_current_token_balance ->
@@ -85,26 +60,28 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
           }
         ]
 
-        updated_balance = BalanceReader.get_balances_of(stale_current_token_balances_to_fetch)[:ok]
+        balance_response = BalanceReader.get_balances_of(stale_current_token_balances_to_fetch)
+        updated_balance = balance_response[:ok]
 
-        token_balance =
+        if updated_balance do
           %{}
           |> Map.put(:address_hash, stale_current_token_balance.address_hash)
           |> Map.put(:token_contract_address_hash, stale_current_token_balance.token_contract_address_hash)
           |> Map.put(:block_number, block_number)
-
-        if updated_balance do
-          token_balance
           |> Map.put(:value, Decimal.new(updated_balance))
           |> Map.put(:value_fetched_at, DateTime.utc_now())
         else
-          token_balance
+          nil
         end
       end)
 
+    filtered_current_token_balances_update_params =
+      current_token_balances_update_params
+      |> Enum.filter(&(!is_nil(&1)))
+
     Chain.import(%{
       address_current_token_balances: %{
-        params: current_token_balances_update_params
+        params: filtered_current_token_balances_update_params
       },
       broadcast: :on_demand
     })

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -28,7 +28,6 @@ defmodule Indexer.Supervisor do
     ReplacedTransaction,
     Token,
     TokenBalance,
-    TokenBalanceOnDemand,
     TokenInstance,
     TokenTotalSupplyOnDemand,
     TokenUpdater,
@@ -128,7 +127,6 @@ defmodule Indexer.Supervisor do
       # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
       {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
-      {TokenBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
       {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
 
       # Temporary workers


### PR DESCRIPTION
## Motivation

Memory leak in Token balance on demand fetcher

## Changelog

Re-write Token balance on-demand fetcher as ordinary Module instead of Genserver process

Chore:
- Fix the issue when rendering of tokens dropdown at address page is called 6 times on the page: use checksummed address in the URI and ignore NaN balance in the state


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
