### PR TITLE
Get token type for token balance update if it is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#4818](https://github.com/blockscout/blockscout/pull/4818) - Fix for extract_omni_bridged_token_metadata_wrapper method
 - [#4812](https://github.com/blockscout/blockscout/pull/4812), [#4815](https://github.com/blockscout/blockscout/pull/4815) - Check if exists custom_cap property of extended token object before access it
 - [#4810](https://github.com/blockscout/blockscout/pull/4810) - Show `nil` block.size as `N/A bytes`
+- [#4806](https://github.com/blockscout/blockscout/pull/4806) - Get token type for token balance update if it is empty
 - [#4802](https://github.com/blockscout/blockscout/pull/4802) - Fix floating tooltip on the main page
 - [#4801](https://github.com/blockscout/blockscout/pull/4801) - Added clauses and tests for get_total_staked_and_ordered/1
 - [#4798](https://github.com/blockscout/blockscout/pull/4798) - Token instance View contract icon Safari fix

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -6358,6 +6358,17 @@ defmodule Explorer.Chain do
     |> TypeDecoder.decode_raw(types)
   end
 
+  def get_token_type(hash) do
+    query =
+      from(
+        token in Token,
+        where: token.contract_address_hash == ^hash,
+        select: token.type
+      )
+
+    Repo.one(query)
+  end
+
   @doc """
   Checks if an `t:Explorer.Chain.Address.t/0` with the given `hash` exists.
 

--- a/apps/indexer/test/indexer/fetcher/token_balance_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_balance_test.exs
@@ -151,6 +151,7 @@ defmodule Indexer.Fetcher.TokenBalanceTest do
           token_contract_address_hash: to_string(token_balance.token_contract_address_hash),
           token_id: nil,
           value: nil,
+          token_type: nil,
           value_fetched_at: nil
         }
       ]


### PR DESCRIPTION
## Motivation

An error of such kind appears when indexing token balances:
`application=indexer count=200 error_count=200 [debug] failed to import token balances: [#Ecto.Changeset<action: nil, changes: %{address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<91, 180, 86, 205, 9, 216, 81, 86, 225, 130, 210, 199, 121, 126, 180, 154, 67, 132, 1, 135>>}, block_number: 10963708, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<192, 42, 170, 57, 178, 35, 254, 141, 10, 14, 92, 79, 39, 234, 217, 8, 60, 117, 108, 194>>}, value: #Decimal<1>, value_fetched_at: ~U[2021-10-24 20:29:17.692398Z]}, errors: [token_type: {"can't be blank", [validation: :required]}]`

## Changelog

Check if all items in token balances changeset contain token type and if some of the items don't have a token type, fetch it from `tokens` table

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
