### PR TITLE
Access token type from token object.

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -65,7 +65,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
           %{}
           |> Map.put(:address_hash, stale_current_token_balance.address_hash)
           |> Map.put(:token_contract_address_hash, stale_current_token_balance.token_contract_address_hash)
-          |> Map.put(:token_type, stale_current_token_balance.token_type)
+          |> Map.put(:token_type, stale_current_token_balance.token.type)
           |> Map.put(:block_number, block_number)
           |> Map.put(:value, Decimal.new(updated_balance))
           |> Map.put(:value_fetched_at, DateTime.utc_now())


### PR DESCRIPTION
When trying to fetch token balances the token type is being retrieved from `Explorer.Chain.Address.CurrentTokenBalance` which fails, as the property is on it's `Explorer.Chain.Token` field, rather than directly on the object proper. This results in the following error.

```
Task #PID<0.26535.4> started from #PID<0.26534.4> terminating
** (KeyError) key :token_type not found in: %Explorer.Chain.Address.CurrentTokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, "address_current_token_balances">, address: #Ecto.Association.NotLoaded<association :address is not loaded>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<170, 150, 63, 201, 114, 129, 217, 99, 45, 150, 112, 10, 182, 42, 77, 19, 64, 249, 162, 138>>}, block_number: 6810831, id: 192377275, inserted_at: ~U[2021-05-06 10:10:56.227962Z], old_value: #Decimal<2000000073418594032886674>, token: %Explorer.Chain.Token{__meta__: #Ecto.Schema.Metadata<:loaded, "tokens">, bridged: nil, cataloged: true, contract_address: #Ecto.Association.NotLoaded<association :contract_address is not loaded>, contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<16, 200, 146, 166, 236, 67, 165, 62, 69, 208, 185, 22, 180, 183, 211, 131, 177, 183, 140, 15>>}, decimals: #Decimal<18>, holder_count: 2399, inserted_at: ~U[2021-03-10 18:49:40.441207Z], name: "Celo Euro", symbol: "cEUR", total_supply: #Decimal<8003013307755930066348778>, type: "ERC-20", updated_at: ~U[2021-08-19 22:33:36.797029Z]}, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<16, 200, 146, 166, 236, 67, 165, 62, 69, 208, 185, 22, 180, 183, 211, 131, 177, 183, 140, 15>>}, updated_at: ~U[2021-08-19 21:35:31.933769Z], value: #Decimal<2000000073534267351136878>, value_fetched_at: ~U[2021-08-19 21:35:31.928448Z]}
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:68: anonymous fn/3 in Indexer.Fetcher.TokenBalanceOnDemand.fetch_and_update/3
    (elixir 1.11.4) lib/enum.ex:1411: Enum."-map/2-lists^map/1-0-"/2
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:51: Indexer.Fetcher.TokenBalanceOnDemand.fetch_and_update/3
    (indexer 0.1.0) lib/indexer/fetcher/token_balance_on_demand.ex:40: Indexer.Fetcher.TokenBalanceOnDemand.do_trigger_fetch/4
    (elixir 1.11.4) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (stdlib 3.14.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<1.27585641/0 in BlockScoutWeb.AddressTokenBalanceController.index/2>
    Args: []
```

This changes the `TokenBalanceOnDemand` fetcher to access the correct field instead.