### PR TITLE
Do not fill pending blocks ops with block numbers below TRACE_FIRST_BLOCK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268), [#5313](https://github.com/blockscout/blockscout/pull/5313) - Contract names display improvement
 
 ### Fixes
+- [#5513](https://github.com/blockscout/blockscout/pull/5513) - Do not fill pending blocks ops with block numbers below TRACE_FIRST_BLOCK
 - [#5508](https://github.com/blockscout/blockscout/pull/5508) - Hide indexing banner if we fetched internal transactions from TRACE_FIRST_BLOCK
 - [#5504](https://github.com/blockscout/blockscout/pull/5504) - Extend TRACE_FIRST_BLOCK env var to geth variant
 - [#5488](https://github.com/blockscout/blockscout/pull/5488) - Split long contract output to multiple lines

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -313,7 +313,7 @@ defmodule EthereumJSONRPC do
   end
 
   def block_numbers_in_range(block_numbers) do
-    min_block = trace_first_block_to_fetch()
+    min_block = first_block_to_fetch(:trace_first_block)
 
     block_numbers
     |> Enum.filter(fn block_number ->
@@ -483,10 +483,6 @@ defmodule EthereumJSONRPC do
            |> json_rpc(json_rpc_named_arguments) do
       {:ok, Blocks.from_responses(responses, id_to_params)}
     end
-  end
-
-  defp trace_first_block_to_fetch do
-    first_block_to_fetch(:trace_first_block)
   end
 
   def first_block_to_fetch(config) do

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -46,19 +46,42 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       |> Map.put(:timestamps, timestamps)
 
     hashes = Enum.map(changes_list, & &1.hash)
+
+    minimal_block_height = trace_minimal_block_height()
+
+    hashes_for_pending_block_operations =
+      if minimal_block_height > 0 do
+        changes_list
+        |> Enum.filter(&(&1.number >= minimal_block_height))
+        |> Enum.map(& &1.hash)
+      else
+        hashes
+      end
+
     consensus_block_numbers = consensus_block_numbers(changes_list)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
     multi
     |> Multi.run(:lose_consensus, fn repo, _ ->
-      lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
+      {:ok, nonconsensus_items} = lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
+
+      nonconsensus_hashes =
+        if minimal_block_height > 0 do
+          nonconsensus_items
+          |> Enum.filter(fn {number, _hash} -> number >= minimal_block_height end)
+          |> Enum.map(fn {_number, hash} -> hash end)
+        else
+          hashes
+        end
+
+      {:ok, nonconsensus_hashes}
     end)
     |> Multi.run(:blocks, fn repo, _ ->
       # Note, needs to be executed after `lose_consensus` for lock acquisition
       insert(repo, changes_list, insert_options)
     end)
     |> Multi.run(:new_pending_operations, fn repo, %{lose_consensus: nonconsensus_hashes} ->
-      new_pending_operations(repo, nonconsensus_hashes, hashes, insert_options)
+      new_pending_operations(repo, nonconsensus_hashes, hashes_for_pending_block_operations, insert_options)
     end)
     |> Multi.run(:uncle_fetched_block_second_degree_relations, fn repo, _ ->
       update_block_second_degree_relations(repo, hashes, %{
@@ -298,7 +321,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           on: block.hash == s.hash,
           # we don't want to remove consensus from blocks that will be upserted
           where: block.hash not in ^hashes,
-          select: block.hash
+          select: {block.number, block.hash}
         ),
         [set: [consensus: false, updated_at: updated_at]],
         timeout: timeout
@@ -319,7 +342,14 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     lose_consensus(ExplorerRepo, [], block_numbers, [], opts)
   end
 
-  defp new_pending_operations(repo, nonconsensus_hashes, hashes, %{timeout: timeout, timestamps: timestamps}) do
+  defp trace_minimal_block_height do
+    EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
+  end
+
+  defp new_pending_operations(repo, nonconsensus_hashes, hashes, %{
+         timeout: timeout,
+         timestamps: timestamps
+       }) do
     if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.RSK do
       {:ok, []}
     else

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -609,7 +609,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   end
 
   defp remove_consensus_of_invalid_blocks(repo, invalid_block_numbers) do
-    minimal_block = first_block_to_fetch()
+    minimal_block = EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
 
     if Enum.count(invalid_block_numbers) > 0 do
       update_query =
@@ -641,10 +641,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     else
       {:ok, []}
     end
-  end
-
-  def first_block_to_fetch do
-    EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
   end
 
   def update_pending_blocks_status(repo, pending_hashes, invalid_block_hashes) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5499

## Motivation

If `TRACE_FIRST_BLOCK` environment variable is set, Blockscout continues to fill `pending_block_operations` table below that block height, which it shouldn't do because internal transactions will not be fetched for those blocks.

## Changelog

Prevent filling `pending_block_operations` table with blocks, which numbers lower than `TRACE_FIRST_BLOCK`.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
