### PR TITLE
Fix bug with empty array in write contract page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4240](https://github.com/blockscout/blockscout/pull/4240) - `[]` is accepted in write contract page
 - [#4236](https://github.com/blockscout/blockscout/pull/4236), [#4242](https://github.com/blockscout/blockscout/pull/4242) - Fix typo, constructor instead of contructor
 - [#4167](https://github.com/blockscout/blockscout/pull/4167) - Deduplicate block numbers in acquire_blocks function
 - [#4149](https://github.com/blockscout/blockscout/pull/4149) - Exclude smart_contract_additional_sources from JSON encoding in address schema

--- a/apps/block_scout_web/assets/js/lib/smart_contract/common_helpers.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/common_helpers.js
@@ -27,7 +27,7 @@ export function prepareMethodArgs ($functionInputs, inputs) {
     sanitizedInputValue = replaceDoubleQuotes(sanitizedInputValue, inputType, inputComponents)
 
     if (isArrayInputType(inputType) || isTupleInputType(inputType)) {
-      if (sanitizedInputValue === '') {
+      if (sanitizedInputValue === '' || sanitizedInputValue === '[]') {
         return [[]]
       } else {
         if (sanitizedInputValue.startsWith('[') && sanitizedInputValue.endsWith(']')) {


### PR DESCRIPTION
### Changes to resolve issue #4206 

- added additional check in `apps/block_scout_web/assets/js/lib/smart_contract/common_helpers.js` `prepareMethodArgs()`
