### PR TITLE
Fix warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#5538](https://github.com/blockscout/blockscout/pull/5538) - Fix internal transaction's tile bug
 
 ### Chore
+- [#5640](https://github.com/blockscout/blockscout/pull/5640) - Clean up and fix tests, reduce amount of warnings
 - [#5625](https://github.com/blockscout/blockscout/pull/5625) - Get rid of some redirects to checksummed address url
 - [#5623](https://github.com/blockscout/blockscout/pull/5623) - Allow hyphen in DB password
 - [#5543](https://github.com/blockscout/blockscout/pull/5543) - Increase max_restarts to 1_000 (from 3 by default) for explorer, block_scout_web supervisors

--- a/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.AddressChannelTest do
     test "can retrieve current balance card of the address", %{socket: socket, address: address} do
       ref = push(socket, "get_balance", %{})
 
-      assert_reply(ref, :ok, %{balance: sent_balance, balance_card: balance_card})
+      assert_reply(ref, :ok, %{balance: sent_balance, balance_card: _balance_card})
 
       assert sent_balance == address.fetched_coin_balance.value
       # assert balance_card =~ "/address/#{address.hash}/token-balances"

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_read_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_read_contract_controller_test.exs
@@ -2,7 +2,6 @@ defmodule BlockScoutWeb.AddressReadContractControllerTest do
   use BlockScoutWeb.ConnCase, async: true
   use ExUnit.Case, async: false
 
-  alias BlockScoutWeb.AddressControllerTest
   alias Explorer.ExchangeRates.Token
   alias Explorer.Chain.Address
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_token_controller_test.exs
@@ -111,7 +111,7 @@ defmodule BlockScoutWeb.AddressTokenControllerTest do
         value: 1000
       )
 
-      %Token{name: name, type: type, inserted_at: inserted_at} = token
+      %Token{name: name, type: type, inserted_at: _inserted_at} = token
 
       conn =
         get(conn, address_token_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address.hash)), %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
   use BlockScoutWeb.ConnCase
   alias Explorer.Chain.SmartContract
-  alias Explorer.{Chain, Factory}
+  alias Explorer.Chain
+  # alias Explorer.{Chain, Factory}
 
   import Mox
 
@@ -832,23 +833,23 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
     })
   end
 
-  defp verify_schema do
-    resolve_schema(%{
-      "type" => "object",
-      "properties" => %{
-        "Address" => %{"type" => "string"},
-        "SourceCode" => %{"type" => "string"},
-        "ABI" => %{"type" => "string"},
-        "ContractName" => %{"type" => "string"},
-        "CompilerVersion" => %{"type" => "string"},
-        "DecompiledSourceCode" => %{"type" => "string"},
-        "DecompilerVersion" => %{"type" => "string"},
-        "OptimizationUsed" => %{"type" => "string"}
-      }
-    })
-  end
+  # defp verify_schema do
+  #   resolve_schema(%{
+  #     "type" => "object",
+  #     "properties" => %{
+  #       "Address" => %{"type" => "string"},
+  #       "SourceCode" => %{"type" => "string"},
+  #       "ABI" => %{"type" => "string"},
+  #       "ContractName" => %{"type" => "string"},
+  #       "CompilerVersion" => %{"type" => "string"},
+  #       "DecompiledSourceCode" => %{"type" => "string"},
+  #       "DecompilerVersion" => %{"type" => "string"},
+  #       "OptimizationUsed" => %{"type" => "string"}
+  #     }
+  #   })
+  # end
 
-  defp resolve_schema(result \\ %{}) do
+  defp resolve_schema(result) do
     %{
       "type" => "object",
       "properties" => %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -209,11 +209,11 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     })
   end
 
-  defp ethsupply_schema do
-    resolve_schema(%{
-      "type" => ["string", "null"]
-    })
-  end
+  # defp ethsupply_schema do
+  #   resolve_schema(%{
+  #     "type" => ["string", "null"]
+  #   })
+  # end
 
   defp ethsupplyexchange_schema do
     resolve_schema(%{
@@ -233,7 +233,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     })
   end
 
