### PR TITLE
Fix /blocks page freezing in case of large blocks numbers gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- [#6243](https://github.com/blockscout/blockscout/pull/6243) - Fix freezes on `/blocks` page
 - [#6162](https://github.com/blockscout/blockscout/pull/6162) - Extend token symbol type varchar(255) -> text
 - [#6158](https://github.com/blockscout/blockscout/pull/6158) - Add missing clause for merge_twin_vyper_contract_with_changeset function
 - [#6090](https://github.com/blockscout/blockscout/pull/6090) - Fix metadata fetching for ERC-1155 tokens instances 

--- a/apps/block_scout_web/assets/js/pages/blocks.js
+++ b/apps/block_scout_web/assets/js/pages/blocks.js
@@ -71,6 +71,7 @@ function withMissingBlocks (reducer) {
     const blockNumbers = keys(blockNumbersToItems).map(x => parseInt(x, 10))
     const minBlock = min(blockNumbers)
     const maxBlock = max(blockNumbers)
+    if (maxBlock - minBlock > 100) return result
 
     return Object.assign({}, result, {
       items: rangeRight(minBlock, maxBlock + 1)


### PR DESCRIPTION
Close #5701 

## Motivation
In case of /blocks page recieves blocks from backend with a significant difference between min and max block numbers, page freezes and browser crashes. It happens because of `withMissingBlocks` function in `apps/block_scout_web/assets/js/pages/blocks.js`

## Changelog
- add limit on min and max block numbers difference

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
