### PR TITLE
Fix endless Fetching tokens... message on empty addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4601](https://github.com/blockscout/blockscout/pull/4601) - Fix endless Fetching tokens... message on empty addresses
 - [#4591](https://github.com/blockscout/blockscout/pull/4591) - Add step and min value for txValue input field
 - [#4589](https://github.com/blockscout/blockscout/pull/4589) - Fix solid outputs on contract read page
 - [#4586](https://github.com/blockscout/blockscout/pull/4586) - Fix floating tooltips on the token transfer family blocks

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -77,8 +77,10 @@ export function reducer (state = initialState, action) {
 
 let fetchedTokenBalanceBlockNumber = 0
 function loadTokenBalance (blockNumber) {
-  if (blockNumber >= fetchedTokenBalanceBlockNumber) {
+  if (blockNumber > fetchedTokenBalanceBlockNumber) {
     fetchedTokenBalanceBlockNumber = blockNumber
+    setTimeout(loadTokenBalanceDropdown, 1000)
+  } else if (fetchedTokenBalanceBlockNumber === 0 && blockNumber === null) {
     setTimeout(loadTokenBalanceDropdown, 1000)
   }
 }
@@ -94,7 +96,7 @@ const elements = {
       return { balanceCard: $el.html(), balance: parseFloat($el.find('.current-balance-in-wei').attr('data-wei-value')) }
     },
     render ($el, state, oldState) {
-      if (oldState.balance === state.balance || isNaN(state.balance)) return
+      if (oldState.balance === state.balance || (isNaN(oldState.balance) && isNaN(state.balance))) return
       $el.empty().append(state.balanceCard)
       loadTokenBalance(state.fetchedCoinBalanceBlockNumber)
       updateAllCalculatedUsdValues()

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -92,7 +92,12 @@ defmodule BlockScoutWeb.AddressController do
         validation_count: validation_count
       })
     else
-      _ -> not_found(conn)
+      _ ->
+        json(conn, %{
+          transaction_count: 0,
+          gas_usage_count: 0,
+          validation_count: 0
+        })
     end
   end
 


### PR DESCRIPTION
## Motivation

Endless "Fetching tokens..." warning on empty addresses. For instance, https://blockscout.com/xdai/mainnet/address/0x8c461F78760988C4135e263a87DD736F8b671ff0/transactions

<img width="459" alt="Screenshot 2021-09-02 at 13 05 03" src="https://user-images.githubusercontent.com/4341812/131825043-4205ad63-8773-4924-b723-2f669b292573.png">

## Changelog

Change the condition to load dropdown with tokens


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
