### PR TITLE
Fix address counter on empty chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#6736](https://github.com/blockscout/blockscout/pull/6736) - Fix `/tokens` in old UI
 - [#6705](https://github.com/blockscout/blockscout/pull/6705) - Fix `/smart-contracts` bugs in API v2
+- [#6746](https://github.com/blockscout/blockscout/pull/6746) - Fix -1 address counter
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Fixes
 
+- [#6746](https://github.com/blockscout/blockscout/pull/6746) - Fix -1 address counter
 - [#6736](https://github.com/blockscout/blockscout/pull/6736) - Fix `/tokens` in old UI
 - [#6705](https://github.com/blockscout/blockscout/pull/6705) - Fix `/smart-contracts` bugs in API v2
-- [#6746](https://github.com/blockscout/blockscout/pull/6746) - Fix -1 address counter
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -194,7 +194,7 @@ defmodule Explorer.Chain do
     if is_nil(cached_value) || cached_value == 0 do
       %Postgrex.Result{rows: [[count]]} = Repo.query!("SELECT reltuples FROM pg_class WHERE relname = 'addresses';")
 
-      count
+      max(count, 0)
     else
       cached_value
     end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -103,6 +103,11 @@ defmodule Explorer.ChainTest do
       assert is_integer(addresses_with_balance)
       assert addresses_with_balance == 3
     end
+
+    test "returns 0 on empty table" do
+      start_supervised!(AddressesCounter)
+      assert 0 == Chain.address_estimated_count()
+    end
   end
 
   describe "last_db_block_status/0" do


### PR DESCRIPTION
Fix #6730 

## Changelog

Instead of returning count from `reltuples` return `max(count, 0)`
https://github.com/blockscout/blockscout/blob/f83c27f84159483952f3924db6111e2d72037b11/apps/explorer/lib/explorer/chain.ex#L194-L197
the reason for this is that `reltuples` is equal to `-1` in fresh new table
![image](https://user-images.githubusercontent.com/53992153/213906417-0a932005-9f57-48d8-b943-9c84885f41ba.png)



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
