### PR TITLE
Disable token holder refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 ### Chore
+- [#5674](https://github.com/blockscout/blockscout/pull/5674) - Disable token holder refreshing
 - [#5661](https://github.com/blockscout/blockscout/pull/5661) - Fixes yaml syntax for boolean env variables in docker compose
 
 

--- a/apps/block_scout_web/assets/js/pages/token_counters.js
+++ b/apps/block_scout_web/assets/js/pages/token_counters.js
@@ -1,9 +1,8 @@
 import $ from 'jquery'
 import omit from 'lodash.omit'
 import humps from 'humps'
-import { subscribeChannel } from '../socket'
 import { createStore, connectElements } from '../lib/redux_helpers.js'
-import { createAsyncLoadStore, loadPage } from '../lib/async_listing_load'
+import { createAsyncLoadStore } from '../lib/async_listing_load'
 import '../app'
 import {
   openQrModal
@@ -20,11 +19,6 @@ export function reducer (state = initialState, action) {
     case 'PAGE_LOAD':
     case 'ELEMENTS_LOAD': {
       return Object.assign({}, state, omit(action, 'type'))
-    }
-    case 'CHANNEL_DISCONNECTED': {
-      return Object.assign({}, state, {
-        channelDisconnected: true
-      })
     }
     case 'COUNTERS_FETCHED': {
       return Object.assign({}, state, {
@@ -95,25 +89,7 @@ if ($('[data-page="token-holders-list"]').length) {
     window.loading = true
   }
 
-  const asyncElements = {
-    '[data-selector="channel-disconnected-message"]': {
-      render ($el, state) {
-        if (state.channelDisconnected && !window.loading) $el.show()
-      }
-    }
-  }
-
-  const store = createAsyncLoadStore(reducer, initialState, null)
-  connectElements({ store, asyncElements })
-
-  const addressHash = $('[data-page="token-details"]')[0].dataset.pageAddressHash
-  const tokensChannel = subscribeChannel(`tokens:${addressHash}`)
-  tokensChannel.onError(() => store.dispatch({ type: 'CHANNEL_DISCONNECTED' }))
-  tokensChannel.on('token_transfer', (_msg) => {
-    const uri = new URL(window.location)
-    loadPage(store, uri.pathname + uri.search)
-    updateCounters()
-  })
+  createAsyncLoadStore(reducer, initialState, null)
 }
 
 $('.btn-qr-icon').click(_event => {

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -11,7 +11,7 @@
     <div class="card">
       <%= render OverviewView, "_tabs.html", assigns %>
       <!-- Token Holders -->
-      <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
+      <div class="card-body" data-async-listing="<%= @current_path %>">
         <%= render BlockScoutWeb.CommonComponentsView, "_channel_disconnected_message.html", text: gettext("Connection Lost") %>
         <h2 class="card-title list-title-description"><%= gettext "Token Holders" %></h2>
 


### PR DESCRIPTION

## Motivation

Hot refresh of token holders makes the token holders' page blink over time when the there is much activity with the token

## Changelog

Cherry-pick from Celo fork https://github.com/celo-org/blockscout/pull/669

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
