### PR TITLE
Remove internal transactions deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#6568](https://github.com/blockscout/blockscout/pull/6568) - Drop unfetched_token_balances index
 - [#6647](https://github.com/blockscout/blockscout/pull/6647) - Pending block operations update
 - [#6542](https://github.com/blockscout/blockscout/pull/6542) - Init mixpanel and amplitude analytics
+- [#6713](https://github.com/blockscout/blockscout/pull/6713) - Remove internal transactions deletion
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -14,7 +14,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   alias Explorer.Repo, as: ExplorerRepo
   alias Explorer.Utility.MissingBlockRange
 
-  import Ecto.Query, only: [from: 2, or_where: 3]
+  import Ecto.Query, only: [from: 2]
 
   @behaviour Runner
 
@@ -115,17 +115,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         :block_pending,
         :internal_transactions,
         :valid_internal_transactions_without_first_traces_of_trivial_transactions
-      )
-    end)
-    |> Multi.run(:remove_left_over_internal_transactions, fn repo,
-                                                             %{
-                                                               valid_internal_transactions: valid_internal_transactions
-                                                             } ->
-      Instrumenter.block_import_stage_runner(
-        fn -> remove_left_over_internal_transactions(repo, valid_internal_transactions) end,
-        :block_pending,
-        :internal_transactions,
-        :remove_left_over_internal_transactions
       )
     end)
     |> Multi.run(:internal_transactions, fn repo,
@@ -415,42 +404,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     # This allows us to use a more efficient upserting logic, while keeping the
     # uniqueness valid.
     SQL.query(repo, "SET CONSTRAINTS internal_transactions_pkey DEFERRED")
-  end
-
-  def remove_left_over_internal_transactions(repo, valid_internal_transactions) do
-    # Removes internal transactions that were part of a block before a refetch
-    # and have not been upserted with new ones (if any exist).
-
-    case valid_internal_transactions do
-      [] ->
-        {:ok, []}
-
-      _ ->
-        try do
-          delete_query_for_block_hash_block_index =
-            valid_internal_transactions
-            |> Enum.group_by(& &1.block_hash, & &1.block_index)
-            |> Enum.map(fn {block_hash, indexes} -> {block_hash, Enum.max(indexes)} end)
-            |> Enum.reduce(InternalTransaction, fn {block_hash, max_index}, acc ->
-              or_where(acc, [it], it.block_hash == ^block_hash and it.block_index > ^max_index)
-            end)
-
-          # removes old records with the same primary key (transaction hash, transaction index)
-          delete_query =
-            valid_internal_transactions
-            |> Enum.map(fn params -> {params.transaction_hash, params.index} end)
-            |> Enum.reduce(delete_query_for_block_hash_block_index, fn {transaction_hash, index}, acc ->
-              or_where(acc, [it], it.transaction_hash == ^transaction_hash and it.index == ^index)
-            end)
-
-          # ShareLocks order already enforced by `acquire_pending_internal_txs` (see docs: sharelocks.md)
-          {count, result} = repo.delete_all(delete_query, [])
-
-          {:ok, {count, result}}
-        rescue
-          postgrex_error in Postgrex.Error -> {:error, %{exception: postgrex_error}}
-        end
-    end
   end
 
   defp update_transactions(repo, valid_internal_transactions, transactions, %{

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -277,33 +277,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       assert PendingBlockOperation |> Repo.get(full_block.hash) |> is_nil()
     end
 
-    test "removes old records with the same primary key (transaction_hash, index)" do
-      full_block = insert(:block)
-      another_full_block = insert(:block)
-
-      transaction = insert(:transaction) |> with_block(full_block)
-
-      insert(:internal_transaction,
-        index: 0,
-        transaction: transaction,
-        block_hash: another_full_block.hash,
-        block_index: 0
-      )
-
-      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
-
-      transaction_changes = make_internal_transaction_changes(transaction, 0, nil)
-
-      assert {:ok, %{remove_left_over_internal_transactions: {1, nil}}} =
-               run_internal_transactions([transaction_changes])
-
-      assert from(i in InternalTransaction,
-               where: i.transaction_hash == ^transaction.hash and i.block_hash == ^another_full_block.hash
-             )
-             |> Repo.one()
-             |> is_nil()
-    end
-
     test "removes consensus to blocks where not all transactions are filled" do
       full_block = insert(:block)
       transaction_a = insert(:transaction) |> with_block(full_block)

--- a/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
@@ -24,7 +24,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollectorTest do
       MissingBlockRange.clear_batch(batch)
 
       insert(:block, number: 1_200_000)
-      Process.sleep(500)
+      Process.sleep(1000)
 
       assert [1_199_999..1_100_001//-1] = batch = MissingBlockRange.get_latest_batch(1)
       MissingBlockRange.clear_batch(batch)


### PR DESCRIPTION
## Motivation

There is no need to delete internal transactions before insert since we have on_conflict policy