### PR TITLE
Dedup to Uniq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4579](https://github.com/blockscout/blockscout/pull/4579) - Write contract page: Resize inputs; Improve multiplier selector
 
 ### Fixes
+- [#4840](https://github.com/blockscout/blockscout/pull/4840) - Replace Enum.dedup with Enum.uniq where actually uniq items are expected
 - [#4835](https://github.com/blockscout/blockscout/pull/4835) - Fix view for broken token icons
 - [#4830](https://github.com/blockscout/blockscout/pull/4830) - Speed up txs per day chart data collection
 - [#4818](https://github.com/blockscout/blockscout/pull/4818) - Fix for extract_omni_bridged_token_metadata_wrapper method

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -221,7 +221,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     block_numbers =
       changes_list
       |> Enum.map(& &1.block_number)
-      |> Enum.dedup()
+      |> Enum.uniq()
 
     query =
       from(

--- a/apps/indexer/lib/indexer/transform/address_coin_balances_daily.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances_daily.ex
@@ -41,7 +41,7 @@ defmodule Indexer.Transform.AddressCoinBalancesDaily do
 
     coin_balances_daily_params_set =
       coin_balances_daily_params_list
-      |> Enum.dedup()
+      |> Enum.uniq()
       |> Enum.into(MapSet.new())
 
     coin_balances_daily_params_set
@@ -64,7 +64,7 @@ defmodule Indexer.Transform.AddressCoinBalancesDaily do
 
     coin_balances_daily_params_set =
       coin_balances_daily_params_list
-      |> Enum.dedup()
+      |> Enum.uniq()
       |> Enum.into(MapSet.new())
 
     coin_balances_daily_params_set

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -41,17 +41,17 @@ defmodule Indexer.Transform.TokenTransfers do
     |> Enum.map(fn token_transfer ->
       token_transfer.token_contract_address_hash
     end)
-    |> Enum.dedup()
+    |> Enum.uniq()
     |> Enum.each(&update_token/1)
 
-    tokens_dedup = tokens |> Enum.dedup()
+    tokens_uniq = tokens |> Enum.uniq()
 
-    token_transfers_from_logs_dedup = %{
-      tokens: tokens_dedup,
+    token_transfers_from_logs_uniq = %{
+      tokens: tokens_uniq,
       token_transfers: token_transfers
     }
 
-    token_transfers_from_logs_dedup
+    token_transfers_from_logs_uniq
   end
 
   defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc, type \\ :erc20_erc721) do


### PR DESCRIPTION
## Motivation

`Enum.dedup/1` was mistakenly used for the aim of filtering unique items.

## Changelog

`Enum.dedup/1` replaced with `Enum.uniq/1` in several places in indexer.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
