### PR TITLE
Use token_symbol helper when no symbol exists for a given token in ad…

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
@@ -8,7 +8,7 @@
       class="border-bottom"
       data-dropdown-token-balance-test
       data-token-name="<%= token_name(token_balance.token) %>"
-      data-token-symbol="<%= token_balance.token.symbol %>"
+      data-token-symbol="<%= token_symbol(token_balance.token) %>"
     >
       <%= link(
             to: token_path(@conn, :show, to_string(token_balance.token.contract_address_hash)),
@@ -36,7 +36,7 @@
         <div class="row">
           <% col_md = if token_balance.token.usd_value, do: "col-md-6", else: "col-md-12" %>
           <p class="mb-0 <%= col_md %> ">
-            <%= format_according_to_decimals(token_balance.value, token_balance.token.decimals) %> <%= token_balance.token.symbol %>
+            <%= format_according_to_decimals(token_balance.value, token_balance.token.decimals) %> <%= token_symbol(token_balance.token) %>
           </p>
           <%= if token_balance.token.usd_value do %>
             <p class="mb-0 col-md-6 text-right text-muted">


### PR DESCRIPTION
Token balances couldn't be retrieved for a given account when that account owned tokens with an empty name or symbol. ( see https://github.com/celo-org/blockscout/issues/358 )

This PR uses the helper method in this situation which replaces the name with a shorted version of the token contract hash