### PR TITLE
Fix internal server error on contract verification options page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4308](https://github.com/blockscout/blockscout/pull/4308) - Fix internal server error on contract verification options page
 - [#4307](https://github.com/blockscout/blockscout/pull/4307) - Fix for composing IPFS URLs for NFTs images
 - [#4306](https://github.com/blockscout/blockscout/pull/4306) - Check token instance images MIME types
 - [#4295](https://github.com/blockscout/blockscout/pull/4295) - Mobile view fix: transaction tile tx hash overflow

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3693,14 +3693,20 @@ defmodule Explorer.Chain do
     end
   end
 
-  def smart_contract_verified?(address_hash) do
-    query =
-      from(
-        smart_contract in SmartContract,
-        where: smart_contract.address_hash == ^address_hash
-      )
+  def smart_contract_verified?(address_hash_str) do
+    case string_to_address_hash(address_hash_str) do
+      {:ok, address_hash} ->
+        query =
+          from(
+            smart_contract in SmartContract,
+            where: smart_contract.address_hash == ^address_hash
+          )
 
-    if Repo.one(query), do: true, else: false
+        if Repo.one(query), do: true, else: false
+
+      _ ->
+        false
+    end
   end
 
   defp fetch_transactions(paging_options \\ nil) do


### PR DESCRIPTION
## Motivation

`https://blockscout.com/xdai/mainnet/address/%5D/contract_verifications/new` page open causes internal server error

## Changelog

Check if `address_hash_str` is valid in smart_contract_verified?/1 function

## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
