### PR TITLE
Add displaying pending transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4312](https://github.com/blockscout/blockscout/pull/4312) - Display pending transactions on address page
 - [#4299](https://github.com/blockscout/blockscout/pull/4299) - Added sourcify verification api endpoint
 - [#4267](https://github.com/blockscout/blockscout/pull/4267) - Extend verification through [Sourcify](https://sourcify.dev) smart-contract verification: fetch smart contract metadata from Sourcify repo if it has been already verified there
 - [#4241](https://github.com/blockscout/blockscout/pull/4241) - Reload transactions on the main page without reloading of the whole page

--- a/apps/block_scout_web/assets/js/pages/address/transactions.js
+++ b/apps/block_scout_web/assets/js/pages/address/transactions.js
@@ -91,6 +91,12 @@ if ($('[data-page="address-transactions"]').length) {
       msg: humps.camelizeKeys(msg)
     })
   })
+  addressChannel.on('pending_transaction', (msg) => {
+    store.dispatch({
+      type: 'RECEIVED_NEW_TRANSACTION',
+      msg: humps.camelizeKeys(msg)
+    })
+  })
 
   const rewardsChannel = subscribeChannel(`rewards:${addressHash}`)
   rewardsChannel.onError(() => store.dispatch({ type: 'CHANNEL_DISCONNECTED' }))

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -182,7 +182,7 @@ defmodule BlockScoutWeb.Chain do
   def paging_options(%{"inserted_at" => inserted_at_string, "hash" => hash_string}) do
     with {:ok, inserted_at, _} <- DateTime.from_iso8601(inserted_at_string),
          {:ok, hash} <- string_to_transaction_hash(hash_string) do
-      [paging_options: %{@default_paging_options | key: {inserted_at, hash}}]
+      [paging_options: %{@default_paging_options | key: {inserted_at, hash}, is_pending_tx: true}]
     else
       _ ->
         [paging_options: @default_paging_options]

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -24,7 +24,8 @@ defmodule BlockScoutWeb.AddressChannel do
     "internal_transaction",
     "transaction",
     "verification_result",
-    "token_transfer"
+    "token_transfer",
+    "pending_transaction"
   ])
 
   {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
@@ -138,6 +139,8 @@ defmodule BlockScoutWeb.AddressChannel do
 
     {:noreply, socket}
   end
+
+  def handle_out("pending_transaction", data, socket), do: handle_transaction(data, socket, "transaction")
 
   def handle_transaction(%{address: address, transaction: transaction}, socket, event) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -18,7 +18,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
       [created_contract_address: :names] => :optional,
       [from_address: :names] => :optional,
       [to_address: :names] => :optional,
-      :block => :required
+      :block => :optional
     }
   ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -36,7 +36,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
 
-      results_plus_one = Chain.address_to_mined_transactions_with_rewards(address_hash, options)
+      results_plus_one = Chain.address_to_transactions_with_rewards(address_hash, options)
       {results, next_page} = split_list_by_page(results_plus_one)
 
       next_page_url =

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -332,11 +332,11 @@ defmodule Explorer.Chain do
       the `block_number` and `index` that are passed.
 
   """
-  @spec address_to_mined_transactions_with_rewards(Hash.Address.t(), [paging_options | necessity_by_association_option]) ::
+  @spec address_to_transactions_with_rewards(Hash.Address.t(), [paging_options | necessity_by_association_option]) ::
           [
             Transaction.t()
           ]
-  def address_to_mined_transactions_with_rewards(address_hash, options \\ []) when is_list(options) do
+  def address_to_transactions_with_rewards(address_hash, options \\ []) when is_list(options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
     if Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:has_emission_funds] do

--- a/apps/explorer/lib/explorer/paging_options.ex
+++ b/apps/explorer/lib/explorer/paging_options.ex
@@ -4,11 +4,12 @@ defmodule Explorer.PagingOptions do
   number and index.
   """
 
-  @type t :: %__MODULE__{key: key, page_size: page_size, page_number: page_number}
+  @type t :: %__MODULE__{key: key, page_size: page_size, page_number: page_number, is_pending_tx: is_pending_tx}
 
   @typep key :: any()
   @typep page_size :: non_neg_integer()
   @typep page_number :: pos_integer()
+  @typep is_pending_tx :: atom()
 
