### PR TITLE
DB denormalization: block consensus and timestamp in transaction table

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -153,7 +153,7 @@ jobs:
         id: dialyzer-cache
         with:
           path: priv/plts
-          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash_13-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-mixlockhash_14-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-dialyzer-"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#5948](https://github.com/blockscout/blockscout/pull/5948) - Fix unexpected messages in `CoinBalanceOnDemand`
 
 ### Chore
+- [#5322](https://github.com/blockscout/blockscout/pull/5322) - DB denormalization: block consensus and timestamp in transaction table
 - [#5836](https://github.com/blockscout/blockscout/pull/5836) - Bump comeonin from 4.1.2 to 5.3.3
 - [#5869](https://github.com/blockscout/blockscout/pull/5869) - Bump reduce-reducers from 0.4.3 to 1.0.4 in /apps/block_scout_web/assets
 - [#5919](https://github.com/blockscout/blockscout/pull/5919) - Bump floki from 0.32.1 to 0.33.1

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
@@ -22,8 +22,7 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
       [token_transfers: :token] => :optional,
       [token_transfers: :to_address] => :optional,
       [token_transfers: :from_address] => :optional,
-      [token_transfers: :token_contract_address] => :optional,
-      :block => :required
+      [token_transfers: :token_contract_address] => :optional
     }
   ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -29,7 +29,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
       [created_contract_address: :names] => :optional,
       [from_address: :names] => :optional,
       [to_address: :names] => :optional,
-      :block => :optional,
       [created_contract_address: :smart_contract] => :optional,
       [from_address: :smart_contract] => :optional,
       [to_address: :smart_contract] => :optional

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -74,7 +74,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionController do
   end
 
   defp transaction_from_hash(transaction_hash) do
-    case Chain.hash_to_transaction(transaction_hash, necessity_by_association: %{block: :required}) do
+    case Chain.hash_to_transaction(transaction_hash) do
       {:error, :not_found} -> {:transaction, :error}
       {:ok, transaction} -> {:transaction, {:ok, transaction}}
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/recent_transactions_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/recent_transactions_controller.ex
@@ -13,7 +13,6 @@ defmodule BlockScoutWeb.RecentTransactionsController do
       recent_transactions =
         Chain.recent_collated_transactions(
           necessity_by_association: %{
-            :block => :required,
             [created_contract_address: :names] => :optional,
             [from_address: :names] => :optional,
             [to_address: :names] => :optional,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -37,7 +37,6 @@ defmodule BlockScoutWeb.TransactionController do
 
   @default_options [
     necessity_by_association: %{
-      :block => :required,
       [created_contract_address: :names] => :optional,
       [from_address: :names] => :optional,
       [to_address: :names] => :optional,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_internal_transaction_controller.ex
@@ -21,10 +21,10 @@ defmodule BlockScoutWeb.TransactionInternalTransactionController do
               [created_contract_address: :names] => :optional,
               [from_address: :names] => :optional,
               [to_address: :names] => :optional,
-              [transaction: :block] => :optional,
               [created_contract_address: :smart_contract] => :optional,
               [from_address: :smart_contract] => :optional,
-              [to_address: :smart_contract] => :optional
+              [to_address: :smart_contract] => :optional,
+              :transaction => :optional
             }
           ],
           paging_options(params)

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -129,7 +129,7 @@ defmodule BlockScoutWeb.Notifier do
     |> Stream.map(
       &(InternalTransaction.where_nonpending_block()
         |> Repo.get_by(transaction_hash: &1.transaction_hash, index: &1.index)
-        |> Repo.preload([:from_address, :to_address, transaction: :block]))
+        |> Repo.preload([:from_address, :to_address, :transaction]))
     )
     |> Enum.each(&broadcast_internal_transaction/1)
   end
@@ -154,7 +154,7 @@ defmodule BlockScoutWeb.Notifier do
               token_contract_address_hash: &1.token_contract_address_hash,
               log_index: &1.log_index
             )
-            |> Repo.preload([:from_address, :to_address, :token, transaction: :block]))
+            |> Repo.preload([:from_address, :to_address, :token, :transaction]))
         )
 
       token_transfers_full
@@ -167,7 +167,6 @@ defmodule BlockScoutWeb.Notifier do
     |> Enum.map(& &1.hash)
     |> Chain.hashes_to_transactions(
       necessity_by_association: %{
-        :block => :optional,
         [created_contract_address: :names] => :optional,
         [from_address: :names] => :optional,
         [to_address: :names] => :optional

--- a/apps/block_scout_web/lib/block_scout_web/templates/block/_link.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/block/_link.html.eex
@@ -1,4 +1,4 @@
 <%= link(
   gettext("Block #%{number}", number: to_string(@block.number)),
-  to: block_path(BlockScoutWeb.Endpoint, :show, @block)
+  to: block_path(BlockScoutWeb.Endpoint, :show, @block.hash)
 ) %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/internal_transaction/_tile.html.eex
@@ -33,7 +33,7 @@
           to: block_path(BlockScoutWeb.Endpoint, :show, @internal_transaction.block_number)
         ) %>
       </span>
-      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= @internal_transaction.transaction.block.timestamp %>"></span>
+      <span class="mr-2 mr-md-0 order-2" in-tile data-from-now="<%= @internal_transaction.transaction.block_timestamp %>"></span>
       <%= if assigns[:current_address] do %>
         <span class="mr-2 mr-md-0 order-0 order-md-3">
           <%= if assigns[:current_address].hash == @internal_transaction.from_address_hash do %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/transfer/_token_transfer.html.eex
@@ -44,7 +44,7 @@
           to: block_path(BlockScoutWeb.Endpoint, :show, @token_transfer.block_number)
         ) %>
       </span>
-      <span class="mr-2 mr-md-0 order-2" data-from-now="<%= @token_transfer.transaction.block && @token_transfer.transaction.block.timestamp %>"></span>
+      <span class="mr-2 mr-md-0 order-2" data-from-now="<%= @token_transfer.transaction.block_timestamp %>"></span>
     </div>
   </div>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/logs_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/logs_view.ex
@@ -44,6 +44,8 @@ defmodule BlockScoutWeb.API.RPC.LogsView do
     |> integer_to_hex()
   end
 
