### PR TITLE
Define coin name in balance tooltip via variable

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/overview.html.eex
@@ -162,7 +162,7 @@
           <dl class="row">
             <dt class="col-sm-4 col-md-4 col-lg-3 text-muted">
               <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
-              text: gettext("Address balance in xDAI (doesn't include ERC20, ERC721, ERC1155 tokens).") %>
+              text: gettext("Address balance in") <> " " <> Explorer.coin_name() <> " " <> gettext("doesn't include ERC20, ERC721, ERC1155 tokens).") %>
               <%= gettext("Balance") %>
             </dt>
             <dd data-selector="current-coin-balance" class="col-sm-8 col-md-8 col-lg-9" data-test="address_balance">

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -38,7 +38,7 @@
             <%= if Enum.member?(market_chart_config, :price) do %>
               <div class="dashboard-banner-chart-legend-item price-per-day">
                   <span class="dashboard-banner-chart-legend-label">
-                  <%= System.get_env("COIN_NAME") || System.get_env("COIN") %> <%= gettext "Price" %>
+                  <%= Explorer.coin_name() %> <%= gettext "Price" %>
                   </span>
                   <div class="dashboard-banner-chart-legend-value-container">
                     <span class="dashboard-banner-chart-legend-value inline" data-selector="exchange-rate" data-wei-value="<%= Explorer.Chain.Wei.from(Decimal.new(1), :ether).value %>" data-usd-exchange-rate="<%= @exchange_rate.usd_value %>">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -157,11 +157,6 @@ msgid "Address (external or contract) sending the transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:165
-msgid "Address balance in xDAI (doesn't include ERC20, ERC721, ERC1155 tokens)."
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:50
 msgid "Address of the token contract"
 msgstr ""
@@ -2645,4 +2640,14 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/gas_price_oracle_legend_item.html.eex:20
 msgid "Slow"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/overview.html.eex:165
+msgid "Address balance in"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/overview.html.eex:165
+msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -157,11 +157,6 @@ msgid "Address (external or contract) sending the transaction."
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/address/overview.html.eex:165
-msgid "Address balance in xDAI (doesn't include ERC20, ERC721, ERC1155 tokens)."
-msgstr ""
-
-#, elixir-format
 #: lib/block_scout_web/templates/tokens/overview/_details.html.eex:50
 msgid "Address of the token contract"
 msgstr ""
@@ -2645,4 +2640,14 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/gas_price_oracle_legend_item.html.eex:20
 msgid "Slow"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/address/overview.html.eex:165
+msgid "Address balance in"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/address/overview.html.eex:165
+msgid "doesn't include ERC20, ERC721, ERC1155 tokens)."
 msgstr ""

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -12,6 +12,7 @@ disable_webapp = System.get_env("DISABLE_WEBAPP")
 config :explorer,
   ecto_repos: [Explorer.Repo],
   coin: System.get_env("COIN") || "POA",
+  coin_name: System.get_env("COIN_NAME") || System.get_env("COIN") || "POA",
   token_functions_reader_max_retries: 3,
   allowed_evm_versions:
     System.get_env("ALLOWED_EVM_VERSIONS") ||

--- a/apps/explorer/lib/explorer.ex
+++ b/apps/explorer/lib/explorer.ex
@@ -13,4 +13,8 @@ defmodule Explorer do
   def coin do
     Application.get_env(:explorer, :coin)
   end
+
+  def coin_name do
+    Application.get_env(:explorer, :coin_name)
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5763

## Motivation

"xDai" is hardcoded in balance tooltip

## Changelog

Define coin name in tooltip via `COIN_NAME` or `COIN` env variables

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
