### PR TITLE
Create contract source code file paths backfiller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 ### Chore
+- [#5152](https://github.com/blockscout/blockscout/pull/5152) - Create backfiller paths for sources of contracts verified through Sourcify
 - [#5142](https://github.com/blockscout/blockscout/pull/5142) - Updated some outdated npm packages
 - [#5140](https://github.com/blockscout/blockscout/pull/5140) - Babel minor and core-js major updates
 - [#5139](https://github.com/blockscout/blockscout/pull/5139) - Eslint major update

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -190,7 +190,7 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
       "abi" => abi,
       "secondary_sources" => secondary_sources,
       "compilation_target_file_path" => compilation_target_file_path
-    } = parse_params_from_sourcify(address_hash_string, verification_metadata)
+    } = Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata)
 
     ContractController.publish(conn, %{
       "addressHash" => address_hash_string,
@@ -225,98 +225,6 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
            valid?: false
          }}, conn}}
     ]
-  end
-
-  def parse_params_from_sourcify(address_hash_string, verification_metadata) do
-    [verification_metadata_json] =
-      verification_metadata
-      |> Enum.filter(&(Map.get(&1, "name") == "metadata.json"))
-
-    full_params_initial = parse_json_from_sourcify_for_insertion(verification_metadata_json)
-
-    verification_metadata_sol =
-      verification_metadata
-      |> Enum.filter(fn %{"name" => name, "content" => _content} -> name =~ ".sol" end)
-
-    verification_metadata_sol
-    |> Enum.reduce(full_params_initial, fn %{"name" => name, "content" => content, "path" => _path} = param,
-                                           full_params_acc ->
-      compilation_target_file_name = Map.get(full_params_acc, "compilation_target_file_name")
-
-      if String.downcase(name) == String.downcase(compilation_target_file_name) do
-        %{
-          "params_to_publish" => extract_primary_source_code(content, Map.get(full_params_acc, "params_to_publish")),
-          "abi" => Map.get(full_params_acc, "abi"),
-          "secondary_sources" => Map.get(full_params_acc, "secondary_sources"),
-          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
-          "compilation_target_file_name" => compilation_target_file_name
-        }
-      else
-        secondary_sources = [
-          prepare_additional_source(address_hash_string, param) | Map.get(full_params_acc, "secondary_sources")
-        ]
-
-        %{
-          "params_to_publish" => Map.get(full_params_acc, "params_to_publish"),
-          "abi" => Map.get(full_params_acc, "abi"),
-          "secondary_sources" => secondary_sources,
-          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
-          "compilation_target_file_name" => compilation_target_file_name
-        }
-      end
-    end)
-  end
-
-  defp prepare_additional_source(address_hash_string, %{"name" => _name, "content" => content, "path" => path}) do
-    splitted_path =
-      path
-      |> String.split("/")
-
-    trimmed_path =
-      splitted_path
-      |> Enum.slice(9..Enum.count(splitted_path))
-      |> Enum.join("/")
-
-    %{
-      "address_hash" => address_hash_string,
-      "file_name" => "/" <> trimmed_path,
-      "contract_source_code" => content
-    }
-  end
-
-  defp extract_primary_source_code(content, params) do
-    params
-    |> Map.put("contract_source_code", content)
-  end
-
-  def parse_json_from_sourcify_for_insertion(verification_metadata_json) do
-    %{"name" => _, "content" => content} = verification_metadata_json
-    content_json = Sourcify.decode_json(content)
-    compiler_version = "v" <> (content_json |> Map.get("compiler") |> Map.get("version"))
-    abi = content_json |> Map.get("output") |> Map.get("abi")
-    settings = Map.get(content_json, "settings")
-    compilation_target_file_path = settings |> Map.get("compilationTarget") |> Map.keys() |> Enum.at(0)
-    compilation_target_file_name = compilation_target_file_path |> String.split("/") |> Enum.at(-1)
-    contract_name = settings |> Map.get("compilationTarget") |> Map.get("#{compilation_target_file_path}")
-    optimizer = Map.get(settings, "optimizer")
-
-    params =
-      %{}
-      |> Map.put("name", contract_name)
-      |> Map.put("compiler_version", compiler_version)
-      |> Map.put("evm_version", Map.get(settings, "evmVersion"))
-      |> Map.put("optimization", Map.get(optimizer, "enabled"))
-      |> Map.put("optimization_runs", Map.get(optimizer, "runs"))
-      |> Map.put("external_libraries", Map.get(settings, "libraries"))
-      |> Map.put("verified_via_sourcify", true)
-
-    %{
-      "params_to_publish" => params,
-      "abi" => abi,
-      "compilation_target_file_path" => compilation_target_file_path,
-      "compilation_target_file_name" => compilation_target_file_name,
-      "secondary_sources" => []
-    }
   end
 
   def parse_optimization_runs(%{"runs" => runs}) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -204,7 +204,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
     case Sourcify.get_metadata(address_hash_string) do
       {:ok, verification_metadata} ->
         %{"params_to_publish" => params_to_publish, "abi" => abi, "secondary_sources" => secondary_sources} =
