### PR TITLE
Fix render bug in transaction's input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixes
 - [#4388](https://github.com/blockscout/blockscout/pull/4388) - Fix internal server error on contract page for insctances without sourcify envs
-- [#4385](https://github.com/blockscout/blockscout/pull/4385) - Fix html template for transaction's input
+- [#4385](https://github.com/blockscout/blockscout/pull/4385) - Fix html template for transaction's input; Add copy text for tuples
 
 ### Chore
 - [#4384](https://github.com/blockscout/blockscout/pull/4384) - Fix Elixir version in `.tool-versions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - [#4388](https://github.com/blockscout/blockscout/pull/4388) - Fix internal server error on contract page for insctances without sourcify envs
+- [#4385](https://github.com/blockscout/blockscout/pull/4385) - Fix html template for transaction's input
 
 ### Chore
 - [#4384](https://github.com/blockscout/blockscout/pull/4384) - Fix Elixir version in `.tool-versions`

--- a/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
@@ -63,6 +63,17 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
     hex(value)
   end
 
+  defp do_copy_text({:tuple, types}, value) do
+    values =
+      value
+      |> Tuple.to_list()
+      |> Enum.with_index()
+      |> Enum.map(fn {val, ind} -> do_copy_text(Enum.at(types, ind), val) end)
+      |> Enum.intersperse(", ")
+
+    ~E|(<%= values %>)|
+  end
+
   defp do_copy_text(_type, value) do
     to_string(value)
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
@@ -95,48 +95,17 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
       |> Tuple.to_list()
       |> Enum.with_index()
       |> Enum.map(fn {value, i} ->
-        type = Enum.at(types, i)
-
-        case type do
-          {:tuple, types} ->
-            do_value_html_from_tuple(types, value)
-
-          _ ->
-            res = do_value_html(type, value)
-            [_, {:safe, html_val}] = res
-            html_val
-        end
+        do_value_html(Enum.at(types, i), value)
       end)
 
-    "(" <> Enum.join(values_list, ",") <> ")"
+    delimited = Enum.intersperse(values_list, ",")
+    ~E|(<%= delimited %>)|
   end
 
   defp do_value_html(type, value, depth) do
     spacing = String.duplicate(" ", depth * 2)
     ~E|<%= spacing %><%=base_value_html(type, value)%>|
     [spacing, base_value_html(type, value)]
-  end
-
-  defp do_value_html_from_tuple(types, values) do
-    values_list =
-      values
-      |> Tuple.to_list()
-      |> Enum.with_index()
-      |> Enum.map(fn {value, i} ->
-        type = Enum.at(types, i)
-
-        case type do
-          :address ->
-            [_, {:safe, html_val}] = do_value_html(:address_text, value)
-            html_val
-
-          _ ->
-            [_, {:safe, html_val}] = do_value_html(type, value)
-            html_val
-        end
-      end)
-
-    Enum.join(values_list, ",")
   end
 
   defp base_value_html(_, {:dynamic, value}) do


### PR DESCRIPTION
## Motivation

### Changelog
- Now addresses in nested tuples in transaction's input are also links 
- Add :tuple clause for `apps\block_scout_web\lib\block_scout_web\views\abi_encoded_value_view.ex -> do_copy_text/2`
- Fix render bug in transaction's input

Before: 

![image](https://user-images.githubusercontent.com/32202610/125817647-776e9433-4496-4664-a734-00e698e825f0.png)

After:

![image](https://user-images.githubusercontent.com/32202610/125817768-531c2c34-b491-4233-a9e7-5b1698c24af1.png)

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
