### PR TITLE
Handle :econnrefused in pending transactions fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - [#4977](https://github.com/blockscout/blockscout/pull/4977) - Export token transfers on address: include transfers on contract itself
+- [#4976](https://github.com/blockscout/blockscout/pull/4976) - Handle :econnrefused in pending transactions fetcher
 - [#4965](https://github.com/blockscout/blockscout/pull/4965) - Fix search field appearance on medium size screens
 - [#4945](https://github.com/blockscout/blockscout/pull/4945) - Fix `Verify & Publish` button link
 - [#4888](https://github.com/blockscout/blockscout/pull/4888) - Fix fetch_top_tokens method: add nulls last for token holders desc order

--- a/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_transaction.ex
@@ -141,6 +141,11 @@ defmodule Indexer.Fetcher.PendingTransaction do
 
         :ok
 
+      {:error, :econnrefused} ->
+        Logger.error("connection_refused")
+
+        :ok
+
       {:error, {:bad_gateway, _}} ->
         Logger.error("bad_gateway")
 


### PR DESCRIPTION
## Motivation

Eliminate pending transactions fetcher termination:
```
2021-12-03T10:18:28.379 fetcher=pending_transaction [error] Task #PID<0.26811.31> started from Indexer.Fetcher.PendingTransaction terminating
** (CaseClauseError) no case clause matching: {:error, :econnrefused}
    (indexer 0.1.0) lib/indexer/fetcher/pending_transaction.ex:120: Indexer.Fetcher.PendingTransaction.task/1
    (elixir 1.12.2) lib/task/supervised.ex:90: Task.Supervised.invoke_mfa/2
    (elixir 1.12.2) lib/task/supervised.ex:35: Task.Supervised.reply/5
    (stdlib 3.15.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: #Function<2.38596988/0 in Indexer.Fetcher.PendingTransaction.handle_info/2>
    Args: []
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
