### PR TITLE
Reduced the size of js bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4701](https://github.com/blockscout/blockscout/pull/4701) - Reduced the size of js bundles
 - [#4686](https://github.com/blockscout/blockscout/pull/4686) - Block page: check gas limit value before division
 - [#4678](https://github.com/blockscout/blockscout/pull/4678) - Internal transactions indexer: fix issue of some pending transactions never become confirmed
 - [#4668](https://github.com/blockscout/blockscout/pull/4668) - Fix css for dark theme

--- a/apps/block_scout_web/assets/js/app.js
+++ b/apps/block_scout_web/assets/js/app.js
@@ -21,7 +21,6 @@ import './locale'
 
 import './pages/layout'
 import './pages/dark-mode-switcher'
-import './pages/stakes'
 
 import './lib/clipboard_buttons'
 import './lib/currency'

--- a/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
+++ b/apps/block_scout_web/assets/js/view_specific/raw-trace/code_highlighting.js
@@ -1,7 +1,7 @@
 import hljs from 'highlight.js/lib/core'
-import hljsDefineSolidity from 'highlightjs-solidity'
+import json from 'highlight.js/lib/languages/json'
 
-hljsDefineSolidity(hljs)
+hljs.registerLanguage('json', json)
 
 // only activate highlighting on pages with this selector
 if (document.querySelectorAll('[data-activate-highlight]').length > 0) {

--- a/apps/block_scout_web/assets/js/view_specific/raw_trace/code_highlighting.js
+++ b/apps/block_scout_web/assets/js/view_specific/raw_trace/code_highlighting.js
@@ -1,7 +1,0 @@
-import $ from 'jquery'
-import hljs from 'highlight.js'
-
-// only activate highlighting on pages with this selector
-if ($('[data-activate-highlight]').length > 0) {
-  hljs.initHighlightingOnLoad()
-}

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -20,6 +20,7 @@
         "dropzone": "^5.7.2",
         "eth-net-props": "^1.0.33",
         "highlight.js": "^10.4.0",
+        "highlightjs-solidity": "^2.0.1",
         "https-browserify": "^1.0.0",
         "humps": "^2.0.1",
         "jquery": "^3.4.0",
@@ -8237,6 +8238,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/highlightjs-solidity": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-2.0.1.tgz",
+      "integrity": "sha512-9YY+HQpXMTrF8HgRByjeQhd21GXAz2ktMPTcs6oWSj5HJR52fgsNoelMOmgigwcpt9j4tu4IVSaWaJB2n2TbvQ=="
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -24730,6 +24736,11 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
       "integrity": "sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA=="
+    },
+    "highlightjs-solidity": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-2.0.1.tgz",
+      "integrity": "sha512-9YY+HQpXMTrF8HgRByjeQhd21GXAz2ktMPTcs6oWSj5HJR52fgsNoelMOmgigwcpt9j4tu4IVSaWaJB2n2TbvQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -32,6 +32,7 @@
     "dropzone": "^5.7.2",
     "eth-net-props": "^1.0.33",
     "highlight.js": "^10.4.0",
+    "highlightjs-solidity": "^2.0.1",
     "https-browserify": "^1.0.0",
     "humps": "^2.0.1",
     "jquery": "^3.4.0",


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

Including the staking page to the app.js bloats all the js bundles with unnecessary web3 dependency.

Before:
![image](https://user-images.githubusercontent.com/20768968/134514286-7c47ffd5-74f7-42e5-bb55-0174470a263c.png)

After:
![image](https://user-images.githubusercontent.com/20768968/134514376-f9a9a7bd-031d-47d4-908a-8c3be874d86b.png)

## Changelog

### Enhancements
Optimizes the size of the code highlighting script by removing unnecessary dependencies and including only relevant languages to the build. And fixes the 404 issue for the script on the raw traces tab.

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
