### PR TITLE
Indexer performance update: Deduplicate tokens in the indexer token transfers transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#4452](https://github.com/blockscout/blockscout/pull/4452) - Add names for smart-conrtact's function response
 
 ### Fixes
+- [#4542](https://github.com/blockscout/blockscout/pull/4542) - Indexer performance update: Deduplicate tokens in the indexer token transfers transformer
 - [#4535](https://github.com/blockscout/blockscout/pull/4535) - Indexer performance update:: Eliminate multiple updates of the same token while parsing mint/burn token transfers batch
 - [#4527](https://github.com/blockscout/blockscout/pull/4527) - Indexer performance update: refactor coin balance daily fetcher
 - [#4525](https://github.com/blockscout/blockscout/pull/4525) - Uncataloged token transfers query performance improvement

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -35,7 +35,14 @@ defmodule Indexer.Transform.TokenTransfers do
     |> Enum.dedup()
     |> Enum.each(&update_token/1)
 
-    token_transfers_from_logs
+    tokens_dedup = token_transfers_from_logs.tokens |> Enum.dedup()
+
+    token_transfers_from_logs_dedup = %{
+      tokens: tokens_dedup,
+      token_transfers: token_transfers_from_logs.token_transfers
+    }
+
+    token_transfers_from_logs_dedup
   end
 
   defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc) do


### PR DESCRIPTION
## Motivation

In the catchup block indexer resulting set of tokens before the update in the DB is not unique.

## Changelog

Deduplicate tokens set before update in the DB.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
