### PR TITLE
graphql: add user-selected ordering to transactions for address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#5739](https://github.com/blockscout/blockscout/pull/5739) - Erigon archive node support
 - [#5732](https://github.com/blockscout/blockscout/pull/5732) - Manage testnet label (right to the navbar logo)
 - [#5699](https://github.com/blockscout/blockscout/pull/5699) - Switch to basic (non-pro) API endpoint for Coingecko requests, if API key is not provided
+- [#5345](https://github.com/blockscout/blockscout/pull/5345) - Graphql: add user-selected ordering to transactions for address query
 
 ### Fixes
 - [#5768](https://github.com/blockscout/blockscout/pull/5768) - Outstanding rows limit for missing blocks query (catchup fetcher)

--- a/apps/block_scout_web/lib/block_scout_web/resolvers/transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/resolvers/transaction.ex
@@ -13,9 +13,11 @@ defmodule BlockScoutWeb.Resolvers.Transaction do
   end
 
   def get_by(%Address{hash: address_hash}, args, _) do
+    connection_args = Map.take(args, [:after, :before, :first, :last])
+
     address_hash
-    |> GraphQL.address_to_transactions_query()
-    |> Connection.from_query(&Repo.all/1, args, options(args))
+    |> GraphQL.address_to_transactions_query(args.order)
+    |> Connection.from_query(&Repo.all/1, connection_args, options(args))
   end
 
   defp options(%{before: _}), do: []

--- a/apps/block_scout_web/lib/block_scout_web/schema/scalars.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/scalars.ex
@@ -113,4 +113,9 @@ defmodule BlockScoutWeb.Schema.Scalars do
     value(:reward)
     value(:selfdestruct)
   end
+
+  enum :sort_order do
+    value(:asc)
+    value(:desc)
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schema/types.ex
@@ -33,6 +33,7 @@ defmodule BlockScoutWeb.Schema.Types do
 
     connection field(:transactions, node_type: :transaction) do
       arg(:count, :integer)
+      arg(:order, type: :sort_order, default_value: :desc)
       resolve(&Transaction.get_by/3)
 
       complexity(fn

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -24,15 +24,15 @@ defmodule Explorer.GraphQL do
   Returns a query to fetch transactions with a matching `to_address_hash`,
   `from_address_hash`, or `created_contract_address_hash` field for a given address hash.
 
-  Orders transactions by descending block number and index.
+  Orders transactions by `block_number` and `index` according to to `order`
   """
-  @spec address_to_transactions_query(Hash.Address.t()) :: Ecto.Query.t()
-  def address_to_transactions_query(address_hash) do
+  @spec address_to_transactions_query(Hash.Address.t(), :desc | :asc) :: Ecto.Query.t()
+  def address_to_transactions_query(address_hash, order) do
     Transaction
-    |> order_by([transaction], desc: transaction.block_number, desc: transaction.index)
     |> where([transaction], transaction.to_address_hash == ^address_hash)
     |> or_where([transaction], transaction.from_address_hash == ^address_hash)
     |> or_where([transaction], transaction.created_contract_address_hash == ^address_hash)
+    |> order_by([transaction], [{^order, transaction.block_number}, {^order, transaction.index}])
   end
 
   @doc """

--- a/apps/explorer/test/explorer/graphql_test.exs
+++ b/apps/explorer/test/explorer/graphql_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.GraphQLTest do
         :address
         |> insert()
         |> Map.get(:hash)
-        |> GraphQL.address_to_transactions_query()
+        |> GraphQL.address_to_transactions_query(:desc)
         |> Repo.replica().all()
 
       assert result == []
@@ -25,7 +25,7 @@ defmodule Explorer.GraphQLTest do
 
       [found_transaction] =
         address_hash
-        |> GraphQL.address_to_transactions_query()
+        |> GraphQL.address_to_transactions_query(:desc)
         |> Repo.replica().all()
 
       assert found_transaction.hash == transaction.hash
@@ -38,7 +38,7 @@ defmodule Explorer.GraphQLTest do
 
       [found_transaction] =
         address_hash
-        |> GraphQL.address_to_transactions_query()
+        |> GraphQL.address_to_transactions_query(:desc)
         |> Repo.replica().all()
 
       assert found_transaction.hash == transaction.hash
@@ -51,7 +51,7 @@ defmodule Explorer.GraphQLTest do
 
       [found_transaction] =
         address_hash
-        |> GraphQL.address_to_transactions_query()
+        |> GraphQL.address_to_transactions_query(:desc)
         |> Repo.replica().all()
 
       assert found_transaction.hash == transaction.hash
@@ -78,7 +78,7 @@ defmodule Explorer.GraphQLTest do
 
       found_transactions =
         address_hash
-        |> GraphQL.address_to_transactions_query()
+        |> GraphQL.address_to_transactions_query(:desc)
         |> Repo.replica().all()
 
       block_number_and_index_order =


### PR DESCRIPTION
Closes #5323

## Motivation

Currently, graphql queries only allow descending ordering (newest block to oldest)

This PR adds the ability to specify if you want ascending or descending order instead of hard-coding it which allows services to sync a subset of the chain using graphql by syncing from the oldest block to the latest block

## Changelog

### Enhancements
- [#5345](https://github.com/blockscout/blockscout/pull/5345) - Graphql: add user-selected ordering to transactions for address query

## Upgrading

This change is backwards-compatible as when no ordering is specified, descending ordering is used

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
