### PR TITLE
Remove caching for api v2 txs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 - [#6475](https://github.com/blockscout/blockscout/pull/6475) - Fix token name with unicode graphemes shortening
 - [#6420](https://github.com/blockscout/blockscout/pull/6420) - Fix address logs search
-- [#6390](https://github.com/blockscout/blockscout/pull/6390) - Fix transactions responses in API v2
+- [#6390](https://github.com/blockscout/blockscout/pull/6390), [#6502](https://github.com/blockscout/blockscout/pull/6502) - Fix transactions responses in API v2
 - [#6357](https://github.com/blockscout/blockscout/pull/6357), [#6409](https://github.com/blockscout/blockscout/pull/6409), [#6428](https://github.com/blockscout/blockscout/pull/6428) - Fix definitions of NETWORK_PATH, API_PATH, SOCKET_ROOT: process trailing slash
 - [#6338](https://github.com/blockscout/blockscout/pull/6338) - Fix token search with space
 - [#6329](https://github.com/blockscout/blockscout/pull/6329) - Prevent logger from truncating response from rust verifier service in case of an error

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -74,7 +74,6 @@ defmodule Explorer.Chain do
     NewContractsCounter,
     NewVerifiedContractsCounter,
     Transactions,
-    TransactionsApiV2,
     Uncles,
     VerifiedContractsCounter
   }
@@ -3326,45 +3325,14 @@ defmodule Explorer.Chain do
     method_id_filter = Keyword.get(options, :method)
     type_filter = Keyword.get(options, :type)
 
-    if is_nil(paging_options.key) and (method_id_filter == [] || is_nil(method_id_filter)) and
-         (type_filter == [] || is_nil(type_filter)) do
-      old_ui?
-      |> take_enough_from_txs_cache(paging_options.page_size)
-      |> case do
-        nil ->
-          transactions =
-            fetch_recent_collated_transactions(
-              old_ui?,
-              paging_options,
-              necessity_by_association,
-              method_id_filter,
-              type_filter
-            )
-
-          update_transactions_cache(old_ui?, transactions)
-          transactions
-
-        transactions ->
-          transactions
-      end
-    else
-      fetch_recent_collated_transactions(
-        old_ui?,
-        paging_options,
-        necessity_by_association,
-        method_id_filter,
-        type_filter
-      )
-    end
+    fetch_recent_collated_transactions(
+      old_ui?,
+      paging_options,
+      necessity_by_association,
+      method_id_filter,
+      type_filter
+    )
   end
-
-  defp take_enough_from_txs_cache(old_ui?, amount)
-  defp take_enough_from_txs_cache(true, amount), do: Transactions.take_enough(amount)
-  defp take_enough_from_txs_cache(false, amount), do: TransactionsApiV2.take_enough(amount)
-
-  defp update_transactions_cache(old_ui?, txs)
-  defp update_transactions_cache(true, txs), do: Transactions.update(txs)
-  defp update_transactions_cache(false, txs), do: TransactionsApiV2.update(txs)
 
   # RAP - random access pagination
   @spec recent_collated_transactions_for_rap([paging_options | necessity_by_association_option]) :: %{


### PR DESCRIPTION
## Motivation

After last PR merging /transactions endpoint give 504 timeout error on POA 

## Changelog
- Remove caching for api v2 txs

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
