### PR TITLE
Index to speedup query for acquiring consensus block hashes with requirement to fetch internal transactions for them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixes
 
+- [#6552](https://github.com/blockscout/blockscout/pull/6552) - Index to speedup query for acquiring consensus block hashes with requirement to fetch internal transactions for them
 - [#6512](https://github.com/blockscout/blockscout/pull/6512) - Allow gasUsed in failed internal txs; Leave error field for staticcall
 - [#6532](https://github.com/blockscout/blockscout/pull/6532) - Fix index creation migration
 - [#6473](https://github.com/blockscout/blockscout/pull/6473) - Fix state changes for contract creation transactions

--- a/apps/explorer/priv/repo/migrations/20221206095503_add_blocks_hash_consensus_index.exs
+++ b/apps/explorer/priv/repo/migrations/20221206095503_add_blocks_hash_consensus_index.exs
@@ -1,0 +1,14 @@
+defmodule Explorer.Repo.Migrations.AddBlocksHashConsensusIndex do
+  use Ecto.Migration
+
+  def change do
+    create(
+      index(
+        :blocks,
+        [:hash],
+        name: :consensus_block_hashes,
+        where: ~s(consensus)
+      )
+    )
+  end
+end


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/6561

## Motivation

When `pending_block_operations` table has a huge number of rows, this query is very slow:
```
 20335 | 01:31:31.6449         | SELECT b0."number" FROM "blocks" AS b0 INNER JOIN "pending_block_operations" AS p1 ON p1."block_hash" = b0."hash" WHERE (p1."fetch_internal_transactions") AND (b0."consensus")                                                                                                                                                                                                                                                                                                                                                                                                                     | active
```

It is used to acquire block hashes in order to fetch internal transactions.


## Changelog

Create a partial index on `blocks` table:
```
"consensus_block_hashes" btree (hash) WHERE consensus
```

And replacing

```
"pending_block_operations_block_hash_index_partial" btree (block_hash) WHERE fetch_internal_transactions = true
```

with

```
"pending_block_operations_fetch_internal_transactions_index" btree (fetch_internal_transactions)
```

Now, the query execution plan is using the newly created index:
```
sokol=# explain analyze SELECT b0."number" FROM "blocks" AS b0 INNER JOIN "pending_block_operations" AS p1 ON p1."block_hash" = b0."hash" WHERE (p1."fetch_internal_transactions") AND (b0."consensus");
                                                                                QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=8.78..306.48 rows=28 width=8) (actual time=0.047..0.226 rows=11 loops=1)
   ->  Bitmap Heap Scan on pending_block_operations p1  (cost=8.35..70.16 rows=28 width=33) (actual time=0.022..0.039 rows=28 loops=1)
         Filter: fetch_internal_transactions
         Heap Blocks: exact=5
         ->  Bitmap Index Scan on pending_block_operations_fetch_internal_transactions_index  (cost=0.00..8.35 rows=28 width=0) (actual time=0.013..0.013 rows=28 loops=1)
               Index Cond: (fetch_internal_transactions = true)
   ->  Index Scan using consensus_block_hashes on blocks b0  (cost=0.42..8.44 rows=1 width=41) (actual time=0.006..0.006 rows=0 loops=28)
         Index Cond: (hash = p1.block_hash)
 Planning Time: 0.467 ms
 Execution Time: 0.277 ms
(10 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
