### PR TITLE
Fix internal transaction fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement
 
 ### Fixes
+- [#5457](https://github.com/blockscout/blockscout/pull/5457) - Fix internal transaction fetching with `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true`
 - [#5455](https://github.com/blockscout/blockscout/pull/5455) - Fix unverified_smart_contract function: add md5 of bytecode to the changeset
 - [#5443](https://github.com/blockscout/blockscout/pull/5443) - Geth: display tx revert reason
 - [#5416](https://github.com/blockscout/blockscout/pull/5416) - Fix getsourcecode for EOA addresses

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -14,6 +14,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Chain.Import.Runner.Tokens
   alias Explorer.Repo, as: ExplorerRepo
+  alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
 
   @behaviour Runner
 
@@ -320,7 +321,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   end
 
   defp new_pending_operations(repo, nonconsensus_hashes, hashes, %{timeout: timeout, timestamps: timestamps}) do
-    if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.RSK do
+    if InternalTransactionSupervisor.disabled?() || Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.RSK do
       {:ok, []}
     else
       sorted_pending_ops =

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -321,7 +321,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   end
 
   defp new_pending_operations(repo, nonconsensus_hashes, hashes, %{timeout: timeout, timestamps: timestamps}) do
-    if InternalTransactionSupervisor.disabled?() || Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.RSK do
+    if InternalTransactionSupervisor.disabled?() ||
+         Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.RSK do
       {:ok, []}
     else
       sorted_pending_ops =


### PR DESCRIPTION
Fix `Indexing tokens - We're indexing this chain right now. Some of the counts may be inaccurate.` with `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true`

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues]
If start with `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true`, Since there is data in the pending_block_operations table, `Indexing tokens` will always be displayed

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
