### PR TITLE
Fix elixir version in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.11.4
+elixir 1.11.4-otp-23
 erlang 23.3.4.1
 nodejs 14.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4388](https://github.com/blockscout/blockscout/pull/4388) - Fix internal server error on contract page for insctances without sourcify envs
 
 ### Chore
+- [#4384](https://github.com/blockscout/blockscout/pull/4384) - Fix Elixir version in `.tool-versions`
 - [#4382](https://github.com/blockscout/blockscout/pull/4382) - Replace awesomplete with autocomplete.js
 - [#4371] - (https://github.com/blockscout/blockscout/pull/4371) - Place search outside of burger in mobile view
 - [#4355](https://github.com/blockscout/blockscout/pull/4355) - Do not redirect to 404 page with empty string in the search field


### PR DESCRIPTION
In ASDF's `.tool-version` OTP version Elixir compiled with should match Erlang OTP version.

elixir version 1.11.4 mean 1.11.4-otp-21