### PR TITLE
Fix copy-paste typo in token_transfers_counter.ex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#4475](https://github.com/blockscout/blockscout/pull/4475) - Tx page facelifting
 
 ### Fixes
+- [#4483](https://github.com/blockscout/blockscout/pull/4483) - Fix copy-paste typo in `token_transfers_counter.ex`
 - [#4473](https://github.com/blockscout/blockscout/pull/4473), [#4481](https://github.com/blockscout/blockscout/pull/4481) - Search autocomplete: fix for address/block/tx hash
 - [#4472](https://github.com/blockscout/blockscout/pull/4472) - Search autocomplete: fix Cannot read property toLowerCase of undefined 
 - [#4456](https://github.com/blockscout/blockscout/pull/4456) - URL encoding for NFT media files URLs

--- a/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Counters.TokenTransfersCounter do
 
   alias Explorer.Chain
 
-  @cache_name :token_holders_counter
+  @cache_name :token_transfers_counter
   @last_update_key "last_update"
 
   @ets_opts [


### PR DESCRIPTION
## Motivation
There was a typo in `apps\explorer\lib\explorer\counters\token_transfers_counter.ex` . Names of caches in `token_transfers_counter.ex` and `token_holders_counter.ex` were the same.

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
