### PR TITLE
Fix contract read page error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Chore
 - [#4444](https://github.com/blockscout/blockscout/pull/4444) - Main page performance cumulative update
-- [#4439](https://github.com/blockscout/blockscout/pull/4439) - Fix revert response in contract's output
+- [#4439](https://github.com/blockscout/blockscout/pull/4439), - [#4465](https://github.com/blockscout/blockscout/pull/4465) - Fix revert response in contract's output
 
 
 ## 3.7.2-beta

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -17,7 +17,12 @@ defmodule BlockScoutWeb.SmartContractView do
 
   def writable?(function) when is_nil(function), do: false
 
-  def outputs?(outputs) when not is_nil(outputs), do: Enum.any?(outputs)
+  def outputs?(outputs) when not is_nil(outputs) do
+    case outputs do
+      {:error, _} -> false
+      _ -> Enum.any?(outputs)
+    end
+  end
 
   def outputs?(outputs) when is_nil(outputs), do: false
 


### PR DESCRIPTION
## Motivation

```
Request: GET /smart-contracts?hash=0xb538938335f8f79a5879c6ce6682fc72de08c630&type=regular&action=read
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Enumerable not implemented for {:error, "(-32015) VM execution error. (Reverted 0x6c61737444617465206d75737420626520626967676572207468616e20666972737444617465)"} of type Tuple. This protocol is implemented for the following type(s): Indexer.BoundQueue, Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.Stream, DBConnection.PrepareStream, Timex.Interval, Flow, HashSet, Range, Map, Function, List, Stream, Date.Range, HashDict, GenEvent.Stream, MapSet, File.Stream, IO.Stream
        (elixir 1.11.4) lib/enum.ex:1: Enumerable.impl_for!/1
        (elixir 1.11.4) lib/enum.ex:141: Enumerable.reduce/3
        (elixir 1.11.4) lib/enum.ex:369: Enum.any?/2
        (block_scout_web 0.0.1) lib/block_scout_web/templates/smart_contract/_functions.html.eex:98: anonymous fn/3 in BlockScoutWeb.SmartContractView."_functions.html"/1
        (elixir 1.11.4) lib/enum.ex:2193: Enum."-reduce/3-lists^foldl/2-0-"/3
        (block_scout_web 0.0.1) lib/block_scout_web/templates/smart_contract/_functions.html.eex:31: BlockScoutWeb.SmartContractView."_functions.html"/1
        (phoenix 1.5.6) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.6) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/smart_contract_controller.ex:1: BlockScoutWeb.SmartContractController.phoenix_controller_pipeline/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.6) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 0.0.1) lib/plug/debugger.ex:136: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 0.0.1) lib/spandex_phoenix.ex:156: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.6) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.8.0) /Users/barrakuda/Documents/code/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.8.0) /Users/barrakuda/Documents/code/blockscout/deps/cowboy/src/cowboy_stream_h.erl:300: :cowboy_stream_h.execute/3
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
