### PR TITLE
Typo: constructor instead of contructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
-- [#4236](https://github.com/blockscout/blockscout/pull/4236) - Fix typo, constructor instead of contructor
+- [#4236](https://github.com/blockscout/blockscout/pull/4236), [#4242](https://github.com/blockscout/blockscout/pull/4242) - Fix typo, constructor instead of contructor
 - [#4167](https://github.com/blockscout/blockscout/pull/4167) - Deduplicate block numbers in acquire_blocks function
 - [#4149](https://github.com/blockscout/blockscout/pull/4149) - Exclude smart_contract_additional_sources from JSON encoding in address schema
 - [#4137](https://github.com/blockscout/blockscout/pull/4137) - Get token balance query improvement

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -229,7 +229,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
     |> required_param(params, "contractSourceCode", "contract_source_code")
     |> optional_param(params, "evmVersion", "evm_version")
     |> optional_param(params, "constructorArguments", "constructor_arguments")
-    |> optional_param(params, "autodetectConstructorArguments", "autodetect_contructor_args")
+    |> optional_param(params, "autodetectConstructorArguments", "autodetect_constructor_args")
     |> optional_param(params, "optimizationRuns", "optimization_runs")
     |> parse_optimization_runs()
   end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
@@ -136,24 +136,24 @@
             <div class="center-column">
               <div class="form-radios-group">
                 <div class="radio-big">
-                  <%= radio_button f, :autodetect_contructor_args, false, checked: !fetch_constructor_arguments_automatically, class: "form-check-input autodetectfalse" %>
+                  <%= radio_button f, :autodetect_constructor_args, false, checked: !fetch_constructor_arguments_automatically, class: "form-check-input autodetectfalse" %>
                   <div class="radio-icon"></div>
-                  <%= label :autodetect_contructor_args, :false, gettext("No"), class: "radio-text" %>
+                  <%= label :autodetect_constructor_args, :false, gettext("No"), class: "radio-text" %>
                 </div>
                 <div class="radio-big">
-                  <%= radio_button f, :autodetect_contructor_args, true, checked: fetch_constructor_arguments_automatically, class: "form-check-input autodetecttrue", "aria-describedby": "autodetect_contructor_args-help-block" %>
+                  <%= radio_button f, :autodetect_constructor_args, true, checked: fetch_constructor_arguments_automatically, class: "form-check-input autodetecttrue", "aria-describedby": "autodetect_constructor_args-help-block" %>
                   <div class="radio-icon"></div>
-                  <%= label :autodetect_contructor_args, :true, gettext("Yes"), class: "radio-text" %>
+                  <%= label :autodetect_constructor_args, :true, gettext("Yes"), class: "radio-text" %>
                 </div>
               </div>
-              <%= error_tag f, :autodetect_contructor_args, id: "autodetect_contructor_args-help-block", class: "text-danger form-error" %>
+              <%= error_tag f, :autodetect_constructor_args, id: "autodetect_constructor_args-help-block", class: "text-danger form-error" %>
             </div>
           </div>
         </div>
 
         <div class="smart-contract-form-group constructor-arguments" style="display: <%= display_constructor_arguments_text_area %>">
           <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :contructor_arguments, gettext("ABI-encoded Constructor Arguments (if required by the contract)") %>
+            <%= label f, :constructor_arguments, gettext("ABI-encoded Constructor Arguments (if required by the contract)") %>
             <div class="center-column">
               <%= textarea f, :constructor_arguments, class: "form-control border-rounded monospace", rows: 3, "aria-describedby": "contract-constructor-arguments-help-block" %>
               <%= error_tag f, :constructor_arguments, id: "contract-constructor-arguments-help-block", class: "text-danger form-error", "data-test": "contract-constructor-arguments-error" %>

--- a/apps/explorer/lib/explorer/smart_contract/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/publisher.ex
@@ -28,11 +28,11 @@ defmodule Explorer.SmartContract.Publisher do
     params_with_external_libaries = add_external_libraries(params, external_libraries)
 
     case Verifier.evaluate_authenticity(address_hash, params_with_external_libaries) do
-      {:ok, %{abi: abi, contructor_arguments: contructor_arguments}} ->
-        params_with_contructor_arguments =
-          Map.put(params_with_external_libaries, "constructor_arguments", contructor_arguments)
+      {:ok, %{abi: abi, constructor_arguments: constructor_arguments}} ->
+        params_with_constructor_arguments =
+          Map.put(params_with_external_libaries, "constructor_arguments", constructor_arguments)
 
-        publish_smart_contract(address_hash, params_with_contructor_arguments, abi)
+        publish_smart_contract(address_hash, params_with_constructor_arguments, abi)
 
       {:ok, %{abi: abi}} ->
         publish_smart_contract(address_hash, params_with_external_libaries, abi)

--- a/apps/explorer/lib/explorer/smart_contract/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/verifier.ex
@@ -60,7 +60,7 @@ defmodule Explorer.SmartContract.Verifier do
     constructor_arguments = Map.get(params, "constructor_arguments", "")
     evm_version = Map.get(params, "evm_version")
     optimization_runs = Map.get(params, "optimization_runs", 200)
-    autodetect_contructor_arguments = params |> Map.get("autodetect_contructor_args", "false") |> parse_boolean()
+    autodetect_constructor_arguments = params |> Map.get("autodetect_constructor_args", "false") |> parse_boolean()
 
     solc_output =
       CodeCompiler.run(
@@ -77,7 +77,7 @@ defmodule Explorer.SmartContract.Verifier do
       solc_output,
       address_hash,
       constructor_arguments,
-      autodetect_contructor_arguments,
+      autodetect_constructor_arguments,
       contract_source_code,
       name
     )
@@ -95,7 +95,7 @@ defmodule Explorer.SmartContract.Verifier do
          {:ok, %{"abi" => abi, "bytecode" => bytecode}},
          address_hash,
          arguments_data,
-         autodetect_contructor_arguments,
+         autodetect_constructor_arguments,
          contract_source_code,
          contract_name
        ) do
@@ -131,11 +131,11 @@ defmodule Explorer.SmartContract.Verifier do
           !try_library_verification(generated_bytecode, blockchain_bytecode_without_whisper) ->
         {:error, :generated_bytecode}
 
-      has_constructor_with_params?(abi) && autodetect_contructor_arguments ->
+      has_constructor_with_params?(abi) && autodetect_constructor_arguments ->
         result = ConstructorArguments.find_constructor_arguments(address_hash, abi, contract_source_code, contract_name)
 
         if result do
-          {:ok, %{abi: abi, contructor_arguments: result}}
+          {:ok, %{abi: abi, constructor_arguments: result}}
         else
           {:error, :constructor_arguments}
         end

--- a/apps/explorer/test/explorer/smart_contract/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/publisher_test.exs
@@ -37,7 +37,7 @@ defmodule Explorer.SmartContract.PublisherTest do
       assert smart_contract.abi == contract_code_info.abi
     end
 
-    test "detects and adds contructor arguments if autodetection is checked" do
+    test "detects and adds constructor arguments if autodetection is checked" do
       path = File.cwd!() <> "/test/support/fixture/smart_contract/solidity_0.5.9_smart_contract.sol"
       contract = File.read!(path)
 
@@ -65,7 +65,7 @@ defmodule Explorer.SmartContract.PublisherTest do
         "evm_version" => "petersburg",
         "name" => "TestToken",
         "optimization" => false,
-        "autodetect_contructor_args" => "true"
+        "autodetect_constructor_args" => "true"
       }
 
       assert {:ok, result} = Publisher.publish(contract_address.hash, params)


### PR DESCRIPTION
## Motivation

Finalization of https://github.com/blockscout/blockscout/pull/4236

## Changelog

Replace `contructor` with `constructor` in variables names

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
