### PR TITLE
Fix Cannot find module solc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 - [#5797](https://github.com/blockscout/blockscout/pull/5797) - Fix flickering token tooltip
+- [#5798](https://github.com/blockscout/blockscout/pull/5798) - Copy explorer node_modules to result image
 
 ### Chore
 - [#5796](https://github.com/blockscout/blockscout/pull/5796) - Add job for e2e tests on every push to master + fix job "Merge 'master' to specific branch after release"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,5 +85,6 @@ FROM bitwalker/alpine-elixir-phoenix:1.13
 WORKDIR /app
 
 COPY --from=builder /opt/release/blockscout .
+COPY --from=builder /app/apps/explorer/node_modules ./node_modules
 
 


### PR DESCRIPTION
Resolves #5793 

## Motivation

Npm module `solc` is used directly on host machine via `node` command. Since we are using `mix release` on building, we don't have explorer npm modules in docker image anymore. So it is necessary to include packages like this to docker image.

## Changelog

Added copying of explorer's node_modules to result docker image.
