### PR TITLE
Fix nil.timestamp issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4796](https://github.com/blockscout/blockscout/pull/4796) - Fix nil.timestamp issue
 - [#4764](https://github.com/blockscout/blockscout/pull/4764) - Add cleaning of substrings of `require` messages from parsed constructor arguments
 - [#4778](https://github.com/blockscout/blockscout/pull/4778) - Migrate :optimization_runs field type: `int4 -> int8` in `smart_contracts` table
 - [#4768](https://github.com/blockscout/blockscout/pull/4768) - Block Details page: handle zero division

--- a/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances_daily.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances_daily.ex
@@ -83,7 +83,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalancesDaily do
             end)
 
           if target_item do
-            if change.value > target_item.value do
+            if Map.has_key?(change, :value) && Map.has_key?(target_item, :value) && change.value > target_item.value do
               acc_updated = List.delete(acc, target_item)
               [change | acc_updated]
             else

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -112,7 +112,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
               false
 
             _ ->
-              sequence_opts = put_memory_monitor([ranges: missing_ranges, step: -1 * blocks_batch_size], state)
+              step = step(first, last, blocks_batch_size)
+              sequence_opts = put_memory_monitor([ranges: missing_ranges, step: step], state)
               gen_server_opts = [name: @sequence_name]
               {:ok, sequence} = Sequence.start_link(sequence_opts, gen_server_opts)
               Sequence.cap(sequence)
@@ -124,6 +125,10 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
         %{first_block_number: first, last_block_number: last, missing_block_count: missing_block_count, shrunk: shrunk}
     end
+  end
+
+  defp step(first, last, blocks_batch_size) do
+    if first < last, do: blocks_batch_size, else: -1 * blocks_batch_size
   end
 
   @async_import_remaining_block_data_options ~w(address_hash_to_fetched_balance_block_number)a


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4767

## Motivation

Accessing timestamp prop of nil block object.

## Changelog

Get timestamp of block from the node if it is missing in blocks changeset in order to fill address coin balance daily changest.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
