### PR TITLE
Add nil clause for format_integer_to_currency/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#6736](https://github.com/blockscout/blockscout/pull/6736) - Fix `/tokens` in old UI
 - [#6705](https://github.com/blockscout/blockscout/pull/6705) - Fix `/smart-contracts` bugs in API v2
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/currency_helpers.ex
@@ -13,7 +13,13 @@ defmodule BlockScoutWeb.CurrencyHelpers do
       iex> BlockScoutWeb.CurrencyHelpers.format_integer_to_currency(1000000)
       "1,000,000"
   """
-  @spec format_integer_to_currency(non_neg_integer()) :: String.t()
+  @spec format_integer_to_currency(non_neg_integer() | nil) :: String.t()
+  def format_integer_to_currency(value)
+
+  def format_integer_to_currency(nil) do
+    "-"
+  end
+
   def format_integer_to_currency(value) do
     {:ok, formatted} = Number.to_string(value, format: "#,##0")
 


### PR DESCRIPTION
## Motivation

```
Request: GET /tokens?type=JSON
** (exit) an exception was raised:
    ** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a number

        :erlang.abs(nil)
        (ex_cldr_numbers 2.29.0) lib/cldr/number/formatter/decimal_formatter.ex:145: Cldr.Number.Formatter.Decimal.absolute_value/4
        (block_scout_web 5.0.0) lib/cldr/number/backend/decimal_formatter.ex:1: BlockScoutWeb.Cldr.Number.Formatter.Decimal.to_string/3
        (ex_cldr_numbers 2.29.0) lib/cldr/number.ex:431: Cldr.Number.to_string/3
        (block_scout_web 5.0.0) lib/block_scout_web/views/currency_helpers.ex:18: BlockScoutWeb.CurrencyHelpers.format_integer_to_currency/1
        (block_scout_web 5.0.0) lib/block_scout_web/templates/tokens/_tile.html.eex:40: BlockScoutWeb.TokensView."_tile.html"/1
        (phoenix 1.5.13) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.13) lib/phoenix/view.ex:479: Phoenix.View.render_to_string/3

```
## Changelog
- Add nil clause for format_integer_to_currency/1

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
