### PR TITLE
Token balances fetcher retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5268](https://github.com/blockscout/blockscout/pull/5268), [#5313](https://github.com/blockscout/blockscout/pull/5313) - Contract names display improvement
 
 ### Fixes
+- [#5528](https://github.com/blockscout/blockscout/pull/5528) - Token balances fetcher retry
 - [#5524](https://github.com/blockscout/blockscout/pull/5524) - ContractState module resistance to unresponsive archive node
 - [#5513](https://github.com/blockscout/blockscout/pull/5513) - Do not fill pending blocks ops with block numbers below TRACE_FIRST_BLOCK
 - [#5508](https://github.com/blockscout/blockscout/pull/5508) - Hide indexing banner if we fetched internal transactions from TRACE_FIRST_BLOCK

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -87,7 +87,13 @@ defmodule Indexer.TokenBalances do
     |> unfetched_token_balances(fetched_token_balances)
     |> schedule_token_balances
 
-    {:ok, fetched_token_balances}
+    failed_token_balances =
+      requested_token_balances
+      |> MapSet.new()
+      |> MapSet.difference(MapSet.new(fetched_token_balances))
+      |> MapSet.to_list()
+
+    {:ok, %{fetched_token_balances: fetched_token_balances, failed_token_balances: failed_token_balances}}
   end
 
   def to_address_current_token_balances(address_token_balances) when is_list(address_token_balances) do

--- a/apps/indexer/test/indexer/token_balances_test.exs
+++ b/apps/indexer/test/indexer/token_balances_test.exs
@@ -46,7 +46,7 @@ defmodule Indexer.TokenBalancesTest do
                address_hash: ^address_hash_string,
                block_number: 1_000,
                value_fetched_at: _
-             } = List.first(result)
+             } = List.first(result.fetched_token_balances)
     end
 
     test "fetches balances of ERC-1155 tokens" do
@@ -74,15 +74,18 @@ defmodule Indexer.TokenBalancesTest do
 
       {:ok, result} = TokenBalances.fetch_token_balances_from_blockchain(data)
 
-      assert [
-               %{
-                 value: 2,
-                 token_contract_address_hash: ^token_contract_address_hash,
-                 address_hash: ^address_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               }
-             ] = result
+      assert %{
+               failed_token_balances: [],
+               fetched_token_balances: [
+                 %{
+                   value: 2,
+                   token_contract_address_hash: ^token_contract_address_hash,
+                   address_hash: ^address_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 }
+               ]
+             } = result
     end
 
     test "fetches multiple balances of tokens" do
@@ -166,60 +169,63 @@ defmodule Indexer.TokenBalancesTest do
 
       {:ok, result} = TokenBalances.fetch_token_balances_from_blockchain(data)
 
-      assert [
-               %{
-                 value: 1_000_000_000_000_000_000_000_000,
-                 token_contract_address_hash: ^token_1_contract_address_hash,
-                 address_hash: ^address_1_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 3_000_000_000_000_000_000_000_000_000,
-                 token_contract_address_hash: ^token_2_contract_address_hash,
-                 address_hash: ^address_2_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 1,
-                 token_contract_address_hash: ^token_3_contract_address_hash,
-                 address_hash: ^address_2_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 6_000_000_000_000_000_000_000_000_000,
-                 token_contract_address_hash: ^token_2_contract_address_hash,
-                 address_hash: ^token_2_contract_address_hash,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 5_000_000_000_000_000_000_000_000_000,
-                 token_contract_address_hash: ^token_2_contract_address_hash,
-                 address_hash: ^address_3_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 6_000_000_000_000_000_000_000_000_000,
-                 token_contract_address_hash: ^token_2_contract_address_hash,
-                 address_hash: ^token_2_contract_address_hash,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               },
-               %{
-                 value: 2,
-                 token_contract_address_hash: ^token_4_contract_address_hash,
-                 address_hash: ^address_2_hash_string,
-                 block_number: 1_000,
-                 value_fetched_at: _
-               }
-             ] = result
+      assert %{
+               failed_token_balances: [],
+               fetched_token_balances: [
+                 %{
+                   value: 1_000_000_000_000_000_000_000_000,
+                   token_contract_address_hash: ^token_1_contract_address_hash,
+                   address_hash: ^address_1_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 3_000_000_000_000_000_000_000_000_000,
+                   token_contract_address_hash: ^token_2_contract_address_hash,
+                   address_hash: ^address_2_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 1,
+                   token_contract_address_hash: ^token_3_contract_address_hash,
+                   address_hash: ^address_2_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 6_000_000_000_000_000_000_000_000_000,
+                   token_contract_address_hash: ^token_2_contract_address_hash,
+                   address_hash: ^token_2_contract_address_hash,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 5_000_000_000_000_000_000_000_000_000,
+                   token_contract_address_hash: ^token_2_contract_address_hash,
+                   address_hash: ^address_3_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 6_000_000_000_000_000_000_000_000_000,
+                   token_contract_address_hash: ^token_2_contract_address_hash,
+                   address_hash: ^token_2_contract_address_hash,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 },
+                 %{
+                   value: 2,
+                   token_contract_address_hash: ^token_4_contract_address_hash,
+                   address_hash: ^address_2_hash_string,
+                   block_number: 1_000,
+                   value_fetched_at: _
+                 }
+               ]
+             } = result
     end
 
-    test "ignores calls that gave errors to try fetch they again later" do
+    test "returns calls that gave errors to try fetch they again later" do
       address = insert(:address, hash: "0x7113ffcb9c18a97da1b9cfc43e6cb44ed9165509")
       token = insert(:token, contract_address: build(:contract_address))
 
@@ -236,7 +242,24 @@ defmodule Indexer.TokenBalancesTest do
 
       get_balance_from_blockchain_with_error()
 
-      assert TokenBalances.fetch_token_balances_from_blockchain(token_balances) == {:ok, []}
+      assert TokenBalances.fetch_token_balances_from_blockchain(token_balances) ==
+               {:ok,
+                %{
+                  failed_token_balances: [
+                    %{
+                      address_hash: "0x7113ffcb9c18a97da1b9cfc43e6cb44ed9165509",
+                      block_number: 1000,
+                      error: "(-32015) VM execution error. (Reverted 0x)",
+                      retries_count: 1,
+                      token_contract_address_hash: to_string(token.contract_address_hash),
+                      token_id: 11,
+                      token_type: "ERC-20",
+                      value: nil,
+                      value_fetched_at: nil
+                    }
+                  ],
+                  fetched_token_balances: []
+                }}
     end
   end
 


### PR DESCRIPTION
## Motivation

If token balance fething failed, retry of fetching work only with restart of the application.


## Changelog

Retry fetching of failed token balances on-fly in `TokenBalance.run/2` up to 3 times. It should mititgate the issue with empty current token balances.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
