### PR TITLE
Add metrics for block import stages, runners, steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#6073](https://github.com/blockscout/blockscout/pull/6073) - Add vyper support for rust verifier microservice integration
 - [#6111](https://github.com/blockscout/blockscout/pull/6111) - Add Prometheus metrics to indexer
 - [#6168](https://github.com/blockscout/blockscout/pull/6168) - Token instance fetcher checks instance owner and updates current token balance
+- [#6209](https://github.com/blockscout/blockscout/pull/6209) - Add metrics for block import stages, runners, steps
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalances do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Address.CoinBalance
   alias Explorer.Chain.{Block, Hash, Import, Wei}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -44,7 +45,12 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalances do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :address_coin_balances, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :address_referencing,
+        :coin_balances,
+        :address_coin_balances
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances_daily.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/coin_balances_daily.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalancesDaily do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Address.CoinBalanceDaily
   alias Explorer.Chain.{Hash, Import, Wei}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -44,7 +45,12 @@ defmodule Explorer.Chain.Import.Runner.Address.CoinBalancesDaily do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :address_coin_balances_daily, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :address_referencing,
+        :coin_balances_daily,
+        :address_coin_balances_daily
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.Import
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -42,7 +43,12 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :address_token_balances, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :token_blances,
+        :address_token_balances
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
   alias Ecto.{Multi, Repo}
   alias Explorer.Chain.{Address, Hash, Import, Transaction}
   alias Explorer.Chain.Import.Runner
+  alias Explorer.Prometheus.Instrumenter
 
   import Ecto.Query, only: [from: 2]
 
@@ -59,11 +60,21 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
 
     multi
     |> Multi.run(:addresses, fn repo, _ ->
-      insert(repo, changes_list_with_defaults, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list_with_defaults, insert_options) end,
+        :addresses,
+        :addresses,
+        :addresses
+      )
     end)
     |> Multi.run(:created_address_code_indexed_at_transactions, fn repo, %{addresses: addresses}
                                                                    when is_list(addresses) ->
-      update_transactions(repo, addresses, update_transactions_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> update_transactions(repo, addresses, update_transactions_options) end,
+        :addresses,
+        :addresses,
+        :created_address_code_indexed_at_transactions
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/rewards.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Block.Reward
   alias Explorer.Chain.Import
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -37,7 +38,14 @@ defmodule Explorer.Chain.Import.Runner.Block.Rewards do
       |> Map.put_new(:timeout, @timeout)
       |> Map.put(:timestamps, timestamps)
 
-    Multi.run(multi, option_key(), fn repo, _ -> insert(repo, changes_list, insert_options) end)
+    Multi.run(multi, option_key(), fn repo, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_following,
+        :rewards,
+        option_key()
+      )
+    end)
   end
 
   @impl Import.Runner

--- a/apps/explorer/lib/explorer/chain/import/runner/block/second_degree_relations.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/block/second_degree_relations.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Import.Runner.Block.SecondDegreeRelations do
 
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Block, Hash, Import}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -46,7 +47,12 @@ defmodule Explorer.Chain.Import.Runner.Block.SecondDegreeRelations do
       |> Map.put_new(:timeout, @timeout)
 
     Multi.run(multi, :block_second_degree_relations, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_following,
+        :second_degree_relations,
+        :block_second_degree_relations
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -13,6 +13,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.Import.Runner
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Chain.Import.Runner.Tokens
+  alias Explorer.Prometheus.Instrumenter
   alias Explorer.Repo, as: ExplorerRepo
 
   @behaviour Runner
@@ -61,8 +62,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     consensus_block_numbers = consensus_block_numbers(changes_list)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    multi
-    |> Multi.run(:lose_consensus, fn repo, _ ->
+    run_func = fn repo ->
       {:ok, nonconsensus_items} = lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
 
       nonconsensus_hashes =
@@ -75,64 +75,141 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         end
 
       {:ok, nonconsensus_hashes}
+    end
+
+    multi
+    |> Multi.run(:lose_consensus, fn repo, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> run_func.(repo) end,
+        :address_referencing,
+        :blocks,
+        :lose_consensus
+      )
     end)
     |> Multi.run(:blocks, fn repo, _ ->
-      # Note, needs to be executed after `lose_consensus` for lock acquisition
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          # Note, needs to be executed after `lose_consensus` for lock acquisition
+          insert(repo, changes_list, insert_options)
+        end,
+        :address_referencing,
+        :blocks,
+        :blocks
+      )
     end)
     |> Multi.run(:new_pending_operations, fn repo, %{lose_consensus: nonconsensus_hashes} ->
-      new_pending_operations(repo, nonconsensus_hashes, hashes_for_pending_block_operations, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          new_pending_operations(repo, nonconsensus_hashes, hashes_for_pending_block_operations, insert_options)
+        end,
+        :address_referencing,
+        :blocks,
+        :new_pending_operations
+      )
     end)
     |> Multi.run(:uncle_fetched_block_second_degree_relations, fn repo, _ ->
-      update_block_second_degree_relations(repo, hashes, %{
-        timeout:
-          options[Runner.Block.SecondDegreeRelations.option_key()][:timeout] ||
-            Runner.Block.SecondDegreeRelations.timeout(),
-        timestamps: timestamps
-      })
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          update_block_second_degree_relations(repo, hashes, %{
+            timeout:
+              options[Runner.Block.SecondDegreeRelations.option_key()][:timeout] ||
+                Runner.Block.SecondDegreeRelations.timeout(),
+            timestamps: timestamps
+          })
+        end,
+        :address_referencing,
+        :blocks,
+        :uncle_fetched_block_second_degree_relations
+      )
     end)
     |> Multi.run(:delete_rewards, fn repo, _ ->
-      delete_rewards(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> delete_rewards(repo, changes_list, insert_options) end,
+        :address_referencing,
+        :blocks,
+        :delete_rewards
+      )
     end)
     |> Multi.run(:fork_transactions, fn repo, _ ->
-      fork_transactions(%{
-        repo: repo,
-        timeout: options[Runner.Transactions.option_key()][:timeout] || Runner.Transactions.timeout(),
-        timestamps: timestamps,
-        blocks_changes: changes_list
-      })
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          fork_transactions(%{
+            repo: repo,
+            timeout: options[Runner.Transactions.option_key()][:timeout] || Runner.Transactions.timeout(),
+            timestamps: timestamps,
+            blocks_changes: changes_list
+          })
+        end,
+        :address_referencing,
+        :blocks,
+        :fork_transactions
+      )
     end)
     |> Multi.run(:derive_transaction_forks, fn repo, %{fork_transactions: transactions} ->
-      derive_transaction_forks(%{
-        repo: repo,
-        timeout: options[Runner.Transaction.Forks.option_key()][:timeout] || Runner.Transaction.Forks.timeout(),
-        timestamps: timestamps,
-        transactions: transactions
-      })
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          derive_transaction_forks(%{
+            repo: repo,
+            timeout: options[Runner.Transaction.Forks.option_key()][:timeout] || Runner.Transaction.Forks.timeout(),
+            timestamps: timestamps,
+            transactions: transactions
+          })
+        end,
+        :address_referencing,
+        :blocks,
+        :derive_transaction_forks
+      )
     end)
     |> Multi.run(:acquire_contract_address_tokens, fn repo, _ ->
-      acquire_contract_address_tokens(repo, consensus_block_numbers)
+      Instrumenter.block_import_stage_runner(
+        fn -> acquire_contract_address_tokens(repo, consensus_block_numbers) end,
+        :address_referencing,
+        :blocks,
+        :acquire_contract_address_tokens
+      )
     end)
     |> Multi.run(:delete_address_token_balances, fn repo, _ ->
-      delete_address_token_balances(repo, consensus_block_numbers, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> delete_address_token_balances(repo, consensus_block_numbers, insert_options) end,
+        :address_referencing,
+        :blocks,
+        :delete_address_token_balances
+      )
     end)
     |> Multi.run(:delete_address_current_token_balances, fn repo, _ ->
-      delete_address_current_token_balances(repo, consensus_block_numbers, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> delete_address_current_token_balances(repo, consensus_block_numbers, insert_options) end,
+        :address_referencing,
+        :blocks,
+        :delete_address_current_token_balances
+      )
     end)
     |> Multi.run(:derive_address_current_token_balances, fn repo,
                                                             %{
                                                               delete_address_current_token_balances:
                                                                 deleted_address_current_token_balances
                                                             } ->
-      derive_address_current_token_balances(repo, deleted_address_current_token_balances, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> derive_address_current_token_balances(repo, deleted_address_current_token_balances, insert_options) end,
+        :address_referencing,
+        :blocks,
+        :derive_address_current_token_balances
+      )
     end)
     |> Multi.run(:blocks_update_token_holder_counts, fn repo,
                                                         %{
                                                           delete_address_current_token_balances: deleted,
                                                           derive_address_current_token_balances: inserted
                                                         } ->
-      deltas = CurrentTokenBalances.token_holder_count_deltas(%{deleted: deleted, inserted: inserted})
-      Tokens.update_holder_counts_with_deltas(repo, deltas, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          deltas = CurrentTokenBalances.token_holder_count_deltas(%{deleted: deleted, inserted: inserted})
+          Tokens.update_holder_counts_with_deltas(repo, deltas, insert_options)
+        end,
+        :address_referencing,
+        :blocks,
+        :blocks_update_token_holder_counts
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Block, Hash, Import, InternalTransaction, PendingBlockOperation, Transaction}
   alias Explorer.Chain.Import.Runner
+  alias Explorer.Prometheus.Instrumenter
   alias Explorer.Repo, as: ExplorerRepo
 
   import Ecto.Query, only: [from: 2, or_where: 3]
@@ -54,26 +55,53 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
     multi
     |> Multi.run(:acquire_blocks, fn repo, _ ->
-      acquire_blocks(repo, changes_list)
+      Instrumenter.block_import_stage_runner(
+        fn -> acquire_blocks(repo, changes_list) end,
+        :block_pending,
+        :internal_transactions,
+        :acquire_blocks
+      )
     end)
     |> Multi.run(:acquire_pending_internal_txs, fn repo, %{acquire_blocks: block_hashes} ->
-      acquire_pending_internal_txs(repo, block_hashes)
+      Instrumenter.block_import_stage_runner(
+        fn -> acquire_pending_internal_txs(repo, block_hashes) end,
+        :block_pending,
+        :internal_transactions,
+        :acquire_pending_internal_txs
+      )
     end)
     |> Multi.run(:acquire_transactions, fn repo, %{acquire_pending_internal_txs: pending_block_hashes} ->
-      acquire_transactions(repo, pending_block_hashes)
+      Instrumenter.block_import_stage_runner(
+        fn -> acquire_transactions(repo, pending_block_hashes) end,
+        :block_pending,
+        :internal_transactions,
+        :acquire_transactions
+      )
     end)
     |> Multi.run(:invalid_block_numbers, fn _, %{acquire_transactions: transactions} ->
-      invalid_block_numbers(transactions, internal_transactions_params)
+      Instrumenter.block_import_stage_runner(
+        fn -> invalid_block_numbers(transactions, internal_transactions_params) end,
+        :block_pending,
+        :internal_transactions,
+        :invalid_block_numbers
+      )
     end)
     |> Multi.run(:valid_internal_transactions, fn _,
                                                   %{
                                                     acquire_transactions: transactions,
                                                     invalid_block_numbers: invalid_block_numbers
                                                   } ->
-      valid_internal_transactions(
-        transactions,
-        internal_transactions_params,
-        invalid_block_numbers
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          valid_internal_transactions(
+            transactions,
+            internal_transactions_params,
+            invalid_block_numbers
+          )
+        end,
+        :block_pending,
+        :internal_transactions,
+        :valid_internal_transactions
       )
     end)
     |> Multi.run(:valid_internal_transactions_without_first_traces_of_trivial_transactions, fn _,
@@ -81,35 +109,69 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
                                                                                                  valid_internal_transactions:
                                                                                                    valid_internal_transactions
                                                                                                } ->
-      valid_internal_transactions_without_first_trace(valid_internal_transactions)
+      Instrumenter.block_import_stage_runner(
+        fn -> valid_internal_transactions_without_first_trace(valid_internal_transactions) end,
+        :block_pending,
+        :internal_transactions,
+        :valid_internal_transactions_without_first_traces_of_trivial_transactions
+      )
     end)
     |> Multi.run(:remove_left_over_internal_transactions, fn repo,
-                                                             %{valid_internal_transactions: valid_internal_transactions} ->
-      remove_left_over_internal_transactions(repo, valid_internal_transactions)
+                                                             %{
+                                                               valid_internal_transactions: valid_internal_transactions
+                                                             } ->
+      Instrumenter.block_import_stage_runner(
+        fn -> remove_left_over_internal_transactions(repo, valid_internal_transactions) end,
+        :block_pending,
+        :internal_transactions,
+        :remove_left_over_internal_transactions
+      )
     end)
     |> Multi.run(:internal_transactions, fn repo,
                                             %{
                                               valid_internal_transactions_without_first_traces_of_trivial_transactions:
                                                 valid_internal_transactions_without_first_traces_of_trivial_transactions
                                             } ->
-      insert(repo, valid_internal_transactions_without_first_traces_of_trivial_transactions, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          insert(repo, valid_internal_transactions_without_first_traces_of_trivial_transactions, insert_options)
+        end,
+        :block_pending,
+        :internal_transactions,
+        :internal_transactions
+      )
     end)
     |> Multi.run(:update_transactions, fn repo,
                                           %{
                                             valid_internal_transactions: valid_internal_transactions,
                                             acquire_transactions: transactions
                                           } ->
-      update_transactions(repo, valid_internal_transactions, transactions, update_transactions_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> update_transactions(repo, valid_internal_transactions, transactions, update_transactions_options) end,
+        :block_pending,
+        :internal_transactions,
+        :update_transactions
+      )
     end)
     |> Multi.run(:remove_consensus_of_invalid_blocks, fn repo, %{invalid_block_numbers: invalid_block_numbers} ->
-      remove_consensus_of_invalid_blocks(repo, invalid_block_numbers)
+      Instrumenter.block_import_stage_runner(
+        fn -> remove_consensus_of_invalid_blocks(repo, invalid_block_numbers) end,
+        :block_pending,
+        :internal_transactions,
+        :remove_consensus_of_invalid_blocks
+      )
     end)
     |> Multi.run(:update_pending_blocks_status, fn repo,
                                                    %{
                                                      acquire_pending_internal_txs: pending_block_hashes,
                                                      remove_consensus_of_invalid_blocks: invalid_block_hashes
                                                    } ->
-      update_pending_blocks_status(repo, pending_block_hashes, invalid_block_hashes)
+      Instrumenter.block_import_stage_runner(
+        fn -> update_pending_blocks_status(repo, pending_block_hashes, invalid_block_hashes) end,
+        :block_pending,
+        :internal_transactions,
+        :update_pending_blocks_status
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/logs.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/logs.ex
@@ -7,6 +7,7 @@ defmodule Explorer.Chain.Import.Runner.Logs do
 
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Import, Log}
+  alias Explorer.Prometheus.Instrumenter
 
   import Ecto.Query, only: [from: 2]
 
@@ -41,7 +42,12 @@ defmodule Explorer.Chain.Import.Runner.Logs do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :logs, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :logs,
+        :logs
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/token_transfers.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/token_transfers.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Import.Runner.TokenTransfers do
 
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Import, TokenTransfer}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -41,7 +42,12 @@ defmodule Explorer.Chain.Import.Runner.TokenTransfers do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :token_transfers, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :token_transfers,
+        :token_transfers
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
 
   alias Ecto.{Multi, Repo}
   alias Explorer.Chain.{Hash, Import, Token}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -155,7 +156,12 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :tokens, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :tokens,
