### PR TITLE
Indexer performance update: Eliminate multiple updates of the same token while parsing mint/burn token transfers batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#4452](https://github.com/blockscout/blockscout/pull/4452) - Add names for smart-conrtact's function response
 
 ### Fixes
+- [#4535](https://github.com/blockscout/blockscout/pull/4535) - Indexer performance update:: Eliminate multiple updates of the same token while parsing mint/burn token transfers batch
 - [#4527](https://github.com/blockscout/blockscout/pull/4527) - Indexer performance update: refactor coin balance daily fetcher
 - [#4525](https://github.com/blockscout/blockscout/pull/4525) - Uncataloged token transfers query performance improvement
 - [#4513](https://github.com/blockscout/blockscout/pull/4513) - Fix installation with custom default path: add NETWORK_PATH variable to the current_path

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -18,9 +18,24 @@ defmodule Indexer.Transform.TokenTransfers do
   def parse(logs) do
     initial_acc = %{tokens: [], token_transfers: []}
 
-    logs
-    |> Enum.filter(&(&1.first_topic == unquote(TokenTransfer.constant())))
-    |> Enum.reduce(initial_acc, &do_parse/2)
+    token_transfers_from_logs =
+      logs
+      |> Enum.filter(&(&1.first_topic == unquote(TokenTransfer.constant())))
+      |> Enum.reduce(initial_acc, &do_parse/2)
+
+    token_transfers = token_transfers_from_logs.token_transfers
+
+    token_transfers
+    |> Enum.filter(fn token_transfer ->
+      token_transfer.to_address_hash == @burn_address || token_transfer.from_address_hash == @burn_address
+    end)
+    |> Enum.map(fn token_transfer ->
+      token_transfer.token_contract_address_hash
+    end)
+    |> Enum.dedup()
+    |> Enum.each(&update_token/1)
+
+    token_transfers_from_logs
   end
 
   defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc) do
@@ -58,8 +73,6 @@ defmodule Indexer.Transform.TokenTransfers do
       type: "ERC-20"
     }
 
-    update_token(log.address_hash, token_transfer)
-
     {token, token_transfer}
   end
 
@@ -84,8 +97,6 @@ defmodule Indexer.Transform.TokenTransfers do
       contract_address_hash: log.address_hash,
       type: "ERC-721"
     }
-
-    update_token(log.address_hash, token_transfer)
 
     {token, token_transfer}
   end
@@ -112,28 +123,26 @@ defmodule Indexer.Transform.TokenTransfers do
       type: "ERC-721"
     }
 
-    update_token(log.address_hash, token_transfer)
-
     {token, token_transfer}
   end
 
-  defp update_token(address_hash_string, token_transfer) do
-    if token_transfer.to_address_hash == @burn_address || token_transfer.from_address_hash == @burn_address do
-      {:ok, address_hash} = Chain.string_to_address_hash(address_hash_string)
+  defp update_token(nil), do: :ok
 
-      token_params =
-        address_hash_string
-        |> MetadataRetriever.get_functions_of()
+  defp update_token(address_hash_string) do
+    {:ok, address_hash} = Chain.string_to_address_hash(address_hash_string)
 
-      token = Repo.get_by(Token, contract_address_hash: address_hash)
+    token_params =
+      address_hash_string
+      |> MetadataRetriever.get_functions_of()
 
-      if token do
-        token_to_update =
-          token
-          |> Repo.preload([:contract_address])
+    token = Repo.get_by(Token, contract_address_hash: address_hash)
 
-        {:ok, _} = Chain.update_token(%{token_to_update | updated_at: DateTime.utc_now()}, token_params)
-      end
+    if token do
+      token_to_update =
+        token
+        |> Repo.preload([:contract_address])
+
+      {:ok, _} = Chain.update_token(%{token_to_update | updated_at: DateTime.utc_now()}, token_params)
     end
 
     :ok


### PR DESCRIPTION
## Motivation

With parsing token transfers, Blockscout updates token's data (name, symbol, decimals, totalSupply) in the DB from the blockchain. But it makes requests to the archive node for each token in the token transfers batch even if there are repeating tokens. Blockscout should make as requests for the tokens data as the number of unique tokens in that batch. It should reduce the number of requests to the node and the number of writes to the DB.

## Changelog

Request tokens' data on token transfer only for unique tokens in the batch. 

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
