### PR TITLE
Extend token name from string to text type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#6038](https://github.com/blockscout/blockscout/pull/6038) - Extend token name from string to text type
 - [#6037](https://github.com/blockscout/blockscout/pull/6037) - Fix order of results in txlistinternal API endpoint
 - [#6036](https://github.com/blockscout/blockscout/pull/6036) - Fix address checksum on transaction page
 - [#6032](https://github.com/blockscout/blockscout/pull/6032) - Sort by address.hash column in accountlist API endpoint

--- a/apps/explorer/priv/repo/migrations/20220902083436_extend_token_name_type.exs
+++ b/apps/explorer/priv/repo/migrations/20220902083436_extend_token_name_type.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.ExtendTokenNameType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tokens) do
+      modify(:name, :text, null: true)
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/5682
Resolves https://github.com/blockscout/blockscout/issues/5934

## Motivation

Token names can be longer than 255 symbols, which is the current limit of token name type in the DB

## Changelog

Modify `tokens` table name column type from `character varying(255)` to `text`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
