### PR TITLE
Fix false pending txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4353](https://github.com/blockscout/blockscout/pull/4353) - Added live-reload on the token holders page
 
 ### Fixes
+- [#4360](https://github.com/blockscout/blockscout/pull/4360) - Fix false-pending transactions in reorg blocks
 - [#4388](https://github.com/blockscout/blockscout/pull/4388) - Fix internal server error on contract page for insctances without sourcify envs
 - [#4385](https://github.com/blockscout/blockscout/pull/4385) - Fix html template for transaction's input; Add copy text for tuples
 

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -13,6 +13,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
   alias Ecto.Changeset
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Import.Runner.Blocks
+  alias Explorer.Chain.Transaction
 
   @interval :timer.hours(3)
 
@@ -83,7 +84,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
               fetcher: :pending_transactions_to_refetch
             )
 
-            fetch_block_and_invalidate(block_hash)
+            fetch_block_and_invalidate(block_hash, pending_tx)
           else
             Logger.debug(
               "Transaction with hash #{pending_tx_hash_str} is still pending. Do nothing.",
@@ -129,7 +130,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
     end
   end
 
-  defp fetch_block_and_invalidate(block_hash) do
+  defp fetch_block_and_invalidate(block_hash, pending_tx) do
     case Chain.fetch_block_by_hash(block_hash) do
       %{number: number, consensus: consensus} ->
         Logger.debug(
@@ -139,7 +140,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
           fetcher: :pending_transactions_to_refetch
         )
 
-        invalidate_block(number, consensus)
+        invalidate_block(number, block_hash, consensus, pending_tx)
 
       _ ->
         Logger.debug(
@@ -149,14 +150,24 @@ defmodule Indexer.PendingTransactionsSanitizer do
     end
   end
 
-  defp invalidate_block(number, consensus) do
+  defp invalidate_block(block_number, block_hash, consensus, pending_tx) do
     if consensus do
       opts = %{
         timeout: 60_000,
         timestamps: %{updated_at: DateTime.utc_now()}
       }
 
-      Blocks.lose_consensus(Repo, [], [number], [], opts)
+      Blocks.lose_consensus(Repo, [], [block_number], [], opts)
+    else
+      changeset =
+        pending_tx
+        |> Transaction.changeset()
+        |> Changeset.put_change(:block_number, block_number)
+        |> Changeset.put_change(:block_hash, block_hash)
+
+      Repo.update(changeset)
+
+      Logger.debug("Pending tx with hash #{pending_tx.hash} assigned to block ##{block_number}")
     end
   end
 end


### PR DESCRIPTION
Close #4348 

## Changelog

### Bug Fixes
- Added else branch in `pending_transactions_sanitizer.ex/invalidate_block`
- Pending txs included in reorg blocks will marked as `dropped/replaced` via sanitizer

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
