### PR TITLE
Allow special characters for password in DB URL parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5690](https://github.com/blockscout/blockscout/pull/5690) - Allow special characters for password in DB URL parser
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -29,7 +29,7 @@ defmodule Explorer.Repo.ConfigHelper do
 
   # sobelow_skip ["DOS.StringToAtom"]
   defp extract_parameters(database_url) do
-    ~r/\w*:\/\/(?<username>\w+):(?<password>[a-zA-Z0-9_-]*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>\w+)/
+    ~r/\w*:\/\/(?<username>\w+):(?<password>[a-zA-Z0-9-*#!%^&$_]*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>\w+)/
     |> Regex.named_captures(database_url)
     |> Keyword.new(fn {k, v} -> {String.to_atom(k), v} end)
     |> Keyword.put(:url, database_url)

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -28,13 +28,13 @@ defmodule Explorer.Repo.ConfigHelperTest do
       assert result[:database] == "test_database"
     end
 
-    test "parse params from database url with hyphen in password" do
-      database_url = "postgresql://test_username:test-password@hostname.test.com:7777/test_database"
+    test "parse params from database url with special characters in password" do
+      database_url = "postgresql://test_username:awN!l#W*g$P%t-l^q&d@hostname.test.com:7777/test_database"
 
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
 
       assert result[:username] == "test_username"
-      assert result[:password] == "test-password"
+      assert result[:password] == "awN!l#W*g$P%t-l^q&d"
       assert result[:hostname] == "hostname.test.com"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5688

## Motivation

Complex passwords with a set of different special characters are not allowed in DB URL parser.

## Changelog

Change the regexp pattern to support [#!%^&$] special characters except `@`.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
