### PR TITLE
Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#5538](https://github.com/blockscout/blockscout/pull/5538) - Fix internal transaction's tile bug
 
 ### Chore
+- [#5543](https://github.com/blockscout/blockscout/pull/5543) - Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors
 - [#5536](https://github.com/blockscout/blockscout/pull/5536) - NPM audit fix
 
 

--- a/apps/block_scout_web/assets/js/pages/transaction.js
+++ b/apps/block_scout_web/assets/js/pages/transaction.js
@@ -53,7 +53,12 @@ if ($transactionDetailsPage.length) {
   connectElements({ store, elements })
 
   const pathParts = window.location.pathname.split('/')
-  if (pathParts.length > 3 && pathParts[3] !== '') {
+  const shouldScroll = pathParts.includes('internal-transactions') ||
+  pathParts.includes('token-transfers') ||
+  pathParts.includes('logs') ||
+  pathParts.includes('token-transfers') ||
+  pathParts.includes('raw-trace')
+  if (shouldScroll) {
     document.getElementById('transaction-tabs').scrollIntoView()
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.Application do
       {BlocksIndexedCounter, name: BlocksIndexedCounter}
     ]
 
-    opts = [strategy: :one_for_one, name: BlockScoutWeb.Supervisor]
+    opts = [strategy: :one_for_one, name: BlockScoutWeb.Supervisor, max_restarts: 1_000]
     Supervisor.start_link(children, opts)
   end
 

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -68,7 +68,7 @@ defmodule Explorer.Application do
 
     children = base_children ++ configurable_children()
 
-    opts = [strategy: :one_for_one, name: Explorer.Supervisor]
+    opts = [strategy: :one_for_one, name: Explorer.Supervisor, max_restarts: 1_000]
 
     Supervisor.start_link(children, opts)
   end

--- a/apps/explorer/lib/explorer/staking/contract_state.ex
+++ b/apps/explorer/lib/explorer/staking/contract_state.ex
@@ -163,7 +163,7 @@ defmodule Explorer.Staking.ContractState do
            contracts: %{
              staking: staking_contract_address
            }
-         }, {:continue, []}}
+         }, {:stop, "The archive node is unavailable"}}
     end
   end
 

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -268,7 +268,20 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
           task: %Task{ref: ref}
         } = state
       ) do
-    Logger.info("Index had to catch up, but the but request is timing out, so retrying immediately.")
+    Logger.info("Index had to catch up, but the request is timing out, so retrying immediately.")
+
+    send(self(), :catchup_index)
+
+    {:noreply, %__MODULE__{state | task: nil}}
+  end
+
+  def handle_info(
+        {_ref1, {:error, :enetunreach}},
+        %__MODULE__{
+          task: _
+        } = state
+      ) do
+    Logger.info("Index had to catch up, but the request is timing out, so retrying immediately.")
 
     send(self(), :catchup_index)
 


### PR DESCRIPTION
## Motivation

Increase the number of restarts of the explorer and block_scout_web applications from default 3 to 1000.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