+  defp datetime_to_hex(nil), do: nil
+
   defp datetime_to_hex(datetime) do
     datetime
     |> DateTime.to_unix()

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/transaction_view.ex
@@ -58,7 +58,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionView do
   defp prepare_transaction(transaction, block_height, logs, next_page_params) do
     %{
       "hash" => "#{transaction.hash}",
-      "timeStamp" => "#{DateTime.to_unix(transaction.block.timestamp)}",
+      "timeStamp" => "#{DateTime.to_unix(transaction.block_timestamp)}",
       "blockNumber" => "#{transaction.block_number}",
       "confirmations" => "#{block_height - transaction.block_number}",
       "success" => if(transaction.status == :ok, do: true, else: false),

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -31,10 +31,14 @@ defmodule BlockScoutWeb.TransactionView do
   defdelegate formatted_timestamp(block), to: BlockView
 
   def block_number(%Transaction{block_number: nil}), do: gettext("Block Pending")
-  def block_number(%Transaction{block: block}), do: [view_module: BlockView, partial: "_link.html", block: block]
+
+  def block_number(%Transaction{block_number: number, block_hash: hash}),
+    do: [view_module: BlockView, partial: "_link.html", block: %Block{number: number, hash: hash}]
+
   def block_number(%Reward{block: block}), do: [view_module: BlockView, partial: "_link.html", block: block]
 
   def block_timestamp(%Transaction{block_number: nil, inserted_at: time}), do: time
+  def block_timestamp(%Transaction{block_timestamp: time}), do: time
   def block_timestamp(%Transaction{block: %Block{timestamp: time}}), do: time
   def block_timestamp(%Reward{block: %Block{timestamp: time}}), do: time
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -63,8 +63,13 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:349
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_metatags.html.eex:2
+msgid "%{subnetwork} Staking DApp - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:353
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -445,8 +450,8 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:342
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:346
 msgid "Confirmed"
 msgstr ""
 
@@ -523,13 +528,13 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:457
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:461
 msgid "Contract Call"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:454
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:458
 msgid "Contract Creation"
 msgstr ""
 
@@ -841,18 +846,18 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:214
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:218
 msgid "ERC-1155 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:216
 #, elixir-autogen, elixir-format
 msgid "ERC-20 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:213
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:217
 msgid "ERC-721 "
 msgstr ""
 
@@ -922,13 +927,13 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:353
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:357
 msgid "Error: %{reason}"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:351
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:355
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1213,12 +1218,9 @@ msgid "Internal Transaction"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:361
-#: lib/block_scout_web/views/transaction_view.ex:512
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/transaction_view.ex:516
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1320,12 +1322,9 @@ msgid "Log Index"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:372
-#: lib/block_scout_web/views/transaction_view.ex:513
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:366
+#: lib/block_scout_web/views/transaction_view.ex:517
 msgid "Logs"
 msgstr ""
 
@@ -1352,8 +1351,8 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:319
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:323
 msgid "Max of"
 msgstr ""
 
@@ -1580,10 +1579,10 @@ msgstr ""
 msgid "Parent Hash"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
-#: lib/block_scout_web/views/transaction_view.ex:348
-#: lib/block_scout_web/views/transaction_view.ex:386
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:390
 msgid "Pending"
 msgstr ""
 
@@ -1670,9 +1669,7 @@ msgid "Raw Input"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:514
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:518
 msgid "Raw Trace"
 msgstr ""
 
@@ -1895,8 +1892,7 @@ msgid "Submit an Issue"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:350
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:354
 msgid "Success"
 msgstr ""
 
@@ -2148,15 +2144,13 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
-#: lib/block_scout_web/views/transaction_view.ex:448
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:452
 msgid "Token Burning"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:449
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:453
 msgid "Token Creation"
 msgstr ""
 
@@ -2182,32 +2176,23 @@ msgstr ""
 msgid "Token ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
-#: lib/block_scout_web/views/transaction_view.ex:447
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:451
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
-#: lib/block_scout_web/views/transaction_view.ex:450
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:454
 msgid "Token Transfer"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
-#: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:363
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
-#: lib/block_scout_web/views/tokens/overview_view.ex:39
-#: lib/block_scout_web/views/transaction_view.ex:511
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19 lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
+#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16 lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:194 lib/block_scout_web/views/tokens/overview_view.ex:41
+#: lib/block_scout_web/views/transaction_view.ex:515
 msgid "Token Transfers"
 msgstr ""
 
@@ -2309,8 +2294,7 @@ msgid "Total transactions"
 msgstr ""
 
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:460
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:464
 msgid "Transaction"
 msgstr ""
 
@@ -2441,8 +2425,8 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:341
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:345
 msgid "Unconfirmed"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -63,13 +63,8 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_metatags.html.eex:2
-msgid "%{subnetwork} Staking DApp - BlockScout"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:353
+#, elixir-autogen, elixir-format
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -450,8 +445,8 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:346
+#, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
@@ -528,13 +523,13 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:461
+#, elixir-autogen, elixir-format
 msgid "Contract Call"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:458
+#, elixir-autogen, elixir-format
 msgid "Contract Creation"
 msgstr ""
 
@@ -846,8 +841,8 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:218
+#, elixir-autogen, elixir-format
 msgid "ERC-1155 "
 msgstr ""
 
@@ -856,8 +851,8 @@ msgstr ""
 msgid "ERC-20 "
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:217
+#, elixir-autogen, elixir-format
 msgid "ERC-721 "
 msgstr ""
 
@@ -927,13 +922,13 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:357
+#, elixir-autogen, elixir-format
 msgid "Error: %{reason}"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:355
+#, elixir-autogen, elixir-format
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1218,9 +1213,12 @@ msgid "Internal Transaction"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
+#: lib/block_scout_web/views/address_view.ex:361
 #: lib/block_scout_web/views/transaction_view.ex:516
+#, elixir-autogen
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1322,9 +1320,12 @@ msgid "Log Index"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:366
+#: lib/block_scout_web/templates/address_logs/index.html.eex:10
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:8
+#: lib/block_scout_web/views/address_view.ex:372
 #: lib/block_scout_web/views/transaction_view.ex:517
+#, elixir-autogen
 msgid "Logs"
 msgstr ""
 
@@ -1351,8 +1352,8 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:323
+#, elixir-autogen, elixir-format
 msgid "Max of"
 msgstr ""
 
@@ -1579,10 +1580,10 @@ msgstr ""
 msgid "Parent Hash"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
+#: lib/block_scout_web/views/transaction_view.ex:352
 #: lib/block_scout_web/views/transaction_view.ex:390
+#, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
@@ -1669,7 +1670,9 @@ msgid "Raw Input"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:518
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
+#: lib/block_scout_web/views/transaction_view.ex:518
+#, elixir-autogen
 msgid "Raw Trace"
 msgstr ""
 
@@ -1893,6 +1896,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
 #: lib/block_scout_web/views/transaction_view.ex:354
+#, elixir-autogen
 msgid "Success"
 msgstr ""
 
@@ -2144,13 +2148,15 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:452
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
+#: lib/block_scout_web/views/transaction_view.ex:452
+#, elixir-autogen, elixir-format
 msgid "Token Burning"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:453
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
+#: lib/block_scout_web/views/transaction_view.ex:453
+#, elixir-autogen, elixir-format
 msgid "Token Creation"
 msgstr ""
 
@@ -2176,23 +2182,32 @@ msgstr ""
 msgid "Token ID"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
+#: lib/block_scout_web/views/transaction_view.ex:451
+#, elixir-autogen, elixir-format
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:454
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
+#: lib/block_scout_web/views/transaction_view.ex:454
+#, elixir-autogen
 msgid "Token Transfer"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19 lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16 lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:357
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:194 lib/block_scout_web/views/tokens/overview_view.ex:41
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
+#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
+#: lib/block_scout_web/views/address_view.ex:363
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
+#: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:515
+#, elixir-autogen
 msgid "Token Transfers"
 msgstr ""
 
@@ -2295,6 +2310,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
 #: lib/block_scout_web/views/transaction_view.ex:464
+#, elixir-autogen
 msgid "Transaction"
 msgstr ""
 
@@ -2425,8 +2441,8 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:345
+#, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -63,8 +63,13 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:349
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/stakes/_metatags.html.eex:2
+msgid "%{subnetwork} Staking DApp - BlockScout"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:353
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -445,8 +450,8 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:342
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:346
 msgid "Confirmed"
 msgstr ""
 
@@ -523,13 +528,13 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:457
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:461
 msgid "Contract Call"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:454
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:458
 msgid "Contract Creation"
 msgstr ""
 
@@ -841,18 +846,18 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:214
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:218
 msgid "ERC-1155 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:212
+#: lib/block_scout_web/views/transaction_view.ex:216
 #, elixir-autogen, elixir-format
 msgid "ERC-20 "
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:213
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:217
 msgid "ERC-721 "
 msgstr ""
 
@@ -922,13 +927,13 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:353
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:357
 msgid "Error: %{reason}"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:351
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:355
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1213,12 +1218,9 @@ msgid "Internal Transaction"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:361
-#: lib/block_scout_web/views/transaction_view.ex:512
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/transaction_view.ex:516
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1320,12 +1322,9 @@ msgid "Log Index"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:372
-#: lib/block_scout_web/views/transaction_view.ex:513
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:366
+#: lib/block_scout_web/views/transaction_view.ex:517
 msgid "Logs"
 msgstr ""
 
@@ -1352,8 +1351,8 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:319
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:323
 msgid "Max of"
 msgstr ""
 
@@ -1580,10 +1579,10 @@ msgstr ""
 msgid "Parent Hash"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
-#: lib/block_scout_web/views/transaction_view.ex:348
-#: lib/block_scout_web/views/transaction_view.ex:386
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
+#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/views/transaction_view.ex:390
 msgid "Pending"
 msgstr ""
 
@@ -1670,9 +1669,7 @@ msgid "Raw Input"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:514
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:518
 msgid "Raw Trace"
 msgstr ""
 
@@ -1895,8 +1892,7 @@ msgid "Submit an Issue"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
-#: lib/block_scout_web/views/transaction_view.ex:350
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:354
 msgid "Success"
 msgstr ""
 
@@ -2148,15 +2144,13 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
-#: lib/block_scout_web/views/transaction_view.ex:448
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:452
 msgid "Token Burning"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
-#: lib/block_scout_web/views/transaction_view.ex:449
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:453
 msgid "Token Creation"
 msgstr ""
 
@@ -2182,32 +2176,23 @@ msgstr ""
 msgid "Token ID"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
-#: lib/block_scout_web/views/transaction_view.ex:447
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:451
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
-#: lib/block_scout_web/views/transaction_view.ex:450
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:454
 msgid "Token Transfer"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
-#: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
-#: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
-#: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:363
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
-#: lib/block_scout_web/views/tokens/overview_view.ex:39
-#: lib/block_scout_web/views/transaction_view.ex:511
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19 lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
+#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16 lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:194 lib/block_scout_web/views/tokens/overview_view.ex:41
+#: lib/block_scout_web/views/transaction_view.ex:515
 msgid "Token Transfers"
 msgstr ""
 
@@ -2309,8 +2294,7 @@ msgid "Total transactions"
 msgstr ""
 
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
-#: lib/block_scout_web/views/transaction_view.ex:460
-#, elixir-autogen, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:464
 msgid "Transaction"
 msgstr ""
 
@@ -2441,8 +2425,8 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#: lib/block_scout_web/views/transaction_view.ex:341
-#, elixir-autogen, elixir-format
+#, elixir-format
+#: lib/block_scout_web/views/transaction_view.ex:345
 msgid "Unconfirmed"
 msgstr ""
 

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -63,13 +63,8 @@ msgstr ""
 msgid "%{subnetwork} Explorer - BlockScout"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/stakes/_metatags.html.eex:2
-msgid "%{subnetwork} Staking DApp - BlockScout"
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:353
+#, elixir-autogen, elixir-format
 msgid "(Awaiting internal transactions for status)"
 msgstr ""
 
@@ -450,8 +445,8 @@ msgstr ""
 msgid "Compiler version"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:346
+#, elixir-autogen, elixir-format
 msgid "Confirmed"
 msgstr ""
 
@@ -528,13 +523,13 @@ msgstr ""
 msgid "Contract Address Pending"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:461
+#, elixir-autogen, elixir-format
 msgid "Contract Call"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:458
+#, elixir-autogen, elixir-format
 msgid "Contract Creation"
 msgstr ""
 
@@ -846,8 +841,8 @@ msgstr ""
 msgid "EIP-1167"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:218
+#, elixir-autogen, elixir-format
 msgid "ERC-1155 "
 msgstr ""
 
@@ -856,8 +851,8 @@ msgstr ""
 msgid "ERC-20 "
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:217
+#, elixir-autogen, elixir-format
 msgid "ERC-721 "
 msgstr ""
 
@@ -927,13 +922,13 @@ msgstr ""
 msgid "Error trying to fetch balances."
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:357
+#, elixir-autogen, elixir-format
 msgid "Error: %{reason}"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:355
+#, elixir-autogen, elixir-format
 msgid "Error: (Awaiting internal transactions for reason)"
 msgstr ""
 
@@ -1218,9 +1213,12 @@ msgid "Internal Transaction"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:28
-#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17 lib/block_scout_web/templates/transaction/_tabs.html.eex:11
-#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6 lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
+#: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
+#: lib/block_scout_web/views/address_view.ex:361
 #: lib/block_scout_web/views/transaction_view.ex:516
+#, elixir-autogen
 msgid "Internal Transactions"
 msgstr ""
 
@@ -1322,9 +1320,12 @@ msgid "Log Index"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:41
-#: lib/block_scout_web/templates/address_logs/index.html.eex:10 lib/block_scout_web/templates/transaction/_tabs.html.eex:17
-#: lib/block_scout_web/templates/transaction_log/index.html.eex:8 lib/block_scout_web/views/address_view.ex:366
+#: lib/block_scout_web/templates/address_logs/index.html.eex:10
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
+#: lib/block_scout_web/templates/transaction_log/index.html.eex:8
+#: lib/block_scout_web/views/address_view.ex:372
 #: lib/block_scout_web/views/transaction_view.ex:517
+#, elixir-autogen
 msgid "Logs"
 msgstr ""
 
@@ -1351,8 +1352,8 @@ msgstr ""
 msgid "Max Priority Fee per Gas"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:323
+#, elixir-autogen, elixir-format
 msgid "Max of"
 msgstr ""
 
@@ -1579,10 +1580,10 @@ msgstr ""
 msgid "Parent Hash"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:55
-#: lib/block_scout_web/templates/stakes/_stakes_modal_delegators_list.html.eex:184 lib/block_scout_web/views/transaction_view.ex:352
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:57
+#: lib/block_scout_web/views/transaction_view.ex:352
 #: lib/block_scout_web/views/transaction_view.ex:390
+#, elixir-autogen, elixir-format
 msgid "Pending"
 msgstr ""
 
@@ -1669,7 +1670,9 @@ msgid "Raw Input"
 msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:24
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7 lib/block_scout_web/views/transaction_view.ex:518
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:7
+#: lib/block_scout_web/views/transaction_view.ex:518
+#, elixir-autogen
 msgid "Raw Trace"
 msgstr ""
 
@@ -1893,6 +1896,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/transaction/_emission_reward_tile.html.eex:8
 #: lib/block_scout_web/views/transaction_view.ex:354
+#, elixir-autogen
 msgid "Success"
 msgstr ""
 
@@ -2144,13 +2148,15 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3 lib/block_scout_web/views/transaction_view.ex:452
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:3
+#: lib/block_scout_web/views/transaction_view.ex:452
+#, elixir-autogen, elixir-format
 msgid "Token Burning"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7 lib/block_scout_web/views/transaction_view.ex:453
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:7
+#: lib/block_scout_web/views/transaction_view.ex:453
+#, elixir-autogen, elixir-format
 msgid "Token Creation"
 msgstr ""
 
@@ -2176,23 +2182,32 @@ msgstr ""
 msgid "Token ID"
 msgstr ""
 
-#, elixir-format
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5 lib/block_scout_web/views/transaction_view.ex:451
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:5
+#: lib/block_scout_web/views/transaction_view.ex:451
+#, elixir-autogen, elixir-format
 msgid "Token Minting"
 msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:9
-#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11 lib/block_scout_web/views/transaction_view.ex:454
+#: lib/block_scout_web/templates/common_components/_token_transfer_type_display_name.html.eex:11
+#: lib/block_scout_web/views/transaction_view.ex:454
+#, elixir-autogen
 msgid "Token Transfer"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:13
-#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19 lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
-#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16 lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
-#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14 lib/block_scout_web/templates/transaction/_tabs.html.eex:4
-#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7 lib/block_scout_web/views/address_view.ex:357
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:194 lib/block_scout_web/views/tokens/overview_view.ex:41
+#: lib/block_scout_web/templates/address_token_transfer/index.html.eex:19
+#: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:3
+#: lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:16
+#: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:5
+#: lib/block_scout_web/templates/tokens/transfer/index.html.eex:14
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
+#: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
+#: lib/block_scout_web/views/address_view.ex:363
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
+#: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:515
+#, elixir-autogen
 msgid "Token Transfers"
 msgstr ""
 
@@ -2295,6 +2310,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address_logs/_logs.html.eex:19
 #: lib/block_scout_web/views/transaction_view.ex:464
+#, elixir-autogen
 msgid "Transaction"
 msgstr ""
 
@@ -2425,8 +2441,8 @@ msgstr ""
 msgid "Uncles"
 msgstr ""
 
-#, elixir-format
 #: lib/block_scout_web/views/transaction_view.ex:345
+#, elixir-autogen, elixir-format
 msgid "Unconfirmed"
 msgstr ""
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -1203,7 +1203,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       for block <- Enum.concat([blocks1, blocks2, blocks3]) do
         2
-        |> insert_list(:transaction, from_address: address)
+        |> insert_list(:transaction, from_address: address, block_timestamp: block.timestamp)
         |> with_block(block)
       end
 
@@ -1251,7 +1251,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       for block <- Enum.concat([blocks1, blocks2, blocks3]) do
         2
-        |> insert_list(:transaction, from_address: address)
+        |> insert_list(:transaction, from_address: address, block_timestamp: block.timestamp)
         |> with_block(block)
       end
 
@@ -1299,7 +1299,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       for block <- Enum.concat([blocks1, blocks2, blocks3]) do
         2
-        |> insert_list(:transaction, from_address: address)
+        |> insert_list(:transaction, from_address: address, block_timestamp: block.timestamp)
         |> with_block(block)
       end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -76,7 +76,14 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, block: block, address: address, transaction: transaction, data: "0x010101")
