### PR TITLE
Set infinite timeout for fetch_min_missing_block_cache method DB query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#3888](https://github.com/blockscout/blockscout/pull/3888) - EIP-1967 contract proxy pattern detection fix
 
 ### Chore
+- [#4314](https://github.com/blockscout/blockscout/pull/4314) - Set infinite timeout for fetch_min_missing_block_cache method DB query
 - [#4300](https://github.com/blockscout/blockscout/pull/4300) - Remove clear_build.sh script
 - [#4268](https://github.com/blockscout/blockscout/pull/4268) - Migration to Chart.js 3.0
 - [#4253](https://github.com/blockscout/blockscout/pull/4253) - Elixir 1.11.4, npm audit fix

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2516,7 +2516,7 @@ defmodule Explorer.Chain do
         )
 
       query
-      |> Repo.one() || 0
+      |> Repo.one(timeout: :infinity) || 0
     else
       0
     end


### PR DESCRIPTION
## Motivation

```
{"error":{"initial_call":null,"reason":"** (DBConnection.ConnectionError) tcp recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)\n    (ecto_sql 3.5.3) lib/ecto/adapters/sql.ex:751: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.5.3) lib/ecto/adapters/sql.ex:684: Ecto.Adapters.SQL.execute/5\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:229: Ecto.Repo.Queryable.execute/4\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:17: Ecto.Repo.Queryable.all/3\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:149: Ecto.Repo.Queryable.one/3\n    (explorer 0.0.1) lib/explorer/chain.ex:2687: Explorer.Chain.fetch_min_missing_block_cache/0\n    (explorer 0.0.1) lib/explorer/chain/cache/min_missing_block.ex:28: Explorer.Chain.Cache.MinMissingBlockNumber.fetch_min_missing_block/0\n    (elixir 1.11.4) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2\n"},"logging.googleapis.com/sourceLocation":{"file":null,"line":0,"function":null},"message":"Task #PID<0.18593.19> started from Explorer.Chain.Cache.MinMissingBlockNumber terminating\n** (DBConnection.ConnectionError) tcp recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)\n    (ecto_sql 3.5.3) lib/ecto/adapters/sql.ex:751: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.5.3) lib/ecto/adapters/sql.ex:684: Ecto.Adapters.SQL.execute/5\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:229: Ecto.Repo.Queryable.execute/4\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:17: Ecto.Repo.Queryable.all/3\n    (ecto 3.5.5) lib/ecto/repo/queryable.ex:149: Ecto.Repo.Queryable.one/3\n    (explorer 0.0.1) lib/explorer/chain.ex:2687: Explorer.Chain.fetch_min_missing_block_cache/0\n    (explorer 0.0.1) lib/explorer/chain/cache/min_missing_block.ex:28: Explorer.Chain.Cache.MinMissingBlockNumber.fetch_min_missing_block/0\n    (elixir 1.11.4) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2\nFunction: #Function<0.83273533/0 in Explorer.Chain.Cache.MinMissingBlockNumber.\"-fun.fetch_min_missing_block/0-\">\n    Args: []","severity":"ERROR","time":"2021-06-23T14:16:37.208Z"}
```

when query execution takes more than 6o seconds (default timeout)

## Changelog

Set infinity timeout `fetch_min_missing_block_cache` method DB query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
