### PR TITLE
Return all ERC-1155's token instances in tokenList api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 - [#5383](https://github.com/blockscout/blockscout/pull/5383) - Fix reload transactions button
 - [#5375](https://github.com/blockscout/blockscout/pull/5375) - Fix pending transactions fetcher
+- [#5374](https://github.com/blockscout/blockscout/pull/5374) - Return all ERC-1155's token instances in tokenList api endpoint
 - [#5342](https://github.com/blockscout/blockscout/pull/5342) - Fix 500 error on NF token page with nil metadata
 - [#5319](https://github.com/blockscout/blockscout/pull/5319), [#5357](https://github.com/blockscout/blockscout/pull/5357) - Empty blocks sanitizer performance improvement
 - [#5310](https://github.com/blockscout/blockscout/pull/5310) - Fix flash on reload in dark mode

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -205,6 +205,7 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "symbol" => token.symbol,
       "type" => token.type
     }
+    |> (&if(is_nil(token.id), do: &1, else: Map.put(&1, "id", token.id))).()
   end
 
   defp balance(address) do

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -318,14 +318,14 @@ defmodule Explorer.Etherscan do
         inner_join: t in assoc(ctb, :token),
         where: ctb.address_hash == ^address_hash,
         where: ctb.value > 0,
-        distinct: :token_contract_address_hash,
         select: %{
           balance: ctb.value,
           contract_address_hash: ctb.token_contract_address_hash,
           name: t.name,
           decimals: t.decimals,
           symbol: t.symbol,
-          type: t.type
+          type: t.type,
+          id: ctb.token_id
         }
       )
 

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1616,7 +1616,8 @@ defmodule Explorer.EtherscanTest do
           name: token_balance.token.name,
           decimals: token_balance.token.decimals,
           symbol: token_balance.token.symbol,
-          type: token_balance.token.type
+          type: token_balance.token.type,
+          id: token_balance.token_id
         }
       ]
 


### PR DESCRIPTION
Close #5304 

## Changelog

### Bug Fixes
- Change `tokenlist` method. Now method returns all instances of ERC-1155.
Example: 
```
{
  "message": "OK",
  "result": [
    {
      "balance": "1",
      "contractAddress": "0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a",
      "decimals": "",
      "id": "106",
      "name": "SNAFU",
      "symbol": "SNAFU",
      "type": "ERC-1155"
    },
    {
      "balance": "1",
      "contractAddress": "0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a",
      "decimals": "",
      "id": "28",
      "name": "SNAFU",
      "symbol": "SNAFU",
      "type": "ERC-1155"
    },
    {
      "balance": "2",
      "contractAddress": "0xed1efc6efceaab9f6d609fec89c9e675bf1efb0a",
      "decimals": "",
      "id": "169",
      "name": "SNAFU",
      "symbol": "SNAFU",
      "type": "ERC-1155"
    }
  ],
  "status": "1"
}
```
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
