### PR TITLE
Pin address page's overview block rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#4739](https://github.com/blockscout/blockscout/pull/4739) - Improve logs and inputs decoding
 - [#4747](https://github.com/blockscout/blockscout/pull/4747) - Advanced CSV export
 - [#4745](https://github.com/blockscout/blockscout/pull/4745) - Vyper contracts verification
-- [#4699](https://github.com/blockscout/blockscout/pull/4699), [#4793](https://github.com/blockscout/blockscout/pull/4793) - Address page facelifting
+- [#4699](https://github.com/blockscout/blockscout/pull/4699), [#4793](https://github.com/blockscout/blockscout/pull/4793), [#4820](https://github.com/blockscout/blockscout/pull/4820) - Address page facelifting
 - [#4667](https://github.com/blockscout/blockscout/pull/4667) - Transaction Page: Add expand/collapse button for long contract method data
 - [#4641](https://github.com/blockscout/blockscout/pull/4641), [#4733](https://github.com/blockscout/blockscout/pull/4733) - Improve Read Contract page logic
 - [#4660](https://github.com/blockscout/blockscout/pull/4660) - Save Sourcify path instead of filename

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -121,11 +121,6 @@ const elements = {
         if (oldState.transactionCount === state.transactionCount) return
         const transactionsDSName = (state.transactionCount > 1) ? ' Transactions' : ' Transaction'
         $el.empty().append(numeral(state.transactionCount).format() + transactionsDSName)
-        $el.show()
-        $('.address-transactions-count-item').removeAttr('style')
-      } else {
-        $el.hide()
-        $('.address-transactions-count-item').css('display', 'none')
       }
     }
   },
@@ -138,11 +133,6 @@ const elements = {
         if (oldState.tokenTransferCount === state.tokenTransferCount) return
         const transfersDSName = (state.tokenTransferCount > 1) ? ' Transfers' : ' Transfer'
         $el.empty().append(numeral(state.tokenTransferCount).format() + transfersDSName)
-        $el.show()
-        $('.address-transfers-count-item').removeAttr('style')
-      } else {
-        $el.hide()
-        $('.address-transfers-count-item').css('display', 'none')
       }
     }
   },
@@ -154,11 +144,6 @@ const elements = {
       if (state.countersFetched && state.gasUsageCount) {
         if (oldState.gasUsageCount === state.gasUsageCount) return
         $el.empty().append(numeral(state.gasUsageCount).format())
-        $el.show()
-        $('.address-gas-used-item').removeAttr('style')
-      } else {
-        $el.hide()
-        $('.address-gas-used-item').css('display', 'none')
       }
     }
   },

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -205,9 +205,11 @@
             <dd class="col-sm-8 col-md-8 col-lg-9" data-test="address_transaction_count">
               <%= if @conn.request_path |> String.contains?("/transactions") do %>
                 <a href="#txs" class="page-link bs-label large btn-no-border-link-to-tems" data-selector="transaction-count">
+                0 <%= gettext("Transactions") %>
                 </a>
               <% else %>
                 <a href="<%= AccessHelpers.get_path(@conn, :address_transaction_path, :index, @address.hash)%>#txs" class="page-link bs-label large btn-no-border-link-to-tems" data-selector="transaction-count">
+                0 <%= gettext("Transactions") %>
                 </a>
               <% end %>
             </dd>
@@ -222,9 +224,11 @@
             <dd class="col-sm-8 col-md-8 col-lg-9" data-test="address_transfer_count">
               <%= if @conn.request_path |> String.contains?("/token-transfers") do %>
                 <a href="#transfers" class="page-link bs-label large btn-no-border-link-to-tems" data-selector="transfer-count">
+                0 <%= gettext("Transfers") %>
                 </a>
               <% else %>
                 <a href="<%= AccessHelpers.get_path(@conn, :address_token_transfers_path, :index, @address.hash)%>#transfers" class="page-link bs-label large btn-no-border-link-to-tems" data-selector="transfer-count">
+                0 <%= gettext("Transfers") %>
                 </a>
               <% end %>
             </dd>
@@ -238,6 +242,7 @@
             </dt>
             <dd class="col-sm-8 col-md-8 col-lg-9" data-test="address_gas_used">
               <span data-selector="gas-usage-count">
+              0
               </span>
             </dd>
           </dl>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -398,7 +398,7 @@ msgid "Block number containing the transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:249
+#: lib/block_scout_web/templates/address/overview.html.eex:254
 msgid "Block number in which the address was updated."
 msgstr ""
 
@@ -420,7 +420,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:48
-#: lib/block_scout_web/templates/address/overview.html.eex:266 lib/block_scout_web/templates/address_validation/index.html.eex:15
+#: lib/block_scout_web/templates/address/overview.html.eex:271 lib/block_scout_web/templates/address_validation/index.html.eex:15
 #: lib/block_scout_web/views/address_view.ex:356
 msgid "Blocks Validated"
 msgstr ""
@@ -1176,7 +1176,7 @@ msgid "Gas Price"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:237
+#: lib/block_scout_web/templates/address/overview.html.eex:241
 #: lib/block_scout_web/templates/block/_tile.html.eex:73 lib/block_scout_web/templates/block/overview.html.eex:172
 msgid "Gas Used"
 msgstr ""
@@ -1187,8 +1187,8 @@ msgid "Gas Used by Transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:236
-#: lib/block_scout_web/templates/address/overview.html.eex:265
+#: lib/block_scout_web/templates/address/overview.html.eex:240
+#: lib/block_scout_web/templates/address/overview.html.eex:270
 msgid "Gas used by the address."
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgid "JSON RPC error"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:255
 msgid "Last Balance Update"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgid "Number of transactions related to this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:219
+#: lib/block_scout_web/templates/address/overview.html.eex:221
 msgid "Number of transfers to/from this address."
 msgstr ""
 
@@ -2677,7 +2677,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:203 lib/block_scout_web/templates/address_transaction/index.html.eex:17
+#: lib/block_scout_web/templates/address/overview.html.eex:203 lib/block_scout_web/templates/address/overview.html.eex:208
+#: lib/block_scout_web/templates/address/overview.html.eex:212 lib/block_scout_web/templates/address_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/block/overview.html.eex:74 lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:236 lib/block_scout_web/templates/layout/_topnav.html.eex:41
 #: lib/block_scout_web/views/address_view.ex:347
@@ -2695,7 +2696,8 @@ msgid "Transactions sent"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:220
+#: lib/block_scout_web/templates/address/overview.html.eex:222
+#: lib/block_scout_web/templates/address/overview.html.eex:227 lib/block_scout_web/templates/address/overview.html.eex:231
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 msgid "Transfers"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -398,7 +398,7 @@ msgid "Block number containing the transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:249
+#: lib/block_scout_web/templates/address/overview.html.eex:254
 msgid "Block number in which the address was updated."
 msgstr ""
 
@@ -420,7 +420,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:48
-#: lib/block_scout_web/templates/address/overview.html.eex:266 lib/block_scout_web/templates/address_validation/index.html.eex:15
+#: lib/block_scout_web/templates/address/overview.html.eex:271 lib/block_scout_web/templates/address_validation/index.html.eex:15
 #: lib/block_scout_web/views/address_view.ex:356
 msgid "Blocks Validated"
 msgstr ""
@@ -1176,7 +1176,7 @@ msgid "Gas Price"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:237
+#: lib/block_scout_web/templates/address/overview.html.eex:241
 #: lib/block_scout_web/templates/block/_tile.html.eex:73 lib/block_scout_web/templates/block/overview.html.eex:172
 msgid "Gas Used"
 msgstr ""
@@ -1187,8 +1187,8 @@ msgid "Gas Used by Transaction"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:236
-#: lib/block_scout_web/templates/address/overview.html.eex:265
+#: lib/block_scout_web/templates/address/overview.html.eex:240
+#: lib/block_scout_web/templates/address/overview.html.eex:270
 msgid "Gas used by the address."
 msgstr ""
 
@@ -1345,7 +1345,7 @@ msgid "JSON RPC error"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:250
+#: lib/block_scout_web/templates/address/overview.html.eex:255
 msgid "Last Balance Update"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgid "Number of transactions related to this address."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:219
+#: lib/block_scout_web/templates/address/overview.html.eex:221
 msgid "Number of transfers to/from this address."
 msgstr ""
 
@@ -2677,7 +2677,8 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/_tabs.html.eex:7
-#: lib/block_scout_web/templates/address/overview.html.eex:203 lib/block_scout_web/templates/address_transaction/index.html.eex:17
+#: lib/block_scout_web/templates/address/overview.html.eex:203 lib/block_scout_web/templates/address/overview.html.eex:208
+#: lib/block_scout_web/templates/address/overview.html.eex:212 lib/block_scout_web/templates/address_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/block/overview.html.eex:74 lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:236 lib/block_scout_web/templates/layout/_topnav.html.eex:41
 #: lib/block_scout_web/views/address_view.ex:347
@@ -2695,7 +2696,8 @@ msgid "Transactions sent"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:220
+#: lib/block_scout_web/templates/address/overview.html.eex:222
+#: lib/block_scout_web/templates/address/overview.html.eex:227 lib/block_scout_web/templates/address/overview.html.eex:231
 #: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:50
 msgid "Transfers"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
@@ -89,7 +89,7 @@ defmodule BlockScoutWeb.AddressControllerTest do
                "transaction_count" => 0,
                "token_transfer_count" => 0,
                "validation_count" => 0,
-               "gas_usage_count" => 0,
+               "gas_usage_count" => nil,
                "crc_total_worth" => "0"
              } ==
                response

--- a/apps/explorer/lib/explorer/counters/address_gas_usage_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_gas_usage_counter.ex
@@ -48,9 +48,7 @@ defmodule Explorer.Counters.AddressTransactionsGasUsageCounter do
 
   def fetch(address) do
     if cache_expired?(address) do
-      Task.start_link(fn ->
-        update_cache(address)
-      end)
+      update_cache(address)
     end
 
     address_hash_string = get_address_hash_string(address)

--- a/apps/explorer/lib/explorer/counters/address_token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_token_transfers_counter.ex
@@ -48,9 +48,7 @@ defmodule Explorer.Counters.AddressTokenTransfersCounter do
 
   def fetch(address) do
     if cache_expired?(address) do
-      Task.start_link(fn ->
-        update_cache(address)
-      end)
+      update_cache(address)
     end
 
     address_hash_string = get_address_hash_string(address)

--- a/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
@@ -48,9 +48,7 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
 
   def fetch(address) do
     if cache_expired?(address) do
-      Task.start_link(fn ->
-        update_cache(address)
-      end)
+      update_cache(address)
     end
 
     address_hash_string = get_address_hash_string(address)


### PR DESCRIPTION
## Motivation

The number of rows in the address page's overview block is changing (jumping).

## Changelog

Pin all rows except validations count (because we don't know beforehand is it validator address or not) on address page's overview block.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
