### PR TITLE
Fix inconsistent behaviour of getsourcecode method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixes
 
+- [#6094](https://github.com/blockscout/blockscout/pull/6094) - Fix inconsistent behaviour of `getsourcecode` method
+
 ### Chore
 
 ## 4.1.8-beta

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   alias BlockScoutWeb.API.RPC.Helpers
   alias Explorer.Chain
   alias Explorer.Chain.Events.Publisher, as: EventsPublisher
-  alias Explorer.Chain.{Hash, SmartContract}
+  alias Explorer.Chain.{Address, Hash, SmartContract}
   alias Explorer.Chain.SmartContract.VerificationStatus
   alias Explorer.Etherscan.Contracts
   alias Explorer.SmartContract.Helper
@@ -404,7 +404,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
       address = Contracts.address_hash_to_address_with_source_code(address_hash)
 
       render(conn, :getsourcecode, %{
-        contract: address
+        contract: address || %Address{hash: address_hash, smart_contract: nil}
       })
     else
       {:address_param, :error} ->
@@ -412,9 +412,6 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
 
       {:format, :error} ->
         render(conn, :error, error: @invalid_address)
-
-      {:contract, :not_found} ->
-        render(conn, :getsourcecode, %{contract: nil, address_hash: nil})
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
 
   alias BlockScoutWeb.AddressView
   alias BlockScoutWeb.API.RPC.RPCView
+  alias Ecto.Association.NotLoaded
   alias Explorer.Chain
   alias Explorer.Chain.{Address, DecompiledSmartContract, SmartContract}
 
@@ -32,25 +33,6 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
 
   def render("show.json", %{result: result}) do
     RPCView.render("show.json", data: result)
-  end
-
-  defp prepare_source_code_contract(nil) do
-    %{
-      "Address" => "",
-      "SourceCode" => "",
-      "ABI" => "Contract source code not verified",
-      "ContractName" => "",
-      "CompilerVersion" => "",
-      "DecompiledSourceCode" => "",
-      "DecompilerVersion" => decompiler_version(nil),
-      "OptimizationUsed" => "",
-      "OptimizationRuns" => "",
-      "EVMVersion" => "",
-      "ConstructorArguments" => "",
-      "ExternalLibraries" => "",
-      "FileName" => "",
-      "IsProxy" => "false"
-    }
   end
 
   defp prepare_source_code_contract(address) do
@@ -219,6 +201,8 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
       "OptimizationUsed" => if(contract.optimization, do: "1", else: "0")
     }
   end
+
+  defp latest_decompiled_smart_contract(%NotLoaded{}), do: nil
 
   defp latest_decompiled_smart_contract([]), do: nil
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -396,20 +396,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
       expected_result = [
         %{
-          "Address" => "",
-          "SourceCode" => "",
-          "ABI" => "Contract source code not verified",
-          "ContractName" => "",
-          "CompilerVersion" => "",
-          "OptimizationUsed" => "",
-          "DecompiledSourceCode" => "",
-          "DecompilerVersion" => "",
-          "ConstructorArguments" => "",
-          "EVMVersion" => "",
-          "ExternalLibraries" => "",
-          "OptimizationRuns" => "",
-          "FileName" => "",
-          "IsProxy" => "false"
+          "Address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
         }
       ]
 


### PR DESCRIPTION
Close #5749 

## Changelog
- Fix inconsistent behaviour of getsourcecode method
- For all cases method will return at least `Address` field (for unverified and non-existing in DB addresses response will be: `{"message":"OK","result":[{"Address":"0xc57de7d1771549b56bdad1a55aae776e43fe090a"}],"status":"1"}`)

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
