### PR TITLE
Allow and manage insecure HTTP connection to the archive node

### DIFF
--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +20,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +20,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth
   ],


### PR DESCRIPTION
## Motivation

Bypass expired SSL certificates on some nodes.

## Changelog

Manage insecure HTTP connection via `ETHEREUM_JSONRPC_HTTP_INSECURE` env variable. Docs update in https://github.com/blockscout/docs/pull/99.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
