### PR TITLE
Contract verification forms refactoring

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: '24.2'
+  OTP_VERSION: '24.2.2'
   ELIXIR_VERSION: '1.12.3'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#4862](https://github.com/blockscout/blockscout/pull/4862) - Fix internal transactions pagination
 
 ### Chore
+- [#5230](https://github.com/blockscout/blockscout/pull/5230) - Contract verification forms refactoring
 - [#5227](https://github.com/blockscout/blockscout/pull/5227) - Major update of css-loader npm package
 - [#5226](https://github.com/blockscout/blockscout/pull/5226) - Update mini-css-extract-plugin, css-minimizer-webpack-plugin packages
 - [#5224](https://github.com/blockscout/blockscout/pull/5224) - Webpack config refactoring

--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -143,41 +143,46 @@ if ($contractVerificationPage.length) {
 
   $(function () {
     function standardJSONBehavior () {
-      $('#json-dropzone-form').removeClass('dz-clickable')
+      $('#standard-json-dropzone-form').removeClass('dz-clickable')
       this.on('addedfile', function (_file) {
-        $('#verify-via-standart-json-input-submit').prop('disabled', false)
+        $('#verify-via-standard-json-input-submit').prop('disabled', false)
         $('#file-help-block').text('')
         $('#dropzone-previews').addClass('dz-started')
       })
 
       this.on('removedfile', function (_file) {
         if (this.files.length === 0) {
-          $('#verify-via-standart-json-input-submit').prop('disabled', true)
+          $('#verify-via-standard-json-input-submit').prop('disabled', true)
           $('#dropzone-previews').removeClass('dz-started')
         }
       })
     }
 
     function metadataJSONBehavior () {
+      $('#metadata-json-dropzone-form').removeClass('dz-clickable')
       this.on('addedfile', function (_file) {
         changeVisibilityOfVerifyButton(this.files.length)
         $('#file-help-block').text('')
+        $('#dropzone-previews').addClass('dz-started')
       })
 
       this.on('removedfile', function (_file) {
         changeVisibilityOfVerifyButton(this.files.length)
+        if (this.files.length === 0) {
+          $('#dropzone-previews').removeClass('dz-started')
+        }
       })
     }
 
-    const $jsonDropzoneMetadata = $('#metadata-json-dropzone')
-    const $jsonDropzoneStandardInput = $('#json-dropzone-form')
+    const $jsonDropzoneMetadata = $('#metadata-json-dropzone-form')
+    const $jsonDropzoneStandardInput = $('#standard-json-dropzone-form')
 
     if ($jsonDropzoneMetadata.length || $jsonDropzoneStandardInput.length) {
       const func = $jsonDropzoneMetadata.length ? metadataJSONBehavior : standardJSONBehavior
       const maxFiles = $jsonDropzoneMetadata.length ? 100 : 1
       const acceptedFiles = $jsonDropzoneMetadata.length ? 'text/plain,application/json,.sol,.json' : 'text/plain,application/json,.json'
-      const tag = $jsonDropzoneMetadata.length ? '#metadata-json-dropzone' : '#json-dropzone-form'
-      const previewsContainer = $jsonDropzoneMetadata.length ? undefined : '#dropzone-previews'
+      const tag = $jsonDropzoneMetadata.length ? '#metadata-json-dropzone-form' : '#standard-json-dropzone-form'
+      const jsonVerificationType = $jsonDropzoneMetadata.length ? 'json:metadata' : 'json:standard'
 
       var dropzone = new Dropzone(tag, {
         autoProcessQueue: false,
@@ -187,17 +192,17 @@ if ($contractVerificationPage.length) {
         addRemoveLinks: true,
         maxFilesize: 10,
         maxFiles: maxFiles,
-        previewsContainer: previewsContainer,
-        params: { address_hash: $('#smart_contract_address_hash').val() },
+        previewsContainer: '#dropzone-previews',
+        params: { address_hash: $('#smart_contract_address_hash').val(), verification_type: jsonVerificationType },
         init: func
       })
     }
 
     function changeVisibilityOfVerifyButton (filesLength) {
       if (filesLength > 0) {
-        $('#verify-via-json-submit').prop('disabled', false)
+        $('#verify-via-metadata-json-submit').prop('disabled', false)
       } else {
-        $('#verify-via-json-submit').prop('disabled', true)
+        $('#verify-via-metadata-json-submit').prop('disabled', true)
       }
     }
 
@@ -254,7 +259,7 @@ if ($contractVerificationPage.length) {
       }
     })
 
-    $('#verify-via-standart-json-input-submit').on('click', (event) => {
+    $('#verify-via-standard-json-input-submit').on('click', (event) => {
       event.preventDefault()
       if (dropzone.files.length > 0) {
         dropzone.processQueue()
@@ -263,7 +268,8 @@ if ($contractVerificationPage.length) {
       }
     })
 
-    $('#verify-via-json-submit').on('click', function () {
+    $('#verify-via-metadata-json-submit').on('click', (event) => {
+      event.preventDefault()
       if (dropzone.files.length > 0) {
         dropzone.processQueue()
       } else {

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -197,19 +197,23 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def select_contract_type_and_form_view(params) do
-    verification_from_json_upload? = Map.has_key?(params, "file")
-    verification_from_flattened_source? = Map.has_key?(params, "external_libraries")
+    verification_from_metadata_json? =
+      Map.has_key?(params, "verification_type") && Map.get(params, "verification_type") == "json:metadata"
 
-    verification_from_standard_json_input? = verification_from_json_upload? && Map.has_key?(params, "smart_contract")
+    verification_from_standard_json_input? =
+      Map.has_key?(params, "verification_type") && Map.get(params, "verification_type") == "json:standard"
 
-    compiler = if verification_from_flattened_source? || verification_from_standard_json_input?, do: :solc, else: :vyper
+    verification_from_vyper? =
+      Map.has_key?(params, "verification_type") && Map.get(params, "verification_type") == "vyper"
+
+    compiler = if verification_from_vyper?, do: :vyper, else: :solc
 
     view =
       cond do
         verification_from_standard_json_input? -> AddressContractVerificationViaStandardJsonInputView
-        verification_from_json_upload? -> AddressContractVerificationViaJsonView
-        verification_from_flattened_source? -> AddressContractVerificationViaFlattenedCodeView
-        true -> AddressContractVerificationVyperView
+        verification_from_metadata_json? -> AddressContractVerificationViaJsonView
+        verification_from_vyper? -> AddressContractVerificationVyperView
+        true -> AddressContractVerificationViaFlattenedCodeView
       end
 
     %{view: view, compiler: compiler}

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -77,28 +77,6 @@ defmodule BlockScoutWeb.Router do
     end
   end
 
-  # if path != api_path do
-  #   scope to_string(api_path) <> "/verify_smart_contract" do
-  #     pipe_through(:api)
-
-  #     if Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:enabled] do
-  #       post("/contract_verifications", BlockScoutWeb.AddressContractVerificationController, :create)
-  #     else
-  #       post("/contract_verifications", BlockScoutWeb.AddressContractVerificationViaFlattenedCodeController, :create)
-  #     end
-  #   end
-  # else
-  #   scope "/verify_smart_contract" do
-  #     pipe_through(:api)
-
-  #     if Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:enabled] do
-  #       post("/contract_verifications", BlockScoutWeb.AddressContractVerificationController, :create)
-  #     else
-  #       post("/contract_verifications", BlockScoutWeb.AddressContractVerificationViaFlattenedCodeController, :create)
-  #     end
-  #   end
-  # end
-
   if Application.get_env(:block_scout_web, WebRouter)[:enabled] do
     forward("/", BlockScoutWeb.WebRouter)
   else

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification/new.html.eex
@@ -9,16 +9,7 @@
           [],
           fn f -> %>
 
-        <div class="smart-contract-form-group">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :address_hash, gettext("Contract Address") %>
-            <div class="center-column">
-              <%= text_input f, :address_hash, class: "form-control border-rounded", "aria-describedby": "contract-address-help-block", readonly: true %>
-              <%= error_tag f, :address_hash, id: "contract-address-help-block", class: "text-danger form-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
-          </div>
-        </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_address_field.html", address_hash: @address_hash, f: f %>
 
         <div class="smart-contract-form-group">
           <div class="smart-contract-form-group-inner-wrapper">

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex
@@ -1,9 +1,10 @@
 <div class="smart-contract-form-group">
     <div class="smart-contract-form-group-inner-wrapper">
-        <label for="smart_contract_address_hash"><%= gettext("Contract Address") %></label>
-        <div class="center-column">
-            <input aria-describedby="contract-address-help-block" class="form-control border-rounded" id="smart_contract_address_hash" name="smart_contract[address_hash]" type="text" value=<%= @address_hash %> readonly="">
-        </div>
-        <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
+    <%= label @f, :address_hash, gettext("Contract Address") %>
+    <div class="center-column">
+        <%= text_input @f, :address_hash, class: "form-control border-rounded", id: "smart_contract_address_hash", "aria-describedby": "contract-address-help-block", readonly: true %>
+        <%= error_tag @f, :address_hash, id: "contract-address-help-block", class: "text-danger form-error" %>
+    </div>
+    <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
     </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex
@@ -1,0 +1,9 @@
+<div class="smart-contract-form-group">
+    <div class="smart-contract-form-group-inner-wrapper">
+    <%= label :external_libraries, @library, gettext("Library Address") %>
+    <div class="center-column">
+        <%= text_input :external_libraries, @library_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+    </div>
+    <div class="smart-contract-form-group-tooltip"><%= if assigns[:tooltip_text] do @tooltip_text end %></div>
+    </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex
@@ -1,0 +1,9 @@
+<div class="smart-contract-form-group">
+    <div class="smart-contract-form-group-inner-wrapper">
+    <%= label :external_libraries, @library, gettext("Library Name") %>
+    <div class="center-column">
+        <%= text_input :external_libraries, @library_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+    </div>
+    <div class="smart-contract-form-group-tooltip"><%= if assigns[:tooltip_text] do @tooltip_text end %></div>
+    </div>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
@@ -18,16 +18,7 @@
           [],
           fn f -> %>
 
-        <div class="smart-contract-form-group">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :address_hash, gettext("Contract Address") %>
-            <div class="center-column">
-              <%= text_input f, :address_hash, class: "form-control border-rounded", "aria-describedby": "contract-address-help-block", readonly: true %>
-              <%= error_tag f, :address_hash, id: "contract-address-help-block", class: "text-danger form-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
-          </div>
-        </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_address_field.html", address_hash: @address_hash, f: f %>
 
         <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_name_field.html", f: f, tooltip: "Must match the name specified in the code. For example, in <span class=\"tooltip-quote\">contract MyContract {..}</span> <strong>MyContract</strong> is the contract name.", contract_name_value: contract_name_value %>
 
@@ -100,113 +91,41 @@
           <h2 class="smart-contract-title margin-bottom-md"><%= gettext "Contract Libraries" %></h2>
 
           <div class="contract-library-form-group js-contract-library-form-group active">
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library1, gettext("Library Name") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library1_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip">A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one.</div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html",
+              library: :library1,
+              library_name: :library1_name,
+              tooltip_text: "A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one."
+            %>
 
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library1, gettext("Library Address") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library1_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip">The 0x library address. This can be found in the generated json file or Truffle output (if using truffle).</div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html",
+              library: :library1,
+              library_address: :library1_address,
+              tooltip_text: "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
+            %>
           </div>
 
           <div class="contract-library-form-group js-contract-library-form-group">
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library2, gettext("Library Name") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library2_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library2, library_name: :library2_name %>
 
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library2, gettext("Library Address") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library2_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library2, library_address: :library2_address %>
           </div>
 
           <div class="contract-library-form-group js-contract-library-form-group">
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library3, gettext("Library Name") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library3_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library3, library_name: :library3_name %>
 
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library3, gettext("Library Address") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library3_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library3, library_address: :library3_address %>
           </div>
 
           <div class="contract-library-form-group js-contract-library-form-group">
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library4, gettext("Library Name") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library4_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library4, library_name: :library4_name %>
 
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library4, gettext("Library Address") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library4_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library4, library_address: :library4_address %>
           </div>
 
           <div class="contract-library-form-group js-contract-library-form-group">
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label :external_libraries, :library5, gettext("Library Name") %>
-                <div class="center-column">
-                  <%= text_input :external_libraries, :library5_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library5, library_name: :library5_name %>
 
-            <div class="smart-contract-form-group">
-              <div class="smart-contract-form-group-inner-wrapper">
-                <%= label f, :library5, gettext("Library Address") %>
-                <div class="center-column">
-                  <%= text_input f, :library5_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
-                </div>
-                <div class="smart-contract-form-group-tooltip"></div>
-              </div>
-            </div>
+            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library5, library_address: :library5_address %>
           </div>
 
           <div class="add-contract-library-wrapper js-add-contract-library-wrapper">

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex
@@ -3,34 +3,27 @@
 
   <div class="new-smart-contract-form">
       <h1 class="smart-contract-title"><%= gettext "New Smart Contract Verification" %></h1>
-
-      <div class="smart-contract-form-group">
-        <div class="smart-contract-form-group-inner-wrapper">
-          <label for="smart_contract_address_hash"><%= gettext("Contract Address") %></label>
-          <div class="center-column">
-            <input aria-describedby="contract-address-help-block" class="form-control border-rounded" id="smart_contract_address_hash" name="smart_contract[address_hash]" type="text" value=<%= @address_hash %> readonly="">
-          </div>
-          <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
-        </div>
-      </div>
+      <%= form_for @changeset,
+        address_contract_verification_path(@conn, :create),
+        [id: "metadata-json-dropzone-form"],
+        fn f -> %>
+      <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_address_field.html", address_hash: @address_hash, f: f %>
 
       <div class="smart-contract-form-group">
         <div class="smart-contract-form-group-inner-wrapper">
         <label for="smart_contract_metadata_json"><%= gettext("Sources and Metadata JSON") %></label>
           <div class="center-column">
-            <%= form_for @changeset,
-            address_contract_verification_path(@conn, :create),
-            [class: "dropzone-1", style: "display: flex; margin: 0 auto;", id: "metadata-json-dropzone"],
-            fn f -> %>
+            <div class="dropzone-1 dropzone-previews" style="display: flex; margin: 0 auto;", id="dropzone-previews">
               <div style="text-align: center;">
-                <span class="dz-message btn-full-primary"><%= gettext("Drop sources and metadata JSON file or click here") %></span>
+                <span class="dz-message btn-full-primary" id="dz-button-message"><%= gettext("Drop sources and metadata JSON file or click here") %></span>
                 <%= error_tag f, :file, id: "file-help-block", class: "text-danger form-error", style: "max-width: 600px;" %>
               </div>
-            <% end %>
+            </div>
           </div>
           <div class="smart-contract-form-group-tooltip">Drop all Solidity contract source files and JSON metadata file(s) created during contract compilation into the drop zone.</div>
         </div>
       </div>
+
       <div class="smart-contract-form-buttons">
         <button
           class="position-absolute w-118 btn-full-primary d-none mr-2"
@@ -41,7 +34,7 @@
         >
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html", loading_text: gettext("Loading...") %>
         </button>
-        <button id="verify-via-json-submit" class="btn-full-primary mr-2" disabled data-button-loading="animation"><%= gettext("Verify & publish") %></button>
+        <button id="verify-via-metadata-json-submit" class="btn-full-primary mr-2" disabled data-button-loading="animation"><%= gettext("Verify & publish") %></button>
         <%= reset gettext("Reset"), class: "btn-line mr-2 js-smart-contract-form-reset" %>
         <%=
           link(
@@ -51,6 +44,7 @@
             )
         %>
       </div>
+      <% end %>
     </div>
     <script defer data-cfasync="false" src="<%= static_path(@conn, "/js/verification-form.js") %>"></script>
     <script defer data-cfasync="false" src="<%= static_path(@conn, "/js/dropzone.js") %>"></script>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex
@@ -4,17 +4,13 @@
 <% fetch_constructor_arguments_automatically = if metadata_for_verification, do: true, else: false %>
 <% display_constructor_arguments_text_area = if fetch_constructor_arguments_automatically, do: "none", else: "block" %>
 <section data-page="contract-verification" class="container new-smart-contract-container">
-  <div data-selector="channel-disconnected-message" class="d-none">
-    <div data-selector="reload-button" class="alert alert-danger">
-      <a href="#" class="alert-link"><%= gettext "Connection Lost" %></a>
-    </div>
-  </div>
+  <%= render BlockScoutWeb.CommonComponentsView, "_channel_disconnected_message.html", text: gettext("Connection Lost") %>
 
   <div class="new-smart-contract-form">
       <h1 class="smart-contract-title"><%= gettext "New Smart Contract Verification" %></h1>
       <%= form_for @changeset,
                 address_contract_verification_path(@conn, :create),
-                [id: "json-dropzone-form"],
+                [id: "standard-json-dropzone-form"],
                 fn f -> %>      
       <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_address_field.html", address_hash: @address_hash, f: f %>
 
@@ -53,7 +49,7 @@
         >
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html", loading_text: gettext("Loading...") %>
         </button>
-        <button id="verify-via-standart-json-input-submit" class="btn-full-primary mr-2" disabled data-button-loading="animation"><%= gettext("Verify & publish") %></button>
+        <button id="verify-via-standard-json-input-submit" class="btn-full-primary mr-2" disabled data-button-loading="animation"><%= gettext("Verify & publish") %></button>
         <%= reset gettext("Reset"), class: "btn-line mr-2 js-smart-contract-form-reset" %>
         <%=
           link(

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex
@@ -13,38 +13,11 @@
           [],
           fn f -> %>
 
-        <div class="smart-contract-form-group">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :address_hash, gettext("Contract Address") %>
-            <div class="center-column">
-              <%= text_input f, :address_hash, class: "form-control border-rounded", "aria-describedby": "contract-address-help-block", readonly: true %>
-              <%= error_tag f, :address_hash, id: "contract-address-help-block", class: "text-danger form-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip">The 0x address supplied on contract creation.</div>
-          </div>
-        </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_address_field.html", address_hash: @address_hash, f: f %>
 
-        <div class="smart-contract-form-group">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :name, gettext("Contract Name") %>
-            <div class="center-column">
-              <%= text_input f, :name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block", "data-test": "contract_name", value: contract_name_value, disabled: "true" %>
-              <%= error_tag f, :name, id: "contract-name-help-block", class: "text-danger form-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip">Must match the name specified in the code.</div>
-          </div>
-        </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_contract_name_field.html", f: f, tooltip: "Must match the name specified in the code. For example, in <span class=\"tooltip-quote\">contract MyContract {..}</span> <strong>MyContract</strong> is the contract name.", contract_name_value: contract_name_value %>
 
-        <div class="smart-contract-form-group">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :compiler_version, gettext("Compiler") %>
-            <div class="center-column">
-              <%= select f, :compiler_version, @compiler_versions, class: "form-control border-rounded", selected: compiler_version, "aria-describedby": "compiler-help-block" %>
-              <%= error_tag f, :compiler_version, id: "compiler-help-block", class: "text-danger form-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip"></div>
-          </div>
-        </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_compiler_field.html", f: f, compiler_version: compiler_version, compiler_versions: @compiler_versions %>
 
         <div class="smart-contract-form-group">
           <div class="smart-contract-form-group-inner-wrapper">
@@ -57,15 +30,10 @@
           </div>
         </div>
 
-        <div class="smart-contract-form-group constructor-arguments" style="display: block">
-          <div class="smart-contract-form-group-inner-wrapper">
-            <%= label f, :constructor_arguments, gettext("ABI-encoded Constructor Arguments (if required by the contract)") %>
-            <div class="center-column">
-              <%= textarea f, :constructor_arguments, class: "form-control border-rounded monospace", rows: 3, "aria-describedby": "contract-constructor-arguments-help-block" %>
-              <%= error_tag f, :constructor_arguments, id: "contract-constructor-arguments-help-block", class: "text-danger form-error", "data-test": "contract-constructor-arguments-error" %>
-            </div>
-            <div class="smart-contract-form-group-tooltip">Add arguments in <a href="https://solidity.readthedocs.io/en/develop/abi-spec.html" target="_blank">ABI hex encoded form</a>. Constructor arguments are written right to left, and will be found at the end of the input created bytecode. They may also be <a href="https://abi.hashex.org/" target="_blank">parsed here.</a></div>
-          </div>
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_constructor_args.html", f: f, display_constructor_arguments_text_area: "block" %>
+
+        <div class="d-none">
+          <input type="text" id="verification_type" name="verification_type" value="vyper" />
         </div>
 
         <div class="smart-contract-form-buttons">

--- a/apps/block_scout_web/lib/block_scout_web/web_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/web_router.ex
@@ -140,7 +140,7 @@ defmodule BlockScoutWeb.WebRouter do
       )
 
       resources(
-        "/verify-via-json",
+        "/verify-via-metadata-json",
         AddressContractVerificationViaJsonController,
         only: [:new],
         as: :verify_contract_via_json

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -135,7 +135,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_constructor_args.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:62
 msgid "ABI-encoded Constructor Arguments (if required by the contract)"
 msgstr ""
 
@@ -488,11 +487,11 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:114
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:231
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:48
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:60
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:85 lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:105
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:150
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:41
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:56
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:53 lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:54
 msgid "Cancel"
 msgstr ""
@@ -587,7 +586,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_compiler_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:40
 msgid "Compiler"
 msgstr ""
 
@@ -615,7 +613,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:2
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:11
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:2
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:9
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:7
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:6 lib/block_scout_web/templates/tokens/holder/index.html.eex:15
 msgid "Connection Lost"
 msgstr ""
@@ -659,11 +657,7 @@ msgid "Contract ABI"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:14
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:23
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:9
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:18 lib/block_scout_web/views/address_view.ex:102
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:3 lib/block_scout_web/views/address_view.ex:102
 msgid "Contract Address"
 msgstr ""
 
@@ -690,14 +684,13 @@ msgid "Contract Creation Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:100
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:91
 msgid "Contract Libraries"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:93
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:29
 msgid "Contract Name"
 msgstr ""
 
@@ -992,12 +985,12 @@ msgid "Download"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:26
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:18
 msgid "Drop sources and metadata JSON file or click here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:33
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:29
 msgid "Drop the standard input JSON file or click here"
 msgstr ""
 
@@ -1040,7 +1033,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:76
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:40
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:31
 msgid "EVM Version"
 msgstr ""
 
@@ -1060,12 +1053,12 @@ msgid "Emission Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:82
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:73
 msgid "Enter the Solidity Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:51
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:24
 msgid "Enter the Vyper Contract Code"
 msgstr ""
 
@@ -1426,20 +1419,12 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:115
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:137
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:159
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:181
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:203
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:3
 msgid "Library Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:105
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:127
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:149
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:171
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:193
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:3
 msgid "Library Name"
 msgstr ""
 
@@ -1484,11 +1469,11 @@ msgid "Loading chart..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:79
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:225
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:42
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:54
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:79 lib/block_scout_web/templates/address_read_contract/index.html.eex:12
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:70
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:144
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:35
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:50
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:47 lib/block_scout_web/templates/address_read_contract/index.html.eex:12
 #: lib/block_scout_web/templates/address_read_proxy/index.html.eex:12 lib/block_scout_web/templates/address_write_contract/index.html.eex:12
 #: lib/block_scout_web/templates/address_write_proxy/index.html.eex:12 lib/block_scout_web/templates/tokens/contract/index.html.eex:16
 msgid "Loading..."
@@ -1672,7 +1657,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:5
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:5
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:14
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:10
 msgid "New Smart Contract Verification"
 msgstr ""
 
@@ -1687,9 +1672,9 @@ msgid "New Vyper Smart Contract Verification"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:89 lib/block_scout_web/templates/address_contract_verification/new.html.eex:97
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:105
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:73
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:80 lib/block_scout_web/templates/address_contract_verification/new.html.eex:88
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:96
 msgid "Next"
 msgstr ""
 
@@ -1701,7 +1686,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_fetch_constructor_args.html.eex:9
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_include_nightly_builds_field.html.eex:9
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:56 lib/block_scout_web/templates/stakes/_rows.html.eex:24
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:47 lib/block_scout_web/templates/stakes/_rows.html.eex:24
 msgid "No"
 msgstr ""
 
@@ -1769,7 +1754,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:70
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:72
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:63
 msgid "Optimization runs"
 msgstr ""
 
@@ -1990,10 +1975,10 @@ msgid "Request URL"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:228
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:45
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:57
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:82
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:147
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:38
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:53
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:50
 msgid "Reset"
 msgstr ""
 
@@ -2178,7 +2163,7 @@ msgid "Source Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:19
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:14
 msgid "Sources and Metadata JSON"
 msgstr ""
 
@@ -2245,7 +2230,7 @@ msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:29
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:25
 msgid "Standard Input JSON"
 msgstr ""
 
@@ -3003,10 +2988,10 @@ msgid "Verify & Publish"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:227
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:44
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:56
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:81
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:146
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:37
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:52
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:49
 msgid "Verify & publish"
 msgstr ""
 
@@ -3022,17 +3007,17 @@ msgid "Version"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:42
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:33
 msgid "Via Sourcify: Sources and metadata JSON file"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:36
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:27
 msgid "Via Standard Input JSON"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:31
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:22
 msgid "Via flattened source code"
 msgstr ""
 
@@ -3088,7 +3073,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:48
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:39
 msgid "Vyper contract"
 msgstr ""
 
@@ -3167,7 +3152,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_fetch_constructor_args.html.eex:14
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_include_nightly_builds_field.html.eex:14
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:61 lib/block_scout_web/templates/stakes/_rows.html.eex:24
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:52 lib/block_scout_web/templates/stakes/_rows.html.eex:24
 msgid "Yes"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -135,7 +135,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_constructor_args.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:62
 msgid "ABI-encoded Constructor Arguments (if required by the contract)"
 msgstr ""
 
@@ -488,11 +487,11 @@ msgid "Call Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:114
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:231
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:48
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:60
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:85 lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:105
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:150
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:41
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:56
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:53 lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:54
 msgid "Cancel"
 msgstr ""
@@ -587,7 +586,6 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_compiler_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:40
 msgid "Compiler"
 msgstr ""
 
@@ -615,7 +613,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:2
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:11
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:2
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:9
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:7
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:6 lib/block_scout_web/templates/tokens/holder/index.html.eex:15
 msgid "Connection Lost"
 msgstr ""
@@ -659,11 +657,7 @@ msgid "Contract ABI"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:14
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:23
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:9
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:18 lib/block_scout_web/views/address_view.ex:102
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_address_field.html.eex:3 lib/block_scout_web/views/address_view.ex:102
 msgid "Contract Address"
 msgstr ""
 
@@ -690,14 +684,13 @@ msgid "Contract Creation Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:100
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:91
 msgid "Contract Libraries"
 msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address/overview.html.eex:93
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_contract_name_field.html.eex:3
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:29
 msgid "Contract Name"
 msgstr ""
 
@@ -992,12 +985,12 @@ msgid "Download"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:26
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:18
 msgid "Drop sources and metadata JSON file or click here"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:33
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:29
 msgid "Drop the standard input JSON file or click here"
 msgstr ""
 
@@ -1040,7 +1033,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:76
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:40
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:31
 msgid "EVM Version"
 msgstr ""
 
@@ -1060,12 +1053,12 @@ msgid "Emission Reward"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:82
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:73
 msgid "Enter the Solidity Contract Code"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:51
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:24
 msgid "Enter the Vyper Contract Code"
 msgstr ""
 
@@ -1426,20 +1419,12 @@ msgid "Less than"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:115
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:137
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:159
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:181
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:203
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:3
 msgid "Library Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:105
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:127
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:149
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:171
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:193
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:3
 msgid "Library Name"
 msgstr ""
 
@@ -1484,11 +1469,11 @@ msgid "Loading chart..."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:79
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:225
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:42
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:54
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:79 lib/block_scout_web/templates/address_read_contract/index.html.eex:12
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:70
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:144
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:35
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:50
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:47 lib/block_scout_web/templates/address_read_contract/index.html.eex:12
 #: lib/block_scout_web/templates/address_read_proxy/index.html.eex:12 lib/block_scout_web/templates/address_write_contract/index.html.eex:12
 #: lib/block_scout_web/templates/address_write_proxy/index.html.eex:12 lib/block_scout_web/templates/tokens/contract/index.html.eex:16
 msgid "Loading..."
@@ -1672,7 +1657,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:5
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:5
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:14
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:10
 msgid "New Smart Contract Verification"
 msgstr ""
 
@@ -1687,9 +1672,9 @@ msgid "New Vyper Smart Contract Verification"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:82
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:89 lib/block_scout_web/templates/address_contract_verification/new.html.eex:97
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:105
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:73
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:80 lib/block_scout_web/templates/address_contract_verification/new.html.eex:88
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:96
 msgid "Next"
 msgstr ""
 
@@ -1701,7 +1686,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_fetch_constructor_args.html.eex:9
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_include_nightly_builds_field.html.eex:9
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:56 lib/block_scout_web/templates/stakes/_rows.html.eex:24
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:47 lib/block_scout_web/templates/stakes/_rows.html.eex:24
 msgid "No"
 msgstr ""
 
@@ -1769,7 +1754,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract/index.html.eex:70
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:72
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:63
 msgid "Optimization runs"
 msgstr ""
 
@@ -1990,10 +1975,10 @@ msgid "Request URL"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:228
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:45
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:57
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:82
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:147
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:38
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:53
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:50
 msgid "Reset"
 msgstr ""
 
@@ -2178,7 +2163,7 @@ msgid "Source Pool"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:19
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:14
 msgid "Sources and Metadata JSON"
 msgstr ""
 
@@ -2245,7 +2230,7 @@ msgid "Staking epochs are not specified or not in the allowed range"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:29
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:25
 msgid "Standard Input JSON"
 msgstr ""
 
@@ -3003,10 +2988,10 @@ msgid "Verify & Publish"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:227
-#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:44
-#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:56
-#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:81
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:146
+#: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:37
+#: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:52
+#: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:49
 msgid "Verify & publish"
 msgstr ""
 
@@ -3022,17 +3007,17 @@ msgid "Version"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:42
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:33
 msgid "Via Sourcify: Sources and metadata JSON file"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:36
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:27
 msgid "Via Standard Input JSON"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:31
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:22
 msgid "Via flattened source code"
 msgstr ""
 
@@ -3088,7 +3073,7 @@ msgid "View transaction %{transaction} on %{subnetwork}"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:48
+#: lib/block_scout_web/templates/address_contract_verification/new.html.eex:39
 msgid "Vyper contract"
 msgstr ""
 
@@ -3167,7 +3152,7 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_fetch_constructor_args.html.eex:14
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_include_nightly_builds_field.html.eex:14
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:61 lib/block_scout_web/templates/stakes/_rows.html.eex:24
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:52 lib/block_scout_web/templates/stakes/_rows.html.eex:24
 msgid "Yes"
 msgstr ""
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4152,47 +4152,48 @@ defmodule Explorer.Chain do
   Finds metadata for verification of a contract from verified twins: contracts with the same bytecode
   which were verified previously, returns a single t:SmartContract.t/0
   """
-  def get_address_verified_twin_contract(address_hash) do
-    case Repo.get(Address, address_hash) do
-      nil ->
+  def get_address_verified_twin_contract(hash) when is_binary(hash) do
+    case string_to_address_hash(hash) do
+      {:ok, address_hash} -> get_address_verified_twin_contract(address_hash)
+      _ -> %{:verified_contract => nil, :additional_sources => nil}
+    end
+  end
+
+  def get_address_verified_twin_contract(%Explorer.Chain.Hash{} = address_hash) do
+    with target_address <- Repo.get(Address, address_hash),
+         false <- is_nil(target_address),
+         %{contract_code: %Chain.Data{bytes: contract_code_bytes}} <- target_address do
+      target_address_hash = target_address.hash
+
+      contract_code_md5 =
+        Base.encode16(:crypto.hash(:md5, "\\x" <> Base.encode16(contract_code_bytes, case: :lower)),
+          case: :lower
+        )
+
+      verified_contract_twin_query =
+        from(
+          address in Address,
+          inner_join: smart_contract in SmartContract,
+          on: address.hash == smart_contract.address_hash,
+          where: fragment("md5(contract_code::text)") == ^contract_code_md5,
+          where: address.hash != ^target_address_hash,
+          select: smart_contract,
+          limit: 1
+        )
+
+      verified_contract_twin =
+        verified_contract_twin_query
+        |> Repo.one(timeout: 10_000)
+
+      verified_contract_twin_additional_sources = get_contract_additional_sources(verified_contract_twin)
+
+      %{
+        :verified_contract => verified_contract_twin,
+        :additional_sources => verified_contract_twin_additional_sources
+      }
+    else
+      _ ->
         %{:verified_contract => nil, :additional_sources => nil}
-
-      target_address ->
-        target_address_hash = target_address.hash
-        contract_code = target_address.contract_code
-
-        case contract_code do
-          %Chain.Data{bytes: contract_code_bytes} ->
-            contract_code_md5 =
-              Base.encode16(:crypto.hash(:md5, "\\x" <> Base.encode16(contract_code_bytes, case: :lower)),
-                case: :lower
-              )
-
-            verified_contract_twin_query =
-              from(
-                address in Address,
-                inner_join: smart_contract in SmartContract,
-                on: address.hash == smart_contract.address_hash,
-                where: fragment("md5(contract_code::text)") == ^contract_code_md5,
-                where: address.hash != ^target_address_hash,
-                select: smart_contract,
-                limit: 1
-              )
-
-            verified_contract_twin =
-              verified_contract_twin_query
-              |> Repo.one(timeout: 10_000)
-
-            verified_contract_twin_additional_sources = get_contract_additional_sources(verified_contract_twin)
-
-            %{
-              :verified_contract => verified_contract_twin,
-              :additional_sources => verified_contract_twin_additional_sources
-            }
-
-          _ ->
-            %{:verified_contract => nil, :additional_sources => nil}
-        end
     end
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -45,7 +45,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
     end
   end
 
-  def publish_with_standart_json_input(%{"address_hash" => address_hash} = params, json_input) do
+  def publish_with_standard_json_input(%{"address_hash" => address_hash} = params, json_input) do
     case Verifier.evaluate_authenticity_via_standard_json_input(address_hash, params, json_input) do
       {:ok, %{abi: abi, constructor_arguments: constructor_arguments}, additional_params} ->
         params_with_constructor_arguments =

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher_worker.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher_worker.ex
@@ -25,7 +25,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherWorker do
   def perform({%{"address_hash" => address_hash} = params, json_input, uid}) when is_binary(uid) do
     VerificationStatus.insert_status(uid, :pending, address_hash)
 
-    case Publisher.publish_with_standart_json_input(params, json_input) do
+    case Publisher.publish_with_standard_json_input(params, json_input) do
       {:ok, _contract} ->
         VerificationStatus.update_status(uid, :pass)
 
@@ -36,7 +36,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherWorker do
 
   def perform({%{"address_hash" => address_hash} = params, json_input, conn}) do
     result =
-      case Publisher.publish_with_standart_json_input(params, json_input) do
+      case Publisher.publish_with_standard_json_input(params, json_input) do
         {:ok, _contract} = result ->
           result
 


### PR DESCRIPTION
## Changelog

- "Contract Address" is re-used from `_contract_address_field.html.eex` template In all contract verification forms
- `_library_address.html.eex` and `_library_name.html.eex` templates created and re-used
- `get_address_verified_twin_contract` - check, that address hash is valid, added
- an additional param `verification_type` is added to the request `/verify_smart_contract/contract_verifications`: [`json:metadata`, `json:standard`, `vyper`]


Chore:
- Erlang OTP version updated to `24.2.2` in GithubActions workflow config
- Commented code removed from the router
- Fix typos in the naming

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
