### PR TITLE
Fix floating tooltips on token transfer block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#4586](https://github.com/blockscout/blockscout/pull/4586) - Fix floating tooltips on the token transfer family blocks
 - [#4587](https://github.com/blockscout/blockscout/pull/4587) - Enable navbar menu on Search results page
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_btn_copy_for_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_btn_copy_for_table.html.eex
@@ -1,0 +1,15 @@
+    <span
+        id='<%= if assigns[:id] do @id end %>'
+        class="btn-copy-icon <%= if assigns[:additional_classes] do @additional_classes |> Enum.join(" ") end %>"
+        style='<%= if assigns[:style] do @style end %>'
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32.5 32.5" width="32" height="32"  aria-label='<%= @aria_label %>'
+        data-clipboard-text='<%= @clipboard_text %>'
+        data-toggle='tooltip'
+        title='<%= @title %>'
+        data-placement='top'
+        data-clipboard-text='<%= @clipboard_text %>'
+        >
+            <path fill-rule="evenodd" d="M23.5 20.5a1 1 0 0 1-1-1v-9h-9a1 1 0 0 1 0-2h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zm-3-7v10a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1zm-2 1h-8v8h8v-8z"/>
+        </svg>
+    </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex
@@ -8,7 +8,7 @@
                 <%= render BlockScoutWeb.AddressView, "_link.html", address: from_address, contract: BlockScoutWeb.AddressView.contract?(from_address), use_custom_tooltip: false, trimmed: false %>
         </td>
         <td style="word-break: break-all; white-space: nowrap;">
-                <%= render BlockScoutWeb.CommonComponentsView, "_btn_copy.html",
+                <%= render BlockScoutWeb.CommonComponentsView, "_btn_copy_for_table.html",
                         additional_classes: ["btn-copy-icon-small", "btn-copy-icon-custom", "btn-copy-icon-no-borders", "btn-copy-token-transfer"],
                         clipboard_text: from_address,
                         aria_label: gettext("Copy From Address"),
@@ -25,11 +25,11 @@
                 
         </td>
         <td style="word-break: break-all; white-space: nowrap;">
-                <%= render BlockScoutWeb.CommonComponentsView, "_btn_copy.html",
+                <%= render BlockScoutWeb.CommonComponentsView, "_btn_copy_for_table.html",
                 additional_classes: ["btn-copy-icon-small", "btn-copy-icon-custom", "btn-copy-icon-no-borders", "btn-copy-token-transfer"],
                 clipboard_text: to_address,
-                aria_label: gettext("Copy From Address"),
-                title: gettext("Copy From Address"),
+                aria_label: gettext("Copy To Address"),
+                title: gettext("Copy To Address"),
                 style: "position: relative;"%>
         </td>
 </tr>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -737,8 +737,6 @@ msgstr ""
 #:
 #: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:14
 #: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:15
-#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:31
-#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:32
 #: lib/block_scout_web/templates/transaction/overview.html.eex:165
 #: lib/block_scout_web/templates/transaction/overview.html.eex:166
 msgid "Copy From Address"
@@ -773,6 +771,9 @@ msgid "Copy Source Code"
 msgstr ""
 
 #, elixir-format
+#:
+#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:31
+#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:32
 #: lib/block_scout_web/templates/transaction/overview.html.eex:194
 #: lib/block_scout_web/templates/transaction/overview.html.eex:195
 #: lib/block_scout_web/templates/transaction/overview.html.eex:204

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -737,8 +737,6 @@ msgstr ""
 #:
 #: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:14
 #: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:15
-#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:31
-#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:32
 #: lib/block_scout_web/templates/transaction/overview.html.eex:165
 #: lib/block_scout_web/templates/transaction/overview.html.eex:166
 msgid "Copy From Address"
@@ -773,6 +771,9 @@ msgid "Copy Source Code"
 msgstr ""
 
 #, elixir-format
+#:
+#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:31
+#: lib/block_scout_web/templates/transaction/_total_transfers_from_to.html.eex:32
 #: lib/block_scout_web/templates/transaction/overview.html.eex:194
 #: lib/block_scout_web/templates/transaction/overview.html.eex:195
 #: lib/block_scout_web/templates/transaction/overview.html.eex:204


### PR DESCRIPTION
## Motivation
Broken floating tooltips 

![image](https://user-images.githubusercontent.com/32202610/131400802-9e00a079-2019-4447-b449-c61b7e2062ed.png)

## Changelog


### Bug Fixes
- Fix floating tooltips on the token transfer family blocks

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
