### PR TITLE
Fix DATABASE_URL config parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#4690](https://github.com/blockscout/blockscout/pull/4690) - Improve pagination: introduce pagination with random access to pages; Integrate it to the Transactions List page
 
 ### Fixes
+- [#5192](https://github.com/blockscout/blockscout/pull/5192) - Fix DATABASE_URL config parser
 - [#5169](https://github.com/blockscout/blockscout/pull/5169) - Fix several UI bugs; Add tooltip to the prev/next block buttons
 - [#5184](https://github.com/blockscout/blockscout/pull/5184) - eth_call method: remove from param from the request, if it is null
 - [#5172](https://github.com/blockscout/blockscout/pull/5172), [#5182](https://github.com/blockscout/blockscout/pull/5182) - Reduced the size of js bundles

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -29,7 +29,7 @@ config :explorer, Explorer.Counters.AverageBlockTime,
 
 config :explorer, Explorer.Chain.Events.Listener,
   enabled:
-    if(System.get_env("DISABLE_WEBAPP") == nil && System.get_env("DISABLE_INDEXER") == nil,
+    if(System.get_env("DISABLE_WEBAPP") == "true" && System.get_env("DISABLE_INDEXER") == "true",
       do: false,
       else: true
     )

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -140,6 +140,8 @@ config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: :ti
 
 config :explorer, Explorer.Market.History.Cataloger, enabled: System.get_env("DISABLE_INDEXER") != "true"
 
+config :explorer, Explorer.Chain.Cache.MinMissingBlockNumber, enabled: System.get_env("DISABLE_WRITE_API") != "true"
+
 txs_stats_init_lag =
   System.get_env("TXS_HISTORIAN_INIT_LAG", "0")
   |> Integer.parse()

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -63,8 +63,7 @@ defmodule Explorer.Application do
       con_cache_child_spec(RSK.cache_name(), ttl_check_interval: :timer.minutes(1), global_ttl: :timer.minutes(30)),
       Transactions,
       Accounts,
-      Uncles,
-      MinMissingBlockNumber
+      Uncles
     ]
 
     children = base_children ++ configurable_children()
@@ -96,7 +95,8 @@ defmodule Explorer.Application do
       configure(Explorer.Counters.AverageBlockTime),
       configure(Explorer.Counters.Bridge),
       configure(Explorer.Validator.MetadataProcessor),
-      configure(Explorer.Staking.ContractState)
+      configure(Explorer.Staking.ContractState),
+      configure(MinMissingBlockNumber)
     ]
     |> List.flatten()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -6672,30 +6672,6 @@ defmodule Explorer.Chain do
 
   defp boolean_to_check_result(false), do: :not_found
 
-  def extract_db_name(db_url) do
-    if db_url == nil do
-      ""
-    else
-      db_url
-      |> String.split("/")
-      |> Enum.take(-1)
-      |> Enum.at(0)
-    end
-  end
-
-  def extract_db_host(db_url) do
-    if db_url == nil do
-      ""
-    else
-      db_url
-      |> String.split("@")
-      |> Enum.take(-1)
-      |> Enum.at(0)
-      |> String.split(":")
-      |> Enum.at(0)
-    end
-  end
-
   @doc """
   Fetches the first trace from the Parity trace URL.
   """

--- a/apps/explorer/lib/explorer/chain/events/listener.ex
+++ b/apps/explorer/lib/explorer/chain/events/listener.ex
@@ -6,23 +6,15 @@ defmodule Explorer.Chain.Events.Listener do
   use GenServer
 
   alias Postgrex.Notifications
-  import Explorer.Chain, only: [extract_db_name: 1, extract_db_host: 1]
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, "chain_event", name: __MODULE__)
   end
 
   def init(channel) do
-    explorer_repo =
+    {:ok, pid} =
       :explorer
       |> Application.get_env(Explorer.Repo)
-
-    db_url = explorer_repo[:url]
-
-    {:ok, pid} =
-      explorer_repo
-      |> Keyword.put(:database, extract_db_name(db_url))
-      |> Keyword.put(:hostname, extract_db_host(db_url))
       |> Notifications.start_link()
 
     ref = Notifications.listen!(pid, channel)

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -1,0 +1,62 @@
+defmodule Explorer.Repo.ConfigHelper do
+  @moduledoc """
+  Extracts values from environment and adds them to application config.
+
+  Notably, this module processes the DATABASE_URL environment variable and extracts discrete parameters.
+
+  The priority of vars is DATABASE_URL components < postgrex enviroment vars < application config vars, with values being overwritted by higher priority.
+  """
+
+  # set in apps/*/config/*.exs
+  @app_env_vars [
+    username: "DATABASE_USER",
+    password: "DATABASE_PASSWORD",
+    host: "DATABASE_HOST",
+    port: "DATABASE_PORT",
+    database: "DATABASE_DB"
+  ]
+
+  # https://hexdocs.pm/postgrex/Postgrex.html#start_link/1-options
+  @postgrex_env_vars [
+    username: "PGUSER",
+    password: "PGPASSWORD",
+    host: "PGHOST",
+    port: "PGPORT",
+    database: "PGDATABASE"
+  ]
+
+  def get_db_config(opts) do
+    url = opts[:url] || System.get_env("DATABASE_URL")
+    env_function = opts[:env_func] || (&System.get_env/1)
+
+    url
+    |> extract_parameters()
+    |> Keyword.merge(get_env_vars(@postgrex_env_vars, env_function))
+    |> Keyword.merge(get_env_vars(@app_env_vars, env_function))
+  end
+
+  defp extract_parameters(empty) when empty == nil or empty == "", do: []
+
+  # sobelow_skip ["DOS.StringToAtom"]
+  defp extract_parameters(database_url) do
+    ~r/\w*:\/\/(?<username>\w+):(?<password>\w*)?@(?<hostname>[a-zA-Z\d\.]+):(?<port>\d+)\/(?<database>\w+)/
+    |> Regex.named_captures(database_url)
+    |> Keyword.new(fn {k, v} -> {String.to_atom(k), v} end)
+    |> Keyword.put(:url, database_url)
+    |> Enum.filter(fn
+      # don't include keys with empty values
+      {_, ""} -> false
+      _ -> true
+    end)
+  end
+
+  defp get_env_vars(vars, env_function) do
+    Enum.reduce(vars, [], fn {name, var}, opts ->
+      case env_function.(var) do
+        nil -> opts
+        "" -> opts
+        env_value -> Keyword.put(opts, name, env_value)
+      end
+    end)
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5334,40 +5334,6 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "extract_db_name/1" do
-    test "extracts correct db name" do
-      db_url = "postgresql://viktor:@localhost:5432/blockscout-dev-1"
-      assert Chain.extract_db_name(db_url) == "blockscout-dev-1"
-    end
-
-    test "returns empty db name" do
-      db_url = ""
-      assert Chain.extract_db_name(db_url) == ""
-    end
-
-    test "returns nil db name" do
-      db_url = nil
-      assert Chain.extract_db_name(db_url) == ""
-    end
-  end
-
-  describe "extract_db_host/1" do
-    test "extracts correct db host" do
-      db_url = "postgresql://viktor:@localhost:5432/blockscout-dev-1"
-      assert Chain.extract_db_host(db_url) == "localhost"
-    end
-
-    test "returns empty db name" do
-      db_url = ""
-      assert Chain.extract_db_host(db_url) == ""
-    end
-
-    test "returns nil db name" do
-      db_url = nil
-      assert Chain.extract_db_host(db_url) == ""
-    end
-  end
-
   describe "fetch_first_trace/2" do
     test "fetched first trace", %{
       json_rpc_named_arguments: json_rpc_named_arguments

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -1,0 +1,72 @@
+defmodule Explorer.Repo.ConfigHelperTest do
+  use Explorer.DataCase
+
+  alias Explorer.Repo.ConfigHelper
+
+  describe "get_db_config/1" do
+    test "parse params from database url" do
+      database_url = "postgresql://test_username:test_password@127.8.8.1:7777/test_database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test_username"
+      assert result[:password] == "test_password"
+      assert result[:hostname] == "127.8.8.1"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
+    test "get username without password" do
+      database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test_username"
+      refute result[:password]
+      assert result[:hostname] == "127.8.8.1"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
+    test "get hostname instead of ip" do
+      database_url = "postgresql://test_username:@cooltesthost:7777/test_database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test_username"
+      refute result[:password]
+      assert result[:hostname] == "cooltesthost"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
+    test "overwrite database url param with postgrex vars" do
+      database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
+
+      vars = %{"PGUSER" => "postgrex_user", "PGPASSWORD" => "postgrex_password"}
+      func = fn v -> vars[v] end
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: func})
+
+      assert result[:username] == "postgrex_user"
+      assert result[:password] == "postgrex_password"
+      assert result[:hostname] == "127.8.8.1"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
+    test "overwrite database url param and postgrex with app env" do
+      database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
+
+      vars = %{"PGUSER" => "postgrex_user", "PGPASSWORD" => "postgrex_password", "DATABASE_USER" => "app_db_user"}
+      func = fn v -> vars[v] end
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: func})
+
+      assert result[:username] == "app_db_user"
+      assert result[:password] == "postgrex_password"
+      assert result[:hostname] == "127.8.8.1"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+  end
+end

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -22,7 +22,7 @@ defmodule Explorer.Repo.ConfigHelperTest do
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
 
       assert result[:username] == "test_username"
