### PR TITLE
Geth: display tx revert reason

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -18,7 +18,6 @@ lib/phoenix/router.ex:324
 lib/phoenix/router.ex:402
 lib/block_scout_web/views/layout_view.ex:145: The call 'Elixir.Poison.Parser':'parse!'
 lib/block_scout_web/views/layout_view.ex:237: The call 'Elixir.Poison.Parser':'parse!'
-lib/block_scout_web/controllers/api/rpc/transaction_controller.ex:22
 lib/explorer/smart_contract/reader.ex:435
 lib/indexer/fetcher/token_total_supply_on_demand.ex:16
 lib/explorer/exchange_rates/source.ex:110

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement
 
 ### Fixes
+- [#5443](https://github.com/blockscout/blockscout/pull/5443) - Geth: display tx revert reason
 - [#5416](https://github.com/blockscout/blockscout/pull/5416) - Fix getsourcecode for EOA addresses
 - [#5411](https://github.com/blockscout/blockscout/pull/5411) - Fix character_not_in_repertoire error for tx revert reason
 - [#5410](https://github.com/blockscout/blockscout/pull/5410) - Handle exited realtime fetcher

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -17,12 +17,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionController do
       {logs, next_page} = split_list_by_page(logs)
 
       transaction_updated =
-        if error == "Reverted" do
-          if revert_reason == nil do
-            %Transaction{transaction | revert_reason: Chain.fetch_tx_revert_reason(transaction)}
-          else
-            transaction
-          end
+        if (error == "Reverted" || error == "execution reverted") && !revert_reason do
+          %Transaction{transaction | revert_reason: Chain.fetch_tx_revert_reason(transaction)}
         else
           transaction
         end

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -121,7 +121,7 @@
             </dd>
           </dl>
           <!-- Revert reason -->
-          <%= if status == {:error, "Reverted"} do %>
+          <%= if status == {:error, "Reverted"} || status == {:error, "execution reverted"} do %>
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted">
               <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",

--- a/apps/explorer/lib/explorer/chain/gas.ex
+++ b/apps/explorer/lib/explorer/chain/gas.ex
@@ -6,5 +6,5 @@ defmodule Explorer.Chain.Gas do
   """
 
   @typedoc @moduledoc
-  @type t :: non_neg_integer()
+  @type t :: false | nil | %Decimal{:coef => non_neg_integer(), :exp => integer(), :sign => -1 | 1}
 end


### PR DESCRIPTION
## Motivation

Tx revert reason doesn't appear in the case of Geth-like archive node.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
