### PR TITLE
Allow hyphen in DB password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#5538](https://github.com/blockscout/blockscout/pull/5538) - Fix internal transaction's tile bug
 
 ### Chore
+- [#5623](https://github.com/blockscout/blockscout/pull/5623) - Allow hyphen in DB password
 - [#5543](https://github.com/blockscout/blockscout/pull/5543) - Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors
 - [#5536](https://github.com/blockscout/blockscout/pull/5536) - NPM audit fix
 

--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -2,8 +2,8 @@ defmodule Explorer.ExchangeRates.Source do
   @moduledoc """
   Behaviour for fetching exchange rates from external sources.
   """
-  alias Explorer.ExchangeRates.{Source, Token}
   alias Explorer.ExchangeRates.Source.CoinGecko
+  alias Explorer.ExchangeRates.Token
   alias HTTPoison.{Error, Response}
 
   @doc """

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -29,7 +29,7 @@ defmodule Explorer.Repo.ConfigHelper do
 
   # sobelow_skip ["DOS.StringToAtom"]
   defp extract_parameters(database_url) do
-    ~r/\w*:\/\/(?<username>\w+):(?<password>\w*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>\w+)/
+    ~r/\w*:\/\/(?<username>\w+):(?<password>[a-zA-Z0-9_-]*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>\w+)/
     |> Regex.named_captures(database_url)
     |> Keyword.new(fn {k, v} -> {String.to_atom(k), v} end)
     |> Keyword.put(:url, database_url)

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -28,6 +28,18 @@ defmodule Explorer.Repo.ConfigHelperTest do
       assert result[:database] == "test_database"
     end
 
+    test "parse params from database url with hyphen in password" do
+      database_url = "postgresql://test_username:test-password@hostname.test.com:7777/test_database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test_username"
+      assert result[:password] == "test-password"
+      assert result[:hostname] == "hostname.test.com"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
     test "get username without password" do
       database_url = "postgresql://test_username:@127.8.8.1:7777/test_database"
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5608

## Motivation

Hyphen is not allowed in the DB password

## Changelog

Allow hyphen in DB password since it is not prohibited on DB connection level.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
