### PR TITLE
Fix decompiled contracts bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4067](https://github.com/blockscout/blockscout/pull/4067) - Display LP tokens USD value and custom metadata in tokens dropdown at address page
 
 ### Fixes
+- [#4316](https://github.com/blockscout/blockscout/pull/4316) - Fix `/decompiled-contracts` bug
 - [#4310](https://github.com/blockscout/blockscout/pull/4310) - Fix logo URL redirection, set font-family defaults for chart.js
 - [#4308](https://github.com/blockscout/blockscout/pull/4308) - Fix internal server error on contract verification options page
 - [#4307](https://github.com/blockscout/blockscout/pull/4307) - Fix for composing IPFS URLs for NFTs images

--- a/apps/block_scout_web/lib/block_scout_web/views/address_decompiled_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_decompiled_contract_view.ex
@@ -230,6 +230,10 @@ defmodule BlockScoutWeb.AddressDecompiledContractView do
     end)
   end
 
+  def last_decompiled_contract_version(decompiled_contracts) when is_nil(decompiled_contracts), do: nil
+
+  def last_decompiled_contract_version(decompiled_contracts) when decompiled_contracts == [], do: nil
+
   def last_decompiled_contract_version(decompiled_contracts) do
     Enum.max_by(decompiled_contracts, & &1.decompiler_version)
   end


### PR DESCRIPTION
## Motivation

If you try to access https://blockscout.com/xdai/mainnet/address/0x587aC2b6D8B49C8Df77C14fbec926A4Fed3695f3/decompiled-contracts you will get 500 HTTP error response

## Changelog

### Bug Fixes
- added additional clauses for `last_decompiled_contract_version` method

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
