### PR TITLE
Add Prometheus metrics to indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#6092](https://github.com/blockscout/blockscout/pull/6092) - Blockscout Account functionality
 - [#6073](https://github.com/blockscout/blockscout/pull/6073) - Add vyper support for rust verifier microservice integration
+- [#6111](https://github.com/blockscout/blockscout/pull/6111) - Add Prometheus metrics to indexer
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -6,9 +6,13 @@ defmodule Indexer.Application do
   use Application
 
   alias Indexer.Memory
+  alias Indexer.Prometheus.PendingBlockOperationsCollector
+  alias Prometheus.Registry
 
   @impl Application
   def start(_type, _args) do
+    Registry.register_collector(PendingBlockOperationsCollector)
+
     memory_monitor_options =
       case Application.get_env(:indexer, :memory_limit) do
         nil -> %{}

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -33,6 +33,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
   alias Indexer.{Block, Tracer}
   alias Indexer.Block.Realtime.TaskSupervisor
   alias Indexer.Fetcher.CoinBalance
+  alias Indexer.Prometheus
   alias Indexer.Transform.Addresses
   alias Timex.Duration
 
@@ -295,6 +296,8 @@ defmodule Indexer.Block.Realtime.Fetcher do
     {fetch_duration, result} =
       :timer.tc(fn -> fetch_and_import_range(block_fetcher, block_number_to_fetch..block_number_to_fetch) end)
 
+    Prometheus.Instrumenter.block_full_process(fetch_duration, __MODULE__)
+
     case result do
       {:ok, %{inserted: inserted, errors: []}} ->
         log_import_timings(inserted, fetch_duration, time_before)
@@ -310,6 +313,8 @@ defmodule Indexer.Block.Realtime.Fetcher do
         end)
 
       {:error, {:import = step, [%Changeset{} | _] = changesets}} ->
+        Prometheus.Instrumenter.import_errors()
+
         params = %{
           changesets: changesets,
           block_number_to_fetch: block_number_to_fetch,
@@ -333,6 +338,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
         end
 
       {:error, {:import = step, reason}} ->
+        Prometheus.Instrumenter.import_errors()
         Logger.error(fn -> inspect(reason) end, step: step)
 
       {:error, {step, reason}} ->
@@ -363,6 +369,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   defp log_import_timings(%{blocks: [%{number: number, timestamp: timestamp}]}, fetch_duration, time_before) do
     node_delay = Timex.diff(time_before, timestamp, :seconds)
+    Prometheus.Instrumenter.node_delay(node_delay)
 
     Logger.debug("Block #{number} fetching duration: #{fetch_duration / 1_000_000}s. Node delay: #{node_delay}s.",
       fetcher: :block_import_timings

--- a/apps/indexer/lib/indexer/prometheus/instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/instrumenter.ex
@@ -1,0 +1,61 @@
+defmodule Indexer.Prometheus.Instrumenter do
+  @moduledoc """
+  Blocks fetch and import metrics for `Prometheus`.
+  """
+
+  use Prometheus.Metric
+
+  @histogram [
+    name: :block_full_processing_duration_microseconds,
+    labels: [:fetcher],
+    buckets: [1000, 5000, 10000, 100_000],
+    duration_unit: :microseconds,
+    help: "Block whole processing time including fetch and import"
+  ]
+
+  @histogram [
+    name: :block_import_duration_microseconds,
+    labels: [:fetcher],
+    buckets: [1000, 5000, 10000, 100_000],
+    duration_unit: :microseconds,
+    help: "Block import time"
+  ]
+
+  @histogram [
+    name: :block_batch_fetch_request_duration_microseconds,
+    labels: [:fetcher],
+    buckets: [1000, 5000, 10000, 100_000],
+    duration_unit: :microseconds,
+    help: "Block fetch batch request processing time"
+  ]
+
+  @gauge [name: :missing_block_count, help: "Number of missing blocks in the database"]
+
+  @gauge [name: :delay_from_last_node_block, help: "Delay from the last block on the node in seconds"]
+
+  @counter [name: :import_errors_count, help: "Number of database import errors"]
+
+  def block_full_process(time, fetcher) do
+    Histogram.observe([name: :block_full_processing_duration_microseconds, labels: [fetcher]], time)
+  end
+
+  def block_import(time, fetcher) do
+    Histogram.observe([name: :block_import_duration_microseconds, labels: [fetcher]], time)
+  end
+
+  def block_batch_fetch(time, fetcher) do
+    Histogram.observe([name: :block_batch_fetch_request_duration_microseconds, labels: [fetcher]], time)
+  end
+
+  def missing_blocks(missing_block_count) do
+    Gauge.set([name: :missing_block_count], missing_block_count)
+  end
+
+  def node_delay(delay) do
+    Gauge.set([name: :delay_from_last_node_block], delay)
+  end
+
+  def import_errors(error_count \\ 1) do
+    Counter.inc([name: :import_errors_count], error_count)
+  end
+end

--- a/apps/indexer/lib/indexer/prometheus/pending_block_operations_collector.ex
+++ b/apps/indexer/lib/indexer/prometheus/pending_block_operations_collector.ex
@@ -1,0 +1,29 @@
+defmodule Indexer.Prometheus.PendingBlockOperationsCollector do
+  @moduledoc """
+  Custom collector to count number of records in pending_block_operations table.
+  """
+
+  use Prometheus.Collector
+
+  alias Explorer.Chain.PendingBlockOperation
+  alias Explorer.Repo
+  alias Prometheus.Model
+
+  def collect_mf(_registry, callback) do
+    callback.(
+      create_gauge(
+        :pending_block_operations_count,
+        "Number of records in pending_block_operations table",
+        Repo.aggregate(PendingBlockOperation, :count)
+      )
+    )
+  end
+
+  def collect_metrics(:pending_block_operations_count, count) do
+    Model.gauge_metrics([{count}])
+  end
+
+  defp create_gauge(name, help, data) do
+    Model.create_mf(name, help, :gauge, __MODULE__, data)
+  end
+end


### PR DESCRIPTION
## Changelog

Added following metrics for Prometheus:
- `block_full_processing_duration_microseconds` - time needed to fully fetch and import a block
- `block_import_duration_microseconds` - time needed to import a block to the database
- `block_batch_fetch_request_duration_microseconds` - time needed to perform a batch `eth_getBlockByNumber` request
- `missing_block_count` - the number of missing blocks in the database
- `delay_from_last_node_block` - the delay from the last block on the node in seconds
- `import_errors_count` - the number of errors while importing blocks to the database
- `pending_block_operations_count` - the number of records in pending_block_operations table

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
