### PR TITLE
Fix docker sed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,14 @@ RUN mix do deps.get, local.rebar --force, deps.compile
 ADD . .
 
 ARG COIN
-RUN if [ "$COIN" != "" ]; then sed -i s/"POA"/"${COIN}"/g apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po; fi
+RUN if [ "$COIN" != "" ]; then\
+    lineNum="$(grep -n 'msgid \"Ether\"' apps/block_scout_web/priv/gettext/default.pot | head -n 1 | cut -d: -f1)";\
+    lineToChange=`expr $lineNum + 1`;\
+    sed -i "${lineToChange}s/msgstr \"\"/msgstr \"${COIN}\"/" apps/block_scout_web/priv/gettext/default.pot;\
+    lineNum="$(grep -n 'msgid \"Ether\"' apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po | head -n 1 | cut -d: -f1)";\
+    lineToChange=`expr $lineNum + 1`;\
+    sed -i "${lineToChange}s/msgstr \"\"/msgstr \"${COIN}\"/" apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po;\
+    fi
 
 # Run forderground build and phoenix digest
 RUN mix compile


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

Took a long time to get the dockerfile 'currency' portion working.
Detailed the issue in the bug fixes column.

## Changelog
Fix invalid docker sed line for 'currency' display.

### Enhancements
Ensured required lines changes works with COIN argument

### Bug Fixes
So there isn't any "POA" anymore at default.pot / default.po. Thus, no matter whatever coin you put, it will never be changed.
My changes will check for a previous line "Ether" which is the id and change the next line accordingly IF there is a COIN argument. 

### Incompatible Changes

NA

## Upgrading

NA

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [X] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [X] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools

JUSTIFICATION: This is a docker image fix and there isn't tests for docker right now. However, rest assured, I have tested it locally and it is working well. Feel free to build the dockerfile on your end. Add `--build-arg COIN=randomcointest` to the end of your docker build command. The rest are not marked as it is irrelevant to this PR.