### PR TITLE
Fix wrong miner address shown for post EIP-1559 block for clique network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5676](https://github.com/blockscout/blockscout/pull/5676) - Fix wrong miner address shown for post EIP-1559 block for clique network
 
 ### Chore
 - [#5674](https://github.com/blockscout/blockscout/pull/5674) - Disable token holder refreshing

--- a/apps/indexer/lib/indexer/transform/blocks.ex
+++ b/apps/indexer/lib/indexer/transform/blocks.ex
@@ -35,9 +35,8 @@ defmodule Indexer.Transform.Blocks do
     recover_pub_key(signature_hash, decode(signature))
   end
 
-  # Signature hash calculated from the block header.
-  # Needed for PoA-based chains
-  defp signature_hash(block) do
+  # Get EIP-1559 compatible block header
+  defp get_header_data(block) do
     header_data = [
       decode(block.parent_hash),
       decode(block.sha3_uncles),
@@ -55,6 +54,19 @@ defmodule Indexer.Transform.Blocks do
       decode(block.mix_hash),
       decode(block.nonce)
     ]
+
+    if Map.has_key?(block, :base_fee_per_gas) do
+      # credo:disable-for-next-line
+      header_data ++ [block.base_fee_per_gas]
+    else
+      header_data
+    end
+  end
+
+  # Signature hash calculated from the block header.
+  # Needed for PoA-based chains
+  defp signature_hash(block) do
+    header_data = get_header_data(block)
 
     ExKeccak.hash_256(ExRLP.encode(header_data))
   end


### PR DESCRIPTION
Finalizes https://github.com/blockscout/blockscout/pull/5669
fixes #5380, fixes #2775, fixes #5065


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
