### PR TITLE
Extend Sourcify smart-contract verification: fetch smart contract metadata from Sourcify repo if it has been already verified there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4267](https://github.com/blockscout/blockscout/pull/4267) - Extend verification through [Sourcify](https://sourcify.dev) smart-contract verification: fetch smart contract metadata from Sourcify repo if it has been already verified there
 - [#4241](https://github.com/blockscout/blockscout/pull/4241) - Reload transactions on the main page without reloading of the whole page
 - [#4218](https://github.com/blockscout/blockscout/pull/4218) - Hide long arrays in smart-contract's 
 - [#4205](https://github.com/blockscout/blockscout/pull/4205) - Total transactions fees per day API endpoint

--- a/apps/block_scout_web/assets/css/components/_new_smart_contract.scss
+++ b/apps/block_scout_web/assets/css/components/_new_smart_contract.scss
@@ -63,6 +63,7 @@ $new-smart-contract-center-column-margin-right: 30px;
 
   .radio-big {
     margin-right: 20px;
+    margin-bottom: 1rem;
 
     &:last-child {
       margin-right: 0;

--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -232,14 +232,14 @@ if ($contractVerificationPage.length) {
   $('.verify-via-flattened-code').on('click', function () {
     if ($(this).prop('checked')) {
       $('#verify_via_flattened_code_button').show()
-      $('#verify_via_json_button').hide()
+      $('#verify_via_sourcify_button').hide()
     }
   })
 
-  $('.verify-via-json').on('click', function () {
+  $('.verify-via-sourcify').on('click', function () {
     if ($(this).prop('checked')) {
       $('#verify_via_flattened_code_button').hide()
-      $('#verify_via_json_button').show()
+      $('#verify_via_sourcify_button').show()
     }
   })
 }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
     end
   end
 
-  defp get_metadata_and_publish(address_hash_string, conn) do
+  def get_metadata_and_publish(address_hash_string, conn) do
     case Sourcify.get_metadata(address_hash_string) do
       {:ok, verification_metadata} ->
         %{"params_to_publish" => params_to_publish, "abi" => abi, "secondary_sources" => secondary_sources} =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
@@ -1,15 +1,24 @@
 defmodule BlockScoutWeb.AddressContractVerificationViaJsonController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
   alias Explorer.Chain.SmartContract
+  alias Explorer.ThirdPartyIntegrations.Sourcify
 
   def new(conn, %{"address_id" => address_hash_string}) do
-    changeset =
-      SmartContract.changeset(
-        %SmartContract{address_hash: address_hash_string},
-        %{}
-      )
+    case Sourcify.check_by_address(address_hash_string) do
+      {:ok, _verified_status} ->
+        VerificationController.get_metadata_and_publish(address_hash_string, conn)
+        redirect(conn, to: address_path(conn, :show, address_hash_string))
 
-    render(conn, "new.html", changeset: changeset, address_hash: address_hash_string)
+      _ ->
+        changeset =
+          SmartContract.changeset(
+            %SmartContract{address_hash: address_hash_string},
+            %{}
+          )
+
+        render(conn, "new.html", changeset: changeset, address_hash: address_hash_string)
+    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -35,9 +35,9 @@
                   <%= label :verify_via, :true, gettext("Flattened source code"), class: "radio-text" %>
                 </div>
                 <div class="radio-big">
-                  <%= radio_button f, :verify_via, false, class: "form-check-input verify-via-json" %>
+                  <%= radio_button f, :verify_via, false, class: "form-check-input verify-via-sourcify" %>
                   <div class="radio-icon"></div>
-                  <%= label :verify_via, :false, gettext("Sources and metadata JSON file"), class: "radio-text" %>
+                  <%= label :verify_via, :false, gettext("Sourcify: Sources and metadata JSON file"), class: "radio-text" %>
                 </div>
               </div>
               <%= error_tag f, :verify_via, id: "verify_via-help-block", class: "text-danger form-error" %>
@@ -50,7 +50,10 @@
                       data-template="<div class='tooltip' role='tooltip'><div class='arrow'></div><div class='tooltip-inner'></div></div>"
                       title="If using a flat file for contract verification, you can use the POA Solidity flattener or the Truffle flattener">
                       <i style="color: #f7b32b;" class="fa fa-info-circle ml-1" data-test="token-bridge-supply"></i></span><br/>
-            2. Verification through raw source files and standard JSON file(s) with metadata from the Solidity contract compilation process.</div>
+            2. Verification through <a href="https://sourcify.dev">Sourcify</a>.<br/>
+              a) if smart-contract already verified on Sourcify, it will automatically fetch the data from the <a href="https://repo.sourcify.dev">repo</a><br/>
+              b) otherwise you will be asked to upload source files and JSON metadata file(s).</div>
+              
           </div>
         </div>
 
@@ -78,7 +81,7 @@
           <%= link(
             gettext("Next"),
             to: address_verify_contract_via_json_path(@conn, :new, @address_hash),
-            id: "verify_via_json_button",
+            id: "verify_via_sourcify_button",
             class: "btn-full-primary mr-2",
             style: "display: none;",
             "data-button-loading": "animation"

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -264,7 +264,7 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:88
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:91
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:305
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:56
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
@@ -1020,7 +1020,7 @@ msgid "Loading..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:69
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:72
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:299
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:50
 msgid "Loading...."
@@ -2781,8 +2781,8 @@ msgid "Flattened source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:72
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:79
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:75
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
 msgid "Next"
 msgstr ""
 
@@ -2793,11 +2793,11 @@ msgid "Sources and Metadata JSON"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:40
-msgid "Sources and metadata JSON file"
+#: lib/block_scout_web/templates/address_contract/index.html.eex:33
+msgid "This contract has been verified via Sourcify."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:33
-msgid "This contract has been verified via Sourcify."
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:40
+msgid "Sourcify: Sources and metadata JSON file"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -264,7 +264,7 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:88
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:91
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:305
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:56
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
@@ -1020,7 +1020,7 @@ msgid "Loading..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:69
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:72
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:299
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:50
 msgid "Loading...."
@@ -2781,8 +2781,8 @@ msgid "Flattened source code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:72
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:79
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:75
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
 msgid "Next"
 msgstr ""
 
@@ -2793,11 +2793,11 @@ msgid "Sources and Metadata JSON"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:40
-msgid "Sources and metadata JSON file"
+#: lib/block_scout_web/templates/address_contract/index.html.eex:33
+msgid "This contract has been verified via Sourcify."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract/index.html.eex:33
-msgid "This contract has been verified via Sourcify."
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:40
+msgid "Sourcify: Sources and metadata JSON file"
 msgstr ""

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
@@ -84,7 +84,7 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
 
   defp process_sourcify_response(url, body) do
     cond do
-      url =~ "checkByAddresses" ->
+      url =~ "check-by-addresses" ->
         parse_check_by_address_http_response(body)
 
       url =~ "/verify" ->
@@ -174,7 +174,7 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
   end
 
   defp check_by_address_url do
-    "#{base_server_url()}" <> "/checkByAddresses"
+    "#{base_server_url()}" <> "/check-by-addresses"
   end
 
   defp get_metadata_url do


### PR DESCRIPTION
Resolves issue #4155 

- Added functionality to fetch smart-contracts metadata via [Sourcify](https://sourcify.dev)
- In `sourcify.ex`: checkByAddresses _(deprecated)_ -> check-by-addresses