-  defp resolve_schema(result \\ %{}) do
+  defp resolve_schema(result) do
     %{
       "type" => "object",
       "properties" => %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v1/verified_smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v1/verified_smart_contract_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V1.VerifiedControllerTest do
   use BlockScoutWeb.ConnCase
 
-  alias Explorer.Factory
+  # alias Explorer.Factory
 
   # alias Explorer.Chain.DecompiledSmartContract
 
@@ -76,7 +76,7 @@ defmodule BlockScoutWeb.API.V1.VerifiedControllerTest do
   #   assert Jason.decode!(response.resp_body) == %{"status" => "success"}
   # end
 
-  defp api_v1_verified_smart_contract_path(conn, action) do
-    "/api" <> ApiRoutes.api_v1_verified_smart_contract_path(conn, action)
-  end
+  # defp api_v1_verified_smart_contract_path(conn, action) do
+  #   "/api" <> ApiRoutes.api_v1_verified_smart_contract_path(conn, action)
+  # end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/chain_controller_test.exs
@@ -205,21 +205,21 @@ defmodule BlockScoutWeb.ChainControllerTest do
 
       "0x" <> non_prefix_hash = to_string(transaction.hash)
 
-      conn = get(conn, "search?q=#{to_string(non_prefix_hash)}")
+      conn = get(conn, "/search?q=#{to_string(non_prefix_hash)}")
 
       assert redirected_to(conn) == transaction_path(conn, :show, transaction)
     end
 
     test "finds an address by hash", %{conn: conn} do
       address = insert(:address)
-      conn = get(conn, "search?q=#{to_string(address.hash)}")
+      conn = get(conn, "/search?q=#{to_string(address.hash)}")
 
       assert redirected_to(conn) == address_path(conn, :show, address)
     end
 
     test "finds an address by hash when there are extra spaces", %{conn: conn} do
       address = insert(:address)
-      conn = get(conn, "search?q=#{to_string(address.hash)}")
+      conn = get(conn, "/search?q=#{to_string(address.hash)}")
 
       assert redirected_to(conn) == address_path(conn, :show, address)
     end
@@ -228,13 +228,13 @@ defmodule BlockScoutWeb.ChainControllerTest do
       address = insert(:address)
       "0x" <> non_prefix_hash = to_string(address.hash)
 
-      conn = get(conn, "search?q=#{to_string(non_prefix_hash)}")
+      conn = get(conn, "/search?q=#{to_string(non_prefix_hash)}")
 
       assert redirected_to(conn) == address_path(conn, :show, address)
     end
 
     test "redirects to result page when it finds nothing", %{conn: conn} do
-      conn = get(conn, "search?q=zaphod")
+      conn = get(conn, "/search?q=zaphod")
       assert conn.status == 302
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_controller_test.exs
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.TransactionControllerTest do
   use BlockScoutWeb.ConnCase
 
   import BlockScoutWeb.WebRouter.Helpers,
-    only: [transaction_path: 3, transaction_internal_transaction_path: 3, transaction_token_transfer_path: 3]
+    only: [transaction_path: 3]
 
   alias Explorer.Chain.Transaction
 

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -604,13 +604,13 @@ defmodule EthereumJSONRPCTest do
       # Can't be faked reliably on real chain
       moxed_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
 
-      unknown_error = {:error, %{"code" => 500, "message" => "Unknown error"}}
+      unknown_error = %{"code" => 500, "message" => "Unknown error"}
 
       expect(EthereumJSONRPC.Mox, :json_rpc, fn _json, _options ->
-        unknown_error
+        {:error, unknown_error}
       end)
 
-      assert {:error, unknown_error} =
+      assert {:error, ^unknown_error} =
                EthereumJSONRPC.fetch_block_number_by_tag("latest", moxed_json_rpc_named_arguments)
     end
   end

--- a/apps/explorer/test/explorer/chain/cache/uncles_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/uncles_test.exs
@@ -21,7 +21,7 @@ defmodule Explorer.Chain.Cache.UnclesTest do
 
       Uncles.update_from_second_degree_relations([second_degree_relation])
 
-      assert [%{hash: uncle_hash}] = Uncles.all()
+      assert [%{hash: ^uncle_hash}] = Uncles.all()
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
               %{
                 address_token_balances: [
                   %TokenBalance{
-                    address_hash: address_hash,
+                    address_hash: ^address_hash,
                     block_number: ^block_number,
                     token_contract_address_hash: ^token_contract_address_hash,
                     value: ^value,

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -647,7 +647,8 @@ defmodule Explorer.Chain.ImportTest do
 
       assert {:ok, _} = Import.all(options)
 
-      assert [block_hash] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      {:ok, block_hash_casted} = Explorer.Chain.Hash.Full.cast(block_hash)
+      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
 
       assert {:ok, _} = Import.all(internal_txs_options)
 
@@ -736,7 +737,8 @@ defmodule Explorer.Chain.ImportTest do
 
       assert {:ok, _} = Import.all(options)
 
-      assert [block_hash] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      {:ok, block_hash_casted} = Explorer.Chain.Hash.Full.cast(block_hash)
+      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
 
       assert {:ok, _} = Import.all(internal_txs_options)
 

--- a/apps/explorer/test/explorer/chain/supply/token_bridge_test.exs
+++ b/apps/explorer/test/explorer/chain/supply/token_bridge_test.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Supply.TokenBridgeTest do
 
   import Mox
 
-  alias Explorer.Chain.Supply.TokenBridge
+  # alias Explorer.Chain.Supply.TokenBridge
 
   @moduletag :capture_log
 

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -382,7 +382,7 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       abi = [method]
       method_with_id = Map.put(method, "method_id", "0cbf0601")
-      assert [method_with_id] = Reader.get_abi_with_method_id(abi)
+      assert [^method_with_id] = Reader.get_abi_with_method_id(abi)
     end
 
     test "do not crash in some corner cases" do
@@ -399,7 +399,7 @@ defmodule Explorer.SmartContract.ReaderTest do
         }
       ]
 
-      assert abi = Reader.get_abi_with_method_id(abi)
+      assert ^abi = Reader.get_abi_with_method_id(abi)
     end
   end
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -1222,8 +1222,7 @@ defmodule Explorer.SmartContract.Solidity.VerifierTest do
       assert {:ok,
               %{
                 abi: abi,
-                constructor_arguments:
-                  "000000000000000000000000fb5a36f0e12cef9f88d95f0e02cad4ba183336dc0000000000000000000000000000000000000000000000000000000000000032"
+                constructor_arguments: ^constructor_arguments
               }} = Verifier.evaluate_authenticity(contract_address.hash, params)
 
       assert abi != nil

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -425,7 +425,7 @@ defmodule Indexer.Block.Catchup.FetcherTest do
       assert count(Chain.Block) == 1
       assert count(Reward) == 0
 
-      assert_receive {:block_numbers, [block_number]}, 5_000
+      assert_receive {:block_numbers, [^block_number]}, 5_000
     end
 
     test "async fetches beneficiaries when entire call errors out", %{
@@ -568,7 +568,7 @@ defmodule Indexer.Block.Catchup.FetcherTest do
       assert count(Chain.Block) == 1
       assert count(Reward) == 0
 
-      assert_receive {:block_numbers, [block_number]}, 5_000
+      assert_receive {:block_numbers, [^block_number]}, 5_000
     end
   end
 

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -5,7 +5,6 @@ defmodule Indexer.Block.FetcherTest do
 
   import Mox
   import EthereumJSONRPC, only: [integer_to_quantity: 1]
-  import EthereumJSONRPC.Case
 
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Log, Transaction, Wei}
@@ -745,7 +744,7 @@ defmodule Indexer.Block.FetcherTest do
 
              %{id: id, method: "trace_block"} ->
                block_quantity = integer_to_quantity(block_number)
-               res = eth_block_number_fake_response(block_quantity)
+               _res = eth_block_number_fake_response(block_quantity)
 
                %{
                  id: id,
@@ -792,7 +791,7 @@ defmodule Indexer.Block.FetcherTest do
         end)
       end
 
-      assert {:ok, %{errors: [], inserted: %{block_rewards: block_rewards}}} =
+      assert {:ok, %{errors: [], inserted: %{block_rewards: _block_rewards}}} =
                Fetcher.fetch_and_import_range(block_fetcher, block_number..block_number)
 
       assert Repo.one!(select(Chain.Block.Reward, fragment("COUNT(*)"))) == 2

--- a/apps/indexer/test/indexer/fetcher/block_reward_test.exs
+++ b/apps/indexer/test/indexer/fetcher/block_reward_test.exs
@@ -117,7 +117,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       assert count(Chain.Block.Reward) == 0
 
@@ -192,7 +192,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       parent = self()
 
@@ -324,7 +324,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       assert count(Chain.Block.Reward) == 0
       assert count(Chain.Address.CoinBalance) == 0
@@ -414,7 +414,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       assert count(Chain.Block.Reward) == 0
       assert count(Chain.Address.CoinBalance) == 0
@@ -494,7 +494,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       assert count(Chain.Block.Reward) == 1
       assert count(Chain.Address.CoinBalance) == 1
@@ -635,7 +635,7 @@ defmodule Indexer.Fetcher.BlockRewardTest do
         }
       end)
 
