### PR TITLE
Re-use _btn_copy.html for raw trace page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Chore
 
+- [#6045](https://github.com/blockscout/blockscout/pull/6045) - Re-use _btn_copy.html for raw trace page
 - [#6035](https://github.com/blockscout/blockscout/pull/6035) - Hide copy btn if no raw trace
 - [#6034](https://github.com/blockscout/blockscout/pull/6034) - Suppress empty sections in supported chain dropdown
 - [#5939](https://github.com/blockscout/blockscout/pull/5939) - Bump sweetalert2 from 11.4.26 to 11.4.27 in /apps/block_scout_web/assets

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -7,6 +7,7 @@
 * Node JS version (`node -v`):
 * Operating System:
 * Blockscout Version/branch/commit:
+* Archive node type && version (Erigon/Geth/Nethermind/Ganache/?):
 
 ### Steps to reproduce
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction_raw_trace/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction_raw_trace/index.html.eex
@@ -6,20 +6,14 @@
     <div class="card-body">
       <h2 class="card-title"><%= gettext "Raw Trace" %>
         <%= if Enum.count(@internal_transactions) > 0 do %>
-          <span
-            aria-label="Copy Value"
-            class="btn-copy-icon tx-raw-input transaction-input"
-            id="tx-raw-input"
-            data-clipboard-text="<%= for {line, _} <- raw_traces_with_lines(@internal_transactions), do: line %>"
-            data-placement="top"
-            data-toggle="tooltip"
-            title='<%= gettext("Copy Raw Trace") %>'
-            style="float: right;"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32.5 32.5" width="32" height="32">
-              <path fill-rule="evenodd" d="M23.5 20.5a1 1 0 0 1-1-1v-9h-9a1 1 0 0 1 0-2h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zm-3-7v10a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-10a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1zm-2 1h-8v8h8v-8z"/>
-            </svg>
-          </span>
+          <% raw_trace_text = for {line, _} <- raw_traces_with_lines(@internal_transactions), do: line %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_btn_copy.html",
+            id: "tx-raw-trace-input",
+            additional_classes: ["tx-raw-input", "transaction-input"],
+            clipboard_text: raw_trace_text,
+            aria_label: gettext("Copy Value"),
+            title: gettext("Copy Raw Trace"),
+            style: "float: right;" %>
         <% end %>
       </h2>
       <%= if Enum.count(@internal_transactions) > 0 do %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Copy Parent Hash"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:16
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:15
 #, elixir-autogen, elixir-format
 msgid "Copy Raw Trace"
 msgstr ""
@@ -686,6 +686,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:41
 #: lib/block_scout_web/templates/transaction/overview.html.eex:463
 #: lib/block_scout_web/templates/transaction/overview.html.eex:469
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Copy Value"
 msgstr ""
@@ -2861,7 +2862,7 @@ msgstr ""
 msgid "truffle flattener"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:29
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "No trace entries found."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -635,7 +635,7 @@ msgstr ""
 msgid "Copy Parent Hash"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:16
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:15
 #, elixir-autogen, elixir-format
 msgid "Copy Raw Trace"
 msgstr ""
@@ -686,6 +686,7 @@ msgstr ""
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:41
 #: lib/block_scout_web/templates/transaction/overview.html.eex:463
 #: lib/block_scout_web/templates/transaction/overview.html.eex:469
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Copy Value"
 msgstr ""
@@ -2861,7 +2862,7 @@ msgstr ""
 msgid "truffle flattener"
 msgstr ""
 
-#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:29
+#: lib/block_scout_web/templates/transaction_raw_trace/index.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "No trace entries found."
 msgstr ""


### PR DESCRIPTION
## Motivation

Re-use _btn_copy.html for raw trace page

Also, issue template extended with the question about archive node type & version.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
