### PR TITLE
Fix unverified_smart_contract function: add md5 of bytecode to the changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement
 
 ### Fixes
+- [#5455](https://github.com/blockscout/blockscout/pull/5455) - Fix unverified_smart_contract function: add md5 of bytecode to the changeset
 - [#5443](https://github.com/blockscout/blockscout/pull/5443) - Geth: display tx revert reason
 - [#5416](https://github.com/blockscout/blockscout/pull/5416) - Fix getsourcecode for EOA addresses
 - [#5411](https://github.com/blockscout/blockscout/pull/5411) - Fix character_not_in_repertoire error for tx revert reason

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -15,7 +15,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   alias Explorer.SmartContract.Vyper.Publisher, as: VyperPublisher
   alias Explorer.ThirdPartyIntegrations.Sourcify
 
-  @smth_went_wrong "Something went wrong while publishing the contract."
+  @smth_went_wrong "Something went wrong while publishing the contract"
   @verified "Smart-contract already verified."
   @invalid_address "Invalid address hash"
   @invalid_args "Invalid args format"
@@ -46,10 +46,22 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
         }}} ->
         render(conn, :error, error: @verified)
 
+      {:publish, {:error, error}} ->
+        Logger.error(fn ->
+          [
+            @smth_went_wrong,
+            ": ",
+            inspect(error)
+          ]
+        end)
+
+        render(conn, :error, error: "#{@smth_went_wrong}: #{inspect(error.errors)}")
+
       {:publish, error} ->
         Logger.error(fn ->
           [
             @smth_went_wrong,
+            ": ",
             inspect(error)
           ]
         end)

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -5,7 +5,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
 
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
-  alias Explorer.SmartContract.CompilerVersion
+  alias Explorer.SmartContract.{CompilerVersion, Helper}
   alias Explorer.SmartContract.Solidity.Verifier
 
   @doc """
@@ -91,7 +91,10 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   end
 
   defp unverified_smart_contract(address_hash, params, error, error_message, json_verification \\ false) do
-    attrs = attributes(address_hash, params)
+    attrs =
+      address_hash
+      |> attributes(params)
+      |> Helper.add_contract_code_md5()
 
     changeset =
       SmartContract.invalid_contract_changeset(


### PR DESCRIPTION
## Motivation

An error like this on smart-contract verification with wrong data:
```
2022-04-12T13:51:39.560 application=block_scout_web request_id=FuUqcBSo6HEjK1cAADtS [error] Something went wrong while publishing the contract.{:error, #Ecto.Changeset<action: :insert, changes: %{address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<55, 208, 237, 37, 143, 55, 169, 102, 243, 59, 117, 181, 174, 116, 134, 145, 122, 10, 230, 20>>}, compiler_version: "0.8.13+commit.abaa5c0e", contract_source_code: "pragma solidity ^0.8.0; contract Example { }", is_vyper_contract: false, name: "Example", optimization: false, optimization_runs: 200}, errors: [contract_source_code: {"There was an error compiling your contract.", []}, contract_code_md5: {"can't be blank", [validation: :required]}], data: #Explorer.Chain.SmartContract<>, valid?: false>}
```

## Changelog

add md5 of smart-contract's bytecode to the changeset

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
