### PR TITLE
Empty blocks sanitizer performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement
 
 ### Fixes
+- [#5319](https://github.com/blockscout/blockscout/pull/5319) - Empty blocks sanitizer performance improvement
 - [#5306](https://github.com/blockscout/blockscout/pull/5306) - Fix indexer bug
 - [#5300](https://github.com/blockscout/blockscout/pull/5300), [#5305](https://github.com/blockscout/blockscout/pull/5305) - Token instance page: general video improvements
 - [#5136](https://github.com/blockscout/blockscout/pull/5136) - Improve contract verification

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3392,15 +3392,11 @@ defmodule Explorer.Chain do
   def unprocessed_empty_blocks_query_list(limit) do
     query =
       from(block in Block,
-        as: :block,
-        where: block.consensus == true,
+        left_join: transaction in Transaction,
+        on: block.number == transaction.block_number,
+        where: is_nil(transaction.block_number),
         where: is_nil(block.is_empty),
-        where:
-          not exists(
-            from(transaction in Transaction,
-              where: transaction.block_number == parent_as(:block).number
-            )
-          ),
+        where: block.consensus == true,
         select: {block.number, block.hash},
         order_by: [desc: block.number],
         limit: ^limit


### PR DESCRIPTION
## Motivation

Empty blocks sanitizer init query is extremely slow on database with huge amount of transactions/blocks.

<img width="197" alt="Screenshot 2022-03-14 at 19 25 10" src="https://user-images.githubusercontent.com/4341812/158216618-9532e9c7-5b11-435d-8b2a-8d499b8e1661.png">


## Changelog

After implementation:
```
EXPLAIN ANALYZE SELECT b0.number, b0.hash FROM blocks AS b0 LEFT OUTER JOIN transactions AS t1 ON b0.number = t1.block_number WHERE (t1.block_number IS NULL) AND (b0.is_empty IS NULL) AND (b0.consensus = TRUE) ORDER BY b0.number DESC LIMIT 400;
                                                                                   QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------
 Limit  (cost=1.01..1410.08 rows=400 width=41) (actual time=0.083..17411.425 rows=400 loops=1)
   ->  Nested Loop Anti Join  (cost=1.01..48819091.63 rows=13858518 width=41) (actual time=0.082..17411.283 rows=400 loops=1)
         ->  Index Scan Backward using one_consensus_block_at_height on blocks b0  (cost=0.43..40321570.36 rows=13918783 width=41) (actual t
ime=0.005..33.869 rows=4274 loops=1)
               Filter: (is_empty IS NULL)
         ->  Index Only Scan using transactions_block_number_idx on transactions t1  (cost=0.58..729.78 rows=22246 width=4) (actual time=4.0
65..4.065 rows=1 loops=4274)
               Index Cond: (block_number = b0.number)
               Heap Fetches: 5240
 Planning time: 7.181 ms
 Execution time: 17411.718 ms
(9 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
