### PR TITLE
Copy public tags functionality to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#6316](https://github.com/blockscout/blockscout/pull/6316) - Copy public tags functionality to master
 - [#6196](https://github.com/blockscout/blockscout/pull/6196) - INDEXER_CATCHUP_BLOCKS_BATCH_SIZE and INDEXER_CATCHUP_BLOCKS_CONCURRENCY env varaibles
 - [#6187](https://github.com/blockscout/blockscout/pull/6187) - Filter by created time of verified contracts in listcontracts API endpoint
 - [#6092](https://github.com/blockscout/blockscout/pull/6092) - Blockscout Account functionality

--- a/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
@@ -11,17 +11,17 @@ defmodule BlockScoutWeb.Models.GetAddressTags do
   alias Explorer.Tags.{AddressTag, AddressToTag}
 
   def get_address_tags(nil, nil),
-    do: %{personal_tags: [], watchlist_names: []}
+    do: %{common_tags: [], personal_tags: [], watchlist_names: []}
 
   def get_address_tags(%Hash{} = address_hash, current_user) do
     %{
-      # common_tags: get_tags_on_address(address_hash),
+      common_tags: get_tags_on_address(address_hash),
       personal_tags: get_personal_tags(address_hash, current_user),
       watchlist_names: get_watchlist_names_on_address(address_hash, current_user)
     }
   end
 
-  def get_address_tags(_, _), do: %{personal_tags: [], watchlist_names: []}
+  def get_address_tags(_, _), do: %{common_tags: [], personal_tags: [], watchlist_names: []}
 
   def get_public_tags(%Hash{} = address_hash) do
     %{

--- a/apps/block_scout_web/lib/block_scout_web/models/get_transaction_tags.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/get_transaction_tags.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.Models.GetTransactionTags do
   Get various types of tags associated with the transaction
   """
 
-  import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
+  import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2, get_tags_on_address: 1]
 
   alias Explorer.Account.TagTransaction
   alias Explorer.Chain.Transaction
@@ -18,7 +18,13 @@ defmodule BlockScoutWeb.Models.GetTransactionTags do
     Map.put(addresses_tags, :personal_tx_tag, tx_tag)
   end
 
-  def get_transaction_with_addresses_tags(_, _), do: %{personal_tags: [], watchlist_names: [], personal_tx_tag: nil}
+  def get_transaction_with_addresses_tags(%Transaction{} = transaction, _),
+    do: %{
+      common_tags: get_tags_on_address(transaction.to_address_hash),
+      personal_tags: [],
+      watchlist_names: [],
+      personal_tx_tag: nil
+    }
 
   def get_transaction_tags(transaction_hash, %{id: identity_id}) do
     Repo.account_repo().get_by(TagTransaction, tx_hash_hash: transaction_hash, identity_id: identity_id)
@@ -34,6 +40,7 @@ defmodule BlockScoutWeb.Models.GetTransactionTags do
     to_tags = get_address_tags(transaction.to_address_hash, %{id: identity_id, watchlist_id: watchlist_id})
 
     %{
+      common_tags: get_tags_on_address(transaction.to_address_hash),
       personal_tags: Enum.dedup(from_tags.personal_tags ++ to_tags.personal_tags),
       watchlist_names: Enum.dedup(from_tags.watchlist_names ++ to_tags.watchlist_names)
     }

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_labels.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_labels.html.eex
@@ -1,3 +1,6 @@
+<%= for common_tag <- @tags.common_tags do %>
+  <%= render BlockScoutWeb.FormView, "_tag.html", text: common_tag.display_name, additional_classes: [tag_name_to_label(common_tag.label), "ml-1"] %>
+<% end %>
 <%= for personal_tag <- @tags.personal_tags do %>
   <%= if personal_tag.address_hash do %>
     <%= if personal_tag.label =~ "dark forest" do %>

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -87,6 +87,8 @@ config :explorer, Explorer.Chain.Cache.GasUsage,
 
 config :explorer, Explorer.Integrations.EctoLogger, query_time_ms_threshold: :timer.seconds(2)
 
+config :explorer, Explorer.Tags.AddressTag.Cataloger, enabled: true
+
 config :explorer, Explorer.Chain.Cache.MinMissingBlockNumber, enabled: System.get_env("DISABLE_WRITE_API") != "true"
 
 config :explorer, Explorer.Repo, migration_timestamps: [type: :utc_datetime_usec]

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -100,6 +100,7 @@ defmodule Explorer.Application do
       configure(Explorer.Counters.AverageBlockTime),
       configure(Explorer.Counters.Bridge),
       configure(Explorer.Validator.MetadataProcessor),
+      configure(Explorer.Tags.AddressTag.Cataloger),
       configure(MinMissingBlockNumber)
     ]
     |> List.flatten()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -98,6 +98,7 @@ config :block_scout_web,
   max_length_to_show_string_without_trimming: System.get_env("MAX_STRING_LENGTH_WITHOUT_TRIMMING", "2040"),
   re_captcha_secret_key: System.get_env("RE_CAPTCHA_SECRET_KEY", nil),
   re_captcha_client_key: System.get_env("RE_CAPTCHA_CLIENT_KEY", nil),
+  new_tags: System.get_env("NEW_TAGS"),
   chain_id: System.get_env("CHAIN_ID"),
   json_rpc: System.get_env("JSON_RPC"),
   verification_max_libraries: verification_max_libraries


### PR DESCRIPTION
## Changelog
- copy missed part of public tags functionality from xdai branch
new envs:
  - `NEW_TAGS`
    -  example: `NEW_TAGS='[ {"tag": "tag_name", "title": "name to display"} ]'`

  - `CUSTOM_CONTRACT_ADDRESSES_${tag_name}` 
    - example:  `CUSTOM_CONTRACT_ADDRESSES_TAG_NAME=0x0000000000000000000000000000000000000001,0x0000000000000000000000000000000000000000`
 
Addresses should exist in `addresses` table

Result of setting example envs:

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/32202610/197220890-a6b7d139-6f75-4fa7-9f22-446d93ea5415.png">
<img width="1293" alt="image" src="https://user-images.githubusercontent.com/32202610/197221109-9f9e7efc-7441-4b6f-b96f-593b61411d88.png">

[PR](https://github.com/blockscout/docs/pull/85) to docs
## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
