### PR TITLE
Migrate fontawesome 5 -> 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#4862](https://github.com/blockscout/blockscout/pull/4862) - Fix internal transactions pagination
 
 ### Chore
+- [#5223](https://github.com/blockscout/blockscout/pull/5223) - Migrate fontawesome 5 -> 6
 - [#5202](https://github.com/blockscout/blockscout/pull/5202) - Docker setup Makefile release/publish tasks
 - [#5195](https://github.com/blockscout/blockscout/pull/5195) - Add Berlin, London to the list of default EVM versions
 - [#5190](https://github.com/blockscout/blockscout/pull/5190) - Set 8545 as default port everywhere except Ganache JSON RPC variant

--- a/apps/block_scout_web/assets/css/app.scss
+++ b/apps/block_scout_web/assets/css/app.scss
@@ -137,8 +137,4 @@ $fa-font-path: "~@fortawesome/fontawesome-free/webfonts";
   dashboardLineColorMarket: $dashboard-line-color-market;
   dashboardLineColorPrice: $dashboard-line-color-price;
   dashboardLineColorTransactions: $dashboard-line-color-transactions;
-  primary: $primary;
-  secondary: $secondary;
-  darkprimary: $dark-primary;
-  darksecondary: $dark-secondary;
 }

--- a/apps/block_scout_web/assets/css/components/_btn_swap.scss
+++ b/apps/block_scout_web/assets/css/components/_btn_swap.scss
@@ -1,7 +1,7 @@
 .btn-swap {
-    background-size: 15px 16px;
-    width: 15px;
-    height: 16px;
+    background-size: 20px 21px;
+    width: 20px;
+    height: 21px;
     background-repeat: no-repeat;
     display: inline-block;
     margin-bottom: 3px;
@@ -9,12 +9,24 @@
     cursor: pointer;
 
     &.honeypot {
-        background-image: url("/images/icons/exchanges/honeyswap.png");
+        background-image: url("/images/icons/swap/honeyswap.png");
     }
     &.sushi {
-        margin-top: -14px;
+        background-image: url("/images/icons/swap/sushi.svg");
     }
     &.swapr {
-        background-image: url("/images/icons/exchanges/swapr.png");
+        background-image: url("/images/icons/swap/swapr.svg");
+    }
+    &.curve {
+        background-image: url("/images/icons/swap/curve.svg");
+    }
+    &.component {
+        background-image: url("/images/icons/swap/component.png");
+    }
+    &.cowswap {
+        background-image: url("/images/icons/swap/cowswap.png");
+    }
+    &.oneinch {
+        background-image: url("/images/icons/swap/1inch.svg");
     }
 }

--- a/apps/block_scout_web/assets/css/main-page.scss
+++ b/apps/block_scout_web/assets/css/main-page.scss
@@ -75,15 +75,3 @@
 @import "components/_fontawesome_icon";
 
 @import "theme/dark-theme";
-
-:export {
-  dashboardBannerChartAxisFontColor: $dashboard-banner-chart-axis-font-color;
-  dashboardBannerChartAxisFontAltColor: $dashboard-banner-chart-axis-font-color-alt;
-  dashboardLineColorMarket: $dashboard-line-color-market;
-  dashboardLineColorPrice: $dashboard-line-color-price;
-  dashboardLineColorTransactions: $dashboard-line-color-transactions;
-  primary: $primary;
-  secondary: $secondary;
-  darkprimary: $dark-primary;
-  darksecondary: $dark-secondary;
-}

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -7,7 +7,7 @@
       "name": "blockscout",
       "license": "GPL-3.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^5.15.3",
+        "@fortawesome/fontawesome-free": "^6.0.0-beta3",
         "@tarekraafat/autocomplete.js": "^10.2.6",
         "@walletconnect/web3-provider": "^1.0.8",
         "assert": "^2.0.0",
@@ -82,11 +82,11 @@
         "jest": "^27.4.7",
         "mini-css-extract-plugin": "^1.6.2",
         "node-sass": "^7.0.1",
-        "postcss": "^8.3.5",
-        "postcss-loader": "^4.3.0",
-        "sass-loader": "^12.3.0",
+        "postcss": "^8.4.6",
+        "postcss-loader": "^6.2.1",
+        "sass-loader": "^12.6.0",
         "style-loader": "^1.3.0",
-        "webpack": "^5.67.0",
+        "webpack": "^5.69.1",
         "webpack-cli": "^4.9.2"
       },
       "engines": {
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
-      "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==",
+      "version": "6.0.0-beta3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.0.0-beta3.tgz",
+      "integrity": "sha512-4SqOuhC8tSLeQvbW1nDmq6T7+8vdSgHy/w7PRwCFzMQCbKuYFIir/3UuWsV1QblX1lt7SGlSgwbaCv9XhRt8HA==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -3154,9 +3154,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-      "integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/@types/eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
       "dev": true,
       "dependencies": {
         "@types/eslint": "*",
@@ -3174,9 +3174,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -13574,14 +13574,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
       "dev": true,
       "dependencies": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -13704,19 +13704,17 @@
       }
     },
     "node_modules/postcss-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
-      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+      "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
       "dev": true,
       "dependencies": {
         "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.4"
+        "klona": "^2.0.5",
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13724,39 +13722,7 @@
       },
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-      "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
@@ -15417,9 +15383,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.3.0.tgz",
-      "integrity": "sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "dev": true,
       "dependencies": {
         "klona": "^2.0.4",
@@ -15434,8 +15400,9 @@
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
         "sass": "^1.3.0",
+        "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
@@ -15446,6 +15413,9 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         }
       }
@@ -15821,9 +15791,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -17664,13 +17634,13 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.67.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
-      "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
@@ -19644,9 +19614,9 @@
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
-      "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg=="
+      "version": "6.0.0-beta3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.0.0-beta3.tgz",
+      "integrity": "sha512-4SqOuhC8tSLeQvbW1nDmq6T7+8vdSgHy/w7PRwCFzMQCbKuYFIir/3UuWsV1QblX1lt7SGlSgwbaCv9XhRt8HA=="
     },
     "@gar/promisify": {
       "version": "1.1.2",
@@ -20367,9 +20337,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-      "integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+      "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -20377,9 +20347,9 @@
       }
     },
     "@types/eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
       "dev": true,
       "requires": {
         "@types/eslint": "*",
@@ -20387,9 +20357,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -28589,14 +28559,14 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.1.30",
+        "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-calc": {
@@ -28683,40 +28653,16 @@
       "requires": {}
     },
     "postcss-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
-      "integrity": "sha512-M/dSoIiNDOo8Rk0mUqoj4kpGq91gcxCfb9PoyZVdZ76/AuhxylHDYZblNE8o+EQ9AMSASeMFEKxZf5aU6wlx1Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+      "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.4",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "semver": "^7.3.4"
+        "klona": "^2.0.5",
+        "semver": "^7.3.5"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-          "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -30001,9 +29947,9 @@
       }
     },
     "sass-loader": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.3.0.tgz",
