### PR TITLE
Total transactions fees per day API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4205](https://github.com/blockscout/blockscout/pull/4205) - Total transactions fees per day API endpoint
 - [#4158](https://github.com/blockscout/blockscout/pull/4158) - Calculate total fee per day
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -73,4 +73,17 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
   defp to_address_hash(address_hash_string) do
     {:format, Chain.string_to_address_hash(address_hash_string)}
   end
+
+  def totalfees(conn, params) do
+    case Map.fetch(params, "date") do
+      {:ok, date} ->
+        case Chain.get_total_fees_per_day(date) do
+          {:ok, total_fees} -> render(conn, "totalfees.json", total_fees: total_fees)
+          {:error, error} -> render(conn, :error, error: error)
+        end
+
+      _ ->
+        render(conn, :error, error: "Required date input is missing.")
+    end
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -324,6 +324,20 @@ defmodule BlockScoutWeb.Etherscan do
     }
   }
 
+  @stats_totalfees_example_value %{
+    "status" => "1",
+    "message" => "OK",
+    "result" => %{
+      "total_fees" => "75411956011480008034"
+    }
+  }
+
+  @stats_totalfees_example_value_error %{
+    "status" => "0",
+    "message" => "An incorrect input date provided. It should be in ISO 8601 format (yyyy-mm-dd).",
+    "result" => nil
+  }
+
   @block_getblockreward_example_value %{
     "status" => "1",
     "message" => "OK",
@@ -1130,6 +1144,17 @@ defmodule BlockScoutWeb.Etherscan do
         type: "timestamp",
         definition: "Last updated timestamp.",
         example: ~s("1537234460")
+      }
+    }
+  }
+
+  @total_fees_model %{
+    name: "TotalFees",
+    fields: %{
+      total_fees: %{
+        type: "total_fees",
+        definition: "Total transaction fees in Wei are paid by users to validators per day.",
+        example: ~s("75411956011480008034")
       }
     }
   }
@@ -2067,6 +2092,43 @@ defmodule BlockScoutWeb.Etherscan do
     ]
   }
 
+  @stats_totalfees_action %{
+    name: "totalfees",
+    description: "Gets total transaction fees in Wei are paid by users to validators per day.",
+    required_params: [
+      %{
+        key: "date",
+        placeholder: "date",
+        type: "string",
+        description: "day in ISO 8601 format (yyyy-mm-dd)"
+      }
+    ],
+    optional_params: [],
+    responses: [
+      %{
+        code: "200",
+        description: "successful operation",
+        example_value: Jason.encode!(@stats_totalfees_example_value),
+        model: %{
+          name: "Result",
+          fields: %{
+            status: @status_type,
+            message: @message_type,
+            result: %{
+              type: "model",
+              model: @total_fees_model
+            }
+          }
+        }
+      },
+      %{
+        code: "200",
+        description: "error",
+        example_value: Jason.encode!(@stats_totalfees_example_value_error)
+      }
+    ]
+  }
+
   @block_eth_block_number_action %{
     name: "eth_block_number",
     description: "Mimics Ethereum JSON RPC's eth_blockNumber. Returns the lastest block number",
@@ -2602,7 +2664,8 @@ defmodule BlockScoutWeb.Etherscan do
       @stats_ethsupplyexchange_action,
       @stats_ethsupply_action,
       @stats_coinsupply_action,
-      @stats_coinprice_action
+      @stats_coinprice_action,
+      @stats_totalfees_action
     ]
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -23,6 +23,10 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
     RPCView.render("show.json", data: prepare_rates(rates))
   end
 
+  def render("totalfees.json", %{total_fees: total_fees}) do
+    RPCView.render("show.json", data: total_fees)
+  end
+
   def render("error.json", assigns) do
     RPCView.render("error.json", assigns)
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -79,6 +79,7 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Import.Runner
   alias Explorer.Chain.InternalTransaction.{CallType, Type}
+  alias Explorer.Chain.Transaction.History.TransactionStats
   alias Explorer.Counters.{AddressesCounter, AddressesWithBalanceCounter}
   alias Explorer.Market.MarketHistoryCache
   alias Explorer.{PagingOptions, Repo}
@@ -6312,6 +6313,28 @@ defmodule Explorer.Chain do
       1 -> "eth"
       56 -> "bsc"
       _ -> ""
+    end
+  end
+
+  @doc """
+  It is used by `totalfees` API endpoint of `stats` module for retrieving of total fee per day
+  """
+  @spec get_total_fees_per_day(String.t()) :: {:ok, non_neg_integer() | nil} | {:error, String.t()}
+  def get_total_fees_per_day(date_string) do
+    case Date.from_iso8601(date_string) do
+      {:ok, date} ->
+        query =
+          from(
+            tx_stats in TransactionStats,
+            where: tx_stats.date == ^date,
+            select: tx_stats.total_fee
+          )
+
+        total_fees = Repo.one(query)
+        {:ok, total_fees}
+
+      _ ->
+        {:error, "An incorrect input date provided. It should be in ISO 8601 format (yyyy-mm-dd)."}
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -70,7 +70,6 @@ defmodule Explorer.Chain.Transaction.History.Historian do
             join: block in Block,
             on: transaction.block_hash == block.hash,
             where: block.consensus == true,
-            where: transaction.status == ^1,
             select: fragment("SUM(? * ?)", transaction.gas_price, transaction.gas_used)
           )
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4202

## Motivation

Create API endpoint which returns total fees paid to validators per day

## Changelog

An example of a Request URL:
`http://localhost:4000/api?module=stats&action=totalfees&date=2021-05-27`

Successful response example:
```
{
  "message": "OK",
  "result": {
    "total_fees": "75411956011480008034"
  },
  "status": "1"
}
```

<img width="1290" alt="Screenshot 2021-06-02 at 15 21 24" src="https://user-images.githubusercontent.com/4341812/120479083-35434f80-c3b6-11eb-95b3-c3a69281805e.png">

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
