### PR TITLE
Refactor contract libs render, CONTRACT_VERIFICATION_MAX_LIBRARIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Chore
 
+- [#6204](https://github.com/blockscout/blockscout/pull/6204) - Refactor contract libs render, CONTRACT_VERIFICATION_MAX_LIBRARIES, refactor parsing integer env vars in config
 - [#6195](https://github.com/blockscout/blockscout/pull/6195) - Docker compose configs improvements: Redis container name and persistent storage
 - [#6192](https://github.com/blockscout/blockscout/pull/6192) - Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
 - [#6183](https://github.com/blockscout/blockscout/pull/6183) - Transparent coin name definition

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -570,7 +570,7 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   defp parse_optimization_runs(other), do: other
 
   defp fetch_external_libraries(params) do
-    Enum.reduce(1..10, %{}, fn number, acc ->
+    Enum.reduce(1..Application.get_env(:block_scout_web, :verification_max_libraries), %{}, fn number, acc ->
       case Map.fetch(params, "library#{number}Name") do
         {:ok, library_name} ->
           library_address = Map.get(params, "library#{number}Address")

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
@@ -55,7 +55,10 @@ defmodule BlockScoutWeb.API.V1.VerifiedSmartContractController do
   end
 
   defp fetch_external_libraries(params) do
-    keys = Enum.flat_map(1..10, fn i -> ["library#{i}_name", "library#{i}_address"] end)
+    keys =
+      Enum.flat_map(1..Application.get_env(:block_scout_web, :verification_max_libraries), fn i ->
+        ["library#{i}_name", "library#{i}_address"]
+      end)
 
     Map.take(params, keys)
   end

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_libraries_other.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_libraries_other.html.eex
@@ -1,0 +1,8 @@
+<%= for library_index <- 2..Application.get_env(:block_scout_web, :verification_max_libraries) do %>
+    <% library = "library" <> to_string(library_index) |> String.to_atom() %>
+    <div class="contract-library-form-group js-contract-library-form-group">
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: library, index: library_index %>
+
+        <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: library, index: library_index %>
+    </div>
+<% end %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex
@@ -1,8 +1,9 @@
+<% library_address = "library" <> to_string(@index) <>  "_address" |> String.to_atom() %>
 <div class="smart-contract-form-group">
     <div class="smart-contract-form-group-inner-wrapper">
-    <%= label :external_libraries, @library, gettext("Library Address") %>
+    <%= label :external_libraries, @library, gettext("Library") <> " " <> to_string(@index) <> " " <> gettext("Address") %>
     <div class="center-column">
-        <%= text_input :external_libraries, @library_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+        <%= text_input :external_libraries, library_address, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
     </div>
     <div class="smart-contract-form-group-tooltip"><%= if assigns[:tooltip_text] do @tooltip_text end %></div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex
@@ -1,0 +1,13 @@
+<div class="contract-library-form-group js-contract-library-form-group active">
+    <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html",
+        library: :library1,
+        index: 1,
+        tooltip_text: gettext("A library name called in the .sol file. Multiple libraries (up to ") <> to_string(Application.get_env(:block_scout_web, :verification_max_libraries)) <> gettext(") may be added for each contract. Click the Add Library button to add an additional one.")
+    %>
+
+    <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html",
+        library: :library1,
+        index: 1,
+        tooltip_text: gettext "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
+    %>
+</div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex
@@ -1,8 +1,9 @@
+<% library_name = "library" <> to_string(@index) <>  "_name" |> String.to_atom() %>
 <div class="smart-contract-form-group">
     <div class="smart-contract-form-group-inner-wrapper">
-    <%= label :external_libraries, @library, gettext("Library Name") %>
+    <%= label :external_libraries, @library, gettext("Library") <> " " <> to_string(@index) <> " " <> gettext("Name") %>
     <div class="center-column">
-        <%= text_input :external_libraries, @library_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
+        <%= text_input :external_libraries, library_name, class: "form-control border-rounded", "aria-describedby": "contract-name-help-block" %>
     </div>
     <div class="smart-contract-form-group-tooltip"><%= if assigns[:tooltip_text] do @tooltip_text end %></div>
     </div>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex
@@ -85,43 +85,9 @@
         <div class="smart-contract-libraries-wrapper js-smart-contract-libraries-wrapper">
           <h2 class="smart-contract-title margin-bottom-md"><%= gettext "Contract Libraries" %></h2>
 
-          <div class="contract-library-form-group js-contract-library-form-group active">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html",
-              library: :library1,
-              library_name: :library1_name,
-              tooltip_text: gettext "A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one."
-            %>
+          <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_first.html" %>
 
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html",
-              library: :library1,
-              library_address: :library1_address,
-              tooltip_text: gettext "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
-            %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library2, library_name: :library2_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library2, library_address: :library2_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library3, library_name: :library3_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library3, library_address: :library3_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library4, library_name: :library4_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library4, library_address: :library4_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library5, library_name: :library5_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library5, library_address: :library5_address %>
-          </div>
+          <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_libraries_other.html" %>
 
           <div class="add-contract-library-wrapper js-add-contract-library-wrapper">
             <span class="btn-line js-btn-add-contract-library"><%= gettext "Add Library" %></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex
@@ -79,43 +79,9 @@
         <div class="smart-contract-libraries-wrapper js-smart-contract-libraries-wrapper">
           <h2 class="smart-contract-title margin-bottom-md"><%= gettext "Contract Libraries" %></h2>
 
-          <div class="contract-library-form-group js-contract-library-form-group active">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html",
-              library: :library1,
-              library_name: :library1_name,
-              tooltip_text: gettext "A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one."
-            %>
+          <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_first.html" %>
 
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html",
-              library: :library1,
-              library_address: :library1_address,
-              tooltip_text: gettext "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
-            %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library2, library_name: :library2_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library2, library_address: :library2_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library3, library_name: :library3_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library3, library_address: :library3_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library4, library_name: :library4_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library4, library_address: :library4_address %>
-          </div>
-
-          <div class="contract-library-form-group js-contract-library-form-group">
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_name.html", library: :library5, library_name: :library5_name %>
-
-            <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_library_address.html", library: :library5, library_address: :library5_address %>
-          </div>
+          <%= render BlockScoutWeb.AddressContractVerificationCommonFieldsView, "_libraries_other.html" %>
 
           <div class="add-contract-library-wrapper js-add-contract-library-wrapper">
             <span class="btn-line js-btn-add-contract-library"><%= gettext "Add Library" %></span>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -91,12 +91,6 @@ msgstr ""
 msgid "A block producer who successfully included the block onto the blockchain."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:92
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:86
-#, elixir-autogen, elixir-format
-msgid "A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one."
-msgstr ""
-
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "A string with the name of the action to be invoked."
@@ -192,8 +186,8 @@ msgstr ""
 msgid "Add Custom ABI"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:127
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:121
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:93
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:87
 #, elixir-autogen, elixir-format
 msgid "Add Library"
 msgstr ""
@@ -225,6 +219,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:23
 #: lib/block_scout_web/templates/account/watchlist_address/form.html.eex:12
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
 #: lib/block_scout_web/views/address_view.ex:107
 #, elixir-autogen, elixir-format
@@ -501,9 +496,9 @@ msgstr ""
 
 #: lib/block_scout_web/templates/account/public_tags_request/form.html.eex:62
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:120
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:145
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:111
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:41
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:141
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:107
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:55
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:51
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
@@ -1472,16 +1467,6 @@ msgstr ""
 msgid "Less than"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:3
-#, elixir-autogen, elixir-format
-msgid "Library Address"
-msgstr ""
-
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:3
-#, elixir-autogen, elixir-format
-msgid "Library Name"
-msgstr ""
-
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "License Expires"
@@ -1518,9 +1503,9 @@ msgid "Loading chart..."
 msgstr ""
 
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:77
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:139
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:105
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:35
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:133
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:99
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:49
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:45
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:41
@@ -1676,6 +1661,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/index.html.eex:22
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:22
 #: lib/block_scout_web/templates/account/watchlist_address/form.html.eex:19
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:59
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:4
@@ -2047,9 +2033,9 @@ msgstr ""
 msgid "Request to edit a public tag/label"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:142
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:108
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:38
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:138
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:104
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:52
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:48
 #, elixir-autogen, elixir-format
@@ -2292,8 +2278,7 @@ msgstr ""
 msgid "Test Networks"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:98
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:92
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:11
 #, elixir-autogen, elixir-format
 msgid "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
 msgstr ""
@@ -2940,9 +2925,9 @@ msgstr ""
 msgid "Verify & Publish"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:141
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:107
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:37
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:137
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:103
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:51
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:47
 #, elixir-autogen, elixir-format
@@ -3260,4 +3245,20 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Indexing Internal Transactions"
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:5
+#, elixir-autogen, elixir-format
+msgid ") may be added for each contract. Click the Add Library button to add an additional one."
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:5
+#, elixir-autogen, elixir-format
+msgid "A library name called in the .sol file. Multiple libraries (up to "
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
+#, elixir-autogen, elixir-format
+msgid "Library"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -91,12 +91,6 @@ msgstr ""
 msgid "A block producer who successfully included the block onto the blockchain."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:92
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:86
-#, elixir-autogen, elixir-format
-msgid "A library name called in the .sol file. Multiple libraries (up to 5) may be added for each contract. Click the Add Library button to add an additional one."
-msgstr ""
-
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "A string with the name of the action to be invoked."
@@ -192,8 +186,8 @@ msgstr ""
 msgid "Add Custom ABI"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:127
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:121
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:93
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:87
 #, elixir-autogen, elixir-format
 msgid "Add Library"
 msgstr ""
@@ -225,6 +219,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:23
 #: lib/block_scout_web/templates/account/watchlist_address/form.html.eex:12
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:16
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:20
 #: lib/block_scout_web/views/address_view.ex:107
 #, elixir-autogen, elixir-format
@@ -501,9 +496,9 @@ msgstr ""
 
 #: lib/block_scout_web/templates/account/public_tags_request/form.html.eex:62
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:120
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:145
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:111
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:41
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:141
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:107
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:55
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:51
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:47
@@ -1472,16 +1467,6 @@ msgstr ""
 msgid "Less than"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:3
-#, elixir-autogen, elixir-format
-msgid "Library Address"
-msgstr ""
-
-#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:3
-#, elixir-autogen, elixir-format
-msgid "Library Name"
-msgstr ""
-
 #: lib/block_scout_web/templates/address/_validator_metadata_modal.html.eex:24
 #, elixir-autogen, elixir-format
 msgid "License Expires"
@@ -1518,9 +1503,9 @@ msgid "Loading chart..."
 msgstr ""
 
 #: lib/block_scout_web/templates/address_contract_verification/new.html.eex:77
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:139
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:105
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:35
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:133
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:99
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:49
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:45
 #: lib/block_scout_web/templates/address_read_contract/index.html.eex:41
@@ -1676,6 +1661,7 @@ msgstr ""
 #: lib/block_scout_web/templates/account/tag_transaction/index.html.eex:22
 #: lib/block_scout_web/templates/account/watchlist/show.html.eex:22
 #: lib/block_scout_web/templates/account/watchlist_address/form.html.eex:19
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:52
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:59
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:4
@@ -2047,9 +2033,9 @@ msgstr ""
 msgid "Request to edit a public tag/label"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:142
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:108
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:38
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:138
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:104
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:52
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:48
 #, elixir-autogen, elixir-format
@@ -2292,8 +2278,7 @@ msgstr ""
 msgid "Test Networks"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:98
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:92
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:11
 #, elixir-autogen, elixir-format
 msgid "The 0x library address. This can be found in the generated json file or Truffle output (if using truffle)."
 msgstr ""
@@ -2940,9 +2925,9 @@ msgstr ""
 msgid "Verify & Publish"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:141
+#: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:107
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:37
-#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:137
+#: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:103
 #: lib/block_scout_web/templates/address_contract_verification_via_standard_json_input/new.html.eex:51
 #: lib/block_scout_web/templates/address_contract_verification_vyper/new.html.eex:47
 #, elixir-autogen, elixir-format
@@ -3260,4 +3245,20 @@ msgstr ""
 #: lib/block_scout_web/templates/layout/app.html.eex:44
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Indexing Internal Transactions"
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:5
+#, elixir-autogen, elixir-format
+msgid ") may be added for each contract. Click the Add Library button to add an additional one."
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_first.html.eex:5
+#, elixir-autogen, elixir-format, fuzzy
+msgid "A library name called in the .sol file. Multiple libraries (up to "
+msgstr ""
+
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_address.html.eex:4
+#: lib/block_scout_web/templates/address_contract_verification_common_fields/_library_name.html.eex:4
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Library"
 msgstr ""

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -260,7 +260,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
 
   defp add_external_libraries(params, external_libraries) do
     clean_external_libraries =
-      Enum.reduce(1..10, %{}, fn number, acc ->
+      Enum.reduce(1..Application.get_env(:block_scout_web, :verification_max_libraries), %{}, fn number, acc ->
         address_key = "library#{number}_address"
         name_key = "library#{number}_name"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,26 +2,29 @@ import Config
 
 import Bitwise
 
+indexer_memory_limit_default = 1
+
 indexer_memory_limit =
   "INDEXER_MEMORY_LIMIT"
-  |> System.get_env("1")
+  |> System.get_env(to_string(indexer_memory_limit_default))
   |> Integer.parse()
   |> case do
     {integer, ""} -> integer
-    _ -> 1
+    _ -> indexer_memory_limit_default
   end
 
 config :indexer,
   memory_limit: indexer_memory_limit <<< 30
 
+indexer_empty_blocks_sanitizer_batch_size_default = 100
+
 indexer_empty_blocks_sanitizer_batch_size =
-  if System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE") do
-    case Integer.parse(System.get_env("INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE")) do
-      {integer, ""} -> integer
-      _ -> 100
-    end
-  else
-    100
+  "INDEXER_EMPTY_BLOCKS_SANITIZER_BATCH_SIZE"
+  |> System.get_env(to_string(indexer_empty_blocks_sanitizer_batch_size_default))
+  |> Integer.parse()
+  |> case do
+    {integer, ""} -> integer
+    _ -> indexer_empty_blocks_sanitizer_batch_size_default
   end
 
 config :indexer, Indexer.Fetcher.EmptyBlocksSanitizer, batch_size: indexer_empty_blocks_sanitizer_batch_size
@@ -65,6 +68,17 @@ config :block_scout_web, BlockScoutWeb.Chain,
   enable_testnet_label: System.get_env("SHOW_TESTNET_LABEL", "false") == "true",
   testnet_label_text: System.get_env("TESTNET_LABEL_TEXT", "Testnet")
 
+verification_max_libraries_default = 10
+
+verification_max_libraries =
+  "CONTRACT_VERIFICATION_MAX_LIBRARIES"
+  |> System.get_env(to_string(verification_max_libraries_default))
+  |> Integer.parse()
+  |> case do
+    {integer, ""} -> integer
+    _ -> verification_max_libraries_default
+  end
+
 config :block_scout_web,
   link_to_other_explorers: System.get_env("LINK_TO_OTHER_EXPLORERS") == "true",
   other_explorers: System.get_env("OTHER_EXPLORERS"),
@@ -85,7 +99,8 @@ config :block_scout_web,
   re_captcha_secret_key: System.get_env("RE_CAPTCHA_SECRET_KEY", nil),
   re_captcha_client_key: System.get_env("RE_CAPTCHA_CLIENT_KEY", nil),
   chain_id: System.get_env("CHAIN_ID"),
-  json_rpc: System.get_env("JSON_RPC")
+  json_rpc: System.get_env("JSON_RPC"),
+  verification_max_libraries: verification_max_libraries
 
 default_api_rate_limit = 50
 default_api_rate_limit_str = Integer.to_string(default_api_rate_limit)
@@ -217,9 +232,10 @@ address_sum_global_ttl =
   |> System.get_env("")
   |> Integer.parse()
   |> case do
-    {integer, ""} -> :timer.seconds(integer)
-    _ -> :timer.minutes(60)
+    {integer, ""} -> integer
+    _ -> 3600
   end
+  |> :timer.seconds()
 
 config :explorer, Explorer.Chain.Cache.AddressSum, global_ttl: address_sum_global_ttl
 


### PR DESCRIPTION
## Motivation

Repeating code in the rendering of contract libs at verification page.

## Changelog

- Define several .eex templates for contract libs inputs rendering in order to prevent repeating pieces of code.
- Add `CONTRACT_VERIFICATION_MAX_LIBRARIES` to manage max number of supported libraries in the runtime environment.

Docs update PR https://github.com/blockscout/docs/pull/79

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
