### PR TITLE
Pending block operations update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [#6565](https://github.com/blockscout/blockscout/pull/6565) - Set restart: :permanent for permanent fetchers
 - [#6568](https://github.com/blockscout/blockscout/pull/6568) - Drop unfetched_token_balances index
 - [#6583](https://github.com/blockscout/blockscout/pull/6583) - Missing ranges collector
+- [#6647](https://github.com/blockscout/blockscout/pull/6647) - Pending block operations update
 
 ### Fixes
 

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_app_test.exs
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), Decimal.from_float(0.5)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash)
+  #     insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
   #     session
   #     |> AppPage.visit_page()
@@ -48,7 +48,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), 1) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash)
+  #     insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
   #     session
   #     |> AppPage.visit_page()
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio_blocks(), Decimal.from_float(0.5)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash)
+  #     insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
   #     session
   #     |> AppPage.visit_page()
@@ -96,7 +96,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     assert Decimal.compare(Explorer.Chain.indexed_ratio(), Decimal.from_float(0.9)) == :eq
 
-  #     insert(:pending_block_operation, block_hash: block.hash)
+  #     insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
   #     session
   #     |> AppPage.visit_page()
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.ViewingAppTest do
 
   #     block_hash = block.hash
 
-  #     insert(:pending_block_operation, block_hash: block_hash)
+  #     insert(:pending_block_operation, block_hash: block_hash, block_number: block.number)
 
   #     BlocksIndexedCounter.calculate_blocks_indexed()
 

--- a/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/transaction_view_test.exs
@@ -192,7 +192,7 @@ defmodule BlockScoutWeb.TransactionViewTest do
         |> insert()
         |> with_block(block, status: :error)
 
-      insert(:pending_block_operation, block_hash: block.hash)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       status = TransactionView.transaction_status(transaction)
       assert TransactionView.formatted_result(status) == "Error: (Awaiting internal transactions for reason)"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2749,6 +2749,7 @@ defmodule Explorer.Chain do
     query =
       from(
         po in PendingBlockOperation,
+        where: not is_nil(po.block_number),
         select: po.block_number
       )
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2754,10 +2754,8 @@ defmodule Explorer.Chain do
   def stream_blocks_with_unfetched_internal_transactions(initial, reducer) when is_function(reducer, 2) do
     query =
       from(
-        b in Block,
-        join: pending_ops in assoc(b, :pending_operations),
-        where: b.consensus,
-        select: b.number
+        po in PendingBlockOperation,
+        select: po.block_number
       )
 
     Repo.stream_reduce(query, initial, reducer)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2728,20 +2728,14 @@ defmodule Explorer.Chain do
   Returns a stream of all blocks with unfetched internal transactions, using
   the `pending_block_operation` table.
 
-  Only blocks with consensus are returned.
-
-      iex> non_consensus = insert(:block, consensus: false)
-      iex> insert(:pending_block_operation, block: non_consensus)
       iex> unfetched = insert(:block)
-      iex> insert(:pending_block_operation, block: unfetched)
+      iex> insert(:pending_block_operation, block: unfetched, block_number: unfetched.number)
       iex> {:ok, number_set} = Explorer.Chain.stream_blocks_with_unfetched_internal_transactions(
       ...>   MapSet.new(),
       ...>   fn number, acc ->
       ...>     MapSet.put(acc, number)
       ...>   end
       ...> )
-      iex> non_consensus.number in number_set
-      false
       iex> unfetched.number in number_set
       true
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -51,14 +51,11 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
     minimal_block_height = trace_minimal_block_height()
 
-    hashes_for_pending_block_operations =
-      if minimal_block_height > 0 do
-        changes_list
-        |> Enum.filter(&(&1.number >= minimal_block_height))
-        |> Enum.map(& &1.hash)
-      else
-        hashes
-      end
+    items_for_pending_ops =
+      changes_list
+      |> filter_by_min_height(&(&1.number >= minimal_block_height))
+      |> Enum.filter(& &1.consensus)
+      |> Enum.map(&{&1.number, &1.hash})
 
     consensus_block_numbers = consensus_block_numbers(changes_list)
 
@@ -66,16 +63,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     run_func = fn repo ->
       {:ok, nonconsensus_items} = lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
 
-      nonconsensus_hashes =
-        if minimal_block_height > 0 do
-          nonconsensus_items
-          |> Enum.filter(fn {number, _hash} -> number >= minimal_block_height end)
-          |> Enum.map(fn {_number, hash} -> hash end)
-        else
-          hashes
-        end
-
-      {:ok, nonconsensus_hashes}
+      {:ok, filter_by_min_height(nonconsensus_items, fn {number, _hash} -> number >= minimal_block_height end)}
     end
 
     multi
@@ -98,10 +86,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :blocks
       )
     end)
