### PR TITLE
Docker compose configs improvements: Redis container name and persistent storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Chore
 
+- [#6195](https://github.com/blockscout/blockscout/pull/6195) - Docker compose configs improvements: Redis container name and persistent storage
 - [#6192](https://github.com/blockscout/blockscout/pull/6192) - Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
 - [#6183](https://github.com/blockscout/blockscout/pull/6183) - Transparent coin name definition
 - [#6155](https://github.com/blockscout/blockscout/pull/6155), [#6189](https://github.com/blockscout/blockscout/pull/6189) - Refactor Ethereum JSON RPC variants

--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14
@@ -51,3 +56,4 @@ services:
       -  ./envs/common-smart-contract-verifier.env
     ports:
       - 8043:8043
+

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -1,9 +1,19 @@
 version: '3.8'
 
 services:
+  redis_db:
+    image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
+    command: redis-server
+    volumes:
+      - ./redis-data:/data
+
   blockscout:
     depends_on:
       - smart-contract-verifier
+      - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
     restart: always
     container_name: 'blockscout'

--- a/docker-compose/docker-compose-no-rust-verification.yml
+++ b/docker-compose/docker-compose-no-rust-verification.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,7 +3,12 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
     command: redis-server
+    volumes:
+      - ./redis-data:/data
 
   db:
     image: postgres:14


### PR DESCRIPTION
## Motivation

Docker compose Redis DB config improvements

## Changelog

- add `redis_db` container name
- add persistent volume on the host machine at `./redis_data`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
