### PR TITLE
Update token balances indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#6443](https://github.com/blockscout/blockscout/pull/6443) - Drop internal transactions order index
 - [#6450](https://github.com/blockscout/blockscout/pull/6450) - INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE and INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY env variables
 - [#6454](https://github.com/blockscout/blockscout/pull/6454) - INDEXER_RECEIPTS_BATCH_SIZE, INDEXER_RECEIPTS_CONCURRENCY, INDEXER_COIN_BALANCES_BATCH_SIZE, INDEXER_COIN_BALANCES_CONCURRENCY env variables
+- [#6476](https://github.com/blockscout/blockscout/pull/6476) - Update token balances indexes
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -242,51 +242,15 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce CurrentTokenBalance ShareLocks order (see docs: sharelocks.md)
-    %{
-      changes_list_no_token_id: changes_list_no_token_id,
-      changes_list_with_token_id: changes_list_with_token_id
-    } =
+    ordered_changes_list =
       changes_list
-      |> Enum.reduce(%{changes_list_no_token_id: [], changes_list_with_token_id: []}, fn change, acc ->
-        updated_change =
-          if Map.has_key?(change, :token_id) and Map.get(change, :token_type) == "ERC-1155" do
-            change
-          else
-            Map.put(change, :token_id, nil)
-          end
-
-        if updated_change.token_id do
-          changes_list_with_token_id = [updated_change | acc.changes_list_with_token_id]
-
-          %{
-            changes_list_no_token_id: acc.changes_list_no_token_id,
-            changes_list_with_token_id: changes_list_with_token_id
-          }
+      |> Enum.map(fn change ->
+        if Map.has_key?(change, :token_id) and Map.get(change, :token_type) == "ERC-1155" do
+          change
         else
-          changes_list_no_token_id = [updated_change | acc.changes_list_no_token_id]
-
-          %{
-            changes_list_no_token_id: changes_list_no_token_id,
-            changes_list_with_token_id: acc.changes_list_with_token_id
-          }
+          Map.put(change, :token_id, nil)
         end
       end)
-
-    ordered_changes_list_no_token_id =
-      changes_list_no_token_id
-      |> Enum.group_by(fn %{
-                            address_hash: address_hash,
-                            token_contract_address_hash: token_contract_address_hash
-                          } ->
-        {address_hash, token_contract_address_hash}
-      end)
-      |> Enum.map(fn {_, grouped_address_token_balances} ->
-        Enum.max_by(grouped_address_token_balances, fn %{block_number: block_number} -> block_number end)
-      end)
-      |> Enum.sort_by(&{&1.token_contract_address_hash, &1.address_hash})
-
-    ordered_changes_list_with_token_id =
-      changes_list_with_token_id
       |> Enum.group_by(fn %{
                             address_hash: address_hash,
                             token_contract_address_hash: token_contract_address_hash,
@@ -295,16 +259,18 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
         {address_hash, token_contract_address_hash, token_id}
       end)
       |> Enum.map(fn {_, grouped_address_token_balances} ->
-        Enum.max_by(grouped_address_token_balances, fn %{block_number: block_number} -> block_number end)
+        Enum.max_by(grouped_address_token_balances, fn balance ->
+          {Map.get(balance, :block_number), Map.get(balance, :value_fetched_at)}
+        end)
       end)
       |> Enum.sort_by(&{&1.token_contract_address_hash, &1.token_id, &1.address_hash})
 
-    {:ok, inserted_changes_list_no_token_id} =
-      if Enum.count(ordered_changes_list_no_token_id) > 0 do
+    {:ok, inserted_changes_list} =
+      if Enum.count(ordered_changes_list) > 0 do
         Import.insert_changes_list(
           repo,
-          ordered_changes_list_no_token_id,
-          conflict_target: {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash) WHERE token_id IS NULL>},
+          ordered_changes_list,
+          conflict_target: {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, COALESCE(token_id, 0))>},
           on_conflict: on_conflict,
           for: CurrentTokenBalance,
           returning: true,
@@ -315,24 +281,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
         {:ok, []}
       end
 
-    {:ok, inserted_changes_list_with_token_id} =
-      if Enum.count(ordered_changes_list_with_token_id) > 0 do
-        Import.insert_changes_list(
-          repo,
-          ordered_changes_list_with_token_id,
-          conflict_target:
-            {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, token_id) WHERE token_id IS NOT NULL>},
-          on_conflict: on_conflict,
-          for: CurrentTokenBalance,
-          returning: true,
-          timeout: timeout,
-          timestamps: timestamps
-        )
-      else
-        {:ok, []}
-      end
-
-    inserted_changes_list_no_token_id ++ inserted_changes_list_with_token_id
+    inserted_changes_list
   end
 
   defp default_on_conflict do
@@ -351,9 +300,10 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
       ],
       where:
         fragment("? < EXCLUDED.block_number", current_token_balance.block_number) or
-          (fragment("EXCLUDED.value IS NOT NULL") and
-             is_nil(current_token_balance.value_fetched_at) and
-             fragment("? = EXCLUDED.block_number", current_token_balance.block_number))
+          (fragment("? = EXCLUDED.block_number", current_token_balance.block_number) and
+             fragment("EXCLUDED.value IS NOT NULL") and
+             (is_nil(current_token_balance.value_fetched_at) or
+                fragment("? < EXCLUDED.value_fetched_at", current_token_balance.value_fetched_at)))
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -66,58 +66,15 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
-    %{
-      changes_list_no_token_id: changes_list_no_token_id,
-      changes_list_with_token_id: changes_list_with_token_id
-    } =
+    ordered_changes_list =
       changes_list
-      |> Enum.reduce(%{changes_list_no_token_id: [], changes_list_with_token_id: []}, fn change, acc ->
-        updated_change =
-          if Map.has_key?(change, :token_id) and Map.get(change, :token_type) == "ERC-1155" do
-            change
-          else
-            Map.put(change, :token_id, nil)
-          end
-
-        if updated_change.token_id do
-          changes_list_with_token_id = [updated_change | acc.changes_list_with_token_id]
-
-          %{
-            changes_list_no_token_id: acc.changes_list_no_token_id,
-            changes_list_with_token_id: changes_list_with_token_id
-          }
+      |> Enum.map(fn change ->
+        if Map.has_key?(change, :token_id) and Map.get(change, :token_type) == "ERC-1155" do
+          change
         else
-          changes_list_no_token_id = [updated_change | acc.changes_list_no_token_id]
-
-          %{
-            changes_list_no_token_id: changes_list_no_token_id,
-            changes_list_with_token_id: acc.changes_list_with_token_id
-          }
+          Map.put(change, :token_id, nil)
         end
       end)
-
-    ordered_changes_list_no_token_id =
-      changes_list_no_token_id
-      |> Enum.group_by(fn %{
-                            address_hash: address_hash,
-                            token_contract_address_hash: token_contract_address_hash,
-                            block_number: block_number
-                          } ->
-        {token_contract_address_hash, address_hash, block_number}
-      end)
-      |> Enum.map(fn {_, grouped_address_token_balances} ->
-        dedup = Enum.dedup(grouped_address_token_balances)
-
-        if Enum.count(dedup) > 1 do
-          Enum.max_by(dedup, fn %{value_fetched_at: value_fetched_at} -> value_fetched_at end)
-        else
-          Enum.at(dedup, 0)
-        end
-      end)
-      |> Enum.sort_by(&{&1.token_contract_address_hash, &1.address_hash, &1.block_number})
-
-    ordered_changes_list_with_token_id =
-      changes_list_with_token_id
       |> Enum.group_by(fn %{
                             address_hash: address_hash,
                             token_contract_address_hash: token_contract_address_hash,
@@ -128,20 +85,20 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       end)
       |> Enum.map(fn {_, grouped_address_token_balances} ->
         if Enum.count(grouped_address_token_balances) > 1 do
-          Enum.max_by(grouped_address_token_balances, fn %{value_fetched_at: value_fetched_at} -> value_fetched_at end)
+          Enum.max_by(grouped_address_token_balances, fn balance -> Map.get(balance, :value_fetched_at) end)
         else
           Enum.at(grouped_address_token_balances, 0)
         end
       end)
       |> Enum.sort_by(&{&1.token_contract_address_hash, &1.token_id, &1.address_hash, &1.block_number})
 
-    {:ok, inserted_changes_list_no_token_id} =
-      if Enum.count(ordered_changes_list_no_token_id) > 0 do
+    {:ok, inserted_changes_list} =
+      if Enum.count(ordered_changes_list) > 0 do
         Import.insert_changes_list(
           repo,
-          ordered_changes_list_no_token_id,
+          ordered_changes_list,
           conflict_target:
-            {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, block_number) WHERE token_id IS NULL>},
+            {:unsafe_fragment, ~s<(address_hash, token_contract_address_hash, COALESCE(token_id, 0), block_number)>},
           on_conflict: on_conflict,
           for: TokenBalance,
           returning: true,
@@ -151,26 +108,6 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       else
         {:ok, []}
       end
-
-    {:ok, inserted_changes_list_with_token_id} =
-      if Enum.count(ordered_changes_list_with_token_id) > 0 do
-        Import.insert_changes_list(
-          repo,
-          ordered_changes_list_with_token_id,
-          conflict_target:
-            {:unsafe_fragment,
-             ~s<(address_hash, token_contract_address_hash, token_id, block_number) WHERE token_id IS NOT NULL>},
-          on_conflict: on_conflict,
-          for: TokenBalance,
-          returning: true,
-          timeout: timeout,
-          timestamps: timestamps
-        )
-      else
-        {:ok, []}
-      end
-
-    inserted_changes_list = inserted_changes_list_no_token_id ++ inserted_changes_list_with_token_id
 
     {:ok, inserted_changes_list}
   end
@@ -180,7 +117,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       token_balance in TokenBalance,
       update: [
         set: [
-          value: fragment("EXCLUDED.value"),
+          value: fragment("COALESCE(EXCLUDED.value, ?)", token_balance.value),
           value_fetched_at: fragment("EXCLUDED.value_fetched_at"),
           token_type: fragment("EXCLUDED.token_type"),
           inserted_at: fragment("LEAST(EXCLUDED.inserted_at, ?)", token_balance.inserted_at),
@@ -188,9 +125,8 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
         ]
       ],
       where:
-        fragment("EXCLUDED.value IS NOT NULL") and
-          (is_nil(token_balance.value_fetched_at) or
-             fragment("? < EXCLUDED.value_fetched_at", token_balance.value_fetched_at))
+        is_nil(token_balance.value_fetched_at) or fragment("EXCLUDED.value_fetched_at IS NULL") or
+          fragment("? < EXCLUDED.value_fetched_at", token_balance.value_fetched_at)
     )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20221117075456_modify_address_token_balances_indexes.exs
+++ b/apps/explorer/priv/repo/migrations/20221117075456_modify_address_token_balances_indexes.exs
@@ -1,0 +1,58 @@
+defmodule Explorer.Repo.Migrations.ModifyAddressTokenBalancesIndexes do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      unique_index(
+        :address_token_balances,
+        ~w(address_hash token_contract_address_hash block_number)a,
+        name: :fetched_token_balances,
+        where: "token_id IS NULL"
+      )
+    )
+
+    drop_if_exists(
+      unique_index(
+        :address_token_balances,
+        ~w(address_hash token_contract_address_hash token_id block_number)a,
+        name: :fetched_token_balances_with_token_id,
+        where: "token_id IS NOT NULL"
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(
+        :address_token_balances,
+        [:address_hash, :token_contract_address_hash, "COALESCE(token_id, 0)", :block_number],
+        name: :fetched_token_balances
+      )
+    )
+
+    drop_if_exists(
+      unique_index(
+        :address_token_balances,
+        ~w(address_hash token_contract_address_hash block_number)a,
+        name: :unfetched_token_balances,
+        where: "value_fetched_at IS NULL and token_id IS NULL"
+      )
+    )
+
+    drop_if_exists(
+      unique_index(
+        :address_token_balances,
+        ~w(address_hash token_contract_address_hash token_id block_number)a,
+        name: :unfetched_token_balances_with_token_id,
+        where: "value_fetched_at IS NULL and token_id IS NOT NULL"
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(
+        :address_token_balances,
+        [:address_hash, :token_contract_address_hash, "COALESCE(token_id, 0)", :block_number],
+        name: :unfetched_token_balances,
+        where: "value_fetched_at IS NULL"
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20221117080657_modify_address_current_token_balances_indexes.exs
+++ b/apps/explorer/priv/repo/migrations/20221117080657_modify_address_current_token_balances_indexes.exs
@@ -1,0 +1,31 @@
+defmodule Explorer.Repo.Migrations.ModifyAddressCurrentTokenBalancesIndexes do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      unique_index(
+        :address_current_token_balances,
+        ~w(address_hash token_contract_address_hash)a,
+        name: :fetched_current_token_balances,
+        where: "token_id IS NULL"
+      )
+    )
+
+    drop_if_exists(
+      unique_index(
+        :address_current_token_balances,
+        ~w(address_hash token_contract_address_hash token_id)a,
+        name: :fetched_current_token_balances_with_token_id,
+        where: "token_id IS NOT NULL"
+      )
+    )
+
+    create_if_not_exists(
+      unique_index(
+        :address_current_token_balances,
+        [:address_hash, :token_contract_address_hash, "COALESCE(token_id, 0)"],
+        name: :fetched_current_token_balances
+      )
+    )
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
@@ -97,20 +97,6 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                   %Explorer.Chain.Address.CurrentTokenBalance{
                     address_hash: ^address_hash,
                     block_number: ^block_number,
-                    token_contract_address_hash: ^token_erc_20_contract_address_hash,
-                    value: ^value_3,
-                    token_id: ^token_id_3
-                  },
-                  %Explorer.Chain.Address.CurrentTokenBalance{
-                    address_hash: ^address_hash,
-                    block_number: ^block_number,
-                    token_contract_address_hash: ^token_erc_721_contract_address_hash,
-                    value: ^value_5,
-                    token_id: nil
-                  },
-                  %Explorer.Chain.Address.CurrentTokenBalance{
-                    address_hash: ^address_hash,
-                    block_number: ^block_number,
                     token_contract_address_hash: ^token_contract_address_hash,
                     value: ^value_1,
                     token_id: ^token_id_1
@@ -121,6 +107,20 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                     token_contract_address_hash: ^token_contract_address_hash,
                     value: ^value_2,
                     token_id: ^token_id_2
+                  },
+                  %Explorer.Chain.Address.CurrentTokenBalance{
+                    address_hash: ^address_hash,
+                    block_number: ^block_number,
+                    token_contract_address_hash: ^token_erc_20_contract_address_hash,
+                    value: ^value_3,
+                    token_id: ^token_id_3
+                  },
+                  %Explorer.Chain.Address.CurrentTokenBalance{
+                    address_hash: ^address_hash,
+                    block_number: ^block_number,
+                    token_contract_address_hash: ^token_erc_721_contract_address_hash,
+                    value: ^value_5,
+                    token_id: nil
                   }
                 ],
                 address_current_token_balances_update_token_holder_counts: [
@@ -172,7 +172,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                      block_number: block_number,
                      token_contract_address_hash: token_erc_721.contract_address_hash,
                      value: value_4,
-                     value_fetched_at: DateTime.utc_now(),
+                     value_fetched_at: DateTime.add(DateTime.utc_now(), -1),
                      token_id: token_id_4,
                      token_type: "ERC-721"
                    },


### PR DESCRIPTION
## Motivation
Currently, we are using double unique indexes for token balances tables because the field `token_id` presented in this index might be NULL or not NULL. In terms of performance, it's more useful to have one such index.

In addition, there is an inconsistency in token balances import logic. According to the current algorithm, we are collecting balances to be updated in the block fetcher pipeline, but the actual update happens only in async mode after the block is processed by fetcher. But, according to the current logic of actions on conflict in token balance update, we are updating token balance only if the new balance value is not null. So we won't store the information about balances to be update for tokens for which the address already has a balance and therefore we won't update such balances in the async mode after all.

## Changelog
- Double indexes on token balances tables are replaced with single ones
- Updated token balances runners `on_conflict` condition in order to new indexes
- Token balance import pipeline takes into account that new balances can be empty and stores them with the empty `value_fetched_at` field