### PR TITLE
Sort by address.hash column in accountlist API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#6032](https://github.com/blockscout/blockscout/pull/6032) - Sort by address.hash column in accountlist API endpoint
 - [#6017](https://github.com/blockscout/blockscout/pull/6017), [#6028](https://github.com/blockscout/blockscout/pull/6028) - Move "contract interaction" and "Add chain to MM" env vars to runtime
 - [#6012](https://github.com/blockscout/blockscout/pull/6012) - Fix display of estimated addresses counter on the main page
 - [#5978](https://github.com/blockscout/blockscout/pull/5978) - Allow timestamp param in the log of eth_getTransactionReceipt method

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -82,6 +82,49 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
              ] = response["result"]
     end
 
+    test "sort by hash", %{params: params, conn: conn} do
+      inserted_at = Timex.shift(Timex.now(), minutes: -10)
+
+      first_address =
+        insert(:address,
+          hash: "0x0000000000000000000000000000000000000001",
+          fetched_coin_balance: 10,
+          inserted_at: inserted_at
+        )
+
+      second_address =
+        insert(:address,
+          hash: "0x0000000000000000000000000000000000000002",
+          fetched_coin_balance: 100,
+          inserted_at: inserted_at
+        )
+
+      first_address_hash = to_string(first_address.hash)
+      second_address_hash = to_string(second_address.hash)
+
+      first_address_inserted_at = to_string(first_address.inserted_at)
+      second_address_inserted_at = to_string(second_address.inserted_at)
+
+      response =
+        conn
+        |> get("/api", params)
+        |> json_response(200)
+
+      schema = listaccounts_schema()
+      assert :ok = ExJsonSchema.Validator.validate(schema, response)
+      assert response["message"] == "OK"
+      assert response["status"] == "1"
+
+      assert [
+               %{
+                 "address" => ^first_address_hash
+               },
+               %{
+                 "address" => ^second_address_hash
+               }
+             ] = response["result"]
+    end
+
     test "with a stale balance", %{conn: conn, params: params} do
       now = Timex.now()
 

--- a/apps/explorer/lib/explorer/etherscan/addresses.ex
+++ b/apps/explorer/lib/explorer/etherscan/addresses.ex
@@ -18,7 +18,7 @@ defmodule Explorer.Etherscan.Addresses do
     query =
       from(
         address in Address,
-        order_by: [asc: address.inserted_at],
+        order_by: [asc: address.inserted_at, asc: address.hash],
         offset: ^offset,
         limit: ^limit
       )


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6023


## Motivation

Results of `accountlist` API endpoint are non-deterministic.

## Changelog

Add ascending sorting by `address.hash` together with `address.inserted_at` in order making results deterministic.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
