### PR TITLE
Manage token balance on-demand fetcher threshold via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 ### Chore
+- [#3870](https://github.com/blockscout/blockscout/pull/3870) - Manage token balance on-demand fetcher threshold via env var
 
 
 ## 3.7.0-beta

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -41,6 +41,18 @@ config :indexer,
 config :indexer, Indexer.Fetcher.PendingTransaction.Supervisor,
   disabled?: System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu"
 
+token_balance_on_demand_fetcher_threshold =
+  if System.get_env("TOKEN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD_MINUTES") do
+    case Integer.parse(System.get_env("TOKEN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD_MINUTES")) do
+      {integer, ""} -> integer
+      _ -> 60
+    end
+  else
+    60
+  end
+
+config :indexer, Indexer.Fetcher.TokenBalanceOnDemand, threshold: token_balance_on_demand_fetcher_threshold
+
 # config :indexer, Indexer.Fetcher.ReplacedTransaction.Supervisor, disabled?: true
 if System.get_env("POS_STAKING_CONTRACT") do
   config :indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -4,8 +4,6 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
 
   """
 
-  @latest_balance_stale_threshold :timer.hours(24)
-
   use Indexer.Fetcher
 
   alias Explorer.Chain
@@ -105,7 +103,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
         if average_block_time == 0 do
           {:error, :empty_database}
         else
-          block_number - div(@latest_balance_stale_threshold, average_block_time)
+          block_number - div(:timer.minutes(Application.get_env(:indexer, __MODULE__)[:threshold]), average_block_time)
         end
     end
   end


### PR DESCRIPTION
## Motivation

Availability to manage token balance on-demand fetcher update threshold via env var

## Changelog

`TOKEN_BALANCE_ON_DEMAND_FETCHER_THRESHOLD_MINUTES `

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