-  defstruct [:key, :page_size, page_number: 1]
+  defstruct [:key, :page_size, page_number: 1, is_pending_tx: false]
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -383,13 +383,13 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "address_to_mined_transactions_with_rewards/2" do
+  describe "address_to_transactions_with_rewards/2" do
     test "without transactions" do
       %Address{hash: address_hash} = insert(:address)
 
       assert Repo.aggregate(Transaction, :count, :hash) == 0
 
-      assert [] == Chain.address_to_mined_transactions_with_rewards(address_hash)
+      assert [] == Chain.address_to_transactions_with_rewards(address_hash)
     end
 
     test "with from transactions" do
@@ -401,7 +401,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :from)
+               Chain.address_to_transactions_with_rewards(address_hash, direction: :from)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -414,7 +414,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :to)
+               Chain.address_to_transactions_with_rewards(address_hash, direction: :to)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -428,7 +428,7 @@ defmodule Explorer.ChainTest do
 
       # only contains "from" transaction
       assert [transaction] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :from)
+               Chain.address_to_transactions_with_rewards(address_hash, direction: :from)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -441,7 +441,7 @@ defmodule Explorer.ChainTest do
         |> with_block()
 
       assert [transaction] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash, direction: :to)
+               Chain.address_to_transactions_with_rewards(address_hash, direction: :to)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -460,7 +460,7 @@ defmodule Explorer.ChainTest do
         |> with_block(block)
 
       assert [transaction2, transaction1] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash)
+               Chain.address_to_transactions_with_rewards(address_hash)
                |> Repo.preload([:block, :to_address, :from_address])
     end
 
@@ -481,7 +481,7 @@ defmodule Explorer.ChainTest do
           transaction_index: transaction.index
         )
 
-      assert [] == Chain.address_to_mined_transactions_with_rewards(address.hash)
+      assert [] == Chain.address_to_transactions_with_rewards(address.hash)
     end
 
     test "returns transactions that have token transfers for the given to_address" do
@@ -499,7 +499,7 @@ defmodule Explorer.ChainTest do
       )
 
       assert [transaction.hash] ==
-               Chain.address_to_mined_transactions_with_rewards(address_hash)
+               Chain.address_to_transactions_with_rewards(address_hash)
                |> Enum.map(& &1.hash)
     end
 
@@ -519,7 +519,7 @@ defmodule Explorer.ChainTest do
 
       assert second_page_hashes ==
                address_hash
-               |> Chain.address_to_mined_transactions_with_rewards(
+               |> Chain.address_to_transactions_with_rewards(
                  paging_options: %PagingOptions{
                    key: {block_number, index},
                    page_size: 2
@@ -568,7 +568,7 @@ defmodule Explorer.ChainTest do
 
       result =
         address_hash
-        |> Chain.address_to_mined_transactions_with_rewards()
+        |> Chain.address_to_transactions_with_rewards()
         |> Enum.map(& &1.hash)
 
       assert [fourth, third, second, first, sixth, fifth] == result
@@ -619,7 +619,7 @@ defmodule Explorer.ChainTest do
         end
       )
 
-      res = Chain.address_to_mined_transactions_with_rewards(block.miner.hash)
+      res = Chain.address_to_transactions_with_rewards(block.miner.hash)
 
       assert [{_, _}] = res
 
@@ -683,7 +683,7 @@ defmodule Explorer.ChainTest do
         end
       )
 
-      assert [_, {_, _}] = Chain.address_to_mined_transactions_with_rewards(block.miner.hash, direction: :to)
+      assert [_, {_, _}] = Chain.address_to_transactions_with_rewards(block.miner.hash, direction: :to)
 
       on_exit(fn ->
         Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
@@ -719,7 +719,7 @@ defmodule Explorer.ChainTest do
       |> with_block()
       |> Repo.preload(:token_transfers)
 
-      assert [_] = Chain.address_to_mined_transactions_with_rewards(block.miner.hash, direction: :from)
+      assert [_] = Chain.address_to_transactions_with_rewards(block.miner.hash, direction: :from)
 
       Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
     end
@@ -743,7 +743,7 @@ defmodule Explorer.ChainTest do
         address_type: :emission_funds
       )
 
-      assert [] == Chain.address_to_mined_transactions_with_rewards(block.miner.hash)
+      assert [] == Chain.address_to_transactions_with_rewards(block.miner.hash)
     end
   end
 


### PR DESCRIPTION
Close #4147 

## Changelog
- Added displaying pending txs on `/address/${address_hash}/transactions` page

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
