### PR TITLE
Add specific tx receipt fields for the GoQuorum client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - [#4690](https://github.com/blockscout/blockscout/pull/4690) - Improve pagination: introduce pagination with random access to pages; Integrate it to the Transactions List page
+- [#4995](https://github.com/blockscout/blockscout/pull/4995) - Add specific tx receipt fields for the GoQuorum client
 
 ### Fixes
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -304,6 +304,11 @@ defmodule EthereumJSONRPC.Receipt do
     :ignore
   end
 
+  # GoQuorum specific transaction receipt fields
+  defp entry_to_elixir({key, _}) when key in ~w(isPrivacyMarkerTransaction) do
+    :ignore
+  end
+
   defp entry_to_elixir({key, value}) do
     {:error, {:unknown_key, %{key: key, value: value}}}
   end


### PR DESCRIPTION
 [#4995](https://github.com/blockscout/blockscout/pull/4995) - Add specific tx receipt fields for the GoQuorum client


## Motivation

Add specific extra fields in the transaction receipt response to allow GoQuorum to use Blockscout

## Changelog

### Enhancements
-  GoQuorum specific transaction receipt fields added ie `isPrivacyMarkerTransaction`

## Checklist for your Pull Request (PR)

  - [X] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [X] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [X] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [X] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [X] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
