### PR TITLE
Add transaction state changes feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
 - [#5968](https://github.com/blockscout/blockscout/pull/5968) - Add call type in the response of txlistinternal API method
 - [#5860](https://github.com/blockscout/blockscout/pull/5860) - Integrate rust verifier micro-service ([blockscout-rs/verifier](https://github.com/blockscout/blockscout-rs/tree/main/verification))
 - [#6001](https://github.com/blockscout/blockscout/pull/6001) - Add ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES env var that filters requests and query node only if the block quantity is "latest"
+- [#5944](https://github.com/blockscout/blockscout/pull/5944) - Add tab with state changes to transaction page
 
 ### Fixes
 

--- a/apps/block_scout_web/assets/js/pages/transaction.js
+++ b/apps/block_scout_web/assets/js/pages/transaction.js
@@ -57,7 +57,8 @@ if ($transactionDetailsPage.length) {
   pathParts.includes('token-transfers') ||
   pathParts.includes('logs') ||
   pathParts.includes('token-transfers') ||
-  pathParts.includes('raw-trace')
+  pathParts.includes('raw-trace') ||
+  pathParts.includes('state')
   if (shouldScroll) {
     document.getElementById('transaction-tabs').scrollIntoView()
   }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
@@ -1,0 +1,461 @@
+defmodule BlockScoutWeb.TransactionStateController do
+  use BlockScoutWeb, :controller
+
+  alias BlockScoutWeb.{
+    AccessHelpers,
+    Controller,
+    TransactionController,
+    TransactionStateView
+  }
+
+  alias Explorer.{Chain, Chain.Wei, Market, PagingOptions}
+  alias Explorer.ExchangeRates.Token
+  alias Phoenix.View
+  alias Indexer.Fetcher.{CoinBalance, TokenBalance}
+
+  import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
+  import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
+  import BlockScoutWeb.Models.GetTransactionTags, only: [get_transaction_with_addresses_tags: 2]
+  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+
+  @burn_address_hash burn_address_hash
+
+  def index(conn, %{"transaction_id" => transaction_hash_string, "type" => "JSON"} = params) do
+    with {:ok, transaction_hash} <- Chain.string_to_transaction_hash(transaction_hash_string),
+         :ok <- Chain.check_transaction_exists(transaction_hash),
+         {:ok, transaction} <-
+           Chain.hash_to_transaction(
+             transaction_hash,
+             necessity_by_association: %{
+               [block: :miner] => :required,
+               from_address: :required,
+               to_address: :required
+             }
+           ),
+         {:ok, false} <-
+           AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
+         {:ok, false} <-
+           AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
+      full_options = [
+        necessity_by_association: %{
+          [from_address: :smart_contract] => :optional,
+          [to_address: :smart_contract] => :optional,
+          [from_address: :names] => :optional,
+          [to_address: :names] => :optional,
+          from_address: :required,
+          to_address: :required,
+          token: :required
+        },
+        # we need to consider all token transfers in block to show whole state change of transaction
+        paging_options: %PagingOptions{key: nil, page_size: nil}
+      ]
+
+      token_transfers = Chain.transaction_to_token_transfers(transaction_hash, full_options)
+
+      block = transaction.block
+
+      block_txs =
+        Chain.block_to_transactions(block.hash,
+          necessity_by_association: %{},
+          paging_options: %PagingOptions{key: nil, page_size: nil}
+        )
+
+      {from_before, to_before, miner_before} = coin_balances_before(transaction, block_txs)
+
+      from_hash = transaction.from_address_hash
+      from = transaction.from_address
+      from_after = do_update_coin_balance_from_tx(from_hash, transaction, from_before, block)
+
+      from_coin_entry =
+        View.render_to_string(
+          TransactionStateView,
+          "_state_change.html",
+          coin_or_token_transfers: :coin,
+          address: from,
+          burn_address_hash: @burn_address_hash,
+          balance_before: from_before,
+          balance_after: from_after,
+          balance_diff: Wei.sub(from_after, from_before),
+          conn: conn
+        )
+
+      to_hash = transaction.to_address_hash
+      to = transaction.to_address
+      to_after = do_update_coin_balance_from_tx(to_hash, transaction, to_before, block)
+
+      to_coin_entry =
+        View.render_to_string(
+          TransactionStateView,
+          "_state_change.html",
+          coin_or_token_transfers: :coin,
+          address: to,
+          burn_address_hash: @burn_address_hash,
+          balance_before: to_before,
+          balance_after: to_after,
+          balance_diff: Wei.sub(to_after, to_before),
+          conn: conn
+        )
+
+      miner_hash = block.miner_hash
+      miner = block.miner
+      miner_after = do_update_coin_balance_from_tx(miner_hash, transaction, miner_before, block)
+
+      miner_entry =
+        View.render_to_string(
+          TransactionStateView,
+          "_state_change.html",
+          coin_or_token_transfers: :coin,
+          address: miner,
+          burn_address_hash: @burn_address_hash,
+          balance_before: miner_before,
+          balance_after: miner_after,
+          balance_diff: Wei.sub(miner_after, miner_before),
+          miner: true,
+          conn: conn
+        )
+
+      token_balances_before = token_balances_before(token_transfers, transaction, block_txs)
+
+      token_balances_after =
+        do_update_token_balances_from_token_transfers(
+          token_transfers,
+          token_balances_before,
+          :include_transfers
+        )
+
+      items =
+        for {address, balances} <- token_balances_after,
+            {token_hash, {balance, transfers}} <- balances do
+          balance_before = token_balances_before[address][token_hash]
+
+          View.render_to_string(
+            TransactionStateView,
+            "_state_change.html",
+            coin_or_token_transfers: transfers,
+            address: address,
+            burn_address_hash: @burn_address_hash,
+            balance_before: balance_before,
+            balance_after: balance,
+            balance_diff: Decimal.sub(balance, balance_before),
+            conn: conn
+          )
+        end
+
+      json(conn, %{items: [from_coin_entry, to_coin_entry, miner_entry | items]})
+    else
+      {:restricted_access, _} ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+
+      :error ->
+        TransactionController.set_invalid_view(conn, transaction_hash_string)
+
+      {:error, :not_found} ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+
+      :not_found ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+    end
+  end
+
+  def index(conn, %{"transaction_id" => transaction_hash_string} = params) do
+    with {:ok, transaction_hash} <- Chain.string_to_transaction_hash(transaction_hash_string),
+         {:ok, transaction} <-
+           Chain.hash_to_transaction(
+             transaction_hash,
+             necessity_by_association: %{
+               :block => :optional,
+               [created_contract_address: :names] => :optional,
+               [from_address: :names] => :optional,
+               [to_address: :names] => :optional,
+               [to_address: :smart_contract] => :optional,
+               :token_transfers => :optional
+             }
+           ),
+         {:ok, false} <-
+           AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
+         {:ok, false} <-
+           AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
+      render(
+        conn,
+        "index.html",
+        exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+        block_height: Chain.block_height(),
+        current_path: Controller.current_full_path(conn),
+        show_token_transfers: Chain.transaction_has_token_transfers?(transaction_hash),
+        transaction: transaction,
+        from_tags: get_address_tags(transaction.from_address_hash, current_user(conn)),
+        to_tags: get_address_tags(transaction.to_address_hash, current_user(conn)),
+        tx_tags:
+          get_transaction_with_addresses_tags(
+            transaction,
+            current_user(conn)
+          ),
+        current_user: current_user(conn)
+      )
+    else
+      :not_found ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+
+      :error ->
+        TransactionController.set_invalid_view(conn, transaction_hash_string)
+
+      {:error, :not_found} ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+
+      {:restricted_access, _} ->
+        TransactionController.set_not_found_view(conn, transaction_hash_string)
+    end
+  end
+
+  def coin_balance(address_hash, _block_number) when is_nil(address_hash) do
+    %Wei{value: Decimal.new(0)}
+  end
+
+  def coin_balance(address_hash, block_number) do
+    case Chain.get_coin_balance(address_hash, block_number) do
+      %{value: val} when not is_nil(val) ->
+        val
+
+      _ ->
+        json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+        CoinBalance.run([{address_hash.bytes, block_number}], json_rpc_named_arguments)
+        # after CoinBalance.run balance is fetched and imported, so we can call coin_balance again
+        coin_balance(address_hash, block_number)
+    end
+  end
+
+  def coin_balances_before(tx, block_txs) do
+    block = tx.block
+
+    from_before = coin_balance(tx.from_address_hash, block.number - 1)
+    to_before = coin_balance(tx.to_address_hash, block.number - 1)
+    miner_before = coin_balance(block.miner_hash, block.number - 1)
+
+    block_txs
+    |> Enum.reduce_while(
+      {from_before, to_before, miner_before},
+      fn block_tx, {block_from, block_to, block_miner} = state ->
+        if block_tx.index < tx.index do
+          {:cont,
+           {do_update_coin_balance_from_tx(tx.from_address_hash, block_tx, block_from, block),
+            do_update_coin_balance_from_tx(tx.to_address_hash, block_tx, block_to, block),
+            do_update_coin_balance_from_tx(tx.block.miner_hash, block_tx, block_miner, block)}}
+        else
+          # txs ordered by index ascending, so we can halt after facing index greater or equal than index of our tx
+          {:halt, state}
+        end
+      end
+    )
+  end
+
+  defp do_update_coin_balance_from_tx(address_hash, tx, balance, block) do
+    from = tx.from_address_hash
+    to = tx.to_address_hash
+    miner = block.miner_hash
+
+    case address_hash do
+      ^from -> Wei.sub(balance, from_loss(tx))
+      ^to -> Wei.sum(balance, to_profit(tx))
+      ^miner -> Wei.sum(balance, miner_profit(tx, block))
+      _ -> balance
+    end
+  end
+
+  def token_balance(@burn_address_hash, _token_transfer, _block_number) do
+    Decimal.new(0)
+  end
+
+  def token_balance(address_hash, token_transfer, block_number) do
+    token = token_transfer.token
+    token_contract_address_hash = token.contract_address_hash
+
+    case Chain.get_token_balance(address_hash, token_contract_address_hash, block_number) do
+      %{value: val} when not is_nil(val) ->
+        val
+
+      # we haven't fetched this balance yet
+      _ ->
+        json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+        token_id_int =
+          case token_transfer.token_id do
+            %Decimal{} -> Decimal.to_integer(token_transfer.token_id)
+            id_int when is_integer(id_int) -> id_int
+            _ -> token_transfer.token_id
+          end
+
+        TokenBalance.run(
+          [
+            {address_hash.bytes, token_contract_address_hash.bytes, block_number, token.type, token_id_int, 0}
+          ],
+          json_rpc_named_arguments
+        )
+
+        # after TokenBalance.run balance is fetched and imported, so we can call token_balance again
+        token_balance(address_hash, token_transfer, block_number)
+    end
+  end
+
+  def token_balances_before(token_transfers, tx, block_txs) do
+    balances_before =
+      token_transfers
+      |> Enum.reduce(%{}, fn transfer, balances_map ->
+        from = transfer.from_address
+        to = transfer.to_address
+        token_hash = transfer.token_contract_address_hash
+        prev_block = transfer.block_number - 1
+
+        balances_with_from =
+          case balances_map do
+            # from address already in the map
+            %{^from => %{^token_hash => _}} ->
+              balances_map
+
+            # we need to add from address into the map
+            _ ->
+              put_in(
+                balances_map,
+                Enum.map([from, token_hash], &Access.key(&1, %{})),
+                token_balance(from.hash, transfer, prev_block)
+              )
+          end
+
+        case balances_with_from do
+          # to address already in the map
+          %{^to => %{^token_hash => _}} ->
+            balances_with_from
+
+          # we need to add to address into the map
+          _ ->
+            put_in(
+              balances_with_from,
+              Enum.map([to, token_hash], &Access.key(&1, %{})),
+              token_balance(to.hash, transfer, prev_block)
+            )
+        end
+      end)
+
+    block_txs
+    |> Enum.reduce_while(
+      balances_before,
+      fn block_tx, state ->
+        if block_tx.index < tx.index do
+          {:cont, do_update_token_balances_from_token_transfers(block_tx.token_transfers, state)}
+        else
+          # txs ordered by index ascending, so we can halt after facing index greater or equal than index of our tx
+          {:halt, state}
+        end
+      end
+    )
+  end
+
+  defp do_update_token_balances_from_token_transfers(
+         token_transfers,
+         balances_map,
+         include_transfers \\ :no
+       ) do
+    Enum.reduce(
+      token_transfers,
+      balances_map,
+      &token_transfers_balances_reducer(&1, &2, include_transfers)
+    )
+  end
+
+  defp token_transfers_balances_reducer(transfer, state_balances_map, include_transfers) do
+    from = transfer.from_address
+    to = transfer.to_address
+    token = transfer.token_contract_address_hash
+
+    balances_map_from_included =
+      case state_balances_map do
+        # from address is needed to be updated in our map
+        %{^from => %{^token => val}} ->
+          put_in(
+            state_balances_map,
+            Enum.map([from, token], &Access.key(&1, %{})),
+            do_update_balance(val, :from, transfer, include_transfers)
+          )
+
+        # we are not interested in this address
+        _ ->
+          state_balances_map
+      end
+
+    case balances_map_from_included do
+      # to address is needed to be updated in our map
+      %{^to => %{^token => val}} ->
+        put_in(
+          balances_map_from_included,
+          Enum.map([to, token], &Access.key(&1, %{})),
+          do_update_balance(val, :to, transfer, include_transfers)
+        )
+
+      # we are not interested in this address
+      _ ->
+        balances_map_from_included
+    end
+  end
+
+  # point of this function is to include all transfers for frontend if option :include_transfer is passed
+  defp do_update_balance(old_val, type, transfer, include_transfers) do
+    transfer_amount = if is_nil(transfer.amount), do: 1, else: transfer.amount
+
+    case {include_transfers, old_val, type} do
+      {:include_transfers, {val, transfers}, :from} ->
+        {Decimal.sub(val, transfer_amount), [{type, transfer} | transfers]}
+
+      {:include_transfers, {val, transfers}, :to} ->
+        {Decimal.add(val, transfer_amount), [{type, transfer} | transfers]}
+
+      {:include_transfers, val, :from} ->
+        {Decimal.sub(val, transfer_amount), [{type, transfer}]}
+
+      {:include_transfers, val, :to} ->
+        {Decimal.add(val, transfer_amount), [{type, transfer}]}
+
+      {_, val, :from} ->
+        Decimal.sub(val, transfer_amount)
+
+      {_, val, :to} ->
+        Decimal.add(val, transfer_amount)
+    end
+  end
+
+  def from_loss(tx) do
+    {_, fee} = Chain.fee(tx, :wei)
+
+    if error?(tx) do
+      %Wei{value: fee}
+    else
+      Wei.sum(tx.value, %Wei{value: fee})
+    end
+  end
+
+  def to_profit(tx) do
+    if error?(tx) do
+      %Wei{value: 0}
+    else
+      tx.value
+    end
+  end
+
+  def miner_profit(tx, block) do
+    base_fee_per_gas = block.base_fee_per_gas || %Wei{value: Decimal.new(0)}
+    max_priority_fee_per_gas = tx.max_priority_fee_per_gas || tx.gas_price
+    max_fee_per_gas = tx.max_fee_per_gas || tx.gas_price
+
+    priority_fee_per_gas =
+      Enum.min_by([max_priority_fee_per_gas, Wei.sub(max_fee_per_gas, base_fee_per_gas)], fn x ->
+        Wei.to(x, :wei)
+      end)
+
+    Wei.mult(priority_fee_per_gas, tx.gas_used)
+  end
+
+  defp error?(tx) do
+    case Chain.transaction_to_status(tx) do
+      {:error, _} -> true
+      _ -> false
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -104,7 +104,8 @@
         @view_module == Elixir.BlockScoutWeb.TransactionInternalTransactionView ||
         @view_module == Elixir.BlockScoutWeb.TransactionLogView ||
         @view_module == Elixir.BlockScoutWeb.TransactionRawTraceView ||
-        @view_module == Elixir.BlockScoutWeb.TransactionTokenTransferView
+        @view_module == Elixir.BlockScoutWeb.TransactionTokenTransferView ||
+        @view_module == Elixir.BlockScoutWeb.TransactionStateView
       ) -> %>
         <% to_address = @transaction && @transaction.to_address && "0x" <> Base.encode16(@transaction.to_address.hash.bytes, case: :lower) %>
         <% {:ok, created_from_address} = if @transaction.to_address_hash, do: Chain.hash_to_address(@transaction.to_address_hash), else: {:ok, nil} %>
@@ -245,6 +246,7 @@
       @view_module != Elixir.BlockScoutWeb.TransactionLogView &&
       @view_module != Elixir.BlockScoutWeb.TransactionRawTraceView &&
       @view_module != Elixir.BlockScoutWeb.TransactionTokenTransferView &&
+      @view_module != Elixir.BlockScoutWeb.TransactionStateView &&
       @view_module != Elixir.BlockScoutWeb.AddressTransactionView &&
       @view_module != Elixir.BlockScoutWeb.AddressTokenTransferView &&
       @view_module != Elixir.BlockScoutWeb.AddressTokenView &&

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tabs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_tabs.html.eex
@@ -25,4 +25,10 @@
       class: "card-tab #{tab_status("raw-trace", @conn.request_path)}",
       to: AccessHelpers.get_path(@conn, :transaction_raw_trace_path, :index, @transaction)
       ) %>
+  <%= link(
+        gettext("State changes"),
+        class: "card-tab #{tab_status("state", @conn.request_path)}",
+        to: AccessHelpers.get_path(@conn, :transaction_state_path, :index, @transaction)
+      ) 
+    %>
 </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_metatags.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_metatags.html.eex
@@ -1,0 +1,1 @@
+<%= render BlockScoutWeb.TransactionView, "_metatags.html", conn: @conn, transaction: @transaction %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_state_change.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_state_change.html.eex
@@ -1,0 +1,66 @@
+<% coin_or_transfer = if @coin_or_token_transfers == :coin, do: :coin, else: elem(List.first(@coin_or_token_transfers), 1)%>
+<%= if coin_or_transfer != :coin and coin_or_transfer.token.type != "ERC-20" or has_diff?(@balance_diff) do %>
+  <tr>
+    <%= if @address.hash == @burn_address_hash do %>
+      <td class="stakes-td">
+        <dt class="text-muted">
+          <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
+                    text: gettext("Address used in token mintings and burnings.") %>
+          <%= gettext("Burn address") %>
+        </dt>
+      </td>
+      <td class="stakes-td">
+        <%= render BlockScoutWeb.AddressView, "_link.html", address: @address, contract: BlockScoutWeb.AddressView.contract?(@address), use_custom_tooltip: false %>
+      </td>
+      <td class="stakes-td"></td>
+      <td class="stakes-td"></td>
+    <% else %>
+      <%= if Map.get(assigns, :miner) do %>
+        <td class="stakes-td">
+          <dt class="text-muted">
+            <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
+                    text: gettext("A block producer who successfully included the block onto the blockchain.") %>
+            <%= gettext("Miner") %>
+          </dt>
+        </td>
+        <td class="stakes-td">
+          <%= render BlockScoutWeb.AddressView, "_link.html", address: @address, contract: false, use_custom_tooltip: false %>
+        </td>
+      <% else %>
+        <td class="stakes-td"></td>
+        <td class="stakes-td">
+          <%= render BlockScoutWeb.AddressView, "_link.html", address: @address, contract: BlockScoutWeb.AddressView.contract?(@address), use_custom_tooltip: false %>
+        </td>
+      <% end %>
+      <%= if not_negative?(@balance_before) and not_negative?(@balance_after) do %>
+        <td class="stakes-td">
+          <span><%= display_value(@balance_before, coin_or_transfer) %></span>
+        </td>
+        <td class="stakes-td">
+          <span><%= display_value(@balance_after, coin_or_transfer) %></span>
+        </td>
+      <% else %>
+        <td class="stakes-td"></td>
+        <td class="stakes-td"></td>
+      <% end %>
+    <% end %>
+    <td class="stakes-td">
+      <%= if is_list(@coin_or_token_transfers) and elem(List.first(@coin_or_token_transfers), 1).token.type != "ERC-20" do %>
+        <%= for {type, transfer} <- @coin_or_token_transfers do %>
+          <%= case type do %>
+            <% :from ->  %>
+            <div class="py-1 mr-4 text-danger">▼ <%= display_nft(transfer) %></div>
+            <% :to -> %>
+            <div class="py-1 mr-4 text-success">▲ <%= display_nft(transfer) %></div>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= if not_negative?(@balance_diff) do %>
+          <span class="mr-4 text-success">▲ <%= display_value(@balance_diff, coin_or_transfer) %></span>
+        <% else %>
+          <span class="mr-4 text-danger">▼ <%= display_value(absolute_value_of(@balance_diff), coin_or_transfer) %></span>
+        <% end %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_state_change.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_state_change.html.eex
@@ -1,3 +1,4 @@
+<!-- <%= @address.hash %> -->
 <% coin_or_transfer = if @coin_or_token_transfers == :coin, do: :coin, else: elem(List.first(@coin_or_token_transfers), 1)%>
 <%= if coin_or_transfer != :coin and coin_or_transfer.token.type != "ERC-20" or has_diff?(@balance_diff) do %>
   <tr>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_token_balance.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/_token_balance.html.eex
@@ -1,0 +1,1 @@
+<%= format_according_to_decimals(@balance, @transfer.token.decimals) %><%= " " %><%= render BlockScoutWeb.TransactionView, "_link_to_token_symbol.html", transfer: @transfer %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_state/index.html.eex
@@ -1,0 +1,51 @@
+<section class="container">
+  <%= render BlockScoutWeb.TransactionView, "overview.html", assigns %>
+  <div class="card">
+    <%= render BlockScoutWeb.TransactionView, "_tabs.html", assigns %>
+    <div class="card-body" data-async-load data-async-listing="<%= @current_path %>">
+      <h2 class="card-title list-title-description"><%= gettext "State changes" %></h2>
+      <div data-error-message class="alert alert-danger col-12 text-left" style="display: none; padding: 0.75rem 0rem; cursor: pointer;">
+        <span href="#" class="alert alert-danger"><%= gettext("Something went wrong, click to reload.") %></span>
+      </div>
+      <%= cond do %>
+        <% Chain.transaction_to_status(@transaction) == :pending -> %>
+        <div class="tile tile-muted text-center">
+          <span><%= gettext "The changes from this transaction have not yet happened since the transaction is still pending." %></span>
+        </div>
+        <% not has_state_changes?(@transaction) -> %>
+        <div class="tile tile-muted text-center">
+          <span><%= gettext "This transaction hasn't changed state." %></span>
+        </div>
+        <% true ->  %>
+        <div class="addresses-table-container">
+          <div class="stakes-table-container">
+            <table>
+              <thead>
+                <tr>
+                  <th class="stakes-table-th">
+                    <div class="stakes-table-th-content">&nbsp;</div>
+                  </th>
+                  <th class="stakes-table-th">
+                    <div class="stakes-table-th-content"><%= gettext "Address" %></div>
+                  </th>
+                  <th class="stakes-table-th">
+                    <div class="stakes-table-th-content"><%= gettext "Balance before" %></div>
+                  </th>
+                  <th class="stakes-table-th">
+                    <div class="stakes-table-th-content"><%= gettext "Balance after" %></div>
+                  </th>
+                  <th class="stakes-table-th">
+                    <div class="stakes-table-th-content"><%= gettext "Change" %></div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody data-items>
+                <%= render BlockScoutWeb.CommonComponentsView, "_table-loader.html", columns_num: 5 %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_state_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_state_view.ex
@@ -1,0 +1,48 @@
+defmodule BlockScoutWeb.TransactionStateView do
+  use BlockScoutWeb, :view
+
+  alias Explorer.Chain
+  alias Explorer.Chain.Wei
+
+  import BlockScoutWeb.TransactionStateController, only: [from_loss: 1, to_profit: 1]
+
+  def has_diff?(%Wei{value: val}) do
+    not Decimal.eq?(val, Decimal.new(0))
+  end
+
+  def has_diff?(val) do
+    not Decimal.eq?(val, Decimal.new(0))
+  end
+
+  def not_negative?(%Wei{value: val}) do
+    not Decimal.negative?(val)
+  end
+
+  def not_negative?(val) do
+    not Decimal.negative?(val)
+  end
+
+  def absolute_value_of(%Wei{value: val}) do
+    %Wei{value: Decimal.abs(val)}
+  end
+
+  def absolute_value_of(val) do
+    Decimal.abs(val)
+  end
+
+  def has_state_changes?(tx) do
+    has_diff?(from_loss(tx)) or has_diff?(to_profit(tx))
+  end
+
+  def display_value(balance, :coin) do
+    format_wei_value(balance, :ether)
+  end
+
+  def display_value(balance, token_transfer) do
+    render("_token_balance.html", transfer: token_transfer, balance: balance)
+  end
+
+  def display_nft(token_transfer) do
+    render(BlockScoutWeb.TransactionView, "_total_transfers.html", transfer: token_transfer)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -15,7 +15,7 @@ defmodule BlockScoutWeb.TransactionView do
   import BlockScoutWeb.AddressView, only: [from_address_hash: 1, short_token_id: 2, tag_name_to_label: 1]
   import BlockScoutWeb.Tokens.Helpers
 
-  @tabs ["token-transfers", "internal-transactions", "logs", "raw-trace"]
+  @tabs ["token-transfers", "internal-transactions", "logs", "raw-trace", "state"]
 
   @token_burning_title "Token Burning"
   @token_minting_title "Token Minting"
@@ -513,6 +513,7 @@ defmodule BlockScoutWeb.TransactionView do
   defp tab_name(["internal-transactions"]), do: gettext("Internal Transactions")
   defp tab_name(["logs"]), do: gettext("Logs")
   defp tab_name(["raw-trace"]), do: gettext("Raw Trace")
+  defp tab_name(["state"]), do: gettext("State changes")
 
   defp get_transaction_type_from_token_transfers(token_transfers) do
     token_transfers_types =

--- a/apps/block_scout_web/lib/block_scout_web/web_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/web_router.ex
@@ -144,6 +144,11 @@ defmodule BlockScoutWeb.WebRouter do
         only: [:index],
         as: :token_transfer
       )
+
+      resources("/state", TransactionStateController,
+        only: [:index],
+        as: :state
+      )
     end
 
     resources("/accounts", AddressController, only: [:index])

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -76,7 +76,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:224
+#: lib/block_scout_web/templates/layout/app.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -87,6 +87,7 @@ msgid "64-bit hash of value verifying proof-of-work (note: null for POA chains).
 msgstr ""
 
 #: lib/block_scout_web/templates/block/overview.html.eex:97
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "A block producer who successfully included the block onto the blockchain."
 msgstr ""
@@ -221,6 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:29
 #: lib/block_scout_web/views/address_view.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -1592,6 +1594,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/_tile.html.eex:41
 #: lib/block_scout_web/templates/block/overview.html.eex:98
 #: lib/block_scout_web/templates/chain/_block.html.eex:16
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "Miner"
 msgstr ""
@@ -2201,6 +2204,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/index.html.eex:25
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:8
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Something went wrong, click to reload."
@@ -3261,6 +3265,48 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
 #, elixir-autogen, elixir-format
 msgid "Library"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:9
+#, elixir-autogen, elixir-format
+msgid "Address used in token mintings and burnings."
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:35
+#, elixir-autogen, elixir-format
+msgid "Balance after"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:32
+#, elixir-autogen, elixir-format
+msgid "Balance before"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:10
+#, elixir-autogen, elixir-format
+msgid "Burn address"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:38
+#, elixir-autogen, elixir-format
+msgid "Change"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:29
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:6
+#: lib/block_scout_web/views/transaction_view.ex:516
+#, elixir-autogen, elixir-format
+msgid "State changes"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "The changes from this transaction have not yet happened since the transaction is still pending."
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:17
+#, elixir-autogen, elixir-format
+msgid "This transaction hasn't changed state."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/overview.html.eex:120

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -76,7 +76,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:224
+#: lib/block_scout_web/templates/layout/app.html.eex:225
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""
@@ -87,6 +87,7 @@ msgid "64-bit hash of value verifying proof-of-work (note: null for POA chains).
 msgstr ""
 
 #: lib/block_scout_web/templates/block/overview.html.eex:97
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "A block producer who successfully included the block onto the blockchain."
 msgstr ""
@@ -221,6 +222,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:29
 #: lib/block_scout_web/views/address_view.ex:107
 #, elixir-autogen, elixir-format
 msgid "Address"
@@ -1592,6 +1594,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/_tile.html.eex:41
 #: lib/block_scout_web/templates/block/overview.html.eex:98
 #: lib/block_scout_web/templates/chain/_block.html.eex:16
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "Miner"
 msgstr ""
@@ -2201,6 +2204,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/index.html.eex:25
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:13
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:15
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:8
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Something went wrong, click to reload."
@@ -3261,6 +3265,48 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Library"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:9
+#, elixir-autogen, elixir-format
+msgid "Address used in token mintings and burnings."
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:35
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Balance after"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:32
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Balance before"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/_state_change.html.eex:10
+#, elixir-autogen, elixir-format
+msgid "Burn address"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:38
+#, elixir-autogen, elixir-format
+msgid "Change"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction/_tabs.html.eex:29
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:6
+#: lib/block_scout_web/views/transaction_view.ex:516
+#, elixir-autogen, elixir-format
+msgid "State changes"
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "The changes from this transaction have not yet happened since the transaction is still pending."
+msgstr ""
+
+#: lib/block_scout_web/templates/transaction_state/index.html.eex:17
+#, elixir-autogen, elixir-format
+msgid "This transaction hasn't changed state."
 msgstr ""
 
 #: lib/block_scout_web/templates/address/overview.html.eex:120

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_state_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_state_controller_test.exs
@@ -1,0 +1,167 @@
+defmodule BlockScoutWeb.TransactionStateControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  import Mox
+
+  import BlockScoutWeb.WebRouter.Helpers, only: [transaction_state_path: 3]
+  import BlockScoutWeb.WeiHelpers, only: [format_wei_value: 2]
+  import EthereumJSONRPC, only: [integer_to_quantity: 1]
+  alias Explorer.Chain.Wei
+  alias EthereumJSONRPC.Blocks
+
+  describe "GET index/3" do
+    test "loads existing transaction", %{conn: conn} do
+      transaction = insert(:transaction)
+      conn = get(conn, transaction_state_path(conn, :index, transaction.hash))
+
+      assert html_response(conn, 200)
+    end
+
+    test "with missing transaction", %{conn: conn} do
+      hash = transaction_hash()
+      conn = get(conn, transaction_state_path(BlockScoutWeb.Endpoint, :index, hash))
+
+      assert html_response(conn, 404)
+    end
+
+    test "with invalid transaction hash", %{conn: conn} do
+      conn = get(conn, transaction_state_path(BlockScoutWeb.Endpoint, :index, "nope"))
+
+      assert html_response(conn, 422)
+    end
+
+    test "returns fetched state changes for the transaction with token transfer", %{conn: conn} do
+      block = insert(:block)
+      address_a = insert(:address)
+      address_b = insert(:address)
+      token = insert(:token, type: "ERC-20")
+
+      insert(:fetched_balance,
+        address_hash: address_a.hash,
+        value: 1_000_000_000_000_000_000,
+        block_number: block.number
+      )
+
+      insert(:fetched_balance,
+        address_hash: address_b.hash,
+        value: 2_000_000_000_000_000_000,
+        block_number: block.number
+      )
+
+      transaction =
+        :transaction
+        |> insert(from_address: address_a, to_address: address_b, value: 1000)
+        |> with_block(status: :ok)
+
+      insert(:fetched_balance,
+        address_hash: transaction.block.miner_hash,
+        value: 2_500_000,
+        block_number: block.number
+      )
+
+      token_transfer =
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          token: token,
+          token_contract_address: token.contract_address
+        )
+
+      insert(
+        :token_balance,
+        address: token_transfer.from_address,
+        token: token,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 3_000_000,
+        block_number: block.number
+      )
+
+      insert(
+        :token_balance,
+        address: token_transfer.to_address,
+        token: token,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 1000,
+        block_number: block.number
+      )
+
+      # to check if we can display transaction overview
+      get(conn, transaction_state_path(conn, :index, transaction))
+      conn = get(conn, transaction_state_path(conn, :index, transaction), %{type: "JSON"})
+
+      {:ok, %{"items" => items}} = conn.resp_body |> Poison.decode()
+      full_text = Enum.join(items)
+
+      assert(String.contains?(full_text, format_wei_value(%Wei{value: Decimal.new(1, 1, 18)}, :ether)))
+
+      assert(String.contains?(full_text, format_wei_value(%Wei{value: Decimal.new(1, 2, 18)}, :ether)))
+
+      assert(length(items) == 5)
+    end
+
+    test "fetch coin balances if needed", %{conn: conn} do
+      EthereumJSONRPC.Mox
+      |> stub(:json_rpc, fn
+        [%{id: id, method: "eth_getBalance", params: _}], _options ->
+          {:ok, [%{id: id, result: integer_to_quantity(123)}]}
+
+        [%{id: id, method: "eth_getBlockByNumber", params: _}], _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: %{
+                 "author" => "0x0000000000000000000000000000000000000000",
+                 "difficulty" => "0x20000",
+                 "extraData" => "0x",
+                 "gasLimit" => "0x663be0",
+                 "gasUsed" => "0x0",
+                 "hash" => "0x5b28c1bfd3a15230c9a46b399cd0f9a6920d432e85381cc6a140b06e8410112f",
+                 "logsBloom" =>
+                   "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                 "miner" => "0x0000000000000000000000000000000000000000",
+                 "number" => integer_to_quantity(1),
+                 "parentHash" => "0x0000000000000000000000000000000000000000000000000000000000000000",
+                 "receiptsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                 "sealFields" => [
+                   "0x80",
+                   "0xb8410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                 ],
+                 "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                 "signature" =>
+                   "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                 "size" => "0x215",
+                 "stateRoot" => "0xfad4af258fd11939fae0c6c6eec9d340b1caac0b0196fd9a1bc3f489c5bf00b3",
+                 "step" => "0",
+                 "timestamp" => "0x0",
+                 "totalDifficulty" => "0x20000",
+                 "transactions" => [],
+                 "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                 "uncles" => []
+               }
+             }
+           ]}
+      end)
+
+      insert(:block)
+      insert(:block)
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(from_address: address_a, to_address: address_b, value: 1000)
+        |> with_block(status: :ok)
+
+      conn = get(conn, transaction_state_path(conn, :index, transaction), %{type: "JSON"})
+
+      {:ok, %{"items" => items}} = conn.resp_body |> Poison.decode()
+      full_text = Enum.join(items)
+
+      assert(String.contains?(full_text, format_wei_value(%Wei{value: Decimal.new(123)}, :ether)))
+      assert(length(items) == 3)
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4351,6 +4351,8 @@ defmodule Explorer.Chain do
 
   defp handle_paging_options(query, nil), do: query
 
