### PR TITLE
parse base fee from eth RPC

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -19,7 +19,6 @@ defmodule EthereumJSONRPC.Block do
           miner_hash: EthereumJSONRPC.hash(),
           mix_hash: EthereumJSONRPC.hash(),
           nonce: EthereumJSONRPC.hash(),
-          base_fee_per_gas: non_neg_integer(),
           number: non_neg_integer(),
           parent_hash: EthereumJSONRPC.hash(),
           receipts_root: EthereumJSONRPC.hash(),
@@ -46,7 +45,6 @@ defmodule EthereumJSONRPC.Block do
    * `"mixHash"` - Generated from [DAG](https://ethereum.stackexchange.com/a/10353) as part of Proof-of-Work for EthHash
      algorithm.  **[Geth](https://github.com/ethereum/go-ethereum/wiki/geth) + Proof-of-Work-only**
    * `"nonce"` -  `t:EthereumJSONRPC.nonce/0`. `nil` when its pending block.
-   * `"baseFeePerGas"` -  `t:EthereumJSONRPC.quantity/0` EIP1559 base fee for this block.
    * `"number"` - the block number `t:EthereumJSONRPC.quantity/0`. `nil` when block is pending.
    * `"parentHash" - the `t:EthereumJSONRPC.hash/0` of the parent block.
    * `"receiptsRoot"` - `t:EthereumJSONRPC.hash/0` of the root of the receipts.
@@ -202,7 +200,6 @@ defmodule EthereumJSONRPC.Block do
           "hash" => hash,
           "logsBloom" => logs_bloom,
           "miner" => miner_hash,
-          "baseFeePerGas" => base_fee_per_gas,
           "number" => number,
           "parentHash" => parent_hash,
           "receiptsRoot" => receipts_root,
@@ -225,7 +222,6 @@ defmodule EthereumJSONRPC.Block do
       miner_hash: miner_hash,
       mix_hash: Map.get(elixir, "mixHash", "0x0"),
       nonce: Map.get(elixir, "nonce", 0),
-      base_fee_per_gas: base_fee_per_gas,
       number: number,
       parent_hash: parent_hash,
       receipts_root: receipts_root,
@@ -248,7 +244,6 @@ defmodule EthereumJSONRPC.Block do
           "gasUsed" => gas_used,
           "hash" => hash,
           "logsBloom" => logs_bloom,
-          "baseFeePerGas" => base_fee_per_gas,
           "miner" => miner_hash,
           "number" => number,
           "parentHash" => parent_hash,
@@ -271,7 +266,6 @@ defmodule EthereumJSONRPC.Block do
       miner_hash: miner_hash,
       mix_hash: Map.get(elixir, "mixHash", "0x0"),
       nonce: Map.get(elixir, "nonce", 0),
-      base_fee_per_gas: base_fee_per_gas,
       number: number,
       parent_hash: parent_hash,
       receipts_root: receipts_root,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -19,6 +19,7 @@ defmodule EthereumJSONRPC.Block do
           miner_hash: EthereumJSONRPC.hash(),
           mix_hash: EthereumJSONRPC.hash(),
           nonce: EthereumJSONRPC.hash(),
+          base_fee_per_gas: non_neg_integer(),
           number: non_neg_integer(),
           parent_hash: EthereumJSONRPC.hash(),
           receipts_root: EthereumJSONRPC.hash(),
@@ -45,6 +46,7 @@ defmodule EthereumJSONRPC.Block do
    * `"mixHash"` - Generated from [DAG](https://ethereum.stackexchange.com/a/10353) as part of Proof-of-Work for EthHash
      algorithm.  **[Geth](https://github.com/ethereum/go-ethereum/wiki/geth) + Proof-of-Work-only**
    * `"nonce"` -  `t:EthereumJSONRPC.nonce/0`. `nil` when its pending block.
+   * `"baseFeePerGas"` -  `t:EthereumJSONRPC.quantity/0` EIP1559 base fee for this block.
    * `"number"` - the block number `t:EthereumJSONRPC.quantity/0`. `nil` when block is pending.
    * `"parentHash" - the `t:EthereumJSONRPC.hash/0` of the parent block.
    * `"receiptsRoot"` - `t:EthereumJSONRPC.hash/0` of the root of the receipts.
@@ -200,6 +202,7 @@ defmodule EthereumJSONRPC.Block do
           "hash" => hash,
           "logsBloom" => logs_bloom,
           "miner" => miner_hash,
+          "baseFeePerGas" => base_fee_per_gas,
           "number" => number,
           "parentHash" => parent_hash,
           "receiptsRoot" => receipts_root,
@@ -222,6 +225,7 @@ defmodule EthereumJSONRPC.Block do
       miner_hash: miner_hash,
       mix_hash: Map.get(elixir, "mixHash", "0x0"),
       nonce: Map.get(elixir, "nonce", 0),
+      base_fee_per_gas: base_fee_per_gas,
       number: number,
       parent_hash: parent_hash,
       receipts_root: receipts_root,
@@ -244,6 +248,7 @@ defmodule EthereumJSONRPC.Block do
           "gasUsed" => gas_used,
           "hash" => hash,
           "logsBloom" => logs_bloom,
+          "baseFeePerGas" => base_fee_per_gas,
           "miner" => miner_hash,
           "number" => number,
           "parentHash" => parent_hash,
@@ -266,6 +271,7 @@ defmodule EthereumJSONRPC.Block do
       miner_hash: miner_hash,
       mix_hash: Map.get(elixir, "mixHash", "0x0"),
       nonce: Map.get(elixir, "nonce", 0),
+      base_fee_per_gas: base_fee_per_gas,
       number: number,
       parent_hash: parent_hash,
       receipts_root: receipts_root,
@@ -480,7 +486,7 @@ defmodule EthereumJSONRPC.Block do
   end
 
   defp entry_to_elixir({key, quantity})
-       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice number size cumulativeDifficulty totalDifficulty paidFees) and
+       when key in ~w(difficulty gasLimit gasUsed minimumGasPrice baseFeePerGas number size cumulativeDifficulty totalDifficulty paidFees) and
               not is_nil(quantity) do
     {key, quantity_to_integer(quantity)}
   end


### PR DESCRIPTION
## Motivation
This will parse blocks from RPC which are expected ot have a base fee field post London hard fork (EIP1559). Without this blocks will not parse.

This does not add base fee field to database or surface it to the Transaction view as that is out of scope for this PR, doing so would require language additions of "Base Fee" as well as View/Database updates and some integration/functional tests. I left that for the blockscout team after initially trying (and failing) due to not understanding how to integrate a new field into the database. I am sure I can figure it out if needed as I can learn it but I am new to the codebase and the coded language here so I left it out.

Related to #4480 