### PR TITLE
ignore some receipt fileds for metis

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -304,6 +304,11 @@ defmodule EthereumJSONRPC.Receipt do
     :ignore
   end
 
+  # Metis fields
+  defp entry_to_elixir({key, _}) when key in ~w(l1GasUsed l1GasPrice l1FeeScalar l1Fee) do
+    :ignore
+  end
+
   # GoQuorum specific transaction receipt fields
   defp entry_to_elixir({key, _}) when key in ~w(isPrivacyMarkerTransaction) do
     :ignore


### PR DESCRIPTION
## Motivation

Add ignore rule for Metis RPC


```
curl -X POST 'https://andromeda.metis.io/?owner=1088' -H 'Content-Type: application/json' --data-raw '{
	"id": "1",
	"jsonrpc": "2.0",
	"method": "eth_getTransactionReceipt",
	"params": ["0x931d5f82512a2116cde0963f6747022353260c6958f990c1ca5472b2f4290938"]
}'
```

```json
{
    "jsonrpc": "2.0",
    "id": "1",
    "result": {
        "blockHash": "0xe24f003576c40c17237df00c9f4193d80b63894df708082c974acd6816335351",
        "blockNumber": "0x3fca00",
        "contractAddress": null,
        "cumulativeGasUsed": "0x5208",
        "from": "0xc519c75cf9de75311e6797cb3a3c641a01bdb1d5",
        "gasUsed": "0x5208",
        "l1Fee": "0x0",
        "l1FeeScalar": "8",
        "l1GasPrice": "0x0",
        "l1GasUsed": "0x1256",
        "logs": [],
        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
        "status": "0x1",
        "to": "0x9bfed8dffcf24e044f17aae9a0a9d8f96fef51a0",
        "transactionHash": "0x931d5f82512a2116cde0963f6747022353260c6958f990c1ca5472b2f4290938",
        "transactionIndex": "0x0"
    }
}
```


## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a 

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
