### PR TITLE
Docker: Final layer needs file(1) command for file_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- [#6077](https://github.com/blockscout/blockscout/pull/6077) - Docker: Final layer needs file(1) command for file_info
 
 ### Chore
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,8 @@ RUN mkdir -p /opt/release \
 ##############################################################
 FROM bitwalker/alpine-elixir-phoenix:1.13
 
+RUN apk --no-cache --update add file
+
 WORKDIR /app
 
 COPY --from=builder /opt/release/blockscout .


### PR DESCRIPTION
Otherwise you get errors like

```
Request: GET /token/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d/instance/9244/token-transfers
** (exit) an exception was raised:
    ** (ErlangError) Erlang error: :enoent
        (elixir 1.13.1) lib/system.ex:1044: System.cmd("file", ["--mime-type", "/tmpbriefly-1662/briefly-576456308231461724-FSgoFfxhJar62GttAgjA"], [])
        (file_info 0.0.4) lib/file_info.ex:16: FileInfo.get_info/1
        (block_scout_web 4.1.8) lib/block_scout_web/views/tokens/instance/overview_view.ex:67: BlockScoutWeb.Tokens.Instance.OverviewView.media_type/1
        (block_scout_web 4.1.8) lib/block_scout_web/templates/tokens/instance/overview/_details.html.eex:64: BlockScoutWeb.Tokens.Instance.OverviewView."_details.html"/1
        (block_scout_web 4.1.8) lib/block_scout_web/templates/tokens/instance/transfer/index.html.eex:2: BlockScoutWeb.Tokens.Instance.TransferView."index.html"/1
        (phoenix 1.5.13) lib/phoenix/view.ex:310: Phoenix.View.render_within/3
        (phoenix 1.5.13) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.13) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
```