### PR TITLE
Set docker-compose pull_policy to always

### DIFF
--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -29,6 +29,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     links:
@@ -52,6 +53,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -61,6 +63,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -27,6 +27,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     links:
@@ -53,6 +54,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -62,6 +64,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -29,6 +29,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     links:
@@ -52,6 +53,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -61,6 +63,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -27,6 +27,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     links:
@@ -51,6 +52,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -60,6 +62,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -29,6 +29,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     links:
@@ -52,6 +53,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -61,6 +63,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -15,6 +15,7 @@ services:
       - smart-contract-verifier
       - redis_db
     image: blockscout/blockscout:${DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'blockscout'
     command: bash -c "bin/blockscout eval \"Elixir.Explorer.ReleaseTasks.create_and_migrate()\" && bin/blockscout start"
@@ -35,6 +36,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -44,6 +46,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -58,6 +58,7 @@ services:
 
   smart-contract-verifier:
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'
     env_file:
@@ -67,6 +68,7 @@ services:
 
   visualizer:
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
     restart: always
     container_name: 'visualizer'
     env_file:


### PR DESCRIPTION
## Motivation

Force to update `latest` tags of Docker images.

## Changelog

Set `pull_policy: false` for containers which use `latest` tag by default.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
