### PR TITLE
Handling stale error when try delete notification

### DIFF
--- a/apps/explorer/lib/explorer/chain/events/listener.ex
+++ b/apps/explorer/lib/explorer/chain/events/listener.ex
@@ -25,10 +25,13 @@ defmodule Explorer.Chain.Events.Listener do
   end
 
   def handle_info({:notification, _pid, _ref, _topic, payload}, state) do
-    payload
-    |> expand_payload()
-    |> decode_payload!()
-    |> broadcast()
+    expanded_payload = expand_payload(payload)
+
+    if expanded_payload != nil do
+      expanded_payload
+      |> decode_payload!()
+      |> broadcast()
+    end
 
     {:noreply, state}
   end
@@ -69,7 +72,12 @@ defmodule Explorer.Chain.Events.Listener do
         nil
 
       %{data: data} = notification ->
-        Repo.delete(notification)
+        try do
+          Repo.delete(notification)
+        rescue
+          Ecto.StaleEntryError -> nil
+        end
+
         data
     end
   end


### PR DESCRIPTION
Closes #6621 
## Motivation

When we have a haproxy architecture with 2 instances for web + 1 database + 1 indexer this we got scalability in terms of api and availability (the only failure point is the indexer) plus remove the issue of verifying the same smart contract in 2 databases behind the load balancer.

![image](https://user-images.githubusercontent.com/12281088/208645748-3b18a005-eea8-47c2-9444-08b1dfa6160e.png)

In new version 4.1.8-beta i got the following errors: 

![image](https://user-images.githubusercontent.com/12281088/208646039-09534da3-7eaf-408d-b592-abb35b16254b.png)

![image](https://user-images.githubusercontent.com/12281088/208646645-2d1bf86f-667f-4612-9026-7f35014e22e1.png)


## Changelog
 
### Bug Fixes

- Fix postgres notifications when try delete a notification in stale state


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
