### PR TITLE
Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Chore
 
+- [#6192](https://github.com/blockscout/blockscout/pull/6192) - Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
 - [#6183](https://github.com/blockscout/blockscout/pull/6183) - Transparent coin name definition
 - [#6155](https://github.com/blockscout/blockscout/pull/6155), [#6189](https://github.com/blockscout/blockscout/pull/6189) - Refactor Ethereum JSON RPC variants
 - [#6125](https://github.com/blockscout/blockscout/pull/6125) - Rename obsolete "parity" EthereumJSONRPC.Variant to "nethermind"

--- a/apps/block_scout_web/assets/js/lib/indexing.js
+++ b/apps/block_scout_web/assets/js/lib/indexing.js
@@ -8,7 +8,7 @@ function tryUpdateIndexedStatus (el, indexedRatio = el.dataset.indexedRatio, ind
   const blocksPercentComplete = numeral(indexedRatio).format('0%')
   let indexedText
   if (blocksPercentComplete === '100%') {
-    indexedText = window.localized['Indexing Tokens']
+    indexedText = window.localized['Indexing Internal Transactions']
   } else {
     indexedText = `${blocksPercentComplete} ${window.localized['Blocks Indexed']}`
   }

--- a/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
@@ -41,7 +41,7 @@ defmodule BlockScoutWeb.Counters.BlocksIndexedCounter do
     finished? =
       case Decimal.compare(ratio, 1) do
         :lt -> false
-        _ -> Chain.finished_indexing?()
+        _ -> Chain.finished_internal_transactions_indexing?()
       end
 
     Notifier.broadcast_blocks_indexed_ratio(ratio, finished?)

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -41,7 +41,7 @@
       window.localized = {
         'Blocks Indexed': '<%= gettext("Blocks Indexed") %>',
         'Block Processing': '<%= gettext("Block Mined, awaiting import...") %>',
-        'Indexing Tokens': '<%= gettext("Indexing Tokens") %>',
+        'Indexing Internal Transactions': '<%= gettext("Indexing Internal Transactions") %>',
         'Less than': '<%= gettext("Less than") %>',
         'Market Cap': '<%= gettext("Market Cap") %>',
         'Price': '<%= gettext("Price") %>',
@@ -216,7 +216,7 @@
           <%= raw(System.get_env("MAINTENANCE_ALERT_MESSAGE")) %>
         </div>
       <% end %>
-      <%= if not Explorer.Chain.finished_indexing?() do %>
+      <%= if not Explorer.Chain.finished_internal_transactions_indexing?() do %>
         <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
           <span data-indexed-ratio="<%=Explorer.Chain.indexed_ratio() %>"></span>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1414,11 +1414,6 @@ msgstr ""
 msgid "Indexed?"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
-#, elixir-autogen, elixir-format
-msgid "Indexing Tokens"
-msgstr ""
-
 #: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:3
 #, elixir-autogen, elixir-format
 msgid "Input"
@@ -3260,4 +3255,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "truffle flattener"
+msgstr ""
+
+#: lib/block_scout_web/templates/layout/app.html.eex:44
+#, elixir-autogen, elixir-format
+msgid "Indexing Internal Transactions"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1414,11 +1414,6 @@ msgstr ""
 msgid "Indexed?"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:44
-#, elixir-autogen, elixir-format
-msgid "Indexing Tokens"
-msgstr ""
-
 #: lib/block_scout_web/templates/transaction/_decoded_input.html.eex:3
 #, elixir-autogen, elixir-format
 msgid "Input"
@@ -3260,4 +3255,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "truffle flattener"
+msgstr ""
+
+#: lib/block_scout_web/templates/layout/app.html.eex:44
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Indexing Internal Transactions"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
@@ -52,7 +52,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     session
   #     |> AppPage.visit_page()
-  #     |> assert_has(AppPage.indexed_status("Indexing Tokens"))
+  #     |> assert_has(AppPage.indexed_status("Indexing Internal Transactions"))
   #   end
 
   #   test "updates blocks indexed percentage", %{session: session} do
@@ -106,7 +106,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     BlocksIndexedCounter.calculate_blocks_indexed()
 
-  #     assert_has(session, AppPage.indexed_status("Indexing Tokens"))
+  #     assert_has(session, AppPage.indexed_status("Indexing Internal Transactions"))
   #   end
 
   #   test "removes message when chain is indexed", %{session: session} do
@@ -129,7 +129,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     session
   #     |> AppPage.visit_page()
-  #     |> assert_has(AppPage.indexed_status("Indexing Tokens"))
+  #     |> assert_has(AppPage.indexed_status("Indexing Internal Transactions"))
 
   #     Repo.update_all(
   #       from(p in PendingBlockOperation, where: p.block_hash == ^block_hash),

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1185,7 +1185,7 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "finished_indexing?/0" do
+  describe "finished_internal_transactions_indexing?/0" do
     test "finished indexing" do
       block = insert(:block, number: 1)
 
@@ -1193,11 +1193,11 @@ defmodule Explorer.ChainTest do
       |> insert()
       |> with_block(block)
 
-      assert Chain.finished_indexing?()
+      assert Chain.finished_internal_transactions_indexing?()
     end
 
     test "finished indexing (no txs)" do
-      assert Chain.finished_indexing?()
+      assert Chain.finished_internal_transactions_indexing?()
     end
 
     test "not finished indexing" do
@@ -1209,7 +1209,7 @@ defmodule Explorer.ChainTest do
 
       insert(:pending_block_operation, block: block, fetch_internal_transactions: true)
 
-      refute Chain.finished_indexing?()
+      refute Chain.finished_internal_transactions_indexing?()
     end
   end
 


### PR DESCRIPTION
## Motivation

<img width="1379" alt="Screenshot 2022-09-29 at 23 55 49" src="https://user-images.githubusercontent.com/4341812/193130352-22a16e28-aa7d-451b-8f84-a6b7f4998831.png">

This message appears on the main page while Blockscout fetches internal transactions. However, it doesn't take into account, that when `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true` is provided, the internal transactions fetcher is disabled. Thus, the message will never disappear.

## Changelog

Hide mentioned message, if `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true`.

As a side note: before this PR, the message claimed: "Indexing Tokens ...". It would be fairer to indicate, that we index internal transactions at this time. Thus, the message changed to "Indexing Internal Transactions ...".

Docs update PR https://github.com/blockscout/docs/pull/77

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
