### PR TITLE
Fixed bug that sometimes lead to incorrect ordering of token transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 - [#3946](https://github.com/blockscout/blockscout/pull/3946) - Get NFT metadata from URIs with status_code 301
-- [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix 
+- [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix
+- [#3989](https://github.com/blockscout/blockscout/pull/3989) - Fixed bug that sometimes lead to incorrect ordering of token transfers
 
 ### Chore
 - [#3934](https://github.com/blockscout/blockscout/pull/3934) - Update nimble_csv package

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -461,6 +461,7 @@ defmodule Explorer.Etherscan do
         inner_join: t in Transaction,
         on: tt.transaction_hash == t.hash and tt.block_number == t.block_number and tt.block_hash == t.block_hash,
         inner_join: b in assoc(t, :block),
+        order_by: [{^options.order_by_direction, tt.block_number}, {^options.order_by_direction, tt.token_log_index}],
         select: %{
           token_contract_address_hash: tt.token_contract_address_hash,
           transaction_hash: tt.transaction_hash,


### PR DESCRIPTION
Fixes #3988.

## Changelog

### Bug Fixes
* Fixed bug that sometimes lead to incorrect ordering of token transfers

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
