### PR TITLE
Fix write contract page input data processing (tuple, bytes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5071](https://github.com/blockscout/blockscout/pull/5071) - Fix write page contract tuple input
 - [#5034](https://github.com/blockscout/blockscout/pull/5034) - Fix broken functions input at transation page
 - [#5025](https://github.com/blockscout/blockscout/pull/5025) - Add standard input JSON files validation
 - [#5051](https://github.com/blockscout/blockscout/pull/5051) - Fix 500 response when ABI method was parsed as nil

--- a/apps/block_scout_web/assets/__tests__/lib/smart_contract/common_helpers.js
+++ b/apps/block_scout_web/assets/__tests__/lib/smart_contract/common_helpers.js
@@ -28,6 +28,24 @@ const twoFieldHTML =
     ' <input type="submit" value="Write">' + 
     '</form>'
 
+test('prepare contract args | type: address', () => {
+    document.body.innerHTML = oneFieldHTML
+
+    var inputs = [
+        {
+            "type": "address",
+            "name": "arg1",
+            "internalType": "address"
+        }
+    ]
+
+    document.getElementById('first').value = ' 0x000000000000000000 0000000000000000000000 '
+    const expectedValue = ['0x0000000000000000000000000000000000000000']
+    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
+    
+    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
+})
+
 test('prepare contract args | type: address[]*2', () => {
     document.body.innerHTML = twoFieldHTML
 
@@ -56,24 +74,6 @@ test('prepare contract args | type: address[]*2', () => {
           '0x0000000000000000000000000000000000000003'
         ]
       ]
-    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
-    
-    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
-})
-
-test('prepare contract args | type: address', () => {
-    document.body.innerHTML = oneFieldHTML
-
-    var inputs = [
-        {
-            "type": "address",
-            "name": "arg1",
-            "internalType": "address"
-        }
-    ]
-
-    document.getElementById('first').value = ' 0x000000000000000000 0000000000000000000000 '
-    const expectedValue = ['0x0000000000000000000000000000000000000000']
     const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
     
     expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
@@ -114,19 +114,36 @@ test('prepare contract args | type: string[]', () => {
     expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
 })
 
-test('prepare contract args | type: bool[]', () => {
+test('prepare contract args | type: bytes32', () => {
     document.body.innerHTML = oneFieldHTML
 
     var inputs = [
         {
-            "type": "bool[]",
+            "type": "bytes32",
             "name": "arg1",
-            "internalType": "bool[]"
+            "internalType": "bytes32"
         }
     ]
 
-    document.getElementById('first').value = ' true , false '
-    const expectedValue = [[true, false]]
+    document.getElementById('first').value = ' "  0x0000000000000000000000000000000000000000 " '
+    const expectedValue = ['0x0000000000000000000000000000000000000000']
+    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
+    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
+})
+
+test('prepare contract args | type: bytes32[]', () => {
+    document.body.innerHTML = oneFieldHTML
+
+    var inputs = [
+        {
+            "type": "bytes32[]",
+            "name": "arg1",
+            "internalType": "bytes32[]"
+        }
+    ]
+
+    document.getElementById('first').value = ' "  0x0000000000000000000000000000000000000000 " , "    0x0000000000000000000000000000000000000001   " '
+    const expectedValue = [['0x0000000000000000000000000000000000000000','0x0000000000000000000000000000000000000001']]
     const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
     expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
 })
@@ -148,6 +165,22 @@ test('prepare contract args | type: bool', () => {
     expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
 })
 
+test('prepare contract args | type: bool[]', () => {
+    document.body.innerHTML = oneFieldHTML
+
+    var inputs = [
+        {
+            "type": "bool[]",
+            "name": "arg1",
+            "internalType": "bool[]"
+        }
+    ]
+
+    document.getElementById('first').value = ' true , false '
+    const expectedValue = [[true, false]]
+    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
+    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
+})
 
 test('prepare contract args | type: uint256', () => {
     document.body.innerHTML = oneFieldHTML
@@ -179,6 +212,74 @@ test('prepare contract args | type: uint256[]', () => {
 
     document.getElementById('first').value = ' 156 000 , 10 690 000 , 59874 '
     const expectedValue = [['156000', '10690000', '59874']]
+    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
+    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
+})
+
+test('prepare contract args | type: tuple', () => {
+    document.body.innerHTML = oneFieldHTML
+
+    var inputs = [
+        {
+            "type": "tuple",
+            "name": "mintParams",
+            "internalType": "struct ISynthereumLiquidityPool.MintParams",
+            "components": [
+                {
+                    "type": "uint256",
+                    "name": "minNumTokens",
+                    "internalType": "uint256"
+                },
+                {
+                    "type": "uint256",
+                    "name": "collateralAmount",
+                    "internalType": "uint256"
+                },
+                {
+                    "type": "uint256",
+                    "name": "expiration",
+                    "internalType": "uint256"
+                },
+                {
+                    "type": "address",
+                    "name": "recipient",
+                    "internalType": "address"
+                }
+            ]
+        }
+    ]
+
+    document.getElementById('first').value = '[0,   "200000000000000000000","1672938000"  ,"0xc31249BA48763dF46388BA5C4E7565d62ed4801C"]'
+    const expectedValue = [["0","200000000000000000000","1672938000","0xc31249BA48763dF46388BA5C4E7565d62ed4801C"]]
+    const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
+    expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
+})
+
+test('prepare contract args | type: tuple[]', () => {
+    document.body.innerHTML = oneFieldHTML
+
+    var inputs = [
+        {
+            "type": "tuple[]",
+            "name": "mintParams",
+            "internalType": "struct ISynthereumLiquidityPool.MintParams",
+            "components": [
+                {
+                    "type": "uint256",
+                    "name": "minNumTokens",
+                    "internalType": "uint256"
+                },
+                {
+                    "type": "address",
+                    "name": "recipient",
+                    "internalType": "address"
+                }
+            ]
+        }
+    ]
+
+    document.getElementById('first').value = '[["200000000000000000000"  ,"0xc31249BA48763dF46388BA5C4E7565d62ed4801C"], ["100500" ,  "0x9fbaD00ae18FAe064C728E6B535a6cB950c8C40A "]]'
+    const expectedValue = [[["200000000000000000000","0xc31249BA48763dF46388BA5C4E7565d62ed4801C"], ["100500","0x9fbaD00ae18FAe064C728E6B535a6cB950c8C40A"]]]
     const $functionInputs = $('[data-function-form]').find('input[name=function_input]')
     expect(prepareMethodArgs($functionInputs, inputs)).toEqual(expectedValue)
 })


### PR DESCRIPTION
## Motivation

Tuple and bytes as well as arrays of tuple and bytes input types are not processing correctly on the Write contract page.
Missing tests were added.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
