### PR TITLE
Get token balance query improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 - [#4236](https://github.com/blockscout/blockscout/pull/4236) - Fix typo, constructor instead of contructor
 - [#4149](https://github.com/blockscout/blockscout/pull/4149) - Exclude smart_contract_additional_sources from JSON encoding in address schema
+- [#4137](https://github.com/blockscout/blockscout/pull/4137) - Get token balance query improvement
 - [#4038](https://github.com/blockscout/blockscout/pull/4038) - Add clause for abi_decode_address_output/1 when is_nil(address)
 - [#3989](https://github.com/blockscout/blockscout/pull/3989), [4061](https://github.com/blockscout/blockscout/pull/4061) - Fixed bug that sometimes lead to incorrect ordering of token transfers
 - [#3946](https://github.com/blockscout/blockscout/pull/3946) - Get NFT metadata from URIs with status_code 301

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2462,13 +2462,13 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
 
     test "with contract address and address with existing balance in token_balances table", %{conn: conn} do
-      token_balance = insert(:token_balance)
+      current_token_balance = insert(:address_current_token_balance)
 
       params = %{
         "module" => "account",
         "action" => "tokenbalance",
-        "contractaddress" => to_string(token_balance.token_contract_address_hash),
-        "address" => to_string(token_balance.address_hash)
+        "contractaddress" => to_string(current_token_balance.token_contract_address_hash),
+        "address" => to_string(current_token_balance.address_hash)
       }
 
       assert response =
@@ -2476,7 +2476,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                |> get("/api", params)
                |> json_response(200)
 
-      assert response["result"] == to_string(token_balance.value)
+      assert response["result"] == to_string(current_token_balance.value)
       assert response["status"] == "1"
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(tokenbalance_schema(), response)

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -293,12 +293,11 @@ defmodule Explorer.Etherscan do
       ) do
     query =
       from(
-        tb in TokenBalance,
-        where: tb.token_contract_address_hash == ^contract_address_hash,
-        where: tb.address_hash == ^address_hash,
-        order_by: [desc: :block_number],
+        ctb in CurrentTokenBalance,
+        where: ctb.token_contract_address_hash == ^contract_address_hash,
+        where: ctb.address_hash == ^address_hash,
         limit: 1,
-        select: tb
+        select: ctb
       )
 
     Repo.one(query)

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1586,46 +1586,13 @@ defmodule Explorer.EtherscanTest do
 
   describe "get_token_balance/2" do
     test "with a single matching token_balance record" do
-      token_balance =
-        %{token_contract_address_hash: contract_address_hash, address_hash: address_hash} = insert(:token_balance)
+      address_current_token_balance =
+        %{token_contract_address_hash: contract_address_hash, address_hash: address_hash} =
+        insert(:address_current_token_balance)
 
       found_token_balance = Etherscan.get_token_balance(contract_address_hash, address_hash)
 
-      assert found_token_balance.id == token_balance.id
-    end
-
-    test "returns token balance in latest block" do
-      token = insert(:token)
-
-      contract_address_hash = token.contract_address_hash
-
-      address = insert(:address)
-
-      token_details1 = %{
-        token_contract_address_hash: contract_address_hash,
-        address: address,
-        block_number: 5
-      }
-
-      token_details2 = %{
-        token_contract_address_hash: contract_address_hash,
-        address: address,
-        block_number: 15
-      }
-
-      token_details3 = %{
-        token_contract_address_hash: contract_address_hash,
-        address: address,
-        block_number: 10
-      }
-
-      _token_balance1 = insert(:token_balance, token_details1)
-      token_balance2 = insert(:token_balance, token_details2)
-      _token_balance3 = insert(:token_balance, token_details3)
-
-      found_token_balance = Etherscan.get_token_balance(contract_address_hash, address.hash)
-
-      assert found_token_balance.id == token_balance2.id
+      assert found_token_balance.id == address_current_token_balance.id
     end
   end
 


### PR DESCRIPTION
## Motivation

Improve `get_token_balance` function

## Changelog

Instead of `address_token_balances` table use `address_current_token_balances` table

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
