### PR TITLE
Handle exited realtime fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - [#5416](https://github.com/blockscout/blockscout/pull/5416) - Fix getsourcecode for EOA addresses
+- [#5410](https://github.com/blockscout/blockscout/pull/5410) - Handle exited realtime fetcher
 - [#5383](https://github.com/blockscout/blockscout/pull/5383) - Fix reload transactions button
 - [#5381](https://github.com/blockscout/blockscout/pull/5381), [#5397](https://github.com/blockscout/blockscout/pull/5397) - Fix exchange rate broadcast error
 - [#5375](https://github.com/blockscout/blockscout/pull/5375) - Fix pending transactions fetcher

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -155,6 +155,14 @@ defmodule Indexer.Block.Realtime.Fetcher do
         Logger.debug(fn -> ["Could not connect to websocket: #{inspect(reason)}. Continuing with polling."] end)
         state
     end
+  catch
+    :exit, _reason ->
+      if Map.get(state, :timer) && state.timer do
+        Process.cancel_timer(state.timer)
+      end
+
+      timer = schedule_polling()
+      %{state | timer: timer}
   end
 
   defp subscribe_to_new_heads(state, _), do: state


### PR DESCRIPTION
## Motivation

```
** (stop) exited in: GenServer.call(Indexer.Block.Realtime.WebSocket, {:subscribe, "newHeads", []}, 5000)
    ** (EXIT) time out
    (elixir 1.12.3) lib/gen_server.ex:1024: GenServer.call/3
    (indexer 0.1.0) lib/indexer/block/realtime/fetcher.ex:156: Indexer.Block.Realtime.Fetcher.subscribe_to_new_heads/2
    (indexer 0.1.0) lib/indexer/block/realtime/fetcher.ex:74: Indexer.Block.Realtime.Fetcher.handle_continue/2
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:437: :gen_server.loop/7
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
