### PR TITLE
No missing blocks in UI on the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#6127](https://github.com/blockscout/blockscout/pull/6127) - No missing blocks in UI on the main page
 - [#6090](https://github.com/blockscout/blockscout/pull/6090) - Fix metadata fetching for ERC-1155 tokens instances 
 - [#6091](https://github.com/blockscout/blockscout/pull/6091) - Improve fetching media type for NFT
 - [#6094](https://github.com/blockscout/blockscout/pull/6094) - Fix inconsistent behaviour of `getsourcecode` method

--- a/apps/block_scout_web/assets/__tests__/pages/chain.js
+++ b/apps/block_scout_web/assets/__tests__/pages/chain.js
@@ -99,12 +99,11 @@ describe('RECEIVED_NEW_BLOCK', () => {
     ])
   })
 
-  test('inserts place holders if block received out of order', () => {
+  test('displays only sequential blocks', () => {
     window.localized = {}
     const state = Object.assign({}, initialState, {
       blocks: [
         { blockNumber: 3, chainBlockHtml: 'test 3' },
-        { blockNumber: 2, chainBlockHtml: 'test 2' },
         { blockNumber: 1, chainBlockHtml: 'test 1' },
         { blockNumber: 0, chainBlockHtml: 'test 0' }
       ]
@@ -112,16 +111,14 @@ describe('RECEIVED_NEW_BLOCK', () => {
     const action = {
       type: 'RECEIVED_NEW_BLOCK',
       msg: {
-        chainBlockHtml: 'test 6',
-        blockNumber: 6
+        chainBlockHtml: 'test 4',
+        blockNumber: 4
       }
     }
     const output = reducer(state, action)
 
     expect(output.blocks).toEqual([
-      { blockNumber: 6, chainBlockHtml: 'test 6' },
-      { blockNumber: 5, chainBlockHtml: placeHolderBlock(5) },
-      { blockNumber: 4, chainBlockHtml: placeHolderBlock(4) },
+      { blockNumber: 4, chainBlockHtml: 'test 4' },
       { blockNumber: 3, chainBlockHtml: 'test 3' }
     ])
   })
@@ -200,7 +197,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
       { blockNumber: 3, chainBlockHtml: 'test 3' }
     ])
   })
-  test('skipped blocks list replaced when another block comes in with +3 blockheight', () => {
+  test('skipped blocks list doesn\'t appear when another block comes in with +3 blockheight', () => {
     window.localized = {}
     const state = Object.assign({}, initialState, {
       blocks: [
@@ -220,10 +217,7 @@ describe('RECEIVED_NEW_BLOCK', () => {
     const output = reducer(state, action)
 
     expect(output.blocks).toEqual([
-      { blockNumber: 10, chainBlockHtml: 'test 10' },
-      { blockNumber: 9, chainBlockHtml: placeHolderBlock(9) },
-      { blockNumber: 8, chainBlockHtml: placeHolderBlock(8) },
-      { blockNumber: 7, chainBlockHtml: placeHolderBlock(7) }
+      { blockNumber: 10, chainBlockHtml: 'test 10' }
     ])
   })
 })

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -361,6 +361,11 @@ $tile-body-a-color: #5959d8 !default;
         margin-left: -6px;
         margin-right: -6px;
       }
+      @include media-breakpoint-up(md) {
+        &:nth-child(n + 2) {
+          justify-content: flex-end;
+        }
+      }
     }
   }
 }

--- a/apps/block_scout_web/assets/js/pages/chain.js
+++ b/apps/block_scout_web/assets/js/pages/chain.js
@@ -47,7 +47,8 @@ function baseReducer (state = initialState, action) {
       })
     }
     case 'RECEIVED_NEW_BLOCK': {
-      if (!state.blocks.length || state.blocks[0].blockNumber < action.msg.blockNumber) {
+      const comingBlockNumber = action.msg.blockNumber
+      if (!state.blocks.length || state.blocks[0].blockNumber < comingBlockNumber) {
         let pastBlocks
         if (state.blocks.length < BLOCKS_PER_PAGE) {
           pastBlocks = state.blocks
@@ -55,18 +56,20 @@ function baseReducer (state = initialState, action) {
           $('.miner-address-tooltip').tooltip('hide')
           pastBlocks = state.blocks.slice(0, -1)
         }
+        let blocks = [
+          action.msg,
+          ...pastBlocks
+        ]
+        blocks = filterSequentialBlocks(blocks)
         return Object.assign({}, state, {
           averageBlockTime: action.msg.averageBlockTime,
-          blocks: [
-            action.msg,
-            ...pastBlocks
-          ],
-          blockCount: action.msg.blockNumber + 1
+          blocks,
+          blockCount: comingBlockNumber + 1
         })
       } else {
         return Object.assign({}, state, {
-          blocks: state.blocks.map((block) => block.blockNumber === action.msg.blockNumber ? action.msg : block),
-          blockCount: action.msg.blockNumber + 1
+          blocks: state.blocks.map((block) => block.blockNumber === comingBlockNumber ? action.msg : block),
+          blockCount: comingBlockNumber + 1
         })
       }
     }
@@ -77,7 +80,8 @@ function baseReducer (state = initialState, action) {
       return Object.assign({}, state, { blocksLoading: false })
     }
     case 'BLOCKS_FETCHED': {
-      return Object.assign({}, state, { blocks: [...action.msg.blocks], blocksLoading: false })
+      const sequentialBlocks = filterSequentialBlocks(action.msg.blocks)
+      return Object.assign({}, state, { blocks: [...sequentialBlocks], blocksLoading: false })
     }
     case 'BLOCKS_REQUEST_ERROR': {
       return Object.assign({}, state, { blocksError: true, blocksLoading: false })
@@ -146,6 +150,24 @@ function baseReducer (state = initialState, action) {
     default:
       return state
   }
+}
+
+function filterSequentialBlocks (blocks) {
+  let sequenceIsBroken = false
+  return blocks.filter((block, index) => {
+    if (index === 0) {
+      return true
+    } else if (block.blockNumber + 1 === (blocks[index - 1]).blockNumber) {
+      if (!sequenceIsBroken) {
+        return true
+      } else {
+        return false
+      }
+    } else {
+      sequenceIsBroken = true
+      return false
+    }
+  })
 }
 
 function withMissingBlocks (reducer) {

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_chain_test.exs
@@ -67,7 +67,7 @@ defmodule BlockScoutWeb.ViewingChainTest do
       |> assert_has(ChainPage.blocks(count: 4))
     end
 
-    test "inserts place holder blocks on render for out of order blocks", %{session: session} do
+    test "doesn't insert place holder blocks on render for out of order blocks", %{session: session} do
       insert(:block, number: 409)
 
       start_supervised!(AddressesCounter)
@@ -75,8 +75,8 @@ defmodule BlockScoutWeb.ViewingChainTest do
 
       session
       |> ChainPage.visit_page()
-      |> assert_has(ChainPage.block(%Block{number: 408}))
-      |> assert_has(ChainPage.place_holder_blocks(3))
+      |> refute_has(ChainPage.block(%Block{number: 408}))
+      |> refute_has(ChainPage.place_holder_blocks(3))
     end
   end
 


### PR DESCRIPTION
Improvement of https://github.com/blockscout/blockscout/pull/5491

## Motivation

Front-end fixes to improve appearance of blocks on the main page

## Changelog

Return to the UI only sequence of the blocks without breaks

![Screenshot 2022-09-16 at 18 30 56](https://user-images.githubusercontent.com/4341812/190675878-199593f6-6fb9-474c-be0f-af4118bf2b87.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
