### PR TITLE
Display low-quality media assets in inventory tab, and high-quality - on instance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement
 
 ### Fixes
-- [#5300](https://github.com/blockscout/blockscout/pull/5300) - Token instance page: general video improvements
+- [#5300](https://github.com/blockscout/blockscout/pull/5300), [#5305](https://github.com/blockscout/blockscout/pull/5305) - Token instance page: general video improvements
 - [#5136](https://github.com/blockscout/blockscout/pull/5136) - Improve contract verification
 - [#5285](https://github.com/blockscout/blockscout/pull/5285) - Fix verified smart-contract bytecode twins feature
 - [#5269](https://github.com/blockscout/blockscout/pull/5269) - Address Page: Fix implementation address align

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -61,12 +61,12 @@
       <div class="card">
         <div class="card-body">
           <div class="erc721-media" >
-            <%= if media_type(media_src(@token_instance.instance)) == "video" do %>
+            <%= if media_type(media_src(@token_instance.instance, true)) == "video" do %>
               <video controls autoplay playsinline style="width: 100%;">
-                <source src=<%= media_src(@token_instance.instance) %> type="video/mp4">
+                <source src=<%= media_src(@token_instance.instance, true) %> type="video/mp4">
               </video>
             <% else %>
-              <img src=<%= media_src(@token_instance.instance) %> />
+              <img src=<%= media_src(@token_instance.instance, true) %> />
             <% end %>
           </div>
         </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -25,17 +25,17 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
 
   def media_src(nil), do: @stub_image
 
-  def media_src(instance) do
-    result = get_media_src(instance.metadata)
+  def media_src(instance, high_quality_media? \\ nil) do
+    result = get_media_src(instance.metadata, high_quality_media?)
 
     if String.trim(result) == "", do: media_src(nil), else: result
   end
 
-  defp get_media_src(nil), do: media_src(nil)
+  defp get_media_src(nil, _), do: media_src(nil)
 
-  defp get_media_src(metadata) do
+  defp get_media_src(metadata, high_quality_media?) do
     cond do
-      metadata["animation_url"] ->
+      metadata["animation_url"] && high_quality_media? ->
         retrieve_image(metadata["animation_url"])
 
       metadata["image_url"] ->

--- a/apps/block_scout_web/test/block_scout_web/views/tokens/instance/overview_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/tokens/instance/overview_view_test.exs
@@ -94,8 +94,29 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewViewTest do
 
       data = Jason.decode!(json)
 
-      assert OverviewView.media_src(%{metadata: data}) ==
+      assert OverviewView.media_src(%{metadata: data}, true) ==
                "https://assets.cargo.build/611a883b0d039100261bfe79/b89cf189-13e9-47ed-b801-a1f6aa15a7bf/376db72d-f8dc-44bb-b6ac-0e8a31fc6164-comp-1_8mp4.mp4"
+    end
+
+    test "doesn't fetch image from animation_url if high_quality_media? flag didn't passed" do
+      json = """
+        {
+          "name": "Zombie MILF",
+          "image": "https://assets.cargo.build/611a883b0d039100261bfe79/b89cf189-13e9-47ed-b801-a1f6aa15a7bf/a0784ea0-45be-41cd-9cdd-cc40ad20f20d-zombiepngpng.png",
+          "description": "grab your crossbow, ‘cause you’re gonna turn when this MILFy zombie bites you!",
+          "external_url": "https://app.cargo.build/marketplace?tokenDetail=611a876d0d14af00085bf25c:120",
+          "animation_url": "https://assets.cargo.build/611a883b0d039100261bfe79/b89cf189-13e9-47ed-b801-a1f6aa15a7bf/376db72d-f8dc-44bb-b6ac-0e8a31fc6164-comp-1_8mp4.mp4",
+          "cargoDisplayContent": {
+            "type": "video",
+            "files": ["https://assets.cargo.build/611a883b0d039100261bfe79/b89cf189-13e9-47ed-b801-a1f6aa15a7bf/376db72d-f8dc-44bb-b6ac-0e8a31fc6164-comp-1_8mp4.mp4"]
+          }
+        }
+      """
+
+      data = Jason.decode!(json)
+
+      assert OverviewView.media_src(%{metadata: data}) ==
+               "https://assets.cargo.build/611a883b0d039100261bfe79/b89cf189-13e9-47ed-b801-a1f6aa15a7bf/a0784ea0-45be-41cd-9cdd-cc40ad20f20d-zombiepngpng.png"
     end
   end
 end


### PR DESCRIPTION
Inspired by https://github.com/blockscout/blockscout/pull/5300#issuecomment-1065037029

## Motivation

Display low quality media files in inventory tab and high quality media files - on the token instance page.

## Changelog

Implement `high_quality_media?` flag in order to choose from which property get the asset's media file link:
`animation_url` - is for high quality media files

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
