### PR TITLE
Аdded check in web if a contract already verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4294](https://github.com/blockscout/blockscout/pull/4294) - User wont be able to open verification pages for verified smart-contract
 - [#4240](https://github.com/blockscout/blockscout/pull/4240) - `[]` is accepted in write contract page
 - [#4236](https://github.com/blockscout/blockscout/pull/4236), [#4242](https://github.com/blockscout/blockscout/pull/4242) - Fix typo, constructor instead of contructor
 - [#4167](https://github.com/blockscout/blockscout/pull/4167) - Deduplicate block numbers in acquire_blocks function

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -10,27 +10,31 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
   alias Explorer.ThirdPartyIntegrations.Sourcify
 
   def new(conn, %{"address_id" => address_hash_string}) do
-    changeset =
-      SmartContract.changeset(
-        %SmartContract{address_hash: address_hash_string},
-        %{}
+    if Chain.smart_contract_verified?(address_hash_string) do
+      redirect(conn, to: address_path(conn, :show, address_hash_string))
+    else
+      changeset =
+        SmartContract.changeset(
+          %SmartContract{address_hash: address_hash_string},
+          %{}
+        )
+
+      compiler_versions =
+        case CompilerVersion.fetch_versions() do
+          {:ok, compiler_versions} ->
+            compiler_versions
+
+          {:error, _} ->
+            []
+        end
+
+      render(conn, "new.html",
+        changeset: changeset,
+        compiler_versions: compiler_versions,
+        evm_versions: CodeCompiler.allowed_evm_versions(),
+        address_hash: address_hash_string
       )
-
-    compiler_versions =
-      case CompilerVersion.fetch_versions() do
-        {:ok, compiler_versions} ->
-          compiler_versions
-
-        {:error, _} ->
-          []
-      end
-
-    render(conn, "new.html",
-      changeset: changeset,
-      compiler_versions: compiler_versions,
-      evm_versions: CodeCompiler.allowed_evm_versions(),
-      address_hash: address_hash_string
-    )
+    end
   end
 
   def create(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
@@ -2,23 +2,28 @@ defmodule BlockScoutWeb.AddressContractVerificationViaJsonController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
+  alias Explorer.Chain
   alias Explorer.Chain.SmartContract
   alias Explorer.ThirdPartyIntegrations.Sourcify
 
   def new(conn, %{"address_id" => address_hash_string}) do
-    case Sourcify.check_by_address(address_hash_string) do
-      {:ok, _verified_status} ->
-        VerificationController.get_metadata_and_publish(address_hash_string, conn)
-        redirect(conn, to: address_path(conn, :show, address_hash_string))
+    if Chain.smart_contract_verified?(address_hash_string) do
+      redirect(conn, to: address_path(conn, :show, address_hash_string))
+    else
+      case Sourcify.check_by_address(address_hash_string) do
+        {:ok, _verified_status} ->
+          VerificationController.get_metadata_and_publish(address_hash_string, conn)
+          redirect(conn, to: address_path(conn, :show, address_hash_string))
 
-      _ ->
-        changeset =
-          SmartContract.changeset(
-            %SmartContract{address_hash: address_hash_string},
-            %{}
-          )
+        _ ->
+          changeset =
+            SmartContract.changeset(
+              %SmartContract{address_hash: address_hash_string},
+              %{}
+            )
 
-        render(conn, "new.html", changeset: changeset, address_hash: address_hash_string)
+          render(conn, "new.html", changeset: changeset, address_hash: address_hash_string)
+      end
     end
   end
 end


### PR DESCRIPTION
## Motivation

To prevent user's useless actions to verify already verified smart-contract

## Changelog

### Enhancements
Now before rendering page, performs check if the smart-contract verified. And if verified, then user will redirected to smart-contract page

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