+
+      insert(:log,
+        block: block,
+        block_number: block.number,
+        address: address,
+        transaction: transaction,
+        data: "0x010101"
+      )
 
       params = params(api_params, [%{"address" => to_string(address.hash)}])
 
@@ -94,7 +101,15 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, block: block, address: address, transaction: transaction, data: "0x010101", first_topic: "0x01")
+
+      insert(:log,
+        block: block,
+        block_number: block.number,
+        address: address,
+        transaction: transaction,
+        data: "0x010101",
+        first_topic: "0x01"
+      )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => ["0x01"]}])
 
@@ -112,8 +127,24 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       block = insert(:block, number: 0)
 
       transaction = insert(:transaction, from_address: address) |> with_block(block)
-      insert(:log, address: address, block: block, transaction: transaction, data: "0x010101", first_topic: "0x01")
-      insert(:log, address: address, block: block, transaction: transaction, data: "0x020202", first_topic: "0x00")
+
+      insert(:log,
+        address: address,
+        block: block,
+        block_number: block.number,
+        transaction: transaction,
+        data: "0x010101",
+        first_topic: "0x01"
+      )
+
+      insert(:log,
+        address: address,
+        block: block,
+        block_number: block.number,
+        transaction: transaction,
+        data: "0x020202",
+        first_topic: "0x00"
+      )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => [["0x01", "0x00"]]}])
 
@@ -135,7 +166,13 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         |> with_block(block)
 
       inserted_records =
-        insert_list(2000, :log, block: block, address: contract_address, transaction: transaction, first_topic: "0x01")
+        insert_list(2000, :log,
+          block: block,
+          block_number: block.number,
+          address: contract_address,
+          transaction: transaction,
+          first_topic: "0x01"
+        )
 
       params = params(api_params, [%{"address" => to_string(contract_address), "topics" => [["0x01"]]}])
 
@@ -150,7 +187,6 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
       next_page_params = %{
         "blockNumber" => Integer.to_string(transaction.block_number, 16),
-        "transactionIndex" => transaction.index,
         "logIndex" => Integer.to_string(last_log_index, 16)
       }
 
