### PR TITLE
Add config for GasUsage Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 
 ### Chore
+- [#4819](https://github.com/blockscout/blockscout/pull/4819) - Add config for GasUsage Cache
 - [#4735](https://github.com/blockscout/blockscout/pull/4735) - Code clean up: Remove clauses for outdated ganache bugs
 - [#4726](https://github.com/blockscout/blockscout/pull/4726) - Update chart.js
 - [#4707](https://github.com/blockscout/blockscout/pull/4707) - Top navigation: Move Accounts tab to Tokens

--- a/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.Counters.BlocksIndexedCounter do
   # It is undesirable to automatically start the counter in all environments.
   # Consider the test environment: if it initiates but does not finish before a
   # test ends, that test will fail.
-  config = Application.get_env(:block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter)
+  config = Application.get_env(:block_scout_web, __MODULE__)
   @enabled Keyword.get(config, :enabled)
 
   @doc """

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -241,18 +241,11 @@ config :explorer, Explorer.Chain.Cache.Accounts,
   ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
   global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
 
-config :explorer, Explorer.Chain.Cache.PendingTransactions,
-  enabled:
-    if(System.get_env("ETHEREUM_JSONRPC_VARIANT") == "besu",
-      do: false,
-      else: true
-    ),
-  ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
-  global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
-
 config :explorer, Explorer.Chain.Cache.Uncles,
   ttl_check_interval: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(1), else: false),
   global_ttl: if(System.get_env("DISABLE_INDEXER") == "true", do: :timer.seconds(5))
+
+config :explorer, Explorer.Chain.Cache.GasUsage, enabled: false
 
 config :explorer, Explorer.ThirdPartyIntegrations.Sourcify,
   server_url: System.get_env("SOURCIFY_SERVER_URL") || "https://sourcify.dev/server",

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -6,6 +6,8 @@ defmodule Explorer.Chain.Cache.GasUsage do
   require Logger
 
   @default_cache_period :timer.hours(2)
+  config = Application.get_env(:explorer, __MODULE__)
+  @enabled Keyword.get(config, :enabled)
 
   use Explorer.Chain.MapCache,
     name: :gas_usage,
@@ -26,25 +28,29 @@ defmodule Explorer.Chain.Cache.GasUsage do
   end
 
   defp handle_fallback(:async_task) do
-    # If this gets called it means an async task was requested, but none exists
-    # so a new one needs to be launched
-    {:ok, task} =
-      Task.start(fn ->
-        try do
-          result = Chain.fetch_sum_gas_used()
+    if @enabled do
+      # If this gets called it means an async task was requested, but none exists
+      # so a new one needs to be launched
+      {:ok, task} =
+        Task.start(fn ->
+          try do
+            result = Chain.fetch_sum_gas_used()
 
-          set_sum(result)
-        rescue
-          e ->
-            Logger.debug([
-              "Coudn't update gas used sum test #{inspect(e)}"
-            ])
-        end
+            set_sum(result)
+          rescue
+            e ->
+              Logger.debug([
+                "Coudn't update gas used sum test #{inspect(e)}"
+              ])
+          end
 
-        set_async_task(nil)
-      end)
+          set_async_task(nil)
+        end)
 
-    {:update, task}
+      {:update, task}
+    else
+      {:update, nil}
+    end
   end
 
   # By setting this as a `callback` an async task will be started each time the


### PR DESCRIPTION
## Motivation

There is no availability to disable GasUsage cache via config

## Changelog

Add `enabled` prop for GasUsage cache.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
