### PR TITLE
Fix mobile styles for tx tile

### DIFF
--- a/apps/block_scout_web/assets/css/components/_transaction.scss
+++ b/apps/block_scout_web/assets/css/components/_transaction.scss
@@ -51,3 +51,9 @@
 		width: 60%;
 	}
 }
+
+.text-nowrap-small-screen {
+	@include media-breakpoint-up(sm) {
+		white-space: nowrap !important;
+	}
+}

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_token_transfer.html.eex
@@ -1,4 +1,4 @@
-<div class="text-nowrap row mt-3 mt-sm-0" data-test="token_transfer">
+<div class="text-nowrap-small-screen row mt-3 mt-sm-0" data-test="token_transfer">
   <span class="col-xs-12 col-lg-5" style="display: inline-table;">
     <%= if from_or_to_address?(@token_transfer, @address) do %>
       <%= if @token_transfer.from_address_hash == @address.hash do %>


### PR DESCRIPTION
## Motivation

Token transfer title: token name is out of borders in mobile view

![image](https://user-images.githubusercontent.com/4341812/113713822-6e31b180-96f0-11eb-899b-dcf9fe5e1541.png)


## Changelog

Set `white-space: nowrap !important;` everytime except mobile view. Currently it is applied for each view.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
