### PR TITLE
Transaction Page: Add expand/collapse button for long contract method data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#4667](https://github.com/blockscout/blockscout/pull/4667) - Transaction Page: Add expand/collapse button for long contract method data
 - [#4641](https://github.com/blockscout/blockscout/pull/4641) - Improve Read Contract page logic
 - [#4660](https://github.com/blockscout/blockscout/pull/4660) - Save Sourcify path instead of filename
 - [#4655](https://github.com/blockscout/blockscout/pull/4655) - EIP-3091 support

--- a/apps/block_scout_web/assets/js/pages/transaction.js
+++ b/apps/block_scout_web/assets/js/pages/transaction.js
@@ -123,3 +123,34 @@ if ($transactionDetailsPage.length) {
       })
   })
 }
+
+$(function () {
+  const $collapseButton = $('[button-collapse-input]')
+  const $expandButton = $('[button-expand-input]')
+
+  $collapseButton.on('click', event => {
+    const $button = event.target
+    const $parent = $button.parentElement
+    const $collapseButton = $parent.querySelector('[button-collapse-input]')
+    const $expandButton = $parent.querySelector('[button-expand-input]')
+    const $hiddenText = $parent.querySelector('[data-hidden-text]')
+    const $placeHolder = $parent.querySelector('[data-placeholder-dots]')
+    $collapseButton.classList.add('d-none')
+    $expandButton.classList.remove('d-none')
+    $hiddenText.classList.add('d-none')
+    $placeHolder.classList.remove('d-none')
+  })
+
+  $expandButton.on('click', event => {
+    const $button = event.target
+    const $parent = $button.parentElement
+    const $collapseButton = $parent.querySelector('[button-collapse-input]')
+    const $expandButton = $parent.querySelector('[button-expand-input]')
+    const $hiddenText = $parent.querySelector('[data-hidden-text]')
+    const $placeHolder = $parent.querySelector('[data-placeholder-dots]')
+    $expandButton.classList.add('d-none')
+    $collapseButton.classList.remove('d-none')
+    $hiddenText.classList.remove('d-none')
+    $placeHolder.classList.add('d-none')
+  })
+})

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -49,7 +49,8 @@ config :block_scout_web,
   dark_forest_addresses_v_0_5: System.get_env("CUSTOM_CONTRACT_ADDRESSES_DARK_FOREST_V_0_5"),
   circles_addresses: System.get_env("CUSTOM_CONTRACT_ADDRESSES_CIRCLES"),
   test_tokens_addresses: System.get_env("CUSTOM_CONTRACT_ADDRESSES_TEST_TOKEN"),
-  max_size_to_show_array_as_is: Integer.parse(System.get_env("MAX_SIZE_UNLESS_HIDE_ARRAY", "50"))
+  max_size_to_show_array_as_is: Integer.parse(System.get_env("MAX_SIZE_UNLESS_HIDE_ARRAY", "50")),
+  max_length_to_show_string_without_trimming: System.get_env("MAX_STRING_LENGTH_WITHOUT_TRIMMING", "2040")
 
 config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: true
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex
@@ -11,6 +11,7 @@
   </table>
 </div>
 
+<% max_length = get_max_length() %>
 <%= unless Enum.empty?(@mapping) do %>
   <div class="table-responsive text-center">
     <table style="color: black; table-layout: fixed;" summary="<%= gettext "Transaction Inputs" %>" class="table thead-light table-bordered">
@@ -47,7 +48,9 @@
                       </svg>
                     </span>
                 <% end %>
-                <pre class="transaction-input-text pre-wrap" style="margin-bottom: 0px;"><code style="line-height: 25px;"><%= BlockScoutWeb.ABIEncodedValueView.value_html(type, value) %></code></pre>
+                <% template = BlockScoutWeb.ABIEncodedValueView.value_html(type, value)%>
+                <% string = template_to_string(template) %>
+                <pre class="transaction-input-text pre-wrap" style="margin-bottom: 0px;"><code style="line-height: 25px;"><%= if String.length(string) > max_length do %><div data-input-container><% input = trim(max_length, string) %><%= input[:show] %><span data-placeholder-dots>...</span><button type="button" class="btn-line" id="button-expand" aria-label="Expand" button-expand-input><%= gettext "Expand" %></button><span class="more d-none" data-hidden-text><%= input[:hide] %></span><button type="button" class="btn-line d-none" aria-label="Collapse" button-collapse-input><%= gettext "Collapse" %></button></div><% else %><%= template %><% end %></code></pre>
               <% end %>
           </td>
         </tr>

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -547,4 +547,25 @@ defmodule BlockScoutWeb.TransactionView do
   defp tenderly_chain_path do
     System.get_env("TENDERLY_CHAIN_PATH") || "/"
   end
