### PR TITLE
BS api v2: smart contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [#6440](https://github.com/blockscout/blockscout/pull/6440) - Add support for base64 encoded NFT metadata
 - [#6407](https://github.com/blockscout/blockscout/pull/6407) - Indexed ratio for int txs fetching stage
 - [#6324](https://github.com/blockscout/blockscout/pull/6324) - Add verified contracts list page
-- [#6379](https://github.com/blockscout/blockscout/pull/6379), [#6429](https://github.com/blockscout/blockscout/pull/6429) - API v2 for frontend
+- [#6379](https://github.com/blockscout/blockscout/pull/6379), [#6429](https://github.com/blockscout/blockscout/pull/6429), [#6642](https://github.com/blockscout/blockscout/pull/6642) - API v2 for frontend
 - [#6351](https://github.com/blockscout/blockscout/pull/6351) - Enable forum link env var
 - [#6316](https://github.com/blockscout/blockscout/pull/6316) - Copy public tags functionality to master
 - [#6196](https://github.com/blockscout/blockscout/pull/6196) - INDEXER_CATCHUP_BLOCKS_BATCH_SIZE and INDEXER_CATCHUP_BLOCKS_CONCURRENCY env varaibles

--- a/apps/block_scout_web/.sobelow-conf
+++ b/apps/block_scout_web/.sobelow-conf
@@ -7,6 +7,7 @@
   format: "compact",
   ignore: ["Config.Headers", "Config.CSWH", "XSS.SendResp", "XSS.Raw"],
   ignore_files: [
-    "apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex"
+    "apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex",
+    "apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex"
   ]
 ]

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -96,19 +96,19 @@ const readWriteFunction = (element) => {
 const container = $('[data-smart-contract-functions]')
 
 if (container.length) {
-  getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
-    loadFunctions(container, false, currentAccount)
-  }, () => {
-    loadFunctions(container, false, null)
-  })
+  getWalletAndLoadFunctions()
 }
 
 const customABIContainer = $('[data-smart-contract-functions-custom]')
 
 if (customABIContainer.length) {
+  getWalletAndLoadFunctions()
+}
+
+function getWalletAndLoadFunctions () {
   getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
     loadFunctions(container, false, currentAccount)
   }, () => {
-    loadFunctions(container, true, null)
+    loadFunctions(container, false, null)
   })
 }

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -13,7 +13,7 @@ const loadFunctions = (element, isCustomABI, from) => {
 
   $.get(
     url,
-    { hash, type, action, is_custom_abi: isCustomABI, from: from },
+    { hash, type, action, is_custom_abi: isCustomABI, from },
     response => $element.html(response)
   )
     .done(function () {
@@ -97,14 +97,18 @@ const container = $('[data-smart-contract-functions]')
 
 if (container.length) {
   getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
-    loadFunctions(container, false, currentAccount)}, () => {loadFunctions(container, false, null)
-    })
+    loadFunctions(container, false, currentAccount)
+  }, () => {
+    loadFunctions(container, false, null)
+  })
 }
 
 const customABIContainer = $('[data-smart-contract-functions-custom]')
 
 if (customABIContainer.length) {
   getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
-    loadFunctions(container, false, currentAccount)}, () => {loadFunctions(container, true, null)
-    })
+    loadFunctions(container, false, currentAccount)
+  }, () => {
+    loadFunctions(container, true, null)
+  })
 }

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -1,10 +1,10 @@
 import $ from 'jquery'
-import { connectSelector, disconnectSelector, getContractABI, getMethodInputs, prepareMethodArgs } from './common_helpers'
+import { connectSelector, disconnectSelector, getCurrentAccountPromise, getContractABI, getMethodInputs, prepareMethodArgs } from './common_helpers'
 import { queryMethod, callMethod } from './interact'
 import { walletEnabled, connectToWallet, disconnectWallet, web3ModalInit } from './connect.js'
 import '../../pages/address'
 
