### PR TITLE
Display search results categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4424](https://github.com/blockscout/blockscout/pull/4424) - Display search results categories
 - [#4423](https://github.com/blockscout/blockscout/pull/4423) - Add creation time of contract in the results of the search
 - [#4391](https://github.com/blockscout/blockscout/pull/4391) - Add batched transactions on the `address/{addressHash}/transactions` page
 - [#4353](https://github.com/blockscout/blockscout/pull/4353) - Added live-reload on the token holders page

--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -65,6 +65,9 @@ const resultItemElement = (item, data) => {
   item.innerHTML = `
   <span style="text-overflow: ellipsis; white-space: nowrap; overflow: hidden;">
     ${data.match}
+  </span>
+  <span style="display: flex; align-items: center; font-size: 13px; font-weight: 100; text-transform: uppercase; color: rgb(33,33,33);">
+    ${data.value.type}
   </span>`
 }
 const config = (id) => {

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1112,7 +1112,8 @@ defmodule Explorer.Chain do
               contract_address_hash: token.contract_address_hash,
               symbol: token.symbol,
               name: token.name,
-              holder_count: token.holder_count
+              holder_count: token.holder_count,
+              type: "token"
             },
             order_by: [desc: token.holder_count]
           )
@@ -1136,7 +1137,8 @@ defmodule Explorer.Chain do
             select: %{
               contract_address_hash: smart_contract.address_hash,
               name: smart_contract.name,
-              inserted_at: address.inserted_at
+              inserted_at: address.inserted_at,
+              type: "contract"
             },
             order_by: [desc: smart_contract.inserted_at]
           )


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/4379

## Motivation

Add display of category to which search result belongs

## Changelog

<img width="413" alt="Screenshot 2021-07-23 at 00 01 23" src="https://user-images.githubusercontent.com/4341812/126709141-4f77b1c9-c003-411e-a2b7-a686bb363616.png">


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
