### PR TITLE
Addition of `revertReason`

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/parity/trace.ex
@@ -466,6 +466,8 @@ defmodule EthereumJSONRPC.Parity.Trace do
 
   defp entry_to_elixir({"index", index} = entry) when is_integer(index), do: entry
 
+  defp entry_to_elixir({"revertReason", reason} = entry) when is_binary(reason), do: entry
+  
   defp entry_to_elixir({"result" = key, result}) do
     {key, Result.to_elixir(result)}
   end


### PR DESCRIPTION
## Motivation

The current implementation of BESU throws `revertReason` on a reverted transaction, which is not handled by blockscout and blockscout throws errors indefinitely. 

## Changelog

Added `revertReason` handler to the `tracer.ex`

### Bug Fixes

Addition of the `revertReason` fixes the issue and renders the revert reason on the transaction page without any problem.

### Incompatible Changes
Current implementation is not tested on Parity, or Geth or any other EVM blockchains. The current fix only solves the issue on Besu blockchains.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [X] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
