### PR TITLE
Unescape characters for string output type in the contract response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
 
 ### Chore

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -6,7 +6,7 @@ defmodule Explorer.SmartContract.Reader do
   [wiki](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI).
   """
 
-  alias EthereumJSONRPC.Contract
+  alias EthereumJSONRPC.{Contract, Encoder}
   alias Explorer.Chain
   alias Explorer.Chain.{Hash, SmartContract}
   alias Explorer.SmartContract.Helper
@@ -501,6 +501,14 @@ defmodule Explorer.SmartContract.Reader do
 
   defp new_value(%{"type" => :bytes} = output, values, index) do
     Map.put_new(output, "value", bytes_to_string(Enum.at(values, index)))
+  end
+
+  defp new_value(%{"type" => :string} = output, [value], _index) do
+    Map.put_new(output, "value", Encoder.unescape(value))
+  end
+
+  defp new_value(%{"type" => "string"} = output, [value], _index) do
+    Map.put_new(output, "value", Encoder.unescape(value))
   end
 
   defp new_value(output, [value], _index) do

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,6 +1,7 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
-export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+# export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+export CHROMEDRIVER_VERSION=`92.0.4515.43`
 curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
 unzip chromedriver_linux64.zip
 sudo chmod +x chromedriver


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/4445

## Motivation

Escaping of `\x` blocks decoding of UTF-8 encoded string in contract string type output.


## Changelog

Add `unescape` function taken from https://elixirforum.com/t/how-to-properly-convert-this-octal-encoded-utf16-be-string-to-utf8/33220/11 and implement it in the case of `string` output type.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
