### PR TITLE
Deduplicate addresses and coin balances before inserting to the DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#5455](https://github.com/blockscout/blockscout/pull/5455) - Fix unverified_smart_contract function: add md5 of bytecode to the changeset
 - [#5454](https://github.com/blockscout/blockscout/pull/5454) - Docker: Fix the qemu-x86_64 signal 11 error on Apple Silicon
 - [#5443](https://github.com/blockscout/blockscout/pull/5443) - Geth: display tx revert reason
+- [#5420](https://github.com/blockscout/blockscout/pull/5420) - Deduplicate addresses and coin balances before inserting to the DB
 - [#5416](https://github.com/blockscout/blockscout/pull/5416) - Fix getsourcecode for EOA addresses
 - [#5411](https://github.com/blockscout/blockscout/pull/5411) - Fix character_not_in_repertoire error for tx revert reason
 - [#5410](https://github.com/blockscout/blockscout/pull/5410) - Handle exited realtime fetcher

--- a/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
@@ -72,7 +72,10 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalances do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce CoinBalance ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, &{&1.address_hash, &1.block_number})
+    ordered_changes_list =
+      changes_list
+      |> Enum.sort_by(&{&1.address_hash, &1.block_number})
+      |> Enum.dedup()
 
     {:ok, _} =
       Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -81,7 +81,19 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Address ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = sort_changes_list(changes_list)
+    ordered_changes_list =
+      changes_list
+      |> Enum.group_by(fn %{
+                            hash: hash
+                          } ->
+        {hash}
+      end)
+      |> Enum.map(fn {_, grouped_addresses} ->
+        Enum.max_by(grouped_addresses, fn address ->
+          address_max_by(address)
+        end)
+      end)
+      |> Enum.sort_by(& &1.hash)
 
     Import.insert_changes_list(
       repo,
@@ -93,6 +105,19 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
       timeout: timeout,
       timestamps: timestamps
     )
+  end
+
+  defp address_max_by(address) do
+    cond do
+      Map.has_key?(address, :address) ->
+        address.fetched_coin_balance_block_number
+
+      Map.has_key?(address, :nonce) ->
+        address.nonce
+
+      true ->
+        address
+    end
   end
 
   defp default_on_conflict do
@@ -137,10 +162,6 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
             address.fetched_coin_balance_block_number
           ) or fragment("GREATEST(?, EXCLUDED.nonce) IS DISTINCT FROM  ?", address.nonce, address.nonce)
     )
-  end
-
-  defp sort_changes_list(changes_list) do
-    Enum.sort_by(changes_list, & &1.hash)
   end
 
   defp update_transactions(repo, addresses, %{timeout: timeout, timestamps: timestamps}) do


### PR DESCRIPTION
## Motivation

Finalization of https://github.com/blockscout/blockscout/pull/5327

## Changelog

Deduplicate addresses and coin balances before insert operation into the DB.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
