### PR TITLE
Fix broken token icons; Disable animation in lists of data in order t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#5667](https://github.com/blockscout/blockscout/pull/5667) - Address page: scroll to selected tab's data
 
 ### Fixes
+- [#5680](https://github.com/blockscout/blockscout/pull/5680) - Fix broken token icons; Disable animation in lists; Fix doubled requests for some pages
 - [#5671](https://github.com/blockscout/blockscout/pull/5671) - Fix double requests for token exchange rates; Disable fetching `btc_value` by default (add `EXCHANGE_RATES_FETCH_BTC_VALUE` env variable); Add `CACHE_EXCHANGE_RATES_PERIOD` env variable
 - [#5676](https://github.com/blockscout/blockscout/pull/5676) - Fix wrong miner address shown for post EIP-1559 block for clique network
 

--- a/apps/block_scout_web/assets/js/lib/async_listing_load.js
+++ b/apps/block_scout_web/assets/js/lib/async_listing_load.js
@@ -367,12 +367,14 @@ function firstPageLoad (store) {
 
 const $element = $('[data-async-load]')
 if ($element.length) {
-  if (Object.prototype.hasOwnProperty.call($element.data(), 'noFirstLoading')) {
-    enableFirstLoading = false
-  }
-  if (enableFirstLoading) {
-    const store = createStore(asyncReducer)
-    connectElements({ store, elements })
-    firstPageLoad(store)
+  if (!Object.prototype.hasOwnProperty.call($element.data(), 'noSelfCalls')) {
+    if (Object.prototype.hasOwnProperty.call($element.data(), 'noFirstLoading')) {
+      enableFirstLoading = false
+    }
+    if (enableFirstLoading) {
+      const store = createStore(asyncReducer)
+      connectElements({ store, elements })
+      firstPageLoad(store)
+    }
   }
 }

--- a/apps/block_scout_web/assets/js/lib/list_morph.js
+++ b/apps/block_scout_web/assets/js/lib/list_morph.js
@@ -35,7 +35,7 @@ export default function (container, newElements, { key, horizontal } = {}) {
   const overlap = intersectionBy(newList, currentList, 'id').map(({ id, el }) => ({ id, el: updateAllAges($(el))[0] }))
   // remove old items
   const removals = differenceBy(currentList, newList, 'id')
-  let canAnimate = !horizontal && newList.length > 0
+  let canAnimate = false && !horizontal && newList.length > 0 // disabled animation in order to speed up UI
   removals.forEach(({ el }) => {
     if (!canAnimate) return el.remove()
     const $el = $(el)
@@ -59,7 +59,7 @@ export default function (container, newElements, { key, horizontal } = {}) {
 
   // add new items
   const finalList = newList.map(({ id, el }) => get(find(currentList, { id }), 'el', el)).reverse()
-  canAnimate = !horizontal
+  canAnimate = false && !horizontal // disabled animation in order to speed up UI
   finalList.forEach((el, i) => {
     if (el.parentElement) return
     if (!canAnimate) return container.insertBefore(el, get(finalList, `[${i - 1}]`))

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/holder/index.html.eex
@@ -11,7 +11,7 @@
     <div class="card">
       <%= render OverviewView, "_tabs.html", assigns %>
       <!-- Token Holders -->
-      <div class="card-body" data-async-listing="<%= @current_path %>">
+      <div class="card-body" data-async-listing="<%= @current_path %>" data-no-self-calls>
         <%= render BlockScoutWeb.CommonComponentsView, "_channel_disconnected_message.html", text: gettext("Connection Lost") %>
         <h2 class="card-title list-title-description"><%= gettext "Token Holders" %></h2>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/index.html.eex
@@ -6,7 +6,7 @@
 >
   <%= render BlockScoutWeb.Advertisement.TextAdView, "index.html", conn: @conn %>
   <div class="card">
-    <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
+    <div class="card-body" data-async-load data-async-listing="<%= @current_path %>" data-no-self-calls>
 	  <h1 class="card-title list-title-description"><%= gettext "Tokens" %></h1>
 
 	<div class="list-top-pagination-container-wrapper tokens-list-search-input-outer-container d-flex" style="float: right;">


### PR DESCRIPTION
…o speed up UI; Fix double requests for some pages

Close #5672 

## Motivation
- broken token icons
![image](https://user-images.githubusercontent.com/32202610/174075531-4efdd106-e6c2-4754-8fbd-dd0cc9d0fac9.png)

- animation for lists was slowing down UI, we disabled it

## Changelog
- disable animation for lists
- fix doubled request for `token-holder` and `token` endpoints
- hide broken icons

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
