### PR TITLE
Process type field in eth_getTransactionReceipt response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#3748](https://github.com/blockscout/blockscout/pull/3748) - Skip null topics in eth_getLogs API endpoint
 
 ### Chore
+- [#3831](https://github.com/blockscout/blockscout/pull/3831) - Process type field in eth_getTransactionReceipt response
 - [#3802](https://github.com/blockscout/blockscout/pull/3802) - Extend Become a Candidate popup in Staking DApp
 - [#3801](https://github.com/blockscout/blockscout/pull/3801) - Poison package update
 - [#3799](https://github.com/blockscout/blockscout/pull/3799) - Update credo, dialyxir mix packages

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -253,7 +253,7 @@ defmodule EthereumJSONRPC.Receipt do
   # hash format
   # gas is passed in from the `t:EthereumJSONRPC.Transaction.params/0` to allow pre-Byzantium status to be derived
   defp entry_to_elixir({key, _} = entry)
-       when key in ~w(blockHash contractAddress from gas logsBloom root to transactionHash revertReason),
+       when key in ~w(blockHash contractAddress from gas logsBloom root to transactionHash revertReason type),
        do: {:ok, entry}
 
   defp entry_to_elixir({key, quantity})


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/3776

## Motivation

A new field type is returned from `eth_getTransactionReceipt` method. We should allow such transaction receipts.

```
2021-04-20T05:42:27.287 application=indexer fetcher=block_catchup [error] Catchup index stream exited with reason ({%ArgumentError{message: "Could not convert receipt to elixir\n\nReceipt:\n  %{\"blockHash\" => \"0x999fdedac3fb63e77d4054951382e8d70a14c4f747c6fef4f53ce27e0f0f5e36\", \"blockNumber\" => \"0x13dc146\", \"contractAddress\" => nil, \"cumulativeGasUsed\" => \"0xaaf0\", \"error\" => \"\", \"from\" => \"0xdad49e6cbde849353ab27dec6319e687bfc91a41\", \"gas\" => 2500000, \"gasUsed\" => \"0xaaf0\", \"logs\" => [], \"logsBloom\" => \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\", \"status\" => \"0x1\", \"to\" => \"0x67e90a54aeea85f21949c645082fe95d77bc1e70\", \"transactionHash\" => \"0x7bd10ff508afa7a38f81c5e9a0170a3a5cc43f5f31017f6188eee9f9bdb4b55e\", \"transactionIndex\" => \"0x0\", \"type\" => \"0x00\"}\n\nErrors:\n  {:unknown_key, %{key: \"type\", value: \"0x00\"}}\n"}, [{EthereumJSONRPC.Receipt, :ok!, 2, [file: 'lib/ethereum_jsonrpc/receipt.ex', line: 236]}, {Enum, :"-map/2-lists^map/1-0-", 2, [file: 'lib/enum.ex', line: 1411]}, {EthereumJSONRPC.Receipts, :fetch, 2, [file: 'lib/ethereum_jsonrpc/receipts.ex', line: 138]}, {Task.Supervised, :invoke_mfa, 2, [file: 'lib/task/supervised.ex', line: 90]}, {Task.Supervised, :reply, 5, [file: 'lib/task/supervised.ex', line: 35]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}]}). Restarting
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
