### PR TITLE
Internal transactions indexer: fix issue of some pending transactions never become confirmed

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -94,8 +94,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
                                             } ->
       insert(repo, valid_internal_transactions_without_first_traces_of_trivial_transactions, insert_options)
     end)
-    |> Multi.run(:update_transactions, fn repo, %{valid_internal_transactions: valid_internal_transactions} ->
-      update_transactions(repo, valid_internal_transactions, update_transactions_options)
+    |> Multi.run(:update_transactions, fn repo,
+                                          %{
+                                            valid_internal_transactions: valid_internal_transactions,
+                                            acquire_transactions: transactions
+                                          } ->
+      update_transactions(repo, valid_internal_transactions, transactions, update_transactions_options)
     end)
     |> Multi.run(:remove_consensus_of_invalid_blocks, fn repo, %{invalid_block_numbers: invalid_block_numbers} ->
       remove_consensus_of_invalid_blocks(repo, invalid_block_numbers)
@@ -252,7 +256,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       from(
         t in Transaction,
         where: t.block_hash in ^pending_block_hashes,
-        select: map(t, [:hash, :block_hash, :block_number]),
+        select: map(t, [:hash, :block_hash, :block_number, :cumulative_gas_used]),
         # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
         order_by: t.hash,
         lock: "FOR UPDATE"
@@ -387,7 +391,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     end
   end
 
-  defp update_transactions(repo, valid_internal_transactions, %{
+  defp update_transactions(repo, valid_internal_transactions, transactions, %{
          timeout: timeout,
          timestamps: timestamps
        }) do
@@ -403,6 +407,9 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         end)
         |> Enum.map(fn trace ->
           %{
+            block_hash: Map.get(trace, :block_hash),
+            block_number: Map.get(trace, :block_number),
+            gas_used: Map.get(trace, :gas_used),
             transaction_hash: Map.get(trace, :transaction_hash),
             created_contract_address_hash: Map.get(trace, :created_contract_address_hash),
             error: Map.get(trace, :error),
@@ -416,36 +423,59 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         |> MapSet.new(& &1.transaction_hash)
         |> MapSet.to_list()
 
+      json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
+
       result =
         Enum.reduce_while(params, 0, fn first_trace, transaction_hashes_iterator ->
-          update_query =
-            from(
-              t in Transaction,
-              where: t.hash == ^first_trace.transaction_hash,
-              # ShareLocks order already enforced by `acquire_transactions` (see docs: sharelocks.md)
-              update: [
-                set: [
-                  created_contract_address_hash: ^first_trace.created_contract_address_hash,
-                  error: ^first_trace.error,
-                  status: ^first_trace.status,
-                  updated_at: ^timestamps.updated_at
-                ]
-              ]
-            )
+          transaction_hash = Map.get(first_trace, :transaction_hash)
 
-          transaction_hashes_iterator = transaction_hashes_iterator + 1
+          transaction_from_db =
+            transactions
+            |> Enum.find(fn transaction ->
+              transaction.hash == transaction_hash
+            end)
 
-          try do
-            {_transaction_count, result} = repo.update_all(update_query, [], timeout: timeout)
+          cond do
+            !transaction_from_db ->
+              transaction_receipt_from_node =
+                fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
 
-            if valid_internal_transactions_count == transaction_hashes_iterator do
-              {:halt, result}
-            else
-              {:cont, transaction_hashes_iterator}
-            end
-          rescue
-            postgrex_error in Postgrex.Error ->
-              {:halt, %{exception: postgrex_error, transaction_hashes: transaction_hashes}}
+              update_transactions_inner(
+                repo,
+                valid_internal_transactions_count,
+                transaction_hashes,
+                transaction_hashes_iterator,
+                timeout,
+                timestamps,
+                first_trace,
+                transaction_receipt_from_node
+              )
+
+            transaction_from_db && Map.get(transaction_from_db, :cumulative_gas_used) ->
+              update_transactions_inner(
+                repo,
+                valid_internal_transactions_count,
+                transaction_hashes,
+                transaction_hashes_iterator,
+                timeout,
+                timestamps,
+                first_trace
+              )
+
+            true ->
+              transaction_receipt_from_node =
+                fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments)
+
+              update_transactions_inner(
+                repo,
+                valid_internal_transactions_count,
+                transaction_hashes,
+                transaction_hashes_iterator,
+                timeout,
+                timestamps,
+                first_trace,
+                transaction_receipt_from_node
+              )
           end
         end)
 
@@ -457,6 +487,104 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
           {:ok, result}
       end
     end
+  end
+
+  defp fetch_transaction_receipt_from_node(transaction_hash, json_rpc_named_arguments) do
+    receipt_response =
+      EthereumJSONRPC.fetch_transaction_receipts(
+        [
+          %{
+            :hash => to_string(transaction_hash),
+            :gas => 0
+          }
+        ],
+        json_rpc_named_arguments
+      )
+
+    case receipt_response do
+      {:ok,
+       %{
+         :receipts => [
+           receipt
+         ]
+       }} ->
+        receipt
+
+      _ ->
+        %{:cumulative_gas_used => nil}
+    end
+  end
+
+  defp update_transactions_inner(
+         repo,
+         valid_internal_transactions_count,
+         transaction_hashes,
+         transaction_hashes_iterator,
+         timeout,
+         timestamps,
+         first_trace,
+         transaction_receipt_from_node \\ nil
+       ) do
+    set = generate_transaction_set_to_update(first_trace, transaction_receipt_from_node, timestamps)
+
+    update_query =
+      from(
+        t in Transaction,
+        where: t.hash == ^first_trace.transaction_hash,
+        # ShareLocks order already enforced by `acquire_transactions` (see docs: sharelocks.md)
+        update: [
+          set: ^set
+        ]
+      )
+
+    transaction_hashes_iterator = transaction_hashes_iterator + 1
+
+    try do
+      {_transaction_count, result} = repo.update_all(update_query, [], timeout: timeout)
+
+      if valid_internal_transactions_count == transaction_hashes_iterator do
+        {:halt, result}
+      else
+        {:cont, transaction_hashes_iterator}
+      end
+    rescue
+      postgrex_error in Postgrex.Error ->
+        {:halt, %{exception: postgrex_error, transaction_hashes: transaction_hashes}}
+    end
+  end
+
+  def generate_transaction_set_to_update(first_trace, transaction_receipt_from_node, timestamps) do
+    default_set = [
+      created_contract_address_hash: first_trace.created_contract_address_hash,
+      error: first_trace.error,
+      status: first_trace.status,
+      updated_at: timestamps.updated_at
+    ]
+
+    set =
+      default_set
+      |> Keyword.put_new(:block_hash, first_trace.block_hash)
+      |> Keyword.put_new(:block_number, first_trace.block_number)
+      |> Keyword.put_new(:index, transaction_receipt_from_node && transaction_receipt_from_node.transaction_index)
+      |> Keyword.put_new(
+        :cumulative_gas_used,
+        transaction_receipt_from_node && transaction_receipt_from_node.cumulative_gas_used
+      )
+
+    set_with_gas_used =
+      if first_trace.gas_used do
+        Keyword.put_new(set, :gas_used, first_trace.gas_used)
+      else
+        if transaction_receipt_from_node && transaction_receipt_from_node.gas_used do
+          Keyword.put_new(set, :gas_used, transaction_receipt_from_node.gas_used)
+        else
+          set
+        end
+      end
+
+    filtered_set = Enum.reject(set_with_gas_used, fn {_key, value} -> is_nil(value) end)
+
+    filtered_set
   end
 
   defp remove_consensus_of_invalid_blocks(repo, invalid_block_numbers) do


### PR DESCRIPTION
## Motivation

Check constraint violation on transactions update from internal transactions:

`
2021-09-22T10:02:11.556 application=indexer fetcher=internal_transaction step=update_transactions count=10 error_count=10 [error] failed to import internal transactions for blocks: %{exception: %Postgrex.Error{connection_id: 26245, message: nil, postgres: %{code: :check_violation, constraint: "status", detail: "Failing row contains (null, null, 250000, 89602868567, null, \\xd9b74fd8f9e69ff45a1f7e07cc3106d6b1fa3b3ff616d407ea3861902e165c..., null, \\x, 36879668, 2491383878535995488279521215521881858038120066050117420264006418..., 5488171561368591118540607534447152719879393889735935592636586416..., 1, 1, 81442603985372310, 2021-08-21 13:05:26.847668, 2021-09-22 09:59:50.922441, null, null, \\xea674fdde714fd979de3edf0f56aa9716b898ec8, \\x1a678ae70e3ea0cc8cbfcd564d1d036e64ca93eb, null, null, null, \\xc5c0b00435633ac0a6e25760f7d7b8800f1588799d2856bbe8751525465bc3..., null, null, null, null).", file: "execMain.c", line: "2070", message: "new row for relation \"transactions\" violates check constraint \"status\"", pg_code: "23514", routine: "ExecConstraints", schema: "public", severity: "ERROR", table: "transactions", unknown: "ERROR"}, query: nil}, transaction_hashes: [%Explorer.Chain.Hash{byte_count: 32, bytes: <<150, 241, 174, 124, 26, 87, 105, 57, 90, 243, 52, 111, 7, 39, 224, 230, 121, 35, 95, 117, 164, 151, 169, 187, 0, 150, 105, 153, 5, 176, 97, 123>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<90, 212, 186, 108, 140, 149, 9, 60, 47, 180, 163, 243, 29, 53, 9, 125, 26, 189, 98, 2, 134, 65, 142, 209, 188, 189, 204, 10, 171, 64, 187, 179>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<131, 128, 52, 45, 102, 182, 91, 69, 51, 225, 14, 199, 149, 213, 43, 100, 217, 123, 174, 91, 107, 94, 105, 46, 54, 208, 200, 189, 169, 2, 113, 183>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<18, 96, 246, 229, 17, 131, 12, 62, 152, 212, 77, 72, 230, 198, 201, 37, 19, 147, 72, 84, 2, 147, 201, 248, 150, 86, 172, 170, 46, 6, 7, 92>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<157, 254, 125, 86, 120, 189, 208, 103, 214, 149, 48, 39, 222, 234, 207, 201, 217, 212, 57, 148, 65, 232, 153, 202, 243, 133, 112, 37, 64, 194, 15, 132>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<159, 169, 111, 10, 183, 97, 187, 34, 227, 2, 134, 72, 5, 235, 85, 208, 12, 229, 219, 152, 206, 160, 166, 93, 165, 142, 45, 253, 56, 6, 197, 212>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<132, 107, 203, 99, 101, 225, 132, 80, 67, 209, 89, 118, 199, 179, 176, 250, 254, 215, 50, 86, 137, 228, 66, 40, 46, 118, 101, 139, 162, 18, 202, 6>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<222, 156, 243, 180, 205, 147, 139, 22, 164, 201, 59, 151, 129, 82, 212, 88, 202, 74, 172, 86, 204, 173, 7, 72, 219, 238, 165, 13, 140, 194, 177, 66>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<51, 110, 119, 164, 184, 167, 171, 247, 193, 255, 241, 34, 119, 115, 199, 113, 128, 210, 241, 92, 33, 109, 106, 141, 167, 186, 185, 174, 158, 179, 237, 100>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<65, 185, 11, 1, 189, 26, 164, 126, 202, 241, 102, 61, 147, 210, 171, 239, 169, 179, 23, 123, 30, 98, 15, 24, 177, 184, 183, 132, 97, 252, 166, 9>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<195, 163, 76, 247, 202, 239, 244, 162, 166, 33, 154, 9, 71, 216, 115, 83, 21, 77, 133, 80, 9, 72, 2, 79, 67, 233, 156, 212, 205, 203, 92, 181>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<50, 167, 108, 56, 150, 159, 101, 214, 86, 73, 37, 238, 14, 88, 122, 68, 202, 119, 167, 183, 108, 120, 138, 114, 45, 159, 174, 164, 134, 196, 198, 144>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<75, 94, 164, 89, 159, 112, 194, 39, 50, 22, 23, 89, 105, 177, 20, 240, 147, 236, 154, 56, 174, 131, 234, 89, 250, 245, 244, 87, 194, 83, 243, 96>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<180, 29, 232, 191, 99, 63, 179, 59, 26, 121, 127, 255, 138, 130, 178, 133, 54, 183, 50, 159, 144, 181, 125, 92, 133, 12, 111, 224, 76, 181, 34, 61>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<165, 56, 58, 216, 195, 215, 12, 38, 229, 141, 191, 234, 57, 146, 210, 37, 48, 184, 243, 88, 237, 229, 247, 175, 193, 30, 22, 93, 157, 251, 222, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<199, 178, 118, 100, 205, 157, 224, 198, 214, 176, 42, 59, 39, 240, 255, 226, 247, 58, 25, 39, 192, 228, 3, 71, 24, 186, 177, 255, 120, 131, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<0, 108, 178, 117, 210, 179, 138, 212, 159, 106, 79, 65, 5, 204, 165, 142, 145, 196, 223, 236, 133, 131, 55, 207, 228, 254, 131, 41, 227, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<9, 28, 45, 206, 24, 126, 238, 162, 29, 126, 4, 97, 149, 175, 73, 167, 182, 192, 7, 48, 54, 230, 85, 24, 164, 102, 58, 25, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<123, 58, 93, 43, 119, 164, 202, 201, 44, 125, 13, 85, 57, 253, 164, 17, 45, 231, 211, 126, 218, 48, 142, 28, 58, 44, 11, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<255, 216, 212, 16, 90, 104, 41, 90, 77, 13, 180, 189, 131, 83, 250, 228, 86, 12, 126, 253, 149, 75, 255, 239, 172, 82, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<163, 59, 82, 53, 110, 90, 205, 166, 156, 0, 134, 255, 46, 227, 70, 70, 130, 177, 244, 186, 122, 135, 33, 17, 62, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<199, 116, 140, 25, 2, 68, 137, 209, 181, 251, 7, 177, 15, 110, 107, 177, 250, 150, 244, 234, 127, 145, 242, 47, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<42, 241, 50, 196, 99, 253, 88, 69, 177, 130, 173, 116, 226, 225, 211, 189, 250, 23, 3, 189, 1, 146, 99, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<17, 224, 122, 30, 48, 80, 166, 129, 142, 189, 238, 182, 237, 57, 24, 125, 240, 164, 188, 86, 15, 87, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<10, 30, 149, 240, 123, 197, 62, 22, 103, 86, 12, 45, 141, 228, 79, 206, 241, 252, 28, 25, 48, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<168, 37, 117, 130, 221, 207, 6, 31, 53, 54, 193, 121, 63, 67, 164, 243, 87, 55, 121, 119, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<233, 249, 247, 10, 130, 186, 14, 241, 192, 231, 196, 58, 129, 179, 184, 18, 0, 141, 109, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<147, 197, 223, 171, 213, 215, 173, 233, 229, 140, 107, 98, 130, 186, 13, 190, 169, 230, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<73, 204, 29, 166, 135, 99, 150, 48, 182, 146, 241, 241, 221, 109, 155, 231, 229, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<76, 32, 138, 154, 30, 12, 141, 194, 185, 206, 11, 17, 104, 238, 184, 246, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<205, 22, 6, 199, 34, 199, 175, 49, 207, 200, 142, 157, 86, 213, 201, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<0, 36, 246, 0, 93, 5, 242, 171, 229, 215, 99, 222, 81, 247, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<59, 242, 3, 142, 144, 24, 30, 49, 218, 37, 220, 222, 84, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<118, 138, 27, 80, 47, 99, 186, 101, 75, 82, 199, 3, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<32, 226, 68, 158, 173, 39, 88, 68, 231, 94, 26, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<210, 132, 58, 33, 224, 173, 217, 153, 203, 5, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<185, 194, 94, 217, 244, 94, 100, 174, 23, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<109, 67, 15, 108, 172, 75, 26, 231, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<159, 172, 249, 201, 66, 250, 159, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<212, 112, 136, 1, 83, 9, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<1, 92, 125, 193, 168, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<187, 233, 123, 218, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<116, 194, 110, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<206, 128, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<225, ...>>}, %Explorer.Chain.Hash{byte_count: 32, bytes: <<...>>}, %Explorer.Chain.Hash{byte_count: 32, ...}, %Explorer.Chain.Hash{...}, ...]}
`

## Changelog

Set `block_hash`, `block_number`, `index`, `gas_used`, `cumulative_gas_used` on update. 

`block_hash`, `block_number`, `gas_used` - from internal transactions
`index`, `cumulative_gas_used` - from node's transaction receipt


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
