### PR TITLE
Fix unfetched token balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#6094](https://github.com/blockscout/blockscout/pull/6094) - Fix inconsistent behaviour of `getsourcecode` method
 - [#6105](https://github.com/blockscout/blockscout/pull/6105) - Fix some token transfers broadcasting
 - [#6106](https://github.com/blockscout/blockscout/pull/6106) - Fix 500 response on `/coin-balance` for empty address
+- [#6118](https://github.com/blockscout/blockscout/pull/6118) - Fix unfetched token balances
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Chain.Address.TokenBalance do
       join: t in Token,
       on: tb.token_contract_address_hash == t.contract_address_hash,
       where:
-        ((tb.address_hash != ^@burn_address_hash and t.type != "ERC-721") or t.type == "ERC-20" or t.type == "ERC-1155") and
+        ((tb.address_hash != ^@burn_address_hash and t.type == "ERC-721") or t.type == "ERC-20" or t.type == "ERC-1155") and
           (is_nil(tb.value_fetched_at) or is_nil(tb.value))
     )
   end


### PR DESCRIPTION
## Motivation

Condition in `TokenBalance.unfetched_token_balances` function will never be true for ERC-721 tokens, so `Indexer.Fetcher.TokenBalance` will always ignore them.

## Changelog

Fixed condition so it works correctly for ERC-721 tokens.