### PR TITLE
Transactions stats: get min/max blocks in one query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix
 
 ### Chore
+- [#4231](https://github.com/blockscout/blockscout/pull/4231) - Transactions stats: get min/max blocks in one query
 - [#4157](https://github.com/blockscout/blockscout/pull/4157) - Fix internal docs generation
 - [#4127](https://github.com/blockscout/blockscout/pull/4127) - Update ex_keccak package
 - [#4063](https://github.com/blockscout/blockscout/pull/4063) - Do not display 4bytes signature in the tx tile for contract creation

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -25,27 +25,13 @@ defmodule Explorer.Chain.Transaction.History.Historian do
       earliest = datetime(day_to_fetch, ~T[00:00:00])
       latest = datetime(day_to_fetch, ~T[23:59:59])
 
-      min_block_query =
+      min_max_block_query =
         from(block in Block,
           where: block.timestamp >= ^earliest and block.timestamp <= ^latest,
-          group_by: block.number,
-          order_by: [asc: min(block.number)],
-          limit: 1,
-          select: min(block.number)
+          select: {min(block.number), max(block.number)}
         )
 
-      min_block = Repo.one(min_block_query, timeout: :infinity)
-
-      max_block_query =
-        from(block in Block,
-          where: block.timestamp >= ^earliest and block.timestamp <= ^latest,
-          group_by: block.number,
-          order_by: [desc: max(block.number)],
-          limit: 1,
-          select: max(block.number)
-        )
-
-      max_block = Repo.one(max_block_query, timeout: :infinity)
+      {min_block, max_block} = Repo.one(min_max_block_query, timeout: :infinity)
 
       if min_block && max_block do
         all_transactions_query =


### PR DESCRIPTION
## Motivation

Min and max block numbers for transactions statistics are calculated in separate queries:

https://github.com/blockscout/blockscout/blob/058b596b0c049fc22f3cc04ae3a16e3fa713995d/apps/explorer/lib/explorer/chain/transaction/history/historian.ex#L28-L46

## Changelog

Combine min and max block numbers into one query.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
