### PR TITLE
Get NFT metadata from URIs with status_code 301

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#3946](https://github.com/blockscout/blockscout/pull/3946) - Get NFT metadata from URIs with status_code 301
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix 
 
 ### Chore

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -85,6 +85,11 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     fetch_metadata(ipfs_url)
   end
 
+  def fetch_json(%{@token_uri => {:ok, ["ipfs://" <> ipfs_uid]}}) do
+    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
+    fetch_metadata(ipfs_url)
+  end
+
   def fetch_json(%{@token_uri => {:ok, [json]}}) do
     {:ok, json} = decode_json(json)
 
@@ -116,6 +121,11 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
 
           check_type(json)
         end
+
+      {:ok, %Response{body: body, status_code: 301}} ->
+        {:ok, json} = decode_json(body)
+
+        check_type(json)
 
       {:ok, %Response{body: body}} ->
         {:error, body}


### PR DESCRIPTION
## Motivation

Metadata failed to fetch from requests to URIs with status code 301.


## Changelog

Process the response if the status code is 301.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
