### PR TITLE
Fix timestamp for blocks pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#4641](https://github.com/blockscout/blockscout/pull/4641) - Improve Read Contract page logic
 - [#4660](https://github.com/blockscout/blockscout/pull/4660) - Save Sourcify path instead of filename
 - [#4656](https://github.com/blockscout/blockscout/pull/4656) - Open in Tenderly button
-- [#4655](https://github.com/blockscout/blockscout/pull/4655) - EIP-3091 support
+- [#4655](https://github.com/blockscout/blockscout/pull/4655), [#4676](https://github.com/blockscout/blockscout/pull/4676) - EIP-3091 support
 - [#4621](https://github.com/blockscout/blockscout/pull/4621) - Add beacon contract address slot for proxy
 - [#4625](https://github.com/blockscout/blockscout/pull/4625) - Contract address page: Add implementation link to the overview of proxy contracts
 - [#4624](https://github.com/blockscout/blockscout/pull/4624) - Support HTML tags in alert message

--- a/apps/block_scout_web/assets/js/lib/from_now.js
+++ b/apps/block_scout_web/assets/js/lib/from_now.js
@@ -22,7 +22,7 @@ function updateAge (el, timestamp) {
   let fromNow = timestamp.fromNow()
   // show the exact time only for transaction details page. Otherwise, short entry
   const elInTile = el.hasAttribute('in-tile')
-  if ((window.location.pathname.includes('/tx/') || window.location.pathname.includes('/blocks/')) && !elInTile) {
+  if ((window.location.pathname.includes('/tx/') || window.location.pathname.includes('/block/') || window.location.pathname.includes('/blocks/')) && !elInTile) {
     const offset = moment().utcOffset() / 60
     const sign = offset && Math.sign(offset) ? '+' : '-'
     const formatDate = `MMMM-DD-YYYY hh:mm:ss A ${sign}${offset} UTC`


### PR DESCRIPTION
## Motivation

Was lost timestamp on the Block Details page

## Changelog

### Bug Fixes
- Change `from_now.js` according to changes done in #4655 

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
