### PR TITLE
[4274] Fix/improve search token-autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4274](https://github.com/blockscout/blockscout/pull/4302) - Fix search token-autocomplete
 - [#4316](https://github.com/blockscout/blockscout/pull/4316) - Fix `/decompiled-contracts` bug
 - [#4310](https://github.com/blockscout/blockscout/pull/4310) - Fix logo URL redirection, set font-family defaults for chart.js
 - [#4308](https://github.com/blockscout/blockscout/pull/4308) - Fix internal server error on contract verification options page

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -94,23 +94,11 @@ defmodule BlockScoutWeb.ChainController do
   def search(conn, _), do: not_found(conn)
 
   def token_autocomplete(conn, %{"q" => term}) when is_binary(term) do
-    if term == "" do
-      json(conn, "{}")
-    else
-      result_tokens =
-        term
-        |> String.trim()
-        |> Chain.search_token()
+    result_tokens = Chain.search_token(term)
+    result_contracts = Chain.search_contract(term)
+    result = result_tokens ++ result_contracts
 
-      result_contracts =
-        term
-        |> String.trim()
-        |> Chain.search_contract()
-
-      result = result_tokens ++ result_contracts
-
-      json(conn, result)
-    end
+    json(conn, result)
   end
 
   def token_autocomplete(conn, _) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -128,6 +128,38 @@ defmodule BlockScoutWeb.ChainControllerTest do
 
       assert Enum.count(json_response(conn, 200)) == 4
     end
+
+    test "find by several words" do
+      insert(:token, name: "first Token")
+      insert(:token, name: "second Token")
+
+      conn =
+        build_conn()
+        |> get("/token-autocomplete?q=fir+tok")
+
+      assert Enum.count(json_response(conn, 200)) == 1
+    end
+
+    test "find by empty query" do
+      insert(:token, name: "MaGiCt0k3n")
+      insert(:smart_contract, name: "MagicContract")
+
+      conn =
+        build_conn()
+        |> get("/token-autocomplete?q=")
+
+      assert Enum.count(json_response(conn, 200)) == 0
+    end
+
+    test "find by non-latin characters" do
+      insert(:token, name: "someToken")
+
+      conn =
+        build_conn()
+        |> get("/token-autocomplete?q=%E0%B8%B5%E0%B8%AB")
+
+      assert Enum.count(json_response(conn, 200)) == 0
+    end
   end
 
   describe "GET search/2" do


### PR DESCRIPTION
*Fix fall on search token-autocomplete by non-latin characters*
*Fix search token-autocomplete by multiple words"

This PR fixes https://github.com/blockscout/blockscout/issues/4274

No breaking changes IMHO

I don't know exactly is it possible to tokens be in non-latin characters. @vbaranov please check this point
This PR not fix search by, for example, "лучшие токены" - this search string will be treat as empty string.

  - [X] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