+  defp handle_paging_options(query, %PagingOptions{key: nil, page_size: nil}), do: query
+
   defp handle_paging_options(query, paging_options) do
     query
     |> page_transaction(paging_options)
@@ -5139,6 +5141,12 @@ defmodule Explorer.Chain do
       balances_with_dates
       |> Enum.sort(fn balance1, balance2 -> balance1.block_number >= balance2.block_number end)
     end
+  end
+
+  def get_token_balance(address_hash, token_contract_address_hash, block_number) do
+    query = TokenBalance.fetch_token_balance(address_hash, token_contract_address_hash, block_number)
+
+    Repo.one(query)
   end
 
   def get_coin_balance(address_hash, block_number) do

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -9,9 +9,6 @@ defmodule Explorer.Chain.Address.TokenBalance do
 
   use Explorer.Schema
 
-  import Ecto.Changeset
-  import Ecto.Query, only: [from: 2]
-
   alias Explorer.Chain
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.{Address, Block, Hash, Token}
@@ -91,6 +88,20 @@ defmodule Explorer.Chain.Address.TokenBalance do
       where:
         ((tb.address_hash != ^@burn_address_hash and t.type == "ERC-721") or t.type == "ERC-20" or t.type == "ERC-1155") and
           (is_nil(tb.value_fetched_at) or is_nil(tb.value))
