### PR TITLE
pending_block_operations table: remove fetch_internal_transactions column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ### Chore
 
+- [#6572](https://github.com/blockscout/blockscout/pull/6572) - pending_block_operations table: remove fetch_internal_transactions column
 - [#6387](https://github.com/blockscout/blockscout/pull/6387) - Fix errors in docker-build and e2e-tests workflows
 - [#6325](https://github.com/blockscout/blockscout/pull/6325) - Set http_only attribute of account authorization cookie to false
 - [#6343](https://github.com/blockscout/blockscout/pull/6343) - Docker-compose persistent logs

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), Decimal.from_float(0.5)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+  #     insert(:pending_block_operation, block_hash: block.hash)
 
   #     session
   #     |> AppPage.visit_page()
@@ -48,7 +48,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), 1) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+  #     insert(:pending_block_operation, block_hash: block.hash)
 
   #     session
   #     |> AppPage.visit_page()
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), Decimal.from_float(0.5)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+  #     insert(:pending_block_operation, block_hash: block.hash)
 
   #     session
   #     |> AppPage.visit_page()
@@ -96,7 +96,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio(), Decimal.from_float(0.9)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+  #     insert(:pending_block_operation, block_hash: block.hash)
 
   #     session
   #     |> AppPage.visit_page()
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     block_hash = block.hash
 
-  #     insert(:pending_block_operation, block_hash: block_hash, fetch_internal_transactions: true)
+  #     insert(:pending_block_operation, block_hash: block_hash)
 
   #     BlocksIndexedCounter.calculate_blocks_indexed()
 
@@ -130,11 +130,6 @@ defmodule BlockScoutWeb.ViewingAppTest do
   #     session
   #     |> AppPage.visit_page()
   #     |> assert_has(AppPage.indexed_status("Indexing Internal Transactions"))
-
-  #     Repo.update_all(
-  #       from(p in PendingBlockOperation, where: p.block_hash == ^block_hash),
-  #       set: [fetch_internal_transactions: false]
-  #     )
 
   #     BlocksIndexedCounter.calculate_blocks_indexed()
 

--- a/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
@@ -192,7 +192,7 @@ defmodule BlockScoutWeb.TransactionViewTest do
         |> insert()
         |> with_block(block, status: :error)
 
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block.hash)
 
       status = TransactionView.transaction_status(transaction)
       assert TransactionView.formatted_result(status) == "Error: (Awaiting internal transactions for reason)"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1253,7 +1253,7 @@ defmodule Explorer.Chain do
 
   @doc """
   Checks to see if the chain is down indexing based on the transaction from the
-  oldest block and the `fetch_internal_transactions` pending operation
+  oldest block and the pending operation
   """
   @spec finished_internal_transactions_indexing?() :: boolean()
   def finished_internal_transactions_indexing? do
@@ -1279,7 +1279,6 @@ defmodule Explorer.Chain do
             from(
               b in Block,
               join: pending_ops in assoc(b, :pending_operations),
-              where: pending_ops.fetch_internal_transactions,
               where: b.consensus and b.number == ^min_block_number
             )
 
@@ -2732,11 +2731,9 @@ defmodule Explorer.Chain do
   Only blocks with consensus are returned.
 
       iex> non_consensus = insert(:block, consensus: false)
-      iex> insert(:pending_block_operation, block: non_consensus, fetch_internal_transactions: true)
+      iex> insert(:pending_block_operation, block: non_consensus)
       iex> unfetched = insert(:block)
