### PR TITLE
Uncataloged token transfers query performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4452](https://github.com/blockscout/blockscout/pull/4452) - Add names for smart-conrtact's function response
 
 ### Fixes
+- [#4525](https://github.com/blockscout/blockscout/pull/4525) - Uncataloged token transfers query performance improvement
 - [#4513](https://github.com/blockscout/blockscout/pull/4513) - Fix installation with custom default path: add NETWORK_PATH variable to the current_path
 - [#4500](https://github.com/blockscout/blockscout/pull/4500) - `/tokens/{addressHash}/instance/{id}/token-transfers`: fix incorrect next page url
 - [#4493](https://github.com/blockscout/blockscout/pull/4493) - Contract's code page: handle null contracts_creation_transaction

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4392,14 +4392,17 @@ defmodule Explorer.Chain do
   def uncataloged_token_transfer_block_numbers do
     query =
       from(l in Log,
-        join: t in assoc(l, :transaction),
-        left_join: tf in TokenTransfer,
-        on: tf.transaction_hash == l.transaction_hash and tf.log_index == l.index,
+        as: :log,
         where: l.first_topic == unquote(TokenTransfer.constant()),
-        where: is_nil(tf.transaction_hash) and is_nil(tf.log_index),
-        where: not is_nil(t.block_hash),
-        select: t.block_number,
-        distinct: t.block_number
+        where:
+          not exists(
+            from(tf in TokenTransfer,
+              where: tf.transaction_hash == parent_as(:log).transaction_hash,
+              where: tf.log_index == parent_as(:log).index
+            )
+          ),
+        select: l.block_number,
+        distinct: l.block_number
       )
 
     Repo.stream_reduce(query, [], &[&1 | &2])

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4877,16 +4877,12 @@ defmodule Explorer.ChainTest do
               gas_used: 0,
               index: 0
             ),
+          block: block,
           address_hash: address.hash
         )
 
-      block_number = log.transaction.block_number
+      block_number = log.block_number
       assert {:ok, [^block_number]} = Chain.uncataloged_token_transfer_block_numbers()
-    end
-
-    test "does not include transactions without a block_number" do
-      insert(:token_transfer_log)
-      assert {:ok, []} = Chain.uncataloged_token_transfer_block_numbers()
     end
   end
 

--- a/apps/indexer/test/indexer/temporary/uncataloged_token_transfers_test.exs
+++ b/apps/indexer/test/indexer/temporary/uncataloged_token_transfers_test.exs
@@ -34,20 +34,23 @@ defmodule Indexer.Temporary.UncatalogedTokenTransfersTest do
       block = insert(:block)
       address = insert(:address)
 
-      log =
-        insert(:token_transfer_log,
-          transaction:
-            insert(:transaction,
-              block_number: block.number,
-              block_hash: block.hash,
-              cumulative_gas_used: 0,
-              gas_used: 0,
-              index: 0
-            ),
-          address_hash: address.hash
+      transaction =
+        insert(:transaction,
+          block_number: block.number,
+          block_hash: block.hash,
+          cumulative_gas_used: 0,
+          gas_used: 0,
+          index: 0
         )
 
-      block_number = log.transaction.block_number
+      log =
+        insert(:token_transfer_log,
+          transaction: transaction,
+          address_hash: address.hash,
+          block: block
+        )
+
+      block_number = log.block_number
 
       expected_state = %{task_ref: nil, block_numbers: [block_number], retry_interval: 1}
       state = %{task_ref: nil, block_numbers: [], retry_interval: 1}


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/4522

## Motivation

Query for `uncataloged_token_transfer_block_numbers` method is slow (> 60 mins on some application instances).

## Changelog

- Remove join with `transactions` table since `block_hash` column is directly available at `logs` table.
- Replace `LEFT JOIN  / IS NULL` approach for finding records in table A, that do not exist in table B, with `NOT EXISTS` approach, which should be faster in Postgres.

`EXPLAIN ANALYZE` for the query before the changes:
```
EXPLAIN ANALYZE SELECT DISTINCT
ON (t1."block_number") t1."block_number"
FROM "logs" AS l0 INNER JOIN "transactions" AS t1 ON t1."hash" = l0."transaction_hash"
LEFT OUTER JOIN "token_transfers" AS t2 ON (t2."transaction_hash" = l0."transaction_hash") AND (t2."log_index" = l0."index")
WHERE (l0."first_topic" = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
AND ((t2."transaction_hash" IS NULL) AND (t2."log_index" IS NULL))
AND (NOT (t1."block_hash" IS NULL));
                                                                          QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=129460.16..129804.55 rows=23858 width=4) (actual time=512.629..517.434 rows=0 loops=1)
   ->  Sort  (cost=129460.16..129632.35 rows=68879 width=4) (actual time=512.628..517.432 rows=0 loops=1)
         Sort Key: t1.block_number
         Sort Method: quicksort  Memory: 25kB
         ->  Gather  (cost=113081.24..123925.12 rows=68879 width=4) (actual time=512.604..517.407 rows=0 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Parallel Hash Join  (cost=112081.24..116037.22 rows=28700 width=4) (actual time=497.722..497.727 rows=0 loops=3)
                     Hash Cond: (l0.transaction_hash = t1.hash)
                     ->  Merge Anti Join  (cost=86494.15..88958.66 rows=31416 width=33) (actual time=397.292..397.294 rows=0 loops=3)
                           Merge Cond: ((l0.transaction_hash = t2.transaction_hash) AND (l0.index = t2.log_index))
                           ->  Sort  (cost=51693.93..51928.16 rows=93691 width=37) (actual time=131.780..139.406 rows=73661 loops=3)
                                 Sort Key: l0.transaction_hash, l0.index
                                 Sort Method: external merge  Disk: 3688kB
                                 Worker 0:  Sort Method: external merge  Disk: 3544kB
                                 Worker 1:  Sort Method: external merge  Disk: 3608kB
                                 ->  Parallel Seq Scan on logs l0  (cost=0.00..41395.10 rows=93691 width=37) (actual time=0.046..79.3
86 rows=73661 loops=3)
                                       Filter: ((first_topic)::text = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523
b3ef'::text)
                                       Rows Removed by Filter: 172442
                           ->  Sort  (cost=34800.22..35355.68 rows=222183 width=37) (actual time=190.408..221.526 rows=221197 loops=3
)
                                 Sort Key: t2.transaction_hash, t2.log_index
                                 Sort Method: external merge  Disk: 10840kB
                                 Worker 0:  Sort Method: external merge  Disk: 10840kB
                                 Worker 1:  Sort Method: external merge  Disk: 10840kB
                                 ->  Seq Scan on token_transfers t2  (cost=0.00..8992.83 rows=222183 width=37) (actual time=0.052..48
.719 rows=221199 loops=3)
                     ->  Parallel Hash  (cost=23203.94..23203.94 rows=117292 width=37) (actual time=83.041..83.042 rows=93988 loops=3
)
                           Buckets: 65536  Batches: 8  Memory Usage: 3072kB
                           ->  Parallel Seq Scan on transactions t1  (cost=0.00..23203.94 rows=117292 width=37) (actual time=0.156..5
1.997 rows=93988 loops=3)
                                 Filter: (block_hash IS NOT NULL)
                                 Rows Removed by Filter: 8727
 Planning Time: 2.094 ms
 Execution Time: 521.339 ms
```

`EXPLAIN ANALYZE for the query after the changes`:

```
EXPLAIN ANALYZE SELECT DISTINCT
ON (l0."block_number") l0."block_number"
FROM "logs" AS l0
WHERE (l0."first_topic" = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
AND l0."block_hash" IS NOT NULL
AND NOT EXISTS (
SELECT 1 FROM "token_transfers" AS t2
WHERE (t2."transaction_hash" = l0."transaction_hash") AND (t2."log_index" = l0."index")
);
                                                                                QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=103928.52..104305.51 rows=20339 width=4) (actual time=472.654..475.359 rows=0 loops=1)
   ->  Sort  (cost=103928.52..104117.02 rows=75398 width=4) (actual time=472.653..475.358 rows=0 loops=1)
         Sort Key: l0.block_number
         Sort Method: quicksort  Memory: 25kB
         ->  Gather  (cost=87816.15..97820.44 rows=75398 width=4) (actual time=472.648..475.351 rows=0 loops=1)
               Workers Planned: 2
               Workers Launched: 2
               ->  Merge Anti Join  (cost=86816.15..89280.64 rows=31416 width=4) (actual time=457.809..457.810 rows=0 loops=3)
                     Merge Cond: ((l0.index = t2.log_index) AND (l0.transaction_hash = t2.transaction_hash))
                     ->  Sort  (cost=52015.93..52250.16 rows=93691 width=41) (actual time=153.101..164.087 rows=73661 loops=3)
                           Sort Key: l0.index, l0.transaction_hash
                           Sort Method: external merge  Disk: 4152kB
                           Worker 0:  Sort Method: external merge  Disk: 3776kB
                           Worker 1:  Sort Method: external merge  Disk: 3776kB
                           ->  Parallel Seq Scan on logs l0  (cost=0.00..41395.10 rows=93691 width=41) (actual time=0.135..92.236 row
s=73661 loops=3)
                                 Filter: ((block_hash IS NOT NULL) AND ((first_topic)::text = '0xddf252ad1be2c89b69c2b068fc378daa952b
a7f163c4a11628f55a4df523b3ef'::text))
                                 Rows Removed by Filter: 172442
                     ->  Sort  (cost=34800.22..35355.68 rows=222183 width=37) (actual time=210.823..255.975 rows=221194 loops=3)
                           Sort Key: t2.log_index, t2.transaction_hash
                           Sort Method: external merge  Disk: 10840kB
                           Worker 0:  Sort Method: external merge  Disk: 10840kB
                           Worker 1:  Sort Method: external merge  Disk: 10840kB
                           ->  Seq Scan on token_transfers t2  (cost=0.00..8992.83 rows=222183 width=37) (actual time=0.050..47.349 r
ows=221199 loops=3)
 Planning Time: 1.096 ms
 Execution Time: 479.153 ms
```



## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
