### PR TITLE
Fix 500 response on empty contract's code page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4452](https://github.com/blockscout/blockscout/pull/4452) - Add names for smart-conrtact's function response
 
 ### Fixes
+- [#4493](https://github.com/blockscout/blockscout/pull/4493) - Contract's code page: handle null contracts_creation_transaction
 - [#4488](https://github.com/blockscout/blockscout/pull/4488) - Tx page: handle empty to_address
 - [#4483](https://github.com/blockscout/blockscout/pull/4483) - Fix copy-paste typo in `token_transfers_counter.ex`
 - [#4473](https://github.com/blockscout/blockscout/pull/4473), [#4481](https://github.com/blockscout/blockscout/pull/4481) - Search autocomplete: fix for address/block/tx hash

--- a/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
@@ -127,6 +127,10 @@ defmodule BlockScoutWeb.AddressContractView do
     address.contracts_creation_transaction.input
   end
 
+  def creation_code(%Address{contracts_creation_transaction: nil}) do
+    nil
+  end
+
   def sourcify_repo_url(address_hash, partial_match) do
     checksummed_hash = Address.checksum(address_hash)
     chain_id = Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:chain_id]


### PR DESCRIPTION
## Motivation
```
Request: GET /address/0xB06e22E06C5Cc68011f8901A7F1F543d0A7adF8B/contracts
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in BlockScoutWeb.AddressContractView.creation_code/1
        (block_scout_web 0.0.1) lib/block_scout_web/views/address_contract_view.ex:122: BlockScoutWeb.AddressContractView.creation_code(%Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, contract_code: %Explorer.Chain.Data{bytes: ""}, contracts_creation_internal_transaction: nil, contracts_creation_transaction: nil, decompiled: false, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, fetched_coin_balance: #Explorer.Chain.Wei<0>, fetched_coin_balance_block_number: 22171247, has_decompiled_code?: nil, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<176, 110, 34, 224, 108, 92, 198, 128, 17, 248, 144, 26, 127, 31, 84, 61, 10, 122, 223, 139>>}, inserted_at: ~U[2021-08-07 09:56:59.235000Z], names: [], nonce: nil, smart_contract: nil, smart_contract_additional_sources: [], stale?: nil, token: nil, updated_at: ~U[2021-08-07 09:56:59.235000Z], verified: false})
        (block_scout_web 0.0.1) lib/block_scout_web/templates/address_contract/index.html.eex:143: BlockScoutWeb.AddressContractView."index.html"/1
        (phoenix 1.5.6) lib/phoenix/view.ex:310: Phoenix.View.render_within/3
        (phoenix 1.5.6) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.6) lib/phoenix/controller.ex:776: Phoenix.Controller.render_and_send/4
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_contract_controller.ex:2: BlockScoutWeb.AddressContractController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/address_contract_controller.ex:2: BlockScoutWeb.AddressContractController.phoenix_controller_pipeline/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.6) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.6) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 0.0.1) lib/plug/debugger.ex:136: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 0.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 0.0.1) lib/spandex_phoenix.ex:156: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.6) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.8.0) e:/blocksckout/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.8.0) e:/blocksckout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:300: :cowboy_stream_h.execute/3
        (cowboy 2.8.0) e:/blocksckout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:291: :cowboy_stream_h.request_process/3
        (stdlib 3.14.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