-      refute result[:password]
+      assert result[:password] == ""
       assert result[:hostname] == "127.8.8.1"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"
@@ -34,36 +34,35 @@ defmodule Explorer.Repo.ConfigHelperTest do
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
 
       assert result[:username] == "test_username"
-      refute result[:password]
+      assert result[:password] == ""
       assert result[:hostname] == "cooltesthost"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"
     end
 
-    test "overwrite database url param with postgrex vars" do
+    test "overwrite postgrex vars param with database url" do
       database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
 
       vars = %{"PGUSER" => "postgrex_user", "PGPASSWORD" => "postgrex_password"}
       func = fn v -> vars[v] end
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: func})
 
-      assert result[:username] == "postgrex_user"
-      assert result[:password] == "postgrex_password"
+      assert result[:username] == "test_username"
+      assert result[:password] == ""
       assert result[:hostname] == "127.8.8.1"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"
     end
 
-    test "overwrite database url param and postgrex with app env" do
+    test "overwrite database password param with empty DATABASE_URL password" do
       database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
 
-      vars = %{"PGUSER" => "postgrex_user", "PGPASSWORD" => "postgrex_password", "DATABASE_USER" => "app_db_user"}
+      vars = %{"PGUSER" => "postgrex_user", "PGPASSWORD" => "postgrex_password"}
       func = fn v -> vars[v] end
-
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: func})
 
-      assert result[:username] == "app_db_user"
-      assert result[:password] == "postgrex_password"
+      assert result[:username] == "test_username"
+      assert result[:password] == ""
       assert result[:hostname] == "127.8.8.1"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5180
Resolves https://github.com/blockscout/blockscout/issues/5130
Resolves https://github.com/blockscout/blockscout/issues/3849
Closes https://github.com/blockscout/blockscout/issues/3840
Closes https://github.com/blockscout/blockscout/issues/4736

## Motivation

`DATABASE_URL` env variable params are not used by `Explorer.Repo` in some combinations with other environment variables.



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
