### PR TITLE
Fix routes: add NETWORK_PATH variable to current_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4452](https://github.com/blockscout/blockscout/pull/4452) - Add names for smart-conrtact's function response
 
 ### Fixes
+- [#4513](https://github.com/blockscout/blockscout/pull/4513) - Fix installation with custom default path: add NETWORK_PATH variable to the current_path
 - [#4500](https://github.com/blockscout/blockscout/pull/4500) - `/tokens/{addressHash}/instance/{id}/token-transfers`: fix incorrect next page url
 - [#4493](https://github.com/blockscout/blockscout/pull/4493) - Contract's code page: handle null contracts_creation_transaction
 - [#4488](https://github.com/blockscout/blockscout/pull/4488) - Tx page: handle empty to_address

--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -122,7 +122,7 @@ const autoCompleteJSMobile = new AutoComplete(config('main-search-autocomplete-m
 const selection = (event) => {
   const selectionValue = event.detail.selection.value
 
-  if (selectionValue.type === 'contract' || selectionValue.type === 'address') {
+  if (selectionValue.type === 'contract' || selectionValue.type === 'address' || selectionValue.type === 'label') {
     window.location = `/address/${selectionValue.address_hash}`
   } else if (selectionValue.type === 'token') {
     window.location = `/tokens/${selectionValue.address_hash}`

--- a/apps/block_scout_web/lib/block_scout_web/checksum_address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/checksum_address.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.ChecksumAddress do
 
   import Plug.Conn
 
+  alias BlockScoutWeb.Controller, as: BlockScoutWebController
   alias Explorer.Chain
   alias Explorer.Chain.Address
   alias Phoenix.Controller
@@ -41,7 +42,7 @@ defmodule BlockScoutWeb.ChecksumAddress do
               end
 
             conn
-            |> Controller.redirect(to: new_path)
+            |> Controller.redirect(to: new_path |> BlockScoutWebController.full_path())
             |> halt
           else
             conn

--- a/apps/block_scout_web/lib/block_scout_web/controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controller.ex
@@ -34,4 +34,25 @@ defmodule BlockScoutWeb.Controller do
       [] -> false
     end
   end
+
+  def current_full_path(conn) do
+    current_path = current_path(conn)
+
+    full_path(current_path)
+  end
+
+  def full_path(path) do
+    url_params = Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url]
+    network_path = url_params[:path]
+
+    if network_path do
+      if path =~ network_path do
+        path
+      else
+        network_path <> path
+      end
+    else
+      path
+    end
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, AddressCoinBalanceView}
+  alias BlockScoutWeb.{AccessHelpers, AddressCoinBalanceView, Controller}
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
   alias Explorer.ExchangeRates.Token
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
         address: address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)})
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.API.RPC.ContractController
+  alias BlockScoutWeb.Controller
   alias Ecto.Changeset
   alias Explorer.Chain
   alias Explorer.Chain.Events.Publisher, as: EventsPublisher
@@ -11,7 +12,12 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
 
   def new(conn, %{"address_id" => address_hash_string}) do
     if Chain.smart_contract_fully_verified?(address_hash_string) do
-      redirect(conn, to: address_path(conn, :show, address_hash_string))
+      address_path =
+        conn
+        |> address_path(:show, address_hash_string)
+        |> Controller.full_path()
+
+      redirect(conn, to: address_path)
     else
       changeset =
         SmartContract.changeset(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_flattened_code_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_flattened_code_controller.ex
@@ -1,13 +1,19 @@
 defmodule BlockScoutWeb.AddressContractVerificationViaFlattenedCodeController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.Controller
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
   alias Explorer.SmartContract.{PublisherWorker, Solidity.CodeCompiler, Solidity.CompilerVersion}
 
   def new(conn, %{"address_id" => address_hash_string}) do
     if Chain.smart_contract_fully_verified?(address_hash_string) do
-      redirect(conn, to: address_path(conn, :show, address_hash_string))
+      address_path =
+        conn
+        |> address_path(:show, address_hash_string)
+        |> Controller.full_path()
+
+      redirect(conn, to: address_path)
     else
       changeset =
         SmartContract.changeset(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_via_json_controller.ex
@@ -2,18 +2,24 @@ defmodule BlockScoutWeb.AddressContractVerificationViaJsonController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
+  alias BlockScoutWeb.Controller
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
   alias Explorer.ThirdPartyIntegrations.Sourcify
 
   def new(conn, %{"address_id" => address_hash_string}) do
+    address_path =
+      conn
+      |> address_path(:show, address_hash_string)
+      |> Controller.full_path()
+
     if Chain.smart_contract_fully_verified?(address_hash_string) do
-      redirect(conn, to: address_path(conn, :show, address_hash_string))
+      redirect(conn, to: address_path)
     else
       case Sourcify.check_by_address(address_hash_string) do
         {:ok, _verified_status} ->
           VerificationController.get_metadata_and_publish(address_hash_string, conn)
-          redirect(conn, to: address_path(conn, :show, address_hash_string))
+          redirect(conn, to: address_path)
 
         _ ->
           changeset =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.AddressController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, AddressView}
+  alias BlockScoutWeb.{AccessHelpers, AddressView, Controller}
   alias Explorer.Counters.{AddressTransactionsCounter, AddressTransactionsGasUsageCounter}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
@@ -71,7 +71,7 @@ defmodule BlockScoutWeb.AddressController do
     total_supply = Chain.total_supply()
 
     render(conn, "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       address_count: Chain.address_estimated_count(),
       total_supply: total_supply
     )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_internal_transaction_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionController do
 
   import BlockScoutWeb.Chain, only: [current_filter: 1, paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, InternalTransactionView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, InternalTransactionView}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Indexer.Fetcher.CoinBalanceOnDemand
@@ -72,7 +72,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionController do
         "index.html",
         address: address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         filter: params["filter"],
         counters_path: address_path(conn, :address_counters, %{"id" => address_hash_string})

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_logs_controller.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.AddressLogsController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, AddressLogsView}
+  alias BlockScoutWeb.{AccessHelpers, AddressLogsView, Controller}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Indexer.Fetcher.CoinBalanceOnDemand
@@ -61,7 +61,7 @@ defmodule BlockScoutWeb.AddressLogsController do
         conn,
         "index.html",
         address: address,
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         counters_path: address_path(conn, :address_counters, %{"id" => address_hash_string})

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.AddressTokenController do
 
   import BlockScoutWeb.Chain, only: [next_page_params: 3, paging_options: 1, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, AddressTokenView}
+  alias BlockScoutWeb.{AccessHelpers, AddressTokenView, Controller}
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
   alias Explorer.ExchangeRates.Token
@@ -66,7 +66,7 @@ defmodule BlockScoutWeb.AddressTokenController do
         conn,
         "index.html",
         address: address,
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)})

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.AddressTokenTransferController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.{AccessHelpers, TransactionView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, TransactionView}
   alias Explorer.ExchangeRates.Token
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
@@ -104,7 +104,7 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
         address: address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         token: token,
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)})
       )
