### PR TITLE
Optimise github actions (#363)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,125 +11,210 @@ on:
 
 env:
   MIX_ENV: test
+  OTP_VERSION: '23.3.4.1'
+  ELIXIR_VERSION: '1.11.4'
 
 jobs:
-  build:
+  build-and-cache:
+    name: Build and Cache deps
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
       - name: "ELIXIR_VERSION.lock"
         run: echo "${ELIXIR_VERSION}" > ELIXIR_VERSION.lock
+
       - name: "OTP_VERSION.lock"
         run: echo "${OTP_VERSION}" > OTP_VERSION.lock
-      - run: mix deps.get
-      - run: npm install
+
+      - name: Restore Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
+
+      - name: Conditionally build Mix deps cache
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+          mix deps.compile
+          cd deps/libsecp256k1
+          make
+
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Conditionally build Explorer NPM Cache
+        if: steps.explorer-npm-cache.outputs.cache-hit != 'true'
+        run: npm install
         working-directory: apps/explorer
-      - run: npm install
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
+      - name: Conditionally build Blockscout Web NPM Cache
+        if: steps.blockscoutweb-npm-cache.outputs.cache-hit != 'true'
+        run: npm install
         working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
   credo:
+    name: Credo
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      
+      - name: Restore Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: mix credo
+
   check_formatted:
+    name: Code formatting checks
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Restore Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: mix format --check-formatted
   dialyzer:
+    name: Dialyzer static analysis
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
-      - name: Unpack PLT cache
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Restore Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+      - name: Restore Dialyzer Cache
+        uses: actions/cache@v2
+        id: dialyzer-cache
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
+
+      - name: Conditionally build Dialyzer Cache
+        if: steps.dialyzer-cache.output.cache-hit != 'true'
         run: |
-          mkdir -p _build/test
-          cp plts/dialyxir*.plt _build/test/ || true
-          mkdir -p ~/.mix
-          cp plts/dialyxir*.plt ~/.mix/ || true
-      - run: mix dialyzer --plt
-      - name: Pack PLT cache
-        run: |
-          mkdir -p plts
-          cp _build/test/dialyxir*.plt plts/
-          cp ~/.mix/dialyxir*.plt plts/
+          mkdir -p priv/plts
+          mix dialyzer --plt
+
       - run: mix dialyzer --halt-exit-status
+        name: Run Dialyzer
+
   gettext:
+    name: Missing translation keys check
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Restore Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: |
           mix gettext.extract --merge | tee stdout.txt
           ! grep "Wrote " stdout.txt
         working-directory: "apps/block_scout_web"
   sobelow:
+    name: Sobelow security analysis
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix deps.compile
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - name: Scan explorer for vulnerabilities
         run: mix sobelow --config
         working-directory: "apps/explorer"
@@ -137,57 +222,99 @@ jobs:
         run: mix sobelow --config
         working-directory: "apps/block_scout_web"
   eslint:
+    name: ESLint
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./node_modules/.bin/eslint --format=junit --output-file="test/eslint/junit.xml" js/**
         working-directory: apps/block_scout_web/assets
   jest:
+    name: JS Tests
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./node_modules/.bin/jest
         working-directory: apps/block_scout_web/assets
+
   test_parity_mox_ethereum_jsonrpc:
+    name: EthereumJSONRPC Tests
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -211,25 +338,22 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
       - run: ./bin/install_chrome_headless.sh
       - name: mix test --exclude no_parity
         run: |
@@ -243,7 +367,9 @@ jobs:
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_explorer:
+    name: Explorer Tests
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -267,25 +393,31 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm
+
       - run: ./bin/install_chrome_headless.sh
       - name: mix test --exclude no_parity
         run: |
@@ -301,7 +433,9 @@ jobs:
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
   test_parity_mox_indexer:
+    name: Indexer Tests
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -325,26 +459,25 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
-      - run: npm rebuild node-sass
-        working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
-      - name: Build assets
-        run: node node_modules/webpack/bin/webpack.js --mode development
-        working-directory: "apps/block_scout_web/assets"
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+
       - run: ./bin/install_chrome_headless.sh
+
       - name: mix test --exclude no_parity
         run: |
           mix ecto.create --quiet
@@ -358,8 +491,11 @@ jobs:
           PGUSER: postgres
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Parity.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
+
   test_parity_mox_block_scout_web:
+    name: Blockscout Web Tests
     runs-on: ubuntu-18.04
+    needs: build-and-cache
     services:
       postgres:
         image: postgres
@@ -383,26 +519,50 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: '23.3.4.1'
-          elixir-version: '1.11.4'
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
       - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run: echo 'export PATH=~/.cargo/bin/:$PATH' >> $GITHUB_ENV
-      - run: mix local.hex --force
-      - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: npm install
-        working-directory: apps/explorer
-      - run: npm install
-        working-directory: apps/block_scout_web/assets
+
+      - name: Mix Deps Cache
+        uses: actions/cache@v2
+        id: deps-cache
+        with:
+          path: | 
+            deps
+            _build
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-mixlockhash-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-"
+
+
+      - name: Restore Explorer NPM Cache
+        uses: actions/cache@v2
+        id: explorer-npm-cache
+        with:
+          path: apps/explorer/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-${{ hashFiles('apps/explorer/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-explorer-npm-
+
+      - name: Restore Blockscout Web NPM Cache
+        uses: actions/cache@v2
+        id: blockscoutweb-npm-cache
+        with:
+          path: apps/block_scout_web/assets/node_modules
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-${{ hashFiles('apps/block_scout_web/assets/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
+
       - run: npm rebuild node-sass
         working-directory: apps/block_scout_web/assets
-      - run: mix compile
-      - run: make
-        working-directory: "deps/libsecp256k1"
+
       - name: Build assets
         run: node node_modules/webpack/bin/webpack.js --mode development
         working-directory: "apps/block_scout_web/assets"
+
       - run: ./bin/install_chrome_headless.sh
+
       - name: mix test --exclude no_parity
         run: |
           mix ecto.create --quiet

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/rolling_window.ex
@@ -104,8 +104,6 @@ defmodule EthereumJSONRPC.RollingWindow do
 
   # Public for testing
   defp sweep(table, delete_match_spec, replace_match_spec) do
-    Logger.debug(fn -> "Sweeping windows" end)
-
     # Delete any rows where all windows empty
     :ets.match_delete(table, delete_match_spec)
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,11 +10,7 @@ defmodule BlockScout.Mixfile do
       version: "2.0",
       apps_path: "apps",
       deps: deps(),
-      dialyzer: [
-        plt_add_deps: :transitive,
-        plt_add_apps: ~w(ex_unit mix)a,
-        ignore_warnings: ".dialyzer-ignore"
-      ],
+      dialyzer: dialyzer(),
       elixir: "~> 1.10",
       preferred_cli_env: [
         credo: :test,
@@ -35,6 +31,16 @@ defmodule BlockScout.Mixfile do
   end
 
   ## Private Functions
+
+  defp dialyzer() do
+    [
+      plt_add_deps: :transitive,
+      plt_add_apps: ~w(ex_unit mix)a,
+      ignore_warnings: ".dialyzer-ignore",
+      plt_core_path: "priv/plts",
+      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+    ]
+  end
 
   defp aliases(env) do
     [


### PR DESCRIPTION
Optimises the workflow by aggressively caching dependencies. 

Notably :

* Cache elixir dependencies
* Cache npm node_modules
* Cache dialyzer persistent lookup table (plt)

These caches are keyed on their respective lock files, for npm this is the `package-lock.json` files in `explorer` and `block_scout_web` apps, for dialyzer and elixir dependencies this is `mix.lock`. These caches will be rebuilt upon changes to npm modules or elixir dependencies, which will result in an initially longer build time but will be persisted across test runs.

Initial results seem to show a reduction in test run time from ~23 minutes to around 14 minutes with fully cached dependencies. Currently the test runs are bounded by the `explorer` test suite, specifically smart contract verification functionality. Further reductions would likely involve significant code level changes which will come in further pull requests.

Also removes the "Sweeping windows" log from the `EthereumJSONRPC` app, which causes test output to drop from ~60k lines to around 2k lines, making it readable in github.

## Before
<img width="587" alt="Screenshot 2021-08-25 at 10 54 40" src="https://user-images.githubusercontent.com/85586/130761336-465f625a-d2fc-4c85-a8a8-b8559306e44d.png">

## After 
<img width="695" alt="Screenshot 2021-08-25 at 10 54 58" src="https://user-images.githubusercontent.com/85586/130761388-594b5eaa-699b-4748-89b4-66afc6aa7190.png">
