### PR TITLE
Fix CSV export of internal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#5860](https://github.com/blockscout/blockscout/pull/5860) - Integrate rust verifier micro-service ([blockscout-rs/verifier](https://github.com/blockscout/blockscout-rs/tree/main/verification))
 
 ### Fixes
+- [#5975](https://github.com/blockscout/blockscout/pull/5975) - Fix CSV export of internal transactions
 - [#5957](https://github.com/blockscout/blockscout/pull/5957) - Server-side reCAPTCHA check for CSV export
 - [#5954](https://github.com/blockscout/blockscout/pull/5954) - Fix ace editor appearance
 - [#5942](https://github.com/blockscout/blockscout/pull/5942), [#5945](https://github.com/blockscout/blockscout/pull/5945) - Fix nightly solidity versions filtering UX

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -22,6 +22,8 @@ defmodule BlockScoutWeb.AddressTransactionController do
   alias Indexer.Fetcher.CoinBalanceOnDemand
   alias Phoenix.View
 
+  alias Plug.Conn
+
   @transaction_necessity_by_association [
     necessity_by_association: %{
       [created_contract_address: :names] => :optional,
@@ -188,7 +190,15 @@ defmodule BlockScoutWeb.AddressTransactionController do
          {:recaptcha, true} <- {:recaptcha, captcha_helper().recaptcha_passed?(recaptcha_response)} do
       address
       |> csv_export_module.export(from_period, to_period)
-      |> Enum.into(put_resp_params(conn, file_name))
+      |> Enum.reduce_while(put_resp_params(conn, file_name), fn chunk, conn ->
+        case Conn.chunk(conn, chunk) do
+          {:ok, conn} ->
+            {:cont, conn}
+
+          {:error, :closed} ->
+            {:halt, conn}
+        end
+      end)
     else
       :error ->
         unprocessable_entity(conn)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -227,37 +227,14 @@ defmodule Explorer.Chain do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
     if direction == nil do
-      query_to_address_hash_wrapped =
-        InternalTransaction
-        |> InternalTransaction.where_nonpending_block()
-        |> InternalTransaction.where_address_fields_match(hash, :to_address_hash)
-        |> InternalTransaction.where_block_number_in_period(from_block, to_block)
-        |> common_where_limit_order(paging_options)
-        |> wrapped_union_subquery()
-
-      query_from_address_hash_wrapped =
-        InternalTransaction
-        |> InternalTransaction.where_nonpending_block()
-        |> InternalTransaction.where_address_fields_match(hash, :from_address_hash)
-        |> InternalTransaction.where_block_number_in_period(from_block, to_block)
-        |> common_where_limit_order(paging_options)
-        |> wrapped_union_subquery()
-
-      query_created_contract_address_hash_wrapped =
-        InternalTransaction
-        |> InternalTransaction.where_nonpending_block()
-        |> InternalTransaction.where_address_fields_match(hash, :created_contract_address_hash)
-        |> InternalTransaction.where_block_number_in_period(from_block, to_block)
-        |> common_where_limit_order(paging_options)
-        |> wrapped_union_subquery()
-
       full_query =
-        query_to_address_hash_wrapped
-        |> union(^query_from_address_hash_wrapped)
-        |> union(^query_created_contract_address_hash_wrapped)
+        InternalTransaction
+        |> InternalTransaction.where_nonpending_block()
+        |> InternalTransaction.where_address_fields_match(hash, nil)
+        |> InternalTransaction.where_block_number_in_period(from_block, to_block)
+        |> common_where_limit_order(paging_options)
 
       full_query
-      |> wrapped_union_subquery()
       |> order_by(
         [q],
         desc: q.block_number,

--- a/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/address_internal_transaction_csv_exporter.ex
@@ -18,6 +18,7 @@ defmodule Explorer.Chain.AddressInternalTransactionCsvExporter do
 
     address.hash
     |> fetch_all_internal_transactions(from_block, to_block, @paging_options)
+    |> Enum.sort_by(&{&1.block_number, &1.index, &1.transaction_index}, :desc)
     |> to_csv_format()
     |> dump_to_stream()
   end

--- a/apps/explorer/test/explorer/chain/address_internal_transaction_csv_exporter_test.exs
+++ b/apps/explorer/test/explorer/chain/address_internal_transaction_csv_exporter_test.exs
@@ -133,6 +133,44 @@ defmodule Explorer.Chain.AddressInternalTransactionCsvExporterTest do
       end)
       |> Enum.count()
 
+      1..200
+      |> Enum.map(fn index ->
+        transaction =
+          :transaction
+          |> insert()
+          |> with_block()
+
+        insert(:internal_transaction,
+          index: index,
+          transaction: transaction,
+          to_address: address,
+          block_number: transaction.block_number,
+          block_hash: transaction.block_hash,
+          block_index: index,
+          transaction_index: transaction.index
+        )
+      end)
+      |> Enum.count()
+
+      1..200
+      |> Enum.map(fn index ->
+        transaction =
+          :transaction
+          |> insert()
+          |> with_block()
+
+        insert(:internal_transaction,
+          index: index,
+          transaction: transaction,
+          created_contract_address: address,
+          block_number: transaction.block_number,
+          block_hash: transaction.block_hash,
+          block_index: index,
+          transaction_index: transaction.index
+        )
+      end)
+      |> Enum.count()
+
       from_period = Timex.format!(Timex.shift(Timex.now(), minutes: -1), "%Y-%m-%d", :strftime)
       to_period = Timex.format!(Timex.now(), "%Y-%m-%d", :strftime)
 
@@ -142,7 +180,7 @@ defmodule Explorer.Chain.AddressInternalTransactionCsvExporterTest do
         |> Enum.to_list()
         |> Enum.drop(1)
 
-      assert Enum.count(result) == 200
+      assert Enum.count(result) == 600
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/address_transaction_csv_exporter_test.exs
+++ b/apps/explorer/test/explorer/chain/address_transaction_csv_exporter_test.exs
@@ -96,6 +96,22 @@ defmodule Explorer.Chain.AddressTransactionCsvExporterTest do
       end)
       |> Enum.count()
 
+      1..200
+      |> Enum.map(fn _ ->
+        :transaction
+        |> insert(to_address: address)
+        |> with_block()
+      end)
+      |> Enum.count()
+
+      1..200
+      |> Enum.map(fn _ ->
+        :transaction
+        |> insert(created_contract_address: address)
+        |> with_block()
+      end)
+      |> Enum.count()
+
       from_period = Timex.format!(Timex.shift(Timex.now(), minutes: -1), "%Y-%m-%d", :strftime)
       to_period = Timex.format!(Timex.now(), "%Y-%m-%d", :strftime)
 
@@ -105,7 +121,7 @@ defmodule Explorer.Chain.AddressTransactionCsvExporterTest do
         |> Enum.to_list()
         |> Enum.drop(1)
 
-      assert Enum.count(result) == 200
+      assert Enum.count(result) == 600
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5643
Resolves https://github.com/blockscout/blockscout/issues/5535

## Motivation

Fix 
- error in CSV export of internal transactions
- warning in general CSV export

## Changelog

We shouldn't use union joins in address to internal transactions query because limit is applied on each  joining part (not at the joint query) and breaking the logic of pagination.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
