### PR TITLE
Add check for nil metadata to avoid empty tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#5809](https://github.com/blockscout/blockscout/pull/5809) - Fix 404 on `/metadata` page
 - [#5786](https://github.com/blockscout/blockscout/pull/5786) - Replace `current_path` with `Controller.current_full_path` in two controllers
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex
@@ -5,7 +5,7 @@
         to: token_instance_path(@conn, :show, @token.contract_address_hash, to_string(@token_instance.token_id))
       )
     %>
-  <%= if @token_instance.instance do %>
+  <%= if @token_instance.instance && @token_instance.instance.metadata do %>
     <%= link(
         gettext("Metadata"),
         to: token_instance_metadata_path(@conn, :index, Address.checksum(@token.contract_address_hash), to_string(@token_instance.token_id)),


### PR DESCRIPTION
## Motivation

If a token instance has `nil` metadata we displaying `Metadata` tab. But this tab will lead to 404 page ([example](https://blockscout.com/xdai/optimism/token/0xC3EEc2E9CD1D777A04e9F1fa2ae2576754144f22/instance/41/token-transfers))

## Changelog
- Add condition to prevent displaying `Metadata` tab for token instance with `nil` metadata

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