+        :tokens
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/transaction/forks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transaction/forks.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Import.Runner.Transaction.Forks do
 
   alias Ecto.{Multi, Repo}
   alias Explorer.Chain.{Hash, Import, Transaction}
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -43,7 +44,12 @@ defmodule Explorer.Chain.Import.Runner.Transaction.Forks do
       |> Map.put(:timestamps, timestamps)
 
     Multi.run(multi, :transaction_forks, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :forks,
+        :transaction_forks
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
   alias Ecto.{Multi, Repo}
   alias Explorer.Chain.{Block, Hash, Import, Transaction}
   alias Explorer.Chain.Import.Runner.TokenTransfers
+  alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
 
@@ -45,10 +46,22 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
     multi
     |> Multi.run(:recollated_transactions, fn repo, _ ->
-      discard_blocks_for_recollated_transactions(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          discard_blocks_for_recollated_transactions(repo, changes_list, insert_options)
+        end,
+        :block_referencing,
+        :transactions,
+        :recollated_transactions
+      )
     end)
     |> Multi.run(:transactions, fn repo, _ ->
-      insert(repo, changes_list, insert_options)
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :transactions,
+        :transactions
+      )
     end)
   end
 

--- a/apps/explorer/lib/explorer/prometheus/instrumenter.ex
+++ b/apps/explorer/lib/explorer/prometheus/instrumenter.ex
@@ -1,0 +1,23 @@
+defmodule Explorer.Prometheus.Instrumenter do
+  @moduledoc """
+  Blocks fetch and import metrics for `Prometheus`.
+  """
+
+  use Prometheus.Metric
+
+  @histogram [
+    name: :block_import_stage_runner_duration_microseconds,
+    labels: [:stage, :runner, :step],
+    buckets: [1000, 5000, 10000, 100_000],
+    duration_unit: :microseconds,
+    help: "Block import stage, runner and step in runner processing time"
+  ]
+
+  def block_import_stage_runner(function, stage, runner, step) do
+    {time, result} = :timer.tc(function)
+
+    Histogram.observe([name: :block_import_stage_runner_duration_microseconds, labels: [stage, runner, step]], time)
+
+    result
+  end
+end


### PR DESCRIPTION
## Changelog

Add new Prometheus metric:
`block_import_stage_runner_duration_microseconds` - metric shows running time of each step of each runner in each stage of block import

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
