### PR TITLE
Missing blocks query: set 500_000 limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#5699](https://github.com/blockscout/blockscout/pull/5699) - Switch to basic (non-pro) API endpoint for Coingecko requests, if API key is not provided
 
 ### Fixes
+- [#5767](https://github.com/blockscout/blockscout/pull/5767) - Missing blocks query: set 500_000 limit
 - [#5737](https://github.com/blockscout/blockscout/pull/5737) - Fix double requests; Fix token balances dropdown view
 - [#5723](https://github.com/blockscout/blockscout/pull/5723) - Add nil clause for Data.to_string/1
 - [#5714](https://github.com/blockscout/blockscout/pull/5714) - Add clause for EthereumJSONRPC.Transaction.elixir_to_params/1 when gas_price is missing in the response

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2998,7 +2998,8 @@ defmodule Explorer.Chain do
         on: b.number == missing_range.number,
         select: missing_range.number,
         order_by: missing_range.number,
-        distinct: missing_range.number
+        distinct: missing_range.number,
+        limit: 500_000
       )
 
     missing_blocks = Repo.all(ordered_missing_query, timeout: :infinity)


### PR DESCRIPTION
Close https://github.com/blockscout/blockscout/pull/5547
Fixes https://github.com/blockscout/blockscout/issues/5544

## Motivation

Add limit for the query to find missing block numbers (init query for catchup fetcher).


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
