### PR TITLE
Split multiple functions arguments to separate query args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 - [#5488](https://github.com/blockscout/blockscout/pull/5488) - Split long contract output to multiple lines
 - [#5487](https://github.com/blockscout/blockscout/pull/5487) - Fix array displaying in decoded constructor args
+- [#5482](https://github.com/blockscout/blockscout/pull/5482) - Fix for querying of the contract read functions
 - [#5455](https://github.com/blockscout/blockscout/pull/5455) - Fix unverified_smart_contract function: add md5 of bytecode to the changeset
 - [#5454](https://github.com/blockscout/blockscout/pull/5454) - Docker: Fix the qemu-x86_64 signal 11 error on Apple Silicon
 - [#5443](https://github.com/blockscout/blockscout/pull/5443) - Geth: display tx revert reason

--- a/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/interact.js
@@ -4,22 +4,23 @@ import { compareChainIDs, formatError, formatTitleAndError, getContractABI, getC
 import BigNumber from 'bignumber.js'
 
 export const queryMethod = (isWalletEnabled, url, $methodId, args, type, functionName, $responseContainer) => {
-  let data = {
+  const data = {
     function_name: functionName,
     method_id: $methodId.val(),
-    type: type,
-    args
+    type: type
   }
+
+  data.args_count = args.length
+  let i = args.length
+
+  while (i--) {
+    data['arg_' + i] = args[i]
+  }
+
   if (isWalletEnabled) {
     getCurrentAccountPromise(window.web3 && window.web3.currentProvider)
       .then((currentAccount) => {
-        data = {
-          function_name: functionName,
-          method_id: $methodId.val(),
-          type: type,
-          from: currentAccount,
-          args
-        }
+        data.from = currentAccount
         $.get(url, data, response => $responseContainer.html(response))
       }
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -105,8 +105,12 @@ defmodule BlockScoutWeb.SmartContractController do
          {:ok, _address} <- Chain.find_contract_address(address_hash, address_options, true) do
       contract_type = if params["type"] == "proxy", do: :proxy, else: :regular
 
-      # we should convert: %{"0" => _, "1" => _} to [_, _]
-      args = params["args"] |> convert_map_to_array()
+      {args_count, _} = Integer.parse(params["args_count"])
+
+      args =
+        if args_count < 1,
+          do: [],
+          else: for(x <- 0..(args_count - 1), do: params["arg_" <> to_string(x)] |> convert_map_to_array())
 
       %{output: outputs, names: names} =
         if params["from"] do

--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -250,6 +250,7 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
           Address.checksum(smart_contract.address_hash),
           function_name: "get",
           method_id: "6d4ce63c",
+          args_count: 0,
           args: []
         )
 


### PR DESCRIPTION
Close #4870 
Close #5478 

## Changelog
- Split multiple functions arguments to separate query args:
- - add `args_count` parameter
- - other parameters has name like `arg_{x}`

![image](https://user-images.githubusercontent.com/32202610/164030413-809bf620-6196-4f18-aca1-8781f900b256.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
