### PR TITLE
geth / puppeth support for multi-stage docker deployment

### DIFF
--- a/docker/geth/Dockerfile
+++ b/docker/geth/Dockerfile
@@ -1,0 +1,213 @@
+# This dockerfile will combine all the stuff needed by blockscout
+# into a single docker image for puppeth usage.
+# Components include: local geth, postgres.
+
+# Build go-ethereum
+FROM ethereum/client-go:latest as builder
+
+# Build postgres && blockscout
+FROM bitwalker/alpine-elixir-phoenix:1.11.4
+
+# postgres 13 build with llvm10 - alpine3.13
+# 70 is the standard uid/gid for "postgres" in Alpine
+# https://git.alpinelinux.org/aports/tree/main/postgresql/postgresql.pre-install?h=3.12-stable
+RUN set -eux; \
+	addgroup -g 70 -S postgres; \
+	adduser -u 70 -S -D -G postgres -H -h /var/lib/postgresql -s /bin/sh postgres; \
+	mkdir -p /var/lib/postgresql; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+# su-exec (gosu-compatible) is installed further down
+
+# make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
+# alpine doesn't require explicit locale-file generation
+ENV LANG en_US.utf8
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+ENV PG_MAJOR 13
+ENV PG_VERSION 13.3
+ENV PG_SHA256 3cd9454fa8c7a6255b6743b767700925ead1b9ab0d7a0f9dcb1151010f8eb4a1
+
+RUN set -eux; \
+	\
+	wget -O postgresql.tar.bz2 "https://ftp.postgresql.org/pub/source/v$PG_VERSION/postgresql-$PG_VERSION.tar.bz2"; \
+	echo "$PG_SHA256 *postgresql.tar.bz2" | sha256sum -c -; \
+	mkdir -p /usr/src/postgresql; \
+	tar \
+		--extract \
+		--file postgresql.tar.bz2 \
+		--directory /usr/src/postgresql \
+		--strip-components 1 \
+	; \
+	rm postgresql.tar.bz2; \
+	\
+	apk add --no-cache --virtual .build-deps \
+		bison \
+		coreutils \
+		dpkg-dev dpkg \
+		flex \
+		gcc \
+#		krb5-dev \
+		libc-dev \
+		libedit-dev \
+		libxml2-dev \
+		libxslt-dev \
+		linux-headers \
+		llvm10-dev clang g++ \
+		make \
+#		openldap-dev \
+		openssl-dev \
+# configure: error: prove not found
+		perl-utils \
+# configure: error: Perl module IPC::Run is required to run TAP tests
+		perl-ipc-run \
+#		perl-dev \
+#		python-dev \
+#		python3-dev \
+#		tcl-dev \
+		util-linux-dev \
+		zlib-dev \
+# https://www.postgresql.org/docs/10/static/release-10.html#id-1.11.6.9.5.13
+		icu-dev \
+	; \
+	\
+	cd /usr/src/postgresql; \
+# update "DEFAULT_PGSOCKET_DIR" to "/var/run/postgresql" (matching Debian)
+# see https://anonscm.debian.org/git/pkg-postgresql/postgresql.git/tree/debian/patches/51-default-sockets-in-var.patch?id=8b539fcb3e093a521c095e70bdfa76887217b89f
+	awk '$1 == "#define" && $2 == "DEFAULT_PGSOCKET_DIR" && $3 == "\"/tmp\"" { $3 = "\"/var/run/postgresql\""; print; next } { print }' src/include/pg_config_manual.h > src/include/pg_config_manual.h.new; \
+	grep '/var/run/postgresql' src/include/pg_config_manual.h.new; \
+	mv src/include/pg_config_manual.h.new src/include/pg_config_manual.h; \
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+# explicitly update autoconf config.guess and config.sub so they support more arches/libcs
+	wget -O config/config.guess 'https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+	wget -O config/config.sub 'https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=7d3d27baf8107b630586c962c057e22149653deb'; \
+# configure options taken from:
+# https://anonscm.debian.org/cgit/pkg-postgresql/postgresql.git/tree/debian/rules?h=9.5
+	./configure \
+		--build="$gnuArch" \
+# "/usr/src/postgresql/src/backend/access/common/tupconvert.c:105: undefined reference to `libintl_gettext'"
+#		--enable-nls \
+		--enable-integer-datetimes \
+		--enable-thread-safety \
+		--enable-tap-tests \
+# skip debugging info -- we want tiny size instead
+#		--enable-debug \
+		--disable-rpath \
+		--with-uuid=e2fs \
+		--with-gnu-ld \
+		--with-pgport=5432 \
+		--with-system-tzdata=/usr/share/zoneinfo \
+		--prefix=/usr/local \
+		--with-includes=/usr/local/include \
+		--with-libraries=/usr/local/lib \
+		\
+# these make our image abnormally large (at least 100MB larger), which seems uncouth for an "Alpine" (ie, "small") variant :)
+#		--with-krb5 \
+#		--with-gssapi \
+#		--with-ldap \
+#		--with-tcl \
+#		--with-perl \
+#		--with-python \
+#		--with-pam \
+		--with-openssl \
+		--with-libxml \
+		--with-libxslt \
+		--with-icu \
+		--with-llvm \
+	; \
+	make -j "$(nproc)" world; \
+	make install-world; \
+	make -C contrib install; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --no-cache --virtual .postgresql-rundeps \
+		$runDeps \
+		bash \
+		su-exec \
+# tzdata is optional, but only adds around 1Mb to image size and is recommended by Django documentation:
+# https://docs.djangoproject.com/en/1.10/ref/databases/#optimizing-postgresql-s-configuration
+		tzdata \
+	; \
+	apk del --no-network .build-deps; \
+	cd /; \
+	rm -rf \
+		/usr/src/postgresql \
+		/usr/local/share/doc \
+		/usr/local/share/man \
+	; \
+	\
+	postgres --version
+
+# make the sample config easier to munge (and "correct by default")
+RUN set -eux; \
+	cp -v /usr/local/share/postgresql/postgresql.conf.sample /usr/local/share/postgresql/postgresql.conf.sample.orig; \
+	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/local/share/postgresql/postgresql.conf.sample; \
+	grep -F "listen_addresses = '*'" /usr/local/share/postgresql/postgresql.conf.sample
+
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
+
+ENV PGDATA /var/lib/postgresql/data
+# this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA"
+VOLUME /var/lib/postgresql/data
+
+RUN wget https://raw.githubusercontent.com/docker-library/postgres/master/$PG_MAJOR/alpine/docker-entrypoint.sh -O /usr/local/bin/docker-entrypoint.sh && \
+    chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Get Rust - mix build requires rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+ENV RUSTFLAGS="-C target-feature=-crt-static"
+
+# Build blockscout
+RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3 file
+
+# Cache elixir deps
+ADD mix.exs mix.lock ./
+ADD apps/block_scout_web/mix.exs ./apps/block_scout_web/
+ADD apps/explorer/mix.exs ./apps/explorer/
+ADD apps/ethereum_jsonrpc/mix.exs ./apps/ethereum_jsonrpc/
+ADD apps/indexer/mix.exs ./apps/indexer/
+RUN mix do deps.get, local.rebar --force, deps.compile
+
+ADD . .
+
+# Run forderground build and phoenix digest
+RUN mix compile
+
+# Add blockscout npm deps
+RUN cd apps/block_scout_web/assets/ && \
+    npm install && \
+    npm run deploy && \
+    cd -
+
+RUN cd apps/explorer/ && \
+    npm install && \
+    apk update && apk del --force-broken-world alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3
+
+RUN mix phx.digest
+
+ENV PORT=4000 \
+    MIX_ENV="prod" \
+    SECRET_KEY_BASE="RMgI4C1HSkxsEjdhtGMfwAHfyT6CKWXOgzCboJflfSm4jeAlic52io05KB6mqzc5" \
+    ETHEREUM_JSONRPC_VARIANT="geth" \
+    ETHEREUM_JSONRPC_HTTP_URL="http://localhost:8545" \
+    ETHEREUM_JSONRPC_WS_URL="ws://localhost:8546" \ 
+    DATABASE_URL="postgresql://postgres:@localhost:5432/explorer?ssl=false" \
+    POSTGRES_PASSWORD=\
+    POSTGRES_USER=postgres\
+    SUBNETWORK=\
+    COIN="ETH"\
+    POSTGRES_HOST_AUTH_METHOD="trust"
+
+COPY --from=builder /usr/local/bin/geth /usr/local/bin
+
+EXPOSE 5432 4000
+


### PR DESCRIPTION
This deploys postgres 13.3 in an alpine 3.13 MUSL environment for lightweight variant of blockscout intended to deploy through docker containers pulling in this image to launch blockscout. Such an example can be seen here: https://github.com/sidhujag/go-ethereum/blob/nevm/cmd/puppeth/module_explorer.go#L34 of how to deploy blockscout using this docker setup

## Motivation

Geth docker support

Question to the blockscout team, would you be open to pushing this docker file to docker hub as the official account (https://hub.docker.com/u/blockscout) this would mean integrating this docker into your release processes to update to latest versions of blockscout.

Relates to #4480 