### PR TITLE
Fix geth transaction tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#6740](https://github.com/blockscout/blockscout/pull/6740) - Fix tokens deadlock
 - [#6759](https://github.com/blockscout/blockscout/pull/6759) - Add `jq` in docker image
 - [#6779](https://github.com/blockscout/blockscout/pull/6779) - Fix missing ranges bounds clearing
+- [#6652](https://github.com/blockscout/blockscout/pull/6652) - Fix geth transaction tracer
 
 ### Chore
 

--- a/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js
+++ b/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js
@@ -207,14 +207,15 @@
 
         const inputOffset = log.stack.peek(2 + stackOffset).valueOf();
         const inputLength = log.stack.peek(3 + stackOffset).valueOf();
-        const inputEnd = inputOffset + inputLength;
+        const inputEnd = Math.min(inputOffset + inputLength, log.memory.length());
+        const input = (inputLength == 0 ? '0x0' : toHex(log.memory.slice(inputOffset, inputEnd)));
 
         const call = {
             type: 'call',
             callType: op.toLowerCase(),
             from: toHex(log.contract.getAddress()),
             to: toHex(to),
-            input: toHex(log.memory.slice(inputOffset, inputEnd)),
+            input: input,
             outputOffset: log.stack.peek(4 + stackOffset).valueOf(),
             outputLength: log.stack.peek(5 + stackOffset).valueOf()
         };


### PR DESCRIPTION
Resolves #6638 

## Motivation

There is a similar [issue](https://github.com/ethereum/go-ethereum/issues/25169) and its [solution](https://github.com/ethereum/go-ethereum/pull/25213/files#diff-782cb2b41601eeac10ef98a1f0aba25685bf93bfd0e8caf4e141ece7e2acf96dR573) in go-ethereum repo which are not yet included in any release, so we can apply this fix on our side for now.

## Changelog

If the tracer tries to access memory beyond the available limit, we limit it to the end of the memory.