### PR TITLE
Add missing columns updates when INSERT ... ON CONFLICT DO UPDATE ... happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - [#4582](https://github.com/blockscout/blockscout/pull/4582) - Fix NaN input on write contract page
 
 ### Chore
+- [#4876](https://github.com/blockscout/blockscout/pull/4876) - Add missing columns updates when INSERT ... ON CONFLICT DO UPDATE ... happens
 - [#4872](https://github.com/blockscout/blockscout/pull/4872) - Set explicit ascending order by hash in acquire transactions query of internal transactions import
 - [#4871](https://github.com/blockscout/blockscout/pull/4871) - Remove cumulative gas used update duplicate
 - [#4860](https://github.com/blockscout/blockscout/pull/4860) - Node 16 support

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -322,6 +322,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
           value: fragment("EXCLUDED.value"),
           value_fetched_at: fragment("EXCLUDED.value_fetched_at"),
           old_value: current_token_balance.value,
+          token_type: fragment("EXCLUDED.token_type"),
           inserted_at: fragment("LEAST(EXCLUDED.inserted_at, ?)", current_token_balance.inserted_at),
           updated_at: fragment("GREATEST(EXCLUDED.updated_at, ?)", current_token_balance.updated_at)
         ]

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -176,6 +176,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
         set: [
           value: fragment("EXCLUDED.value"),
           value_fetched_at: fragment("EXCLUDED.value_fetched_at"),
+          token_type: fragment("EXCLUDED.token_type"),
           inserted_at: fragment("LEAST(EXCLUDED.inserted_at, ?)", token_balance.inserted_at),
           updated_at: fragment("GREATEST(EXCLUDED.updated_at, ?)", token_balance.updated_at)
         ]

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -123,7 +123,8 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
               "GREATEST(EXCLUDED.fetched_coin_balance_block_number, ?)",
               address.fetched_coin_balance_block_number
             ),
-          nonce: fragment("GREATEST(EXCLUDED.nonce, ?)", address.nonce)
+          nonce: fragment("GREATEST(EXCLUDED.nonce, ?)", address.nonce),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", address.updated_at)
         ]
       ],
       # where any of `set`s would make a change

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -118,6 +118,11 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           to_address_hash: fragment("EXCLUDED.to_address_hash"),
           v: fragment("EXCLUDED.v"),
           value: fragment("EXCLUDED.value"),
+          earliest_processing_start: fragment("EXCLUDED.earliest_processing_start"),
+          revert_reason: fragment("EXCLUDED.revert_reason"),
+          max_priority_fee_per_gas: fragment("EXCLUDED.max_priority_fee_per_gas"),
+          max_fee_per_gas: fragment("EXCLUDED.max_fee_per_gas"),
+          type: fragment("EXCLUDED.type"),
           # Don't update `hash` as it is part of the primary key and used for the conflict target
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", transaction.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", transaction.updated_at)
@@ -125,7 +130,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
       ],
       where:
         fragment(
-          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code_indexed_at, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code_indexed_at, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value, EXCLUDED.earliest_processing_start, EXCLUDED.revert_reason, EXCLUDED.max_priority_fee_per_gas, EXCLUDED.max_fee_per_gas, EXCLUDED.type) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           transaction.block_hash,
           transaction.block_number,
           transaction.created_contract_address_hash,
@@ -143,7 +148,12 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           transaction.status,
           transaction.to_address_hash,
           transaction.v,
-          transaction.value
+          transaction.value,
+          transaction.earliest_processing_start,
+          transaction.revert_reason,
+          transaction.max_priority_fee_per_gas,
+          transaction.max_fee_per_gas,
+          transaction.type
         )
     )
   end


### PR DESCRIPTION
## Motivation

Some DB columns in different tables are not updated in UPDATE query when conflict arises on INSERT query.

## Changelog

- add `updated_at` into update when importing addresses
- add `token_type` into update when importing token balances history and current token balances
- add `earliest_processing_start`, `revert_reason`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `type` into update when importing transactions

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
