### PR TITLE
Empty blocks sanitizer improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [#5375](https://github.com/blockscout/blockscout/pull/5375) - Fix pending transactions fetcher
 - [#5374](https://github.com/blockscout/blockscout/pull/5374) - Return all ERC-1155's token instances in tokenList api endpoint
 - [#5342](https://github.com/blockscout/blockscout/pull/5342) - Fix 500 error on NF token page with nil metadata
-- [#5319](https://github.com/blockscout/blockscout/pull/5319), [#5357](https://github.com/blockscout/blockscout/pull/5357) - Empty blocks sanitizer performance improvement
+- [#5319](https://github.com/blockscout/blockscout/pull/5319), [#5357](https://github.com/blockscout/blockscout/pull/5357), [#5425](https://github.com/blockscout/blockscout/pull/5425) - Empty blocks sanitizer performance improvement
 - [#5310](https://github.com/blockscout/blockscout/pull/5310) - Fix flash on reload in dark mode
 - [#5306](https://github.com/blockscout/blockscout/pull/5306) - Fix indexer bug
 - [#5300](https://github.com/blockscout/blockscout/pull/5300), [#5305](https://github.com/blockscout/blockscout/pull/5305) - Token instance page: general video improvements

--- a/apps/indexer/config/config.exs
+++ b/apps/indexer/config/config.exs
@@ -82,6 +82,9 @@ config :indexer, Indexer.Fetcher.CoinBalance.Supervisor,
 config :indexer, Indexer.Fetcher.TokenUpdater.Supervisor,
   disabled?: System.get_env("INDEXER_DISABLE_CATALOGED_TOKEN_UPDATER_FETCHER", "false") == "true"
 
+config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer.Supervisor,
+  disabled?: System.get_env("INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER", "false") == "true"
+
 config :indexer, Indexer.Supervisor, enabled: System.get_env("DISABLE_INDEXER") != "true"
 
 config :indexer, Indexer.Tracer,

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -10,7 +10,6 @@ defmodule Indexer.Supervisor do
   alias Indexer.{
     Block,
     CalcLpTokensTotalLiqudity,
-    EmptyBlocksSanitizer,
     PendingOpsCleaner,
     PendingTransactionsSanitizer,
     SetAmbBridgedMetadataForTokens,
@@ -24,6 +23,7 @@ defmodule Indexer.Supervisor do
     CoinBalance,
     CoinBalanceOnDemand,
     ContractCode,
+    EmptyBlocksSanitizer,
     InternalTransaction,
     PendingTransaction,
     ReplacedTransaction,
@@ -127,7 +127,7 @@ defmodule Indexer.Supervisor do
 
       # Out-of-band fetchers
       {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
-      {EmptyBlocksSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+      {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
       {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
       {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -13,3 +13,15 @@ indexer_memory_limit =
 
 config :indexer,
   memory_limit: indexer_memory_limit <<< 30
+
+indexer_empty_blocks_sanitizer_batch_size =
+  if System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE") do
+    case Integer.parse(System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE")) do
+      {integer, ""} -> integer
+      _ -> 100
+    end
+  else
+    100
+  end
+
+config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer, batch_size: indexer_empty_blocks_sanitizer_batch_size


### PR DESCRIPTION
## Motivation

- Add ability to disable empty blocks sanitizer
- Configure batch size of empty block sanitizer via env variable in runtime.

## Changelog

- `INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE` - a new environment variable to manage the batch size of empty block sanitizer
- `INDEXER_DISABLE_EMPTY_BLOCK_SANITIZER` - a new environment variable to manage enabling/disabling of empty block sanitizer

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
