### PR TITLE
optimiation runs: `int4` -> `int8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4778](https://github.com/blockscout/blockscout/pull/4778) - Migrate :optimization_runs field type: `int4 -> int8` in `smart_contracts` table
 - [#4768](https://github.com/blockscout/blockscout/pull/4768) - Block Details page: handle zero division
 - [#4751](https://github.com/blockscout/blockscout/pull/4751) - Change text and link for `trade STAKE` button
 - [#4746](https://github.com/blockscout/blockscout/pull/4746) - Fix comparison of decimal value

--- a/apps/explorer/priv/repo/migrations/20211017135545_migrate_optimization_runs_to_int8.exs
+++ b/apps/explorer/priv/repo/migrations/20211017135545_migrate_optimization_runs_to_int8.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.MigrateOptimizationRunsToInt8 do
+  use Ecto.Migration
+
+  def up do
+    alter table(:smart_contracts) do
+      modify(:optimization_runs, :bigint)
+    end
+  end
+
+  def down do
+    alter table(:smart_contracts) do
+      modify(:optimization_runs, :integer)
+    end
+  end
+end


### PR DESCRIPTION
Close #4756 

## Changelog

### Enhancements
- Migrate :optimization_runs field type: `int4 -> int8` in `smart_contracts` table

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
