### PR TITLE
Add block_number to block_rewards table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4783](https://github.com/blockscout/blockscout/pull/4783) - Resolves request timeout for getting transactions on Emission funds contract address page
 - [#4764](https://github.com/blockscout/blockscout/pull/4764) - Add cleaning of substrings of `require` messages from parsed constructor arguments
 - [#4778](https://github.com/blockscout/blockscout/pull/4778) - Migrate :optimization_runs field type: `int4 -> int8` in `smart_contracts` table
 - [#4768](https://github.com/blockscout/blockscout/pull/4768) - Block Details page: handle zero division

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -283,7 +283,7 @@ defmodule BlockScoutWeb.Chain do
     %{"holder_count" => holder_count, "name" => token_name}
   end
 
-  defp paging_params({%Reward{block: %{number: number}}, _}) do
+  defp paging_params({%Reward{block_number: number}, _}) do
     %{"block_number" => number, "index" => 0}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex
@@ -1,4 +1,4 @@
-<div class="tile tile-type-emission-reward fade-in" data-identifier-hash="<%= @validator.block.hash %>">
+<div class="tile tile-type-emission-reward fade-in" data-identifier-hash="<%= @validator.block_hash %>">
   <div class="row tile-body">
     <div class="col-md-2 d-flex flex-row flex-md-column align-items-left justify-content-start justify-content-lg-center mb-1 mb-md-0 pl-md-4">
       <span class="tile-label">
@@ -10,8 +10,8 @@
     </div>
     <div class="col-md-7 col-lg-8 d-flex flex-column pr-2 pr-sm-2 pr-md-0">
       <%= link(
-        @validator.block.hash,
-        to: block_path(BlockScoutWeb.Endpoint, :show, @validator.block.hash),
+        @validator.block_hash,
+        to: block_path(BlockScoutWeb.Endpoint, :show, @validator.block_hash),
         class: "text-truncate") %>
       <span class="text-nowrap">
         <%= @emission_funds |> BlockScoutWeb.AddressView.address_partial_selector(nil, @current_address) |> BlockScoutWeb.RenderHelpers.render_partial() %>

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -32,11 +32,20 @@ defmodule BlockScoutWeb.TransactionView do
 
   def block_number(%Transaction{block_number: nil}), do: gettext("Block Pending")
   def block_number(%Transaction{block: block}), do: [view_module: BlockView, partial: "_link.html", block: block]
-  def block_number(%Reward{block: block}), do: [view_module: BlockView, partial: "_link.html", block: block]
+
+  def block_number(%Reward{block_hash: block_hash}) do
+    {:ok, block} = Chain.hash_to_block(block_hash)
+    [view_module: BlockView, partial: "_link.html", block: block]
+  end
 
   def block_timestamp(%Transaction{block_number: nil, inserted_at: time}), do: time
   def block_timestamp(%Transaction{block: %Block{timestamp: time}}), do: time
-  def block_timestamp(%Reward{block: %Block{timestamp: time}}), do: time
+
+  def block_timestamp(%Reward{block_hash: block_hash}) do
+    {:ok, block} = Chain.hash_to_block(block_hash)
+    %Block{timestamp: time} = block
+    time
+  end
 
   def value_transfer?(%Transaction{input: %{bytes: bytes}}) when bytes in [<<>>, nil] do
     true

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -81,7 +81,7 @@ msgid "%{subnetwork} Staking DApp - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:350
+#: lib/block_scout_web/views/transaction_view.ex:359
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgid "Compiler version"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:343
+#: lib/block_scout_web/views/transaction_view.ex:352
 msgid "Confirmed"
 msgstr ""
 
@@ -655,12 +655,12 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:458
+#: lib/block_scout_web/views/transaction_view.ex:467
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:455
+#: lib/block_scout_web/views/transaction_view.ex:464
 msgid "Contract Creation"
 msgstr ""
 
@@ -988,12 +988,12 @@ msgid "EIP-1167"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:221
 msgid "ERC-20 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:213
+#: lib/block_scout_web/views/transaction_view.ex:222
 msgid "ERC-721 "
 msgstr ""
 
@@ -1062,12 +1062,12 @@ msgid "Error trying to fetch balances."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:363
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:361
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:21 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/transaction_view.ex:513
+#: lib/block_scout_web/views/transaction_view.ex:522
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1441,7 +1441,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:357
-#: lib/block_scout_web/views/transaction_view.ex:514
+#: lib/block_scout_web/views/transaction_view.ex:523
 msgid "Logs"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgid "Max Priority Fee per Gas"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:322
+#: lib/block_scout_web/views/transaction_view.ex:331
 msgid "Max of"
 msgstr ""
 
@@ -1713,8 +1713,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:53
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:349
-#: lib/block_scout_web/views/transaction_view.ex:387
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:358
+#: lib/block_scout_web/views/transaction_view.ex:396
 msgid "Pending"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:515
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:524
 msgid "Raw Trace"
 msgstr ""
 
@@ -2145,7 +2145,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:351
+#: lib/block_scout_web/views/transaction_view.ex:360
 msgid "Success"
 msgstr ""
 
@@ -2478,12 +2478,12 @@ msgid "Token"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:449
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:458
 msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:450
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:459
 msgid "Token Creation"
 msgstr ""
 
@@ -2507,13 +2507,13 @@ msgid "Token ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:448
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:457
 msgid "Token Minting"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:460
 msgid "Token Transfer"
 msgstr ""
 
@@ -2524,7 +2524,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:348
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:178 lib/block_scout_web/views/tokens/overview_view.ex:41
-#: lib/block_scout_web/views/transaction_view.ex:512
+#: lib/block_scout_web/views/transaction_view.ex:521
 msgid "Token Transfers"
 msgstr ""
 
@@ -2620,7 +2620,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:461
+#: lib/block_scout_web/views/transaction_view.ex:470
 msgid "Transaction"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgid "Uncles"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:342
+#: lib/block_scout_web/views/transaction_view.ex:351
 msgid "Unconfirmed"
 msgstr ""
 
@@ -3193,7 +3193,7 @@ msgid "validator"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:214
+#: lib/block_scout_web/views/transaction_view.ex:223
 msgid "ERC-1155 "
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -81,7 +81,7 @@ msgid "%{subnetwork} Staking DApp - BlockScout"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:350
+#: lib/block_scout_web/views/transaction_view.ex:359
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgid "Compiler version"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:343
+#: lib/block_scout_web/views/transaction_view.ex:352
 msgid "Confirmed"
 msgstr ""
 
@@ -655,12 +655,12 @@ msgid "Contract Address Pending"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:458
+#: lib/block_scout_web/views/transaction_view.ex:467
 msgid "Contract Call"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:455
+#: lib/block_scout_web/views/transaction_view.ex:464
 msgid "Contract Creation"
 msgstr ""
 
@@ -988,12 +988,12 @@ msgid "EIP-1167"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:221
 msgid "ERC-20 "
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:213
+#: lib/block_scout_web/views/transaction_view.ex:222
 msgid "ERC-721 "
 msgstr ""
 
@@ -1062,12 +1062,12 @@ msgid "Error trying to fetch balances."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:354
+#: lib/block_scout_web/views/transaction_view.ex:363
 msgid "Error: %{reason}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:361
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:21 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:346
-#: lib/block_scout_web/views/transaction_view.ex:513
+#: lib/block_scout_web/views/transaction_view.ex:522
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1441,7 +1441,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:357
-#: lib/block_scout_web/views/transaction_view.ex:514
+#: lib/block_scout_web/views/transaction_view.ex:523
 msgid "Logs"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgid "Max Priority Fee per Gas"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:322
+#: lib/block_scout_web/views/transaction_view.ex:331
 msgid "Max of"
 msgstr ""
 
@@ -1713,8 +1713,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:53
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:349
-#: lib/block_scout_web/views/transaction_view.ex:387
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:358
+#: lib/block_scout_web/views/transaction_view.ex:396
 msgid "Pending"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:515
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:524
 msgid "Raw Trace"
 msgstr ""
 
@@ -2145,7 +2145,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:351
+#: lib/block_scout_web/views/transaction_view.ex:360
 msgid "Success"
 msgstr ""
 
@@ -2478,12 +2478,12 @@ msgid "Token"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:449
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:458
 msgid "Token Burning"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:450
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:459
 msgid "Token Creation"
 msgstr ""
 
@@ -2507,13 +2507,13 @@ msgid "Token ID"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:448
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:457
 msgid "Token Minting"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:460
 msgid "Token Transfer"
 msgstr ""
 
@@ -2524,7 +2524,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:348
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:178 lib/block_scout_web/views/tokens/overview_view.ex:41
-#: lib/block_scout_web/views/transaction_view.ex:512
+#: lib/block_scout_web/views/transaction_view.ex:521
 msgid "Token Transfers"
 msgstr ""
 
@@ -2620,7 +2620,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:461
+#: lib/block_scout_web/views/transaction_view.ex:470
 msgid "Transaction"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgid "Uncles"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:342
+#: lib/block_scout_web/views/transaction_view.ex:351
 msgid "Unconfirmed"
 msgstr ""
 
@@ -3193,7 +3193,7 @@ msgid "validator"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/views/transaction_view.ex:214
+#: lib/block_scout_web/views/transaction_view.ex:223
 msgid "ERC-1155 "
 msgstr ""
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -385,7 +385,7 @@ defmodule Explorer.Chain do
     |> Enum.sort_by(fn item ->
       case item do
         {%Reward{} = emission_reward, _} ->
-          {-emission_reward.block.number, 1}
+          {-emission_reward.block_number, 1}
 
         item ->
           block_number = if item.block_number, do: -item.block_number, else: 0

--- a/apps/explorer/lib/explorer/chain/block/reward.ex
+++ b/apps/explorer/lib/explorer/chain/block/reward.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Chain.Block.Reward do
   alias Explorer.{PagingOptions, Repo}
   alias Explorer.SmartContract.Reader
 
-  @required_attrs ~w(address_hash address_type block_hash reward)a
+  @required_attrs ~w(address_hash address_type block_hash block_number reward)a
 
   @get_payout_by_mining_abi %{
     "type" => "function",
@@ -49,6 +49,7 @@ defmodule Explorer.Chain.Block.Reward do
           address_type: AddressType.t(),
           block: %Ecto.Association.NotLoaded{} | Block.t() | nil,
           block_hash: Hash.Full.t(),
+          block_number: non_neg_integer(),
           reward: Wei.t()
         }
 
@@ -56,6 +57,7 @@ defmodule Explorer.Chain.Block.Reward do
   schema "block_rewards" do
     field(:address_type, AddressType)
     field(:reward, Wei)
+    field(:block_number, :integer)
 
     belongs_to(
       :address,
@@ -85,7 +87,7 @@ defmodule Explorer.Chain.Block.Reward do
   def paginate(query, %PagingOptions{key: nil}), do: query
 
   def paginate(query, %PagingOptions{key: {block_number, _}}) do
-    where(query, [_, block], block.number < ^block_number)
+    where(query, [reward], reward.block_number < ^block_number)
   end
 
   @doc """
@@ -98,10 +100,10 @@ defmodule Explorer.Chain.Block.Reward do
       }) do
     address_rewards =
       __MODULE__
-      |> join_associations()
+      |> preload(:address)
       |> paginate(paging_options)
       |> limit(^paging_options.page_size)
-      |> order_by([_, block], desc: block.number)
+      |> order_by([reward], desc: reward.block_number)
       |> where([reward], reward.address_hash == ^address_hash)
       |> address_rewards_blocks_ranges_clause(min_block_number, max_block_number, paging_options)
       |> Repo.all()
@@ -124,8 +126,8 @@ defmodule Explorer.Chain.Block.Reward do
 
         other_rewards =
           __MODULE__
-          |> join_associations()
-          |> order_by([_, block], desc: block.number)
+          |> preload(:address)
+          |> order_by([reward], desc: reward.block_number)
           |> where([reward], reward.address_type == ^other_type)
           |> where([reward], reward.block_hash in ^block_hashes)
           |> Repo.all()
@@ -206,28 +208,21 @@ defmodule Explorer.Chain.Block.Reward do
     end
   end
 
-  defp join_associations(query) do
-    query
-    |> preload(:address)
-    |> join(:inner, [reward], block in assoc(reward, :block))
-    |> preload(:block)
-  end
-
   defp address_rewards_blocks_ranges_clause(query, min_block_number, max_block_number, paging_options) do
     if is_number(min_block_number) and max_block_number > 0 and min_block_number > 0 do
       cond do
         paging_options.page_number == 1 ->
           query
-          |> where([_, block], block.number >= ^min_block_number)
+          |> where([reward], reward.block_number >= ^min_block_number)
 
         min_block_number == max_block_number ->
           query
-          |> where([_, block], block.number == ^min_block_number)
+          |> where([reward], reward.block_number == ^min_block_number)
 
         true ->
           query
-          |> where([_, block], block.number >= ^min_block_number)
-          |> where([_, block], block.number <= ^max_block_number)
+          |> where([reward], reward.block_number >= ^min_block_number)
+          |> where([reward], reward.block_number <= ^max_block_number)
       end
     else
       query

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -539,8 +539,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
     query =
       from(reward in Reward,
-        inner_join: block in assoc(reward, :block),
-        where: block.hash in ^hashes or block.number in ^numbers,
+        where: reward.block_hash in ^hashes or reward.block_number in ^numbers,
         # Enforce Reward ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: :address_hash, asc: :address_type, asc: :block_hash],
         # acquire locks for `reward`s only

--- a/apps/explorer/priv/repo/migrations/20211019085625_add_block_rewards_block_number_column.exs
+++ b/apps/explorer/priv/repo/migrations/20211019085625_add_block_rewards_block_number_column.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddBlockRewardsBlockNumberColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table(:block_rewards) do
+      add(:block_number, :integer, null: true)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20211019090230_add_block_rewards_block_number_index.exs
+++ b/apps/explorer/priv/repo/migrations/20211019090230_add_block_rewards_block_number_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddBlockRewardsBlockNumberIndex do
+  use Ecto.Migration
+
+  def change do
+    create(index(:block_rewards, [:block_number]))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/scripts/fill_block_number_in_block_rewards_table.sql
+++ b/apps/explorer/priv/repo/migrations/scripts/fill_block_number_in_block_rewards_table.sql
@@ -1,0 +1,5 @@
+UPDATE block_rewards
+SET block_number = b.number
+FROM blocks b
+WHERE b.hash = block_rewards.block_hash
+AND block_rewards.block_number IS NULL;

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -590,6 +590,7 @@ defmodule Explorer.ChainTest do
         :reward,
         address_hash: block.miner_hash,
         block_hash: block.hash,
+        block_number: block.number,
         address_type: :validator
       )
 
@@ -597,6 +598,7 @@ defmodule Explorer.ChainTest do
         :reward,
         address_hash: block.miner_hash,
         block_hash: block.hash,
+        block_number: block.number,
         address_type: :emission_funds
       )
 
@@ -649,6 +651,7 @@ defmodule Explorer.ChainTest do
         :reward,
         address_hash: block.miner_hash,
         block_hash: block.hash,
+        block_number: block.number,
         address_type: :validator
       )
 
@@ -656,6 +659,7 @@ defmodule Explorer.ChainTest do
         :reward,
         address_hash: block.miner_hash,
         block_hash: block.hash,
+        block_number: block.number,
         address_type: :emission_funds
       )
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4340

## Motivation

Request time out on getting transactions/rewards for Emission fund contracts

## Changelog

Add `block_number` column to `block_rewards` table and eliminate joining on `blocks` table in the query for getting latest rewards on the address.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