-      res = eth_block_number_fake_response(block_quantity)
+      _res = eth_block_number_fake_response(block_quantity)
 
       assert count(Chain.Block.Reward) == 0
       assert count(Chain.Address.CoinBalance) == 0

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -299,11 +299,11 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block_hash = block.hash
       insert(:pending_block_operation, block_hash: block_hash, fetch_internal_transactions: true)
 
-      assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
+      assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
       assert {:retry, [block.number]} == InternalTransaction.run([block.number, block.number], json_rpc_named_arguments)
 
-      assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
+      assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
     end
   end
 end

--- a/apps/indexer/test/indexer/fetcher/uncle_block_test.exs
+++ b/apps/indexer/test/indexer/fetcher/uncle_block_test.exs
@@ -196,7 +196,7 @@ defmodule Indexer.Fetcher.UncleBlockTest do
          ]}
       end)
 
-      assert {:retry, [entry]} =
+      assert {:retry, [^entry]} =
                UncleBlock.run(entries, %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments})
     end
   end


### PR DESCRIPTION
## Motivation

During test runs generates a lot of different warnings, some of them are consequence of incorrect test's, some of them just flood the output.

## Changelog

### Enhancements
- get rid of warnings except:
- - some warns in `block_scout_web` module related to csv transaction export implementation: `warning: using Enum.into/2 for conn is deprecated, use Plug.Conn.chunk/2 and Enum.reduce_while/3 instead (see the Plug.Conn.chunk/2 docs for an example)` [code](https://github.com/blockscout/blockscout/blob/master/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex#L171)
- - some others related to `Supervisor`
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
