### PR TITLE
Fix tokenlist API endpoint return only tokens with positive balance

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2560,7 +2560,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with address with existing balance in token_balances table", %{conn: conn} do
-      token_balance = :token_balance |> insert() |> Repo.preload(:token)
+      token_balance = :address_current_token_balance |> insert() |> Repo.preload(:token)
 
       params = %{
         "module" => "account",
@@ -2593,9 +2593,9 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     test "with address with multiple tokens", %{conn: conn} do
       address = insert(:address)
       other_address = insert(:address)
-      insert(:token_balance, address: address)
-      insert(:token_balance, address: address)
-      insert(:token_balance, address: other_address)
+      insert(:address_current_token_balance, address: address)
+      insert(:address_current_token_balance, address: address)
+      insert(:address_current_token_balance, address: other_address)
 
       params = %{
         "module" => "account",

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Etherscan do
 
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Chain.Address.{CurrentTokenBalance, TokenBalance}
   alias Explorer.Chain.{Block, Hash, InternalTransaction, TokenTransfer, Transaction}
 
   @default_options %{
@@ -312,14 +312,14 @@ defmodule Explorer.Etherscan do
   def list_tokens(%Hash{byte_count: unquote(Hash.Address.byte_count())} = address_hash) do
     query =
       from(
-        tb in TokenBalance,
-        inner_join: t in assoc(tb, :token),
-        where: tb.address_hash == ^address_hash,
+        ctb in CurrentTokenBalance,
+        inner_join: t in assoc(ctb, :token),
+        where: ctb.address_hash == ^address_hash,
+        where: ctb.value > 0,
         distinct: :token_contract_address_hash,
-        order_by: [desc: :block_number],
         select: %{
-          balance: tb.value,
-          contract_address_hash: tb.token_contract_address_hash,
+          balance: ctb.value,
+          contract_address_hash: ctb.token_contract_address_hash,
           name: t.name,
           decimals: t.decimals,
           symbol: t.symbol,

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1598,59 +1598,11 @@ defmodule Explorer.EtherscanTest do
       address = insert(:address)
 
       token_balance =
-        :token_balance
+        :address_current_token_balance
         |> insert(address: address)
         |> Repo.preload(:token)
 
-      insert(:token_balance, address: build(:address))
-
-      token_list = Etherscan.list_tokens(address.hash)
-
-      expected_tokens = [
-        %{
-          balance: token_balance.value,
-          contract_address_hash: token_balance.token_contract_address_hash,
-          name: token_balance.token.name,
-          decimals: token_balance.token.decimals,
-          symbol: token_balance.token.symbol,
-          type: token_balance.token.type
-        }
-      ]
-
-      assert token_list == expected_tokens
-    end
-
-    test "returns the latest known balance per token" do
-      # The latest balance is the one with the latest block number
-      address = insert(:address)
-      token = insert(:token)
-
-      token_balance_details1 = %{
-        address: address,
-        token_contract_address_hash: token.contract_address.hash,
-        block_number: 1
-      }
-
-      token_balance_details2 = %{
-        address: address,
-        token_contract_address_hash: token.contract_address.hash,
-        block_number: 2
-      }
-
-      token_balance_details3 = %{
-        address: address,
-        token_contract_address_hash: token.contract_address.hash,
-        block_number: 3
-      }
-
-      insert(:token_balance, token_balance_details1)
-
-      token_balance =
-        :token_balance
-        |> insert(token_balance_details3)
-        |> Repo.preload(:token)
-
-      insert(:token_balance, token_balance_details2)
+      insert(:address_current_token_balance, address: build(:address))
 
       token_list = Etherscan.list_tokens(address.hash)
 


### PR DESCRIPTION
## Motivation

`tokenlist` API endpoint in  `Account` module returns all tokens, that once was owned by address. The endpoint should return current tokens with a positive balance.

## Changelog

Change `token_list` query to use `address_current_token_balances` instead of `address_token_balances` and add a clause to return only tokens with balance > 0.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
