### PR TITLE
Unhandled division by 0

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -238,8 +238,11 @@ defmodule Indexer.Block.Fetcher do
     {import_time, result} = :timer.tc(fn -> callback_module.import(state, options_with_broadcast) end)
 
     no_blocks_to_import = length(options_with_broadcast.blocks.params)
-    no_blocks_to_import_div = if Decimal.compare(no_blocks_to_import, 0) == :eq, do: 1, else: no_blocks_to_import
-    Prometheus.Instrumenter.block_import(import_time / no_blocks_to_import_div, callback_module)
+
+    if no_blocks_to_import != 0 do
+      Prometheus.Instrumenter.block_import(import_time / no_blocks_to_import, callback_module)
+    end
+
     result
   end
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -238,7 +238,8 @@ defmodule Indexer.Block.Fetcher do
     {import_time, result} = :timer.tc(fn -> callback_module.import(state, options_with_broadcast) end)
 
     no_blocks_to_import = length(options_with_broadcast.blocks.params)
-    Prometheus.Instrumenter.block_import(import_time / no_blocks_to_import, callback_module)
+    no_blocks_to_import_div = if Decimal.compare(no_blocks_to_import, 0) == :eq, do: 1, else: no_blocks_to_import
+    Prometheus.Instrumenter.block_import(import_time / no_blocks_to_import_div, callback_module)
     result
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6598

Fix the division if is 0.

Trying resolve the issue #6598.
 
## Changelog 
### Bug Fixes
 Handle zero division on fetcher of indexer


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
