### PR TITLE
Add handling for invalid Sourcify response

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -27,8 +27,8 @@ lib/block_scout_web/templates/address_contract/index.html.eex:158
 lib/block_scout_web/templates/address_contract/index.html.eex:195
 lib/explorer/staking/stake_snapshotting.ex:15: Function do_snapshotting/7 has no local return
 lib/explorer/staking/stake_snapshotting.ex:147
-lib/explorer/third_party_integrations/sourcify.ex:70
 lib/explorer/third_party_integrations/sourcify.ex:73
+lib/explorer/third_party_integrations/sourcify.ex:76
 lib/block_scout_web/views/transaction_view.ex:137
 lib/block_scout_web/views/transaction_view.ex:152
 lib/block_scout_web/views/transaction_view.ex:197

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#5540](https://github.com/blockscout/blockscout/pull/5540) - Tx page: scroll to selected tab's data
 
 ### Fixes
+- [#5647](https://github.com/blockscout/blockscout/pull/5647) - Add handling for invalid Sourcify response
 - [#5635](https://github.com/blockscout/blockscout/pull/5635) - Set CoinGecko source in exchange_rates_source function fix in case of token_bridge
 - [#5629](https://github.com/blockscout/blockscout/pull/5629) - Fix empty coin balance for empty address
 - [#5612](https://github.com/blockscout/blockscout/pull/5612) - Fix token transfers order

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -156,16 +156,18 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
           prepare_verification_error(error, address_hash_string, conn),
           :on_demand
         )
-    end
-  end
 
-  def get_metadata_and_publish(address_hash_string, nil) do
-    case Sourcify.get_metadata(address_hash_string) do
-      {:ok, verification_metadata} ->
-        process_metadata_and_publish(address_hash_string, verification_metadata, false)
+      {:error, error} ->
+        EventsPublisher.broadcast(
+          prepare_verification_error(error, address_hash_string, conn),
+          :on_demand
+        )
 
-      {:error, %{"error" => error}} ->
-        {:error, error: error}
+      _ ->
+        EventsPublisher.broadcast(
+          prepare_verification_error("Unexpected error", address_hash_string, conn),
+          :on_demand
+        )
     end
   end
 
@@ -175,28 +177,43 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
         process_metadata_and_publish(address_hash_string, verification_metadata, false, conn)
 
       {:error, %{"error" => error}} ->
-        EventsPublisher.broadcast(
-          prepare_verification_error(error, address_hash_string, conn),
-          :on_demand
-        )
+        return_sourcify_error(conn, error, address_hash_string)
     end
   end
 
   defp process_metadata_and_publish(address_hash_string, verification_metadata, is_partial, conn \\ nil) do
-    %{
-      "params_to_publish" => params_to_publish,
-      "abi" => abi,
-      "secondary_sources" => secondary_sources,
-      "compilation_target_file_path" => compilation_target_file_path
-    } = Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata)
+    case Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata) do
+      %{
+        "params_to_publish" => params_to_publish,
+        "abi" => abi,
+        "secondary_sources" => secondary_sources,
+        "compilation_target_file_path" => compilation_target_file_path
+      } ->
+        ContractController.publish(conn, %{
+          "addressHash" => address_hash_string,
+          "params" => Map.put(params_to_publish, "partially_verified", is_partial),
+          "abi" => abi,
+          "secondarySources" => secondary_sources,
+          "compilationTargetFilePath" => compilation_target_file_path
+        })
 
-    ContractController.publish(conn, %{
-      "addressHash" => address_hash_string,
-      "params" => Map.put(params_to_publish, "partially_verified", is_partial),
-      "abi" => abi,
-      "secondarySources" => secondary_sources,
-      "compilationTargetFilePath" => compilation_target_file_path
-    })
+      {:error, :metadata} ->
+        return_sourcify_error(conn, "Sourcify did not return metadata", address_hash_string)
+
+      _ ->
+        return_sourcify_error(conn, "Unsuccessful sourcify verification", address_hash_string)
+    end
+  end
+
+  defp return_sourcify_error(nil, error, _address_hash_string) do
+    {:error, error: error}
+  end
+
+  defp return_sourcify_error(conn, error, address_hash_string) do
+    EventsPublisher.broadcast(
+      prepare_verification_error(error, address_hash_string, conn),
+      :on_demand
+    )
   end
 
   def prepare_files_array(files) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_verification_controller.ex
@@ -198,10 +198,10 @@ defmodule BlockScoutWeb.AddressContractVerificationController do
         })
 
       {:error, :metadata} ->
