### PR TITLE
Refactor and optimize Staking DApp

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/explorer/exchange_rates/source.ex:113
 lib/explorer/smart_contract/verifier.ex:89
 lib/block_scout_web/templates/address_contract/index.html.eex:123
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/7 has no local return
-lib/explorer/staking/stake_snapshotting.ex:207
+lib/explorer/staking/stake_snapshotting.ex:147

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#3577](https://github.com/poanetwork/blockscout/pull/3577) - Eliminate GraphiQL page XSS attack
 
 ### Chore
+- [#3745](https://github.com/blockscout/blockscout/pull/3745) - Refactor and optimize Staking DApp
 - [#3744](https://github.com/blockscout/blockscout/pull/3744) - Update Mix packages: timex, hackney, tzdata certifi
 - [#3736](https://github.com/blockscout/blockscout/pull/3736), [#3739](https://github.com/blockscout/blockscout/pull/3739) - Contract writer: Fix sending a transaction with tuple input type
 - [#3719](https://github.com/poanetwork/blockscout/pull/3719) - Rename ethprice API endpoint

--- a/apps/explorer/test/explorer/staking/contract_state_test.exs
+++ b/apps/explorer/test/explorer/staking/contract_state_test.exs
@@ -260,7 +260,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # get_responses, ContractReader.pool_staking_requests
+    # get_pool_staking_responses
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
@@ -374,7 +374,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # get_responses, ContractReader.pool_mining_requests
+    # get_pool_mining_responses
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
@@ -476,7 +476,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # get_responses, ContractReader.staker_requests
+    # get_staker_responses
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
@@ -722,7 +722,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    # invoke do_start_snapshotting()
+    # start_snapshotting
 
     ## get_mining_to_staking_address
     expect(
@@ -745,285 +745,67 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    ## 1 snapshotted_pool_amounts_requests
+    ## snapshotted_pool_amounts_requests
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
       fn requests, _opts ->
-        assert length(requests) == 2
+        assert length(requests) == 4 * 2
 
         {:ok,
          format_responses([
-           # StakingAuRa.stakeAmountTotal
+           # 1.1 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000000000000000000000",
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000000000000000000"
-         ])}
-      end
-    )
+           # 1.2 StakingAuRa.stakeAmount
+           "0x0000000000000000000000000000000000000000000000000000000000000000",
 
-    ## 2 snapshotted_pool_amounts_requests
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 2
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmountTotal
+           # 2.1 StakingAuRa.stakeAmountTotal
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
-         ])}
-      end
-    )
+           # 2.2 StakingAuRa.stakeAmount
+           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
 
-    ## 3 snapshotted_pool_amounts_requests
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 2
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmountTotal
+           # 3.1 StakingAuRa.stakeAmountTotal
            "0x00000000000000000000000000000000000000000000000098a7d9b8314c0000",
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
-         ])}
-      end
-    )
+           # 3.2 StakingAuRa.stakeAmount
+           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
 
-    ## 4 snapshotted_pool_amounts_requests
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 2
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmountTotal
+           # 4.1 StakingAuRa.stakeAmountTotal
            "0x00000000000000000000000000000000000000000000000029a2241af62c0000",
-           # StakingAuRa.stakeAmount
+           # 4.2 StakingAuRa.stakeAmount
            "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
          ])}
       end
     )
 
-    ## 1 snapshotted_staker_amount_request
+    ## get_staker_responses, snapshotted_staker_amount_request
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
       fn requests, _opts ->
-        assert length(requests) == 1
+        assert length(requests) == 14
 
         {:ok,
          format_responses([
            # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000000000000000000"
-         ])}
-      end
-    )
-
-    ## 2 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
-         ])}
-      end
-    )
-
-    ## 3 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
+           "0x0000000000000000000000000000000000000000000000000000000000000000",
+           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
+           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
            "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
          ])}
       end
     )
 
-    ## 4 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
-         ])}
-      end
-    )
-
-    ## 5 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000001bc16d674ec80000"
-         ])}
-      end
-    )
-
-    ## 6 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 7 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 8 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 9 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 10 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 11 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 12 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 13 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## 14 snapshotted_staker_amount_request
-    expect(
-      EthereumJSONRPC.Mox,
-      :json_rpc,
-      fn requests, _opts ->
-        assert length(requests) == 1
-
-        {:ok,
-         format_responses([
-           # StakingAuRa.stakeAmount
-           "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
-         ])}
-      end
-    )
-
-    ## ContractReader.validator_reward_request
+    ## get_validator_reward_responses, validator_reward_request
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,
@@ -1044,7 +826,7 @@ defmodule Explorer.Staking.ContractStateTest do
       end
     )
 
-    ## ContractReader.delegator_reward_request
+    ## get_delegator_reward_responses, delegator_reward_request
     expect(
       EthereumJSONRPC.Mox,
       :json_rpc,


### PR DESCRIPTION
## Motivation

Staking DApp sends big batch JSON RPC requests to the archive node in some cases (especially, when reading info about delegators). This PR refactors DApp's server side code, limits the length of batch requests splitting them into chunks, and optimizes the code of the `StakeSnapshotting` module so snapshotting procedure takes a few seconds instead of a few tens of seconds.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
