### PR TITLE
Fix definitions of NETWORK_PATH, API_PATH, SOCKET_ROOT: process trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#6357](https://github.com/blockscout/blockscout/pull/6357) - Fix definitions of NETWORK_PATH, API_PATH, SOCKET_ROOT: process trailing slash
 - [#6338](https://github.com/blockscout/blockscout/pull/6338) - Fix token search with space
 - [#6329](https://github.com/blockscout/blockscout/pull/6329) - Prevent logger from truncating response from rust verifier service in case of an error
 - [#6309](https://github.com/blockscout/blockscout/pull/6309) - Fix read contract bug and change address tx count

--- a/apps/block_scout_web/assets/js/socket.js
+++ b/apps/block_scout_web/assets/js/socket.js
@@ -2,8 +2,11 @@ import { Socket } from 'phoenix'
 import { locale } from './locale'
 
 let websocketRootUrl = process.env.SOCKET_ROOT
-if (!websocketRootUrl || websocketRootUrl === '/') {
+if (!websocketRootUrl) {
   websocketRootUrl = ''
+}
+if (websocketRootUrl.endsWith('/')) {
+  websocketRootUrl = websocketRootUrl.slice(0, -1)
 }
 
 const socket = new Socket(websocketRootUrl + '/socket', { params: { locale } })

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -5,6 +5,24 @@
 # is restricted to this project.
 import Config
 
+network_path =
+  "NETWORK_PATH"
+  |> System.get_env("/")
+  |> (&(if !String.ends_with?(&1, "/") do
+          &1 <> "/"
+        else
+          &1
+        end)).()
+
+api_path =
+  "API_PATH"
+  |> System.get_env("/")
+  |> (&(if !String.ends_with?(&1, "/") do
+          &1 <> "/"
+        else
+          &1
+        end)).()
+
 # General application configuration
 config :block_scout_web,
   namespace: BlockScoutWeb,
@@ -18,8 +36,8 @@ config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: t
 # Configures the endpoint
 config :block_scout_web, BlockScoutWeb.Endpoint,
   url: [
-    path: System.get_env("NETWORK_PATH") || "/",
-    api_path: System.get_env("API_PATH") || "/"
+    path: network_path,
+    api_path: api_path
   ],
   render_errors: [view: BlockScoutWeb.ErrorView, accepts: ~w(html json)],
   pubsub_server: BlockScoutWeb.PubSub

--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -15,11 +15,7 @@ import Config
 # which you typically run after static files are built.
 config :block_scout_web, BlockScoutWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
-  force_ssl: false,
-  url: [
-    path: System.get_env("NETWORK_PATH") || "/",
-    api_path: System.get_env("API_PATH") || "/"
-  ]
+  force_ssl: false
 
 config :block_scout_web, BlockScoutWeb.Tracer, env: "production", disabled?: true
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/auth_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/auth_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Account.AuthController do
 
   alias BlockScoutWeb.Models.UserFromAuth
   alias Explorer.Account
+  alias Explorer.Repo.ConfigHelper
   alias Plug.CSRFProtection
 
   plug(Ueberauth)
@@ -68,6 +69,6 @@ defmodule BlockScoutWeb.Account.AuthController do
   def current_user(_), do: nil
 
   defp root do
-    System.get_env("NETWORK_PATH") || "/"
+    ConfigHelper.network_path()
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -64,7 +64,7 @@ defmodule BlockScoutWeb.Router do
   path = url_params[:path]
 
   if path != api_path do
-    scope to_string(api_path) <> "/verify_smart_contract" do
+    scope to_string(api_path) <> "verify_smart_contract" do
       pipe_through(:api)
 
       post("/contract_verifications", BlockScoutWeb.AddressContractVerificationController, :create)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -219,6 +219,8 @@ defmodule EthereumJSONRPC.Contract do
     end
   end
 
+  defp format_error(nil), do: {:error, ""}
+
   defp format_error(message) when is_binary(message) do
     {:error, message}
   end

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -57,4 +57,24 @@ defmodule Explorer.Repo.ConfigHelper do
       end
     end)
   end
+
+  def network_path do
+    path = System.get_env("NETWORK_PATH", "/")
+
+    path_from_env(path)
+  end
+
+  def api_path do
+    path = System.get_env("API_PATH", "/")
+
+    path_from_env(path)
+  end
+
+  defp path_from_env(path_env_var) do
+    if String.ends_with?(path_env_var, "/") do
+      path_env_var
+    else
+      path_env_var <> "/"
+    end
+  end
 end

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -22,9 +22,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   ],
   url: [
     scheme: "http",
-    host: System.get_env("BLOCKSCOUT_HOST") || "localhost",
-    path: System.get_env("NETWORK_PATH") || "/",
-    api_path: System.get_env("API_PATH") || "/"
+    host: System.get_env("BLOCKSCOUT_HOST", "localhost")
   ],
   https: [
     port: (port && port + 1) || 4001,


### PR DESCRIPTION
## Motivation

Absence or presence of trailing slash could cause incorrect generation of paths based on NETWORK_PATH, API_PATH, SOCKET_ROOT env variables.

## Changelog

Handle trailing "/" in NETWORK_PATH, API_PATH, SOCKET_ROOT env variables.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
