### PR TITLE
Fix empty contract's function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4592](https://github.com/blockscout/blockscout/pull/4592) - Add `type` field for `receive` and `fallback` entities of a Smart Contract
 - [#4601](https://github.com/blockscout/blockscout/pull/4601) - Fix endless Fetching tokens... message on empty addresses
 - [#4591](https://github.com/blockscout/blockscout/pull/4591) - Add step and min value for txValue input field
 - [#4589](https://github.com/blockscout/blockscout/pull/4589) - Fix solid outputs on contract read page

--- a/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/smart_contract/_functions.html.eex
@@ -38,9 +38,14 @@
   <div class="d-flex py-2 border-bottom" data-function>
     <div class="py-2 pr-2 text-nowrap">
       <%= counter %>.
-
-      <%= function["name"] %>
-
+      <%= case function["type"] do %>
+      <% "fallback" -> %>
+        <%= gettext "fallback" %><%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html", text: gettext("The fallback function is executed on a call to the contract if none of the other functions match the given function signature, or if no data was supplied at all and there is no receive Ether function. The fallback function always receives data, but in order to also receive Ether it must be marked payable.") %>
+      <% "receive" -> %>
+        <%= gettext "receive" %><%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html", text: gettext("The receive function is executed on a call to the contract with empty calldata. This is the function that is executed on plain Ether transfers (e.g. via .send() or .transfer()). If no such function exists, but a payable fallback function exists, the fallback function will be called on a plain Ether transfer. If neither a receive Ether nor a payable fallback function is present, the contract cannot receive Ether through regular transactions and throws an exception.") %>
+      <% _ -> %>
+        <%= function["name"] %>
+      <% end %>
       &#8594;
     </div>
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1020,9 +1020,9 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:126
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:95
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:95
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:131
 msgid "ETH"
 msgstr ""
 
@@ -1814,7 +1814,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:99
 msgid "Query"
 msgstr ""
 
@@ -2213,6 +2213,11 @@ msgid "The block height of a particular block is defined as the number of blocks
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:43
+msgid "The fallback function is executed on a call to the contract if none of the other functions match the given function signature, or if no data was supplied at all and there is no receive Ether function. The fallback function always receives data, but in order to also receive Ether it must be marked payable."
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:23
 msgid "The first amount is the candidate’s own stake, the second is the total amount staked into the pool by the candidate and all delegators."
 msgstr ""
@@ -2245,6 +2250,11 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:34
 msgid "The percentage of stake in a single pool relative to the total amount staked in all active pools. A higher ratio results in a greater likelihood of validator pool selection."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:45
+msgid "The receive function is executed on a call to the contract with empty calldata. This is the function that is executed on plain Ether transfers (e.g. via .send() or .transfer()). If no such function exists, but a payable fallback function exists, the fallback function will be called on a plain Ether transfer. If neither a receive Ether nor a payable fallback function is present, the contract cannot receive Ether through regular transactions and throws an exception."
 msgstr ""
 
 #, elixir-format
@@ -2918,7 +2928,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:125
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:130
 msgid "WEI"
 msgstr ""
 
@@ -2972,7 +2982,7 @@ msgid "Working Stake Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:99
 msgid "Write"
 msgstr ""
 
@@ -3098,6 +3108,11 @@ msgid "custom RPC"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:43
+msgid "fallback"
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:24
 msgid "false"
 msgstr ""
@@ -3134,6 +3149,11 @@ msgstr ""
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:20
 msgid "pool owner"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:45
+msgid "receive"
 msgstr ""
 
 #, elixir-format

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1020,9 +1020,9 @@ msgid "ERC-721 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:90
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:126
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:95
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:95
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:131
 msgid "ETH"
 msgstr ""
 
@@ -1814,7 +1814,7 @@ msgid "QR Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:99
 msgid "Query"
 msgstr ""
 
@@ -2213,6 +2213,11 @@ msgid "The block height of a particular block is defined as the number of blocks
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:43
+msgid "The fallback function is executed on a call to the contract if none of the other functions match the given function signature, or if no data was supplied at all and there is no receive Ether function. The fallback function always receives data, but in order to also receive Ether it must be marked payable."
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:23
 msgid "The first amount is the candidate’s own stake, the second is the total amount staked into the pool by the candidate and all delegators."
 msgstr ""
@@ -2245,6 +2250,11 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_table.html.eex:34
 msgid "The percentage of stake in a single pool relative to the total amount staked in all active pools. A higher ratio results in a greater likelihood of validator pool selection."
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:45
+msgid "The receive function is executed on a call to the contract with empty calldata. This is the function that is executed on plain Ether transfers (e.g. via .send() or .transfer()). If no such function exists, but a payable fallback function exists, the fallback function will be called on a plain Ether transfer. If neither a receive Ether nor a payable fallback function is present, the contract cannot receive Ether through regular transactions and throws an exception."
 msgstr ""
 
 #, elixir-format
@@ -2918,7 +2928,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:125
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:130
 msgid "WEI"
 msgstr ""
 
@@ -2972,7 +2982,7 @@ msgid "Working Stake Amount"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:94
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:99
 msgid "Write"
 msgstr ""
 
@@ -3098,6 +3108,11 @@ msgid "custom RPC"
 msgstr ""
 
 #, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:43
+msgid "fallback"
+msgstr ""
+
+#, elixir-format
 #: lib/block_scout_web/views/address_contract_view.ex:24
 msgid "false"
 msgstr ""
@@ -3134,6 +3149,11 @@ msgstr ""
 #:
 #: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:20
 msgid "pool owner"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/smart_contract/_functions.html.eex:45
+msgid "receive"
 msgstr ""
 
 #, elixir-format


### PR DESCRIPTION
Close #4565 

## Changelog

### Enhancements
- Now entities of Smart Contract such as `receive` and `fallback` fucntions are marked as `receive` and `fallback` respectively

![image](https://user-images.githubusercontent.com/32202610/131860166-8e8af889-dfbc-4e67-8da4-e5121fb63a99.png)

![image](https://user-images.githubusercontent.com/32202610/131987436-c24ebd4f-bcd3-43d6-b5ee-d3ce47d2f189.png)

![image](https://user-images.githubusercontent.com/32202610/131987469-376dfb4d-0903-48d7-899e-8790dbd02125.png)

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
