### PR TITLE
Expand ETHEREUM_JSONRPC_HTTP_INSECURE env variable usage to other than Geth clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#6574](https://github.com/blockscout/blockscout/pull/6574), [#6601](https://github.com/blockscout/blockscout/pull/6601) - Allow and manage insecure HTTP connection to the archive node
 - [#6433](https://github.com/blockscout/blockscout/pull/6433) - Update error pagess
 - [#6544](https://github.com/blockscout/blockscout/pull/6544) - API improvements
 - [#5561](https://github.com/blockscout/blockscout/pull/5561), [#6523](https://github.com/blockscout/blockscout/pull/6523), [#6549](https://github.com/blockscout/blockscout/pull/6549) - Improve working with contracts implementations

--- a/apps/explorer/config/dev/arbitrum.exs
+++ b/apps/explorer/config/dev/arbitrum.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Arbitrum
   ],

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/explorer/config/prod/arbitrum.exs
+++ b/apps/explorer/config/prod/arbitrum.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Arbitrum
   ],

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -1,12 +1,21 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -1,5 +1,14 @@
 import Config
 
+hackney_opts_base = [pool: :ethereum_jsonrpc]
+
+hackney_opts =
+  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
+    [:insecure] ++ hackney_opts_base
+  else
+    hackney_opts_base
+  end
+
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -11,7 +20,7 @@ config :explorer,
         eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.RSK
   ],


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/6574

Extending ETHEREUM_JSONRPC_HTTP_INSECURE env variable usage to than Geth clients.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
