### PR TITLE
Fix error response in contract's output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
 
 ### Chore
+- [#4439](https://github.com/blockscout/blockscout/pull/4439) - Fix revert response in contract's output
 
 
 ## 3.7.2-beta

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_function_response.html.eex
@@ -1,10 +1,14 @@
 <div class="tile tile-muted tile-function-response monospace">
 <pre>
 [ <strong><%= @function_name %></strong> method Response ]
-
-[<%= for item <- @outputs do %>
-<%= if named_argument?(item) do %><span class="function-response-item"><%= item["name"] %></span><% end %>
-<span class="text-muted"><%= raw(values_with_type(item["value"], item["type"])) %></span>
-<% end %>]
+<%= case @outputs do %>
+    <% {:error, message} -> %>
+        <span class="text-muted"><%=raw(values_with_type(message, :error))%></span>
+    <% _ -> %>
+        [<%= for item <- @outputs do %>
+            <%= if named_argument?(item) do %><span class="function-response-item"><%= item["name"] %></span><% end %>
+            <span class="text-muted"><%= raw(values_with_type(item["value"], item["type"])) %></span>
+        <% end %>]
+<% end %>
 </pre>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -100,6 +100,8 @@ defmodule BlockScoutWeb.SmartContractView do
 
   def values_with_type(value, :bool, _components), do: render_type_value("bool", to_string(value))
 
+  def values_with_type(value, :error, _components), do: render_type_value("error", value)
+
   def values_with_type(value, type, _components) do
     render_type_value(type, binary_to_utf_string(value))
   end

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -450,10 +450,15 @@ defmodule Explorer.SmartContract.Reader do
 
   def link_outputs_and_values(blockchain_values, outputs, method_id) do
     default_value = Enum.map(outputs, fn _ -> "" end)
-    {_, value} = Map.get(blockchain_values, method_id, {:ok, default_value})
 
-    for {output, index} <- Enum.with_index(outputs) do
-      new_value(output, List.wrap(value), index)
+    case Map.get(blockchain_values, method_id, {:ok, default_value}) do
+      {:ok, value} ->
+        for {output, index} <- Enum.with_index(outputs) do
+          new_value(output, List.wrap(value), index)
+        end
+
+      {:error, message} ->
+        {:error, message}
     end
   end
 

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -357,6 +357,12 @@ defmodule Explorer.SmartContract.ReaderTest do
                }
              ] = Reader.link_outputs_and_values(blockchain_values, outputs, function_name)
     end
+
+    test "save error message" do
+      blockchain_values = %{"check" => {:error, "Reverted"}}
+
+      assert {:error, "Reverted"} == Reader.link_outputs_and_values(blockchain_values, [], "check")
+    end
   end
 
   defp blockchain_get_function_mock do


### PR DESCRIPTION
## Motivation
In some cases Revert response in contract's output did non printed

## Changelog

### Enhancements
- Added separate case for error mesages from smart-contract

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
