### PR TITLE
Extend Become a Candidate popup in Staking DApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#3748](https://github.com/blockscout/blockscout/pull/3748) - Skip null topics in eth_getLogs API endpoint
 
 ### Chore
+- [#3802](https://github.com/blockscout/blockscout/pull/3802) - Extend Become a Candidate popup in Staking DApp
 - [#3801](https://github.com/blockscout/blockscout/pull/3801) - Poison package update
 - [#3799](https://github.com/blockscout/blockscout/pull/3799) - Update credo, dialyxir mix packages
 - [#3789](https://github.com/blockscout/blockscout/pull/3789) - Update repo organization

--- a/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
+++ b/apps/block_scout_web/assets/js/pages/stakes/become_candidate.js
@@ -31,7 +31,9 @@ export async function openBecomeCandidateModal (event, store) {
         $form,
         {
           'candidate-stake': value => isCandidateStakeValid(value, store, msg),
-          'mining-address': value => isMiningAddressValid(value, store)
+          'mining-address': value => isMiningAddressValid(value, store),
+          'pool-name': value => isPoolNameValid(value, store),
+          'pool-description': value => isPoolDescriptionValid(value, store)
         },
         $modal.find('form button')
       )
@@ -74,12 +76,17 @@ export function becomeCandidateConnectionLost () {
 
 async function becomeCandidate ($modal, store, msg) {
   const state = store.getState()
+  const web3 = state.web3
   const stakingContract = state.stakingContract
   const tokenContract = state.tokenContract
   const decimals = state.tokenDecimals
   const stake = new BigNumber($modal.find('[candidate-stake]').val().replace(',', '.').trim()).shiftedBy(decimals).integerValue()
   const $miningAddressInput = $modal.find('[mining-address]')
+  const $poolNameInput = $modal.find('[pool-name]')
+  const $poolDescriptionInput = $modal.find('[pool-description]')
   const miningAddress = $miningAddressInput.val().trim().toLowerCase()
+  const poolName = $poolNameInput.val().trim()
+  const poolDescription = $poolDescriptionInput.val().trim()
 
   try {
     if (!isSupportedNetwork(store)) return false
@@ -96,7 +103,12 @@ async function becomeCandidate ($modal, store, msg) {
 
     lockModal($modal)
 
-    makeContractCall(tokenContract.methods.transferAndCall(stakingContract.options.address, stake.toFixed(), `${miningAddress}01`), store)
+    const poolNameHex = web3.utils.stripHexPrefix(web3.utils.utf8ToHex(poolName))
+    const poolNameLength = web3.utils.stripHexPrefix(web3.utils.padLeft(web3.utils.numberToHex(poolNameHex.length / 2), 2, '0'))
+    const poolDescriptionHex = web3.utils.stripHexPrefix(web3.utils.utf8ToHex(poolDescription))
+    const poolDescriptionLength = web3.utils.stripHexPrefix(web3.utils.padLeft(web3.utils.numberToHex(poolDescriptionHex.length / 2), 4, '0'))
+
+    makeContractCall(tokenContract.methods.transferAndCall(stakingContract.options.address, stake.toFixed(), `${miningAddress}01${poolNameLength}${poolNameHex}${poolDescriptionLength}${poolDescriptionHex}`), store)
   } catch (err) {
     openErrorModal('Error', err.message)
   }
@@ -127,6 +139,33 @@ function isMiningAddressValid (value, store) {
     return 'Invalid mining address'
   } else if (miningAddress === store.getState().account.toLowerCase()) {
     return 'The mining address cannot match the staking address'
+  }
+
+  return true
+}
+
+function isPoolNameValid (name, store) {
+  const web3 = store.getState().web3
+  const nameHex = web3.utils.stripHexPrefix(web3.utils.utf8ToHex(name.trim()))
+  const nameLength = nameHex.length / 2
+  const maxLength = 256
+
+  if (nameLength > maxLength) {
+    return `Pool name length cannot exceed ${maxLength} bytes`
+  } else if (nameLength === 0) {
+    return 'Pool name shouldn\'t be empty'
+  }
+
+  return true
+}
+
+function isPoolDescriptionValid (description, store) {
+  const web3 = store.getState().web3
+  const descriptionHex = web3.utils.stripHexPrefix(web3.utils.utf8ToHex(description.trim()))
+  const maxLength = 1024
+
+  if (descriptionHex.length / 2 > maxLength) {
+    return `Pool description length cannot exceed ${maxLength} bytes`
   }
 
   return true

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex
@@ -10,6 +10,10 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "candidate-stake", classes: "form-group", input_classes: "form-control n-b-r", attributes: "candidate-stake", type: "text", placeholder: gettext("Amount"), prepend: @token.symbol %>
 
           <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "mining-address", classes: "form-group", input_classes: "form-control", attributes: "mining-address", type: "text", placeholder: gettext("Your Mining Address") %>
+
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "pool-name", classes: "form-group", input_classes: "form-control", attributes: "pool-name", type: "text", placeholder: gettext("Your Pool Name") %>
+
+          <%= render BlockScoutWeb.CommonComponentsView, "_input_group.html", id: "pool-description", classes: "form-group", input_classes: "form-control", attributes: "pool-description", type: "text", placeholder: gettext("Your Pool Short Description (optional)") %>
           <p class="form-p m-b-0"><%= gettext("Minimum Stake:") %>
             <span class="text-dark">
               <%= format_token_amount(@min_candidate_stake, @token) %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2011,7 +2011,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:32
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
 msgid "<p>To become a candidate, your staking address must be funded with %{tokenSymbol} tokens <strong>and</strong> %{coinSymbol} coins, and your OpenEthereum node must be active and configured with the mining address you specify here.</p>\n      <p>To become a delegator, close this window and select an address from the list of pools you would like to place stake on. Click the <strong>Stake</strong> button next to the address to begin the process.</p>"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_empty_content.html.eex:13
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:5
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:29
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:33
 #: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:24
 msgid "Become a Candidate"
 msgstr ""
@@ -2203,7 +2203,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:13
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
 msgid "Minimum Stake:"
 msgstr ""
 
@@ -2539,7 +2539,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:18
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:22
 #: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:28
 msgid "Your Balance:"
 msgstr ""
@@ -2741,4 +2741,16 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_pool_info.html.eex:10
 msgid "Save changes"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:14
+msgid "Your Pool Name"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:16
+msgid "Your Pool Short Description (optional)"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2011,7 +2011,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:32
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
 msgid "<p>To become a candidate, your staking address must be funded with %{tokenSymbol} tokens <strong>and</strong> %{coinSymbol} coins, and your OpenEthereum node must be active and configured with the mining address you specify here.</p>\n      <p>To become a delegator, close this window and select an address from the list of pools you would like to place stake on. Click the <strong>Stake</strong> button next to the address to begin the process.</p>"
 msgstr ""
 
@@ -2059,7 +2059,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_empty_content.html.eex:13
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:5
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:29
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:33
 #: lib/block_scout_web/templates/stakes/_stakes_top.html.eex:24
 msgid "Become a Candidate"
 msgstr ""
@@ -2203,7 +2203,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:13
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:17
 msgid "Minimum Stake:"
 msgstr ""
 
@@ -2539,7 +2539,7 @@ msgstr ""
 
 #, elixir-format
 #:
-#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:18
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:22
 #: lib/block_scout_web/templates/stakes/_stakes_modal_stake.html.eex:28
 msgid "Your Balance:"
 msgstr ""
@@ -2741,4 +2741,16 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_pool_info.html.eex:10
 msgid "Save changes"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:14
+msgid "Your Pool Name"
+msgstr ""
+
+#, elixir-format
+#:
+#: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:16
+msgid "Your Pool Short Description (optional)"
 msgstr ""


### PR DESCRIPTION
## Motivation

In the [previous PR](https://github.com/blockscout/blockscout/pull/3758) I forgot to add pool metadata setting into `Become a Candidate` popup. This PR extends that.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
