### PR TITLE
Fix Sushiswap LP tokens custom metadata fetcher: bytes(n) symbol and name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3564](https://github.com/poanetwork/blockscout/pull/3564) - Staking welcome message
 
 ### Fixes
+- [#3742](https://github.com/blockscout/blockscout/pull/3742) - Fix Sushiswap LP tokens custom metadata fetcher: bytes(n) symbol and name support
 - [#3741](https://github.com/blockscout/blockscout/pull/3741) - Contract reader fix when there are multiple input params including an array type
 - [#3735](https://github.com/blockscout/blockscout/pull/3735) - Token balance on demand fetcher memory leak fix
 - [#3732](https://github.com/poanetwork/blockscout/pull/3732) - POSDAO: fix snapshotting and remove temporary code

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -1086,7 +1086,7 @@ defmodule Explorer.Staking.ContractState do
     |> Jason.decode!()
   end
 
-  defp binary_to_string(binary) do
+  def binary_to_string(binary) do
     binary
     |> :binary.bin_to_list()
     |> Enum.filter(fn x -> x != 0 end)


### PR DESCRIPTION
## Motivation

Missing token name and symbol of MKR in Sushiswap LP token

<img width="493" alt="Screenshot 2021-03-25 at 17 17 01" src="https://user-images.githubusercontent.com/4341812/112487732-03968280-8d8e-11eb-975e-42d6f2cbcd9d.png">


## Changelog

MKR token and symbol getters have `byte32` type, unlike others. This PR enables support in metadata fetcher for Sushiswap LP tokens which have `bytes(n)` type for symbol and token getters in token contract.

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
