### PR TITLE
Improve bridged tokens list API endpoint: add handler for empty page number and page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Current
 
 ### Features
-- [#4989](https://github.com/blockscout/blockscout/pull/4989) - Bridged tokens list API endpoint
+- [#4989](https://github.com/blockscout/blockscout/pull/4989), [#4991](https://github.com/blockscout/blockscout/pull/4991) - Bridged tokens list API endpoint
 - [#4931](https://github.com/blockscout/blockscout/pull/4931) - Web3 modal with Wallet Connect for Write contract page and Staking Dapp
 
 ### Fixes

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
   alias BlockScoutWeb.API.RPC.Helpers
   alias Explorer.{Chain, PagingOptions}
 
+  @default_page_size 50
+
   def gettoken(conn, params) do
     with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
          {:format, {:ok, address_hash}} <- to_address_hash(contractaddress_param),
@@ -55,11 +57,19 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
 
     params_with_paging_options = Helpers.put_pagination_options(%{}, params)
 
+    page_number =
+      if Map.has_key?(params_with_paging_options, :page_number), do: params_with_paging_options.page_number, else: 1
+
+    page_size =
+      if Map.has_key?(params_with_paging_options, :page_size),
+        do: params_with_paging_options.page_size,
+        else: @default_page_size
+
     options = [
       paging_options: %PagingOptions{
         key: nil,
-        page_number: params_with_paging_options.page_number,
-        page_size: params_with_paging_options.page_size
+        page_number: page_number,
+        page_size: page_size
       }
     ]
 


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/4986

## Motivation

If page number/size is not set, the endpoint returns internal server error.

## Changelog

Add handlers of empty page size or/and number


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
