### PR TITLE
Fix token instance fetcher for ERC-1155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [#5948](https://github.com/blockscout/blockscout/pull/5948) - Fix unexpected messages in `CoinBalanceOnDemand`
 - [#6013](https://github.com/blockscout/blockscout/pull/6013) - Fix ERC-1155 tokens fetching
 - [#6043](https://github.com/blockscout/blockscout/pull/6043) - Fix token instance fetching
+- [#6093](https://github.com/blockscout/blockscout/pull/6093) - Fix Indexer.Fetcher.TokenInstance for ERC-1155 tokens
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4555,16 +4555,22 @@ defmodule Explorer.Chain do
         on: token.contract_address_hash == token_transfer.token_contract_address_hash,
         left_join: instance in Instance,
         on:
-          token_transfer.token_id == instance.token_id and
-            token_transfer.token_contract_address_hash == instance.token_contract_address_hash,
-        where: is_nil(instance.token_id) and not is_nil(token_transfer.token_id),
-        select: %{contract_address_hash: token_transfer.token_contract_address_hash, token_id: token_transfer.token_id}
+          token_transfer.token_contract_address_hash == instance.token_contract_address_hash and
+            (token_transfer.token_id == instance.token_id or
+               fragment("? @> ARRAY[?::decimal]", token_transfer.token_ids, instance.token_id)),
+        where:
+          is_nil(instance.token_id) and (not is_nil(token_transfer.token_id) or not is_nil(token_transfer.token_ids)),
+        select: %{
+          contract_address_hash: token_transfer.token_contract_address_hash,
+          token_id: token_transfer.token_id,
+          token_ids: token_transfer.token_ids
+        }
       )
 
     distinct_query =
       from(
         q in subquery(query),
-        distinct: [q.contract_address_hash, q.token_id]
+        distinct: [q.contract_address_hash, q.token_id, q.token_ids]
       )
 
     Repo.stream_reduce(distinct_query, initial, reducer)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4802,7 +4802,7 @@ defmodule Explorer.ChainTest do
   end
 
   describe "stream_unfetched_token_instances/2" do
-    test "reduces wuth given reducer and accumulator" do
+    test "reduces with given reducer and accumulator for ERC-721 token" do
       token_contract_address = insert(:contract_address)
       token = insert(:token, contract_address: token_contract_address, type: "ERC-721")
 
@@ -4827,7 +4827,33 @@ defmodule Explorer.ChainTest do
       assert result.contract_address_hash == token_transfer.token_contract_address_hash
     end
 
-    test "does not fetch token transfers without token id" do
+    test "reduces with given reducer and accumulator for ERC-1155 token" do
+      token_contract_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_contract_address, type: "ERC-1155")
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(insert(:block, number: 1))
+
+      token_transfer =
+        insert(
+          :token_transfer,
+          block_number: 1000,
+          to_address: build(:address),
+          transaction: transaction,
+          token_contract_address: token_contract_address,
+          token: token,
+          token_id: nil,
+          token_ids: [11]
+        )
+
+      assert {:ok, [result]} = Chain.stream_unfetched_token_instances([], &[&1 | &2])
+      assert result.token_ids == token_transfer.token_ids
+      assert result.contract_address_hash == token_transfer.token_contract_address_hash
+    end
+
+    test "does not fetch token transfers without token id or token_ids" do
       token_contract_address = insert(:contract_address)
       token = insert(:token, contract_address: token_contract_address, type: "ERC-721")
 
@@ -4843,7 +4869,8 @@ defmodule Explorer.ChainTest do
         transaction: transaction,
         token_contract_address: token_contract_address,
         token: token,
-        token_id: nil
+        token_id: nil,
+        token_ids: nil
       )
 
       assert {:ok, []} = Chain.stream_unfetched_token_instances([], &[&1 | &2])

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -50,7 +50,20 @@ defmodule Indexer.Fetcher.TokenInstance do
   end
 
   @impl BufferedTask
-  def run([%{contract_address_hash: token_contract_address_hash, token_id: token_id}], _json_rpc_named_arguments) do
+  def run([%{contract_address_hash: hash, token_id: token_id, token_ids: token_ids}], _json_rpc_named_arguments) do
+    all_token_ids =
+      cond do
+        is_nil(token_id) -> token_ids
+        is_nil(token_ids) -> [token_id]
+        true -> [token_id] ++ token_ids
+      end
+
+    Enum.each(all_token_ids, &fetch_instance(hash, &1))
+
+    :ok
+  end
+
+  defp fetch_instance(token_contract_address_hash, token_id) do
     case InstanceMetadataRetriever.fetch_metadata(to_string(token_contract_address_hash), Decimal.to_integer(token_id)) do
       {:ok, %{metadata: metadata}} ->
         params = %{
@@ -82,8 +95,6 @@ defmodule Indexer.Fetcher.TokenInstance do
 
         :ok
     end
-
-    :ok
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/token_instance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance.ex
@@ -103,9 +103,13 @@ defmodule Indexer.Fetcher.TokenInstance do
   def async_fetch(token_transfers) when is_list(token_transfers) do
     data =
       token_transfers
-      |> Enum.reject(fn token_transfer -> is_nil(token_transfer.token_id) end)
+      |> Enum.reject(fn token_transfer -> is_nil(token_transfer.token_id) and is_nil(token_transfer.token_ids) end)
       |> Enum.map(fn token_transfer ->
-        %{contract_address_hash: token_transfer.token_contract_address_hash, token_id: token_transfer.token_id}
+        %{
+          contract_address_hash: token_transfer.token_contract_address_hash,
+          token_id: token_transfer.token_id,
+          token_ids: token_transfer.token_ids
+        }
       end)
       |> Enum.uniq()
 


### PR DESCRIPTION
## Motivation

Token instance fetchers operates only the `token_id` field of token transfer entity while ERC-1155 tokens uses `token_ids` field which means that token instance fetcher just ignores them.

## Changelog

Updated token instance fetcher algorithm so it fetches ERC-1155 token instances as well.