@@ -193,7 +229,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         data: "0x010101",
         first_topic: "0x01",
         second_topic: "0x02",
-        block: block
+        block: block,
+        block_number: block.number
       )
 
       insert(:log, block: block, address: address, transaction: transaction, data: "0x020202", first_topic: "0x01")
@@ -222,7 +259,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         data: "0x010101",
         first_topic: "0x01",
         second_topic: "0x02",
-        block: block
+        block: block,
+        block_number: block.number
       )
 
       insert(:log,
@@ -231,7 +269,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
         data: "0x020202",
         first_topic: "0x01",
         second_topic: "0x03",
-        block: block
+        block: block,
+        block_number: block.number
       )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "topics" => ["0x01", ["0x02", "0x03"]]}])
@@ -258,13 +297,13 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
       transaction4 = insert(:transaction, from_address: address) |> with_block(block4)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101")
+      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202")
+      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303")
+      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
 
-      insert(:log, address: address, transaction: transaction4, data: "0x040404")
+      insert(:log, address: address, transaction: transaction4, data: "0x040404", block_number: block4.number)
 
       params = params(api_params, [%{"address" => to_string(address.hash), "fromBlock" => 1, "toBlock" => 2}])
 
@@ -288,11 +327,11 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101")
+      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202")
+      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303")
+      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
 
       params = params(api_params, [%{"address" => to_string(address.hash), "blockHash" => to_string(block2.hash)}])
 
@@ -316,11 +355,11 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101")
+      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202")
+      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303")
+      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
 
       params =
         params(api_params, [%{"address" => to_string(address.hash), "fromBlock" => "earliest", "toBlock" => "earliest"}])
@@ -345,11 +384,29 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, block: block1, address: address, transaction: transaction1, data: "0x010101")
+      insert(:log,
+        block: block1,
+        block_number: block1.number,
+        address: address,
+        transaction: transaction1,
+        data: "0x010101"
+      )
 
-      insert(:log, block: block2, address: address, transaction: transaction2, data: "0x020202")
+      insert(:log,
+        block: block2,
+        block_number: block2.number,
+        address: address,
+        transaction: transaction2,
+        data: "0x020202"
+      )
 
