### PR TITLE
Increase the number of left symbols in trimmed address hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix 
 
 ### Chore
+- [#3902](https://github.com/blockscout/blockscout/pull/3902) - Increase number of left symbols in short address view
 - [#3894](https://github.com/blockscout/blockscout/pull/3894) - Refactoring: replace inline style display: none with d-none class
 - [#3893](https://github.com/blockscout/blockscout/pull/3893) - Add left/right paddings in tx tile
 - [#3870](https://github.com/blockscout/blockscout/pull/3870) - Manage token balance on-demand fetcher threshold via env var

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -266,7 +266,7 @@ defmodule BlockScoutWeb.AddressView do
   end
 
   def trimmed_hash(address) when is_binary(address) do
-    "#{String.slice(address, 0..5)}–#{String.slice(address, -6..-1)}"
+    "#{String.slice(address, 0..7)}–#{String.slice(address, -6..-1)}"
   end
 
   def trimmed_hash(_), do: ""
@@ -405,6 +405,8 @@ defmodule BlockScoutWeb.AddressView do
   def short_token_id(token_id, max_length) do
     short_string(token_id, max_length)
   end
+
+  def short_string(nil, _max_length), do: ""
 
   def short_string(name, max_length) do
     part_length = Kernel.trunc(max_length / 4)


### PR DESCRIPTION
## Motivation

![Screenshot 2021-05-05 at 11 24](https://user-images.githubusercontent.com/4341812/117115529-e514a580-ad95-11eb-9599-03e9c9c627c2.png)


## Changelog

Display 6 symbols instead of 4 in the short address view

![Screenshot 2021-05-05 at 11 24 09](https://user-images.githubusercontent.com/4341812/117115560-ef36a400-ad95-11eb-8471-23b24f51fab4.png)


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
