### PR TITLE
Search autocomplete fix for address/block/tx hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 ### Fixes
-- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: Fix Cannot read property toLowerCase of undefined 
+- [#4473](https://github.com/blockscout/blockscout/pull/4473) - Search autocomplete: fix for address/block/tx hash
+- [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined 
 - [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs
 - [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount

--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -46,14 +46,29 @@ const searchEngine = (query, record) => {
   if (record && (
     (record.name && record.name.toLowerCase().includes(query.toLowerCase())) ||
       (record.symbol && record.symbol.toLowerCase().includes(query.toLowerCase())) ||
-      (record.contract_address_hash && record.contract_address_hash.toLowerCase().includes(query.toLowerCase()))
+      (record.contract_address_hash && record.contract_address_hash.toLowerCase().includes(query.toLowerCase())) ||
+      (record.transaction_hash && record.transaction_hash.toLowerCase().includes(query.toLowerCase())) ||
+      (record.address_hash && record.address_hash.toLowerCase().includes(query.toLowerCase())) ||
+      (record.block_hash && record.block_hash.toLowerCase().includes(query.toLowerCase()))
   )
   ) {
-    var searchResult = `${record.contract_address_hash}<br/>`
+    var searchResult = ''
+    if (record.type === 'transaction') {
+      searchResult += `${record.transaction_hash}<br/>`
+    } else if (record.type === 'address') {
+      searchResult += `${record.address_hash}<br/>`
+    } else if (record.type === 'block') {
+      searchResult += `${record.block_hash}<br/>`
+    } else {
+      searchResult += `${record.contract_address_hash}<br/>`
+    }
+
     if (record.type === 'label') {
       searchResult += `<div class="fontawesome-icon tag"></div><span> <b>${record.name}</b></span>`
     } else {
-      searchResult += `<b>${record.name}</b>`
+      if (record.name) {
+        searchResult += `<b>${record.name}</b>`
+      }
       if (record.symbol) {
         searchResult += ` (${record.symbol})`
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -100,7 +100,10 @@ defmodule BlockScoutWeb.ChainController do
   def token_autocomplete(conn, %{"q" => term}) when is_binary(term) do
     result_tokens = Chain.search_token(term)
     result_contracts = Chain.search_contract(term)
-    result = result_tokens ++ result_contracts
+    result_transactions = Chain.search_tx(term)
+    result_addresses = Chain.search_address(term)
+    result_blocks = Chain.search_block(term)
+    result = result_tokens ++ result_contracts ++ result_transactions ++ result_addresses ++ result_blocks
 
     json(conn, result)
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1150,6 +1150,63 @@ defmodule Explorer.Chain do
     end
   end
 
+  def search_tx(term) do
+    case Chain.string_to_transaction_hash(term) do
+      {:ok, tx_hash} ->
+        query =
+          from(transaction in Transaction,
+            where: transaction.hash == ^tx_hash,
+            select: %{
+              transaction_hash: transaction.hash,
+              type: "transaction"
+            }
+          )
+
+        Repo.all(query)
+
+      _ ->
+        []
+    end
+  end
+
+  def search_address(term) do
+    case Chain.string_to_address_hash(term) do
+      {:ok, address_hash} ->
+        query =
+          from(address in Address,
+            where: address.hash == ^address_hash,
+            select: %{
+              address_hash: address.hash,
+              type: "address"
+            }
+          )
+
+        Repo.all(query)
+
+      _ ->
+        []
+    end
+  end
+
+  def search_block(term) do
+    case Chain.string_to_block_hash(term) do
+      {:ok, block_hash} ->
+        query =
+          from(block in Block,
+            where: block.hash == ^block_hash,
+            select: %{
+              block_hash: block.hash,
+              type: "block"
+            }
+          )
+
+        Repo.all(query)
+
+      _ ->
+        []
+    end
+  end
+
   @doc """
   Converts `t:Explorer.Chain.Address.t/0` `hash` to the `t:Explorer.Chain.Address.t/0` with that `hash`.
 


### PR DESCRIPTION
## Motivation

Autocomplete displays 0 search result if searching by full address, tx or block hash:

<img width="493" alt="Screenshot 2021-07-30 at 12 29 26" src="https://user-images.githubusercontent.com/4341812/127878951-c547673e-1c9a-495f-a04f-254e2c87271a.png">


## Changelog

Add search by full tx/block/address hash to populate autocomplete.


## Checklist for your Pull Request (PR)


  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