-      insert(:log, block: block3, address: address, transaction: transaction3, data: "0x030303")
+      insert(:log,
+        block: block3,
+        block_number: block3.number,
+        address: address,
+        transaction: transaction3,
+        data: "0x030303"
+      )
 
       changeset = Ecto.Changeset.change(block3, %{consensus: false})
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
@@ -280,7 +280,7 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      log = insert(:log, address: contract_address, transaction: transaction)
+      log = insert(:log, address: contract_address, transaction: transaction, block_number: transaction.block_number)
 
       params = %{
         "module" => "logs",
@@ -334,8 +334,17 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1)
-      insert(:log, address: contract_address, transaction: transaction_block2)
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block1,
+        block_number: transaction_block1.block_number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block2,
+        block_number: transaction_block2.block_number
+      )
 
       params = %{
         "module" => "logs",
@@ -378,8 +387,17 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1)
-      insert(:log, address: contract_address, transaction: transaction_block2)
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block1,
+        block_number: transaction_block1.block_number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block2,
+        block_number: transaction_block2.block_number
+      )
 
       params = %{
         "module" => "logs",

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -738,7 +738,7 @@ defmodule Explorer.Chain do
   def block_reward(block_number) do
     block_hash =
       Block
-      |> where([block], block.number == ^block_number and block.consensus)
+      |> where([block], block.number == ^block_number and block.consensus == true)
       |> select([block], block.hash)
       |> Repo.one!()
 
@@ -758,7 +758,7 @@ defmodule Explorer.Chain do
             left_join: transaction in assoc(block, :transactions),
             inner_join: emission_reward in EmissionReward,
             on: fragment("? <@ ?", block.number, emission_reward.block_range),
-            where: block.number == ^block_number and block.consensus,
+            where: block.number == ^block_number and block.consensus == true,
             group_by: [emission_reward.reward, block.hash],
             select: %Wei{
               value: coalesce(sum(transaction.gas_used * transaction.gas_price), 0) + emission_reward.reward
@@ -826,15 +826,18 @@ defmodule Explorer.Chain do
   def gas_payment_by_block_hash(block_hashes) when is_list(block_hashes) do
     query =
       from(
-        block in Block,
-        left_join: transaction in assoc(block, :transactions),
-        where: block.hash in ^block_hashes and block.consensus == true,
-        group_by: block.hash,
-        select: {block.hash, %Wei{value: coalesce(sum(transaction.gas_used * transaction.gas_price), 0)}}
+        transaction in Transaction,
+        where: transaction.block_hash in ^block_hashes and transaction.block_consensus == true,
+        group_by: transaction.block_hash,
+        select: {transaction.block_hash, %Wei{value: coalesce(sum(transaction.gas_used * transaction.gas_price), 0)}}
       )
 
     query
     |> Repo.all()
+    |> (&if(Enum.count(&1) > 0,
+          do: &1,
+          else: Enum.zip([block_hashes, for(_ <- 1..Enum.count(block_hashes), do: %Wei{value: Decimal.new(0)})])
+        )).()
     |> Enum.into(%{})
   end
 
@@ -1182,10 +1185,10 @@ defmodule Explorer.Chain do
 
         query =
           from(
-            b in Block,
-            join: pending_ops in assoc(b, :pending_operations),
+            block in Block,
+            join: pending_ops in assoc(block, :pending_operations),
             where: pending_ops.fetch_internal_transactions,
-            where: b.consensus and b.number == ^min_block_number
+            where: block.consensus and block.number == ^min_block_number
           )
 
         !Repo.exists?(query)
@@ -2575,11 +2578,11 @@ defmodule Explorer.Chain do
   def stream_blocks_with_unfetched_internal_transactions(initial, reducer) when is_function(reducer, 2) do
     query =
       from(
-        b in Block,
-        join: pending_ops in assoc(b, :pending_operations),
+        block in Block,
+        join: pending_ops in assoc(block, :pending_operations),
         where: pending_ops.fetch_internal_transactions,
-        where: b.consensus,
-        select: b.number
+        where: block.consensus == true,
+        select: block.number
       )
 
     Repo.stream_reduce(query, initial, reducer)
@@ -6006,8 +6009,8 @@ defmodule Explorer.Chain do
 
   defp find_block_timestamp(number) do
     Block
-    |> where([b], b.number == ^number)
-    |> select([b], b.timestamp)
+    |> where([block], block.number == ^number)
+    |> select([block], block.timestamp)
     |> limit(1)
     |> Repo.one()
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -241,7 +241,7 @@ defmodule Explorer.Chain do
         desc: q.transaction_index,
         desc: q.index
       )
-      |> preload(transaction: :block)
+      |> preload(:transaction)
       |> join_associations(necessity_by_association)
       |> Repo.all()
     else
@@ -250,7 +250,7 @@ defmodule Explorer.Chain do
       |> InternalTransaction.where_address_fields_match(hash, direction)
       |> InternalTransaction.where_block_number_in_period(from_block, to_block)
       |> common_where_limit_order(paging_options)
-      |> preload(transaction: :block)
+      |> preload(:transaction)
       |> join_associations(necessity_by_association)
       |> Repo.all()
     end
@@ -542,7 +542,7 @@ defmodule Explorer.Chain do
 
     query
     |> handle_token_transfer_paging_options(paging_options)
-    |> preload(transaction: :block)
+    |> preload(:transaction)
     |> preload(:token)
     |> Repo.all()
   end

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -147,8 +147,8 @@ defmodule Explorer.Chain.Address.CoinBalance do
   def limit_time_interval(query, days_to_consider, nil) do
     query
     |> where(
-      [cb, b],
-      b.timestamp >=
+      [cb, block],
+      block.timestamp >=
         fragment("date_trunc('day', now() - CAST(? AS INTERVAL))", ^%Postgrex.Interval{days: days_to_consider})
     )
   end
@@ -156,8 +156,8 @@ defmodule Explorer.Chain.Address.CoinBalance do
   def limit_time_interval(query, days_to_consider, %{timestamp: timestamp}) do
     query
     |> where(
-      [cb, b],
-      b.timestamp >=
+      [cb, block],
+      block.timestamp >=
         fragment(
           "(? AT TIME ZONE ?) - CAST(? AS INTERVAL)",
           ^timestamp,
@@ -176,10 +176,10 @@ defmodule Explorer.Chain.Address.CoinBalance do
 
     from(
       cb in subquery(coin_balance_query),
-      inner_join: b in Block,
-      on: cb.block_number == b.number,
-      where: b.consensus,
-      select: %{timestamp: b.timestamp, value: cb.value}
+      inner_join: block in Block,
+      on: cb.block_number == block.number,
+      where: block.consensus == true,
+      select: %{timestamp: block.timestamp, value: cb.value}
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_exporter.ex
@@ -88,7 +88,7 @@ defmodule Explorer.Chain.AddressInternalTransactionCsvExporter do
           internal_transaction.block_hash,
           internal_transaction.block_index,
           internal_transaction.transaction_index,
-          internal_transaction.transaction.block.timestamp,
+          internal_transaction.transaction.block_timestamp,
           to_string(internal_transaction.from_address_hash),
           to_string(internal_transaction.to_address_hash),
           to_string(internal_transaction.created_contract_address_hash),

--- a/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_token_transfer_csv_exporter.ex
@@ -69,7 +69,7 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporter do
         [
           to_string(token_transfer.transaction_hash),
           token_transfer.transaction.block_number,
-          token_transfer.transaction.block.timestamp,
+          token_transfer.transaction.block_timestamp,
           token_transfer.from_address_hash |> to_string() |> String.downcase(),
           token_transfer.to_address_hash |> to_string() |> String.downcase(),
           token_transfer.token_contract_address_hash |> to_string() |> String.downcase(),

--- a/apps/explorer/lib/explorer/chain/address_transaction_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_transaction_csv_exporter.ex
@@ -22,8 +22,7 @@ defmodule Explorer.Chain.AddressTransactionCsvExporter do
       [token_transfers: :token] => :optional,
       [token_transfers: :to_address] => :optional,
       [token_transfers: :from_address] => :optional,
-      [token_transfers: :token_contract_address] => :optional,
-      :block => :required
+      [token_transfers: :token_contract_address] => :optional
     }
   ]
 
@@ -89,12 +88,12 @@ defmodule Explorer.Chain.AddressTransactionCsvExporter do
     transaction_lists =
       transactions
       |> Stream.map(fn transaction ->
-        {opening_price, closing_price} = price_at_date(transaction.block.timestamp)
+        {opening_price, closing_price} = price_at_date(transaction.block_timestamp)
 
         [
           to_string(transaction.hash),
           transaction.block_number,
-          transaction.block.timestamp,
+          transaction.block_timestamp,
           to_string(transaction.from_address),
           to_string(transaction.to_address),
           to_string(transaction.created_contract_address),

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -122,8 +122,8 @@ defmodule Explorer.Chain.Block do
   def blocks_without_reward_query do
     consensus_blocks_query =
       from(
-        b in __MODULE__,
-        where: b.consensus == true
+        block in __MODULE__,
+        where: block.consensus == true
       )
 
     validator_rewards =

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -327,6 +327,19 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         timeout: timeout
       )
 
+    repo.update_all(
+      from(
+        transaction in Transaction,
+        join: s in subquery(acquire_query),
+        on: transaction.block_hash == s.hash,
+        # we don't want to remove consensus from blocks that will be upserted
+        where: transaction.block_hash not in ^hashes,
+        select: transaction.block_hash
+      ),
+      [set: [block_consensus: false, updated_at: updated_at]],
+      timeout: timeout
+    )
+
     {:ok, removed_consensus_block_hashes}
   rescue
     postgrex_error in Postgrex.Error ->

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -333,8 +333,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         join: s in subquery(acquire_query),
         on: transaction.block_hash == s.hash,
         # we don't want to remove consensus from blocks that will be upserted
-        where: transaction.block_hash not in ^hashes,
-        select: transaction.block_hash
+        where: transaction.block_hash not in ^hashes
       ),
       [set: [block_consensus: false, updated_at: updated_at]],
       timeout: timeout

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -225,11 +225,11 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
 
     query =
       from(
-        b in Block,
-        where: b.number in ^block_numbers and b.consensus,
-        select: b.hash,
+        block in Block,
+        where: block.number in ^block_numbers and block.consensus == true,
+        select: block.hash,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
-        order_by: [asc: b.hash],
+        order_by: [asc: block.hash],
         lock: "FOR UPDATE"
       )
 
@@ -612,18 +612,28 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     minimal_block = EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
 
     if Enum.count(invalid_block_numbers) > 0 do
-      update_query =
+      update_block_query =
         from(
-          b in Block,
-          where: b.number in ^invalid_block_numbers and b.consensus,
-          where: b.number > ^minimal_block,
-          select: b.hash,
+          block in Block,
+          where: block.number in ^invalid_block_numbers and block.consensus == true,
+          where: block.number > ^minimal_block,
+          select: block.hash,
           # ShareLocks order already enforced by `acquire_blocks` (see docs: sharelocks.md)
           update: [set: [consensus: false]]
         )
 
+      update_transaction_query =
+        from(
+          transaction in Transaction,
+          where: transaction.block_number in ^invalid_block_numbers and transaction.block_consensus,
+          where: transaction.block_number > ^minimal_block,
+          # ShareLocks order already enforced by `acquire_blocks` (see docs: sharelocks.md)
+          update: [set: [block_consensus: false]]
+        )
+
       try do
-        {_num, result} = repo.update_all(update_query, [])
+        {_num, result} = repo.update_all(update_block_query, [])
+        {_num, _result} = repo.update_all(update_transaction_query, [])
 
         Logger.debug(fn ->
           [

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -101,6 +101,8 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           block_hash: fragment("EXCLUDED.block_hash"),
           old_block_hash: transaction.block_hash,
           block_number: fragment("EXCLUDED.block_number"),
+          block_consensus: fragment("EXCLUDED.block_consensus"),
+          block_timestamp: fragment("EXCLUDED.block_timestamp"),
           created_contract_address_hash: fragment("EXCLUDED.created_contract_address_hash"),
           created_contract_code_indexed_at: fragment("EXCLUDED.created_contract_code_indexed_at"),
           cumulative_gas_used: fragment("EXCLUDED.cumulative_gas_used"),
@@ -130,9 +132,11 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
       ],
       where:
         fragment(
-          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code_indexed_at, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value, EXCLUDED.earliest_processing_start, EXCLUDED.revert_reason, EXCLUDED.max_priority_fee_per_gas, EXCLUDED.max_fee_per_gas, EXCLUDED.type) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.block_hash, EXCLUDED.block_number, EXCLUDED.block_consensus, EXCLUDED.block_timestamp, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code_indexed_at, EXCLUDED.cumulative_gas_used, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_price, EXCLUDED.gas_used, EXCLUDED.index, EXCLUDED.input, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.status, EXCLUDED.to_address_hash, EXCLUDED.v, EXCLUDED.value, EXCLUDED.earliest_processing_start, EXCLUDED.revert_reason, EXCLUDED.max_priority_fee_per_gas, EXCLUDED.max_fee_per_gas, EXCLUDED.type) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           transaction.block_hash,
           transaction.block_number,
+          transaction.block_consensus,
+          transaction.block_timestamp,
           transaction.created_contract_address_hash,
           transaction.created_contract_code_indexed_at,
           transaction.cumulative_gas_used,
@@ -184,13 +188,19 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           ),
         on: transaction.hash == new_transaction.hash,
         where: transaction.block_hash != new_transaction.block_hash,
-        select: transaction.block_hash
+        select: %{hash: transaction.hash, block_hash: transaction.block_hash}
       )
 
     block_hashes =
       blocks_with_recollated_transactions
       |> repo.all()
+      |> Enum.map(fn %{block_hash: block_hash} -> block_hash end)
       |> Enum.uniq()
+
+    transaction_hashes =
+      blocks_with_recollated_transactions
+      |> repo.all()
+      |> Enum.map(fn %{hash: hash} -> hash end)
 
     if Enum.empty?(block_hashes) do
       {:ok, []}
@@ -216,6 +226,33 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
       rescue
         postgrex_error in Postgrex.Error ->
           {:error, %{exception: postgrex_error, block_hashes: block_hashes}}
+      end
+    end
+
+    if Enum.empty?(transaction_hashes) do
+      {:ok, []}
+    else
+      query =
+        from(
+          transaction in Transaction,
+          where: transaction.hash in ^transaction_hashes,
+          # Enforce Block ShareLocks order (see docs: sharelocks.md)
+          order_by: [asc: transaction.hash],
+          lock: "FOR UPDATE"
+        )
+
+      try do
+        {_, result} =
+          repo.update_all(
+            from(transaction in Transaction, join: s in subquery(query), on: transaction.hash == s.hash),
+            [set: [block_consensus: false, updated_at: updated_at]],
+            timeout: timeout
+          )
+
+        {:ok, result}
+      rescue
+        postgrex_error in Postgrex.Error ->
+          {:error, %{exception: postgrex_error, transaction_hashes: transaction_hashes}}
       end
     end
   end

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -159,7 +159,7 @@ defmodule Explorer.Chain.TokenTransfer do
       from(
         tt in TokenTransfer,
         where: tt.token_contract_address_hash == ^token_address_hash and not is_nil(tt.block_number),
-        preload: [{:transaction, :block}, :token, :from_address, :to_address],
+        preload: [:transaction, :token, :from_address, :to_address],
         order_by: [desc: tt.block_number]
       )
 
@@ -179,7 +179,7 @@ defmodule Explorer.Chain.TokenTransfer do
         where: tt.token_contract_address_hash == ^token_address_hash,
         where: tt.token_id == ^token_id,
         where: not is_nil(tt.block_number),
-        preload: [{:transaction, :block}, :token, :from_address, :to_address],
+        preload: [:transaction, :token, :from_address, :to_address],
         order_by: [desc: tt.block_number]
       )
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -29,7 +29,7 @@ defmodule Explorer.Chain.Transaction do
 
   alias Explorer.Chain.Transaction.{Fork, Status}
 
