### PR TITLE
Upstream/bugfix/mix compile tests

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - upstream/bugfix/mix_compile_tests
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Explicitly call `mix compile` before running tests.

Tested on CI at https://github.com/celo-org/blockscout/actions/runs/1170225176