### PR TITLE
Sequential blocks broadcast on the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#5491](https://github.com/blockscout/blockscout/pull/5491) - Sequential blocks broadcast on the main page
 - [#5312](https://github.com/blockscout/blockscout/pull/5312) - Add OpenZeppelin proxy storage slot
 - [#5302](https://github.com/blockscout/blockscout/pull/5302) - Add specific tx receipt fields for the GoQuorum client
 - [#5268](https://github.com/blockscout/blockscout/pull/5268) - Contract names display improvement

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -17,10 +17,12 @@ defmodule BlockScoutWeb.Notifier do
   alias Explorer.Chain.{Address, InternalTransaction, TokenTransfer, Transaction}
   alias Explorer.Chain.Supply.RSK
   alias Explorer.Chain.Transaction.History.TransactionStats
-  alias Explorer.Counters.AverageBlockTime
+  alias Explorer.Counters.{AverageBlockTime, Helper}
   alias Explorer.ExchangeRates.Token
   alias Explorer.SmartContract.{CompilerVersion, Solidity.CodeCompiler}
   alias Phoenix.View
+
+  @check_broadcast_sequence_period 500
 
   def handle_event({:chain_event, :addresses, type, addresses}) when type in [:realtime, :on_demand] do
     Endpoint.broadcast("addresses:new_address", "count", %{count: Chain.address_estimated_count()})
@@ -87,7 +89,13 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :blocks, :realtime, blocks}) do
-    Enum.each(blocks, &broadcast_block/1)
+    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
+
+    blocks
+    |> Enum.sort_by(& &1.number, :asc)
+    |> Enum.each(fn block ->
+      broadcast_latest_block?(block, last_broadcasted_block_number)
+    end)
   end
 
   def handle_event({:chain_event, :exchange_rate}) do
@@ -227,6 +235,35 @@ defmodule BlockScoutWeb.Notifier do
       ratio: Decimal.to_string(ratio),
       finished: finished?
     })
+  end
+
+  defp broadcast_latest_block?(block, last_broadcasted_block_number) do
+    cond do
+      last_broadcasted_block_number == 0 || last_broadcasted_block_number == block.number - 1 ||
+          last_broadcasted_block_number < block.number - 4 ->
+        broadcast_block(block)
+        :ets.insert(:last_broadcasted_block, {:number, block.number})
+
+      last_broadcasted_block_number > block.number - 1 ->
+        broadcast_block(block)
+
+      true ->
+        Task.start_link(fn ->
+          schedule_broadcasting(block)
+        end)
+    end
+  end
+
+  defp schedule_broadcasting(block) do
+    :timer.sleep(@check_broadcast_sequence_period)
+    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
+
+    if last_broadcasted_block_number == block.number - 1 do
+      broadcast_block(block)
+      :ets.insert(:last_broadcasted_block, {:number, block.number})
+    else
+      schedule_broadcasting(block)
+    end
   end
 
   defp broadcast_address_coin_balance(%{address_hash: address_hash, block_number: block_number}) do

--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -7,6 +7,7 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   alias BlockScoutWeb.Notifier
   alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Counters.Helper
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -14,6 +15,7 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   @impl true
   def init([]) do
+    Helper.create_cache_table(:last_broadcasted_block)
     Subscriber.to(:address_coin_balances, :realtime)
     Subscriber.to(:addresses, :realtime)
     Subscriber.to(:block_rewards, :realtime)


### PR DESCRIPTION
## Motivation

Prevent broadcasting new block if previous one wasn't indexed yet. The fix is aimed to prevent situation like on this screenshot:

<img width="1380" alt="Screenshot-2022-04-12-at-18-00-17 (1)" src="https://user-images.githubusercontent.com/4341812/164741682-c4c69952-a779-4437-bd86-ba0708575b9d.png">


## Changelog

- Store last broadcasted block number in in-memory cache (ETS).
- If block to be broadcasted has number > cached last broadcasted number + 1, broadcast function waits until previous blocks broadcasted by periodically requesting cached last broadcasted block number value every 0.5 sec.
- In case of 4 blocks gap, which is the maximum number of blocks on the main page, broadcast is allowed again.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