+    )
+  end
+
+  @doc """
+  Builds an `Ecto.Query` to fetch the token balance of the given token contract hash of the given address in the given block.
+  """
+  def fetch_token_balance(address_hash, token_contract_address_hash, block_number) do
+    from(
+      tb in TokenBalance,
+      where: tb.address_hash == ^address_hash,
+      where: tb.token_contract_address_hash == ^token_contract_address_hash,
+      where: tb.block_number <= ^block_number,
+      limit: ^1,
+      order_by: [desc: :block_number]
     )
   end
 end

--- a/apps/explorer/test/explorer/chain/address/token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/token_balance_test.exs
@@ -3,6 +3,7 @@ defmodule Explorer.Chain.Address.TokenBalanceTest do
 
   alias Explorer.Repo
   alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Chain
 
   describe "unfetched_token_balances/0" do
     test "returns only the token balances that have value_fetched_at nil" do
@@ -74,6 +75,48 @@ defmodule Explorer.Chain.Address.TokenBalanceTest do
         |> List.first()
 
       assert result.block_number == token_balance.block_number
+    end
+  end
+
+  describe "fetch_token_balance/3" do
+    test "returns the token balance for the given address" do
+      token_balance = insert(:token_balance)
+
+      result =
+        TokenBalance.fetch_token_balance(
+          token_balance.address_hash,
+          token_balance.token_contract_address_hash,
+          token_balance.block_number
+        )
+        |> Repo.one()
+
+      assert(result.address_hash == token_balance.address_hash)
+    end
+
+    test "returns the token balance only from block less or equal than given for the given address" do
+      address = insert(:address)
+      token_balance_a = insert(:token_balance, address: address, block_number: 10)
+
+      result =
+        TokenBalance.fetch_token_balance(
+          token_balance_a.address_hash,
+          token_balance_a.token_contract_address_hash,
+          token_balance_a.block_number - 3
+        )
+        |> Repo.one()
+
+      assert(is_nil(result))
+      token_balance_b = insert(:token_balance, address: address, block_number: token_balance_a.block_number - 3)
+
+      result =
+        TokenBalance.fetch_token_balance(
+          token_balance_b.address_hash,
+          token_balance_b.token_contract_address_hash,
+          token_balance_b.block_number
+        )
+        |> Repo.one()
+
+      assert(result.value == token_balance_b.value)
     end
   end
 end


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/5583

## Changelog
Add tab with state changes to transaction page that show how balances changed. Some examlpes below:
- [tx](https://blockscout.com/xdai/mainnet/tx/0xfeacfd6eaa41ad529e29d9779fb4d4a8d9e74c22001d40bba66defb815bb4dc2)
![image](https://user-images.githubusercontent.com/53992153/185777644-a1e46453-1239-490a-8d14-7cd97f49985e.png)
- [tx](https://blockscout.com/poa/sokol/tx/0xf2b1c231ff1af2ba4be2282fdc5fb53c2217ca3aa0fc05fbed168d3c81a1dcb7)
![image](https://user-images.githubusercontent.com/53992153/185778134-c9cdd6b4-598b-4382-a6e4-106808567475.png)
In case of multiple transfers of unique tokens of the same contranct all of them diaplayed in one change
- [tx](https://blockscout.com/xdai/mainnet/tx/0x92d6f2f5798d8104c337c55e25dfae50194dcc81f930c94bea32a57bc9425506)
![image](https://user-images.githubusercontent.com/53992153/185776572-3fbc6a4e-19ff-46dc-85f6-ba17f1643d84.png)
Here balance of contract(0x09C131) is unknown, so it isn't displayed

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
