### PR TITLE
add missing keys

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -587,7 +587,7 @@ defmodule EthereumJSONRPC.Block do
   # hash format
   defp entry_to_elixir({key, _} = entry)
        when key in ~w(author extraData hash logsBloom miner mixHash nonce parentHash receiptsRoot sealFields sha3Uncles
-                     signature stateRoot step transactionsRoot uncles bitcoinMergedMiningCoinbaseTransaction bitcoinMergedMiningHeader bitcoinMergedMiningMerkleProof hashForMergedMining committedSeals committee pastCommittedSeals proposerSeal round),
+                     signature stateRoot step transactionsRoot uncles bitcoinMergedMiningCoinbaseTransaction bitcoinMergedMiningHeader bitcoinMergedMiningMerkleProof hashForMergedMining committedSeals committee pastCommittedSeals proposerSeal round blockGasCost extDataGasUsed),
        do: entry
 
   defp entry_to_elixir({"timestamp" = key, timestamp}) do


### PR DESCRIPTION
## Motivation

Bugfix

### Bug Fixes

We noticed exceptions being thrown in indexer because of these two missing keys on sgb/ava node. Adding these two to the list fixed the exceptions.

Unfortunately I am way out of my depth when it comes to elixir to write any tests or even know what this code does so please review or prepare your own fix if needed.
