### PR TITLE
Refine view of popup for reverted tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4626](https://github.com/blockscout/blockscout/pull/4626) - Refine view of popup for reverted tx
 - [#4640](https://github.com/blockscout/blockscout/pull/4640) - Token page: fixes in mobile view
 - [#4612](https://github.com/blockscout/blockscout/pull/4612) - Hide error selector in the contract's functions list
 - [#4615](https://github.com/blockscout/blockscout/pull/4615) - Fix broken style for `View more transfers` button

--- a/apps/block_scout_web/assets/js/lib/smart_contract/common_helpers.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/common_helpers.js
@@ -69,6 +69,18 @@ export const formatError = (error) => {
   return message
 }
 
+export const formatTitleAndError = (error) => {
+  let { message } = error
+  var title = message && message.split('Error: ').length > 1 ? message.split('Error: ')[1] : message
+  title = title && title.split('{').length > 1 ? title.split('{')[0].replace(':', '') : title
+  try {
+    message = message && message.indexOf('{') >= 0 ? JSON.parse(message && message.slice(message.indexOf('{'))).error : ''
+  } catch (exception) {
+    message = ''
+  }
+  return { title: title, message: message }
+}
+
 export const getCurrentAccount = () => {
   return new Promise((resolve, reject) => {
     window.ethereum.request({ method: 'eth_accounts' })

--- a/apps/block_scout_web/assets/js/lib/smart_contract/write.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/write.js
@@ -1,6 +1,6 @@
 import Web3 from 'web3'
 import { openErrorModal, openWarningModal, openSuccessModal, openModalWithMessage } from '../modals'
-import { compareChainIDs, formatError, getContractABI, getCurrentAccount, getMethodInputs, prepareMethodArgs } from './common_helpers'
+import { compareChainIDs, formatError, formatTitleAndError, getContractABI, getCurrentAccount, getMethodInputs, prepareMethodArgs } from './common_helpers'
 
 export const walletEnabled = () => {
   return new Promise((resolve) => {
@@ -100,7 +100,8 @@ export function callMethod (isWalletEnabled, $functionInputs, explorerChainId, $
         const methodToCall = TargetContract.methods[functionName](...args).send(sendParams)
         methodToCall
           .on('error', function (error) {
-            openErrorModal(`Error in sending transaction for method "${functionName}"`, formatError(error), false)
+            var titleAndError = formatTitleAndError(error)
+            openErrorModal(titleAndError.title.length ? titleAndError.title : `Error in sending transaction for method "${functionName}"`, titleAndError.message, false)
           })
           .on('transactionHash', function (txHash) {
             onTransactionHash(txHash, $element, functionName)

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_status.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_modal_status.html.eex
@@ -11,7 +11,7 @@
       <%= render BlockScoutWeb.CommonComponentsView, "_modal_close_button.html" %>
       <div class="modal-body modal-status-body">
         <h2 class="modal-status-title"><%= if assigns[:title] do @title end %></h2>
-        <p class="modal-status-text"><%= if assigns[:text] do @text end %></p>
+        <p class="modal-status-text" style="<%= if @status == "error", do: "word-break: break-all;" %>"><%= if assigns[:text] do @text end %></p>
         <div class="modal-status-button-wrapper">
           <%= if @status !== "question" do %>
             <button class="btn-line" type="button" data-dismiss="modal">


### PR DESCRIPTION
Close #4506 

## Changelog

### Enhancements
- Cut error message in case of reverted tx
- Change title of popup message

![image](https://user-images.githubusercontent.com/32202610/133029658-82f144ff-ebee-409c-a0d9-f55d4b4107c2.png)

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