@@ -196,7 +196,7 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         filter: params["filter"],
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)})
       )
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
 
   import BlockScoutWeb.Chain, only: [current_filter: 1, paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, TransactionView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, TransactionView}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Indexer.Fetcher.CoinBalanceOnDemand
@@ -108,7 +108,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         filter: params["filter"],
         counters_path: address_path(conn, :address_counters, %{"id" => address_hash_string}),
-        current_path: current_path(conn)
+        current_path: Controller.current_full_path(conn)
       )
     else
       :error ->
@@ -131,7 +131,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
               exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
               filter: params["filter"],
               counters_path: address_path(conn, :address_counters, %{"id" => address_hash_string}),
-              current_path: current_path(conn)
+              current_path: Controller.current_full_path(conn)
             )
 
           _ ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.AddressValidationController do
   import BlockScoutWeb.Chain,
     only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, BlockView}
+  alias BlockScoutWeb.{AccessHelpers, BlockView, Controller}
   alias Explorer.ExchangeRates.Token
   alias Explorer.{Chain, Market}
   alias Indexer.Fetcher.CoinBalanceOnDemand
@@ -77,7 +77,7 @@ defmodule BlockScoutWeb.AddressValidationController do
         "index.html",
         address: address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         counters_path: address_path(conn, :address_counters, %{"id" => address_hash_string}),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null()
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.BlockController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.BlockView
+  alias BlockScoutWeb.{BlockView, Controller}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -29,7 +29,12 @@ defmodule BlockScoutWeb.BlockController do
   end
 
   def show(conn, %{"hash_or_number" => hash_or_number}) do
