### PR TITLE
fix csv export of value and gas fee to decimal.

### DIFF
--- a/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_explorer.ex
+++ b/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_explorer.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Chain.AddressInternalTransactionCsvExporter do
           internal_transaction.call_type,
           internal_transaction.gas,
           internal_transaction.gas_used,
-          Wei.to(internal_transaction.value, :wei),
+          Wei.to(internal_transaction.value, :ether),
           internal_transaction.input,
           internal_transaction.output,
           internal_transaction.error

--- a/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
@@ -4,7 +4,7 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporter do
   """
 
   alias Explorer.{Chain, PagingOptions}
-  alias Explorer.Chain.{Address, TokenTransfer}
+  alias Explorer.Chain.{Address, TokenTransfer, CurrencyHelpers}
   alias NimbleCSV.RFC4180
 
   @page_size 150
@@ -75,7 +75,7 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporter do
           token_transfer.token_contract_address_hash |> to_string() |> String.downcase(),
           type(token_transfer, address.hash),
           token_transfer.token.symbol,
-          token_transfer.amount,
+          CurrencyHelpers.divide_decimals(token_transfer.amount, token_transfer.token.decimals),
           fee(token_transfer.transaction),
           token_transfer.transaction.status,
           token_transfer.transaction.error
@@ -95,8 +95,12 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporter do
     transaction
     |> Chain.fee(:wei)
     |> case do
-      {:actual, value} -> value
-      {:maximum, value} -> "Max of #{value}"
+      {:actual, value} ->
+        CurrencyHelpers.divide_decimals(value, Decimal.new(18))
+
+      {:maximum, value} ->
+        token_fee = CurrencyHelpers.divide_decimals(value, Decimal.new(18))
+        "Max of #{token_fee}"
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/address_transaction_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_transaction_csv_exporter.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.AddressTransactionCsvExporter do
 
   alias Explorer.{Chain, Market, PagingOptions, Repo}
   alias Explorer.Market.MarketHistory
-  alias Explorer.Chain.{Address, Transaction, Wei}
+  alias Explorer.Chain.{Address, Transaction, Wei, CurrencyHelpers}
   alias Explorer.ExchangeRates.Token
   alias NimbleCSV.RFC4180
 
@@ -100,7 +100,7 @@ defmodule Explorer.Chain.AddressTransactionCsvExporter do
           to_string(transaction.to_address),
           to_string(transaction.created_contract_address),
           type(transaction, address.hash),
-          Wei.to(transaction.value, :wei),
+          Wei.to(transaction.value, :ether),
           fee(transaction),
           transaction.status,
           transaction.error,
@@ -123,8 +123,12 @@ defmodule Explorer.Chain.AddressTransactionCsvExporter do
     transaction
     |> Chain.fee(:wei)
     |> case do
-      {:actual, value} -> value
-      {:maximum, value} -> "Max of #{value}"
+      {:actual, value} ->
+        CurrencyHelpers.divide_decimals(value, Decimal.new(18))
+
+      {:maximum, value} ->
+        token_fee = CurrencyHelpers.divide_decimals(value, Decimal.new(18))
+        "Max of #{token_fee}"
     end
   end
 


### PR DESCRIPTION
Closes #4762 

## Changelog

### Enhancements
Fix value and gas fee to decimal value when CSV file is exported.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