-      "integrity": "sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "dev": true,
       "requires": {
         "klona": "^2.0.4",
@@ -30306,9 +30252,9 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-support": {
@@ -31781,13 +31727,13 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.67.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.67.0.tgz",
-      "integrity": "sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==",
+      "version": "5.69.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
+      "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.50",
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -19,7 +19,7 @@
     "eslint": "eslint js/**"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.3",
+    "@fortawesome/fontawesome-free": "^6.0.0-beta3",
     "@tarekraafat/autocomplete.js": "^10.2.6",
     "@walletconnect/web3-provider": "^1.0.8",
     "assert": "^2.0.0",
@@ -94,11 +94,11 @@
     "jest": "^27.4.7",
     "mini-css-extract-plugin": "^1.6.2",
     "node-sass": "^7.0.1",
-    "postcss": "^8.3.5",
-    "postcss-loader": "^4.3.0",
-    "sass-loader": "^12.3.0",
+    "postcss": "^8.4.6",
+    "postcss-loader": "^6.2.1",
+    "sass-loader": "^12.6.0",
     "style-loader": "^1.3.0",
-    "webpack": "^5.67.0",
+    "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2"
   },
   "jest": {

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -63,8 +63,8 @@ const dropzoneJs = {
 const appJs =
   {
     entry: {
-      app: './js/app.js',
-      stakes: './js/pages/stakes.js',
+      'app': './js/app.js',
+      'stakes': './js/pages/stakes.js',
       'chart-loader': './js/chart-loader.js',
       'chain': './js/pages/chain.js',
       'blocks': './js/pages/blocks.js',
@@ -92,8 +92,7 @@ const appJs =
       'main-page': './css/main-page.scss',
       'staking': './css/stakes.scss',
       'tokens': './js/pages/token/search.js',
-      'ad': './js/lib/ad.js',
-      'text_ad': './js/lib/text_ad.js',
+      'text-ad': './js/lib/text_ad.js',
       'banner': './js/lib/banner.js',
       'autocomplete': './js/lib/autocomplete.js',
       'search-results': './js/pages/search-results/search.js',

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -63,7 +63,7 @@
               <%= render BlockScoutWeb.IconsView, "_check_dark_forest_icon.html" %>
             </i>
           <% true -> %>
-            <i class="far fa-check-circle"></i>
+            <i class="fa-regular fa-check-circle"></i>
         <% end %>
       <% end %>
     <% end %>
@@ -73,7 +73,7 @@
         to: AccessHelpers.get_path(@conn, :address_decompiled_contract_path, :index, @address.hash),
         class: "card-tab #{tab_status("decompiled-contracts", @conn.request_path)}") do %>
         <%= gettext("Decompiled code") %>
-        <i class="far fa-check-circle"></i>
+        <i class="fa-regular fa-check-circle"></i>
     <% end %>
   <% end %>
   <%= if smart_contract_with_read_only_functions?(@address) do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
@@ -19,13 +19,13 @@
     <%= if @conn.request_path |> String.contains?("/tokens") do %>
       <a href="#tokens" style="text-decoration: none;">
         <span class="btn-wallet-icon">
-          <i class="fas fa-wallet " style="line-height: 31px;"></i>
+          <i class="fa-solid fa-wallet " style="line-height: 31px;"></i>
         </span>
       </a>
     <% else %>
       <a href="<%= AccessHelpers.get_path(@conn, :address_token_path, :index, @address_hash) %>#tokens" style="text-decoration: none;">
         <span class="btn-wallet-icon">
-          <i class="fas fa-wallet" style="line-height: 31px;"></i>
+          <i class="fa-solid fa-wallet" style="line-height: 31px;"></i>
         </span>
       </a>
     <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/advertisement/text_ad/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/advertisement/text_ad/index.html.eex
@@ -1,4 +1,4 @@
-<script defer data-cfasync="false" src="<%= static_path(@conn, "/js/text_ad.js") %>"></script>
+<script defer data-cfasync="false" src="<%= static_path(@conn, "/js/text-ad.js") %>"></script>
 <div class="ad mb-3" style="display: none;">
 <span class='ad-prefix'></span>: <img class="ad-img-url" width=20 height=20 /> <b><span class="ad-name"></span></b> - <span class="ad-short-description"></span> <a class="ad-url"><b><span class="ad-cta-button"></span></a></b>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_model_table.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/api_docs/_model_table.html.eex
@@ -9,7 +9,7 @@
             <span>
               <%= if details[:type] != "model", do: details.type %>
               <%= if details[:definition] do %>
-                <i class="fas fa-info-circle ml-2"
+                <i class="fa-solid fa-info-circle ml-2"
                    data-toggle="tooltip"
                    data-placement="right"
                    data-html="true"

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/overview.html.eex
@@ -215,7 +215,7 @@
                   text: gettext("Ether") <> " " <> gettext("burned from transactions included in the block (Base fee (per unit of gas) * Gas Used).") %>
                   <%= gettext("Burnt Fees") %>
                 </dt>
-                <dd class="col-sm-9 col-lg-10"><i class="fas fa-fire i-tooltip-2"></i> <%= format_wei_value(burned_fee, :ether) %></dd>
+                <dd class="col-sm-9 col-lg-10"><i class="fa-solid fa-fire i-tooltip-2"></i> <%= format_wei_value(burned_fee, :ether) %></dd>
             </dl>
             <!-- Priority Fee / Tip -->
             <dl class="row">

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_i_tooltip_2.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_i_tooltip_2.html.eex
@@ -7,5 +7,5 @@
     data-toggle="tooltip"
     title="<%= @text %>"
 >
-    <i class="fas fa-info-circle"></i>
+    <i class="fa-solid fa-info-circle"></i>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_status_icon.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_status_icon.html.eex
@@ -1,10 +1,10 @@
 <%= case @status do %>
       <% :success -> %>
-        <i style="color: #20b760;" class="far fa-check-circle"></i>
+        <i style="color: #20b760;" class="fa-regular fa-check-circle"></i>
       <% {:error, _} -> %>
-        <i style="color: #dc3545;" class="fas fa-exclamation-circle"></i>
+        <i style="color: #dc3545;" class="fa-solid fa-exclamation-circle"></i>
       <% :awaiting_internal_transactions -> %>
-        <i style="color: #f7b32b;" class="fas fa-exclamation-circle"></i>
+        <i style="color: #f7b32b;" class="fa-solid fa-exclamation-circle"></i>
       <% :pending -> %>
       <% _ -> %>
 <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -171,7 +171,7 @@
                 <%= gettext "Timestamp" %>
               </dt>
               <dd class="col-sm-9 col-lg-10" data-selector="block-timestamp">
-                <i class="far fa-clock"></i>
+                <i class="fa-regular fa-clock"></i>
                 <span>
                   <span data-from-now="<%= block.timestamp %>"></span>
                 </span>
@@ -411,7 +411,7 @@
                   text: gettext("Amount of") <> " " <> gettext("Ether") <> " " <> gettext("burned for this transaction. Equals Block Base Fee per Gas * Gas Used.") %>
                 <%= gettext "Transaction Burnt Fee" %>
               </dt>
-              <dd class="col-sm-9 col-lg-10"><i class="fas fa-fire i-tooltip-2"></i> <%= format_wei_value(burned_fee, :ether) %>
+              <dd class="col-sm-9 col-lg-10"><i class="fa-solid fa-fire i-tooltip-2"></i> <%= format_wei_value(burned_fee, :ether) %>
                 <%= unless empty_exchange_rate?(@exchange_rate) do %>
                   (<span data-wei-value=<%= burned_fee_decimal %> data-usd-exchange-rate=<%= @exchange_rate.usd_value %>></span>)
                 <% end %>


### PR DESCRIPTION
## Motivation

Update `fontawesome` package 5 -> 6

## Changelog
- "@fortawesome/fontawesome-free": "^5.15.3" -> "^6.0.0-beta3"

Chore:
- "postcss": "^8.3.5" -> "^8.4.6"
- "postcss-loader": "^4.3.0" -> "^6.2.1"
- "sass-loader": "^12.3.0" ->  "^12.6.0"
- "webpack": "^5.67.0" -> "^5.69.1"
- Add GC related missing swap button icons


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
