### PR TITLE
Get rid of some redirects to checksummed address url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#5538](https://github.com/blockscout/blockscout/pull/5538) - Fix internal transaction's tile bug
 
 ### Chore
+- [#5625](https://github.com/blockscout/blockscout/pull/5625) - Get rid of some redirects to checksummed address url
 - [#5543](https://github.com/blockscout/blockscout/pull/5543) - Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors
 - [#5536](https://github.com/blockscout/blockscout/pull/5536) - NPM audit fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@
 - [#5538](https://github.com/blockscout/blockscout/pull/5538) - Fix internal transaction's tile bug
 
 ### Chore
-- [#5623](https://github.com/blockscout/blockscout/pull/5623) - Allow hyphen in DB password
 - [#5625](https://github.com/blockscout/blockscout/pull/5625) - Get rid of some redirects to checksummed address url
+- [#5623](https://github.com/blockscout/blockscout/pull/5623) - Allow hyphen in DB password
 - [#5543](https://github.com/blockscout/blockscout/pull/5543) - Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors
 - [#5536](https://github.com/blockscout/blockscout/pull/5536) - NPM audit fix
 

--- a/apps/block_scout_web/lib/phoenix/param.ex
+++ b/apps/block_scout_web/lib/phoenix/param.ex
@@ -1,8 +1,14 @@
 alias Explorer.Chain.{Address, Block, Hash, Transaction}
 
-defimpl Phoenix.Param, for: [Address, Transaction] do
+defimpl Phoenix.Param, for: Transaction do
   def to_param(%@for{hash: hash}) do
     @protocol.to_param(hash)
+  end
+end
+
+defimpl Phoenix.Param, for: Address do
+  def to_param(%@for{} = address) do
+    @for.checksum(address)
   end
 end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/tokens/holder_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.Tokens.HolderControllerTest do
   use BlockScoutWeb.ConnCase, async: true
 
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Address, Hash}
 
   describe "GET index/3" do
     test "with invalid address hash", %{conn: conn} do
@@ -67,7 +67,7 @@ defmodule BlockScoutWeb.Tokens.HolderControllerTest do
 
       assert Enum.all?(second_page_token_balances, fn token_balance ->
                Enum.any?(token_balance_tiles, fn tile ->
-                 String.contains?(tile, to_string(token_balance.address_hash))
+                 String.contains?(tile, Address.checksum(token_balance.address_hash))
                end)
              end)
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_log_controller_test.exs
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
 
   import BlockScoutWeb.WebRouter.Helpers, only: [transaction_log_path: 3]
 
+  alias Explorer.Chain.Address
   alias Explorer.ExchangeRates.Token
 
   describe "GET index/2" do
@@ -44,7 +45,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       {:ok, %{"items" => items}} = conn.resp_body |> Poison.decode()
       first_log = List.first(items)
 
-      assert String.contains?(first_log, to_string(address.hash))
+      assert String.contains?(first_log, Address.checksum(address.hash))
     end
 
     test "returns logs for the transaction with nil to_address", %{conn: conn} do
@@ -67,7 +68,7 @@ defmodule BlockScoutWeb.TransactionLogControllerTest do
       {:ok, %{"items" => items}} = conn.resp_body |> Poison.decode()
       first_log = List.first(items)
 
-      assert String.contains?(first_log, to_string(address.hash))
+      assert String.contains?(first_log, Address.checksum(address.hash))
     end
 
     test "assigns no logs when there are none", %{conn: conn} do


### PR DESCRIPTION
## Motivation

urls for fetching transaction (and other) pages returned by backend contains non checksummed address hash. It leads to redirect when clients fetch page and as the consequence larger waiting time 

## Changelog

### Enhancements
- change Phoenix.Param implementation. Now it returns checksummed address_hash for address
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
