### PR TITLE
Various error handlers with unresponsive JSON RPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 
 ### Chore
+- [#4823](https://github.com/blockscout/blockscout/pull/4823) - Various error handlers with unresponsive JSON RPC endpoint
 - [#4821](https://github.com/blockscout/blockscout/pull/4821) - Block Details page: Remove crossing at the Burnt Fee line
 - [#4819](https://github.com/blockscout/blockscout/pull/4819) - Add config for GasUsage Cache
 - [#4735](https://github.com/blockscout/blockscout/pull/4735) - Code clean up: Remove clauses for outdated ganache bugs

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -71,59 +71,67 @@ defmodule Indexer.Block.Catchup.Fetcher do
       ) do
     Logger.metadata(fetcher: :block_catchup)
 
-    {:ok, latest_block_number} =
-      case latest_block() do
-        nil ->
-          EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
+    with {:ok, latest_block_number} <- fetch_last_block(json_rpc_named_arguments) do
+      case latest_block_number do
+        # let realtime indexer get the genesis block
+        0 ->
+          %{first_block_number: 0, missing_block_count: 0, last_block_number: 0, shrunk: false}
 
-        number ->
-          {:ok, number}
+        _ ->
+          # realtime indexer gets the current latest block
+          first = latest_block_number - 1
+          last = last_block()
+
+          Logger.metadata(first_block_number: first, last_block_number: last)
+
+          missing_ranges = Chain.missing_block_number_ranges(first..last)
+
+          range_count = Enum.count(missing_ranges)
+
+          missing_block_count =
+            missing_ranges
+            |> Stream.map(&Enum.count/1)
+            |> Enum.sum()
+
+          Logger.debug(fn -> "Missed blocks in ranges." end,
+            missing_block_range_count: range_count,
+            missing_block_count: missing_block_count
+          )
+
+          shrunk =
+            case missing_block_count do
+              0 ->
+                false
+
+              _ ->
+                step = step(first, last, blocks_batch_size)
+                sequence_opts = put_memory_monitor([ranges: missing_ranges, step: step], state)
+                gen_server_opts = [name: @sequence_name]
+                {:ok, sequence} = Sequence.start_link(sequence_opts, gen_server_opts)
+                Sequence.cap(sequence)
+
+                stream_fetch_and_import(state, sequence)
+
+                Shrinkable.shrunk?(sequence)
+            end
+
+          %{
+            first_block_number: first,
+            last_block_number: last,
+            missing_block_count: missing_block_count,
+            shrunk: shrunk
+          }
       end
+    end
+  end
 
-    case latest_block_number do
-      # let realtime indexer get the genesis block
-      0 ->
-        %{first_block_number: 0, missing_block_count: 0, last_block_number: 0, shrunk: false}
+  defp fetch_last_block(json_rpc_named_arguments) do
+    case latest_block() do
+      nil ->
+        EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
 
-      _ ->
-        # realtime indexer gets the current latest block
-        first = latest_block_number - 1
-        last = last_block()
-
-        Logger.metadata(first_block_number: first, last_block_number: last)
-
-        missing_ranges = Chain.missing_block_number_ranges(first..last)
-
-        range_count = Enum.count(missing_ranges)
-
-        missing_block_count =
-          missing_ranges
-          |> Stream.map(&Enum.count/1)
-          |> Enum.sum()
-
-        Logger.debug(fn -> "Missed blocks in ranges." end,
-          missing_block_range_count: range_count,
-          missing_block_count: missing_block_count
-        )
-
-        shrunk =
-          case missing_block_count do
-            0 ->
-              false
-
-            _ ->
-              step = step(first, last, blocks_batch_size)
-              sequence_opts = put_memory_monitor([ranges: missing_ranges, step: step], state)
-              gen_server_opts = [name: @sequence_name]
-              {:ok, sequence} = Sequence.start_link(sequence_opts, gen_server_opts)
-              Sequence.cap(sequence)
-
-              stream_fetch_and_import(state, sequence)
-
-              Shrinkable.shrunk?(sequence)
-          end
-
-        %{first_block_number: first, last_block_number: last, missing_block_count: missing_block_count, shrunk: shrunk}
+      number ->
+        {:ok, number}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
@@ -136,6 +136,11 @@ defmodule Indexer.Fetcher.PendingTransaction do
 
         :ok
 
+      {:error, :etimedout} ->
+        Logger.error("timeout")
+
+        :ok
+
       {:error, {:bad_gateway, _}} ->
         Logger.error("bad_gateway")
 


### PR DESCRIPTION
## Motivation

Some errors are not handled if JSON RPC endpoint is not responsive.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
