### PR TITLE
Fix double requests; Fix token balances dropdown view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#5699](https://github.com/blockscout/blockscout/pull/5699) - Switch to basic (non-pro) API endpoint for Coingecko requests, if API key is not provided
 
 ### Fixes
+- [#5737](https://github.com/blockscout/blockscout/pull/5737) - Fix double requests; Fix token balances dropdown view
 - [#5723](https://github.com/blockscout/blockscout/pull/5723) - Add nil clause for Data.to_string/1
 - [#5714](https://github.com/blockscout/blockscout/pull/5714) - Add clause for EthereumJSONRPC.Transaction.elixir_to_params/1 when gas_price is missing in the response
 - [#5697](https://github.com/blockscout/blockscout/pull/5697) - Gas price oracle: ignore gas price rounding for values less than 0.01

--- a/apps/block_scout_web/assets/css/components/_token-balance-dropdown.scss
+++ b/apps/block_scout_web/assets/css/components/_token-balance-dropdown.scss
@@ -102,7 +102,16 @@
   margin-left: 5px;
 }
 
+.ml-20px {
+  margin-left: 20px !important;
+}
+
 .dropdown-row {
   padding-left: 5px;
   padding-right: 5px;
+}
+
+.dropdown-amount {
+  font-size: 12px;
+  opacity: .65;
 }

--- a/apps/block_scout_web/assets/js/pages/address.js
+++ b/apps/block_scout_web/assets/js/pages/address.js
@@ -199,14 +199,14 @@ const elements = {
   },
   '[data-selector="current-coin-balance"]': {
     render ($el, state, oldState) {
-      if (!state.newBlockNumber || state.newBlockNumber > oldState.newBlockNumber) return
+      if (!state.newBlockNumber || state.newBlockNumber <= oldState.newBlockNumber) return
       $el.empty().append(state.currentCoinBalance)
       updateAllCalculatedUsdValues()
     }
   },
   '[data-selector="last-balance-update"]': {
     render ($el, state, oldState) {
-      if (!state.newBlockNumber || state.newBlockNumber > oldState.newBlockNumber) return
+      if (!state.newBlockNumber || state.newBlockNumber <= oldState.newBlockNumber) return
       $el.empty().append(state.currentCoinBalanceBlockNumber)
     }
   },
@@ -306,11 +306,12 @@ if ($addressDetailsPage.length) {
     msg: humps.camelizeKeys(msg)
   }))
 
-  addressChannel.push('get_balance', {})
-    .receive('ok', (msg) => store.dispatch({
-      type: 'RECEIVED_UPDATED_BALANCE',
-      msg: humps.camelizeKeys(msg)
-    }))
+  // following lines causes double /token-balances request
+  // addressChannel.push('get_balance', {})
+  //   .receive('ok', (msg) => store.dispatch({
+  //     type: 'RECEIVED_UPDATED_BALANCE',
+  //     msg: humps.camelizeKeys(msg)
+  //   }))
 
   loadCounters(store)
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_coin_balance/index.html.eex
@@ -21,7 +21,7 @@
           <span><%= gettext("There was a problem loading the chart.") %></span>
         </button>
         <div data-chart-container class="mb-4" style="display: none;">
-          <canvas data-chart="coinBalanceHistoryChart" data-coin_balance_history_data_path="<%= AccessHelpers.get_path(@conn, :address_coin_balance_by_day_path, :index, @address.hash) %>" width="350" height="152"></canvas>
+          <canvas data-chart="coinBalanceHistoryChart" data-coin_balance_history_data_path="<%= AccessHelpers.get_path(@conn, :address_coin_balance_by_day_path, :index, @address) %>" width="350" height="152"></canvas>
         </div>
 
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -6,7 +6,7 @@
   <section data-page="address-internal-transactions">
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
-      <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
+      <div class="card-body" data-async-load data-async-listing="<%= @current_path %>" data-no-self-calls>
         <div data-selector="channel-batching-message" class="d-none">
           <div data-selector="reload-button" class="alert alert-info">
             <a href="#" class="alert-link"><span data-selector="channel-batching-count"></span> <%= gettext "More internal transactions have come in" %></a>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
@@ -32,7 +32,7 @@
               additional_classes: ["token-wallet-icon"]
             %>
           <% end %>
-          <p class="mb-0 col-md-6 pl-0 pr-0 el-1 flex-grow-2"><%= token_name(token) %>
+          <p class="mb-0 col-md-6 pl-0 pr-0 el-1 flex-grow-2 <%= if System.get_env("DISPLAY_TOKEN_ICONS") !== "true", do: "ml-5px" %>"><%= token_name(token) %>
           </p>
           <%= if token_balance.token.usd_value do %>
             <p class="mb-0 col-md-6 text-right usd-total">
@@ -41,8 +41,7 @@
           <% end %>
         </div>
         <div class="row dropdown-row wh-sp">
-          <% col_md = if token_balance.token.usd_value, do: "col-md-6", else: "col-md-12" %>
-          <p class="mb-0 <%= col_md %> el-1 ml-5px">
+          <p class="mb-0 ml-5px <%= if System.get_env("DISPLAY_TOKEN_ICONS") === "true", do: "ml-20px" %>">
             <%= if token_balance.token_type == "ERC-721" && !is_nil(token_balance.token_id) do %>
               1
             <% else %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
@@ -6,7 +6,7 @@
   <section data-page="address-token-transfers" id="transfers">
     <div class="card">
       <%= render BlockScoutWeb.AddressView, "_tabs.html", address: @address, is_proxy: is_proxy, conn: @conn %>
-      <div data-async-load data-async-listing="<%= @current_path %>" class="card-body">
+      <div data-async-load data-async-listing="<%= @current_path %>" class="card-body" data-no-self-calls>
 
         <%= if assigns[:token] do %>
         <h2 class="card-title">


### PR DESCRIPTION
Close #5707 
#5658 

## Changelog
- fix token balances dropdown view
- fix double requests to `/token-balances`, `/internal-transactions` and `/token-transfers`
- fix redirects on loading data for coin-balance chart (replace address hash with checksummed one)

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