-    redirect(conn, to: block_transaction_path(conn, :index, hash_or_number))
+    block_transaction_path =
+      conn
+      |> block_transaction_path(:index, hash_or_number)
+      |> Controller.full_path()
+
+    redirect(conn, to: block_transaction_path)
   end
 
   def reorg(conn, params) do
@@ -104,7 +109,7 @@ defmodule BlockScoutWeb.BlockController do
 
   defp handle_render(full_options, conn, _params) do
     render(conn, "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       block_type: Keyword.get(full_options, :block_type, "Block")
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -6,7 +6,7 @@ defmodule BlockScoutWeb.BlockTransactionController do
 
   import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2, string_to_block_hash: 1]
 
-  alias BlockScoutWeb.TransactionView
+  alias BlockScoutWeb.{Controller, TransactionView}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -110,7 +110,7 @@ defmodule BlockScoutWeb.BlockTransactionController do
           "index.html",
           block: block,
           block_transaction_count: block_transaction_count,
-          current_path: current_path(conn)
+          current_path: Controller.current_full_path(conn)
         )
 
       {:error, {:invalid, :hash}} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.TransactionView
+  alias BlockScoutWeb.{Controller, TransactionView}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -57,7 +57,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
   end
 
   def index(conn, _params) do
-    render(conn, "index.html", current_path: current_path(conn))
+    render(conn, "index.html", current_path: Controller.current_full_path(conn))
   end
 
   defp get_pending_transactions_and_next_page(options) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.SearchController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{ChainController, SearchView}
+  alias BlockScoutWeb.{ChainController, Controller, SearchView}
   alias Phoenix.View
 
   def search_results(conn, %{"q" => query, "type" => "JSON"} = params) do
@@ -61,7 +61,7 @@ defmodule BlockScoutWeb.SearchController do
       conn,
       "results.html",
       query: query,
-      current_path: current_path(conn)
+      current_path: Controller.current_full_path(conn)
     )
   end
 
@@ -70,7 +70,7 @@ defmodule BlockScoutWeb.SearchController do
       conn,
       "results.html",
       query: nil,
-      current_path: current_path(conn)
+      current_path: Controller.current_full_path(conn)
     )
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/stakes_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.StakesController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.StakesView
+  alias BlockScoutWeb.{Controller, StakesView}
   alias Explorer.Chain
   alias Explorer.Chain.{Cache.BlockNumber, Hash, Token}
   alias Explorer.Counters.AverageBlockTime
@@ -172,7 +172,7 @@ defmodule BlockScoutWeb.StakesController do
       top: render_top(conn),
       token: token,
       pools_type: filter,
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       average_block_time: AverageBlockTime.average_block_time(),
       refresh_interval: Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:staking_pool_list_refresh_interval]
     )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/bridged_tokens_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.BridgedTokensView
