### PR TITLE
Move rate limit logs to application start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#6105](https://github.com/blockscout/blockscout/pull/6105) - Fix some token transfers broadcasting
 - [#6106](https://github.com/blockscout/blockscout/pull/6106) - Fix 500 response on `/coin-balance` for empty address
 - [#6118](https://github.com/blockscout/blockscout/pull/6118) - Fix unfetched token balances
+- [#6163](https://github.com/blockscout/blockscout/pull/6163) - Fix rate limit logs
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.Application do
 
   use Application
 
+  alias BlockScoutWeb.API.APILogger
   alias BlockScoutWeb.Counters.BlocksIndexedCounter
   alias BlockScoutWeb.{Endpoint, Prometheus}
   alias BlockScoutWeb.RealtimeEventHandler
@@ -14,6 +15,18 @@ defmodule BlockScoutWeb.Application do
 
     Prometheus.Instrumenter.setup()
     Prometheus.Exporter.setup()
+
+    APILogger.message(
+      "Current global API rate limit #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:global_limit])} reqs/sec"
+    )
+
+    APILogger.message(
+      "Current API rate limit by key #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:limit_by_key])} reqs/sec"
+    )
+
+    APILogger.message(
+      "Current API rate limit by IP #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:limit_by_ip])} reqs/sec"
+    )
 
     # Define workers and child supervisors to be supervised
     children = [

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
@@ -25,18 +25,6 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
   alias Plug.Conn
 
   def init(opts) do
-    APILogger.message(
-      "Current global API rate limit #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:global_limit])} reqs/sec"
-    )
-
-    APILogger.message(
-      "Current API rate limit by key #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:limit_by_key])} reqs/sec"
-    )
-
-    APILogger.message(
-      "Current API rate limit by IP #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:limit_by_ip])} reqs/sec"
-    )
-
     opts
   end
 


### PR DESCRIPTION
## Motivation

Expected behaviour: rate limit logs appears on application start.
Real behaviour: rate limit logs appears on each request.

## Changelog

Moved rate limit logs to `BlockScoutWeb.Application.start/2`.