-        return_sourcify_error(conn, "Sourcify did not return metadata", address_hash_string)
+        return_sourcify_error(conn, Sourcify.no_metadata_message(), address_hash_string)
 
       _ ->
-        return_sourcify_error(conn, "Unsuccessful sourcify verification", address_hash_string)
+        return_sourcify_error(conn, Sourcify.failed_verification_message(), address_hash_string)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -241,10 +241,10 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
             )
 
           {:error, :metadata} ->
-            render(conn, :error, error: "Sourcify did not return metadata")
+            render(conn, :error, error: Sourcify.no_metadata_message())
 
           _ ->
-            render(conn, :error, error: "Unsuccessful sourcify verification")
+            render(conn, :error, error: Sourcify.failed_verification_message())
         end
 
       {:error, %{"error" => error}} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -230,26 +230,48 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   defp get_metadata_and_publish(address_hash_string, conn) do
     case Sourcify.get_metadata(address_hash_string) do
       {:ok, verification_metadata} ->
-        %{"params_to_publish" => params_to_publish, "abi" => abi, "secondary_sources" => secondary_sources} =
-          Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata)
+        case Sourcify.parse_params_from_sourcify(address_hash_string, verification_metadata) do
+          %{"params_to_publish" => params_to_publish, "abi" => abi, "secondary_sources" => secondary_sources} ->
+            publish_and_handle_response_without_broadcast(
+              address_hash_string,
+              params_to_publish,
+              abi,
+              secondary_sources,
+              conn
+            )
 
-        case publish_without_broadcast(%{
-               "addressHash" => address_hash_string,
-               "params" => params_to_publish,
-               "abi" => abi,
-               "secondarySources" => secondary_sources
-             }) do
-          {:ok, _contract} ->
-            {:format, {:ok, address_hash}} = to_address_hash(address_hash_string)
-            address = Contracts.address_hash_to_address_with_source_code(address_hash)
-            render(conn, :verify, %{contract: address})
+          {:error, :metadata} ->
+            render(conn, :error, error: "Sourcify did not return metadata")
 
-          {:error, changeset} ->
-            render(conn, :error, error: changeset)
+          _ ->
+            render(conn, :error, error: "Unsuccessful sourcify verification")
         end
 
       {:error, %{"error" => error}} ->
         render(conn, :error, error: error)
+    end
+  end
+
+  defp publish_and_handle_response_without_broadcast(
+         address_hash_string,
+         params_to_publish,
+         abi,
+         secondary_sources,
+         conn
+       ) do
+    case publish_without_broadcast(%{
+           "addressHash" => address_hash_string,
+           "params" => params_to_publish,
+           "abi" => abi,
+           "secondarySources" => secondary_sources
+         }) do
+      {:ok, _contract} ->
+        {:format, {:ok, address_hash}} = to_address_hash(address_hash_string)
+        address = Contracts.address_hash_to_address_with_source_code(address_hash)
+        render(conn, :verify, %{contract: address})
+
+      {:error, changeset} ->
+        render(conn, :error, error: changeset)
     end
   end
 

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
@@ -7,6 +7,9 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
   alias HTTPoison.{Error, Response}
   alias Tesla.Multipart
 
+  @no_metadata_message "Sourcify did not return metadata"
+  @failed_verification_message "Unsuccessful Sourcify verification"
+
   def check_by_address(address_hash_string) do
     chain_id = config(:chain_id)
     params = [addresses: address_hash_string, chainIds: chain_id]
@@ -307,4 +310,8 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
     chain_id = config(:chain_id)
     "#{base_server_url()}" <> "/files/any/" <> chain_id
   end
