### PR TITLE
Enable navbar menu on Search results page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#4587](https://github.com/blockscout/blockscout/pull/4587) - Enable navbar menu on Search results page
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -232,7 +232,8 @@
       @view_module != Elixir.BlockScoutWeb.Tokens.Instance.OverviewView &&
       @view_module != Elixir.BlockScoutWeb.Tokens.Instance.TransferView &&
       @view_module != Elixir.BlockScoutWeb.APIDocsView &&
-      @view_module != Elixir.BlockScoutWeb.Admin.DashboardView
+      @view_module != Elixir.BlockScoutWeb.Admin.DashboardView &&
+      @view_module != Elixir.BlockScoutWeb.SearchView
     ) do %>
       <script defer data-cfasync="false" src="<%= static_path(@conn, "/js/app.js") %>"></script>
     <% end %>


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4533

## Motivation

Navbar menu is non-interactive on Search results page

## Changelog

Enable missing javascript logic on Search results page

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
