### PR TITLE
Fix tests for list_token_transfers function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ### Features
 
 ### Fixes
+- [#3989](https://github.com/blockscout/blockscout/pull/3989), [4061](https://github.com/blockscout/blockscout/pull/4061) - Fixed bug that sometimes lead to incorrect ordering of token transfers
 - [#3946](https://github.com/blockscout/blockscout/pull/3946) - Get NFT metadata from URIs with status_code 301
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix
-- [#3989](https://github.com/blockscout/blockscout/pull/3989) - Fixed bug that sometimes lead to incorrect ordering of token transfers
 
 ### Chore
 - [#3934](https://github.com/blockscout/blockscout/pull/3934) - Update nimble_csv package

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1174,14 +1174,32 @@ defmodule Explorer.EtherscanTest do
         |> insert()
         |> with_block(first_block)
 
-      insert(:token_transfer, from_address: address, transaction: transaction2)
-      insert(:token_transfer, from_address: address, transaction: transaction1)
-      insert(:token_transfer, from_address: address, transaction: transaction3)
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction2,
+        block: transaction2.block,
+        block_number: transaction2.block_number
+      )
+
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction1,
+        block: transaction1.block,
+        block_number: transaction1.block_number
+      )
+
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction3,
+        block: transaction3.block,
+        block_number: transaction3.block_number
+      )
 
       found_token_transfers = Etherscan.list_token_transfers(address.hash, nil)
 
       block_numbers_order = Enum.map(found_token_transfers, & &1.block_number)
 
+      assert Enum.count(block_numbers_order) == 3
       assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 >= &2))
     end
 
@@ -1206,9 +1224,26 @@ defmodule Explorer.EtherscanTest do
         |> insert()
         |> with_block(first_block)
 
-      insert(:token_transfer, from_address: address, transaction: transaction2)
-      insert(:token_transfer, from_address: address, transaction: transaction1)
-      insert(:token_transfer, from_address: address, transaction: transaction3)
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction2,
+        block: transaction2.block,
+        block_number: transaction2.block_number
+      )
+
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction1,
+        block: transaction1.block,
+        block_number: transaction1.block_number
+      )
+
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction3,
+        block: transaction3.block,
+        block_number: transaction3.block_number
+      )
 
       options = %{order_by_direction: :desc}
 
@@ -1216,6 +1251,7 @@ defmodule Explorer.EtherscanTest do
 
       block_numbers_order = Enum.map(found_token_transfers, & &1.block_number)
 
+      assert Enum.count(block_numbers_order) == 3
       assert block_numbers_order == Enum.sort(block_numbers_order, &(&1 >= &2))
     end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -435,7 +435,7 @@ defmodule Explorer.Factory do
     to_address_hash = address_hash_from_zero_padded_hash_string(log.third_topic)
     from_address_hash = address_hash_from_zero_padded_hash_string(log.second_topic)
 
-    # `to_address` is only the only thing that isn't created from the token_transfer_log_factory
+    # `to_address` is the only thing that isn't created from the token_transfer_log_factory
     to_address = build(:address, hash: to_address_hash)
     from_address = build(:address, hash: from_address_hash)
     contract_code = Map.fetch!(contract_code_info(), :bytecode)


### PR DESCRIPTION
Finalize https://github.com/blockscout/blockscout/pull/3989

## Motivation

Fix tests for `list_token_transfers` method based on this comment:
> During testing I also found that the tests related to token transfer ordering are broken. The list of found token transfers appears to be empty
https://github.com/blockscout/blockscout/issues/3988#issue-884209375

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
