### PR TITLE
Update to Erlang/OTP 24

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -5,11 +5,10 @@
 :0: Unknown type 'Elixir.Address':t/0
 apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex:400: Function timestamp_to_datetime/1 has no local return
 lib/explorer/repo/prometheus_logger.ex:8
+lib/explorer/smart_contract/publisher_worker.ex:1
 lib/explorer/smart_contract/publisher_worker.ex:6
 apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: Function microseconds_time/1 has no local return
 apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: The call 'Elixir.System':convert_time_unit(__@1::any(),'native','microseconds') breaks the contract (integer(),time_unit() | 'native',time_unit() | 'native') -> integer()
-apps/explorer/lib/explorer/smart_contract/publisher_worker.ex:6: The pattern 'false' can never match the type 'true'
-apps/explorer/lib/explorer/smart_contract/publisher_worker.ex:6: The test 5 == 'infinity' can never evaluate to 'true'
 lib/block_scout_web/router.ex:1
 lib/block_scout_web/schema/types.ex:31
 lib/phoenix/router.ex:324

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: '23.3.4.7'
+  OTP_VERSION: '24.1'
   ELIXIR_VERSION: '1.12.3'
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.12.3-otp-23
-erlang 23.3.4.7
+elixir 1.12.3-otp-24
+erlang 24.1
 nodejs 14.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 
 ### Chore
+- [#4704](https://github.com/blockscout/blockscout/pull/4704) - Update to Erlang/OTP 24
 - [#4682](https://github.com/blockscout/blockscout/pull/4682) - Update all possible outdated mix dependencies
 - [#4663](https://github.com/blockscout/blockscout/pull/4663) - Migrate to Elixir 1.12.x
 - [#4661](https://github.com/blockscout/blockscout/pull/4661) - Update NPM packages to resolve vulnerabilities

--- a/apps/explorer/lib/explorer/chain/bridged_token.ex
+++ b/apps/explorer/lib/explorer/chain/bridged_token.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.BridgedToken do
 
   import Ecto.Changeset
 
-  alias Explorer.Chain.{BridgedToken, Hash, Token}
+  alias Explorer.Chain.{Address, BridgedToken, Hash, Token}
   alias Explorer.Repo
 
   @typedoc """

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -18,7 +18,7 @@ defmodule Explorer.Chain.Token.Instance do
   @type t :: %Instance{
           token_id: non_neg_integer(),
           token_contract_address_hash: Hash.Address.t(),
-          metadata: Map.t(),
+          metadata: map(),
           error: String.t()
         }
 

--- a/apps/explorer/lib/explorer/smart_contract/writer.ex
+++ b/apps/explorer/lib/explorer/smart_contract/writer.ex
@@ -4,6 +4,7 @@ defmodule Explorer.SmartContract.Writer do
   """
 
   alias Explorer.Chain
+  alias Explorer.Chain.Hash
   alias Explorer.SmartContract.Helper
 
   @spec write_functions(Hash.t()) :: [%{}]
@@ -23,7 +24,7 @@ defmodule Explorer.SmartContract.Writer do
     end
   end
 
-  @spec write_functions_proxy(Hash.t()) :: [%{}]
+  @spec write_functions_proxy(Hash.t() | String.t()) :: [%{}]
   def write_functions_proxy(implementation_address_hash_string) do
     implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string)
 

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -130,7 +130,7 @@ defmodule Explorer.Token.MetadataRetriever do
   It will retry to fetch each function in the Smart Contract according to :token_functions_reader_max_retries
   configured in the application env case one of them raised error.
   """
-  @spec get_functions_of([String.t()] | Hash.t() | String.t()) :: Map.t() | {:ok, [Map.t()]}
+  @spec get_functions_of([String.t()] | Hash.t() | String.t()) :: map() | {:ok, [map()]}
   def get_functions_of(hashes) when is_list(hashes) do
     requests =
       hashes

--- a/apps/explorer/test/explorer/chain_spec/parity/importer_test.exs
+++ b/apps/explorer/test/explorer/chain_spec/parity/importer_test.exs
@@ -106,9 +106,9 @@ defmodule Explorer.ChainSpec.Parity.ImporterTest do
       assert %{
                address_hash: %Hash{
                  byte_count: 20,
-                 bytes: <<121, 174, 179, 69, 102, 185, 116, 195, 90, 88, 129, 222, 192, 32, 146, 125, 167, 223, 93, 37>>
+                 bytes: <<167, 105, 41, 137, 10, 123, 71, 251, 133, 145, 150, 1, 108, 111, 221, 130, 137, 206, 183, 85>>
                },
-               value: 2_000_000_000_000_000_000_000,
+               value: 5_000_000_000_000_000_000_000,
                contract_code: nil,
                nonce: 0
              } ==

--- a/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance_on_demand.ex
@@ -9,6 +9,7 @@ defmodule Indexer.Fetcher.TokenBalanceOnDemand do
   alias Explorer.Chain
   alias Explorer.Chain.Address.CurrentTokenBalance
   alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Chain.Hash
   alias Explorer.Counters.AverageBlockTime
   alias Explorer.Token.BalanceReader
   alias Timex.Duration

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwalker/alpine-elixir-phoenix:1.12.2
+FROM bitwalker/alpine-elixir-phoenix:1.12.3
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3 file
 


### PR DESCRIPTION
## Motivation

Update to Erlang/OTP 24

## Changelog

- Erlang/OTP 24 pinned
- bitwalker/alpine-elixir-phoenix:1.12.2 -> bitwalker/alpine-elixir-phoenix:1.12.3


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
