### PR TITLE
Fix autocomplete links to txs, blocks, addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [#4475](https://github.com/blockscout/blockscout/pull/4475) - Tx page facelifting
 
 ### Fixes
-- [#4473](https://github.com/blockscout/blockscout/pull/4473) - Search autocomplete: fix for address/block/tx hash
+- [#4473](https://github.com/blockscout/blockscout/pull/4473), [#4481](https://github.com/blockscout/blockscout/pull/4481) - Search autocomplete: fix for address/block/tx hash
 - [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined 
 - [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs
 - [#4453](https://github.com/blockscout/blockscout/pull/4453) - Unescape characters for string output type in the contract response

--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -135,7 +135,15 @@ const selection = (event) => {
   if (selectionValue.symbol) {
     window.location = `/tokens/${selectionValue.contract_address_hash}`
   } else {
-    window.location = `/address/${selectionValue.contract_address_hash}`
+    if (selectionValue.contract_address_hash) {
+      window.location = `/address/${selectionValue.contract_address_hash}`
+    } else if (selectionValue.address_hash) {
+      window.location = `/address/${selectionValue.address_hash}`
+    } else if (selectionValue.transaction_hash) {
+      window.location = `/tx/${selectionValue.transaction_hash}`
+    } else if (selectionValue.block_hash) {
+      window.location = `/blocks/${selectionValue.block_hash}`
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation

Broken link to address/tx/block in autocomplete


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