+
+  def get_max_length do
+    string_value = Application.get_env(:block_scout_web, :max_length_to_show_string_without_trimming)
+
+    case Integer.parse(string_value) do
+      {integer, ""} -> integer
+      _ -> 0
+    end
+  end
+
+  def trim(length, string) do
+    %{show: String.slice(string, 0..length), hide: String.slice(string, (length + 1)..String.length(string))}
+  end
+
+  defp template_to_string(template) when is_list(template) do
+    template_to_string(Enum.at(template, 1))
+  end
+
+  defp template_to_string(template) when is_tuple(template) do
+    safe_to_string(template)
+  end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -769,7 +769,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:20
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38 lib/block_scout_web/templates/transaction/overview.html.eex:448
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:39 lib/block_scout_web/templates/transaction/overview.html.eex:448
 #: lib/block_scout_web/templates/transaction/overview.html.eex:454
 msgid "Copy Value"
 msgstr ""
@@ -828,7 +828,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:107
-#: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7 lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
+#: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7 lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:110
 msgid "Data"
 msgstr ""
@@ -1000,7 +1000,7 @@ msgid "Epochs range(s) or enum, e.g.:   5-9,23-27,47,50"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:30
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
 msgid "Error rendering value"
 msgstr ""
 
@@ -1514,7 +1514,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:59 lib/block_scout_web/templates/log/_data_decoded_view.html.eex:4
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
 msgid "Name"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:2
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -2588,7 +2588,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:5
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
 msgid "Type"
 msgstr ""
 
@@ -3033,4 +3033,14 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
 msgid "<p>To become a candidate, your staking address must be funded with %{tokenSymbol} tokens <strong>and</strong> %{coinSymbol} coins, and your OpenEthereum node must be active and configured with the mining address you specify here.</p>\n      <p>To become a delegator, close this window and select an address from the list of pools you would like to place stake on. Click the <strong>Stake</strong> button next to the address to begin the process.</p>"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:53
+msgid "Collapse"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:53
+msgid "Expand"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -769,7 +769,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:20
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:38 lib/block_scout_web/templates/transaction/overview.html.eex:448
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:39 lib/block_scout_web/templates/transaction/overview.html.eex:448
 #: lib/block_scout_web/templates/transaction/overview.html.eex:454
 msgid "Copy Value"
 msgstr ""
@@ -828,7 +828,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:107
-#: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7 lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
+#: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7 lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:21
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:110
 msgid "Data"
 msgstr ""
@@ -1000,7 +1000,7 @@ msgid "Epochs range(s) or enum, e.g.:   5-9,23-27,47,50"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:30
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:31
 msgid "Error rendering value"
 msgstr ""
 
@@ -1514,7 +1514,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:59 lib/block_scout_web/templates/log/_data_decoded_view.html.eex:4
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:18
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
 msgid "Name"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:2
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:16
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:17
 msgid "Transaction Inputs"
 msgstr ""
 
@@ -2588,7 +2588,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:5
-#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:19
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:20
 msgid "Type"
 msgstr ""
 
@@ -3033,4 +3033,14 @@ msgstr ""
 #, elixir-format, fuzzy
 #: lib/block_scout_web/templates/stakes/_stakes_modal_become_candidate.html.eex:36
 msgid "<p>To become a candidate, your staking address must be funded with %{tokenSymbol} tokens <strong>and</strong> %{coinSymbol} coins, and your OpenEthereum node must be active and configured with the mining address you specify here.</p>\n      <p>To become a delegator, close this window and select an address from the list of pools you would like to place stake on. Click the <strong>Stake</strong> button next to the address to begin the process.</p>"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:53
+msgid "Collapse"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:53
+msgid "Expand"
 msgstr ""


### PR DESCRIPTION
Close #4610 

## Changelog

### Enhancements
- Add expand/collapse button for long contract method data
- Add env variable `MAX_STRING_LENGTH_WITHOUT_TRIMMING` which is responsible for appearing aforementioned button

![image](https://user-images.githubusercontent.com/32202610/134024060-3e002915-d681-442d-8add-0b3ba3e33330.png)

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
