### PR TITLE
Refactoring: replace inline style display: none with d-none class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix 
 
 ### Chore
+- [#3894](https://github.com/blockscout/blockscout/pull/3894) - Refactoring: replace inline style display: none with d-none class
 - [#3893](https://github.com/blockscout/blockscout/pull/3893) - Add left/right paddings in tx tile
 - [#3870](https://github.com/blockscout/blockscout/pull/3870) - Manage token balance on-demand fetcher threshold via env var
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_balance_card.html.eex
@@ -31,7 +31,7 @@
             </span>
             <%= gettext("Fetching tokens...") %>
           </span>
-          <span data-error-message class="mb-0" style="display: none;">
+          <span data-error-message class="mb-0 d-none">
             <%= gettext("Error trying to fetch balances.") %>
           </span>
       </p>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
@@ -25,20 +25,20 @@
           </span>
           <%= gettext("Loading chart") %>...
         </div>
-        <button data-chart-error-message class="alert alert-danger col-12 text-left mb-4" style="display: none;">
+        <button data-chart-error-message class="alert alert-danger col-12 text-left mb-4 d-none">
           <span><%= gettext("There was a problem loading the chart.") %></span>
         </button>
-        <div data-chart-container style="display: none;" class="mb-4">
+        <div data-chart-container class="mb-4 d-none">
           <canvas data-chart="coinBalanceHistoryChart" data-coin_balance_history_data_path="<%= AccessHelpers.get_path(@conn, :address_coin_balance_by_day_path, :index, @address.hash) %>" width="350" height="152"></canvas>
         </div>
 
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
 
-        <div data-error-message class="alert alert-danger col-12 text-left" style="display: none; padding: 0.75rem 0rem; cursor: pointer;">
+        <div data-error-message class="alert alert-danger col-12 text-left d-none" style="padding: 0.75rem 0rem; cursor: pointer;">
           <span href="#" class="alert alert-danger"><%= gettext("Something went wrong, click to reload.") %></span>
         </div>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-coin-balances-list">
             <%= gettext "There is no coin history for this address." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -1,5 +1,5 @@
 <section data-page="contract-verification-choose-type" class="container new-smart-contract-container">
-  <div data-selector="channel-disconnected-message" style="display: none;">
+  <div data-selector="channel-disconnected-message" class="d-none">
     <div data-selector="reload-button" class="alert alert-danger">
       <a href="#" class="alert-link"><%= gettext "Connection Lost" %></a>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
@@ -8,7 +8,7 @@
 <% fetch_constructor_arguments_automatically = if metadata_for_verification, do: true, else: false %>
 <% display_constructor_arguments_text_area = if fetch_constructor_arguments_automatically, do: "none", else: "block" %>
 <section data-page="contract-verification" class="container new-smart-contract-container">
-  <div data-selector="channel-disconnected-message" style="display: none;">
+  <div data-selector="channel-disconnected-message" class="d-none">
     <div data-selector="reload-button" class="alert alert-danger">
       <a href="#" class="alert-link"><%= gettext "Connection Lost" %></a>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex
@@ -1,5 +1,5 @@
 <section data-page="contract-verification" class="container new-smart-contract-container">
-  <div data-selector="channel-disconnected-message" style="display: none;">
+  <div data-selector="channel-disconnected-message" class="d-none">
     <div data-selector="reload-button" class="alert alert-danger">
       <a href="#" class="alert-link"><%= gettext "Connection Lost" %></a>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -7,12 +7,12 @@
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
       <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
-        <div data-selector="channel-batching-message" style="display: none;">
+        <div data-selector="channel-batching-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-info">
             <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More internal transactions have come in" %></a>
           </div>
         </div>
-        <div data-selector="channel-disconnected-message" style="display: none;">
+        <div data-selector="channel-disconnected-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-danger">
             <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer internal transactions" %></a>
           </div>
@@ -50,10 +50,10 @@
           </div>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center">
             <span data-selector="empty-internal-transactions-list"><%= gettext "There are no internal transactions for this address." %></span>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/index.html.eex
@@ -19,11 +19,11 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-logs-list">
             <%= gettext "There are no logs for this address." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token/index.html.eex
@@ -13,11 +13,11 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-token-list">
             <%= gettext "There are no tokens for this address." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
@@ -49,11 +49,11 @@
         </div>
         <% end %>
 
-        <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+        <div data-empty-response-message class="tile tile-muted text-center d-none">
           <span><%= gettext "There are no token transfers for this address." %></span>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span class="alert-link">
             <%= gettext "Something went wrong, click to reload." %>
           </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
@@ -8,7 +8,7 @@
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
       <div class="card-body" data-async-listing="<%= @current_path %>">
-        <div data-selector="channel-disconnected-message" style="display: none;">
+        <div data-selector="channel-disconnected-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-danger">
             <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer transactions" %></a>
           </div>
@@ -46,11 +46,11 @@
           </div>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-transactions-list">
             <%= gettext "There are no transactions for this address." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_validation/index.html.eex
@@ -7,7 +7,7 @@
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
       <div data-async-listing="<%= @current_path %>" class="card-body">
-        <div data-selector="channel-disconnected-message" style="display: none;">
+        <div data-selector="channel-disconnected-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-danger">
             <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer validations" %></a>
           </div>
@@ -16,10 +16,10 @@
 
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
 
-        <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+        <div data-empty-response-message class="tile tile-muted text-center d-none">
           <span><%= gettext "There are no blocks validated by this address." %></span>
         </div>
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span class="alert-link">
             <%= gettext "Something went wrong, click to reload." %>
           </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/admin/dashboard/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/admin/dashboard/index.html.eex
@@ -20,13 +20,13 @@
             <button id="run-create-contract-methods" data-api_path="<%= BlockScoutWeb.AdminRouter.Helpers.create_contract_methods_path(@conn, :create_contract_methods) %>" class="btn btn-primary">
               <%= gettext("Run") %>
 
-              <span data-loading-message class="loading-spinner-small mr-2" style="display: none;">
+              <span data-loading-message class="loading-spinner-small mr-2 d-none">
                 <span class="loading-spinner-block-1"></span>
                 <span class="loading-spinner-block-2"></span>
               </span>
 
-              <span data-success-message style="display: none;"> - Success</span>
-              <span data-error-message style="display: none;"> - Failed</span>
+              <span data-success-message class="d-none"> - Success</span>
+              <span data-error-message class="d-none"> - Failed</span>
             </button>
           </div>
         </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/index.html.eex
@@ -16,7 +16,7 @@
       <div data-items>
         <%= render BlockScoutWeb.CommonComponentsView, "_tile-loader.html" %>
       </div>
-      <div data-empty-response-message style="display: none;">
+      <div data-empty-response-message class="d-none">
           <span><%= gettext "There are no blocks." %></span>
       </div>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block_transaction/index.html.eex
@@ -19,11 +19,11 @@
 
       <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-transactions-list">
             <%= gettext "There are no transactions for this block." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -5,7 +5,7 @@
       <div class="dashboard-banner-network-graph">
         <!-- Graph -->
         <div class="dashboard-banner-chart">
-          <button data-chart-error-message class="alert alert-danger col-12 text-left mt-5" style="display: none;">
+          <button data-chart-error-message class="alert alert-danger col-12 text-left mt-5 d-none">
             <span><%= gettext("There was a problem loading the chart.") %></span>
           </button>
           <canvas data-chart="historyChart"
@@ -20,7 +20,7 @@
 
                   data-history_chart_config = '<%= @chart_config_json %>'
 
-                  width="350" height="152" style="display: none;"></canvas>
+                  width="350" height="152" class="d-none"></canvas>
         </div>
         <!-- Legend -->
         <script>
@@ -179,7 +179,7 @@
       <%= link(gettext("View All Blocks"), to: block_path(BlockScoutWeb.Endpoint, :index), class: "btn-line float-right") %>
       <h2 class="card-title"><%= gettext "Blocks" %></h2>
       <div class="row" data-selector="chain-block-list" data-url="<%= chain_blocks_path(@conn, :chain_blocks) %>">
-        <button data-selector="error-message" class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-selector="error-message" class="alert alert-danger col-12 text-left d-none">
           <span class="alert-link">
             <%= gettext "Something went wrong, click to reload." %>
           </span>
@@ -236,13 +236,13 @@
     <div class="card-body">
       <%= link(gettext("View All Transactions"), to: transaction_path(BlockScoutWeb.Endpoint, :index), class: "btn-line float-right") %>
       <h2 class="card-title lg-card-title"><%= gettext "Transactions" %></h2>
-      <div data-selector="channel-batching-message" style="display: none;">
+      <div data-selector="channel-batching-message" class="d-none">
         <div data-selector="reload-button" class="alert alert-info">
           <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More transactions have come in" %></a>
         </div>
       </div>
       <span data-selector="transactions-list" data-transactions-path="<%= @transactions_path %>">
-        <button data-selector="error-message" class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-selector="error-message" class="alert alert-danger col-12 text-left d-none">
           <span class="alert-link">
             <%= gettext "Something went wrong, click to retry." %>
           </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/pending_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/pending_transaction/index.html.eex
@@ -17,10 +17,10 @@
           <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer transactions" %></a>
         </div>
       </div>
-      <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+      <button data-error-message class="alert alert-danger col-12 text-left d-none">
         <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
       </button>
-      <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+      <div data-empty-response-message class="tile tile-muted text-center d-none">
         <span data-selector="empty-transactions-list">
           <%= gettext "There are no pending transactions." %>
         </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_learn-more.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_learn-more.html.eex
@@ -1,4 +1,4 @@
-<section class="container js-stakes-welcome-alert" style="display: none;">
+<section class="container js-stakes-welcome-alert d-none">
 <div class="card">
   <div class="card-body card-body-flex-column-space-between" style="padding-left: 50px;">
     <button type="button" class="stakes-btn-close-alert js-stakes-btn-close-welcome-alert">

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_table.html.eex
@@ -45,11 +45,11 @@
     <div class="<%= if @pools_type == :validator do %>col-2<% else %>col-3<% end %>"></div>
   </div>
   <div class="stakes-table-body">
-    <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+    <button data-error-message class="alert alert-danger col-12 text-left d-none">
       <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
     </button>
 
-    <div data-empty-response-message style="display: none;">
+    <div data-empty-response-message class="d-none">
       <%= render BlockScoutWeb.StakesView, "_stakes_empty_content.html" %>
     </div>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/stakes/_warning.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/stakes/_warning.html.eex
@@ -1,4 +1,4 @@
-<section class="container js-stakes-warning-alert" style="display: none;">
+<section class="container js-stakes-warning-alert d-none">
 <div class="card">
   <div class="card-body card-body-flex-column-space-between" style="padding-left: 50px;">
     <button type="button" class="stakes-btn-close-alert js-stakes-btn-close-warning">

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -18,10 +18,10 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center">
             <span data-selector="empty-transactions-list">
               <%= gettext "There are no holders for this Token." %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex
@@ -19,11 +19,11 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+        <div data-empty-response-message class="tile tile-muted text-center d-none">
           <span data-selector="empty-transactions-list">
             <%= gettext "There are no transfers for this Token." %>
           </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/index.html.eex
@@ -18,11 +18,11 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-token-list">
             <%= gettext "There are no tokens." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/index.html.eex
@@ -17,11 +17,11 @@
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message class="tile tile-muted text-center" style="display: none;">
+        <div data-empty-response-message class="tile tile-muted text-center d-none">
           <span data-selector="empty-transactions-list">
             <%= gettext "There are no transfers for this Token." %>
           </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/index.html.eex
@@ -13,22 +13,22 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-      <div data-selector="channel-batching-message" style="display: none;">
+      <div data-selector="channel-batching-message" class="d-none">
         <div data-selector="reload-button" class="alert alert-info">
           <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More transactions have come in" %></a>
         </div>
       </div>
-      <div data-selector="channel-disconnected-message" style="display: none;">
+      <div data-selector="channel-disconnected-message" class="d-none">
         <div data-selector="reload-button" class="alert alert-danger">
           <a href="#" class="alert-link"><%= gettext "Connection Lost, click to load newer transactions" %></a>
         </div>
       </div>
 
-      <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+      <button data-error-message class="alert alert-danger col-12 text-left d-none">
         <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
       </button>
 
-      <div data-empty-response-message style="display: none;">
+      <div data-empty-response-message class="d-none">
         <div class="tile tile-muted text-center">
           <span data-selector="empty-internal-transactions-list">
             <%= gettext "There are no transactions." %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -174,12 +174,11 @@
                   <!-- Copy -->
                   <span
                     aria-label="Copy Value"
-                    class="btn-copy-icon tx-utf8-input transaction-input"
+                    class="btn-copy-icon tx-utf8-input transaction-input d-none"
                     data-clipboard-text="<%= @transaction.input.bytes %>"
                     data-placement="top"
                     data-toggle="tooltip"
                     title='<%= gettext("Copy Txn Input") %>'
-                    style="display: none;"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32.5 32.5" width="32" height="32">
                       <path fill-rule="evenodd" d="M23.5 20.5a1 1 0 0 1-1-1v-9h-9a1 1 0 0 1 0-2h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zm-3-7v10a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1zm-2 1h-8v8h8v-8z"/>
@@ -193,7 +192,7 @@
                   </div>
                 </div>
                 <!-- Textfield -->
-                <div class="transaction-input tx-utf8-input" style="display: none;">
+                <div class="transaction-input tx-utf8-input d-none">
                   <div class="tile tile-muted">
                     <pre class="pre-scrollable pre-scrollable-shorty pre-wrap mb-0"><code><%= @transaction.input.bytes %></code></pre>
                   </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex
@@ -9,10 +9,10 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-      <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+      <button data-error-message class="alert alert-danger col-12 text-left d-none">
         <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
       </button>
-      <div data-empty-response-message style="display: none;">
+      <div data-empty-response-message class="d-none">
         <div class="tile tile-muted text-center" data-selector="empty-logs-list">
           <%= gettext "There are no internal transactions for this transaction." %>
         </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_log/index.html.eex
@@ -11,11 +11,11 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-logs-list">
             <%= gettext "There are no logs for this transaction." %>
           </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_token_transfer/index.html.eex
@@ -10,11 +10,11 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
 
-        <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
+        <button data-error-message class="alert alert-danger col-12 text-left d-none">
           <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>
         </button>
 
-        <div data-empty-response-message style="display: none;">
+        <div data-empty-response-message class="d-none">
           <div class="tile tile-muted text-center" data-selector="empty-logs-list">
             <%= gettext "There are no token transfers for this transaction" %>
           </div>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -13,7 +13,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:230
+#: lib/block_scout_web/templates/transaction/overview.html.eex:229
 msgid " Token Transfer"
 msgstr ""
 
@@ -646,8 +646,8 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:33
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:33
-#: lib/block_scout_web/templates/transaction/overview.html.eex:215
-#: lib/block_scout_web/templates/transaction/overview.html.eex:268
+#: lib/block_scout_web/templates/transaction/overview.html.eex:214
+#: lib/block_scout_web/templates/transaction/overview.html.eex:267
 #: lib/block_scout_web/views/wei_helpers.ex:78
 msgid "Ether"
 msgstr ""
@@ -1006,7 +1006,7 @@ msgid "License ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:296
+#: lib/block_scout_web/templates/transaction/overview.html.eex:295
 msgid "Limit"
 msgstr ""
 
@@ -1543,7 +1543,7 @@ msgid "Use the search box to find a hosted network, or select from the list of a
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:290
+#: lib/block_scout_web/templates/transaction/overview.html.eex:289
 msgid "Used"
 msgstr ""
 
@@ -1573,8 +1573,8 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:215
-#: lib/block_scout_web/templates/transaction/overview.html.eex:268
+#: lib/block_scout_web/templates/transaction/overview.html.eex:214
+#: lib/block_scout_web/templates/transaction/overview.html.eex:267
 msgid "Value"
 msgstr ""
 
@@ -1755,7 +1755,7 @@ msgid "Decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:286
+#: lib/block_scout_web/templates/transaction/overview.html.eex:285
 msgid "Gas"
 msgstr ""
 
@@ -1886,7 +1886,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:252
+#: lib/block_scout_web/templates/transaction/overview.html.eex:251
 msgid " Token Burning"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:241
+#: lib/block_scout_web/templates/transaction/overview.html.eex:240
 msgid " Token Minting"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -13,7 +13,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:230
+#: lib/block_scout_web/templates/transaction/overview.html.eex:229
 msgid " Token Transfer"
 msgstr ""
 
@@ -646,8 +646,8 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:33
 #: lib/block_scout_web/templates/transaction/_pending_tile.html.eex:20
 #: lib/block_scout_web/templates/transaction/_tile.html.eex:33
-#: lib/block_scout_web/templates/transaction/overview.html.eex:215
-#: lib/block_scout_web/templates/transaction/overview.html.eex:268
+#: lib/block_scout_web/templates/transaction/overview.html.eex:214
+#: lib/block_scout_web/templates/transaction/overview.html.eex:267
 #: lib/block_scout_web/views/wei_helpers.ex:78
 msgid "Ether"
 msgstr ""
@@ -1006,7 +1006,7 @@ msgid "License ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:296
+#: lib/block_scout_web/templates/transaction/overview.html.eex:295
 msgid "Limit"
 msgstr ""
 
@@ -1543,7 +1543,7 @@ msgid "Use the search box to find a hosted network, or select from the list of a
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:290
+#: lib/block_scout_web/templates/transaction/overview.html.eex:289
 msgid "Used"
 msgstr ""
 
@@ -1573,8 +1573,8 @@ msgid "Validator Info"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:215
-#: lib/block_scout_web/templates/transaction/overview.html.eex:268
+#: lib/block_scout_web/templates/transaction/overview.html.eex:214
+#: lib/block_scout_web/templates/transaction/overview.html.eex:267
 msgid "Value"
 msgstr ""
 
@@ -1755,7 +1755,7 @@ msgid "Decimals"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:286
+#: lib/block_scout_web/templates/transaction/overview.html.eex:285
 msgid "Gas"
 msgstr ""
 
@@ -1886,7 +1886,7 @@ msgid "Transactions"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:252
+#: lib/block_scout_web/templates/transaction/overview.html.eex:251
 msgid " Token Burning"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/overview.html.eex:241
+#: lib/block_scout_web/templates/transaction/overview.html.eex:240
 msgid " Token Minting"
 msgstr ""
 


### PR DESCRIPTION
## Motivation

Replace inline style `style="display: none;"` with a class `class="d-none"`


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
