### PR TITLE
upgrade to OTP24

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: '23.3.4.7'
+  OTP_VERSION: '24.0.6'
   ELIXIR_VERSION: '1.12.3'
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.12.3-otp-23
-erlang 23.3.4.7
+elixir 1.12.3-otp-24
+erlang 24.0.6
 nodejs 14.17.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.12.2
+FROM sidhujag/alpine-elixir-phoenix:1.12.3
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3 file
 


### PR DESCRIPTION
There has been some recent advancements in OTP24 related to performance and alot of our dependencies we just upgraded also use OTP24 by default, upgrade elixir docker dependency as bitwalker has not updated so I created my own docker hub to upgrade elixir docker repos which are updated to OTP24 matched with elixir 1.12.3