### PR TITLE
Handle error in fetch_validators_list method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#4401](https://github.com/blockscout/blockscout/pull/4401) - Fix displaying of token holders with the same amount
 
 ### Chore
+- [#4497](https://github.com/blockscout/blockscout/pull/4497) - Handle error in fetch_validators_list method
 - [#4444](https://github.com/blockscout/blockscout/pull/4444) - Main page performance cumulative update
 - [#4439](https://github.com/blockscout/blockscout/pull/4439), - [#4465](https://github.com/blockscout/blockscout/pull/4465) - Fix revert response in contract's output
 

--- a/apps/explorer/lib/explorer/validator/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/validator/metadata_retriever.ex
@@ -17,12 +17,12 @@ defmodule Explorer.Validator.MetadataRetriever do
 
   defp fetch_validators_list do
     # b7ab4db5 = keccak256(getValidators())
-    %{"b7ab4db5" => {:ok, [validators]}} =
-      Reader.query_contract(config(:validators_contract_address), contract_abi("validators.json"), %{
-        "b7ab4db5" => []
-      })
-
-    validators
+    case Reader.query_contract(config(:validators_contract_address), contract_abi("validators.json"), %{
+           "b7ab4db5" => []
+         }) do
+      %{"b7ab4db5" => {:ok, [validators]}} -> validators
+      _ -> []
+    end
   end
 
   defp fetch_validator_metadata(validator_address) do

--- a/apps/explorer/test/explorer/validator/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/validator/metadata_retriever_test.exs
@@ -68,11 +68,6 @@ defmodule Explorer.Validator.MetadataRetrieverTest do
       assert MetadataRetriever.fetch_data() == expected
     end
 
-    test "raise error when the first contract call fails" do
-      contract_request_with_error()
-      assert_raise(MatchError, fn -> MetadataRetriever.fetch_data() end)
-    end
-
     test "raise error when a call to the metadata contract fails" do
       single_validator_in_list_mox_ok()
       contract_request_with_error()


### PR DESCRIPTION
## Motivation

Error response from `fetch_validators_list` method is not handled.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
