### PR TITLE
Fix Blocks Indexing message appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 - [#6204](https://github.com/blockscout/blockscout/pull/6204) - Refactor contract libs render, CONTRACT_VERIFICATION_MAX_LIBRARIES, refactor parsing integer env vars in config
 - [#6195](https://github.com/blockscout/blockscout/pull/6195) - Docker compose configs improvements: Redis container name and persistent storage
-- [#6192](https://github.com/blockscout/blockscout/pull/6192) - Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
+- [#6192](https://github.com/blockscout/blockscout/pull/6192), [#6207](https://github.com/blockscout/blockscout/pull/6207) - Hide Indexing Internal Transactions message, if INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER=true
 - [#6183](https://github.com/blockscout/blockscout/pull/6183) - Transparent coin name definition
 - [#6155](https://github.com/blockscout/blockscout/pull/6155), [#6189](https://github.com/blockscout/blockscout/pull/6189) - Refactor Ethereum JSON RPC variants
 - [#6125](https://github.com/blockscout/blockscout/pull/6125) - Rename obsolete "parity" EthereumJSONRPC.Variant to "nethermind"

--- a/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/counters/blocks_indexed_counter.ex
@@ -36,15 +36,11 @@ defmodule BlockScoutWeb.Counters.BlocksIndexedCounter do
   end
 
   def calculate_blocks_indexed do
-    ratio = Chain.indexed_ratio()
+    indexed_ratio = Chain.indexed_ratio()
 
-    finished? =
-      case Decimal.compare(ratio, 1) do
-        :lt -> false
-        _ -> Chain.finished_internal_transactions_indexing?()
-      end
+    finished? = Chain.finished_indexing?(indexed_ratio)
 
-    Notifier.broadcast_blocks_indexed_ratio(ratio, finished?)
+    Notifier.broadcast_blocks_indexed_ratio(indexed_ratio, finished?)
   end
 
   defp schedule_next_consolidation do

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -216,10 +216,11 @@
           <%= raw(System.get_env("MAINTENANCE_ALERT_MESSAGE")) %>
         </div>
       <% end %>
-      <%= if not Explorer.Chain.finished_internal_transactions_indexing?() do %>
-        <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">
+      <% indexed_ratio = Explorer.Chain.indexed_ratio() %>
+      <%= if not Explorer.Chain.finished_indexing?(indexed_ratio) do %>
+        <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
-          <span data-indexed-ratio="<%=Explorer.Chain.indexed_ratio() %>"></span>
+          <span data-indexed-ratio="<%= indexed_ratio %>"></span>
           <%= gettext("- We're indexing this chain right now. Some of the counts may be inaccurate.") %>
         </div>
       <% end %>

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -76,7 +76,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:223
+#: lib/block_scout_web/templates/layout/app.html.eex:224
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -76,7 +76,7 @@ msgstr ""
 msgid "(query)"
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:223
+#: lib/block_scout_web/templates/layout/app.html.eex:224
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1200,6 +1200,17 @@ defmodule Explorer.Chain do
   end
 
   @doc """
+  Checks if indexing of blocks and internal transactions finished aka full indexing
+  """
+  @spec finished_indexing?(Decimal.t()) :: boolean()
+  def finished_indexing?(indexed_ratio) do
+    case Decimal.compare(indexed_ratio, 1) do
+      :lt -> false
+      _ -> Chain.finished_internal_transactions_indexing?()
+    end
+  end
+
+  @doc """
   The `t:Explorer.Chain.Transaction.t/0` `gas_price` of the `transaction` in `unit`.
   """
   def gas_price(%Transaction{gas_price: gas_price}, unit) do
@@ -2064,14 +2075,22 @@ defmodule Explorer.Chain do
   def indexed_ratio do
     %{min: min, max: max} = BlockNumber.get_all()
 
+    min_blockchain_block_number =
+      case Integer.parse(Application.get_env(:indexer, :first_block)) do
+        {block_number, _} -> block_number
+        _ -> 0
+      end
+
     case {min, max} do
       {0, 0} ->
         Decimal.new(0)
 
       _ ->
-        result = Decimal.div(max - min + 1, max + 1)
+        result = Decimal.div(max - min + 1, max - min_blockchain_block_number + 1)
 
-        Decimal.round(result, 2, :down)
+        result
+        |> Decimal.round(2, :down)
+        |> Decimal.min(Decimal.new(1))
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1467,6 +1467,12 @@ defmodule Explorer.ChainTest do
   end
 
   describe "indexed_ratio/0" do
+    setup do
+      on_exit(fn ->
+        Application.put_env(:indexer, :first_block, "")
+      end)
+    end
+
     test "returns indexed ratio" do
       for index <- 5..9 do
         insert(:block, number: index)
@@ -1481,6 +1487,17 @@ defmodule Explorer.ChainTest do
 
     test "returns 1.0 if fully indexed blocks" do
       for index <- 0..9 do
+        insert(:block, number: index)
+        Process.sleep(200)
+      end
+
+      assert Decimal.compare(Chain.indexed_ratio(), 1) == :eq
+    end
+
+    test "returns 1.0 if fully indexed blocks starting from given FIRST_BLOCK" do
+      Application.put_env(:indexer, :first_block, "5")
+
+      for index <- 5..9 do
         insert(:block, number: index)
         Process.sleep(200)
       end


### PR DESCRIPTION
## Motivation

"Indexing blocks" alert at the top doesn't appear in case of blocks are still indexing if `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER` env var is set.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