+
+  def no_metadata_message, do: @no_metadata_message
+
+  def failed_verification_message, do: @failed_verification_message
 end

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
@@ -177,43 +177,49 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
   end
 
   def parse_params_from_sourcify(address_hash_string, verification_metadata) do
-    [verification_metadata_json] =
+    filtered_files =
       verification_metadata
       |> Enum.filter(&(Map.get(&1, "name") == "metadata.json"))
 
-    full_params_initial = parse_json_from_sourcify_for_insertion(verification_metadata_json)
+    if Enum.empty?(filtered_files) do
+      {:error, :metadata}
+    else
+      verification_metadata_json = Enum.fetch!(filtered_files, 0)
 
-    verification_metadata_sol =
-      verification_metadata
-      |> Enum.filter(fn %{"name" => name, "content" => _content} -> name =~ ".sol" end)
+      full_params_initial = parse_json_from_sourcify_for_insertion(verification_metadata_json)
 
-    verification_metadata_sol
-    |> Enum.reduce(full_params_initial, fn %{"name" => name, "content" => content, "path" => _path} = param,
-                                           full_params_acc ->
-      compilation_target_file_name = Map.get(full_params_acc, "compilation_target_file_name")
+      verification_metadata_sol =
+        verification_metadata
+        |> Enum.filter(fn %{"name" => name, "content" => _content} -> name =~ ".sol" end)
 
-      if String.downcase(name) == String.downcase(compilation_target_file_name) do
-        %{
-          "params_to_publish" => extract_primary_source_code(content, Map.get(full_params_acc, "params_to_publish")),
-          "abi" => Map.get(full_params_acc, "abi"),
-          "secondary_sources" => Map.get(full_params_acc, "secondary_sources"),
-          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
-          "compilation_target_file_name" => compilation_target_file_name
-        }
-      else
-        secondary_sources = [
-          prepare_additional_source(address_hash_string, param) | Map.get(full_params_acc, "secondary_sources")
-        ]
+      verification_metadata_sol
+      |> Enum.reduce(full_params_initial, fn %{"name" => name, "content" => content, "path" => _path} = param,
+                                             full_params_acc ->
+        compilation_target_file_name = Map.get(full_params_acc, "compilation_target_file_name")
 
-        %{
-          "params_to_publish" => Map.get(full_params_acc, "params_to_publish"),
-          "abi" => Map.get(full_params_acc, "abi"),
-          "secondary_sources" => secondary_sources,
-          "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
-          "compilation_target_file_name" => compilation_target_file_name
-        }
-      end
-    end)
+        if String.downcase(name) == String.downcase(compilation_target_file_name) do
+          %{
+            "params_to_publish" => extract_primary_source_code(content, Map.get(full_params_acc, "params_to_publish")),
+            "abi" => Map.get(full_params_acc, "abi"),
+            "secondary_sources" => Map.get(full_params_acc, "secondary_sources"),
+            "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
+            "compilation_target_file_name" => compilation_target_file_name
+          }
+        else
+          secondary_sources = [
+            prepare_additional_source(address_hash_string, param) | Map.get(full_params_acc, "secondary_sources")
+          ]
+
+          %{
+            "params_to_publish" => Map.get(full_params_acc, "params_to_publish"),
+            "abi" => Map.get(full_params_acc, "abi"),
+            "secondary_sources" => secondary_sources,
+            "compilation_target_file_path" => Map.get(full_params_acc, "compilation_target_file_path"),
+            "compilation_target_file_name" => compilation_target_file_name
+          }
+        end
+      end)
+    end
   end
 
   defp parse_json_from_sourcify_for_insertion(verification_metadata_json) do


### PR DESCRIPTION
Close #5631 
## Motivation
Some times sourcify for some reasons don't return metadata.json for verified contract: [example](https://repo.sourcify.dev/contracts/partial_match/77/0x43Cf33aa82383C33F064165881b484B5A7e206C9/)

## Changelog
### Bug Fixes
- Add handling for cases when sourcify returns invalid data

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