+  alias BlockScoutWeb.{BridgedTokensView, Controller}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -17,7 +17,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
 
   def show(conn, %{"id" => "eth"}) do
     render(conn, "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       chain: "Ethereum",
       chain_id: 1,
       destination: :eth
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
 
   def show(conn, %{"id" => "bsc"}) do
     render(conn, "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       chain: "Binance Smart Chain",
       chain_id: 56,
       destination: :bsc
@@ -43,7 +43,7 @@ defmodule BlockScoutWeb.BridgedTokensController do
 
   def index(conn, _params) do
     render(conn, "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       chain: "Ethereum",
       chain_id: 1,
       destination: :eth

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.Tokens.HolderController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.AccessHelpers
+  alias BlockScoutWeb.{AccessHelpers, Controller}
   alias BlockScoutWeb.Tokens.HolderView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
@@ -61,7 +61,7 @@ defmodule BlockScoutWeb.Tokens.HolderController do
       render(
         conn,
         "index.html",
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         token: Market.add_price(token),
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)})
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/metadata_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/metadata_controller.ex
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.Tokens.Instance.MetadataController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.Controller
   alias Explorer.{Chain, Market}
 
   def index(conn, %{"token_id" => token_address_hash, "instance_id" => token_id}) do
@@ -15,7 +16,7 @@ defmodule BlockScoutWeb.Tokens.Instance.MetadataController do
           conn,
           "index.html",
           token_instance: token_transfer,
-          current_path: current_path(conn),
+          current_path: Controller.current_full_path(conn),
           token: Market.add_price(token),
           total_token_transfers: Chain.count_token_transfers_from_token_hash_and_token_id(hash, token_id)
         )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.Tokens.Instance.TransferController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.Controller
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
@@ -63,7 +64,7 @@ defmodule BlockScoutWeb.Tokens.Instance.TransferController do
         conn,
         "index.html",
         token_instance: token_transfer,
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         token: Market.add_price(token),
         total_token_transfers: Chain.count_token_transfers_from_token_hash_and_token_id(hash, token_id)
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance_controller.ex
@@ -1,13 +1,19 @@
 defmodule BlockScoutWeb.Tokens.InstanceController do
   use BlockScoutWeb, :controller
 
+  alias BlockScoutWeb.Controller
   alias Explorer.Chain
 
   def show(conn, %{"token_id" => token_address_hash, "id" => token_id}) do
     with {:ok, hash} <- Chain.string_to_address_hash(token_address_hash),
          :ok <- Chain.check_token_exists(hash),
          :ok <- Chain.check_erc721_token_instance_exists(token_id, hash) do
-      redirect(conn, to: token_instance_transfer_path(conn, :index, token_address_hash, token_id))
+      token_instance_transfer_path =
+        conn
+        |> token_instance_transfer_path(:index, token_address_hash, token_id)
+        |> Controller.full_path()
+
+      redirect(conn, to: token_instance_transfer_path)
     else
       _ ->
         not_found(conn)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/inventory_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.Tokens.InventoryController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.AccessHelpers
+  alias BlockScoutWeb.{AccessHelpers, Controller}
   alias BlockScoutWeb.Tokens.InventoryView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.{Address, TokenTransfer}
@@ -75,7 +75,7 @@ defmodule BlockScoutWeb.Tokens.InventoryController do
       render(
         conn,
         "index.html",
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         token: Market.add_price(token),
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)})
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/tokens_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/tokens_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TokensController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.TokensView
+  alias BlockScoutWeb.{Controller, TokensView}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -68,6 +68,6 @@ defmodule BlockScoutWeb.TokensController do
   end
 
   def index(conn, _params) do
-    render(conn, "index.html", current_path: current_path(conn))
+    render(conn, "index.html", current_path: Controller.current_full_path(conn))
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.Tokens.TransferController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.AccessHelpers
+  alias BlockScoutWeb.{AccessHelpers, Controller}
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.Tokens.TransferController do
         conn,
         "index.html",
         counters_path: token_path(conn, :token_counters, %{"id" => Address.checksum(address_hash)}),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         token: Market.add_price(token),
         token_total_supply_status: TokenTotalSupplyOnDemand.trigger_fetch(address_hash)
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TransactionController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, TransactionView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, TransactionView}
   alias Explorer.Chain
   alias Phoenix.View
 
@@ -60,7 +60,7 @@ defmodule BlockScoutWeb.TransactionController do
     render(
       conn,
       "index.html",
-      current_path: current_path(conn),
+      current_path: Controller.current_full_path(conn),
       transaction_estimated_count: transaction_estimated_count
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, InternalTransactionView, TransactionController}
+  alias BlockScoutWeb.{AccessHelpers, Controller, InternalTransactionView, TransactionController}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Phoenix.View
@@ -97,7 +97,7 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
         conn,
         "index.html",
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         block_height: Chain.block_height(),
         show_token_transfers: Chain.transaction_has_token_transfers?(transaction_hash),
         transaction: transaction

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TransactionLogController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, TransactionController, TransactionLogView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, TransactionController, TransactionLogView}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Phoenix.View
@@ -91,7 +91,7 @@ defmodule BlockScoutWeb.TransactionLogController do
         "index.html",
         block_height: Chain.block_height(),
         show_token_transfers: Chain.transaction_has_token_transfers?(transaction_hash),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         transaction: transaction,
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null()
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
 
