### PR TITLE
Write contract page: Resize inputs; Improve multiplier selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
 - [#4587](https://github.com/blockscout/blockscout/pull/4587) - Enable navbar menu on Search results page

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -60,7 +60,9 @@
             <%= for input <- function["inputs"] do %>
               <div class="form-group pr-3">
                 <%= if int?(input["type"]) do %>
-                  <input type="number" name="function_input" class="form-control form-control-sm address-input-sm mt-2" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
+                  <input type="number" name="function_input" class="form-control form-control-sm address-input-sm mt-2"
+                  placeholder='<%= input["name"] %>(<%= input["type"] %>)'
+                  style="width: <%= (String.length(input["name"]) + String.length(input["type"]) + 2) * 10 %>px;"/>
                   <span data-dropdown-toggle="" data-toggle="dropdown">
                     <span class="button btn-line button-xs contract-plus-btn-container ml-1 mt-2">
                       <i class="fa fa-plus contract-plus-btn"></i>
@@ -69,12 +71,14 @@
                       <div class="dropdown-item contract-exponentiation-btn" data-power=6>10<sup>6</sup></div>
                       <div class="dropdown-item contract-exponentiation-btn" data-power=8>10<sup>8</sup></div>
                       <div class="dropdown-item contract-exponentiation-btn" data-power=18>10<sup>18</sup></div>
-                      <div class="dropdown-item contract-exponentiation-btn" data-power>10<input type="number" name="custom_power" class="form-control form-control-sm address-input-sm ml-1 custom-power-input" /></div> 
+                      <div class="dropdown-item contract-exponentiation-btn" data-power><input type="number" name="custom_power" class="form-control form-control-sm address-input-sm ml-1 custom-power-input" />10</div> 
                     </div>
                   </span>
 
                 <% else %>
-                  <input type="text" name="function_input" class="form-control form-control-sm address-input-sm mt-2" placeholder='<%= input["name"] %>(<%= input["type"] %>)'  />
+                  <input type="text" name="function_input" class="form-control form-control-sm address-input-sm mt-2" 
+                  placeholder='<%= input["name"] %>(<%= input["type"] %>)' 
+                  size="<%= String.length(input["name"]) + String.length(input["type"]) + 2 %>" />
                 <% end %>
               </div>
             <% end %>
@@ -82,7 +86,8 @@
 
           <%= if Helper.payable?(function) do %>
             <div class="form-group pr-3">
-              <input type="text" name="function_input" tx-value class="form-control form-control-sm address-input-sm mt-2" placeholder='value(<%= gettext("ETH")%>)'  />
+              <input type="number" name="function_input" tx-value
+              data-toggle="tooltip" title='Amount in native token <<%= gettext("ETH")%>>' class="form-control form-control-sm address-input-sm mt-2" placeholder='value(<%= gettext("ETH")%>)'  />
             </div>
           <% end %>
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1003,8 +1003,9 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:85
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:120
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:125
 msgid "ETH"
 msgstr ""
 
@@ -1765,7 +1766,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:89
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
 msgid "Query"
 msgstr ""
 
@@ -2839,7 +2840,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:119
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:124
 msgid "WEI"
 msgstr ""
 
@@ -2893,7 +2894,7 @@ msgid "Working Stake Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:89
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
 msgid "Write"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1003,8 +1003,9 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:85
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:120
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:125
 msgid "ETH"
 msgstr ""
 
@@ -1765,7 +1766,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:89
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
 msgid "Query"
 msgstr ""
 
@@ -2839,7 +2840,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:119
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:124
 msgid "WEI"
 msgstr ""
 
@@ -2893,7 +2894,7 @@ msgid "Working Stake Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:89
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
 msgid "Write"
 msgstr ""
 


### PR DESCRIPTION
Close #4560 
Close https://github.com/blockscout/blockscout/issues/4559

## Changelog

### Enhancements
- Type of input field for transaction value changed to `number`
- Now input fields resized according to length of its placeholder

![image](https://user-images.githubusercontent.com/32202610/131251620-efdbdecc-32bd-4e7d-9221-d2218ab9f3da.png)

- Power selector edited to more intuitive manner

![image](https://user-images.githubusercontent.com/32202610/131251562-4f3ecbe1-b575-447d-893a-79f6759db3d2.png)

- Add tooltip for transaction's value

![image](https://user-images.githubusercontent.com/32202610/131375573-3718abd2-bd2c-40b0-80ea-d208b77ab5ac.png)


## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
