### PR TITLE
Eliminate Jquery import from chart-loader.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#5239](https://github.com/blockscout/blockscout/pull/5239) - Add accounting for block rewards in `getblockreward` api method
 
 ### Chore
+- [#5318](https://github.com/blockscout/blockscout/pull/5318) - Eliminate Jquery import from chart-loader.js
 - [#5317](https://github.com/blockscout/blockscout/pull/5317) - NPM audit
 - [#5303](https://github.com/blockscout/blockscout/pull/5303) - Besu: revertReason support in trace
 - [#5301](https://github.com/blockscout/blockscout/pull/5301) - Allow specific block keys for sgb/ava

--- a/apps/block_scout_web/assets/js/chart-loader.js
+++ b/apps/block_scout_web/assets/js/chart-loader.js
@@ -1,10 +1,8 @@
-import $ from 'jquery'
-
 import { formatAllUsdValues, updateAllCalculatedUsdValues } from './lib/currency'
 import { createMarketHistoryChart } from './lib/history_chart'
 
 (function () {
-  const dashboardChartElement = $('[data-chart="historyChart"]')[0]
+  const dashboardChartElement = document.querySelectorAll('[data-chart="historyChart"]')[0]
   if (dashboardChartElement) {
     window.dashboardChart = createMarketHistoryChart(dashboardChartElement)
   }


### PR DESCRIPTION
## Changelog

Replace Jquery  import with VanillaJS selectors in chart-loader.js

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
