### PR TITLE
Drop internal transactions order index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#6209](https://github.com/blockscout/blockscout/pull/6209) - Add metrics for block import stages, runners, steps
 - [#6257](https://github.com/blockscout/blockscout/pull/6257), [#6276](https://github.com/blockscout/blockscout/pull/6276) - DISABLE_TOKEN_INSTANCE_FETCHER env variable
 - [#6391](https://github.com/blockscout/blockscout/pull/6391), [#6427](https://github.com/blockscout/blockscout/pull/6427) - TokenTransfer token_id -> token_ids migration
+- [#6443](https://github.com/blockscout/blockscout/pull/6443) - Drop internal transactions order index
 
 ### Fixes
 

--- a/apps/explorer/priv/repo/migrations/20221114121811_drop_internal_transactions_order_index.exs
+++ b/apps/explorer/priv/repo/migrations/20221114121811_drop_internal_transactions_order_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.DropInternalTransactionsOrderIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(index(:internal_transactions, ["block_number DESC, transaction_index DESC, index DESC"]))
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6132

## Motivation

Queries that fetch internal transactions for address uses this index in priority of specialized partial indexes (`internal_transactions_to_address_hash_partial_index`, `internal_transactions_from_address_hash_partial_index` and `internal_transactions_created_contract_address_hash_partial_ind`), which slows down such queries.