### PR TITLE
Fix current token balance on-demand fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#4353](https://github.com/blockscout/blockscout/pull/4353) - Added live-reload on the token holders page
 
 ### Fixes
+- [#4430](https://github.com/blockscout/blockscout/pull/4430) - Fix current token balance on-demand fetcher
 - [#4429](https://github.com/blockscout/blockscout/pull/4429) - Fix 500 response on `/tokens/{addressHash}/token-holders?type=JSON` when total supply is zero
 - [#4419](https://github.com/blockscout/blockscout/pull/4419) - Order contracts in the search by inserted_at in descending order
 - [#4418](https://github.com/blockscout/blockscout/pull/4418) - Fix empty search results for the full-word search criteria

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -65,6 +65,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
           %{}
           |> Map.put(:address_hash, stale_current_token_balance.address_hash)
           |> Map.put(:token_contract_address_hash, stale_current_token_balance.token_contract_address_hash)
+          |> Map.put(:token_type, stale_current_token_balance.token_type)
           |> Map.put(:block_number, block_number)
           |> Map.put(:value, Decimal.new(updated_balance))
           |> Map.put(:value_fetched_at, DateTime.utc_now())


### PR DESCRIPTION
## Motivation

On-demand token balance fetcher failed to update token balances in some cases.

## Changelog

The issue is because the update query in the DB is failing. It is failing because the updated object doesn't contain `token_type` property. This PR adds `token_type` to the updated object.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
