### PR TITLE
Fix zero total supply bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4353](https://github.com/blockscout/blockscout/pull/4353) - Added live-reload on the token holders page
 
 ### Fixes
+- [#4429](https://github.com/blockscout/blockscout/pull/4429) - Fix 500 response on `/tokens/{addressHash}/token-holders?type=JSON` when total supply is zero
 - [#4419](https://github.com/blockscout/blockscout/pull/4419) - Order contracts in the search by inserted_at in descending order
 - [#4418](https://github.com/blockscout/blockscout/pull/4418) - Fix empty search results for the full-word search criteria
 - [#4406](https://github.com/blockscout/blockscout/pull/4406) - Fix internal server error on the validator's txs page

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/holder_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/holder_view.ex
@@ -33,6 +33,8 @@ defmodule BlockScoutWeb.Tokens.HolderView do
     "20.0000%"
 
   """
+  def total_supply_percentage(_, 0), do: "N/A%"
+
   def total_supply_percentage(value, total_supply) do
     result =
       value

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/holder_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/holder_view_test.exs
@@ -40,6 +40,13 @@ defmodule BlockScoutWeb.Tokens.HolderViewTest do
 
       assert HolderView.total_supply_percentage(value, total_supply) == "0.0005%"
     end
+
+    test "zero total_supply" do
+      %Token{total_supply: total_supply} = build(:token, total_supply: 0)
+      %TokenBalance{value: value} = build(:token_balance, value: 0)
+
+      assert HolderView.total_supply_percentage(value, total_supply) == "N/A%"
+    end
   end
 
   describe "format_token_balance_value/1" do


### PR DESCRIPTION
Close #4425 

## Changelog

### Bug Fixes
- Added clause for `total_supply_percentage/2`
- Added test for zero total supply case

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
