### PR TITLE
Inventory pagination query performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#3750](https://github.com/blockscout/blockscout/pull/3750) - getblocknobytime block module API endpoint
 
 ### Fixes
+- [#3773](https://github.com/blockscout/blockscout/pull/3773) - Inventory pagination query performance improvement
 - [#3767](https://github.com/blockscout/blockscout/pull/3767) - Decoded contract method input tuple reader fix
 - [#3748](https://github.com/blockscout/blockscout/pull/3748) - Skip null topics in eth_getLogs API endpoint
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -293,7 +293,7 @@ defmodule Explorer.Chain.TokenTransfer do
       tt in TokenTransfer,
       left_join: instance in Instance,
       on: tt.token_contract_address_hash == instance.token_contract_address_hash and tt.token_id == instance.token_id,
-      where: instance.token_contract_address_hash == ^contract_address_hash,
+      where: tt.token_contract_address_hash == ^contract_address_hash,
       order_by: [desc: tt.block_number],
       distinct: [desc: tt.token_id],
       preload: [:to_address],


### PR DESCRIPTION
## Motivation

The DB query for Inventory tab is slow for the next pages after 1st page.

## Changelog

https://github.com/blockscout/blockscout/pull/3773/files#diff-6be189f964972cc8407ceeb151c7a685c5aefa3c662a1082ca7e32f54b2821f9L296-R296

Query performance before the fix:
```
dai=> EXPLAIN ANALYZE (SELECT DISTINCT ON (t0."token_id") t0."amount", t0."block_number", t0."log_index", t0."token_id", t0."from_address_hash", t0."to_address_hash", t0."token_contract_address_hash", t0."transaction_hash", t0."block_hash", t0."inserted_at", t0."updated_at", t1."token_id", t1."metadata", t1."error", t1."token_contract_address_hash", t1."inserted_at", t1."updated_at"
dai(> FROM "token_transfers" AS t0
dai(> LEFT OUTER JOIN "token_instances" AS t1
dai(> ON (t0."token_contract_address_hash" = t1."token_contract_address_hash") AND (t0."token_id" = t1."token_id")
dai(> WHERE (t1."token_contract_address_hash" = '\x22C1f6050E56d2876009903609a2cC3fEf83B415') AND (t0."token_id" < 125661) ORDER BY t0."token_id" DESC, t0."block_number" DESC LIMIT 50);
                                                                                                    QUERY PLAN

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------
 Limit  (cost=17130.62..17130.86 rows=47 width=973) (actual time=110823.562..110825.536 rows=50 loops=1)
   ->  Unique  (cost=17130.62..17130.86 rows=47 width=973) (actual time=110823.561..110825.531 rows=50 loops=1)
         ->  Sort  (cost=17130.62..17130.74 rows=47 width=973) (actual time=110823.560..110825.512 rows=50 loops=1)
               Sort Key: t0.token_id DESC, t0.block_number DESC
               Sort Method: external merge  Disk: 124064kB
               ->  Gather  (cost=1117.65..17129.32 rows=47 width=973) (actual time=51.011..110470.371 rows=111674 loops=1)
                     Workers Planned: 1
                     Workers Launched: 1
                     ->  Nested Loop  (cost=117.65..16124.62 rows=28 width=973) (actual time=49.044..110236.401 rows=55837 loops=2)
                           ->  Parallel Bitmap Heap Scan on token_transfers t0  (cost=117.23..7747.07 rows=1186 width=184) (actual time=38.531..108412.970 rows=55849 l
oops=2)
                                 Recheck Cond: ((token_contract_address_hash = '\x22c1f6050e56d2876009903609a2cc3fef83b415'::bytea) AND (token_id < '125661'::numeric))
                                 Heap Blocks: exact=30770
                                 ->  Bitmap Index Scan on token_transfers_token_contract_address_hash_token_id_block_numb  (cost=0.00..116.73 rows=2017 width=0) (actua
l time=29.216..29.217 rows=111698 loops=1)
                                       Index Cond: ((token_contract_address_hash = '\x22c1f6050e56d2876009903609a2cc3fef83b415'::bytea) AND (token_id < '125661'::numer
ic))
                           ->  Index Scan using token_instances_pkey on token_instances t1  (cost=0.42..7.06 rows=1 width=789) (actual time=0.031..0.031 rows=1 loops=1
11698)
                                 Index Cond: ((token_id = t0.token_id) AND (token_contract_address_hash = '\x22c1f6050e56d2876009903609a2cc3fef83b415'::bytea))
 Planning Time: 0.369 ms
 Execution Time: 110845.058 ms
(18 rows)
```

The query performance after the fix:
```
dai=> EXPLAIN ANALYZE (SELECT DISTINCT ON (t0."token_id") t0."amount", t0."block_number", t0."log_index", t0."token_id", t0."from_address_hash", t0."to_address_hash", t0."token_contract_address_hash", t0."transaction_hash", t0."block_hash", t0."inserted_at", t0."updated_at", t1."token_id", t1."metadata", t1."error", t1."token_contract_address_hash", t1."inserted_at", t1."updated_at"
dai(> FROM "token_transfers" AS t0
dai(> LEFT OUTER JOIN "token_instances" AS t1
dai(> ON (t0."token_contract_address_hash" = t1."token_contract_address_hash") AND (t0."token_id" = t1."token_id")
dai(> WHERE (t0."token_contract_address_hash" = '\x22C1f6050E56d2876009903609a2cC3fEf83B415') AND (t0."token_id" < 125661) ORDER BY t0."token_id" DESC, t0."block_number" DESC LIMIT 50);
                                                                                                      QUERY PLAN

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
------------------------------------------------
 Limit  (cost=0.98..556.46 rows=50 width=973) (actual time=0.038..0.386 rows=50 loops=1)
   ->  Unique  (cost=0.98..21575.99 rows=1942 width=973) (actual time=0.038..0.380 rows=50 loops=1)
         ->  Nested Loop Left Join  (cost=0.98..21570.94 rows=2017 width=973) (actual time=0.035..0.343 rows=50 loops=1)
               ->  Index Scan using token_transfers_token_contract_address_hash_token_id_block_numb on token_transfers t0  (cost=0.56..7318.42 rows=2017 width=184) (ac
tual time=0.023..0.177 rows=50 loops=1)
                     Index Cond: ((token_contract_address_hash = '\x22c1f6050e56d2876009903609a2cc3fef83b415'::bytea) AND (token_id < '125661'::numeric))
               ->  Index Scan using token_instances_pkey on token_instances t1  (cost=0.42..7.07 rows=1 width=789) (actual time=0.003..0.003 rows=1 loops=50)
                     Index Cond: ((token_id = t0.token_id) AND (token_contract_address_hash = t0.token_contract_address_hash) AND (token_contract_address_hash = '\x22c
1f6050e56d2876009903609a2cc3fef83b415'::bytea))
 Planning Time: 104.000 ms
 Execution Time: 0.424 ms
(9 rows)
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
