### PR TITLE
Fix fetch_top_tokens method: add nulls last for token holders desc order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#4888](https://github.com/blockscout/blockscout/pull/4888) - Fix fetch_top_tokens method: add nulls last for token holders desc order
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
@@ -42,6 +42,15 @@ defmodule BlockScoutWeb.CurrencyHelpers do
 
       iex> format_according_to_decimals(205000, Decimal.new(2))
       "2,050"
+
+      iex> format_according_to_decimals(105000, Decimal.new(0))
+      "105,000"
+
+      iex> format_according_to_decimals(105000000000000000000, Decimal.new(100500))
+      "105"
+
+      iex> format_according_to_decimals(105000000000000000000, nil)
+      "105,000,000,000,000,000,000"
   """
   @spec format_according_to_decimals(non_neg_integer() | nil, nil) :: String.t()
   def format_according_to_decimals(nil, _) do
@@ -60,9 +69,13 @@ defmodule BlockScoutWeb.CurrencyHelpers do
 
   @spec format_according_to_decimals(Decimal.t(), Decimal.t()) :: String.t()
   def format_according_to_decimals(value, decimals) do
-    value
-    |> divide_decimals(decimals)
-    |> thousands_separator()
+    if Decimal.cmp(decimals, 18) == :gt do
+      format_according_to_decimals(value, Decimal.new(18))
+    else
+      value
+      |> divide_decimals(decimals)
+      |> thousands_separator()
+    end
   end
 
   defp thousands_separator(value) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2295,7 +2295,7 @@ defmodule Explorer.Chain do
     base_query =
       from(t in Token,
         where: t.total_supply > ^0,
-        order_by: [desc: t.holder_count, asc: t.name],
+        order_by: [desc_nulls_last: t.holder_count, asc: t.name],
         preload: [:contract_address]
       )
 


### PR DESCRIPTION
## Motivation

<img width="1574" alt="Screenshot 2021-11-10 at 19 20 43" src="https://user-images.githubusercontent.com/4341812/141151441-3c89a8d4-ae80-42d8-8e06-ffcf3f1da004.png">

## Changelog

Change ordering `fetch_top_tokens` in query from `holder_count DESC` to `holder_count DESC NULLS LAST`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
