### PR TITLE
Fix unexpected messages in CoinBalanceOnDemand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#5809](https://github.com/blockscout/blockscout/pull/5809) - Fix 404 on `/metadata` page
 - [#5807](https://github.com/blockscout/blockscout/pull/5807) - Update Makefile migrate command due to release build
 - [#5786](https://github.com/blockscout/blockscout/pull/5786) - Replace `current_path` with `Controller.current_full_path` in two controllers
+- [#5948](https://github.com/blockscout/blockscout/pull/5948) - Fix unexpected messages in `CoinBalanceOnDemand`
 
 ### Chore
 - [#5869](https://github.com/blockscout/blockscout/pull/5869) - Bump reduce-reducers from 0.4.3 to 1.0.4 in /apps/block_scout_web/assets

--- a/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
@@ -64,10 +64,12 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemand do
     GenServer.start_link(__MODULE__, json_rpc_named_arguments, server_opts)
   end
 
+  @impl true
   def init(json_rpc_named_arguments) do
     {:ok, %{json_rpc_named_arguments: json_rpc_named_arguments}}
   end
 
+  @impl true
   def handle_cast({:fetch_and_update, block_number, address}, state) do
     result = fetch_and_update(block_number, address, state.json_rpc_named_arguments)
 
@@ -78,15 +80,27 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemand do
     {:noreply, state}
   end
 
+  @impl true
   def handle_cast({:fetch_and_import, block_number, address}, state) do
     fetch_and_import(block_number, address, state.json_rpc_named_arguments)
 
     {:noreply, state}
   end
 
+  @impl true
   def handle_cast({:fetch_and_import_daily_balances, block_number, address}, state) do
     fetch_and_import_daily_balances(block_number, address, state.json_rpc_named_arguments)
 
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:DOWN, _, :process, _, _}, state) do
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({_ref, _}, state) do
     {:noreply, state}
   end
 


### PR DESCRIPTION
Resolves #5517 

## Motivation

Since `Chain.import` uses `Task.async` under the hood and `CoinBalanceOnDemand` uses `Chain.import`, `CoinBalanceOnDemand` receives messages about tasks completion it doesn't expect.

## Changelog

Added stub `handle_info`s so messages like these are not unexpected.
