### PR TITLE
Fix coin_id test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#6106](https://github.com/blockscout/blockscout/pull/6106) - Fix 500 response on `/coin-balance` for empty address
 - [#6118](https://github.com/blockscout/blockscout/pull/6118) - Fix unfetched token balances
 - [#6163](https://github.com/blockscout/blockscout/pull/6163) - Fix rate limit logs
+- [#6223](https://github.com/blockscout/blockscout/pull/6223) - Fix coin_id test
 
 ### Chore
 

--- a/apps/explorer/test/explorer/exchange_rates/source/coin_gecko_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/coin_gecko_test.exs
@@ -115,7 +115,9 @@ defmodule Explorer.ExchangeRates.Source.CoinGeckoTest do
       {:ok, bypass: bypass}
     end
 
-    test "fetches poa coin id by default", %{bypass: bypass} do
+    test "fetches poa coin id", %{bypass: bypass} do
+      Application.put_env(:explorer, :coin, "POA")
+
       Bypass.expect(bypass, "GET", "/coins/list", fn conn ->
         Conn.resp(conn, 200, @coins_list)
       end)


### PR DESCRIPTION
## Motivation

https://github.com/blockscout/blockscout/blob/68209fffe81ef511ee24ea14b15202785db392f5/apps/explorer/test/explorer/exchange_rates/source/coin_gecko_test.exs#L118-L124

This test now is incorrect and fails randomly due to the fact that order of the test is random ([`:seed` option](https://hexdocs.pm/ex_unit/1.12/ExUnit.html#configure/1)) and that happens that this test runs first (i.e. `on_exit` callback hadn't been called yet), so `:explorer, :coin` env var hadn't been set to "POA", thus test fails, because default value for this env is "ETH".

## Changelog

### Bug Fixes
Now we set `:explorer, :coin` env var to "POA" in this test and it checks whether "POA" refers to "poa-network" as in other tests. Seems like there is no default logic in `CoinGecko` module, so there is no sense to test such default behavior.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
