### PR TITLE
EIP-3091 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4655](https://github.com/blockscout/blockscout/pull/4655) - EIP-3091 support
 - [#4621](https://github.com/blockscout/blockscout/pull/4621) - Add beacon contract address slot for proxy
 - [#4625](https://github.com/blockscout/blockscout/pull/4625) - Contract address page: Add implementation link to the overview of proxy contracts
 - [#4624](https://github.com/blockscout/blockscout/pull/4624) - Support HTML tags in alert message

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_controller.ex
@@ -83,7 +83,7 @@ defmodule BlockScoutWeb.BlockController do
             |> Map.delete("type")
             |> Map.put("block_type", block_type)
 
-          block_path(
+          blocks_path(
             conn,
             :index,
             params_with_block_type

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -172,7 +172,7 @@
 <section class="container">
   <div class="card card-chain-blocks js-ad-dependant-mb-3">
     <div class="card-body">
-      <%= link(gettext("View All Blocks"), to: block_path(BlockScoutWeb.Endpoint, :index), class: "btn-line float-right") %>
+      <%= link(gettext("View All Blocks"), to: blocks_path(BlockScoutWeb.Endpoint, :index), class: "btn-line float-right") %>
       <h2 class="card-title"><%= gettext "Blocks" %></h2>
       <div class="row" data-selector="chain-block-list" data-url="<%= chain_blocks_path(@conn, :chain_blocks) %>">
         <button data-selector="error-message" class="alert alert-danger col-12 text-left" style="display: none;">

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -22,7 +22,7 @@
               <%= gettext("Blocks") %>
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarBlocksDropdown">
-              <%= link to: block_path(@conn, :index), class: "dropdown-item #{tab_status("blocks", @conn.request_path)}" do %>
+              <%= link to: blocks_path(@conn, :index), class: "dropdown-item #{tab_status("blocks", @conn.request_path)}" do %>
                 <%= gettext("Blocks") %>
               <% end %>
               <%= link to: uncle_path(@conn, :uncle), class: "dropdown-item #{tab_status("uncles", @conn.request_path)}" do %>

--- a/apps/block_scout_web/lib/block_scout_web/web_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/web_router.ex
@@ -34,7 +34,13 @@ defmodule BlockScoutWeb.WebRouter do
       singleton: true
     )
 
-    resources "/blocks", BlockController, only: [:index, :show], param: "hash_or_number" do
+    resources "/block", BlockController, only: [:show], param: "hash_or_number" do
+      resources("/transactions", BlockTransactionController, only: [:index], as: :transaction)
+    end
+
+    resources("/blocks", BlockController, as: :blocks, only: [:index])
+
+    resources "/blocks", BlockController, as: :block_secondary, only: [:show], param: "hash_or_number" do
       resources("/transactions", BlockTransactionController, only: [:index], as: :transaction)
     end
 
@@ -222,7 +228,58 @@ defmodule BlockScoutWeb.WebRouter do
       )
     end
 
-    resources "/tokens", Tokens.TokenController, only: [:show], as: :token do
+    resources "/token", Tokens.TokenController, only: [:show], as: :token do
+      resources(
+        "/token-transfers",
+        Tokens.TransferController,
+        only: [:index],
+        as: :transfer
+      )
+
+      resources(
+        "/read-contract",
+        Tokens.ReadContractController,
+        only: [:index],
+        as: :read_contract
+      )
+
+      resources(
+        "/token-holders",
+        Tokens.HolderController,
+        only: [:index],
+        as: :holder
+      )
+
+      resources(
+        "/inventory",
+        Tokens.InventoryController,
+        only: [:index],
+        as: :inventory
+      )
+
+      resources(
+        "/instance",
+        Tokens.InstanceController,
+        only: [:show],
+        as: :instance
+      ) do
+        resources(
+          "/token-transfers",
+          Tokens.Instance.TransferController,
+          only: [:index],
+          as: :transfer
+        )
+
+        resources(
+          "/metadata",
+          Tokens.Instance.MetadataController,
+          only: [:index],
+          as: :metadata
+        )
+      end
+    end
+
+    resources "/tokens", Tokens.TokenController, only: [:show], as: :token_secondary do
       resources(
         "/token-transfers",
         Tokens.TransferController,

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
@@ -15,14 +15,14 @@ defmodule BlockScoutWeb.BlockControllerTest do
     test "with block redirects to block transactions route", %{conn: conn} do
       insert(:block, number: 3)
       conn = get(conn, "/blocks/3")
-      assert redirected_to(conn) =~ "/blocks/3/transactions"
+      assert redirected_to(conn) =~ "/block/3/transactions"
     end
 
     test "with uncle block redirects to block_hash route", %{conn: conn} do
       uncle = insert(:block, consensus: false)
 
       conn = get(conn, block_path(conn, :show, uncle))
-      assert redirected_to(conn) =~ "/blocks/#{to_string(uncle.hash)}/transactions"
+      assert redirected_to(conn) =~ "/block/#{to_string(uncle.hash)}/transactions"
     end
   end
 
@@ -33,7 +33,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
       |> Stream.map(& &1.number)
       |> Enum.reverse()
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       items = Map.get(json_response(conn, 200), "items")
 
@@ -51,7 +51,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
         insert(:block_second_degree_relation, uncle_hash: uncle.hash, nephew: Enum.at(blocks, index))
       end
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       items = Map.get(json_response(conn, 200), "items")
 
@@ -65,7 +65,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
       |> insert_list(:transaction)
       |> with_block(block)
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       items = Map.get(json_response(conn, 200), "items")
 
@@ -80,7 +80,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
       block = insert(:block)
 
       conn =
-        get(conn, block_path(conn, :index), %{
+        get(conn, blocks_path(conn, :index), %{
           "type" => "JSON",
           "block_number" => Integer.to_string(block.number)
         })
@@ -96,10 +96,10 @@ defmodule BlockScoutWeb.BlockControllerTest do
         |> insert_list(:block)
         |> Enum.fetch!(10)
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       expected_path =
-        block_path(conn, :index, %{
+        blocks_path(conn, :index, %{
           block_number: number,
           block_type: "Block",
           items_count: "50"
@@ -111,7 +111,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
     test "next_page_path is empty if on last page", %{conn: conn} do
       insert(:block)
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       refute conn |> json_response(200) |> Map.get("next_page_path")
     end
@@ -122,7 +122,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
 
       insert(:block, miner: miner_address, miner_hash: nil)
 
-      conn = get(conn, block_path(conn, :index), %{"type" => "JSON"})
+      conn = get(conn, blocks_path(conn, :index), %{"type" => "JSON"})
 
       items = Map.get(json_response(conn, 200), "items")
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4455
Closes https://github.com/blockscout/blockscout/pull/4576

## Motivation

Support `/block/{number_or_hash}` `/token/{hash}` paths

## Changelog

Makes `/block/{number_or_hash}` `/token/{hash}` are default paths.
`/blocks/{number_or_hash}` `/tokens/{hash}` are still supported, but no links to those paths from the application from this point.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
