### PR TITLE
Fix for concurrent index creation

### DIFF
--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -1,7 +1,9 @@
 import Config
 
 # Configure your database
-config :explorer, Explorer.Repo, timeout: :timer.seconds(80)
+config :explorer, Explorer.Repo,
+  timeout: :timer.seconds(80),
+  migration_lock: nil
 
 # Configure API database
 config :explorer, Explorer.Repo.Replica1, timeout: :timer.seconds(80)

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -3,7 +3,8 @@ import Config
 # Configures the database
 config :explorer, Explorer.Repo,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  migration_lock: nil
 
 # Configures API the database
 config :explorer, Explorer.Repo.Replica1,

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -11,7 +11,8 @@ config :explorer, Explorer.Repo,
   # Default of `5_000` was too low for `BlockFetcher` test
   ownership_timeout: :timer.minutes(7),
   timeout: :timer.seconds(60),
-  queue_target: 1000
+  queue_target: 1000,
+  migration_lock: nil
 
 # Configure API database
 config :explorer, Explorer.Repo.Replica1,

--- a/apps/explorer/priv/repo/migrations/20220919105140_add_method_id_index.exs
+++ b/apps/explorer/priv/repo/migrations/20220919105140_add_method_id_index.exs
@@ -1,6 +1,8 @@
 defmodule Explorer.Repo.Migrations.AddMethodIdIndex do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+
   def up do
     execute("""
       CREATE INDEX CONCURRENTLY method_id ON public.transactions USING btree (substring(input for 4));


### PR DESCRIPTION
## Motivation

Concurrent index creation doesn't work in the `api` branch



## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