-    |> Multi.run(:new_pending_operations, fn repo, %{lose_consensus: nonconsensus_hashes} ->
+    |> Multi.run(:new_pending_operations, fn repo, %{lose_consensus: nonconsensus_items} ->
       Instrumenter.block_import_stage_runner(
         fn ->
-          new_pending_operations(repo, nonconsensus_hashes, hashes_for_pending_block_operations, insert_options)
+          new_pending_operations(repo, nonconsensus_items, items_for_pending_ops, insert_options)
         end,
         :address_referencing,
         :blocks,
@@ -428,7 +416,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
   end
 
-  defp new_pending_operations(repo, nonconsensus_hashes, hashes, %{
+  defp new_pending_operations(repo, nonconsensus_items, items, %{
          timeout: timeout,
          timestamps: timestamps
        }) do
@@ -436,12 +424,12 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       {:ok, []}
     else
       sorted_pending_ops =
-        nonconsensus_hashes
+        items
         |> MapSet.new()
-        |> MapSet.union(MapSet.new(hashes))
+        |> MapSet.difference(MapSet.new(nonconsensus_items))
         |> Enum.sort()
-        |> Enum.map(fn hash ->
-          %{block_hash: hash}
+        |> Enum.map(fn {number, hash} ->
+          %{block_hash: hash, block_number: number}
         end)
 
       Import.insert_changes_list(
@@ -743,5 +731,15 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         acc
       end
     end)
+  end
+
+  defp filter_by_min_height(blocks, filter_func) do
+    minimal_block_height = trace_minimal_block_height()
+
+    if minimal_block_height > 0 do
+      Enum.filter(blocks, &filter_func.(&1))
+    else
+      blocks
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.PendingBlockOperation do
 
   alias Explorer.Chain.{Block, Hash}
 
-  @required_attrs ~w(block_hash)a
+  @required_attrs ~w(block_hash block_number)a
 
   @typedoc """
    * `block_hash` - the hash of the block that has pending operations.
@@ -19,6 +19,8 @@ defmodule Explorer.Chain.PendingBlockOperation do
   @primary_key false
   schema "pending_block_operations" do
     timestamps()
+
+    field(:block_number, :integer)
 
     belongs_to(:block, Block, foreign_key: :block_hash, primary_key: true, references: :hash, type: Hash.Full)
   end

--- a/apps/explorer/priv/repo/migrations/20221223151234_add_block_number_to_pending_block_operations.exs
+++ b/apps/explorer/priv/repo/migrations/20221223151234_add_block_number_to_pending_block_operations.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddBlockNumberToPendingBlockOperations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pending_block_operations) do
+      add(:block_number, :integer)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
   describe "run/1" do
     test "transaction's status becomes :error when its internal_transaction has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
 
@@ -24,7 +24,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become true when its internal_transaction (where index != 0) has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -48,7 +48,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become false when its internal_transaction (where index == 0) has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -67,7 +67,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "transaction's has_error_in_internal_txs become false when its internal_transaction has no error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
       assert nil == transaction.has_error_in_internal_txs
@@ -92,7 +92,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "simple coin transfer's status becomes :error when its internal_transaction has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
 
@@ -112,7 +112,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
 
-      insert(:pending_block_operation, block_hash: a_block.hash)
+      insert(:pending_block_operation, block_hash: a_block.hash, block_number: a_block.number)
 
       assert :ok == transaction1.status
       assert :ok == transaction2.status
@@ -136,7 +136,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       a_block = insert(:block, number: 1000)
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
-      insert(:pending_block_operation, block_hash: a_block.hash)
+      insert(:pending_block_operation, block_hash: a_block.hash, block_number: a_block.number)
 
       assert :ok == transaction1.status
       assert :ok == transaction2.status
@@ -161,7 +161,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction0 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction1 = insert(:transaction) |> with_block(a_block, status: :ok)
       transaction2 = insert(:transaction) |> with_block(a_block, status: :ok)
-      insert(:pending_block_operation, block_hash: a_block.hash)
+      insert(:pending_block_operation, block_hash: a_block.hash, block_number: a_block.number)
 
       assert :ok == transaction0.status
       assert :ok == transaction1.status
@@ -203,7 +203,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
     test "simple coin transfer has no internal transaction inserted" do
       transaction = insert(:transaction) |> with_block(status: :ok)
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
 
@@ -221,7 +221,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction = insert(:transaction) |> with_block(status: :ok)
       pending = insert(:transaction)
 
-      insert(:pending_block_operation, block_hash: transaction.block_hash)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       assert :ok == transaction.status
       assert is_nil(pending.block_hash)
@@ -246,14 +246,14 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       empty_block = insert(:block)
       pending = insert(:transaction)
 
-      insert(:pending_block_operation, block_hash: empty_block.hash)
+      insert(:pending_block_operation, block_hash: empty_block.hash, block_number: empty_block.number)
 
       assert is_nil(pending.block_hash)
 
       full_block = insert(:block)
       inserted = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
       assert full_block.hash == inserted.block_hash
 
@@ -290,7 +290,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
         block_index: 0
       )
 
-      insert(:pending_block_operation, block_hash: full_block.hash)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
       transaction_changes = make_internal_transaction_changes(transaction, 0, nil)
 
@@ -309,7 +309,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       transaction_a = insert(:transaction) |> with_block(full_block)
       transaction_b = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
       transaction_a_changes = make_internal_transaction_changes(transaction_a, 0, nil)
 
@@ -325,12 +325,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
     test "does not remove consensus when block is empty and no transactions are missing" do
       empty_block = insert(:block)
 
-      insert(:pending_block_operation, block_hash: empty_block.hash)
+      insert(:pending_block_operation, block_hash: empty_block.hash, block_number: empty_block.number)
 
       full_block = insert(:block)
       inserted = insert(:transaction) |> with_block(full_block)
 
-      insert(:pending_block_operation, block_hash: full_block.hash)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
       assert full_block.hash == inserted.block_hash
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -44,10 +44,10 @@ defmodule Explorer.ChainTest do
   describe "remove_nonconsensus_blocks_from_pending_ops/0" do
     test "removes pending ops for nonconsensus blocks" do
       block = insert(:block)
-      insert(:pending_block_operation, block: block)
+      insert(:pending_block_operation, block: block, block_number: block.number)
 
       nonconsensus_block = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block)
+      insert(:pending_block_operation, block: nonconsensus_block, block_number: nonconsensus_block.number)
 
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops()
 
@@ -57,13 +57,13 @@ defmodule Explorer.ChainTest do
 
     test "removes pending ops for nonconsensus blocks by block hashes" do
       block = insert(:block)
-      insert(:pending_block_operation, block: block)
+      insert(:pending_block_operation, block: block, block_number: block.number)
 
       nonconsensus_block = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block)
+      insert(:pending_block_operation, block: nonconsensus_block, block_number: nonconsensus_block.number)
 
       nonconsensus_block1 = insert(:block, consensus: false)
-      insert(:pending_block_operation, block: nonconsensus_block1)
+      insert(:pending_block_operation, block: nonconsensus_block1, block_number: nonconsensus_block1.number)
 
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops([nonconsensus_block1.hash])
 
@@ -1209,7 +1209,7 @@ defmodule Explorer.ChainTest do
       |> insert()
       |> with_block(block)
 
-      insert(:pending_block_operation, block: block)
+      insert(:pending_block_operation, block: block, block_number: block.number)
 
       refute Chain.finished_internal_transactions_indexing?()
     end
@@ -1520,7 +1520,7 @@ defmodule Explorer.ChainTest do
         block = insert(:block, number: index)
 
         if index === 0 || index === 5 || index === 7 do
-          insert(:pending_block_operation, block: block)
+          insert(:pending_block_operation, block: block, block_number: block.number)
         end
       end
 

--- a/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
@@ -1,0 +1,67 @@
+defmodule Indexer.Fetcher.PendingBlockOperationsSanitizer do
+  @moduledoc """
+  Set block_number for pending block operations that have it empty
+  """
+
+  use GenServer
+
+  import Ecto.Query
+
+  alias Explorer.Chain.PendingBlockOperation
+  alias Explorer.Repo
+  alias Indexer.Fetcher.InternalTransaction
+
+  @interval :timer.seconds(1)
+  @batch_size 1000
+  @timeout :timer.minutes(1)
+
+  def child_spec(start_link_arguments) do
+    spec = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      restart: :transient,
+      type: :worker
+    }
+
+    Supervisor.child_spec(spec, [])
+  end
+
+  def start_link(_args, gen_server_options \\ []) do
+    GenServer.start_link(__MODULE__, :ok, Keyword.put_new(gen_server_options, :name, __MODULE__))
+  end
+
+  @impl GenServer
+  def init(_) do
+    Process.send_after(self(), :update_batch, @interval)
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:update_batch, state) do
+    case update_batch() do
+      [] ->
+        {:stop, :normal, state}
+
+      _ ->
+        Process.send_after(self(), :update_batch, @interval)
+        {:noreply, state}
+    end
+  end
+
+  def update_batch do
+    cte_query = from(pbo in PendingBlockOperation, where: is_nil(pbo.block_number), limit: @batch_size)
+
+    {_, block_numbers} =
+      PendingBlockOperation
+      |> with_cte("cte", as: ^cte_query)
+      |> join(:inner, [pbo], po in "cte", on: pbo.block_hash == po.block_hash)
+      |> join(:inner, [pbo, po], b in assoc(pbo, :block))
+      |> select([pbo, po, b], b.number)
+      |> update([pbo, po, b], set: [block_number: b.number])
+      |> Repo.update_all([], timeout: @timeout)
+
+    InternalTransaction.async_fetch(block_numbers)
+
+    block_numbers
+  end
+end

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -20,6 +20,7 @@ defmodule Indexer.Supervisor do
     ContractCode,
     EmptyBlocksSanitizer,
     InternalTransaction,
+    PendingBlockOperationsSanitizer,
     PendingTransaction,
     ReplacedTransaction,
     Token,
@@ -139,7 +140,8 @@ defmodule Indexer.Supervisor do
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
         {BlocksTransactionsMismatch.Supervisor,
          [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: memory_monitor]]},
-        {PendingOpsCleaner, [[], []]}
+        {PendingOpsCleaner, [[], []]},
+        {PendingBlockOperationsSanitizer, [[]]}
       ]
       |> List.flatten()
 

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -101,7 +101,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
     block_number = 1_000_006
     block = insert(:block, number: block_number)
-    insert(:pending_block_operation, block_hash: block.hash)
+    insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
     assert :ok = InternalTransaction.run([block_number], json_rpc_named_arguments)
 
@@ -117,7 +117,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
       block = insert(:block)
-      insert(:pending_block_operation, block_hash: block.hash)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       assert InternalTransaction.init(
                [],
@@ -169,7 +169,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
 
       block = insert(:block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash)
+      insert(:pending_block_operation, block_hash: block_hash, block_number: block.number)
 
       assert %{block_hash: block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
@@ -184,7 +184,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       transaction = insert(:transaction) |> with_block(block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash)
+      insert(:pending_block_operation, block_hash: block_hash, block_number: block.number)
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do
@@ -297,7 +297,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       insert(:transaction) |> with_block(block)
       block_hash = block.hash
-      insert(:pending_block_operation, block_hash: block_hash)
+      insert(:pending_block_operation, block_hash: block_hash, block_number: block.number)
 
       assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
 
@@ -312,7 +312,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       block = insert(:block)
       transaction = :transaction |> insert() |> with_block(block)
       block_number = block.number
-      insert(:pending_block_operation, block_hash: block.hash)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do

--- a/apps/indexer/test/indexer/fetcher/pending_block_operations_sanitizer_test.ex
+++ b/apps/indexer/test/indexer/fetcher/pending_block_operations_sanitizer_test.ex
@@ -1,0 +1,31 @@
+defmodule Indexer.Fetcher.PendingBlockOperationsSanitizerTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Repo
+  alias Indexer.Fetcher.PendingBlockOperationsSanitizer
+
+  setup do
+    config = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)
+
+    Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: true)
+
+    on_exit(fn ->
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, config)
+    end)
+  end
+
+  test "updates empty block_numbers" do
+    %{number: block_number1, hash: hash1} = insert(:block)
+    %{number: block_number2, hash: hash2} = insert(:block)
+    %{number: block_number3, hash: hash3} = insert(:block)
+    pending_block_operation1 = insert(:pending_block_operation, block_hash: hash1)
+    pending_block_operation2 = insert(:pending_block_operation, block_hash: hash2)
+    pending_block_operation3 = insert(:pending_block_operation, block_hash: hash3)
+
+    PendingBlockOperationsSanitizer.update_batch()
+
+    assert %{block_number: ^block_number1} = Repo.reload(pending_block_operation1)
+    assert %{block_number: ^block_number2} = Repo.reload(pending_block_operation2)
+    assert %{block_number: ^block_number3} = Repo.reload(pending_block_operation3)
+  end
+end

--- a/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
+++ b/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
@@ -8,7 +8,7 @@ defmodule Indexer.PendingOpsCleanerTest do
     test "deletes non-consensus pending ops on init" do
       block = insert(:block, consensus: false)
 
-      insert(:pending_block_operation, block_hash: block.hash)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       assert Repo.one(from(block in PendingBlockOperation, where: block.block_hash == ^block.hash))
 
@@ -24,7 +24,7 @@ defmodule Indexer.PendingOpsCleanerTest do
 
       block = insert(:block, consensus: false)
 
-      insert(:pending_block_operation, block_hash: block.hash)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       Process.sleep(2_000)
 


### PR DESCRIPTION
Resolves #6561 

## Motivation

Currently we are fetching pending block operations block numbers via joining it with `blocks` table and filtering by consensus. But there is no need to store non-consensus block info in `pending_block_operations` since they are gonna be refetched anyway. Also, it's useful to add some denormalization to `pending_block_operations` so we don't need to join it with blocks and therefore there will be improvement of performance.

## Changelog

- Do not store non-consensus blocks info to `pending_block_operations`
- Added `block_number` field to `pending_block_operations`
