### PR TITLE
Empty blocks sanitizer refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 - [#5342](https://github.com/blockscout/blockscout/pull/5342) - Fix 500 error on NF token page with nil metadata
-- [#5319](https://github.com/blockscout/blockscout/pull/5319) - Empty blocks sanitizer performance improvement
+- [#5319](https://github.com/blockscout/blockscout/pull/5319), [#5357](https://github.com/blockscout/blockscout/pull/5357) - Empty blocks sanitizer performance improvement
 - [#5310](https://github.com/blockscout/blockscout/pull/5310) - Fix flash on reload in dark mode
 - [#5306](https://github.com/blockscout/blockscout/pull/5306) - Fix indexer bug
 - [#5300](https://github.com/blockscout/blockscout/pull/5300), [#5305](https://github.com/blockscout/blockscout/pull/5305) - Token instance page: general video improvements

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3386,27 +3386,6 @@ defmodule Explorer.Chain do
   end
 
   @doc """
-  Returns the list of empty blocks from the DB which have not marked with `t:Explorer.Chain.Block.is_empty/0`.
-  This query used for initializtion of Indexer.EmptyBlocksSanitizer
-  """
-  def unprocessed_empty_blocks_query_list(limit) do
-    query =
-      from(block in Block,
-        left_join: transaction in Transaction,
-        on: block.number == transaction.block_number,
-        where: is_nil(transaction.block_number),
-        where: is_nil(block.is_empty),
-        where: block.consensus == true,
-        select: {block.number, block.hash},
-        order_by: [desc: block.number],
-        limit: ^limit
-      )
-
-    query
-    |> Repo.all(timeout: :infinity)
-  end
-
-  @doc """
   The `string` must start with `0x`, then is converted to an integer and then to `t:Explorer.Chain.Hash.Address.t/0`.
 
       iex> Explorer.Chain.string_to_address_hash("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")

--- a/apps/indexer/lib/indexer/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/empty_blocks_sanitizer.ex
@@ -8,16 +8,18 @@ defmodule Indexer.EmptyBlocksSanitizer do
 
   require Logger
 
+  import Ecto.Query, only: [from: 2, subquery: 1]
   import EthereumJSONRPC, only: [integer_to_quantity: 1, json_rpc: 2, request: 1]
 
   alias Ecto.Changeset
   alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.{Block, Transaction}
   alias Explorer.Chain.Import.Runner.Blocks
 
   # unprocessed emty blocks to fetch at once
-  @limit 400
+  @limit 1000
 
-  @interval :timer.minutes(2)
+  @interval :timer.minutes(1)
 
   defstruct interval: @interval,
             json_rpc_named_arguments: []
@@ -66,7 +68,21 @@ defmodule Indexer.EmptyBlocksSanitizer do
   end
 
   defp sanitize_empty_blocks(json_rpc_named_arguments) do
-    unprocessed_empty_blocks_from_db = Chain.unprocessed_empty_blocks_query_list(@limit)
+    unprocessed_non_empty_blocks_from_db = unprocessed_non_empty_blocks_query_list(@limit)
+
+    uniq_block_hashes = unprocessed_non_empty_blocks_from_db
+
+    if Enum.count(uniq_block_hashes) > 0 do
+      Repo.update_all(
+        from(
+          block in Block,
+          where: block.hash in ^uniq_block_hashes
+        ),
+        set: [is_empty: false, updated_at: Timex.now()]
+      )
+    end
+
+    unprocessed_empty_blocks_from_db = unprocessed_empty_blocks_query_list(@limit)
 
     unprocessed_empty_blocks_from_db
     |> Enum.with_index()
@@ -92,7 +108,7 @@ defmodule Indexer.EmptyBlocksSanitizer do
             fetcher: :empty_blocks_to_refetch
           )
 
-          set_is_empty_for_block(block_hash)
+          set_is_empty_for_block(block_hash, true)
         end
       end
     end)
@@ -102,16 +118,55 @@ defmodule Indexer.EmptyBlocksSanitizer do
     )
   end
 
-  defp set_is_empty_for_block(block_hash) do
+  defp set_is_empty_for_block(block_hash, is_empty) do
     block = Chain.fetch_block_by_hash(block_hash)
 
-    token =
+    block_with_is_empty =
       block
-      |> Changeset.change(%{is_empty: true})
+      |> Changeset.change(%{is_empty: is_empty})
 
-    Repo.update(token)
+    Repo.update(block_with_is_empty)
   rescue
     postgrex_error in Postgrex.Error ->
       {:error, %{exception: postgrex_error}}
+  end
+
+  defp consensus_blocks_with_nil_is_empty_query(limit) do
+    from(block in Block,
+      where: is_nil(block.is_empty),
+      where: block.consensus == true,
+      order_by: [desc: block.number],
+      limit: ^limit
+    )
+  end
+
+  defp unprocessed_non_empty_blocks_query_list(limit) do
+    blocks_query = consensus_blocks_with_nil_is_empty_query(limit)
+
+    query =
+      from(q in subquery(blocks_query),
+        inner_join: transaction in Transaction,
+        on: q.number == transaction.block_number,
+        select: q.hash,
+        distinct: q.hash
+      )
+
+    query
+    |> Repo.all(timeout: :infinity)
+  end
+
+  defp unprocessed_empty_blocks_query_list(limit) do
+    blocks_query = consensus_blocks_with_nil_is_empty_query(limit)
+
+    query =
+      from(q in subquery(blocks_query),
+        left_join: transaction in Transaction,
+        on: q.number == transaction.block_number,
+        where: is_nil(transaction.block_number),
+        select: {q.number, q.hash}
+      )
+
+    query
+    |> Repo.all(timeout: :infinity)
   end
 end


### PR DESCRIPTION
## Motivation

The current query for finding blocks that should be refetched is still slow
<img width="293" alt="Screenshot 2022-03-23 at 17 45 21" src="https://user-images.githubusercontent.com/4341812/159726319-b36ce8ea-fbec-490c-b30b-05a2955996b5.png">

## Changelog

Separate working process into 2 queries:
- 1st one - finds blocks that have transactions and null `in_empty` flag. The worker sets `is_empty=false` flag for those blocks.
- 2nd one - finds blocks that have no transactions and null `in_empty` flag. The worker sets `is_empty=true` flag for those blocks.

Decrease restart of the worker to 1 minute.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
