### PR TITLE
Fix token counters bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4690](https://github.com/blockscout/blockscout/pull/4690) - Improve pagination: introduce pagination with random access to pages; Integrate it to the Transactions List page
 
 ### Fixes
+- [#5154](https://github.com/blockscout/blockscout/pull/5154) - Fix token counters bug
 
 ### Chore
 - [#5153](https://github.com/blockscout/blockscout/pull/5153) - Discord link instead of Gitter

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.Tokens.TokenController do
   def token_counters(conn, %{"id" => address_hash_string}) do
     case Chain.string_to_address_hash(address_hash_string) do
       {:ok, address_hash} ->
-        {transfer_count, token_holder_count} = fetch_token_counters(address_hash, 200)
+        {transfer_count, token_holder_count} = fetch_token_counters(address_hash, 30_000)
 
         json(conn, %{transfer_count: transfer_count, token_holder_count: token_holder_count})
 
@@ -35,7 +35,7 @@ defmodule BlockScoutWeb.Tokens.TokenController do
       end)
 
     [total_token_transfers_task, total_token_holders_task]
-    |> Task.yield_many(:timer.seconds(timeout))
+    |> Task.yield_many(timeout)
     |> Enum.map(fn {_task, res} ->
       case res do
         {:ok, result} ->

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -48,9 +48,7 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   def fetch(address_hash) do
     if cache_expired?(address_hash) do
-      Task.start_link(fn ->
-        update_cache(address_hash)
-      end)
+      update_cache(address_hash)
     end
 
     address_hash_string = to_string(address_hash)

--- a/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
@@ -48,9 +48,7 @@ defmodule Explorer.Counters.TokenTransfersCounter do
 
   def fetch(address_hash) do
     if cache_expired?(address_hash) do
-      Task.start_link(fn ->
-        update_cache(address_hash)
-      end)
+      update_cache(address_hash)
     end
 
     address_hash_string = to_string(address_hash)


### PR DESCRIPTION
## Motivation
First token counters fetching always leaded to infinity loading (only in UI; actually server just sent nil response)

## Changelog
- Fetch token counters from ets cache sequentially, not in parallel, because it already handled in `TokenController`
- Change timeout, as in hexdocs stated, that `yield_many` expect timeout in ms

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
