### PR TITLE
Check if exists custom_cap property of extended token object before access it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4812](https://github.com/blockscout/blockscout/pull/4812) - Check if exists custom_cap property of extended token object before access it
 - [#4810](https://github.com/blockscout/blockscout/pull/4810) - Show `nil` block.size as `N/A bytes`
 - [#4798](https://github.com/blockscout/blockscout/pull/4798) - Token instance View contract icon Safari fix
 - [#4796](https://github.com/blockscout/blockscout/pull/4796) - Fix nil.timestamp issue

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/overview_view.ex
@@ -59,7 +59,7 @@ defmodule BlockScoutWeb.Tokens.OverviewView do
   Get the total value of the token supply in USD.
   """
   def total_supply_usd(token) do
-    if token.custom_cap do
+    if Map.has_key?(token, :custom_cap) && token.custom_cap do
       token.custom_cap
     else
       tokens = CurrencyHelpers.divide_decimals(token.total_supply, token.decimals)


### PR DESCRIPTION
## Motivation

```
Request: GET /token/0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0/token-transfers
** (exit) an exception was raised:
    ** (KeyError) key :custom_cap not found in: %{__meta__: #Ecto.Schema.Metadata<:loaded, "tokens">, __struct__: Explorer.Chain.Token, bridged: nil, cataloged: true, contract_address: %Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, contract_code: %Explorer.Chain.Data{bytes: <<96, 128, 96, 64, 82, 52, 128, 21, 97, 0, 16, 87, 96, 0, 128, 253, 91, 80, 96, 4, 54, 16, 97, 1, 95, 87, 96, 0, 53, 124, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>}, contracts_creation_internal_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_internal_transaction is not loaded>, contracts_creation_transaction: #Ecto.Association.NotLoaded<association :contracts_creation_transaction is not loaded>, decompiled: true, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, fetched_coin_balance: #Explorer.Chain.Wei<0>, fetched_coin_balance_block_number: 13488030, has_decompiled_code?: nil, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<67, 26, 210, 255, 106, 156, 54, 88, 5, 235, 173, 71, 238, 2, 17, 72, 214, 247, 219, 224>>}, inserted_at: ~U[2019-07-25 02:10:45.349094Z], names: #Ecto.Association.NotLoaded<association :names is not loaded>, nonce: nil, smart_contract: nil, smart_contract_additional_sources: #Ecto.Association.NotLoaded<association :smart_contract_additional_sources is not loaded>, stale?: nil, token: #Ecto.Association.NotLoaded<association :token is not loaded>, updated_at: ~U[2019-07-25 02:10:45.349094Z], verified: false}, contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<67, 26, 210, 255, 106, 156, 54, 88, 5, 235, 173, 71, 238, 2, 17, 72, 214, 247, 219, 224>>}, decimals: #Decimal<18>, holder_count: 1652, inserted_at: ~U[2019-07-25 03:39:28.587232Z], name: "dForce", skip_metadata: nil, symbol: "DF", total_supply: #Decimal<999934997348875914379213820>, type: "ERC-20", updated_at: ~U[2021-10-24 10:42:38.416602Z], usd_value: #Decimal<0.216994>}
        (block_scout_web 0.0.1) lib/block_scout_web/views/tokens/overview_view.ex:62: BlockScoutWeb.Tokens.OverviewView.total_supply_usd/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/tokens/overview/_details.html.eex:108: BlockScoutWeb.Tokens.OverviewView."_details.html"/1
        (block_scout_web 0.0.1) lib/block_scout_web/templates/tokens/transfer/index.html.eex:2: BlockScoutWeb.Tokens.TransferView."index.html"/1
        (phoenix 1.5.13) lib/phoenix/view.ex:310: Phoenix.View.render_within/3
        (phoenix 1.5.13) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.13) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/tokens/transfer_controller.ex:1: BlockScoutWeb.Tokens.TransferController.action/2
        (block_scout_web 0.0.1) lib/block_scout_web/controllers/tokens/transfer_controller.ex:1: BlockScoutWeb.Tokens.TransferController.phoenix_controller_pipeline/2
```

## Checklist for your Pull Request (PR)

<!--
  Ideally a PR has all of the checkmarks set.

  If something in this list is irrelevant to your PR, you should still set this
  checkmark indicating that you are sure it is dealt with (be that by irrelevance).

  If you don't set a checkmark (e. g. don't add a test for new functionality),
  please justify why.
-->

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
