### PR TITLE
Fix internal transactions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - [#6327](https://github.com/blockscout/blockscout/pull/6327) - Fix and refactor address logs page and search
 - [#6449](https://github.com/blockscout/blockscout/pull/6449) - Search min_missing_block_number from zero
 - [#6492](https://github.com/blockscout/blockscout/pull/6492) - Remove token instance owner fetching
+- [#6536](https://github.com/blockscout/blockscout/pull/6536) - Fix internal transactions query
 
 ### Chore
 


### PR DESCRIPTION
## Motivation
Sorting in internal transactions query doesn't use any index which slows down internal transactions page loading especially for addresses that have a lot of internal transactions. However, there are several partial indexes that have the same sorting, so we can refactor this query to use these indexes and therefore speed it up.

## Changelog
Split internal transactions query into parts that use their partial indexes.