### PR TITLE
prevent logger from truncating response from rust verifier service in case of an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#6105](https://github.com/blockscout/blockscout/pull/6105) - Fix some token transfers broadcasting
 - [#6106](https://github.com/blockscout/blockscout/pull/6106) - Fix 500 response on `/coin-balance` for empty address
 - [#6118](https://github.com/blockscout/blockscout/pull/6118) - Fix unfetched token balances
+- [#6133](https://github.com/blockscout/blockscout/pull/6133) - Prevent logger from truncating response from rust verifier service in case of an error
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
@@ -57,12 +57,14 @@ defmodule Explorer.SmartContract.RustVerifierInterface do
       {:error, error} ->
         old_truncate = Application.get_env(:logger, :truncate)
         Logger.configure(truncate: :infinity)
+
         Logger.error(fn ->
           [
             "Error while sending request to verification microservice url: #{url}, body: #{inspect(body, limit: :infinity, printable_limit: :infinity)}: ",
             inspect(error, limit: :infinity, printable_limit: :infinity)
           ]
         end)
+
         Logger.configure(truncate: old_truncate)
         {:error, @request_error_msg}
     end
@@ -79,12 +81,14 @@ defmodule Explorer.SmartContract.RustVerifierInterface do
       {:error, error} ->
         old_truncate = Application.get_env(:logger, :truncate)
         Logger.configure(truncate: :infinity)
+
         Logger.error(fn ->
           [
             "Error while sending request to verification microservice url: #{url}: ",
             inspect(error, limit: :infinity, printable_limit: :infinity)
           ]
         end)
+
         Logger.configure(truncate: old_truncate)
         {:error, @request_error_msg}
     end

--- a/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
@@ -55,13 +55,15 @@ defmodule Explorer.SmartContract.RustVerifierInterface do
         proccess_verifier_response(body)
 
       {:error, error} ->
+        old_truncate = Application.get_env(:logger, :truncate)
+        Logger.configure(truncate: :infinity)
         Logger.error(fn ->
           [
             "Error while sending request to verification microservice url: #{url}, body: #{inspect(body, limit: :infinity, printable_limit: :infinity)}: ",
             inspect(error, limit: :infinity, printable_limit: :infinity)
           ]
         end)
-
+        Logger.configure(truncate: old_truncate)
         {:error, @request_error_msg}
     end
   end
@@ -75,13 +77,15 @@ defmodule Explorer.SmartContract.RustVerifierInterface do
         {:error, body}
 
       {:error, error} ->
+        old_truncate = Application.get_env(:logger, :truncate)
+        Logger.configure(truncate: :infinity)
         Logger.error(fn ->
           [
             "Error while sending request to verification microservice url: #{url}: ",
             inspect(error, limit: :infinity, printable_limit: :infinity)
           ]
         end)
-
+        Logger.configure(truncate: old_truncate)
         {:error, @request_error_msg}
     end
   end


### PR DESCRIPTION
Unsure if this qualifies as a bug fix since it fixes the logging..

## Motivation

Error responses received from rust verifier service currently get truncated by the logger even though `IO.inspect(error, limit: :infinity, printable_limit: :infinity)` is being used. I applied the following pattern that saves the original logger's 'truncate', sets it to ':infinity' for logging the response, then restores it as done in [`apps/explorer/lib/explorer/repo.ex`](https://github.com/blockscout/blockscout/blob/7fce1647298dc11d526caa1461cfac3923aabd26/apps/explorer/lib/explorer/repo.ex#L64).

## Changelog
- Prevent logger from truncating response from rust verifier service in case of an error

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
