### PR TITLE
Add search API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -87,7 +87,9 @@ defmodule BlockScoutWeb.ApiRouter do
     pipe_through(:api)
     alias BlockScoutWeb.API.{EthRPC, RPC, V1}
     alias BlockScoutWeb.API.V1.HealthController
+    alias BlockScoutWeb.SearchController
 
+    get("/search", SearchController, :api_search_result)
     get("/health", HealthController, :health)
     get("/gas-price-oracle", V1.GasPriceOracleController, :gas_price_oracle)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
@@ -73,4 +73,21 @@ defmodule BlockScoutWeb.SearchController do
       current_path: Controller.current_full_path(conn)
     )
   end
+
+  def api_search_result(conn, %{"q" => query} = params) do
+    [paging_options: paging_options] = paging_options(params)
+    offset = (max(paging_options.page_number, 1) - 1) * paging_options.page_size
+
+    search_results_plus_one =
+      paging_options
+      |> ChainController.search_by(offset, query)
+
+    {search_results, next_page} = split_list_by_page(search_results_plus_one)
+
+    next_page_params = next_page_params(next_page, search_results, params)
+
+    conn
+    |> put_status(200)
+    |> render(:search_results, %{search_results: search_results, next_page_params: next_page_params})
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/search_view.ex
@@ -16,4 +16,36 @@ defmodule BlockScoutWeb.SearchView do
     |> Regex.replace(safe_result, "<mark class=\'autoComplete_highlight\'>\\g{0}</mark>", global: true)
     |> raw()
   end
+
+  def render("search_results.json", %{search_results: search_results, next_page_params: next_page_params}) do
+    %{"items" => Enum.map(search_results, &prepare_search_result/1), "next_page_params" => next_page_params}
+  end
+
+  def prepare_search_result(%{type: "token"} = search_result) do
+    %{
+      "type" => search_result.type,
+      "name" => search_result.name,
+      "symbol" => search_result.symbol,
+      "address" => search_result.address_hash
+    }
+  end
+
+  def prepare_search_result(%{type: address_or_contract} = search_result)
+      when address_or_contract in ["address", "contract"] do
+    %{"type" => search_result.type, "name" => search_result.name, "address" => search_result.address_hash}
+  end
+
+  def prepare_search_result(%{type: "block"} = search_result) do
+    %{
+      "type" => search_result.type,
+      "block_number" => search_result.block_number,
+      "block_hash" => hash_to_string(search_result.block_hash)
+    }
+  end
+
+  def prepare_search_result(%{type: "transaction"} = search_result) do
+    %{"type" => search_result.type, "tx_hash" => hash_to_string(search_result.tx_hash)}
+  end
+
+  defp hash_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
 end


### PR DESCRIPTION
## Motivation

Current search endpoint does not provide possibility to interract with it without server-side rendering
 
## Changelog
add search endpoint
`/api/v1/search?q=`
## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
