### PR TITLE
Fix empty coin balance for empty address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#5540](https://github.com/blockscout/blockscout/pull/5540) - Tx page: scroll to selected tab's data
 
 ### Fixes
+- [#5629](https://github.com/blockscout/blockscout/pull/5629) - Fix empty coin balance for empty address
 - [#5626](https://github.com/blockscout/blockscout/pull/5626) - Fix vyper compiler versions order
 - [#5603](https://github.com/blockscout/blockscout/pull/5603) - Fix failing verification attempts
 - [#5598](https://github.com/blockscout/blockscout/pull/5598) - Fix token dropdown

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
   alias BlockScoutWeb.{AccessHelpers, AddressCoinBalanceView, Controller}
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.Address
+  alias Explorer.Chain.{Address, Wei}
   alias Explorer.ExchangeRates.Token
   alias Indexer.Fetcher.CoinBalanceOnDemand
   alias Phoenix.View
@@ -84,7 +84,13 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
       {:error, :not_found} ->
         {:ok, address_hash} = Chain.string_to_address_hash(address_hash_string)
-        address = %Chain.Address{hash: address_hash, smart_contract: nil, token: nil}
+
+        address = %Chain.Address{
+          hash: address_hash,
+          smart_contract: nil,
+          token: nil,
+          fetched_coin_balance: %Wei{value: Decimal.new(0)}
+        }
 
         case Chain.Hash.Address.validate(address_hash_string) do
           {:ok, _} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_internal_transaction_controller.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.AddressInternalTransactionController do
 
   alias BlockScoutWeb.{AccessHelpers, Controller, InternalTransactionView}
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.Address
+  alias Explorer.Chain.{Address, Wei}
   alias Explorer.ExchangeRates.Token
   alias Indexer.Fetcher.CoinBalanceOnDemand
   alias Phoenix.View
@@ -94,7 +94,13 @@ defmodule BlockScoutWeb.AddressInternalTransactionController do
 
       {:error, :not_found} ->
         {:ok, address_hash} = Chain.string_to_address_hash(address_hash_string)
-        address = %Chain.Address{hash: address_hash, smart_contract: nil, token: nil}
+
+        address = %Chain.Address{
+          hash: address_hash,
+          smart_contract: nil,
+          token: nil,
+          fetched_coin_balance: %Wei{value: Decimal.new(0)}
+        }
 
         case Chain.Hash.Address.validate(address_hash_string) do
           {:ok, _} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -14,7 +14,8 @@ defmodule BlockScoutWeb.AddressTransactionController do
     AddressInternalTransactionCsvExporter,
     AddressLogCsvExporter,
     AddressTokenTransferCsvExporter,
-    AddressTransactionCsvExporter
+    AddressTransactionCsvExporter,
+    Wei
   }
 
   alias Explorer.ExchangeRates.Token
@@ -130,7 +131,13 @@ defmodule BlockScoutWeb.AddressTransactionController do
 
       {:error, :not_found} ->
         {:ok, address_hash} = Chain.string_to_address_hash(address_hash_string)
-        address = %Chain.Address{hash: address_hash, smart_contract: nil, token: nil}
+
+        address = %Chain.Address{
+          hash: address_hash,
+          smart_contract: nil,
+          token: nil,
+          fetched_coin_balance: %Wei{value: Decimal.new(0)}
+        }
 
         case Chain.Hash.Address.validate(address_hash_string) do
           {:ok, _} ->


### PR DESCRIPTION
## Motivation
For empty addresses (aren't presented in DB) coin balance displayed as empty field:

![image](https://user-images.githubusercontent.com/32202610/171172439-6afba72a-15a0-4476-b4d3-b4f852b7b39e.png)

## Changelog

### Bug Fixes
![image](https://user-images.githubusercontent.com/32202610/171171404-978671f2-4bbe-4227-ad28-2dc10f3104e6.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
