### PR TITLE
Fix get_implementation_address_hash call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- [#5561](https://github.com/blockscout/blockscout/pull/5561) - Improve working with contracts implementations
+- [#5561](https://github.com/blockscout/blockscout/pull/5561), [#6523](https://github.com/blockscout/blockscout/pull/6523) - Improve working with contracts implementations
 - [#6401](https://github.com/blockscout/blockscout/pull/6401) - Add Sol2Uml contract visualization
 - [#6481](https://github.com/blockscout/blockscout/pull/6481) - Smart contract verification improvements
 - [#6444](https://github.com/blockscout/blockscout/pull/6444) - Add support for yul verification via rust microservice

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
   alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
   alias BlockScoutWeb.API.V2.Helper
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.Address
+  alias Explorer.Chain.{Address, SmartContract}
   alias Explorer.ExchangeRates.Token
 
   def render("message.json", assigns) do
@@ -38,7 +38,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
     {implementation_address, implementation_name} =
       with true <- is_proxy,
-           {address, name} <- Chain.get_implementation_address_hash(address.hash, address.smart_contract.abi),
+           {address, name} <- SmartContract.get_implementation_address_hash(address.smart_contract),
            false <- is_nil(address),
            {:ok, address_hash} <- Chain.string_to_address_hash(address),
            checksummed_address <- Address.checksum(address_hash) do


### PR DESCRIPTION
## Motivation
- After https://github.com/blockscout/blockscout/pull/5561 `get_implementation_address_hash` function has changed

## Changelog
- Fix `get_implementation_address_hash` call

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