-          VerificationController.parse_params_from_sourcify(address_hash_string, verification_metadata)
+          Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata)
 
         case publish_without_broadcast(%{
                "addressHash" => address_hash_string,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -26,6 +26,7 @@ defmodule Explorer.Application do
 
   alias Explorer.Market.MarketHistoryCache
   alias Explorer.Repo.PrometheusLogger
+  alias Explorer.ThirdPartyIntegrations.SourcifyFilePathBackfiller
 
   @impl Application
   def start(_type, _args) do
@@ -71,7 +72,9 @@ defmodule Explorer.Application do
 
     opts = [strategy: :one_for_one, name: Explorer.Supervisor]
 
-    Supervisor.start_link(children, opts)
+    started = Supervisor.start_link(children, opts)
+    Task.start(fn -> SourcifyFilePathBackfiller.perform_file_paths_filling() end)
+    started
   end
 
   defp configurable_children do

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
@@ -176,6 +176,98 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
     end
   end
 
+  def parse_params_from_sourcify(address_hash_string, verification_metadata) do
+    [verification_metadata_json] =
+      verification_metadata
+      |> Enum.filter(&(Map.get(&1, "name") == "metadata.json"))
+
+    full_params_initial = parse_json_from_sourcify_for_insertion(verification_metadata_json)
+
+    verification_metadata_sol =
+      verification_metadata
+      |> Enum.filter(fn %{"name" => name, "content" => _content} -> name =~ ".sol" end)
+
+    verification_metadata_sol
+    |> Enum.reduce(full_params_initial, fn %{"name" => name, "content" => content, "path" => _path} = param,
+                                           full_params_acc ->
+      compilation_target_file_name = Map.get(full_params_acc, "compilation_target_file_name")
+
+      if String.downcase(name) == String.downcase(compilation_target_file_name) do
+        %{
+          "params_to_publish" => extract_primary_source_code(content, Map.get(full_params_acc, "params_to_publish")),
+          "abi" => Map.get(full_params_acc, "abi"),
+          "secondary_sources" => Map.get(full_params_acc, "secondary_sources"),
+          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
+          "compilation_target_file_name" => compilation_target_file_name
+        }
+      else
+        secondary_sources = [
+          prepare_additional_source(address_hash_string, param) | Map.get(full_params_acc, "secondary_sources")
+        ]
+
+        %{
+          "params_to_publish" => Map.get(full_params_acc, "params_to_publish"),
+          "abi" => Map.get(full_params_acc, "abi"),
+          "secondary_sources" => secondary_sources,
+          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
+          "compilation_target_file_name" => compilation_target_file_name
+        }
+      end
+    end)
+  end
+
+  defp parse_json_from_sourcify_for_insertion(verification_metadata_json) do
+    %{"name" => _, "content" => content} = verification_metadata_json
+    content_json = decode_json(content)
+    compiler_version = "v" <> (content_json |> Map.get("compiler") |> Map.get("version"))
+    abi = content_json |> Map.get("output") |> Map.get("abi")
+    settings = Map.get(content_json, "settings")
+    compilation_target_file_path = settings |> Map.get("compilationTarget") |> Map.keys() |> Enum.at(0)
+    compilation_target_file_name = compilation_target_file_path |> String.split("/") |> Enum.at(-1)
+    contract_name = settings |> Map.get("compilationTarget") |> Map.get("#{compilation_target_file_path}")
+    optimizer = Map.get(settings, "optimizer")
+
+    params =
+      %{}
+      |> Map.put("name", contract_name)
+      |> Map.put("compiler_version", compiler_version)
+      |> Map.put("evm_version", Map.get(settings, "evmVersion"))
+      |> Map.put("optimization", Map.get(optimizer, "enabled"))
+      |> Map.put("optimization_runs", Map.get(optimizer, "runs"))
+      |> Map.put("external_libraries", Map.get(settings, "libraries"))
+      |> Map.put("verified_via_sourcify", true)
+
+    %{
+      "params_to_publish" => params,
+      "abi" => abi,
+      "compilation_target_file_path" => compilation_target_file_path,
+      "compilation_target_file_name" => compilation_target_file_name,
+      "secondary_sources" => []
+    }
+  end
+
+  defp prepare_additional_source(address_hash_string, %{"name" => _name, "content" => content, "path" => path}) do
+    splitted_path =
+      path
+      |> String.split("/")
+
+    trimmed_path =
+      splitted_path
+      |> Enum.slice(9..Enum.count(splitted_path))
+      |> Enum.join("/")
+
+    %{
+      "address_hash" => address_hash_string,
+      "file_name" => "/" <> trimmed_path,
+      "contract_source_code" => content
+    }
+  end
+
+  defp extract_primary_source_code(content, params) do
+    params
+    |> Map.put("contract_source_code", content)
+  end
+
   def decode_json(data) do
     Jason.decode!(data)
   rescue

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify_file_path_backfiller.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify_file_path_backfiller.ex
@@ -1,0 +1,75 @@
+defmodule Explorer.ThirdPartyIntegrations.SourcifyFilePathBackfiller do
+  @moduledoc """
+  Performs filling file paths for sourcify smart contracts (and its secondary sources) which have no file path
+  """
+
+  alias Ecto.Changeset
+  alias Explorer.Repo
+  alias Explorer.Chain.{SmartContract, SmartContractAdditionalSource}
+
+  alias Explorer.ThirdPartyIntegrations.Sourcify
+
+  import Ecto.Query,
+    only: [
+      from: 2
+    ]
+
+  require Logger
+
+  def perform_file_paths_filling do
+    fetch_all_unfilled_contracts()
+    |> (fn contracts ->
+          Logger.info("Sourcify contracts to fill path: #{Enum.count(contracts)}")
+          contracts
+        end).()
+    |> Enum.each(fn contract ->
+      with {:address_hash, address_hash_string} <-
+             {:address_hash, "0x" <> Base.encode16(contract.address_hash.bytes, case: :lower)},
+           {:ok, _full_or_partial, metadata} <- Sourcify.check_by_address_any(address_hash_string),
+           %{
+             "params_to_publish" => _params_to_publish,
+             "abi" => _abi,
+             "secondary_sources" => secondary_sources,
+             "compilation_target_file_path" => compilation_target_file_path
+           } <- Sourcify.parse_params_from_sourcify(address_hash_string, metadata) do
+        sc_additional_sources_query =
+          from(as in SmartContractAdditionalSource,
+            where: as.address_hash == ^contract.address_hash
+          )
+
+        sc_additional_sources_query
+        |> Repo.all()
+        |> Enum.each(fn source ->
+          new_name = Enum.find(secondary_sources, fn src -> src["file_name"] =~ source.file_name end)["file_name"]
+
+          if !is_nil(new_name) do
+            source
+            |> Changeset.change(%{file_name: new_name})
+            |> Repo.update()
+          end
+        end)
+
+        contract
+        |> Changeset.change(%{file_path: compilation_target_file_path})
+        |> Repo.update()
+      else
+        _error ->
+          Logger.debug([
+            "Coudn't fetch file paths for #{"0x" <> Base.encode16(contract.address_hash.bytes, case: :lower)} from Sourcify"
+          ])
+      end
+    end)
+
+    Logger.info("Filled file paths for Sourcify contracts successfully")
+  end
+
+  def fetch_all_unfilled_contracts do
+    query =
+      from(sc in SmartContract,
+        where: sc.verified_via_sourcify == true and is_nil(sc.file_path)
+      )
+
+    query
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
Close #5132 

## Changelog
- Add method wich is responsible for backfill file paths
- Aforementioned method starts with eplorer
- Move some methods from `BlockScoutWeb.AddressContractVerificationController` to `Explorer.ThirdPartyIntegrations.Sourcify` in order to reuse it and avoid cycles in deps graph

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
