### PR TITLE
Fix implementation address align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5269](https://github.com/blockscout/blockscout/pull/5269) - Address Page: Fix implementation address align
 - [#5259](https://github.com/blockscout/blockscout/pull/5259) - Fix `coin-balances/by-day` bug
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -152,8 +152,7 @@
                 <%= link(
                   implementation_address,
                   to: address_path(@conn, :show, implementation_address),
-                  class: "contract-address mb-2",
-                  style: "margin-top: 0.5rem;"
+                  class: "contract-address"
                 ) 
                 %>
               </dd>


### PR DESCRIPTION
## Motivation
Not aligned implementation address: 

![image](https://user-images.githubusercontent.com/32202610/156937214-d513df1c-5dda-41d2-be6f-436893cfce11.png)

## Changelog
- Align implementation address

![image](https://user-images.githubusercontent.com/32202610/156937244-633a2855-a5dd-4718-a5b0-e9c7e97203c7.png)


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
