### PR TITLE
Set consensus: false for blocks on int transaction foreign_key_violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#6450](https://github.com/blockscout/blockscout/pull/6450) - INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE and INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY env variables
 - [#6454](https://github.com/blockscout/blockscout/pull/6454) - INDEXER_RECEIPTS_BATCH_SIZE, INDEXER_RECEIPTS_CONCURRENCY, INDEXER_COIN_BALANCES_BATCH_SIZE, INDEXER_COIN_BALANCES_CONCURRENCY env variables
 - [#6476](https://github.com/blockscout/blockscout/pull/6476), [#6484](https://github.com/blockscout/blockscout/pull/6484) - Update token balances indexes
+- [#6510](https://github.com/blockscout/blockscout/pull/6510) - Set consensus: false for blocks on int transaction foreign_key_violation
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3044,6 +3044,19 @@ defmodule Explorer.Chain do
     end
   end
 
+  def remove_blocks_consensus(block_numbers) do
+    numbers = List.wrap(block_numbers)
+
+    query =
+      from(
+        block in Block,
+        where: block.number in ^numbers,
+        where: block.consensus
+      )
+
+    Repo.update_all(query, set: [consensus: false])
+  end
+
   @doc """
   Calculates the ranges of missing consensus blocks in `range`.
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -276,7 +276,11 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   defp handle_foreign_key_violation(internal_transactions_params, block_numbers) do
     Chain.remove_blocks_consensus(block_numbers)
-    transaction_hashes = Enum.map(internal_transactions_params, &to_string(&1.transaction_hash))
+
+    transaction_hashes =
+      internal_transactions_params
+      |> Enum.map(&to_string(&1.transaction_hash))
+      |> Enum.uniq()
 
     Logger.error(fn ->
       [

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -2,6 +2,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
   use EthereumJSONRPC.Case, async: false
   use Explorer.DataCase
 
+  import ExUnit.CaptureLog
   import Mox
 
   alias Explorer.Chain
@@ -304,6 +305,166 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       assert {:retry, [block.number]} == InternalTransaction.run([block.number, block.number], json_rpc_named_arguments)
 
       assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
+    end
+
+    test "remove block consensus on foreign_key_violation", %{
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      block = insert(:block)
+      transaction = :transaction |> insert() |> with_block(block)
+      block_number = block.number
+      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        case Keyword.fetch!(json_rpc_named_arguments, :variant) do
+          EthereumJSONRPC.Nethermind ->
+            EthereumJSONRPC.Mox
+            |> expect(:json_rpc, fn [%{id: id, method: "trace_replayBlockTransactions"}], _options ->
+              {:ok,
+               [
+                 %{
+                   id: id,
+                   result: [
+                     %{
+                       "output" => "0x",
+                       "stateDiff" => nil,
+                       "trace" => [
+                         %{
+                           "action" => %{
+                             "callType" => "call",
+                             "from" => "0xa931c862e662134b85e4dc4baf5c70cc9ba74db4",
+                             "gas" => "0x8600",
+                             "input" => "0xb118e2db0000000000000000000000000000000000000000000000000000000000000008",
+                             "to" => "0x1469b17ebf82fedf56f04109e5207bdc4554288c",
+                             "value" => "0x174876e800"
+                           },
+                           "result" => %{"gasUsed" => "0x7d37", "output" => "0x"},
+                           "subtraces" => 1,
+                           "traceAddress" => [],
+                           "type" => "call"
+                         },
+                         %{
+                           "action" => %{
+                             "callType" => "call",
+                             "from" => "0xb37b428a7ddee91f39b26d79d23dc1c89e3e12a7",
+                             "gas" => "0x32dcf",
+                             "input" => "0x42dad49e",
+                             "to" => "0xee4019030fb5c2b68c42105552c6268d56c6cbfe",
+                             "value" => "0x0"
+                           },
+                           "result" => %{
+                             "gasUsed" => "0xb08",
+                             "output" => "0x"
+                           },
+                           "subtraces" => 0,
+                           "traceAddress" => [0],
+                           "type" => "call"
+                         }
+                       ],
+                       "transactionHash" => transaction.hash,
+                       "vmTrace" => nil
+                     },
+                     %{
+                       "output" => "0x",
+                       "stateDiff" => nil,
+                       "trace" => [
+                         %{
+                           "action" => %{
+                             "callType" => "call",
+                             "from" => "0xa931c862e662134b85e4dc4baf5c70cc9ba74db4",
+                             "gas" => "0x8600",
+                             "input" => "0xb118e2db0000000000000000000000000000000000000000000000000000000000000008",
+                             "to" => "0x1469b17ebf82fedf56f04109e5207bdc4554288c",
+                             "value" => "0x174876e800"
+                           },
+                           "result" => %{"gasUsed" => "0x7d37", "output" => "0x"},
+                           "subtraces" => 1,
+                           "traceAddress" => [],
+                           "type" => "call"
+                         },
+                         %{
+                           "action" => %{
+                             "callType" => "call",
+                             "from" => "0xb37b428a7ddee91f39b26d79d23dc1c89e3e12a7",
+                             "gas" => "0x32dcf",
+                             "input" => "0x42dad49e",
+                             "to" => "0xee4019030fb5c2b68c42105552c6268d56c6cbfe",
+                             "value" => "0x0"
+                           },
+                           "result" => %{
+                             "gasUsed" => "0xb08",
+                             "output" => "0x"
+                           },
+                           "subtraces" => 0,
+                           "traceAddress" => [0],
+                           "type" => "call"
+                         }
+                       ],
+                       "transactionHash" => transaction_hash(),
+                       "vmTrace" => nil
+                     }
+                   ]
+                 }
+               ]}
+            end)
+
+          EthereumJSONRPC.Geth ->
+            EthereumJSONRPC.Mox
+            |> expect(:json_rpc, fn [%{id: id, method: "debug_traceTransaction"}], _options ->
+              {:ok,
+               [
+                 %{
+                   id: id,
+                   result: [
+                     %{
+                       "blockNumber" => block.number,
+                       "transactionIndex" => 0,
+                       "transactionHash" => transaction.hash,
+                       "index" => 0,
+                       "traceAddress" => [],
+                       "type" => "call",
+                       "callType" => "call",
+                       "from" => "0xa931c862e662134b85e4dc4baf5c70cc9ba74db4",
+                       "to" => "0x1469b17ebf82fedf56f04109e5207bdc4554288c",
+                       "gas" => "0x8600",
+                       "gasUsed" => "0x7d37",
+                       "input" => "0xb118e2db0000000000000000000000000000000000000000000000000000000000000008",
+                       "output" => "0x",
+                       "value" => "0x174876e800"
+                     },
+                     %{
+                       "blockNumber" => block.number,
+                       "transactionIndex" => 0,
+                       "transactionHash" => transaction_hash(),
+                       "index" => 0,
+                       "traceAddress" => [],
+                       "type" => "call",
+                       "callType" => "call",
+                       "from" => "0xa931c862e662134b85e4dc4baf5c70cc9ba74db4",
+                       "to" => "0x1469b17ebf82fedf56f04109e5207bdc4554288c",
+                       "gas" => "0x8600",
+                       "gasUsed" => "0x7d37",
+                       "input" => "0xb118e2db0000000000000000000000000000000000000000000000000000000000000008",
+                       "output" => "0x",
+                       "value" => "0x174876e800"
+                     }
+                   ]
+                 }
+               ]}
+            end)
+
+          variant_name ->
+            raise ArgumentError, "Unsupported variant name (#{variant_name})"
+        end
+      end
+
+      logs =
+        capture_log(fn ->
+          assert {:retry, [^block_number]} = InternalTransaction.run([block_number], json_rpc_named_arguments)
+        end)
+
+      assert %{consensus: false} = Repo.reload(block)
+      assert logs =~ "foreign_key_violation on internal transactions import, foreign transactions hashes:"
     end
   end
 end


### PR DESCRIPTION
## Motivation
For cases when some transactions in block may be missing (node bug or smth else), it's necessary to have a functionality to reindex such blocks. Otherwise, it may cause endless foreign_key_violation errors on internal transactions import.

## Changelog
Set block consensus to false when we face such error, so catchup indexer will reindex this block.