### PR TITLE
Ability to disable block reward, coin balance, token updater fetchers

### DIFF
--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -69,11 +69,18 @@ config :indexer, Indexer.Fetcher.CoinBalanceOnDemand, threshold: coin_balance_on
 if System.get_env("POS_STAKING_CONTRACT") do
   config :indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true
 else
-  config :indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: false
+  config :indexer, Indexer.Fetcher.BlockReward.Supervisor,
+    disabled?: System.get_env("INDEXER_DISABLE_BLOCK_REWARD_FETCHER", "false") == "true"
 end
 
 config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor,
   disabled?: System.get_env("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER", "false") == "true"
+
+config :indexer, Indexer.Fetcher.CoinBalance.Supervisor,
+  disabled?: System.get_env("INDEXER_DISABLE_ADDRESS_COIN_BALANCE_FETCHER", "false") == "true"
+
+config :indexer, Indexer.Fetcher.TokenUpdater.Supervisor,
+  disabled?: System.get_env("INDEXER_DISABLE_CATALOGED_TOKEN_UPDATER_FETCHER", "false") == "true"
 
 config :indexer, Indexer.Supervisor, enabled: System.get_env("DISABLE_INDEXER") != "true"
 

--- a/apps/indexer/lib/indexer/fetcher/coin_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance.ex
@@ -16,6 +16,7 @@ defmodule Indexer.Fetcher.CoinBalance do
   alias Explorer.Chain.{Block, Hash}
   alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
+  alias Indexer.Fetcher.CoinBalance.Supervisor, as: CoinBalanceSupervisor
 
   @behaviour BufferedTask
 
@@ -34,9 +35,13 @@ defmodule Indexer.Fetcher.CoinBalance do
           %{required(:address_hash) => Hash.Address.t(), required(:block_number) => Block.block_number()}
         ]) :: :ok
   def async_fetch_balances(balance_fields) when is_list(balance_fields) do
-    entries = Enum.map(balance_fields, &entry/1)
+    if CoinBalanceSupervisor.disabled?() do
+      :ok
+    else
+      entries = Enum.map(balance_fields, &entry/1)
 
-    BufferedTask.buffer(__MODULE__, entries)
+      BufferedTask.buffer(__MODULE__, entries)
+    end
   end
 
   @doc false


### PR DESCRIPTION
## Motivation

Add ability to disable next fetchers:
- updater of cataloged tokens metadata
- coin balance
- block reward

The ability to switch off the last 2 fetchers is actual when explorer is connected to a non-archive node.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
