### PR TITLE
Exclude smart_contract_additional_sources from JSON encoding in address schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4149](https://github.com/blockscout/blockscout/pull/4149) - Exclude smart_contract_additional_sources from JSON encoding in address schema
 - [#4038](https://github.com/blockscout/blockscout/pull/4038) - Add clause for abi_decode_address_output/1 when is_nil(address)
 - [#3989](https://github.com/blockscout/blockscout/pull/3989), [4061](https://github.com/blockscout/blockscout/pull/4061) - Fixed bug that sometimes lead to incorrect ordering of token transfers
 - [#3946](https://github.com/blockscout/blockscout/pull/3946) - Get NFT metadata from URIs with status_code 301

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -69,7 +69,8 @@ defmodule Explorer.Chain.Address do
              :token,
              :contracts_creation_internal_transaction,
              :contracts_creation_transaction,
-             :names
+             :names,
+             :smart_contract_additional_sources
            ]}
 
   @derive {Jason.Encoder,
@@ -80,7 +81,8 @@ defmodule Explorer.Chain.Address do
              :token,
              :contracts_creation_internal_transaction,
              :contracts_creation_transaction,
-             :names
+             :names,
+             :smart_contract_additional_sources
            ]}
 
   @primary_key {:hash, Hash.Address, autogenerate: false}


### PR DESCRIPTION
Fixes https://github.com/blockscout/blockscout/issues/4078

## Motivation

```
** (RuntimeError) cannot encode association :smart_contract_additional_sources from Explorer.Chain.Address to JSON because the association was not loaded.

You can either preload the association:

    Repo.preload(Explorer.Chain.Address, :smart_contract_additional_sources)

Or choose to not encode the association when converting the struct to JSON by explicitly listing the JSON fields in your schema:

    defmodule Explorer.Chain.Address do
      # ...

      @derive {Jason.Encoder, only: [:name, :title, ...]}
      schema ... do

    (ecto 3.5.5) lib/ecto/json.ex:4: Jason.Encoder.Ecto.Association.NotLoaded.encode/2
    (explorer 0.0.1) lib/explorer/chain/address.ex:87: Jason.Encoder.Explorer.Chain.Address.encode/2
    (jason 1.2.2) lib/encode.ex:172: Jason.Encode.map_naive/3
    (jason 1.2.2) lib/encode.ex:152: Jason.Encode.list_loop/3
    (jason 1.2.2) lib/encode.ex:153: Jason.Encode.list_loop/3
    (jason 1.2.2) lib/encode.ex:144: Jason.Encode.list/3
    (jason 1.2.2) lib/encode.ex:35: Jason.Encode.encode/2
    (jason 1.2.2) lib/jason.ex:197: Jason.encode_to_iodata!/2
```

## Changelog

Exclude smart_contract_additional_sources from JSON encoding in address schema

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
