### PR TITLE
Fix docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ test
 .circleci
 logs
 apps/*/test
+docker-compose

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -26,12 +26,12 @@ services:
     env_file:
       -  ./envs/common-blockscout.env
     environment:
-        ETHEREUM_JSONRPC_VARIANT: 'ganache'
-        ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
-        ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
-        INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: true
-        DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-        ECTO_USE_SSL: false
+      - ETHEREUM_JSONRPC_VARIANT='ganache'
+      - ETHEREUM_JSONRPC_HTTP_URL=http://host.docker.internal:8545/
+      - ETHEREUM_JSONRPC_WS_URL=ws://host.docker.internal:8545/
+      - INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER=true
+      - DATABASE_URL=postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+      - ECTO_USE_SSL=false
     ports:
       - 4000:4000
 

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -11,10 +11,10 @@ services:
     env_file:
       -  ./envs/common-blockscout.env
     environment:
-        ETHEREUM_JSONRPC_VARIANT: 'geth'
-        ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
-        DATABASE_URL: postgresql://postgres:@host.docker.internal:5432/blockscout?ssl=false
-        ECTO_USE_SSL: false
+      - ETHEREUM_JSONRPC_VARIANT='geth'
+      - ETHEREUM_JSONRPC_HTTP_URL=http://host.docker.internal:8545/
+      - DATABASE_URL=postgresql://postgres:@host.docker.internal:5432/blockscout?ssl=false
+      - ECTO_USE_SSL=false
     ports:
       - 4000:4000
 


### PR DESCRIPTION
Fix the issue:
```
docker-compose -f docker-compose-no-build-ganache.yml up
ERROR: The Compose file './docker-compose-no-build-ganache.yml' is invalid because:
services.blockscout.environment.INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER contains true, which is an invalid type, it should be a string, number, or a null
```