### PR TITLE
Drop unfetched_token_balances index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [#6476](https://github.com/blockscout/blockscout/pull/6476), [#6484](https://github.com/blockscout/blockscout/pull/6484) - Update token balances indexes
 - [#6510](https://github.com/blockscout/blockscout/pull/6510) - Set consensus: false for blocks on int transaction foreign_key_violation
 - [#6565](https://github.com/blockscout/blockscout/pull/6565) - Set restart: :permanent for permanent fetchers
+- [#6568](https://github.com/blockscout/blockscout/pull/6568) - Drop unfetched_token_balances index
 
 ### Fixes
 

--- a/apps/explorer/priv/repo/migrations/20221209123459_drop_unfetched_token_balances_index.exs
+++ b/apps/explorer/priv/repo/migrations/20221209123459_drop_unfetched_token_balances_index.exs
@@ -1,0 +1,14 @@
+defmodule Explorer.Repo.Migrations.DropUnfetchedTokenBalancesIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      unique_index(
+        :address_token_balances,
+        [:address_hash, :token_contract_address_hash, "COALESCE(token_id, -1)", :block_number],
+        name: :unfetched_token_balances,
+        where: "value_fetched_at IS NULL"
+      )
+    )
+  end
+end


### PR DESCRIPTION
## Motivation
Since we have `fetched_token_balances` unique index which is an extended version of `unfetched_token_balances` unique index and there are no inserts that uses `unfetched_token_balances` index, there is no need to keep the second unique index on the same fields.

## Changelog
`unfetched_token_balances` unique index deleted.