### PR TITLE
Fix sending request on each key in token search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#6118](https://github.com/blockscout/blockscout/pull/6118) - Fix unfetched token balances
 - [#6163](https://github.com/blockscout/blockscout/pull/6163) - Fix rate limit logs
 - [#6223](https://github.com/blockscout/blockscout/pull/6223) - Fix coin_id test
+- [#6336](https://github.com/blockscout/blockscout/pull/6336) - Fix sending request on each key in token search
 
 ### Chore
 

--- a/apps/block_scout_web/assets/js/pages/token/search.js
+++ b/apps/block_scout_web/assets/js/pages/token/search.js
@@ -25,6 +25,9 @@ export function reducer (state, action) {
 }
 
 if ($('[data-page="tokens"]').length) {
+  let timer
+  const waitTime = 500
+
   const store = createAsyncLoadStore(reducer, initialState, 'dataset.identifierHash')
 
   store.dispatch({
@@ -32,21 +35,24 @@ if ($('[data-page="tokens"]').length) {
   })
 
   $searchInput.on('input', (event) => {
-    const value = $(event.target).val()
+    clearTimeout(timer)
+    timer = setTimeout(() => {
+      const value = $(event.target).val()
 
-    const loc = window.location.pathname
+      const loc = window.location.pathname
 
-    if (value.length >= 3 || value === '') {
-      store.dispatch({ type: 'START_SEARCH' })
-      store.dispatch({ type: 'START_REQUEST' })
-      $.ajax({
-        url: `${loc}?type=JSON&filter=${value}`,
-        type: 'GET',
-        dataType: 'json',
-        contentType: 'application/json; charset=utf-8'
-      }).done(response => store.dispatch(Object.assign({ type: 'ITEMS_FETCHED' }, humps.camelizeKeys(response))))
-        .fail(() => store.dispatch({ type: 'REQUEST_ERROR' }))
-        .always(() => store.dispatch({ type: 'FINISH_REQUEST' }))
-    }
+      if (value.length >= 3 || value === '') {
+        store.dispatch({ type: 'START_SEARCH' })
+        store.dispatch({ type: 'START_REQUEST' })
+        $.ajax({
+          url: `${loc}?type=JSON&filter=${value}`,
+          type: 'GET',
+          dataType: 'json',
+          contentType: 'application/json; charset=utf-8'
+        }).done(response => store.dispatch(Object.assign({ type: 'ITEMS_FETCHED' }, humps.camelizeKeys(response))))
+          .fail(() => store.dispatch({ type: 'REQUEST_ERROR' }))
+          .always(() => store.dispatch({ type: 'FINISH_REQUEST' }))
+      }
+    }, waitTime)
   })
 }


### PR DESCRIPTION
Fixes #6296 

## Changelog
Add short delay to send request when user stops typing, and not for every button click
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
