### PR TITLE
Add vertical padding to error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#6542](https://github.com/blockscout/blockscout/pull/6542) - Init mixpanel and amplitude analytics
 - [#6574](https://github.com/blockscout/blockscout/pull/6574), [#6601](https://github.com/blockscout/blockscout/pull/6601) - Allow and manage insecure HTTP connection to the archive node
-- [#6433](https://github.com/blockscout/blockscout/pull/6433) - Update error pagess
+- [#6433](https://github.com/blockscout/blockscout/pull/6433), [#6698](https://github.com/blockscout/blockscout/pull/6698) - Update error pagess
 - [#6544](https://github.com/blockscout/blockscout/pull/6544) - API improvements
 - [#5561](https://github.com/blockscout/blockscout/pull/5561), [#6523](https://github.com/blockscout/blockscout/pull/6523), [#6549](https://github.com/blockscout/blockscout/pull/6549) - Improve working with contracts implementations
 - [#6401](https://github.com/blockscout/blockscout/pull/6401) - Add Sol2Uml contract visualization

--- a/apps/block_scout_web/assets/css/components/_errors.scss
+++ b/apps/block_scout_web/assets/css/components/_errors.scss
@@ -19,7 +19,7 @@ main:has(section.error-container) {
 .block-not-found {
 	display: flex;
 	flex-direction: column;
-	padding-bottom: 50px;
+	padding: 6rem 0 9rem 0;
 	@media (min-width: $error-tablet-breakpoint) {
 		flex-direction: row;
 		align-items: center;
@@ -95,7 +95,7 @@ main:has(section.error-container) {
 	justify-content: center;
 	flex-direction: column;
 	margin: auto;
-	padding-bottom: 3rem;
+	padding: 6rem 0 9rem 0;
 	max-width: 827px;
 	gap: 12px;
 


### PR DESCRIPTION
## Motivation
This looks not very good
![image](https://user-images.githubusercontent.com/53992153/211797549-17813000-4488-4555-ade9-63b461d1dd7e.png)


Now it looks like this
![image](https://user-images.githubusercontent.com/53992153/211797609-b75d5119-86f8-4029-894f-5887b20e18c0.png)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
