### PR TITLE
Fix displaying of nested arrays for contracts read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#4976](https://github.com/blockscout/blockscout/pull/4976) - Handle :econnrefused in pending transactions fetcher
 - [#4965](https://github.com/blockscout/blockscout/pull/4965) - Fix search field appearance on medium size screens
 - [#4945](https://github.com/blockscout/blockscout/pull/4945) - Fix `Verify & Publish` button link
+- [#4938](https://github.com/blockscout/blockscout/pull/4938) - Fix displaying of nested arrays for contracts read
 - [#4888](https://github.com/blockscout/blockscout/pull/4888) - Fix fetch_top_tokens method: add nulls last for token holders desc order
 
 ### Chore

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/smart_contract_view_test.exs
@@ -135,7 +135,7 @@ defmodule BlockScoutWeb.SmartContractViewTest do
     if length > @max_size do
       "<details class=\"py-2 word-break-all\"><summary>Click to view</summary>#{output}</details>"
     else
-      "<div class=\"py-2 word-break-all\">#{output}</div>"
+      "<span class=\"word-break-all\" style=\"line-height: 3;\">#{output}</span>"
     end
   end
 


### PR DESCRIPTION
Close #4933 

## Changelog

### Bug Fixes
- Fix displaying of nested arrays for contracts read

[Test contract](https://blockscout.com/poa/sokol/address/0x0EC925Cf5d65c2ad8Ae7fb26957EF1b8e9D73a0C/read-contract) with differrent examples of arrays

![image](https://user-images.githubusercontent.com/32202610/142615183-6559ed7a-b48a-4736-a432-e009e44c8562.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
