### PR TITLE
fix typo on class

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/bridged_tokens/_tile.html.eex
@@ -5,7 +5,7 @@
         <%= @index %>
       </span>
   </td>
-  <td clas="token-icon">
+  <td class="token-icon">
     <%= if System.get_env("DISPLAY_TOKEN_ICONS") === "true" do %>
     <% foreign_chain_id = if Map.has_key?(@bridged_token, :foreign_chain_id), do: @bridged_token.foreign_chain_id, else: nil %>
     <% chain_id_for_token_icon = if foreign_chain_id, do: foreign_chain_id |> Decimal.to_integer() |> to_string(), else: System.get_env("CHAIN_ID") %>


### PR DESCRIPTION
Closes #5059 

Fix typo. SHould be `class`

## Changelog


### Bug Fixes
Fix typo


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
