### PR TITLE
Do not put error status for internal transactions if they actually were not reverted

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -240,27 +240,14 @@ defmodule Indexer.Fetcher.InternalTransaction do
   defp remove_failed_creations(internal_transactions_params) do
     internal_transactions_params
     |> Enum.map(fn internal_transaction_param ->
-      transaction_index = internal_transaction_param[:transaction_index]
-      block_number = internal_transaction_param[:block_number]
-
-      failed_parent =
-        internal_transactions_params
-        |> Enum.filter(fn internal_transactions_param ->
-          internal_transactions_param[:block_number] == block_number &&
-            internal_transactions_param[:transaction_index] == transaction_index &&
-            internal_transactions_param[:trace_address] == [] && !is_nil(internal_transactions_param[:error])
-        end)
-        |> Enum.at(0)
-
-      if failed_parent do
+      if is_nil(internal_transaction_param[:error]) do
+        internal_transaction_param
+      else
         internal_transaction_param
         |> Map.delete(:created_contract_address_hash)
         |> Map.delete(:created_contract_code)
         |> Map.delete(:gas_used)
         |> Map.delete(:output)
-        |> Map.put(:error, failed_parent[:error])
-      else
-        internal_transaction_param
       end
     end)
   end


### PR DESCRIPTION
## Motivation

Internal transactions indexer sets error status for all internal transactions if the parent trace was reverted.

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