-      iex> insert(:pending_block_operation, block: unfetched, fetch_internal_transactions: true)
-      iex> fetched = insert(:block)
-      iex> insert(:pending_block_operation, block: fetched, fetch_internal_transactions: false)
+      iex> insert(:pending_block_operation, block: unfetched)
       iex> {:ok, number_set} = Explorer.Chain.stream_blocks_with_unfetched_internal_transactions(
       ...>   MapSet.new(),
       ...>   fn number, acc ->
@@ -2747,8 +2744,6 @@ defmodule Explorer.Chain do
       false
       iex> unfetched.number in number_set
       true
-      iex> fetched.hash in number_set
-      false
 
   """
   @spec stream_blocks_with_unfetched_internal_transactions(
@@ -2761,7 +2756,6 @@ defmodule Explorer.Chain do
       from(
         b in Block,
         join: pending_ops in assoc(b, :pending_operations),
-        where: pending_ops.fetch_internal_transactions,
         where: b.consensus,
         select: b.number
       )

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -436,14 +436,14 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         |> MapSet.union(MapSet.new(hashes))
         |> Enum.sort()
         |> Enum.map(fn hash ->
-          %{block_hash: hash, fetch_internal_transactions: true}
+          %{block_hash: hash}
         end)
 
       Import.insert_changes_list(
         repo,
         sorted_pending_ops,
         conflict_target: :block_hash,
-        on_conflict: PendingBlockOperation.default_on_conflict(),
+        on_conflict: :nothing,
         for: PendingBlockOperation,
         returning: true,
         timeout: timeout,

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -303,7 +303,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       from(
         pending_ops in PendingBlockOperation,
         where: pending_ops.block_hash in ^block_hashes,
-        where: pending_ops.fetch_internal_transactions,
         select: pending_ops.block_hash,
         # Enforce PendingBlockOperation ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: pending_ops.block_hash],

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -120,8 +120,7 @@ defmodule Explorer.Chain.InternalTransaction do
       foreign_key: :block_hash,
       define_field: false,
       references: :block_hash,
-      type: Hash.Full,
-      where: [fetch_internal_transactions: true]
+      type: Hash.Full
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -7,21 +7,17 @@ defmodule Explorer.Chain.PendingBlockOperation do
 
   alias Explorer.Chain.{Block, Hash}
 
-  @required_attrs ~w(block_hash fetch_internal_transactions)a
+  @required_attrs ~w(block_hash)a
 
   @typedoc """
    * `block_hash` - the hash of the block that has pending operations.
-   * `fetch_internal_transactions` - if the block needs its internal transactions fetched (or not)
   """
   @type t :: %__MODULE__{
-          block_hash: Hash.Full.t(),
-          fetch_internal_transactions: boolean()
+          block_hash: Hash.Full.t()
         }
 
   @primary_key false
   schema "pending_block_operations" do
-    field(:fetch_internal_transactions, :boolean)
-
     timestamps()
 
     belongs_to(:block, Block, foreign_key: :block_hash, primary_key: true, references: :hash, type: Hash.Full)
@@ -48,40 +44,10 @@ defmodule Explorer.Chain.PendingBlockOperation do
     )
   end
 
-  def block_hashes(filter \\ nil)
-
-  def block_hashes(filter) when is_nil(filter) do
+  def block_hashes do
     from(
       pending_ops in __MODULE__,
       select: pending_ops.block_hash
-    )
-  end
-
-  def block_hashes(filters) when is_list(filters) do
-    true_filters = Keyword.new(filters, &{&1, true})
-
-    from(
-      pending_ops in __MODULE__,
-      where: ^true_filters,
-      select: pending_ops.block_hash
-    )
-  end
-
-  def block_hashes(filter), do: block_hashes([filter])
-
-  def default_on_conflict do
-    from(
-      pending_ops in __MODULE__,
-      update: [
-        set: [
-          fetch_internal_transactions:
-            pending_ops.fetch_internal_transactions or fragment("EXCLUDED.fetch_internal_transactions"),
-          # Don't update `block_hash` as it is used for the conflict target
-          inserted_at: pending_ops.inserted_at,
-          updated_at: fragment("EXCLUDED.updated_at")
-        ]
-      ],
-      where: fragment("EXCLUDED.fetch_internal_transactions <> ?", pending_ops.fetch_internal_transactions)
     )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20221212093406_change_index_for_pending_block_operations.exs
+++ b/apps/explorer/priv/repo/migrations/20221212093406_change_index_for_pending_block_operations.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.ChangeIndexForPendingBlockOperations do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      index(
+        :pending_block_operations,
+        [:block_hash],
+        name: "pending_block_operations_block_hash_index_partial",
+        where: ~s("fetch_internal_transactions")
+      )
+    )
+
+    alter table(:pending_block_operations) do
+      remove(:fetch_internal_transactions)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
   describe "run/1" do
     test "transaction's status becomes :error when its internal_transaction has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
 
@@ -24,7 +24,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become true when its internal_transaction (where index != 0) has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -48,7 +48,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become false when its internal_transaction (where index == 0) has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -67,7 +67,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become false when its internal_transaction has no error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -92,7 +92,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "simple coin transfer's status becomes :error when its internal_transaction has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
 
@@ -112,7 +112,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
 
-      insert(:pending_block_operation, block_hash: a_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: a_block.hash)
 
       assert :ok == transaction1.status
       assert :ok == transaction2.status
@@ -136,7 +136,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       a_block = insert(:block, number: 1000)
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
-      insert(:pending_block_operation, block_hash: a_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: a_block.hash)
 
       assert :ok == transaction1.status
       assert :ok == transaction2.status
@@ -161,7 +161,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction0 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
-      insert(:pending_block_operation, block_hash: a_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: a_block.hash)
 
       assert :ok == transaction0.status
       assert :ok == transaction1.status
@@ -203,7 +203,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "simple coin transfer has no internal transaction inserted" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
 
@@ -221,7 +221,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction = insert(:transaction) |> with_block(status: :ok)
       pending = insert(:transaction)
 
-      insert(:pending_block_operation, block_hash: transaction.block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: transaction.block_hash)
 
       assert :ok == transaction.status
       assert is_nil(pending.block_hash)
@@ -246,14 +246,14 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       empty_block = insert(:block)
       pending = insert(:transaction)
 
-      insert(:pending_block_operation, block_hash: empty_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: empty_block.hash)
 
       assert is_nil(pending.block_hash)
 
       full_block = insert(:block)
       inserted = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: full_block.hash)
 
       assert full_block.hash == inserted.block_hash
 
@@ -290,7 +290,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
         block_index: 0
       )
 
-      insert(:pending_block_operation, block_hash: full_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: full_block.hash)
 
       transaction_changes = make_internal_transaction_changes(transaction, 0, nil)
 
@@ -309,7 +309,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction_a = insert(:transaction) |> with_block(full_block)
       transaction_b = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: full_block.hash)
 
       transaction_a_changes = make_internal_transaction_changes(transaction_a, 0, nil)
 
@@ -325,12 +325,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
     test "does not remove consensus when block is empty and no transactions are missing" do
       empty_block = insert(:block)
 
-      insert(:pending_block_operation, block_hash: empty_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: empty_block.hash)
 
       full_block = insert(:block)
       inserted = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: full_block.hash)
 
       assert full_block.hash == inserted.block_hash
 

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -648,11 +648,11 @@ defmodule Explorer.Chain.ImportTest do
       assert {:ok, _} = Import.all(options)
 
       {:ok, block_hash_casted} = Explorer.Chain.Hash.Full.cast(block_hash)
-      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes())
 
       assert {:ok, _} = Import.all(internal_txs_options)
 
-      assert [] == Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      assert [] == Explorer.Repo.all(PendingBlockOperation.block_hashes())
     end
 
     test "blocks with simple coin transfers updates PendingBlockOperation status" do
@@ -738,11 +738,11 @@ defmodule Explorer.Chain.ImportTest do
       assert {:ok, _} = Import.all(options)
 
       {:ok, block_hash_casted} = Explorer.Chain.Hash.Full.cast(block_hash)
-      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      assert [^block_hash_casted] = Explorer.Repo.all(PendingBlockOperation.block_hashes())
 
       assert {:ok, _} = Import.all(internal_txs_options)
 
-      assert [] == Explorer.Repo.all(PendingBlockOperation.block_hashes(:fetch_internal_transactions))
+      assert [] == Explorer.Repo.all(PendingBlockOperation.block_hashes())
     end
 
     test "when the transaction has no to_address and an internal transaction with type create it populates the denormalized created_contract_address_hash" do

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -44,10 +44,10 @@ defmodule Explorer.ChainTest do
   describe "remove_nonconsensus_blocks_from_pending_ops/0" do
     test "removes pending ops for nonconsensus blocks" do
       block = insert(:block)
-      insert(:pending_block_operation, block: block, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: block)
 
       nonconsensus_block = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: nonconsensus_block)
 
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops()
 
@@ -57,13 +57,13 @@ defmodule Explorer.ChainTest do
 
     test "removes pending ops for nonconsensus blocks by block hashes" do
       block = insert(:block)
-      insert(:pending_block_operation, block: block, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: block)
 
       nonconsensus_block = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: nonconsensus_block)
 
       nonconsensus_block1 = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block1, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: nonconsensus_block1)
 
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops([nonconsensus_block1.hash])
 
@@ -1209,7 +1209,7 @@ defmodule Explorer.ChainTest do
       |> insert()
       |> with_block(block)
 
-      insert(:pending_block_operation, block: block, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block: block)
 
       refute Chain.finished_internal_transactions_indexing?()
     end
@@ -1520,7 +1520,7 @@ defmodule Explorer.ChainTest do
         block = insert(:block, number: index)
 
         if index === 0 || index === 5 || index === 7 do
-          insert(:pending_block_operation, block: block, fetch_internal_transactions: true)
+          insert(:pending_block_operation, block: block)
         end
       end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -554,11 +554,7 @@ defmodule Explorer.Factory do
   end
 
   def pending_block_operation_factory do
-    %PendingBlockOperation{
-      # caller MUST supply block
-      # all operations will default to false
-      fetch_internal_transactions: false
-    }
+    %PendingBlockOperation{}
   end
 
   def internal_transaction_factory() do

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -101,7 +101,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
     block_number = 1_000_006
     block = insert(:block, number: block_number)
-    insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+    insert(:pending_block_operation, block_hash: block.hash)
 
     assert :ok = InternalTransaction.run([block_number], json_rpc_named_arguments)
 
@@ -117,7 +117,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
       block = insert(:block)
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block.hash)
 
       assert InternalTransaction.init(
                [],
@@ -131,7 +131,6 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
       block = insert(:block)
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: false)
 
       assert InternalTransaction.init(
                [],
@@ -170,7 +169,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
       block = insert(:block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block_hash)
 
       assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
@@ -185,7 +184,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       transaction = insert(:transaction) |> with_block(block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block_hash)
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do
@@ -298,7 +297,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       insert(:transaction) |> with_block(block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block_hash)
 
       assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
@@ -313,7 +312,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       transaction = :transaction |> insert() |> with_block(block)
       block_number = block.number
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block.hash)
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do

--- a/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
+++ b/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
@@ -8,7 +8,7 @@ defmodule Indexer.PendingOpsCleanerTest do
     test "deletes non-consensus pending ops on init" do
       block = insert(:block, consensus: false)
 
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block.hash)
 
       assert Repo.one(from(block in PendingBlockOperation, where: block.block_hash == ^block.hash))
 
@@ -24,7 +24,7 @@ defmodule Indexer.PendingOpsCleanerTest do
 
       block = insert(:block, consensus: false)
 
-      insert(:pending_block_operation, block_hash: block.hash, fetch_internal_transactions: true)
+      insert(:pending_block_operation, block_hash: block.hash)
 
       Process.sleep(2_000)
 


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/6561

## Motivation

`fetch_internal_transactions` column in `pending_block_operations` table always has `true` value. There is no place in the logic where it is changed to another value.

## Changelog

Remove `fetch_internal_transactions` column from `pending_block_operations` table, which should simplify the number of indexes on the table.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
