### PR TITLE
Create method_id index concurrently

### DIFF
--- a/apps/explorer/priv/repo/migrations/20220919105140_add_method_id_index.exs
+++ b/apps/explorer/priv/repo/migrations/20220919105140_add_method_id_index.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Repo.Migrations.AddMethodIdIndex do
 
   def up do
     execute("""
-      CREATE INDEX method_id ON public.transactions USING btree (substring(input for 4));
+      CREATE INDEX CONCURRENTLY method_id ON public.transactions USING btree (substring(input for 4));
     """)
   end
 


### PR DESCRIPTION
## Motivation

`method_id` index creation took more than an hour on Sokol instance. In other more capable Blockscout instance, it will take longer, and index creation on `transactions` table blocks the indexing as a whole. The suggestion is to create that index concurrently. The drawback is that functionality, which depends on the index, will be broken at the time of index building, but the index creation will not block the indexing of blocks.

## Changelog

Add `CONCURRENTLY` for method_id index creation.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