-  @optional_attrs ~w(max_priority_fee_per_gas max_fee_per_gas block_hash block_number created_contract_address_hash cumulative_gas_used earliest_processing_start
+  @optional_attrs ~w(max_priority_fee_per_gas max_fee_per_gas block_hash block_number block_consensus block_timestamp created_contract_address_hash cumulative_gas_used earliest_processing_start
                      error gas_used index created_contract_code_indexed_at status to_address_hash revert_reason type has_error_in_internal_txs)a
 
   @required_attrs ~w(from_address_hash gas gas_price hash input nonce r s v value)a
@@ -80,6 +80,8 @@ defmodule Explorer.Chain.Transaction do
      `uncles` in one of the `forks`.
    * `block_number` - Denormalized `block` `number`. `nil` when transaction is pending or has only been collated into
      one of the `uncles` in one of the `forks`.
+   * `block_consensus` - consensus of the block where transaction collated.
+   * `block_timestamp` - timestamp of the block where transaction collated.
    * `created_contract_address` - belongs_to association to `address` corresponding to `created_contract_address_hash`.
    * `created_contract_address_hash` - Denormalized `internal_transaction` `created_contract_address_hash`
      populated only when `to_address_hash` is nil.
@@ -140,6 +142,8 @@ defmodule Explorer.Chain.Transaction do
           block: %Ecto.Association.NotLoaded{} | Block.t() | nil,
           block_hash: Hash.t() | nil,
           block_number: Block.block_number() | nil,
+          block_consensus: boolean(),
+          block_timestamp: DateTime.t() | nil,
           created_contract_address: %Ecto.Association.NotLoaded{} | Address.t() | nil,
           created_contract_address_hash: Hash.Address.t() | nil,
           created_contract_code_indexed_at: DateTime.t() | nil,
@@ -176,6 +180,7 @@ defmodule Explorer.Chain.Transaction do
   @derive {Poison.Encoder,
            only: [
              :block_number,
+             :block_timestamp,
              :cumulative_gas_used,
              :error,
              :gas,
@@ -196,6 +201,7 @@ defmodule Explorer.Chain.Transaction do
   @derive {Jason.Encoder,
            only: [
              :block_number,
+             :block_timestamp,
              :cumulative_gas_used,
              :error,
              :gas,
@@ -216,6 +222,8 @@ defmodule Explorer.Chain.Transaction do
   @primary_key {:hash, Hash.Full, autogenerate: false}
   schema "transactions" do
     field(:block_number, :integer)
+    field(:block_consensus, :boolean)
+    field(:block_timestamp, :utc_datetime_usec)
     field(:cumulative_gas_used, :decimal)
     field(:earliest_processing_start, :utc_datetime_usec)
     field(:error, :string)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -717,7 +717,7 @@ defmodule Explorer.Chain.Transaction do
     from(
       t in subquery(query),
       order_by: [desc: t.block_number, desc: t.index],
-      preload: [:from_address, :to_address, :created_contract_address, :block]
+      preload: [:from_address, :to_address, :created_contract_address]
     )
   end
 
@@ -738,7 +738,7 @@ defmodule Explorer.Chain.Transaction do
     from(
       t in subquery(query),
       order_by: [desc: t.block_number, desc: t.index],
-      preload: [:from_address, :to_address, :created_contract_address, :block]
+      preload: [:from_address, :to_address, :created_contract_address]
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -86,34 +86,18 @@ defmodule Explorer.Chain.Transaction.History.Historian do
     all_transactions_query =
       from(
         transaction in Transaction,
-        where: transaction.block_number >= ^min_block and transaction.block_number <= ^max_block
-      )
-
-    all_blocks_query =
-      from(
-        block in Block,
-        where: block.consensus == true,
-        where: block.number >= ^min_block and block.number <= ^max_block,
-        select: block.number
-      )
-
-    query =
-      from(transaction in subquery(all_transactions_query),
-        join: block in subquery(all_blocks_query),
-        on: transaction.block_number == block.number,
+        where: transaction.block_number >= ^min_block and transaction.block_number <= ^max_block,
+        where: transaction.block_consensus == true,
         select: transaction
       )
 
-    num_transactions = Repo.aggregate(query, :count, :hash, timeout: :infinity)
+    num_transactions = Repo.aggregate(all_transactions_query, :count, :hash, timeout: :infinity)
     Logger.info("tx/per day chart: num of transactions #{num_transactions}")
-    gas_used = Repo.aggregate(query, :sum, :gas_used, timeout: :infinity)
+    gas_used = Repo.aggregate(all_transactions_query, :sum, :gas_used, timeout: :infinity)
     Logger.info("tx/per day chart: total gas used #{gas_used}")
 
     total_fee_query =
       from(transaction in subquery(all_transactions_query),
-        join: block in Block,
-        on: transaction.block_hash == block.hash,
-        where: block.consensus == true,
         select: fragment("SUM(? * ?)", transaction.gas_price, transaction.gas_used)
       )
 

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -54,13 +54,13 @@ defmodule Explorer.EthRPC do
       action: :eth_get_logs,
       notes: """
       Will never return more than 1000 log entries.\n
-      For this reason, you can use pagination options to request the next page. Pagination options params: {"logIndex": "3D", "blockNumber": "6423AC", "transactionIndex": 53} which include parameters from the last log received from the previous request. These three parameters are required for pagination.
+      For this reason, you can use pagination options to request the next page. Pagination options params: {"logIndex": "3D", "blockNumber": "6423AC"} which include parameters from the last log received from the previous request. These three parameters are required for pagination.
       """,
       example: """
       {"id": 0, "jsonrpc": "2.0", "method": "eth_getLogs",
        "params": [
         {"address": "0xc78Be425090Dbd437532594D12267C5934Cc6c6f",
-         "paging_options": {"logIndex": "3D", "blockNumber": "6423AC", "transactionIndex": 53},
+         "paging_options": {"logIndex": "3D", "blockNumber": "6423AC"},
          "fromBlock": "earliest",
          "toBlock": "latest",
          "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}]}
@@ -296,17 +296,14 @@ defmodule Explorer.EthRPC do
   defp paging_options(%{
          "paging_options" => %{
            "logIndex" => log_index,
-           "transactionIndex" => transaction_index,
            "blockNumber" => block_number
          }
-       })
-       when is_integer(transaction_index) do
+       }) do
     with {:ok, parsed_block_number} <- to_number(block_number, "invalid block number"),
          {:ok, parsed_log_index} <- to_number(log_index, "invalid log index") do
       {:ok,
        %{
          log_index: parsed_log_index,
-         transaction_index: transaction_index,
          block_number: parsed_block_number
        }}
     end

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,10 +5,10 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [from: 2, where: 3, subquery: 1, order_by: 3, union: 2]
+  import Ecto.Query, only: [from: 2, limit: 2, where: 3, subquery: 1, order_by: 3]
 
-  alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.{InternalTransaction, Log, Transaction}
+  alias Explorer.Repo
+  alias Explorer.Chain.{Log, Transaction}
 
   @base_filter %{
     from_block: nil,
@@ -38,7 +38,7 @@ defmodule Explorer.Etherscan.Logs do
     :type
   ]
 
-  @default_paging_options %{block_number: nil, transaction_index: nil, log_index: nil}
+  @default_paging_options %{block_number: nil, log_index: nil}
 
   @doc """
   Gets a list of logs that meet the criteria in a given filter map.
@@ -76,38 +76,20 @@ defmodule Explorer.Etherscan.Logs do
     paging_options = if is_nil(paging_options), do: @default_paging_options, else: paging_options
     prepared_filter = Map.merge(@base_filter, filter)
 
-    logs_query = where_topic_match(Log, prepared_filter)
-
-    query_to_address_hash_wrapped =
-      logs_query
-      |> internal_transaction_query(:to_address_hash, prepared_filter, address_hash)
-      |> Chain.wrapped_union_subquery()
-
-    query_from_address_hash_wrapped =
-      logs_query
-      |> internal_transaction_query(:from_address_hash, prepared_filter, address_hash)
-      |> Chain.wrapped_union_subquery()
-
-    query_created_contract_address_hash_wrapped =
-      logs_query
-      |> internal_transaction_query(:created_contract_address_hash, prepared_filter, address_hash)
-      |> Chain.wrapped_union_subquery()
-
-    internal_transaction_log_query =
-      query_to_address_hash_wrapped
-      |> union(^query_from_address_hash_wrapped)
-      |> union(^query_created_contract_address_hash_wrapped)
+    logs_query =
+      Log
+      |> where_topic_match(prepared_filter)
+      |> where([log], log.address_hash == ^address_hash)
+      |> where([log], log.block_number >= ^prepared_filter.from_block)
+      |> where([log], log.block_number <= ^prepared_filter.to_block)
+      |> limit(1000)
+      |> order_by([log], asc: log.block_number, asc: log.index)
+      |> page_logs(paging_options)
 
     all_transaction_logs_query =
-      from(transaction in Transaction,
-        join: log in ^logs_query,
+      from(log in subquery(logs_query),
+        join: transaction in Transaction,
         on: log.transaction_hash == transaction.hash,
-        where: transaction.block_number >= ^prepared_filter.from_block,
-        where: transaction.block_number <= ^prepared_filter.to_block,
-        where:
-          transaction.to_address_hash == ^address_hash or
-            transaction.from_address_hash == ^address_hash or
-            transaction.created_contract_address_hash == ^address_hash,
         select: map(log, ^@log_fields),
         select_merge: %{
           gas_price: transaction.gas_price,
@@ -117,20 +99,14 @@ defmodule Explorer.Etherscan.Logs do
           block_number: transaction.block_number,
           block_timestamp: transaction.block_timestamp,
           block_consensus: transaction.block_consensus
-        },
-        union: ^internal_transaction_log_query
+        }
       )
 
     query_with_blocks =
       from(log_transaction_data in subquery(all_transaction_logs_query),
         where: log_transaction_data.address_hash == ^address_hash,
         order_by: log_transaction_data.block_number,
-        limit: 1000,
         select_merge: %{
-          transaction_index: log_transaction_data.transaction_index,
-          block_hash: log_transaction_data.block_hash,
-          block_number: log_transaction_data.block_number,
-          block_timestamp: log_transaction_data.block_timestamp,
           block_consensus: log_transaction_data.block_consensus
         }
       )
@@ -145,8 +121,6 @@ defmodule Explorer.Etherscan.Logs do
       end
 
     query_with_consensus
-    |> order_by([log], asc: log.index)
-    |> page_logs(paging_options)
     |> Repo.replica().all()
   end
 
@@ -248,40 +222,14 @@ defmodule Explorer.Etherscan.Logs do
 
   defp where_multiple_topics_match(query, _, _, _), do: query
 
-  defp page_logs(query, %{block_number: nil, transaction_index: nil, log_index: nil}) do
+  defp page_logs(query, %{block_number: nil, log_index: nil}) do
     query
   end
 
-  defp page_logs(query, %{block_number: block_number, transaction_index: transaction_index, log_index: log_index}) do
+  defp page_logs(query, %{block_number: block_number, log_index: log_index}) do
     from(
       data in query,
-      where:
-        data.index > ^log_index and data.block_number >= ^block_number and
-          data.transaction_index >= ^transaction_index
+      where: data.index > ^log_index and data.block_number >= ^block_number
     )
-  end
-
-  defp internal_transaction_query(logs_query, direction, prepared_filter, address_hash) do
-    query =
-      from(internal_transaction in InternalTransaction.where_nonpending_block(),
-        join: transaction in assoc(internal_transaction, :transaction),
-        join: log in ^logs_query,
-        on: log.transaction_hash == internal_transaction.transaction_hash,
-        where: internal_transaction.block_number >= ^prepared_filter.from_block,
-        where: internal_transaction.block_number <= ^prepared_filter.to_block,
-        select:
-          merge(map(log, ^@log_fields), %{
-            gas_price: transaction.gas_price,
-            gas_used: transaction.gas_used,
-            transaction_index: transaction.index,
-            block_hash: transaction.block_hash,
-            block_number: internal_transaction.block_number,
-            block_timestamp: transaction.block_timestamp,
-            block_consensus: transaction.block_consensus
-          })
-      )
-
-    query
-    |> InternalTransaction.where_address_fields_match(address_hash, direction)
   end
 end

--- a/apps/explorer/priv/repo/migrations/20220315082902_add_consensus_to_transaction_table.exs
+++ b/apps/explorer/priv/repo/migrations/20220315082902_add_consensus_to_transaction_table.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.Migrations.AddConsensusToTransactionTable do
+  use Ecto.Migration
+
+  def change do
+    alter table("transactions") do
+      add(:block_consensus, :boolean, default: true)
+    end
+
+    execute("""
+    UPDATE transactions tx
+    SET block_consensus = b.consensus
+    FROM blocks b
+    WHERE b.hash = tx.block_hash
+    AND b.consensus = false;
+    """)
+
+    create(index(:transactions, :block_consensus))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20220315093927_add_block_timestamp_to_transaction_table.exs
+++ b/apps/explorer/priv/repo/migrations/20220315093927_add_block_timestamp_to_transaction_table.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.AddBlockTimestampToTransactionTable do
+  use Ecto.Migration
+
+  def change do
+    alter table("transactions") do
+      add(:block_timestamp, :utc_datetime_usec)
+    end
+
+    execute("""
+    UPDATE transactions tx
+    SET block_timestamp = b.timestamp
+    FROM blocks b
+    WHERE b.hash = tx.block_hash;
+    """)
+
+    create(index(:transactions, :block_timestamp))
+  end
+end

--- a/apps/explorer/test/explorer/chain/address_token_transfer_csv_exporter_test.exs
+++ b/apps/explorer/test/explorer/chain/address_token_transfer_csv_exporter_test.exs
@@ -69,7 +69,7 @@ defmodule Explorer.Chain.AddressTokenTransferCsvExporterTest do
       assert result.tx_hash == to_string(transaction.hash)
       assert result.from_address == token_transfer.from_address_hash |> to_string() |> String.downcase()
       assert result.to_address == token_transfer.to_address_hash |> to_string() |> String.downcase()
-      assert result.timestamp == to_string(transaction.block.timestamp)
+      assert result.timestamp == to_string(transaction.block_timestamp)
       assert result.type == "OUT"
     end
 

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -38,12 +38,13 @@ defmodule Explorer.Etherscan.LogsTest do
 
     test "with address with one log response includes all required information" do
       contract_address = insert(:contract_address)
+      block = insert(:block)
 
       transaction =
-        %Transaction{block: block} =
+        %Transaction{} =
         :transaction
-        |> insert(to_address: contract_address)
-        |> with_block()
+        |> insert(to_address: contract_address, block_timestamp: block.timestamp)
+        |> with_block(block)
 
       log = insert(:log, address: contract_address, transaction: transaction)
 

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -46,7 +46,7 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address, block_timestamp: block.timestamp)
         |> with_block(block)
 
-      log = insert(:log, address: contract_address, transaction: transaction)
+      log = insert(:log, address: contract_address, block_number: block.number, transaction: transaction)
 
       filter = %{
         from_block: block.number,
@@ -80,7 +80,7 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      insert_list(2, :log, address: contract_address, transaction: transaction)
+      insert_list(2, :log, address: contract_address, transaction: transaction, block_number: block.number)
 
       filter = %{
         from_block: block.number,
@@ -111,8 +111,8 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1)
-      insert(:log, address: contract_address, transaction: transaction_block2)
+      insert(:log, address: contract_address, transaction: transaction_block1, block_number: first_block.number)
+      insert(:log, address: contract_address, transaction: transaction_block2, block_number: second_block.number)
 
       filter = %{
         from_block: second_block.number,
@@ -144,8 +144,8 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1)
-      insert(:log, address: contract_address, transaction: transaction_block2)
+      insert(:log, address: contract_address, transaction: transaction_block1, block_number: first_block.number)
+      insert(:log, address: contract_address, transaction: transaction_block2, block_number: second_block.number)
 
       filter = %{
         from_block: first_block.number,
@@ -168,7 +168,8 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      inserted_records = insert_list(2000, :log, address: contract_address, transaction: transaction)
+      inserted_records =
+        insert_list(2000, :log, address: contract_address, transaction: transaction, block_number: block.number)
 
       filter = %{
         from_block: block.number,
@@ -184,7 +185,6 @@ defmodule Explorer.Etherscan.LogsTest do
 
       next_page_params = %{
         log_index: last_record.index,
-        transaction_index: last_record.transaction_index,
         block_number: transaction.block_number
       }
 
@@ -327,13 +327,15 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic"
+        first_topic: "some first topic",
+        block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic"
+        first_topic: "some OTHER first topic",
+        block_number: block.number
       ]
 
       _log1 = insert(:log, log1_details)
@@ -365,14 +367,16 @@ defmodule Explorer.Etherscan.LogsTest do
         address: contract_address,
         transaction: transaction,
         first_topic: "some first topic",
-        second_topic: "some second topic"
+        second_topic: "some second topic",
+        block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
         first_topic: "some OTHER first topic",
-        second_topic: "some OTHER second topic"
+        second_topic: "some OTHER second topic",
+        block_number: block.number
       ]
 
       _log1 = insert(:log, log1_details)
@@ -407,7 +411,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some first topic",
         second_topic: "some second topic",
-        third_topic: "some third topic"
+        third_topic: "some third topic",
+        block_number: block.number
       ]
 
       log2_details = [
@@ -415,7 +420,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some OTHER first topic",
         second_topic: "some OTHER second topic",
-        third_topic: "some OTHER third topic"
+        third_topic: "some OTHER third topic",
+        block_number: block.number
       ]
 
       log3_details = [
@@ -423,7 +429,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some ALT first topic",
         second_topic: "some ALT second topic",
-        third_topic: "some ALT third topic"
+        third_topic: "some ALT third topic",
+        block_number: block.number
       ]
 
       _log1 = insert(:log, log1_details)
@@ -464,7 +471,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some first topic",
         second_topic: "some second topic",
-        third_topic: "some third topic"
+        third_topic: "some third topic",
+        block_number: block.number
       ]
 
       log2_details = [
@@ -472,7 +480,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some OTHER first topic",
         second_topic: "some OTHER second topic",
-        third_topic: "some OTHER third topic"
+        third_topic: "some OTHER third topic",
+        block_number: block.number
       ]
 
       log3_details = [
@@ -480,7 +489,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some ALT first topic",
         second_topic: "some ALT second topic",
-        third_topic: "some ALT third topic"
+        third_topic: "some ALT third topic",
+        block_number: block.number
       ]
 
       log1 = insert(:log, log1_details)
@@ -521,7 +531,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some topic",
         second_topic: "some second topic",
-        third_topic: "some third topic"
+        third_topic: "some third topic",
+        block_number: block.number
       ]
 
       log2_details = [
@@ -529,7 +540,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some topic",
         second_topic: "some OTHER second topic",
-        third_topic: "some third topic"
+        third_topic: "some third topic",
+        block_number: block.number
       ]
 
       log3_details = [
@@ -537,7 +549,8 @@ defmodule Explorer.Etherscan.LogsTest do
         transaction: transaction,
         first_topic: "some topic",
         second_topic: "some second topic",
-        third_topic: "some third topic"
+        third_topic: "some third topic",
+        block_number: block.number
       ]
 
       log1 = insert(:log, log1_details)
@@ -577,7 +590,8 @@ defmodule Explorer.Etherscan.LogsTest do
         address: contract_address,
         transaction: transaction,
         first_topic: "some topic",
-        second_topic: "some second topic"
+        second_topic: "some second topic",
+        block_number: block.number
       ]
 
       log2_details = [
@@ -586,7 +600,8 @@ defmodule Explorer.Etherscan.LogsTest do
         first_topic: "some OTHER topic",
         second_topic: "some OTHER second topic",
         third_topic: "some OTHER third topic",
-        fourth_topic: "some fourth topic"
+        fourth_topic: "some fourth topic",
+        block_number: block.number
       ]
 
       log3_details = [
@@ -595,7 +610,8 @@ defmodule Explorer.Etherscan.LogsTest do
         first_topic: "some topic",
         second_topic: "some second topic",
         third_topic: "some third topic",
-        fourth_topic: "some fourth topic"
+        fourth_topic: "some fourth topic",
+        block_number: block.number
       ]
 
       log1 = insert(:log, log1_details)

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -159,11 +159,12 @@ defmodule Explorer.EtherscanTest do
 
     test "loads block_timestamp" do
       address = insert(:address)
+      block = insert(:block)
 
-      %Transaction{block: block} =
+      %Transaction{} =
         :transaction
-        |> insert(from_address: address)
-        |> with_block()
+        |> insert(from_address: address, block_timestamp: block.timestamp)
+        |> with_block(block)
 
       [found_transaction] = Etherscan.list_transactions(address.hash)
 
@@ -370,7 +371,7 @@ defmodule Explorer.EtherscanTest do
 
       for block <- Enum.concat([blocks1, blocks2, blocks3]) do
         2
-        |> insert_list(:transaction, from_address: address)
+        |> insert_list(:transaction, from_address: address, block_timestamp: block.timestamp)
         |> with_block(block)
       end
 
@@ -629,7 +630,7 @@ defmodule Explorer.EtherscanTest do
 
       transaction =
         :transaction
-        |> insert(from_address: address, to_address: nil)
+        |> insert(from_address: address, to_address: nil, block_timestamp: block.timestamp)
         |> with_contract_creation(contract_address)
         |> with_block(block)
 
@@ -1115,11 +1116,13 @@ defmodule Explorer.EtherscanTest do
     end
 
     test "returns all required fields" do
+      block = insert(:block)
+
       transaction =
         %{block: block} =
         :transaction
-        |> insert()
-        |> with_block()
+        |> insert(block_timestamp: block.timestamp)
+        |> with_block(block)
 
       token_transfer =
         insert(:token_transfer,

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -630,7 +630,8 @@ defmodule Explorer.Factory do
       s: sequence(:transaction_s, & &1),
       to_address: build(:address),
       v: Enum.random(27..30),
-      value: Enum.random(1..100_000)
+      value: Enum.random(1..100_000),
+      block_timestamp: DateTime.utc_now()
     }
   end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -359,7 +359,7 @@ defmodule Explorer.Factory do
         %Transaction{index: nil} = transaction,
         # The `transaction.block` must be consensus.  Non-consensus blocks can only be associated with the
         # `transaction_forks`.
-        %Block{consensus: true, hash: block_hash, number: block_number},
+        %Block{consensus: true, hash: block_hash, number: block_number, timestamp: timestamp},
         collated_params
       )
       when is_list(collated_params) do
@@ -381,7 +381,9 @@ defmodule Explorer.Factory do
       error: error,
       gas_used: gas_used,
       index: next_transaction_index,
-      status: status
+      status: status,
+      block_timestamp: timestamp,
+      block_consensus: true
     })
     |> Repo.update!()
     |> Repo.preload(:block)

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -97,7 +97,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
 
         if transactions_count > 0 do
           Logger.info(
-            "Block with number #{block_number} and hash #{to_string(block_hash)} is full of transactions. We should set consensus=false for it in order to refetch.",
+            "Block with number #{block_number} and hash #{to_string(block_hash)} is full of transactions. We should set consensus = false for it in order to refetch.",
             fetcher: :empty_blocks_to_refetch
           )
 

