### PR TITLE
general video improvements

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -61,12 +61,12 @@
       <div class="card">
         <div class="card-body">
           <div class="erc721-media" >
-            <%= if media_type(media_src(@token_instance.instance)) == "video" do %>
-              <video autoplay style="width: 100%;">
-                <source src=<%= media_src(@token_instance.instance) %> type="video/mp4">
+            <%= if media_type(media_src_detail(@token_instance.instance)) == "video" do %>
+              <video controls autoplay playsinline style="width: 100%;">
+                <source src=<%= media_src_detail(@token_instance.instance) %> type="video/mp4">
               </video>
             <% else %>
-              <img src=<%= media_src(@token_instance.instance) %> />
+              <img src=<%= media_src_detail(@token_instance.instance) %> />
             <% end %>
           </div>
         </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
@@ -46,7 +46,7 @@
       <!-- substitute the span with <img class="tile-image" /> to token with images -->
       <div class="inventory-erc721-media" >
         <%= if media_type(media_src(@token_transfer.instance)) == "video" do %>
-          <video autoplay>
+          <video>
             <source src=<%= media_src(@token_transfer.instance) %> type="video/mp4">
           </video>
         <% else %>

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -44,6 +44,31 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
     if String.trim(result) == "", do: media_src(nil), else: result
   end
 
+  def media_src_detail(nil), do: @stub_image
+
+  def media_src_detail(instance) do
+    result =
+      cond do
+        instance.metadata && instance.metadata["animation_url"] ->
+          retrieve_image(instance.metadata["animation_url"])
+
+        instance.metadata && instance.metadata["image_url"] ->
+          retrieve_image(instance.metadata["image_url"])
+
+        instance.metadata && instance.metadata["image"] ->
+          retrieve_image(instance.metadata["image"])
+
+        instance.metadata && instance.metadata["properties"]["image"]["description"] ->
+          instance.metadata["properties"]["image"]["description"]
+
+        true ->
+          media_src_detail(nil)
+      end
+
+    if String.trim(result) == "", do: media_src_detail(nil), else: result
+  end
+
+
   def media_type(media_src) when not is_nil(media_src) do
     ext = media_src |> Path.extname() |> String.trim()
 


### PR DESCRIPTION
## Motivation

This patch addresses some issues with video NFTs as displayed by blockscout.

## Changelog

### Enhancements
1. Disable autoplay in inventory to improve load times. IPFS is quite slow so when you have 20 video tokens it's quite bad.
2. Use animation_url metadata to fetch the high quality video on detail page instead of low quality animation. See https://docs.opensea.io/docs/metadata-standards -> animation_url
3. Add controls to detail video

Unfortunately my knowledge of elixir is very limited so this is a rough patch, splitting the media_src function is probably not necessary and can be more elegant. Maybe use this as an idea for better patch. 