-  alias BlockScoutWeb.{AccessHelpers, TransactionController, TransactionTokenTransferView}
+  alias BlockScoutWeb.{AccessHelpers, Controller, TransactionController, TransactionTokenTransferView}
   alias Explorer.{Chain, Market}
   alias Explorer.ExchangeRates.Token
   alias Phoenix.View
@@ -101,7 +101,7 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
         "index.html",
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
         block_height: Chain.block_height(),
-        current_path: current_path(conn),
+        current_path: Controller.current_full_path(conn),
         show_token_transfers: true,
         transaction: transaction
       )

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_addresses_test.exs
@@ -278,6 +278,72 @@ defmodule BlockScoutWeb.ViewingAddressesTest do
       |> assert_has(AddressPage.internal_transactions(count: 3))
       |> assert_has(AddressPage.internal_transaction(internal_transaction))
     end
+
+    test "can filter to see internal transactions from an address only", %{
+      addresses: addresses,
+      session: session
+    } do
+      block = insert(:block, number: 7000)
+
+      from_lincoln =
+        :transaction
+        |> insert(from_address: addresses.lincoln)
+        |> with_block(block)
+
+      from_taft =
+        :transaction
+        |> insert(from_address: addresses.taft)
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: from_lincoln,
+        index: 2,
+        from_address: addresses.lincoln,
+        block_number: from_lincoln.block_number,
+        transaction_index: from_lincoln.index,
+        block_hash: from_lincoln.block_hash,
+        block_index: 2
+      )
+
+      session
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> AddressPage.apply_filter("From")
+      |> assert_has(AddressPage.transaction(from_lincoln))
+      |> refute_has(AddressPage.transaction(from_taft))
+    end
+
+    test "can filter to see internal transactions to an address only", %{
+      addresses: addresses,
+      session: session
+    } do
+      block = insert(:block, number: 7000)
+
+      from_lincoln =
+        :transaction
+        |> insert(to_address: addresses.lincoln)
+        |> with_block(block)
+
+      from_taft =
+        :transaction
+        |> insert(to_address: addresses.taft)
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: from_lincoln,
+        index: 2,
+        from_address: addresses.lincoln,
+        block_number: from_lincoln.block_number,
+        transaction_index: from_lincoln.index,
+        block_hash: from_lincoln.block_hash,
+        block_index: 2
+      )
+
+      session
+      |> AddressPage.visit_page(addresses.lincoln)
+      |> AddressPage.apply_filter("To")
+      |> assert_has(AddressPage.transaction(from_lincoln))
+      |> refute_has(AddressPage.transaction(from_taft))
+    end
   end
 
   describe "viewing token transfers from a specific token" do

--- a/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api_docs_view_test.exs
@@ -39,6 +39,14 @@ defmodule BlockScoutWeb.ApiDocsViewTest do
   end
 
   describe "blockscout_url/2" do
+    setup do
+      on_exit(fn ->
+        Application.put_env(:block_scout_web, BlockScoutWeb.Endpoint,
+          url: [scheme: "http", host: "localhost", api_path: nil, path: nil]
+        )
+      end)
+    end
+
     test "set_path = true returns url with path" do
       Application.put_env(:block_scout_web, BlockScoutWeb.Endpoint,
         url: [scheme: "https", host: "blockscout.com", api_path: "/eth/mainnet", path: "/eth/mainnet"]


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4501

## Motivation

A common path for all routes is not added on redirects and doesn't contain in current_path(conn)

## Changelog

Add value of `NETWORK_PATH` variable into `current_path(conn)` and into redirects

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
