### PR TITLE
Fix fetch_last_token_balance function termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#4931](https://github.com/blockscout/blockscout/pull/4931) - Web3 modal with Wallet Connect for Write contract page and Staking Dapp
 
 ### Fixes
+- [#5019](https://github.com/blockscout/blockscout/pull/5019) - Fix fetch_last_token_balance function termination
 - [#5011](https://github.com/blockscout/blockscout/pull/5011) - Fix `0x0` implementation address
 - [#5008](https://github.com/blockscout/blockscout/pull/5008) - Extend decimals cap in format_according_to_decimals up to 24
 - [#5005](https://github.com/blockscout/blockscout/pull/5005) - Fix falsy appearance `Connection Lost` warning on reload/switch page

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5654,16 +5654,22 @@ defmodule Explorer.Chain do
 
   @spec fetch_last_token_balance(Hash.Address.t(), Hash.Address.t()) :: Decimal.t()
   def fetch_last_token_balance(address_hash, token_contract_address_hash) do
-    address_hash
-    |> CurrentTokenBalance.last_token_balance(token_contract_address_hash)
-    |> Repo.one() || Decimal.new(0)
+    if address_hash !== %{} do
+      address_hash
+      |> CurrentTokenBalance.last_token_balance(token_contract_address_hash) || Decimal.new(0)
+    else
+      Decimal.new(0)
+    end
   end
 
   # @spec fetch_last_token_balance_1155(Hash.Address.t(), Hash.Address.t()) :: Decimal.t()
   def fetch_last_token_balance_1155(address_hash, token_contract_address_hash, token_id) do
-    address_hash
-    |> CurrentTokenBalance.last_token_balance_1155(token_contract_address_hash, token_id)
-    |> Repo.one() || Decimal.new(0)
+    if address_hash !== %{} do
+      address_hash
+      |> CurrentTokenBalance.last_token_balance_1155(token_contract_address_hash, token_id) || Decimal.new(0)
+    else
+      Decimal.new(0)
+    end
   end
 
   @spec address_to_coin_balances(Hash.Address.t(), [paging_options]) :: []

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   import Ecto.Changeset
   import Ecto.Query, only: [from: 2, limit: 2, offset: 2, order_by: 3, preload: 2]
 
-  alias Explorer.{Chain, PagingOptions}
+  alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, BridgedToken, Hash, Token}
 
   @default_paging_options %PagingOptions{page_size: 50}
@@ -188,25 +188,33 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   Builds an `t:Ecto.Query.t/0` to fetch the current balance of the given address for the given token.
   """
   def last_token_balance(address_hash, token_contract_address_hash) do
-    from(
-      tb in __MODULE__,
-      where: tb.token_contract_address_hash == ^token_contract_address_hash,
-      where: tb.address_hash == ^address_hash,
-      select: tb.value
-    )
+    query =
+      from(
+        tb in __MODULE__,
+        where: tb.token_contract_address_hash == ^token_contract_address_hash,
+        where: tb.address_hash == ^address_hash,
+        select: tb.value
+      )
+
+    query
+    |> Repo.one()
   end
 
   @doc """
   Builds an `t:Ecto.Query.t/0` to fetch the current balance of the given address for the given token and token_id
   """
   def last_token_balance_1155(address_hash, token_contract_address_hash, token_id) do
-    from(
-      ctb in __MODULE__,
-      where: ctb.token_contract_address_hash == ^token_contract_address_hash,
-      where: ctb.address_hash == ^address_hash,
-      where: ctb.token_id == ^token_id,
-      select: ctb.value
-    )
+    query =
+      from(
+        ctb in __MODULE__,
+        where: ctb.token_contract_address_hash == ^token_contract_address_hash,
+        where: ctb.address_hash == ^address_hash,
+        where: ctb.token_id == ^token_id,
+        select: ctb.value
+      )
+
+    query
+    |> Repo.one()
   end
 
   @doc """


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/4934

## Motivation

Fixing an error of kind:

```
2021-12-14T21:04:16.957 [error] GenServer #PID<0.735.406> terminating
** (Ecto.Query.CastError) apps/explorer/lib/explorer/chain/address/current_token_balance.ex:191: value `%{}` in `where` cannot be cast to type Explorer.Chain.Hash.Address in query:

from c0 in Explorer.Chain.Address.CurrentTokenBalance,
  where: c0.token_contract_address_hash == ^%Explorer.Chain.Hash{byte_count: 20, bytes: <<183, 211, 17, 226, 235, 85, 242, 246, 138, 148, 64, 218, 56, 231, 152, 146, 16, 185, 160, 94>>},
  where: c0.address_hash == ^%{},
  select: c0.value

    (elixir 1.12.2) lib/enum.ex:2385: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.12.2) lib/enum.ex:1704: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir 1.12.2) lib/enum.ex:1704: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
