### PR TITLE
Add clause for 404 response from CoinGecko; Disable fetching btc_value by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5671](https://github.com/blockscout/blockscout/pull/5671) - Fix double requests for token exchange rates; Disable fetching `btc_value` by default (add `EXCHANGE_RATES_FETCH_BTC_VALUE` env variable)
 
 ### Chore
 - [#5674](https://github.com/blockscout/blockscout/pull/5674) - Disable token holder refreshing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-- [#5671](https://github.com/blockscout/blockscout/pull/5671) - Fix double requests for token exchange rates; Disable fetching `btc_value` by default (add `EXCHANGE_RATES_FETCH_BTC_VALUE` env variable)
+- [#5671](https://github.com/blockscout/blockscout/pull/5671) - Fix double requests for token exchange rates; Disable fetching `btc_value` by default (add `EXCHANGE_RATES_FETCH_BTC_VALUE` env variable); Add `CACHE_EXCHANGE_RATES_PERIOD` env variable
 
 ### Chore
 - [#5674](https://github.com/blockscout/blockscout/pull/5674) - Disable token holder refreshing

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -146,7 +146,8 @@ config :explorer, Explorer.ExchangeRates,
   store: :ets,
   coingecko_coin_id: System.get_env("EXCHANGE_RATES_COINGECKO_COIN_ID"),
   coingecko_api_key: System.get_env("EXCHANGE_RATES_COINGECKO_API_KEY"),
-  coinmarketcap_api_key: System.get_env("EXCHANGE_RATES_COINMARKETCAP_API_KEY")
+  coinmarketcap_api_key: System.get_env("EXCHANGE_RATES_COINMARKETCAP_API_KEY"),
+  fetch_btc_value: System.get_env("EXCHANGE_RATES_FETCH_BTC_VALUE") == "true"
 
 exchange_rates_source =
   cond do

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -23,7 +23,7 @@ config :explorer, Explorer.Repo.Replica1,
   timeout: :timer.seconds(60),
   queue_target: 1000
 
-config :explorer, Explorer.ExchangeRates, enabled: false, store: :ets
+config :explorer, Explorer.ExchangeRates, enabled: false, store: :ets, fetch_btc_value: true
 
 config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: false
 

--- a/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
+++ b/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
@@ -129,26 +129,26 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
     put_into_cache(cache_key(address_hash_str), exchange_rate)
   end
 
-  def fetch_token_exchange_rate(symbol, internal \\ false) do
+  def fetch_token_exchange_rate(symbol, internal_call? \\ false) do
     case Source.fetch_exchange_rates_for_token(symbol) do
       {:ok, [rates]} ->
         rates.usd_value
 
       {:error, "Could not find coin with the given id"} ->
-        if internal, do: :not_found_coingecko, else: nil
+        if internal_call?, do: :not_found_coingecko, else: nil
 
       _ ->
         nil
     end
   end
 
-  def fetch_token_exchange_rate_by_address(address_hash_str, internal \\ false) do
+  def fetch_token_exchange_rate_by_address(address_hash_str, internal_call? \\ false) do
     case Source.fetch_exchange_rates_for_token_address(address_hash_str) do
       {:ok, [rates]} ->
         rates.usd_value
 
       {:error, "Could not find coin with the given id"} ->
-        if internal, do: :not_found_coingecko, else: nil
+        if internal_call?, do: :not_found_coingecko, else: nil
 
       _ ->
         nil

--- a/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
+++ b/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
@@ -61,7 +61,7 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
       |> cache_key()
       |> fetch_from_cache()
 
-    if is_nil(cached_value) || Decimal.cmp(cached_value, 0) == :eq do
+    if is_nil(cached_value) || cached_value == :not_found_coingecko || Decimal.cmp(cached_value, 0) == :eq do
       fetch_from_db(token_hash)
     else
       cached_value
@@ -82,7 +82,7 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
       |> cache_key()
       |> fetch_from_cache()
 
-    if is_nil(cached_value) || Decimal.cmp(cached_value, 0) == :eq do
+    if is_nil(cached_value) || cached_value == :not_found_coingecko || Decimal.cmp(cached_value, 0) == :eq do
       fetch_from_db(token_hash)
     else
       cached_value
@@ -134,6 +134,9 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
       {:ok, [rates]} ->
         rates.usd_value
 
+      {:error, "Could not find coin with the given id"} ->
+        :not_found_coingecko
+
       _ ->
         nil
     end
@@ -143,6 +146,9 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
     case Source.fetch_exchange_rates_for_token_address(address_hash_str) do
       {:ok, [rates]} ->
         rates.usd_value
+
+      {:error, "Could not find coin with the given id"} ->
+        :not_found_coingecko
 
       _ ->
         nil
@@ -174,7 +180,7 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   def put_into_db(token_hash, exchange_rate) do
     token = get_token(token_hash)
 
-    if token && !is_nil(exchange_rate) do
+    if token && !is_nil(exchange_rate) && exchange_rate != :not_found_coingecko do
       token
       |> Changeset.change(%{exchange_rate: exchange_rate})
       |> Repo.update()

--- a/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
+++ b/apps/explorer/lib/explorer/chain/cache/token_exchange_rate.ex
@@ -114,7 +114,7 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   defp update_cache_by_symbol(token_hash, symbol) do
     put_into_cache("#{cache_key(symbol)}_#{@last_update_key}", Helper.current_time())
 
-    exchange_rate = fetch_token_exchange_rate(symbol)
+    exchange_rate = fetch_token_exchange_rate(symbol, true)
 
     put_into_db(token_hash, exchange_rate)
     put_into_cache(cache_key(symbol), exchange_rate)
@@ -123,32 +123,32 @@ defmodule Explorer.Chain.Cache.TokenExchangeRate do
   defp update_cache_by_address_hash_str(token_hash, address_hash_str) do
     put_into_cache("#{cache_key(address_hash_str)}_#{@last_update_key}", Helper.current_time())
 
-    exchange_rate = fetch_token_exchange_rate_by_address(address_hash_str)
+    exchange_rate = fetch_token_exchange_rate_by_address(address_hash_str, true)
 
     put_into_db(token_hash, exchange_rate)
     put_into_cache(cache_key(address_hash_str), exchange_rate)
   end
 
-  def fetch_token_exchange_rate(symbol) do
+  def fetch_token_exchange_rate(symbol, internal \\ false) do
     case Source.fetch_exchange_rates_for_token(symbol) do
       {:ok, [rates]} ->
         rates.usd_value
 
       {:error, "Could not find coin with the given id"} ->
-        :not_found_coingecko
+        if internal, do: :not_found_coingecko, else: nil
 
       _ ->
         nil
     end
   end
 
-  def fetch_token_exchange_rate_by_address(address_hash_str) do
+  def fetch_token_exchange_rate_by_address(address_hash_str, internal \\ false) do
     case Source.fetch_exchange_rates_for_token_address(address_hash_str) do
       {:ok, [rates]} ->
         rates.usd_value
 
       {:error, "Could not find coin with the given id"} ->
-        :not_found_coingecko
+        if internal, do: :not_found_coingecko, else: nil
 
       _ ->
         nil

--- a/apps/explorer/lib/explorer/counters/helper.ex
+++ b/apps/explorer/lib/explorer/counters/helper.ex
@@ -23,6 +23,13 @@ defmodule Explorer.Counters.Helper do
     end
   end
 
+  def cache_period_default_in_minutes(env_var, default_minutes) do
+    case Integer.parse(System.get_env(env_var, "")) do
+      {secs, ""} -> :timer.seconds(secs)
+      _ -> :timer.minutes(default_minutes)
+    end
+  end
+
   def fetch_from_cache(key, cache_name) do
     case :ets.lookup(cache_name, key) do
       [{_, value}] ->

--- a/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
@@ -2,7 +2,7 @@ defmodule Explorer.ExchangeRates do
   @moduledoc """
   Local cache for token exchange rates.
 
-  Exchange rate data is updated every 10 minutes.
+  Exchange rate data is updated every 10 minutes or CACHE_EXCHANGE_RATES_PERIOD seconds.
   """
 
   use GenServer
@@ -10,9 +10,10 @@ defmodule Explorer.ExchangeRates do
   require Logger
 
   alias Explorer.Chain.Events.Publisher
+  alias Explorer.Counters.Helper
   alias Explorer.ExchangeRates.{Source, Token}
 
-  @interval :timer.minutes(10)
+  @interval Helper.cache_period_default_in_minutes("CACHE_EXCHANGE_RATES_PERIOD", 10)
   @table_name :exchange_rates
 
   @impl GenServer

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -18,7 +18,9 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
     current_price = get_current_price(market_data)
 
     id = json_data["id"]
-    btc_value = get_btc_value(id, market_data)
+
+    btc_value =
+      if Application.get_env(:explorer, Explorer.ExchangeRates)[:fetch_btc_value], do: get_btc_value(id, market_data)
 
     circulating_supply_data = market_data && market_data["circulating_supply"]
     total_supply_data = market_data && market_data["total_supply"]

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -19,7 +19,10 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
     current_price = get_current_price(token_properties)
 
     id = token_properties && token_properties["id"]
-    btc_value = get_btc_value(id, token_properties)
+
+    btc_value =
+      if Application.get_env(:explorer, Explorer.ExchangeRates)[:fetch_btc_value],
+        do: get_btc_value(id, token_properties)
 
     circulating_supply_data = get_circulating_supply(token_properties)
 

--- a/apps/explorer/test/explorer/exchange_rates/source/token_bridge_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/token_bridge_test.exs
@@ -27,7 +27,8 @@ defmodule Explorer.ExchangeRates.Source.TokenBridgeTest do
   describe "format_data/1" do
     setup do
       bypass = Bypass.open()
-      Application.put_env(:explorer, ExchangeRates, source: "coin_gecko")
+      envs = Application.get_env(:explorer, ExchangeRates)
+      Application.put_env(:explorer, ExchangeRates, Keyword.put(envs, :source, "coin_gecko"))
       Application.put_env(:explorer, CoinGecko, base_url: "http://localhost:#{bypass.port}")
 
       {:ok, bypass: bypass}


### PR DESCRIPTION
Close #5658 
Close #5646 
https://github.com/blockscout/docs/pull/55
## Changelog
- handle 404 response from CoinGecko
- add `EXCHANGE_RATES_FETCH_BTC_VALUE` env variable
- add `CACHE_EXCHANGE_RATES_PERIOD` env variable
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
