### PR TITLE
Address page: scroll to selected tab's data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Current
 
 ### Features
+- [#5667](https://github.com/blockscout/blockscout/pull/5667) - Address page: scroll to selected tab's data
 
 ### Fixes
 

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -231,6 +231,25 @@ function loadCounters (store) {
 
 const $addressDetailsPage = $('[data-page="address-details"]')
 if ($addressDetailsPage.length) {
+  const pathParts = window.location.pathname.split('/')
+  const shouldScroll = pathParts.includes('transactions') ||
+  pathParts.includes('token-transfers') ||
+  pathParts.includes('tokens') ||
+  pathParts.includes('internal-transactions') ||
+  pathParts.includes('coin-balances') ||
+  pathParts.includes('logs') ||
+  pathParts.includes('validations') ||
+  pathParts.includes('contracts') ||
+  pathParts.includes('decompiled-contracts') ||
+  pathParts.includes('read-contract') ||
+  pathParts.includes('read-proxy') ||
+  pathParts.includes('write-contract') ||
+  pathParts.includes('write-proxy')
+
+  if (shouldScroll) {
+    location.href = '#address-tabs'
+  }
+
   window.onbeforeunload = () => {
     window.loading = true
   }

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_show_address_transactions.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_show_address_transactions.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.AddressTransactionView, "index.html", assigns %> 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_tabs.html.eex
@@ -2,7 +2,7 @@
 <% dark_forest_addresses_list_0_5 = CustomContractsHelpers.get_custom_addresses_list(:dark_forest_addresses_v_0_5) %>
 <% dark_forest_addresses_list = dark_forest_addresses_list_0_4 ++ dark_forest_addresses_list_0_5 %>
 <% current_address = "0x" <> Base.encode16(@address.hash.bytes, case: :lower) %>
-<div class="card-tabs js-card-tabs">
+<div id="address-tabs" class="card-tabs js-card-tabs">
   <%= link(
         gettext("Transactions"),
         class: "card-tab #{tab_status("transactions", @conn.request_path)}",

--- a/apps/block_scout_web/lib/block_scout_web/views/tab_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tab_helpers.ex
@@ -58,6 +58,8 @@ defmodule BlockScoutWeb.TabHelpers do
   iex> BlockScoutWeb.TabHelpers.tab_active?("token", "/page/0xSom3tH1ng/token_transfer")
   false
   """
+  def tab_active?("transactions", "/address/" <> "0x" <> <<_address_hash::binary-size(40)>>), do: true
+
   def tab_active?(tab_name, request_path) do
     String.match?(request_path, ~r/\/\b#{tab_name}\b/)
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_controller_test.exs
@@ -72,7 +72,7 @@ defmodule BlockScoutWeb.AddressControllerTest do
 
       conn = get(conn, "/address/0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")
 
-      assert redirected_to(conn) =~ "/address/0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed/transactions"
+      assert html_response(conn, 200)
     end
   end
 


### PR DESCRIPTION
Close #5641 

## Changelog
- add scrolling to tabs on address page

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
