### PR TITLE
Skip null topics in eth_getLogs API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3748](https://github.com/blockscout/blockscout/pull/3748) - Skip null topics in eth_getLogs API endpoint
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/lib/try_eth_api.js
+++ b/apps/block_scout_web/assets/js/lib/try_eth_api.js
@@ -39,7 +39,11 @@ function parseInput (input) {
     case 'string':
       return value
     case 'json':
-      return JSON.parse(value)
+      try {
+        return JSON.parse(value)
+      } catch (e) {
+        return {}
+      }
     default:
       return value
   }

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -224,6 +224,7 @@ defmodule Explorer.EthRPC do
 
   defp validate_topics(topics) when is_list(topics) do
     topics
+    |> Enum.filter(&(!is_nil(&1)))
     |> Stream.with_index()
     |> Enum.reduce({:ok, %{}}, fn {topic, index}, {:ok, acc} ->
       case cast_topics(topic) do


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/3746

## Motivation

Null topic causes Internal server error in `eth_getLogs` API endpoint

## Changelog

Filter out not null topics before processing in `eth_getLogs` API endpoint

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