-const loadFunctions = (element, isCustomABI) => {
+const loadFunctions = (element, isCustomABI, from) => {
   const $element = $(element)
   const url = $element.data('url')
   const hash = $element.data('hash')
@@ -13,7 +13,7 @@ const loadFunctions = (element, isCustomABI) => {
 
   $.get(
     url,
-    { hash, type, action, is_custom_abi: isCustomABI },
+    { hash, type, action, is_custom_abi: isCustomABI, from: from },
     response => $element.html(response)
   )
     .done(function () {
@@ -96,11 +96,15 @@ const readWriteFunction = (element) => {
 const container = $('[data-smart-contract-functions]')
 
 if (container.length) {
-  loadFunctions(container, false)
+  getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
+    loadFunctions(container, false, currentAccount)}, () => {loadFunctions(container, false, null)
+    })
 }
 
 const customABIContainer = $('[data-smart-contract-functions-custom]')
 
 if (customABIContainer.length) {
-  loadFunctions(customABIContainer, true)
+  getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
+    loadFunctions(container, false, currentAccount)}, () => {loadFunctions(container, true, null)
+    })
 }

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -28,7 +28,6 @@ defmodule BlockScoutWeb.ApiRouter do
   pipeline :api_v2 do
     plug(CheckApiV2)
     plug(:fetch_session)
-    plug(:protect_from_forgery)
   end
 
   alias BlockScoutWeb.Account.Api.V1.{TagsController, UserController}
@@ -130,12 +129,13 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/smart-contracts" do
-      get("/:address_hash", V2.AddressController, :smart_contract)
-      get("/:address_hash/methods-read", V2.AddressController, :methods_read)
-      get("/:address_hash/methods-write", V2.AddressController, :methods_write)
-      get("/:address_hash/methods-read-proxy", V2.AddressController, :methods_read_proxy)
-      get("/:address_hash/methods-write-proxy", V2.AddressController, :methods_write_proxy)
-      get("/:address_hash/query-read-method", V2.AddressController, :query_read_method)
+      get("/:address_hash", V2.SmartContractController, :smart_contract)
+      get("/:address_hash/methods-read", V2.SmartContractController, :methods_read)
+      get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
+      get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
+      get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
+      get("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
+      post("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
     end
 
     scope "/tokens" do

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -31,11 +31,6 @@ defmodule BlockScoutWeb.ApiRouter do
     plug(:protect_from_forgery)
   end
 
-  pipeline :api_v2_no_forgery_protect do
-    plug(CheckApiV2)
-    plug(:fetch_session)
-  end
-
   alias BlockScoutWeb.Account.Api.V1.{TagsController, UserController}
 
   scope "/account/v1", as: :account_v1 do
@@ -141,6 +136,7 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
       get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
       get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
+      post("/:address_hash/query-read-method", BlockScoutWeb.API.V2.SmartContractController, :query_read_method)
     end
 
     scope "/tokens" do
@@ -163,15 +159,6 @@ defmodule BlockScoutWeb.ApiRouter do
         get("/transactions", V2.StatsController, :transactions_chart)
         get("/market", V2.StatsController, :market_chart)
       end
-    end
-  end
-
-  scope "/v2", as: :api_v2 do
-    pipe_through(:api)
-    pipe_through(:api_v2_no_forgery_protect)
-
-    scope "/smart-contracts" do
-      post("/:address_hash/query-read-method", BlockScoutWeb.API.V2.SmartContractController, :query_read_method)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -13,7 +13,10 @@ defmodule BlockScoutWeb.ApiRouter do
   Router for API
   """
   use BlockScoutWeb, :router
+  alias BlockScoutWeb.SmartContractsApiV2Router
   alias BlockScoutWeb.Plug.{CheckAccountAPI, CheckApiV2}
+
+  forward("/v2/smart-contracts", SmartContractsApiV2Router)
 
   pipeline :api do
     plug(:accepts, ["json"])
@@ -128,15 +131,6 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/blocks-validated", V2.AddressController, :blocks_validated)
       get("/:address_hash/coin-balance-history", V2.AddressController, :coin_balance_history)
       get("/:address_hash/coin-balance-history-by-day", V2.AddressController, :coin_balance_history_by_day)
-    end
-
-    scope "/smart-contracts" do
-      get("/:address_hash", V2.SmartContractController, :smart_contract)
-      get("/:address_hash/methods-read", V2.SmartContractController, :methods_read)
-      get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
-      get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
-      get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
-      post("/:address_hash/query-read-method", BlockScoutWeb.API.V2.SmartContractController, :query_read_method)
     end
 
     scope "/tokens" do

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -28,6 +28,12 @@ defmodule BlockScoutWeb.ApiRouter do
   pipeline :api_v2 do
     plug(CheckApiV2)
     plug(:fetch_session)
+    plug(:protect_from_forgery)
+  end
+
+  pipeline :api_v2_no_forgery_protect do
+    plug(CheckApiV2)
+    plug(:fetch_session)
   end
 
   alias BlockScoutWeb.Account.Api.V1.{TagsController, UserController}
@@ -135,7 +141,6 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
       get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
       get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
-      post("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
     end
 
     scope "/tokens" do
@@ -158,6 +163,15 @@ defmodule BlockScoutWeb.ApiRouter do
         get("/transactions", V2.StatsController, :transactions_chart)
         get("/market", V2.StatsController, :market_chart)
       end
+    end
+  end
+
+  scope "/v2", as: :api_v2 do
+    pipe_through(:api)
+    pipe_through(:api_v2_no_forgery_protect)
+
+    scope "/smart-contracts" do
+      post("/:address_hash/query-read-method", BlockScoutWeb.API.V2.SmartContractController, :query_read_method)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -135,7 +135,6 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
       get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
       get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
-      get("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
       post("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
     end
 

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -129,6 +129,15 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash/coin-balance-history-by-day", V2.AddressController, :coin_balance_history_by_day)
     end
 
+    scope "/smart-contracts" do
+      get("/:address_hash", V2.AddressController, :smart_contract)
+      get("/:address_hash/methods-read", V2.AddressController, :methods_read)
+      get("/:address_hash/methods-write", V2.AddressController, :methods_write)
+      get("/:address_hash/methods-read-proxy", V2.AddressController, :methods_read_proxy)
+      get("/:address_hash/methods-write-proxy", V2.AddressController, :methods_write_proxy)
+      get("/:address_hash/query-read-method", V2.AddressController, :query_read_method)
+    end
+
     scope "/tokens" do
       get("/:address_hash", V2.TokenController, :token)
       get("/:address_hash/counters", V2.TokenController, :counters)

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -119,6 +119,7 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:address_hash", V2.AddressController, :address)
       get("/:address_hash/counters", V2.AddressController, :counters)
       get("/:address_hash/token-balances", V2.AddressController, :token_balances)
+      get("/:address_hash/tokens", V2.AddressController, :tokens)
       get("/:address_hash/transactions", V2.AddressController, :transactions)
       get("/:address_hash/token-transfers", V2.AddressController, :token_transfers)
       get("/:address_hash/internal-transactions", V2.AddressController, :internal_transactions)

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.AddressChannel do
   use BlockScoutWeb, :channel
 
   alias BlockScoutWeb.API.V2.AddressView, as: AddressViewAPI
+  alias BlockScoutWeb.API.V2.TransactionView, as: TransactionViewAPI
 
   alias BlockScoutWeb.{
     AddressCoinBalanceView,
@@ -120,10 +121,16 @@ defmodule BlockScoutWeb.AddressChannel do
 
   def handle_out(
         "internal_transaction",
-        %{address: _address, internal_transaction: _internal_transaction},
+        %{address: _address, internal_transaction: internal_transaction},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
       ) do
-    push(socket, "internal_transaction", %{internal_transaction: 1})
+    internal_transaction_json =
+      TransactionViewAPI.render("internal_transaction.json", %{
+        internal_transaction: internal_transaction,
+        conn: nil
+      })
+
+    push(socket, "internal_transaction", %{internal_transaction: internal_transaction_json})
 
     {:noreply, socket}
   end
@@ -236,11 +243,13 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   def handle_transaction(
-        %{address: _address, transaction: _transaction},
+        %{address: _address, transaction: transaction},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket,
         event
       ) do
-    push(socket, event, %{transaction: 1})
+    transaction_json = TransactionViewAPI.render("transaction.json", %{transaction: transaction, conn: nil})
+
+    push(socket, event, %{transaction: transaction_json})
 
     {:noreply, socket}
   end
@@ -269,11 +278,13 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   def handle_token_transfer(
-        %{address: _address, token_transfer: _token_transfer},
+        %{address: _address, token_transfer: token_transfer},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket,
         event
       ) do
-    push(socket, event, %{token_transfer: 1})
+    token_transfer_json = TransactionViewAPI.render("token_transfer.json", %{token_transfer: token_transfer, conn: nil})
+
+    push(socket, event, %{token_transfer: token_transfer_json})
 
     {:noreply, socket}
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -281,6 +281,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         address_hash
         |> Chain.fetch_last_token_balances(
           params
+          |> delete_parameters_from_next_page_params()
           |> paging_options()
           |> Keyword.merge(token_transfers_types_options(params))
         )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -12,9 +12,15 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   import BlockScoutWeb.PagingHelper,
     only: [delete_parameters_from_next_page_params: 1, token_transfers_types_options: 1]
 
+  import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
+
   alias BlockScoutWeb.AccessHelpers
-  alias BlockScoutWeb.API.V2.{AddressView, BlockView, TransactionView}
+  alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
+  alias BlockScoutWeb.AddressView
+  alias BlockScoutWeb.API.V2.{BlockView, TransactionView}
   alias Explorer.{Chain, Market}
+  alias Explorer.Chain.SmartContract
+  alias Explorer.SmartContract.{Reader, Writer}
   alias Indexer.Fetcher.TokenBalanceOnDemand
 
   @transaction_necessity_by_association [
@@ -36,6 +42,14 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       :block => :optional
     }
   ]
+
+  @smart_contract_address_options [
+    necessity_by_association: %{
+      :smart_contract => :optional
+    }
+  ]
+
+  @burn_address "0x0000000000000000000000000000000000000000"
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -249,7 +263,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       conn
       |> put_status(200)
-      |> put_view(AddressView)
       |> render(:coin_balances, %{coin_balances: coin_balances, next_page_params: next_page_params})
     end
   end
@@ -263,8 +276,139 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       conn
       |> put_status(200)
-      |> put_view(AddressView)
       |> render(:coin_balances_by_day, %{coin_balances_by_day: balances_by_day})
+    end
+  end
+
+  def smart_contract(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         _ <- VerificationController.check_and_verify(address_hash_string),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options, true)} do
+      conn
+      |> put_status(200)
+      |> render(:smart_contract, %{address: address})
+    end
+  end
+
+  def methods_read(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
+         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
+      read_only_functions_from_abi =
+        Reader.read_only_functions_from_abi_with_sender(custom_abi.abi, address_hash, params["from"])
+
+      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet_from_abi(custom_abi.abi)
+
+      conn
+      |> put_status(200)
+      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+    end
+  end
+
+  def methods_read(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+      read_only_functions_from_abi = Reader.read_only_functions(address_hash, params["from"]) |> debug("r only")
+
+      read_functions_required_wallet_from_abi =
+        Reader.read_functions_required_wallet(address_hash) |> debug("r req wall")
+
+      conn
+      |> put_status(200)
+      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+    end
+  end
+
+  def methods_write(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
+    with {:format, {:ok, _address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
+         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
+      conn
+      |> put_status(200)
+      |> json(Writer.filter_write_functions(custom_abi.abi))
+    end
+  end
+
+  def methods_write(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+      conn
+      |> put_status(200)
+      |> json(Writer.write_functions(address_hash))
+    end
+  end
+
+  def methods_read_proxy(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
+      implementation_address_hash_string =
+        address.smart_contract
+        |> SmartContract.get_implementation_address_hash()
+        |> Tuple.to_list()
+        |> List.first() || @burn_address
+
+      conn
+      |> put_status(200)
+      |> json(Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"]))
+    end
+  end
+
+  def methods_write_proxy(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
+      implementation_address_hash_string =
+        address.smart_contract
+        |> SmartContract.get_implementation_address_hash()
+        |> Tuple.to_list()
+        |> List.first() || @burn_address
+
+      conn
+      |> put_status(200)
+      |> json(Writer.write_functions_proxy(implementation_address_hash_string))
+    end
+  end
+
+  def query_read_method(
+        conn,
+        %{"address_hash" => address_hash_string, "is_custom_abi" => custom_abi, "contract_type" => type, "args" => args} =
+          params
+      ) do
+    custom_abi =
+      if parse_boolean(params["is_custom_abi"]), do: AddressView.fetch_custom_abi(conn, params["id"]), else: nil
+
+    contract_type = if type == "proxy", do: :proxy, else: :regular
+
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.find_contract_address(address_hash, [])} do
+      %{output: outputs, names: _names} =
+        if custom_abi do
+          Reader.query_function_with_names_custom_abi(
+            address_hash,
+            %{method_id: params["method_id"], args: args},
+            params["from"],
+            custom_abi.abi
+          )
+        else
+          Reader.query_function_with_names(
+            address_hash,
+            %{method_id: params["method_id"], args: args},
+            contract_type,
+            params["from"]
+          )
+        end
+
+      conn
+      |> put_status(200)
+      |> json(outputs)
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -12,15 +12,9 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   import BlockScoutWeb.PagingHelper,
     only: [delete_parameters_from_next_page_params: 1, token_transfers_types_options: 1]
 
-  import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
-
   alias BlockScoutWeb.AccessHelpers
-  alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
-  alias BlockScoutWeb.AddressView
   alias BlockScoutWeb.API.V2.{BlockView, TransactionView}
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.SmartContract
-  alias Explorer.SmartContract.{Reader, Writer}
   alias Indexer.Fetcher.TokenBalanceOnDemand
 
   @transaction_necessity_by_association [
@@ -42,14 +36,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       :block => :optional
     }
   ]
-
-  @smart_contract_address_options [
-    necessity_by_association: %{
-      :smart_contract => :optional
-    }
-  ]
-
-  @burn_address "0x0000000000000000000000000000000000000000"
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -277,138 +263,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       conn
       |> put_status(200)
       |> render(:coin_balances_by_day, %{coin_balances_by_day: balances_by_day})
-    end
-  end
-
-  def smart_contract(conn, %{"address_hash" => address_hash_string} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         _ <- VerificationController.check_and_verify(address_hash_string),
-         {:not_found, {:ok, address}} <-
-           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options, true)} do
-      conn
-      |> put_status(200)
-      |> render(:smart_contract, %{address: address})
-    end
-  end
-
-  def methods_read(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
-         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
-      read_only_functions_from_abi =
-        Reader.read_only_functions_from_abi_with_sender(custom_abi.abi, address_hash, params["from"])
-
-      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet_from_abi(custom_abi.abi)
-
-      conn
-      |> put_status(200)
-      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
-    end
-  end
-
-  def methods_read(conn, %{"address_hash" => address_hash_string} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
-      read_only_functions_from_abi = Reader.read_only_functions(address_hash, params["from"]) |> debug("r only")
-
-      read_functions_required_wallet_from_abi =
-        Reader.read_functions_required_wallet(address_hash) |> debug("r req wall")
-
-      conn
-      |> put_status(200)
-      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
-    end
-  end
-
-  def methods_write(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
-    with {:format, {:ok, _address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
-         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
-      conn
-      |> put_status(200)
-      |> json(Writer.filter_write_functions(custom_abi.abi))
-    end
-  end
-
-  def methods_write(conn, %{"address_hash" => address_hash_string} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
-      conn
-      |> put_status(200)
-      |> json(Writer.write_functions(address_hash))
-    end
-  end
-
-  def methods_read_proxy(conn, %{"address_hash" => address_hash_string} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, address}} <-
-           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
-      implementation_address_hash_string =
-        address.smart_contract
-        |> SmartContract.get_implementation_address_hash()
-        |> Tuple.to_list()
-        |> List.first() || @burn_address
-
-      conn
-      |> put_status(200)
-      |> json(Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"]))
-    end
-  end
-
-  def methods_write_proxy(conn, %{"address_hash" => address_hash_string} = params) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, address}} <-
-           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
-      implementation_address_hash_string =
-        address.smart_contract
-        |> SmartContract.get_implementation_address_hash()
-        |> Tuple.to_list()
-        |> List.first() || @burn_address
-
-      conn
-      |> put_status(200)
-      |> json(Writer.write_functions_proxy(implementation_address_hash_string))
-    end
-  end
-
-  def query_read_method(
-        conn,
-        %{"address_hash" => address_hash_string, "is_custom_abi" => custom_abi, "contract_type" => type, "args" => args} =
-          params
-      ) do
-    custom_abi =
-      if parse_boolean(params["is_custom_abi"]), do: AddressView.fetch_custom_abi(conn, params["id"]), else: nil
-
-    contract_type = if type == "proxy", do: :proxy, else: :regular
-
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.find_contract_address(address_hash, [])} do
-      %{output: outputs, names: _names} =
-        if custom_abi do
-          Reader.query_function_with_names_custom_abi(
-            address_hash,
-            %{method_id: params["method_id"], args: args},
-            params["from"],
-            custom_abi.abi
-          )
-        else
-          Reader.query_function_with_names(
-            address_hash,
-            %{method_id: params["method_id"], args: args},
-            contract_type,
-            params["from"]
-          )
-        end
-
-      conn
-      |> put_status(200)
-      |> json(outputs)
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -279,7 +279,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
          {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       results_plus_one =
         address_hash
-        |> Chain.fetch_last_token_balances(paging_options(params))
+        |> Chain.fetch_last_token_balances(
+          params
+          |> paging_options()
+          |> Keyword.merge(token_transfers_types_options(params))
+        )
         |> Market.add_price()
 
       {tokens, next_page} = split_list_by_page(results_plus_one)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -243,8 +243,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def coin_balance_history(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}, _} <-
-           {:not_found, Chain.hash_to_address(address_hash), :empty_items_with_next_page_params} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash)} do
       full_options = paging_options(params)
 
       results_plus_one = Chain.address_to_coin_balances(address_hash, full_options)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -70,7 +70,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def token_balances(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       token_balances =
         address_hash
         |> Chain.fetch_last_token_balances()
@@ -91,7 +92,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def transactions(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       options =
         @transaction_necessity_by_association
         |> Keyword.merge(paging_options(params))
@@ -112,7 +114,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def token_transfers(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       options =
         @token_transfer_necessity_by_association
         |> Keyword.merge(paging_options(params))
@@ -139,7 +142,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def internal_transactions(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       full_options =
         [
           necessity_by_association: %{
@@ -172,7 +176,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def logs(conn, %{"address_hash" => address_hash_string, "topic" => topic} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       prepared_topic = String.trim(topic)
 
       formatted_topic = if String.starts_with?(prepared_topic, "0x"), do: prepared_topic, else: "0x" <> prepared_topic
@@ -192,7 +197,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def logs(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       results_plus_one = Chain.address_to_logs(address_hash, paging_options(params))
       {logs, next_page} = split_list_by_page(results_plus_one)
 
@@ -207,7 +213,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def blocks_validated(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       full_options =
         Keyword.merge(
           [
@@ -255,7 +262,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   def coin_balance_history_by_day(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
-         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       balances_by_day =
         address_hash
         |> Chain.address_to_balances_by_day(true)
@@ -269,7 +277,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def tokens(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
       results_plus_one =
         address_hash
         |> Chain.fetch_last_token_balances(paging_options(params))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -44,7 +44,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+      |> render(:read_functions, %{functions: read_only_functions_from_abi ++ read_functions_required_wallet_from_abi})
     end
   end
 
@@ -57,7 +57,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+      |> render(:read_functions, %{functions: read_only_functions_from_abi ++ read_functions_required_wallet_from_abi})
     end
   end
 
@@ -94,7 +94,9 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"]))
+      |> render(:read_functions, %{
+        functions: Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string)
+      })
     end
   end
 
@@ -127,7 +129,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
          {:not_found, {:ok, _address}} <- {:not_found, Chain.find_contract_address(address_hash, [])} do
-      result =
+      %{output: output, names: names} =
         if custom_abi do
           Reader.query_function_with_names_custom_abi(
             address_hash,
@@ -146,7 +148,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(result)
+      |> render(:function_response, %{output: output, names: names, contract_address_hash: address_hash})
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -3,12 +3,11 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
   import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
 
-  alias BlockScoutWeb.AccessHelpers
+  alias BlockScoutWeb.{AccessHelpers, AddressView}
   alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
-  alias BlockScoutWeb.AddressView
-  alias Explorer.SmartContract.{Reader, Writer}
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
+  alias Explorer.SmartContract.{Reader, Writer}
 
   @smart_contract_address_options [
     necessity_by_association: %{

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -150,14 +150,14 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
         if custom_abi do
           Reader.query_function_with_names_custom_abi(
             address_hash,
-            %{method_id: params["method_id"], args: args},
+            %{method_id: params["method_id"], args: prepare_args(args)},
             params["from"],
             custom_abi.abi
           )
         else
           Reader.query_function_with_names(
             address_hash,
-            %{method_id: params["method_id"], args: args},
+            %{method_id: params["method_id"], args: prepare_args(args)},
             contract_type,
             params["from"]
           )
@@ -168,4 +168,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       |> render(:function_response, %{output: output, names: names, contract_address_hash: address_hash})
     end
   end
+
+  def prepare_args(list) when is_list(list), do: list
+  def prepare_args(other), do: [other]
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -1,0 +1,152 @@
+defmodule BlockScoutWeb.API.V2.SmartContractController do
+  use BlockScoutWeb, :controller
+
+  import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
+
+  alias BlockScoutWeb.AccessHelpers
+  alias BlockScoutWeb.AddressContractVerificationController, as: VerificationController
+  alias BlockScoutWeb.AddressView
+  alias Explorer.SmartContract.{Reader, Writer}
+  alias Explorer.Chain
+  alias Explorer.Chain.SmartContract
+
+  @smart_contract_address_options [
+    necessity_by_association: %{
+      :smart_contract => :optional
+    }
+  ]
+
+  @burn_address "0x0000000000000000000000000000000000000000"
+
+  action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  def smart_contract(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         _ <- VerificationController.check_and_verify(address_hash_string),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options, true)} do
+      conn
+      |> put_status(200)
+      |> render(:smart_contract, %{address: address})
+    end
+  end
+
+  def methods_read(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
+         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
+      read_only_functions_from_abi =
+        Reader.read_only_functions_from_abi_with_sender(custom_abi.abi, address_hash, params["from"])
+
+      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet_from_abi(custom_abi.abi)
+
+      conn
+      |> put_status(200)
+      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+    end
+  end
+
+  def methods_read(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+      read_only_functions_from_abi = Reader.read_only_functions(address_hash, params["from"])
+
+      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet(address_hash)
+
+      conn
+      |> put_status(200)
+      |> json(read_only_functions_from_abi ++ read_functions_required_wallet_from_abi)
+    end
+  end
+
+  def methods_write(conn, %{"address_hash" => address_hash_string, "is_custom_abi" => "true"} = params) do
+    with {:format, {:ok, _address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
+         {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_read_functions(custom_abi)} do
+      conn
+      |> put_status(200)
+      |> json(Writer.filter_write_functions(custom_abi.abi))
+    end
+  end
+
+  def methods_write(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
+      conn
+      |> put_status(200)
+      |> json(Writer.write_functions(address_hash))
+    end
+  end
+
+  def methods_read_proxy(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
+      implementation_address_hash_string =
+        address.smart_contract
+        |> SmartContract.get_implementation_address_hash()
+        |> Tuple.to_list()
+        |> List.first() || @burn_address
+
+      conn
+      |> put_status(200)
+      |> json(Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"]))
+    end
+  end
+
+  def methods_write_proxy(conn, %{"address_hash" => address_hash_string} = params) do
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, address}} <-
+           {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options)} do
+      implementation_address_hash_string =
+        address.smart_contract
+        |> SmartContract.get_implementation_address_hash()
+        |> Tuple.to_list()
+        |> List.first() || @burn_address
+
+      conn
+      |> put_status(200)
+      |> json(Writer.write_functions_proxy(implementation_address_hash_string))
+    end
+  end
+
+  def query_read_method(
+        conn,
+        %{"address_hash" => address_hash_string, "contract_type" => type, "args" => args} = params
+      ) do
+    custom_abi =
+      if parse_boolean(params["is_custom_abi"]), do: AddressView.fetch_custom_abi(conn, params["id"]), else: nil
+
+    contract_type = if type == "proxy", do: :proxy, else: :regular
+
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.find_contract_address(address_hash, [])} do
+      result =
+        if custom_abi do
+          Reader.query_function_with_names_custom_abi(
+            address_hash,
+            %{method_id: params["method_id"], args: args},
+            params["from"],
+            custom_abi.abi
+          )
+        else
+          Reader.query_function_with_names(
+            address_hash,
+            %{method_id: params["method_id"], args: args},
+            contract_type,
+            params["from"]
+          )
+        end
+
+      conn
+      |> put_status(200)
+      |> json(result)
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -42,7 +42,7 @@ defmodule BlockScoutWeb.SmartContractController do
           end
         else
           if contract_type == "proxy" do
-            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"])
+            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string)
           else
             Reader.read_only_functions(address_hash, params["from"])
           end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -42,9 +42,9 @@ defmodule BlockScoutWeb.SmartContractController do
           end
         else
           if contract_type == "proxy" do
-            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string)
+            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, params["from"])
           else
-            Reader.read_only_functions(address_hash)
+            Reader.read_only_functions(address_hash, params["from"])
           end
         end
 
@@ -101,7 +101,7 @@ defmodule BlockScoutWeb.SmartContractController do
 
   def index(conn, _), do: not_found(conn)
 
-  defp custom_abi_render(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action}) do
+  defp custom_abi_render(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action} = params) do
     with custom_abi <- AddressView.fetch_custom_abi(conn, address_hash_string),
          false <- is_nil(custom_abi),
          abi <- custom_abi.abi,
@@ -110,7 +110,7 @@ defmodule BlockScoutWeb.SmartContractController do
         if action == "write" do
           Writer.filter_write_functions(abi)
         else
-          Reader.read_only_functions_from_abi(abi, address_hash)
+          Reader.read_only_functions_from_abi_with_sender(abi, address_hash, params["from"])
         end
 
       read_functions_required_wallet =

--- a/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
@@ -1,0 +1,31 @@
+# This file in ignore list of `sobelow`, be careful while adding new endpoints here
+defmodule BlockScoutWeb.SmartContractsApiV2Router do
+  @moduledoc """
+    Router for /api/v2/smart-contracts. This route has separate router in order to ignore solelow's warning about missing CSRF protection
+  """
+  use BlockScoutWeb, :router
+  alias BlockScoutWeb.Plug.CheckApiV2
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  pipeline :api_v2_no_forgery_protect do
+    plug(CheckApiV2)
+    plug(:fetch_session)
+  end
+
+  scope "/", as: :api_v2 do
+    pipe_through(:api)
+    pipe_through(:api_v2_no_forgery_protect)
+
+    alias BlockScoutWeb.API.V2
+
+    get("/:address_hash", V2.SmartContractController, :smart_contract)
+    get("/:address_hash/methods-read", V2.SmartContractController, :methods_read)
+    get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
+    get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
+    get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
+    post("/:address_hash/query-read-method", V2.SmartContractController, :query_read_method)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
@@ -83,11 +83,11 @@ defmodule BlockScoutWeb.AddressContractView do
     end
   end
 
-  defp decode_data("0x" <> encoded_data, types) do
+  def decode_data("0x" <> encoded_data, types) do
     decode_data(encoded_data, types)
   end
 
-  defp decode_data(encoded_data, types) do
+  def decode_data(encoded_data, types) do
     encoded_data
     |> Base.decode16!(case: :mixed)
     |> TypeDecoder.decode_raw(types)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.API.V2.AddressView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.AddressView
+  alias ABI.FunctionSelector
+  alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
   alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
   alias BlockScoutWeb.API.V2.Helper
   alias Explorer.{Chain, Market}
@@ -32,6 +33,10 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     Enum.map(coin_balances_by_day, &prepare_coin_balance_history_by_day_entry/1)
   end
 
+  def render("smart_contract.json", %{address: address}) do
+    prepare_smart_contract(address)
+  end
+
   def prepare_address(address, conn \\ nil) do
     base_info = Helper.address_with_info(conn, address, address.hash)
     is_proxy = AddressView.smart_contract_is_proxy?(address)
@@ -55,6 +60,9 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     creation_tx = creator_hash && AddressView.transaction_hash(address)
     token = address.token && TokenView.render("token.json", %{token: Market.add_price(address.token)})
 
+    write_custom_abi? = AddressView.has_address_custom_abi_with_write_functions?(conn, address.hash)
+    read_custom_abi? = AddressView.has_address_custom_abi_with_read_functions?(conn, address.hash)
+
     Map.merge(base_info, %{
       "creator_address_hash" => creator_hash && Address.checksum(creator_hash),
       "creation_tx_hash" => creation_tx,
@@ -63,7 +71,13 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "exchange_rate" => exchange_rate,
       "implementation_name" => implementation_name,
       "implementation_address" => implementation_address,
-      "block_number_balance_updated_at" => address.fetched_coin_balance_block_number
+      "block_number_balance_updated_at" => address.fetched_coin_balance_block_number,
+      "has_custom_methods_read" => read_custom_abi?,
+      "has_custom_methods_write" => write_custom_abi?,
+      "has_methods_read" => AddressView.smart_contract_with_read_only_functions?(address) || read_custom_abi?,
+      "has_methods_write" => AddressView.smart_contract_with_write_functions?(address) || write_custom_abi?,
+      "has_methods_read_proxy" => is_proxy,
+      "has_methods_write_proxy" => AddressView.smart_contract_with_write_functions?(address) && is_proxy
     })
   end
 
@@ -90,5 +104,101 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "date" => coin_balance_by_day.date,
       "value" => coin_balance_by_day.value
     }
+  end
+
+  def prepare_smart_contract(address) do
+    minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
+
+    metadata_for_verification =
+      minimal_proxy_template || Chain.get_address_verified_twin_contract(address.hash).verified_contract
+
+    smart_contract_verified = AddressView.smart_contract_verified?(address)
+    additional_sources_from_twin = Chain.get_address_verified_twin_contract(address.hash).additional_sources
+    fully_verified = Chain.smart_contract_fully_verified?(address.hash)
+
+    additional_sources =
+      if smart_contract_verified, do: address.smart_contract_additional_sources, else: additional_sources_from_twin
+
+    visualize_sol2uml_enabled = Explorer.Visualize.Sol2uml.enabled?()
+    target_contract = if smart_contract_verified, do: address.smart_contract, else: metadata_for_verification
+
+    %{
+      "verified_twin_address_hash" => metadata_for_verification && metadata_for_verification.address_hash,
+      "is_verified" => smart_contract_verified,
+      "is_changed_bytecode" => smart_contract_verified && address.smart_contract.is_changed_bytecode,
+      "is_partially_verified" => address.smart_contract.partially_verified && smart_contract_verified,
+      "is_fully_verified" => fully_verified,
+      "is_verified_via_sourcify" => address.smart_contract.verified_via_sourcify && smart_contract_verified,
+      "is_vyper_contract" => target_contract.is_vyper_contract,
+      "minimal_proxy_address_hash" =>
+        minimal_proxy_template && Address.checksum(metadata_for_verification.address_hash),
+      "sourcify_repo_url" =>
+        if(address.smart_contract.verified_via_sourcify && smart_contract_verified,
+          do: AddressContractView.sourcify_repo_url(address.hash, address.smart_contract.partially_verified)
+        ),
+      "can_be_visualized_via_sol2uml" =>
+        visualize_sol2uml_enabled && !target_contract.is_vyper_contract && !is_nil(target_contract.abi),
+      "name" => target_contract && target_contract.name,
+      "compiler_version" => target_contract.compiler_version,
+      "optimization_enabled" => if(target_contract.is_vyper_contract, do: nil, else: target_contract.optimization),
+      "optimization_runs" => target_contract.optimization_runs,
+      "evm_version" => target_contract.evm_version,
+      "verified_at" => target_contract.inserted_at,
+      "abi" => target_contract.abi,
+      "source_code" => target_contract.contract_source_code,
+      "file_path" => target_contract.file_path,
+      "additional_sources" => Enum.map(additional_sources, &prepare_additional_sourse/1),
+      "compiler_settings" => target_contract.compiler_settings,
+      "external_libraries" => target_contract.external_libraries,
+      "constructor_args" => target_contract.constructor_arguments,
+      "decoded_constructor_args" =>
+        format_constructor_arguments(target_contract.abi, target_contract.constructor_arguments)
+    }
+    |> Map.merge(bytecode_info(address))
+
+    # |>
+  end
+
+  defp bytecode_info(address) do
+    case AddressContractView.contract_creation_code(address) do
+      {:selfdestructed, init} ->
+        %{
+          "is_self_destructed" => true,
+          "deployed_bytecode" => nil,
+          "creation_bytecode" => init
+        }
+
+      {:ok, contract_code} ->
+        %{
+          "is_self_destructed" => false,
+          "deployed_bytecode" => contract_code,
+          "creation_bytecode" => AddressContractView.creation_code(address)
+        }
+    end
+  end
+
+  defp prepare_additional_sourse(source) do
+    %{
+      "source_code" => source.contract_source_code,
+      "file_path" => source.file_name
+    }
+  end
+
+  def format_constructor_arguments(abi, constructor_arguments) do
+    constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
+
+    input_types = Enum.map(constructor_abi["inputs"], &FunctionSelector.parse_specification_type/1)
+
+    result =
+      constructor_arguments
+      |> AddressContractView.decode_data(input_types)
+      |> Enum.zip(constructor_abi["inputs"])
+      |> Enum.map(fn {value, %{"type" => type} = input_arg} ->
+        {ABIEncodedValueView.value_json(type, value), input_arg}
+      end)
+
+    result
+  rescue
+    _ -> nil
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -32,6 +32,10 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     Enum.map(coin_balances_by_day, &prepare_coin_balance_history_by_day_entry/1)
   end
 
+  def render("tokens.json", %{tokens: tokens, next_page_params: next_page_params}) do
+    %{"items" => Enum.map(tokens, &prepare_token_balance/1), "next_page_params" => next_page_params}
+  end
+
   def prepare_address(address, conn \\ nil) do
     base_info = Helper.address_with_info(conn, address, address.hash)
     is_proxy = AddressView.smart_contract_is_proxy?(address)
@@ -72,7 +76,12 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "has_methods_read" => AddressView.smart_contract_with_read_only_functions?(address) || read_custom_abi?,
       "has_methods_write" => AddressView.smart_contract_with_write_functions?(address) || write_custom_abi?,
       "has_methods_read_proxy" => is_proxy,
-      "has_methods_write_proxy" => AddressView.smart_contract_with_write_functions?(address) && is_proxy
+      "has_methods_write_proxy" => AddressView.smart_contract_with_write_functions?(address) && is_proxy,
+      "has_decompiled_code" => AddressView.has_decompiled_code?(address),
+      "has_validated_blocks" => Chain.check_if_validated_blocks_at_address(address.hash),
+      "has_logs" => Chain.check_if_logs_at_address(address.hash),
+      "has_tokens" => Chain.check_if_tokens_at_address(address.hash),
+      "has_token_transfers" => Chain.check_if_token_transfers_at_address(address.hash)
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -1,8 +1,7 @@
 defmodule BlockScoutWeb.API.V2.AddressView do
   use BlockScoutWeb, :view
 
-  alias ABI.FunctionSelector
-  alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
+  alias BlockScoutWeb.AddressView
   alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
   alias BlockScoutWeb.API.V2.Helper
   alias Explorer.{Chain, Market}
@@ -31,10 +30,6 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
   def render("coin_balances_by_day.json", %{coin_balances_by_day: coin_balances_by_day}) do
     Enum.map(coin_balances_by_day, &prepare_coin_balance_history_by_day_entry/1)
-  end
-
-  def render("smart_contract.json", %{address: address}) do
-    prepare_smart_contract(address)
   end
 
   def prepare_address(address, conn \\ nil) do
@@ -104,101 +99,5 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "date" => coin_balance_by_day.date,
       "value" => coin_balance_by_day.value
     }
-  end
-
-  def prepare_smart_contract(address) do
-    minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
-
-    metadata_for_verification =
-      minimal_proxy_template || Chain.get_address_verified_twin_contract(address.hash).verified_contract
-
-    smart_contract_verified = AddressView.smart_contract_verified?(address)
-    additional_sources_from_twin = Chain.get_address_verified_twin_contract(address.hash).additional_sources
-    fully_verified = Chain.smart_contract_fully_verified?(address.hash)
-
-    additional_sources =
-      if smart_contract_verified, do: address.smart_contract_additional_sources, else: additional_sources_from_twin
-
-    visualize_sol2uml_enabled = Explorer.Visualize.Sol2uml.enabled?()
-    target_contract = if smart_contract_verified, do: address.smart_contract, else: metadata_for_verification
-
-    %{
-      "verified_twin_address_hash" => metadata_for_verification && metadata_for_verification.address_hash,
-      "is_verified" => smart_contract_verified,
-      "is_changed_bytecode" => smart_contract_verified && address.smart_contract.is_changed_bytecode,
-      "is_partially_verified" => address.smart_contract.partially_verified && smart_contract_verified,
-      "is_fully_verified" => fully_verified,
-      "is_verified_via_sourcify" => address.smart_contract.verified_via_sourcify && smart_contract_verified,
-      "is_vyper_contract" => target_contract.is_vyper_contract,
-      "minimal_proxy_address_hash" =>
-        minimal_proxy_template && Address.checksum(metadata_for_verification.address_hash),
-      "sourcify_repo_url" =>
-        if(address.smart_contract.verified_via_sourcify && smart_contract_verified,
-          do: AddressContractView.sourcify_repo_url(address.hash, address.smart_contract.partially_verified)
-        ),
-      "can_be_visualized_via_sol2uml" =>
-        visualize_sol2uml_enabled && !target_contract.is_vyper_contract && !is_nil(target_contract.abi),
-      "name" => target_contract && target_contract.name,
-      "compiler_version" => target_contract.compiler_version,
-      "optimization_enabled" => if(target_contract.is_vyper_contract, do: nil, else: target_contract.optimization),
-      "optimization_runs" => target_contract.optimization_runs,
-      "evm_version" => target_contract.evm_version,
-      "verified_at" => target_contract.inserted_at,
-      "abi" => target_contract.abi,
-      "source_code" => target_contract.contract_source_code,
-      "file_path" => target_contract.file_path,
-      "additional_sources" => Enum.map(additional_sources, &prepare_additional_sourse/1),
-      "compiler_settings" => target_contract.compiler_settings,
-      "external_libraries" => target_contract.external_libraries,
-      "constructor_args" => target_contract.constructor_arguments,
-      "decoded_constructor_args" =>
-        format_constructor_arguments(target_contract.abi, target_contract.constructor_arguments)
-    }
-    |> Map.merge(bytecode_info(address))
-
-    # |>
-  end
-
-  defp bytecode_info(address) do
-    case AddressContractView.contract_creation_code(address) do
-      {:selfdestructed, init} ->
-        %{
-          "is_self_destructed" => true,
-          "deployed_bytecode" => nil,
-          "creation_bytecode" => init
-        }
-
-      {:ok, contract_code} ->
-        %{
-          "is_self_destructed" => false,
-          "deployed_bytecode" => contract_code,
-          "creation_bytecode" => AddressContractView.creation_code(address)
-        }
-    end
-  end
-
-  defp prepare_additional_sourse(source) do
-    %{
-      "source_code" => source.contract_source_code,
-      "file_path" => source.file_name
-    }
-  end
-
-  def format_constructor_arguments(abi, constructor_arguments) do
-    constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
-
-    input_types = Enum.map(constructor_abi["inputs"], &FunctionSelector.parse_specification_type/1)
-
-    result =
-      constructor_arguments
-      |> AddressContractView.decode_data(input_types)
-      |> Enum.zip(constructor_abi["inputs"])
-      |> Enum.map(fn {value, %{"type" => type} = input_arg} ->
-        {ABIEncodedValueView.value_json(type, value), input_arg}
-      end)
-
-    result
-  rescue
-    _ -> nil
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -81,6 +81,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def is_smart_contract(_), do: false
 
   def is_verified(%Address{smart_contract: nil}), do: false
+  def is_verified(%Address{smart_contract: %{metadata_from_verified_twin: true}}), do: false
   def is_verified(%Address{smart_contract: %NotLoaded{}}), do: nil
   def is_verified(%Address{smart_contract: _}), do: true
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -99,6 +99,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
     end
   end
 
+  # credo:disable-for-next-line
   def prepare_smart_contract(address) do
     minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -6,7 +6,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   alias BlockScoutWeb.SmartContractView
   alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
   alias Explorer.Chain
-  alias Explorer.Chain.Address
+  alias Explorer.Chain.{Address, SmartContract}
   alias Explorer.Visualize.Sol2uml
 
   def render("smart_contract.json", %{address: address}) do
@@ -100,7 +100,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   end
 
   # credo:disable-for-next-line
-  def prepare_smart_contract(address) do
+  def prepare_smart_contract(%Address{smart_contract: %SmartContract{}} = address) do
     minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
 
     metadata_for_verification =
@@ -149,6 +149,10 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         format_constructor_arguments(target_contract.abi, target_contract.constructor_arguments)
     }
     |> Map.merge(bytecode_info(address))
+  end
+
+  def prepare_smart_contract(address) do
+    bytecode_info(address)
   end
 
   defp bytecode_info(address) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -1,0 +1,109 @@
+defmodule BlockScoutWeb.API.V2.SmartContractView do
+  use BlockScoutWeb, :view
+
+  alias ABI.FunctionSelector
+  alias Explorer.Visualize.Sol2uml
+  alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
+  alias Explorer.Chain
+  alias Explorer.Chain.Address
+
+  def render("smart_contract.json", %{address: address}) do
+    prepare_smart_contract(address)
+  end
+
+  def prepare_smart_contract(address) do
+    minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
+
+    metadata_for_verification =
+      minimal_proxy_template || Chain.get_address_verified_twin_contract(address.hash).verified_contract
+
+    smart_contract_verified = AddressView.smart_contract_verified?(address)
+    additional_sources_from_twin = Chain.get_address_verified_twin_contract(address.hash).additional_sources
+    fully_verified = Chain.smart_contract_fully_verified?(address.hash)
+
+    additional_sources =
+      if smart_contract_verified, do: address.smart_contract_additional_sources, else: additional_sources_from_twin
+
+    visualize_sol2uml_enabled = Sol2uml.enabled?()
+    target_contract = if smart_contract_verified, do: address.smart_contract, else: metadata_for_verification
+
+    %{
+      "verified_twin_address_hash" => metadata_for_verification && metadata_for_verification.address_hash,
+      "is_verified" => smart_contract_verified,
+      "is_changed_bytecode" => smart_contract_verified && address.smart_contract.is_changed_bytecode,
+      "is_partially_verified" => address.smart_contract.partially_verified && smart_contract_verified,
+      "is_fully_verified" => fully_verified,
+      "is_verified_via_sourcify" => address.smart_contract.verified_via_sourcify && smart_contract_verified,
+      "is_vyper_contract" => target_contract.is_vyper_contract,
+      "minimal_proxy_address_hash" =>
+        minimal_proxy_template && Address.checksum(metadata_for_verification.address_hash),
+      "sourcify_repo_url" =>
+        if(address.smart_contract.verified_via_sourcify && smart_contract_verified,
+          do: AddressContractView.sourcify_repo_url(address.hash, address.smart_contract.partially_verified)
+        ),
+      "can_be_visualized_via_sol2uml" =>
+        visualize_sol2uml_enabled && !target_contract.is_vyper_contract && !is_nil(target_contract.abi),
+      "name" => target_contract && target_contract.name,
+      "compiler_version" => target_contract.compiler_version,
+      "optimization_enabled" => if(target_contract.is_vyper_contract, do: nil, else: target_contract.optimization),
+      "optimization_runs" => target_contract.optimization_runs,
+      "evm_version" => target_contract.evm_version,
+      "verified_at" => target_contract.inserted_at,
+      "abi" => target_contract.abi,
+      "source_code" => target_contract.contract_source_code,
+      "file_path" => target_contract.file_path,
+      "additional_sources" => Enum.map(additional_sources, &prepare_additional_sourse/1),
+      "compiler_settings" => target_contract.compiler_settings,
+      "external_libraries" => target_contract.external_libraries,
+      "constructor_args" => target_contract.constructor_arguments,
+      "decoded_constructor_args" =>
+        format_constructor_arguments(target_contract.abi, target_contract.constructor_arguments)
+    }
+    |> Map.merge(bytecode_info(address))
+
+    # |>
+  end
+
+  defp bytecode_info(address) do
+    case AddressContractView.contract_creation_code(address) do
+      {:selfdestructed, init} ->
+        %{
+          "is_self_destructed" => true,
+          "deployed_bytecode" => nil,
+          "creation_bytecode" => init
+        }
+
+      {:ok, contract_code} ->
+        %{
+          "is_self_destructed" => false,
+          "deployed_bytecode" => contract_code,
+          "creation_bytecode" => AddressContractView.creation_code(address)
+        }
+    end
+  end
+
+  defp prepare_additional_sourse(source) do
+    %{
+      "source_code" => source.contract_source_code,
+      "file_path" => source.file_name
+    }
+  end
+
+  def format_constructor_arguments(abi, constructor_arguments) do
+    constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)
+
+    input_types = Enum.map(constructor_abi["inputs"], &FunctionSelector.parse_specification_type/1)
+
+    result =
+      constructor_arguments
+      |> AddressContractView.decode_data(input_types)
+      |> Enum.zip(constructor_abi["inputs"])
+      |> Enum.map(fn {value, %{"type" => type} = input_arg} ->
+        {ABIEncodedValueView.value_json(type, value), input_arg}
+      end)
+
+    result
+  rescue
+    _ -> nil
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -2,12 +2,12 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   use BlockScoutWeb, :view
 
   alias ABI.FunctionSelector
-  alias Explorer.Visualize.Sol2uml
   alias BlockScoutWeb.API.V2.TransactionView
   alias BlockScoutWeb.SmartContractView
   alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
   alias Explorer.Chain
   alias Explorer.Chain.Address
+  alias Explorer.Visualize.Sol2uml
 
   def render("smart_contract.json", %{address: address}) do
     prepare_smart_contract(address)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -50,7 +50,18 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "exchange_rate" => nil,
         "implementation_name" => nil,
         "implementation_address" => nil,
-        "block_number_balance_updated_at" => nil
+        "block_number_balance_updated_at" => nil,
+        "has_custom_methods_read" => false,
+        "has_custom_methods_write" => false,
+        "has_methods_read" => false,
+        "has_methods_write" => false,
+        "has_methods_read_proxy" => false,
+        "has_methods_write_proxy" => false,
+        "has_decompiled_code" => false,
+        "has_validated_blocks" => false,
+        "has_logs" => false,
+        "has_tokens" => false,
+        "has_token_transfers" => false
       }
 
       request = get(conn, "/api/v2/addresses/#{Address.checksum(address.hash)}")
@@ -135,9 +146,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/transactions")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -336,9 +345,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-transfers")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -717,9 +724,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -864,9 +869,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/blocks-validated")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -910,8 +913,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-balances")
 
-      assert response = json_response(request, 200)
-      assert response == []
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -945,9 +947,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/coin-balance-history")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -994,8 +994,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/coin-balance-history-by-day")
 
-      assert response = json_response(request, 200)
-      assert response == []
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -1032,9 +1031,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/logs")
 
-      assert response = json_response(request, 200)
-      assert response["items"] == []
-      assert response["next_page_params"] == nil
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get 422 on invalid address", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -1,0 +1,720 @@
+defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  import Mox
+
+  alias BlockScoutWeb.AddressContractView
+  alias BlockScoutWeb.Models.UserFromAuth
+  alias Explorer.Chain.Address
+
+  describe "/smart-contracts/{address_hash}" do
+    test "get 404 on non existing SC", %{conn: conn} do
+      address = build(:address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{address.hash}")
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
+    test "get 422 on invalid address", %{conn: conn} do
+      request = get(conn, "/api/v2/smart-contracts/0x")
+
+      assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "get smart-contract", %{conn: conn} do
+      target_contract = insert(:smart_contract)
+
+      tx =
+        insert(:transaction,
+          created_contract_address_hash: target_contract.address_hash,
+          input:
+            "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029"
+        )
+        |> with_block()
+
+      correct_response = %{
+        "verified_twin_address_hash" => nil,
+        "is_verified" => true,
+        "is_changed_bytecode" => false,
+        "is_partially_verified" => target_contract.partially_verified,
+        "is_fully_verified" => true,
+        "is_verified_via_sourcify" => target_contract.verified_via_sourcify,
+        "is_vyper_contract" => target_contract.is_vyper_contract,
+        "minimal_proxy_address_hash" => nil,
+        "sourcify_repo_url" =>
+          if(target_contract.verified_via_sourcify,
+            do: AddressContractView.sourcify_repo_url(target_contract.address_hash, target_contract.partially_verified)
+          ),
+        "can_be_visualized_via_sol2uml" => false,
+        "name" => target_contract && target_contract.name,
+        "compiler_version" => target_contract.compiler_version,
+        "optimization_enabled" => if(target_contract.is_vyper_contract, do: nil, else: target_contract.optimization),
+        "optimization_runs" => target_contract.optimization_runs,
+        "evm_version" => target_contract.evm_version,
+        "verified_at" => target_contract.inserted_at |> to_string() |> String.replace(" ", "T"),
+        "source_code" => target_contract.contract_source_code,
+        "file_path" => target_contract.file_path,
+        "additional_sources" => [],
+        "compiler_settings" => target_contract.compiler_settings,
+        "external_libraries" => target_contract.external_libraries,
+        "constructor_args" => target_contract.constructor_arguments,
+        "decoded_constructor_args" => nil,
+        "is_self_destructed" => false,
+        "deployed_bytecode" =>
+          "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
+        "creation_bytecode" =>
+          "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029"
+      }
+
+      blockchain_get_code_mock()
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(target_contract.address_hash)}")
+      response = json_response(request, 200)
+
+      assert ^correct_response = Map.drop(response, ["abi"])
+      assert response["abi"] == target_contract.abi
+    end
+  end
+
+  describe "/smart-contracts/{address_hash}/methods-read" do
+    test "get 404 on non existing SC", %{conn: conn} do
+      address = build(:address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{address.hash}/methods-read")
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
+    test "get 422 on invalid address", %{conn: conn} do
+      request = get(conn, "/api/v2/smart-contracts/0x/methods-read")
+
+      assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "get read-methods", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      blockchain_eth_call_mock()
+
+      request = get(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/methods-read")
+      assert response = json_response(request, 200)
+
+      assert %{
+               "type" => "function",
+               "stateMutability" => "view",
+               "outputs" => [
+                 %{
+                   "type" => "address",
+                   "name" => "",
+                   "internalType" => "address",
+                   "value" => "0xfffffffffffffffffffffffffffffffffffffffe"
+                 }
+               ],
+               "name" => "getCaller",
+               "inputs" => [],
+               "method_id" => "ab470f05"
+             } in response
+
+      assert %{
+               "type" => "function",
+               "stateMutability" => "view",
+               "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool", "value" => ""}],
+               "name" => "isWhitelist",
+               "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}],
+               "method_id" => "c683630d"
+             } in response
+    end
+  end
+
+  describe "/smart-contracts/{address_hash}/query-read-method" do
+    test "get 404 on non existing SC", %{conn: conn} do
+      address = build(:address)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{address.hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
+    test "get 422 on invalid address", %{conn: conn} do
+      request =
+        post(conn, "/api/v2/smart-contracts/0x/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "query-read-method", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [%{data: "0xc683630d000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"}, _]
+             }
+           ],
+           _opts ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x0000000000000000000000000000000000000000000000000000000000000001"
+             }
+           ]}
+        end
+      )
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{
+               "is_error" => false,
+               "result" => %{"names" => ["bool"], "output" => [%{"type" => "bool", "value" => true}]}
+             } == response
+    end
+
+    test "query-read-method returns error 1", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [%{data: "0xc683630d000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"}, _]
+             }
+           ],
+           _opts ->
+          {:ok, [%{id: id, jsonrpc: "2.0", error: %{code: "12345", message: "Error message"}}]}
+        end
+      )
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{"is_error" => true, "result" => %{"code" => "12345", "message" => "Error message"}} == response
+    end
+
+    test "query-read-method returns error 2", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [%{data: "0xc683630d000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"}, _]
+             }
+           ],
+           _opts ->
+          {:error, {:bad_gateway, "request_url"}}
+        end
+      )
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert response = json_response(request, 200)
+      assert %{"is_error" => true, "result" => %{"error" => "Bad gateway"}} == response
+    end
+
+    test "query-read-method returns error 3", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [%{data: "0xc683630d000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"}, _]
+             }
+           ],
+           _opts ->
+          raise FunctionClauseError
+        end
+      )
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{"is_error" => true, "result" => %{"error" => "no function clause matches"}} == response
+    end
+  end
+
+  describe "/smart-contracts/{address_hash}/methods-write" do
+    test "get 404 on non existing SC", %{conn: conn} do
+      address = build(:address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{address.hash}/methods-write")
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
+    test "get 422 on invalid address", %{conn: conn} do
+      request = get(conn, "/api/v2/smart-contracts/0x/methods-write")
+
+      assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "get write-methods", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request = get(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/methods-write")
+      assert response = json_response(request, 200)
+
+      assert [
+               %{
+                 "type" => "function",
+                 "stateMutability" => "nonpayable",
+                 "outputs" => [],
+                 "name" => "disableWhitelist",
+                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+               }
+             ] == response
+    end
+  end
+
+  describe "/smart-contracts/{address_hash}/methods-[write/read] & query read method custom abi" do
+    setup %{conn: conn} do
+      auth = build(:auth)
+
+      {:ok, user} = UserFromAuth.find_or_create(auth)
+
+      {:ok, conn: Plug.Test.init_test_session(conn, current_user: user)}
+    end
+
+    test "get write method from custom abi", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      custom_abi = :custom_abi |> build() |> Map.replace("abi", abi)
+
+      conn
+      |> post(
+        "/api/account/v1/user/custom_abis",
+        custom_abi
+      )
+
+      request =
+        get(conn, "/api/v2/smart-contracts/#{custom_abi["contract_address_hash"]}/methods-write", %{
+          "is_custom_abi" => true
+        })
+
+      assert response = json_response(request, 200)
+
+      assert [
+               %{
+                 "type" => "function",
+                 "stateMutability" => "nonpayable",
+                 "outputs" => [],
+                 "name" => "disableWhitelist",
+                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+               }
+             ] == response
+    end
+
+    test "get read method from custom abi", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      custom_abi = :custom_abi |> build() |> Map.replace("abi", abi)
+
+      conn
+      |> post(
+        "/api/account/v1/user/custom_abis",
+        custom_abi
+      )
+
+      blockchain_eth_call_mock()
+
+      request =
+        get(conn, "/api/v2/smart-contracts/#{custom_abi["contract_address_hash"]}/methods-read", %{
+          "is_custom_abi" => true
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{
+               "type" => "function",
+               "stateMutability" => "view",
+               "outputs" => [
+                 %{
+                   "type" => "address",
+                   "name" => "",
+                   "internalType" => "address",
+                   "value" => "0xfffffffffffffffffffffffffffffffffffffffe"
+                 }
+               ],
+               "name" => "getCaller",
+               "inputs" => [],
+               "method_id" => "ab470f05"
+             } in response
+
+      assert %{
+               "type" => "function",
+               "stateMutability" => "view",
+               "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool", "value" => ""}],
+               "name" => "isWhitelist",
+               "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}],
+               "method_id" => "c683630d"
+             } in response
+    end
+
+    test "query read method", %{conn: conn} do
+      abi = [
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+          "name" => "getCaller",
+          "inputs" => []
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "view",
+          "outputs" => [%{"type" => "bool", "name" => "", "internalType" => "bool"}],
+          "name" => "isWhitelist",
+          "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}]
+        },
+        %{
+          "type" => "function",
+          "stateMutability" => "nonpayable",
+          "outputs" => [],
+          "name" => "disableWhitelist",
+          "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+        }
+      ]
+
+      custom_abi = :custom_abi |> build() |> Map.replace("abi", abi)
+
+      conn
+      |> post(
+        "/api/account/v1/user/custom_abis",
+        custom_abi
+      )
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [%{data: "0xc683630d000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"}, _]
+             }
+           ],
+           _opts ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x0000000000000000000000000000000000000000000000000000000000000001"
+             }
+           ]}
+        end
+      )
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{custom_abi["contract_address_hash"]}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "is_custom_abi" => true,
+          "method_id" => "c683630d"
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{
+               "is_error" => false,
+               "result" => %{"names" => ["bool"], "output" => [%{"type" => "bool", "value" => true}]}
+             } == response
+    end
+  end
+
+  defp blockchain_get_code_mock do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn [%{id: id, method: "eth_getCode", params: [_, _]}], _options ->
+        {:ok,
+         [
+           %{
+             id: id,
+             jsonrpc: "2.0",
+             result:
+               "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029"
+           }
+         ]}
+      end
+    )
+  end
+
+  defp blockchain_eth_call_mock do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn [%{id: id, method: "eth_call", params: params}], opts ->
+        {:ok,
+         [
+           %{
+             id: id,
+             jsonrpc: "2.0",
+             result: "0x000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"
+           }
+         ]}
+      end
+    )
+  end
+
+  defp blockchain_eth_call_mock do
+    expect(
+      EthereumJSONRPC.Mox,
+      :json_rpc,
+      fn [%{id: id, method: "eth_call", params: params}], opts ->
+        {:ok,
+         [
+           %{
+             id: id,
+             jsonrpc: "2.0",
+             result: "0x000000000000000000000000fffffffffffffffffffffffffffffffffffffffe"
+           }
+         ]}
+      end
+    )
+  end
+
+  defp debug(value, key) do
+    require Logger
+    Logger.configure(truncate: :infinity)
+    Logger.info(key)
+    Logger.info(Kernel.inspect(value, limit: :infinity, printable_limit: :infinity))
+    value
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -122,6 +122,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
     end
 
+    test "return 404 on unverified contract", %{conn: conn} do
+      address = insert(:contract_address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}/methods-read")
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
     test "get read-methods", %{conn: conn} do
       abi = [
         %{
@@ -206,6 +213,19 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
     end
 
+    test "return 404 on unverified contract", %{conn: conn} do
+      address = insert(:contract_address)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => ["0xfffffffffffffffffffffffffffffffffffffffe"],
+          "method_id" => "c683630d"
+        })
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
     test "query-read-method", %{conn: conn} do
       abi = [
         %{
@@ -230,6 +250,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
         }
       ]
+
+      blockchain_get_code_mock()
 
       expect(
         EthereumJSONRPC.Mox,
@@ -295,6 +317,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         }
       ]
 
+      blockchain_get_code_mock()
+
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
@@ -349,6 +373,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         }
       ]
 
+      blockchain_get_code_mock()
+
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
@@ -402,6 +428,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         }
       ]
 
+      blockchain_get_code_mock()
+
       expect(
         EthereumJSONRPC.Mox,
         :json_rpc,
@@ -445,6 +473,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       request = get(conn, "/api/v2/smart-contracts/0x/methods-write")
 
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "return 404 on unverified contract", %{conn: conn} do
+      address = insert(:contract_address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}/methods-write")
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get write-methods", %{conn: conn} do
@@ -704,6 +739,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
     end
 
+    test "return 404 on unverified contract", %{conn: conn} do
+      address = insert(:contract_address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}/methods-read-proxy")
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
     test "get read-methods", %{conn: conn} do
       abi = [
         %{
@@ -843,6 +885,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       target_contract = insert(:smart_contract, abi: abi)
 
+      blockchain_get_code_mock()
+
       expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
                                                   id: 0,
                                                   method: "eth_getStorageAt",
@@ -928,6 +972,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       target_contract = insert(:smart_contract, abi: abi)
 
+      blockchain_get_code_mock()
+
       expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
                                                   id: 0,
                                                   method: "eth_getStorageAt",
@@ -997,6 +1043,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       target_contract = insert(:smart_contract, abi: abi)
 
+      blockchain_get_code_mock()
+
       expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
                                                   id: 0,
                                                   method: "eth_getStorageAt",
@@ -1065,6 +1113,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       target_contract = insert(:smart_contract, abi: abi)
 
+      blockchain_get_code_mock()
+
       expect(EthereumJSONRPC.Mox, :json_rpc, fn %{
                                                   id: 0,
                                                   method: "eth_getStorageAt",
@@ -1121,6 +1171,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       request = get(conn, "/api/v2/smart-contracts/0x/methods-write-proxy")
 
       assert %{"message" => "Invalid parameter(s)"} = json_response(request, 422)
+    end
+
+    test "return 404 on unverified contract", %{conn: conn} do
+      address = insert(:contract_address)
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}/methods-write-proxy")
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     test "get write-methods", %{conn: conn} do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1895,11 +1895,7 @@ defmodule Explorer.Chain do
       case address_result do
         %{smart_contract: smart_contract} ->
           if smart_contract do
-            if match?(%NotLoaded{}, smart_contract) do
-              address_result
-            else
-              check_bytecode_matching(address_result)
-            end
+            check_bytecode_matching(address_result, smart_contract)
           else
             address_verified_twin_contract =
               Chain.get_minimal_proxy_template(hash) ||
@@ -1932,7 +1928,9 @@ defmodule Explorer.Chain do
     end
   end
 
-  defp check_bytecode_matching(address) do
+  defp check_bytecode_matching(address, %NotLoaded{}), do: address
+
+  defp check_bytecode_matching(address, _) do
     now = DateTime.utc_now()
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5145,10 +5145,12 @@ defmodule Explorer.Chain do
   end
 
   @spec fetch_last_token_balances(Hash.Address.t(), [paging_options]) :: []
-  def fetch_last_token_balances(address_hash, paging_options) do
+  def fetch_last_token_balances(address_hash, options) do
+    filter = Keyword.get(options, :token_type)
+
     address_hash
-    |> CurrentTokenBalance.last_token_balances(paging_options)
-    |> page_current_token_balances(paging_options)
+    |> CurrentTokenBalance.last_token_balances(options, filter)
+    |> page_current_token_balances(options)
     |> Repo.all()
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -30,6 +30,7 @@ defmodule Explorer.Chain do
   require Logger
 
   alias ABI.TypeDecoder
+  alias Ecto.Association.NotLoaded
   alias Ecto.{Changeset, Multi}
 
   alias EthereumJSONRPC.Transaction, as: EthereumJSONRPCTransaction
@@ -1894,7 +1895,11 @@ defmodule Explorer.Chain do
       case address_result do
         %{smart_contract: smart_contract} ->
           if smart_contract do
-            check_bytecode_matching(address_result)
+            if match?(%NotLoaded{}, smart_contract) do
+              address_result
+            else
+              check_bytecode_matching(address_result)
+            end
           else
             address_verified_twin_contract =
               Chain.get_minimal_proxy_template(hash) ||

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -5147,6 +5147,7 @@ defmodule Explorer.Chain do
   @spec fetch_last_token_balances(Hash.Address.t(), [paging_options]) :: []
   def fetch_last_token_balances(address_hash, options) do
     filter = Keyword.get(options, :token_type)
+    options = Keyword.delete(options, :token_type)
 
     address_hash
     |> CurrentTokenBalance.last_token_balances(options, filter)

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -362,7 +362,9 @@ defmodule Explorer.SmartContract.Reader do
           link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["method_id"])
       end
 
-    Map.replace!(function, "outputs", values)
+    function
+    |> Map.replace!("outputs", values)
+    |> Map.put("abi_outputs", link_outputs_and_values(%{}, Map.get(function, "outputs", []), function["method_id"]))
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -618,6 +618,8 @@ defmodule Explorer.SmartContract.Reader do
     end
   end
 
+  defp parse_item(nil), do: nil
+
   defp parse_item("true"), do: true
   defp parse_item("false"), do: false
 

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -436,9 +436,10 @@ defmodule Explorer.SmartContract.Reader do
       abi
       |> ABI.parse_specification()
 
-    with %{outputs: outputs, method_id: method_id} <- proccess_abi(parsed_final_abi, method_id) do
-      query_contract_and_link_outputs(contract_address_hash, args, from, abi, outputs, method_id, leave_error_as_map)
-    else
+    case proccess_abi(parsed_final_abi, method_id) do
+      %{outputs: outputs, method_id: method_id} ->
+        query_contract_and_link_outputs(contract_address_hash, args, from, abi, outputs, method_id, leave_error_as_map)
+
       {:error, message} ->
         {:error, message}
     end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -875,13 +875,16 @@ defmodule Explorer.Factory do
   end
 
   def address_current_token_balance_with_token_id_factory do
+    {token_type, token_id} = Enum.random([{"ERC-20", nil}, {"ERC-721", nil}, {"ERC-1155", Enum.random(1..100_000)}])
+
     %CurrentTokenBalance{
       address: build(:address),
       token_contract_address_hash: insert(:token).contract_address_hash,
       block_number: block_number(),
       value: Enum.random(1..100_000),
       value_fetched_at: DateTime.utc_now(),
-      token_id: Enum.random([nil, Enum.random(1..100_000)])
+      token_id: token_id,
+      token_type: token_type
     }
   end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -815,7 +815,9 @@ defmodule Explorer.Factory do
       contract_source_code: contract_code_info.source_code,
       optimization: contract_code_info.optimized,
       abi: contract_code_info.abi,
-      contract_code_md5: bytecode_md5
+      contract_code_md5: bytecode_md5,
+      verified_via_sourcify: Enum.random([true, false]),
+      is_vyper_contract: Enum.random([true, false])
     }
   end
 


### PR DESCRIPTION
Close #6571 

## Changelog
- add fetching of wallet address from MM before fetching read smart contract methods (can be fetched if you are logged in metamask)
- `/addresses/{address_hash}/tokens`
- `/v2/smart-contracts/{address_hash}`
- `/v2/smart-contracts/{address_hash}/methods-read` (+custom abi)
- `/v2/smart-contracts/{address_hash}/methods-write` (+custom abi)
- `/v2/smart-contracts/{address_hash}/methods-read-proxy`
- `/v2/smart-contracts/{address_hash}/methods-write-proxy`
- `/v2/smart-contracts/{address_hash}/query-read-method` (+custom abi)
- changed messages format in websockets: internal_transactions, token transfers, transactions
- now /addresses returns 404 if address is not in DB

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
