### PR TITLE
Get rid of downloading each NFT media for determining it's type (vide…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#5860](https://github.com/blockscout/blockscout/pull/5860) - Integrate rust verifier micro-service ([blockscout-rs/verifier](https://github.com/blockscout/blockscout-rs/tree/main/verification))
 
 ### Fixes
+- [#5936](https://github.com/blockscout/blockscout/pull/5936) - Enhance NFT media
 - [#5904](https://github.com/blockscout/blockscout/pull/5904) - Enhance health API endpoint: better parsing HEALTHY_BLOCKS_PERIOD and use it in the response
 - [#5903](https://github.com/blockscout/blockscout/pull/5903) - Disable compile env validation
 - [#5887](https://github.com/blockscout/blockscout/pull/5887) - Added missing environment variables to Makefile container params

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex
@@ -61,13 +61,8 @@
       <div class="card">
         <div class="card-body">
           <div class="erc721-media" >
-            <%= if media_type(media_src(@token_instance.instance, true)) == "video" do %>
-              <video controls autoplay playsinline style="width: 100%;">
-                <source src=<%= media_src(@token_instance.instance, true) %> type="video/mp4">
-              </video>
-            <% else %>
-              <img src=<%= media_src(@token_instance.instance, true) %> />
-            <% end %>
+            <video poster=<%= media_src(@token_instance.instance, true) %> autoplay muted loop preload="true" playsinline style="width: 100%;" src=<%= media_src(@token_instance.instance, true) %> >
+            </video>
           </div>
         </div>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/tokens/inventory/_token.html.eex
@@ -45,13 +45,8 @@
     <div class="pl-5 col-md-2 d-flex flex-column align-items-left justify-content-start justify-content-lg-center">
       <!-- substitute the span with <img class="tile-image" /> to token with images -->
       <div class="inventory-erc721-media" >
-        <%= if media_type(media_src(@token_transfer.instance)) == "video" do %>
-          <video>
-            <source src=<%= media_src(@token_transfer.instance) %> type="video/mp4">
-          </video>
-        <% else %>
-          <img src=<%=media_src(@token_transfer.instance)%> />
-        <% end %>
+        <video poster=<%= media_src(@token_transfer.instance) %> autoplay muted loop preload="true" playsinline style="width: 100%;" src=<%= media_src(@token_transfer.instance) %> >
+        </video>
       </div>
     </div>
   </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex
@@ -53,51 +53,6 @@ defmodule BlockScoutWeb.Tokens.Instance.OverviewView do
     end
   end
 
-  def media_type(media_src) when not is_nil(media_src) do
-    ext = media_src |> Path.extname() |> String.trim()
-
-    mime_type =
-      if ext == "" do
-        case HTTPoison.get(media_src) do
-          {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
-            {:ok, path} = Briefly.create()
-
-            File.write!(path, body)
-
-            case FileInfo.get_info([path]) do
-              %{^path => %FileInfo.Mime{subtype: subtype}} ->
-                subtype
-                |> MIME.type()
-
-              _ ->
-                nil
-            end
-
-          _ ->
-            nil
-        end
-      else
-        ext_with_dot =
-          media_src
-          |> Path.extname()
-
-        "." <> ext = ext_with_dot
-
-        ext
-        |> MIME.type()
-      end
-
-    if mime_type do
-      basic_mime_type = mime_type |> String.split("/") |> Enum.at(0)
-
-      basic_mime_type
-    else
-      nil
-    end
-  end
-
-  def media_type(nil), do: nil
-
   def external_url(nil), do: nil
 
   def external_url(instance) do

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/inventory_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/inventory_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.Tokens.InventoryView do
   use BlockScoutWeb, :view
 
-  import BlockScoutWeb.Tokens.Instance.OverviewView, only: [media_src: 1, media_type: 1]
+  import BlockScoutWeb.Tokens.Instance.OverviewView, only: [media_src: 1]
 
   alias BlockScoutWeb.Tokens.OverviewView
   alias Explorer.Chain

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -408,8 +408,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:6
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:14
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:84
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:92
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:79
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:87
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
@@ -1369,7 +1369,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:196
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:151
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
@@ -1649,7 +1649,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_btn_qr_code.html.eex:10
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:5
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:83
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:78
 #, elixir-autogen, elixir-format
 msgid "QR Code"
 msgstr ""
@@ -2204,7 +2204,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:363
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:150
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:511
 #, elixir-autogen, elixir-format

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -408,8 +408,8 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:37
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:6
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:14
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:84
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:92
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:79
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:87
 #, elixir-autogen, elixir-format
 msgid "Close"
 msgstr ""
@@ -1369,7 +1369,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/tokens/instance/metadata/index.html.eex:18
 #: lib/block_scout_web/templates/tokens/instance/overview/_tabs.html.eex:10
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:196
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:151
 #, elixir-autogen, elixir-format
 msgid "Metadata"
 msgstr ""
@@ -1649,7 +1649,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/common_components/_btn_qr_code.html.eex:10
 #: lib/block_scout_web/templates/common_components/_modal_qr_code.html.eex:5
-#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:83
+#: lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:78
 #, elixir-autogen, elixir-format
 msgid "QR Code"
 msgstr ""
@@ -2204,7 +2204,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
 #: lib/block_scout_web/views/address_view.ex:363
-#: lib/block_scout_web/views/tokens/instance/overview_view.ex:195
+#: lib/block_scout_web/views/tokens/instance/overview_view.ex:150
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:511
 #, elixir-autogen, elixir-format


### PR DESCRIPTION
…o or image)

Close #5857 

## Changelog
- now all NFT media loading as video with `poster` parameter as fallback 

If you need to turn on sound on video: 
- click with right mouse button on video
- select `Show all control elements` or `Show settings`
- turn on sound in player

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
