### PR TITLE
Search min_missing_block_number from zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#6223](https://github.com/blockscout/blockscout/pull/6223) - Fix coin_id test
 - [#6336](https://github.com/blockscout/blockscout/pull/6336) - Fix sending request on each key in token search
 - [#6327](https://github.com/blockscout/blockscout/pull/6327) - Fix and refactor address logs page and search
+- [#6449](https://github.com/blockscout/blockscout/pull/6449) - Search min_missing_block_number from zero
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3009,11 +3009,6 @@ defmodule Explorer.Chain do
   def fetch_min_missing_block_cache do
     max_block_number = BlockNumber.get_max()
 
-    min_missing_block_number =
-      "min_missing_block_number"
-      |> Chain.get_last_fetched_counter()
-      |> Decimal.to_integer()
-
     if max_block_number > 0 do
       query =
         from(b in Block,
@@ -3021,11 +3016,10 @@ defmodule Explorer.Chain do
             missing_range in fragment(
               """
                 (SELECT b1.number
-                FROM generate_series((?)::integer, (?)::integer) AS b1(number)
+                FROM generate_series(0, (?)::integer) AS b1(number)
                 WHERE NOT EXISTS
                   (SELECT 1 FROM blocks b2 WHERE b2.number=b1.number AND b2.consensus))
               """,
-              ^min_missing_block_number,
               ^max_block_number
             ),
           on: b.number == missing_range.number,


### PR DESCRIPTION
## Motivation

Since the consensus of a block can go from true to false, finding the minimum missing block from the previous one is incorrect.

## Changelog

The lower search limit for min missing block query is set to zero.
