### PR TITLE
Add info about proxy contracts to api methods response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#5220](https://github.com/blockscout/blockscout/pull/5220) - Add info about proxy contracts to api methods response
 - [#5200](https://github.com/blockscout/blockscout/pull/5200) - Docker-compose configuration
 - [#5105](https://github.com/blockscout/blockscout/pull/5105) - Redesign token page
 - [#5016](https://github.com/blockscout/blockscout/pull/5016) - Add view for internal transactions error

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -491,7 +491,9 @@ defmodule BlockScoutWeb.Etherscan do
       """,
       "ContractName" => "Test",
       "CompilerVersion" => "v0.2.1-2016-01-30-91a6b35",
-      "OptimizationUsed" => "1"
+      "OptimizationUsed" => "1",
+      "IsProxy" => "true",
+      "ImplementationAddress" => "0x000000000000000000000000000000000000000e"
     }
   }
 
@@ -547,7 +549,9 @@ defmodule BlockScoutWeb.Etherscan do
       "ContractName" => "Test",
       "CompilerVersion" => "v0.2.1-2016-01-30-91a6b35",
       "OptimizationUsed" => "1",
-      "FileName" => "{sourcify path or empty}"
+      "FileName" => "{sourcify path or empty}",
+      "IsProxy" => "true",
+      "ImplementationAddress" => "0x000000000000000000000000000000000000000e"
     }
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -48,7 +48,8 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
       "EVMVersion" => "",
       "ConstructorArguments" => "",
       "ExternalLibraries" => "",
-      "FileName" => ""
+      "FileName" => "",
+      "IsProxy" => "false"
     }
   end
 
@@ -68,6 +69,22 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
     |> set_constructor_arguments(contract)
     |> set_external_libraries(contract)
     |> set_verified_contract_data(contract, address, optimization)
+    |> set_proxy_info(contract)
+  end
+
+  defp set_proxy_info(contract_output, contract) do
+    result =
+      if contract.is_proxy do
+        contract_output
+        |> Map.put_new(:ImplementationAddress, contract.implementation_address_hash_string)
+      else
+        contract_output
+      end
+
+    is_proxy_string = if contract.is_proxy, do: "true", else: "false"
+
+    result
+    |> Map.put_new(:IsProxy, is_proxy_string)
   end
 
   defp set_decompiled_contract_data(contract_output, decompiled_smart_contract) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -3,6 +3,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
   alias Explorer.Chain.SmartContract
   alias Explorer.{Chain, Factory}
 
+  import Mox
+
   describe "listcontracts" do
     setup do
       %{params: %{"module" => "contract", "action" => "listcontracts"}}
@@ -405,7 +407,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           "EVMVersion" => "",
           "ExternalLibraries" => "",
           "OptimizationRuns" => "",
-          "FileName" => ""
+          "FileName" => "",
+          "IsProxy" => "false"
         }
       ]
 
@@ -442,9 +445,12 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           "OptimizationUsed" => "true",
           "OptimizationRuns" => 200,
           "EVMVersion" => "default",
-          "FileName" => ""
+          "FileName" => "",
+          "IsProxy" => "false"
         }
       ]
+
+      get_implementation()
 
       assert response =
                conn
@@ -485,9 +491,12 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           "EVMVersion" => "default",
           "ConstructorArguments" =>
             "00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
-          "FileName" => ""
+          "FileName" => "",
+          "IsProxy" => "false"
         }
       ]
+
+      get_implementation()
 
       assert response =
                conn
@@ -586,9 +595,12 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
             %{"name" => "Test", "address_hash" => "0xb18aed9518d735482badb4e8b7fd8d2ba425ce95"},
             %{"name" => "Test2", "address_hash" => "0x283539e1b1daf24cdd58a3e934d55062ea663c3f"}
           ],
-          "FileName" => ""
+          "FileName" => "",
+          "IsProxy" => "false"
         }
       ]
+
+      get_implementation()
 
       assert response =
                conn
@@ -653,6 +665,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "action" => "verify_via_sourcify",
         "addressHash" => "0x18d89C12e9463Be6343c35C9990361bA4C42AfC2"
       }
+
+      get_implementation()
 
       conn
       |> get("/api", params)
@@ -837,5 +851,33 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
     }
     |> put_in(["properties", "result"], result)
     |> ExJsonSchema.Schema.resolve()
+  end
+
+  def get_implementation do
+    EthereumJSONRPC.Mox
+    |> expect(:json_rpc, fn %{
+                              id: 0,
+                              method: "eth_getStorageAt",
+                              params: [
+                                _,
+                                "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
+                                "latest"
+                              ]
+                            },
+                            _options ->
+      {:ok, "0x0000000000000000000000000000000000000000000000000000000000000000"}
+    end)
+    |> expect(:json_rpc, fn %{
+                              id: 0,
+                              method: "eth_getStorageAt",
+                              params: [
+                                _,
+                                "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50",
+                                "latest"
+                              ]
+                            },
+                            _options ->
+      {:ok, "0x0000000000000000000000000000000000000000000000000000000000000000"}
+    end)
   end
 end


### PR DESCRIPTION
Close #3691 

## Changelog
- Add `IsProxy` and `ImplementationAddress` fields to the success response of `getsourcecode` and `verify` api methods
- `ImplementationAddress` field presents only if `IsProxy` is `true`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
