### PR TITLE
Dark mode switcher localStorage to cookie in order to support new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ### Chore
 
+- [#6581](https://github.com/blockscout/blockscout/pull/6581) - Dark mode switcher localStorage to cookie in order to support new UI
 - [#6572](https://github.com/blockscout/blockscout/pull/6572) - pending_block_operations table: remove fetch_internal_transactions column
 - [#6387](https://github.com/blockscout/blockscout/pull/6387) - Fix errors in docker-build and e2e-tests workflows
 - [#6325](https://github.com/blockscout/blockscout/pull/6325) - Set http_only attribute of account authorization cookie to false

--- a/apps/block_scout_web/assets/js/lib/history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/history_chart.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import Cookies from 'js-cookie'
 import { Chart, LineController, LineElement, PointElement, LinearScale, TimeScale, Title, Tooltip } from 'chart.js'
 import 'chartjs-adapter-luxon'
 import humps from 'humps'
@@ -17,7 +18,7 @@ const grid = {
 }
 
 function getTxChartColor () {
-  if (localStorage.getItem('current-color-mode') === 'dark') {
+  if (Cookies.get('chakra-ui-color-mode') === 'dark') {
     return sassVariables.dashboardLineColorTransactionsDarkTheme
   } else {
     return sassVariables.dashboardLineColorTransactions
@@ -25,7 +26,7 @@ function getTxChartColor () {
 }
 
 function getPriceChartColor () {
-  if (localStorage.getItem('current-color-mode') === 'dark') {
+  if (Cookies.get('chakra-ui-color-mode') === 'dark') {
     return sassVariables.dashboardLineColorPriceDarkTheme
   } else {
     return sassVariables.dashboardLineColorPrice
@@ -33,7 +34,7 @@ function getPriceChartColor () {
 }
 
 function getMarketCapChartColor () {
-  if (localStorage.getItem('current-color-mode') === 'dark') {
+  if (Cookies.get('chakra-ui-color-mode') === 'dark') {
     return sassVariables.dashboardLineColorMarketDarkTheme
   } else {
     return sassVariables.dashboardLineColorMarket

--- a/apps/block_scout_web/assets/js/pages/dark-mode-switcher.js
+++ b/apps/block_scout_web/assets/js/pages/dark-mode-switcher.js
@@ -1,10 +1,11 @@
 import $ from 'jquery'
+import Cookies from 'js-cookie'
 
-$('.dark-mode-changer').click(function () {
-  if (localStorage.getItem('current-color-mode') === 'dark') {
-    localStorage.setItem('current-color-mode', 'light')
+$('.dark-mode-changer').on('click', function () {
+  if (Cookies.get('chakra-ui-color-mode') === 'dark') {
+    Cookies.set('chakra-ui-color-mode', 'light')
   } else {
-    localStorage.setItem('current-color-mode', 'dark')
+    Cookies.set('chakra-ui-color-mode', 'dark')
   }
   // reload each theme switch
   document.location.reload(true)

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -98,10 +98,11 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.13",
+      "license": "MIT"
     },
     "../../../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.0.4"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",

--- a/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
@@ -32,7 +32,7 @@
       if (reCaptchaClientKey) {
         widgetId1 = grecaptcha.render('recaptcha', {
           'sitekey': reCaptchaClientKey,
-          'theme': localStorage.getItem('current-color-mode'),
+          'theme': getCookie('chakra-ui-color-mode'),
           'callback': function () {
             document.getElementById('export-csv-button').disabled = false
           }

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -53,8 +53,14 @@
 
   <body>
     <script defer data-cfasync="false">
+      function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+      }
+
       function applyDarkMode() {
-        if (localStorage.getItem("current-color-mode") === "dark") {
+        if (getCookie('chakra-ui-color-mode') === "dark") {
           document.body.className += " " + "dark-theme-applied";
           document.body.style.backgroundColor = "#1c1d31";
         }
@@ -62,7 +68,7 @@
       window.onload = applyDarkMode()
     </script>
     <script defer data-cfasync="false">
-      if (localStorage.getItem("current-color-mode") === "dark") {
+      if (getCookie('chakra-ui-color-mode') === "dark") {
         if (document.getElementById("top-navbar")) {
           document.getElementById("top-navbar").style.backgroundColor = "#282945";
         }
@@ -76,7 +82,7 @@
       }
     </script>
     <script defer data-cfasync="false">
-      if (localStorage.getItem("current-color-mode") === "dark") {
+      if (getCookie('chakra-ui-color-mode') === "dark") {
         const search = document.getElementById("main-search-autocomplete")
         const searchMobile = document.getElementById("main-search-autocomplete-mobile")
             if (search && search.style) {

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -81,7 +81,7 @@ msgstr ""
 msgid ") may be added for each contract. Click the Add Library button to add an additional one."
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:230
+#: lib/block_scout_web/templates/layout/app.html.eex:236
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -81,7 +81,7 @@ msgstr ""
 msgid ") may be added for each contract. Click the Add Library button to add an additional one."
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:230
+#: lib/block_scout_web/templates/layout/app.html.eex:236
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""


### PR DESCRIPTION
## Motivation

Since we plan to use hybrid mode for explorer (new UI + old UI) we need to synchronize how we dark mode changer works.

## Changelog

The dark mode switcher is changed to use `chakra-ui-color-mode` cookie instead of `current-color-mode` local storage.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
