### PR TITLE
URL encoding for NFT media files URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs
 - [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
 

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -154,7 +154,9 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
   end
 
   defp retrieve_image(image_url) do
-    compose_ipfs_url(image_url)
+    image_url
+    |> URI.encode()
+    |> compose_ipfs_url()
   end
 
   defp compose_ipfs_url(image_url) do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1332,7 +1332,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:176
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:178
 msgid "Metadata"
 msgstr ""
 
@@ -2247,7 +2247,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:175
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:177
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #: lib/block_scout_web/views/transaction_view.ex:405
 msgid "Token Transfers"

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1332,7 +1332,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:176
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:178
 msgid "Metadata"
 msgstr ""
 
@@ -2247,7 +2247,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:175
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:177
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #: lib/block_scout_web/views/transaction_view.ex:405
 msgid "Token Transfers"


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/4441

## Motivation

URLs for media assets are not properly encoded and might contain whitespaces and thus not all assets are displayed on the inventory tab or on the instance page:

<img width="1143" alt="Screenshot 2021-07-29 at 19 03 22" src="https://user-images.githubusercontent.com/4341812/127526071-d14191cd-0035-45cc-8832-2c1a5919fa33.png">


## Changelog

Add URL encoding before rendering an image or other media asset on the page.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
