### PR TITLE
Contract verification fix: check only success creation tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4717](https://github.com/blockscout/blockscout/pull/4717) - Contract verification fix: check only success creation tx
 - [#4713](https://github.com/blockscout/blockscout/pull/4713) - Search input field: sanitize input
 - [#4703](https://github.com/blockscout/blockscout/pull/4703) - Block Details page: Fix pagination on the Transactions tab
 - [#4686](https://github.com/blockscout/blockscout/pull/4686) - Block page: check gas limit value before division

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3665,6 +3665,7 @@ defmodule Explorer.Chain do
       from(
         tx in Transaction,
         where: tx.created_contract_address_hash == ^address_hash,
+        where: tx.status == ^1,
         select: tx.input
       )
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4716

## Motivation

When Blockscout finds a creation transaction for a contract, it doesn't check the status of the transaction but expects one result in the response. However, multiple failed transactions can presence in the DB at the same time.

## Changelog

Add check of the tx status in the query for finding contract creation transaction.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