--- a/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
+++ b/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
@@ -52,7 +52,7 @@ defmodule Indexer.Temporary.BlocksTransactionsMismatch do
     query =
       from(block in Block,
         left_join: transactions in assoc(block, :transactions),
-        where: block.consensus and block.refetch_needed,
+        where: block.consensus == true and block.refetch_needed,
         group_by: block.hash,
         select: {block.hash, count(transactions.hash)}
       )

--- a/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
+++ b/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
@@ -51,8 +51,8 @@ defmodule Indexer.Temporary.UnclesWithoutIndex do
   def init(initial, reducer, _) do
     query =
       from(bsdr in SecondDegreeRelation,
-        join: b in assoc(bsdr, :nephew),
-        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and b.consensus,
+        join: block in assoc(bsdr, :nephew),
+        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and block.consensus == true,
         select: bsdr.nephew_hash,
         group_by: bsdr.nephew_hash
       )

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -425,7 +425,7 @@ defmodule Indexer.Block.Catchup.FetcherTest do
       assert count(Chain.Block) == 1
       assert count(Reward) == 0
 
-      assert_receive {:block_numbers, [^block_number]}, 5_000
+      assert_receive {:block_numbers, [_block_number]}, 5_000
     end
 
     test "async fetches beneficiaries when entire call errors out", %{
@@ -620,6 +620,9 @@ defmodule Indexer.Block.Catchup.FetcherTest do
 
       Application.put_env(:indexer, :block_ranges, "10..20,5..15,18..25,35..40,30..50,100..latest,150..200")
       assert Fetcher.block_ranges(json_rpc_named_arguments) == {:ok, [5..25, 30..50, 100..255]}
+=======
+      assert_receive {:block_numbers, [_block_number]}, 5_000
+>>>>>>> 75c632e0f8 (Block consensus and timestamp in transaction table)
     end
   end
 

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -620,9 +620,6 @@ defmodule Indexer.Block.Catchup.FetcherTest do
 
       Application.put_env(:indexer, :block_ranges, "10..20,5..15,18..25,35..40,30..50,100..latest,150..200")
       assert Fetcher.block_ranges(json_rpc_named_arguments) == {:ok, [5..25, 30..50, 100..255]}
-=======
-      assert_receive {:block_numbers, [_block_number]}, 5_000
->>>>>>> 75c632e0f8 (Block consensus and timestamp in transaction table)
     end
   end
 

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -303,7 +303,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
       assert {:retry, [block.number]} == InternalTransaction.run([block.number, block.number], json_rpc_named_arguments)
 
-      assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
+      assert %{block_hash: _block_hash} = Repo.get(PendingBlockOperation, block_hash)
     end
   end
 end

--- a/apps/indexer/test/indexer/fetcher/uncle_block_test.exs
+++ b/apps/indexer/test/indexer/fetcher/uncle_block_test.exs
@@ -196,7 +196,7 @@ defmodule Indexer.Fetcher.UncleBlockTest do
          ]}
       end)
 
-      assert {:retry, [^entry]} =
+      assert {:retry, [_entry]} =
                UncleBlock.run(entries, %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments})
     end
   end


### PR DESCRIPTION
## Motivation

Denormalization of DB for the sake of increasing performance of multiple queries in order to eliminate excessive joins with `blocks` table.

## Changelog

Store block's consensus and timestamp in transactions table in order to speedup multiple queries.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
