### PR TITLE
Refactor `try rescue` statements to keep stacktrace

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -131,7 +131,7 @@
         {Credo.Check.Warning.UnusedRegexOperation},
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
-        {Credo.Check.Warning.RaiseInsideRescue, false},
+        {Credo.Check.Warning.RaiseInsideRescue},
 
         # Controversial and experimental checks (opt-in, just remove `, false`)
         #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Chore
 
+- [#6786](https://github.com/blockscout/blockscout/pull/6786) - Refactor `try rescue` statements to keep stacktrace
 - [#6695](https://github.com/blockscout/blockscout/pull/6695) - Process errors and warnings with enables check-js feature in VS code
 
 <details>

--- a/apps/block_scout_web/lib/block_scout_web/plug/redis_cookie.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/redis_cookie.ex
@@ -72,7 +72,7 @@ defmodule BlockScoutWeb.Plug.RedisCookie do
          Logger.log(
            log,
            "Plug.Session could not decode incoming session cookie. Reason: " <>
-             Exception.message(e)
+             Exception.format(:error, e, __STACKTRACE__)
          )
 
          %{}

--- a/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
   rescue
     exception ->
       Logger.warn(fn ->
-        ["Error determining value html for #{inspect(type)}: ", Exception.format(:error, exception)]
+        ["Error determining value html for #{inspect(type)}: ", Exception.format(:error, exception, __STACKTRACE__)]
       end)
 
       :error
@@ -34,7 +34,7 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
   rescue
     exception ->
       Logger.warn(fn ->
-        ["Error determining value json for #{inspect(type)}: ", Exception.format(:error, exception)]
+        ["Error determining value json for #{inspect(type)}: ", Exception.format(:error, exception, __STACKTRACE__)]
       end)
 
       nil
@@ -47,7 +47,7 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
   rescue
     exception ->
       Logger.warn(fn ->
-        ["Error determining copy text for #{inspect(type)}: ", Exception.format(:error, exception)]
+        ["Error determining copy text for #{inspect(type)}: ", Exception.format(:error, exception, __STACKTRACE__)]
       end)
 
       :error

--- a/apps/explorer/lib/explorer/account/notify.ex
+++ b/apps/explorer/lib/explorer/account/notify.ex
@@ -20,7 +20,7 @@ defmodule Explorer.Account.Notify do
   rescue
     err ->
       Logger.info("--- Notifier error", fetcher: :account)
-      Logger.info(err, fetcher: :account)
+      :error |> Exception.format(err, __STACKTRACE__) |> Logger.info(fetcher: :account)
   end
 
   defp check_envs do

--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -35,7 +35,8 @@ defmodule Explorer.Chain.Cache.AddressSum do
         rescue
           e ->
             Logger.debug([
-              "Coudn't update address sum test #{inspect(e)}"
+              "Coudn't update address sum: ",
+              Exception.format(:error, e, __STACKTRACE__)
             ])
         end
 

--- a/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
@@ -42,7 +42,8 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
         rescue
           e ->
             Logger.debug([
-              "Coudn't update address sum test #{inspect(e)}"
+              "Coudn't update address sum: ",
+              Exception.format(:error, e, __STACKTRACE__)
             ])
         end
 

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -61,7 +61,8 @@ defmodule Explorer.Chain.Cache.Block do
         rescue
           e ->
             Logger.debug([
-              "Coudn't update block count test #{inspect(e)}"
+              "Coudn't update block count: ",
+              Exception.format(:error, e, __STACKTRACE__)
             ])
         end
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -105,7 +105,8 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
         rescue
           e ->
             Logger.debug([
-              "Coudn't update gas used gas_prices #{inspect(e)}"
+              "Coudn't update gas used gas_prices",
+              Exception.format(:error, e, __STACKTRACE__)
             ])
         end
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -57,7 +57,8 @@ defmodule Explorer.Chain.Cache.GasUsage do
           rescue
             e ->
               Logger.debug([
-                "Coudn't update gas used sum test #{inspect(e)}"
+                "Coudn't update gas used sum: ",
+                Exception.format(:error, e, __STACKTRACE__)
               ])
           end
 

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -58,7 +58,8 @@ defmodule Explorer.Chain.Cache.Transaction do
         rescue
           e ->
             Logger.debug([
-              "Coudn't update transaction count test #{inspect(e)}"
+              "Coudn't update transaction count: ",
+              Exception.format(:error, e, __STACKTRACE__)
             ])
         end
 

--- a/apps/explorer/lib/explorer/chain/contract_method.ex
+++ b/apps/explorer/lib/explorer/chain/contract_method.ex
@@ -87,7 +87,7 @@ defmodule Explorer.Chain.ContractMethod do
     end
   rescue
     e ->
-      message = Exception.format(:error, e)
+      message = Exception.format(:error, e, __STACKTRACE__)
 
       {:error, message}
   end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -218,8 +218,14 @@ defmodule Explorer.Chain.Log do
       {:ok, selector, mapping}
     end
   rescue
-    _ ->
-      Logger.warn(fn -> ["Could not decode input data for log from transaction: ", Hash.to_iodata(transaction.hash)] end)
+    e ->
+      Logger.warn(fn ->
+        [
+          "Could not decode input data for log from transaction: ",
+          Hash.to_iodata(transaction.hash),
+          Exception.format(:error, e, __STACKTRACE__)
+        ]
+      end)
 
       {:error, :could_not_decode}
   end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -674,8 +674,15 @@ defmodule Explorer.Chain.Transaction do
 
     {:ok, result}
   rescue
-    _ ->
-      Logger.warn(fn -> ["Could not decode input data for transaction: ", Hash.to_iodata(hash)] end)
+    e ->
+      Logger.warn(fn ->
+        [
+          "Could not decode input data for transaction: ",
+          Hash.to_iodata(hash),
+          Exception.format(:error, e, __STACKTRACE__)
+        ]
+      end)
+
       {:error, :could_not_decode}
   end
 
@@ -686,8 +693,15 @@ defmodule Explorer.Chain.Transaction do
 
     {:ok, mapping}
   rescue
-    _ ->
-      Logger.warn(fn -> ["Could not decode input data for transaction: ", Hash.to_iodata(hash)] end)
+    e ->
+      Logger.warn(fn ->
+        [
+          "Could not decode input data for transaction: ",
+          Hash.to_iodata(hash),
+          Exception.format(:error, e, __STACKTRACE__)
+        ]
+      end)
+
       {:error, :could_not_decode}
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -30,7 +30,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
         Logger.error(fn ->
           [
             "Error while verifying smart-contract address: #{address_hash}, params: #{inspect(params, limit: :infinity, printable_limit: :infinity)}: ",
-            Exception.format(:error, exception)
+            Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
     end
@@ -113,7 +113,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
         Logger.error(fn ->
           [
             "Error while verifying smart-contract address: #{address_hash}, params: #{inspect(params, limit: :infinity, printable_limit: :infinity)}, json_input: #{inspect(json_input, limit: :infinity, printable_limit: :infinity)}: ",
-            Exception.format(:error, exception)
+            Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
     end

--- a/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
@@ -26,7 +26,7 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
         Logger.error(fn ->
           [
             "Error while verifying smart-contract address: #{address_hash}, params: #{inspect(params, limit: :infinity, printable_limit: :infinity)}: ",
-            Exception.format(:error, exception)
+            Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
     end

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -148,7 +148,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     fetch_json(%{@token_uri => {:ok, [decoded_json]}}, hex_token_id)
   rescue
     e ->
-      Logger.debug(["Unknown metadata format #{inspect(json)}. error #{inspect(e)}"],
+      Logger.debug(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 
@@ -161,7 +161,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     fetch_json(%{@uri => {:ok, [decoded_json]}}, hex_token_id)
   rescue
     e ->
-      Logger.debug(["Unknown metadata format #{inspect(json)}. error #{inspect(e)}"],
+      Logger.debug(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 
@@ -178,7 +178,11 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     end
   rescue
     e ->
-      Logger.debug(["Unknown metadata format base64 #{inspect(base64_encoded_json)}. error #{inspect(e)}"],
+      Logger.debug(
+        [
+          "Unknown metadata format base64 #{inspect(base64_encoded_json)}.",
+          Exception.format(:error, e, __STACKTRACE__)
+        ],
         fetcher: :token_instances
       )
 
@@ -195,7 +199,8 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     end
   rescue
     e ->
-      Logger.debug(["Unknown metadata format base64 #{inspect(base64_encoded_json)}. error #{inspect(e)}"],
+      Logger.debug(
+        ["Unknown metadata format base64 #{inspect(base64_encoded_json)}", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 
@@ -228,7 +233,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     check_type(json, hex_token_id)
   rescue
     e ->
-      Logger.debug(["Unknown metadata format #{inspect(json)}. error #{inspect(e)}"],
+      Logger.debug(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 
@@ -241,7 +246,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     check_type(json, hex_token_id)
   rescue
     e ->
-      Logger.debug(["Unknown metadata format #{inspect(json)}. error #{inspect(e)}"],
+      Logger.debug(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 
@@ -282,7 +287,8 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     end
   rescue
     e ->
-      Logger.debug(["Could not send request to token uri #{inspect(uri)}. error #{inspect(e)}"],
+      Logger.debug(
+        ["Could not send request to token uri #{inspect(uri)}.", Exception.format(:error, e, __STACKTRACE__)],
         fetcher: :token_instances
       )
 

--- a/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
@@ -123,7 +123,7 @@ defmodule Indexer.Fetcher.ReplacedTransaction do
         Logger.error(fn ->
           [
             "failed to update replaced transactions for transactions: ",
-            inspect(reason)
+            Exception.format(:error, reason, __STACKTRACE__)
           ]
         end)
 

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -67,8 +67,11 @@ defmodule Indexer.Transform.TokenTransfers do
       token_transfers: [token_transfer | token_transfers]
     }
   rescue
-    _ in [FunctionClauseError, MatchError] ->
-      Logger.error(fn -> "Unknown token transfer format: #{inspect(log)}" end)
+    e in [FunctionClauseError, MatchError] ->
+      Logger.error(fn ->
+        ["Unknown token transfer format: #{inspect(log)}", Exception.format(:error, e, __STACKTRACE__)]
+      end)
+
       acc
   end
 


### PR DESCRIPTION
Closes #6762 

## Changelog

Example error before:
```
2023-01-30T20:20:44.907 application=indexer fetcher=internal_transaction count=10 error_count=10 [error] failed to fetch internal transactions for blocks: %FunctionClauseError{module: EthereumJSONRPC.Geth, function: :parse_call_tracer_calls, arity: 4, kind: nil, args: nil, clauses: nil}
```
after:
```
2023-01-30T20:21:39.989 application=indexer fetcher=internal_transaction count=10 error_count=10 [error] failed to fetch internal transactions for blocks: ** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Geth.parse_call_tracer_calls/4
    (ethereum_jsonrpc 5.0.0) lib/ethereum_jsonrpc/geth.ex:233: EthereumJSONRPC.Geth.parse_call_tracer_calls({%{"from" => "0x0a70c7294f9deffe389e437347ba1b6de531d16c", "gas" => "0xeef6c", "gasUsed" => "0x48e8d", "input" => "0xa0712d680000000000000000000000000000000000000000000000000000000000000002", "output" => "0x", "to" => "0xd9106423df3a233a5033a3783e5ccac01647fc6c", "type" => "CALL", "value" => "0x0"}, 0}, [], [], false)
    (ethereum_jsonrpc 5.0.0) lib/ethereum_jsonrpc/geth.ex:227: EthereumJSONRPC.Geth.prepare_calls/1
    (ethereum_jsonrpc 5.0.0) lib/ethereum_jsonrpc/geth.ex:178: EthereumJSONRPC.Geth.debug_trace_transaction_response_to_internal_transactions_params/2
    (elixir 1.14.3) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (ethereum_jsonrpc 5.0.0) lib/ethereum_jsonrpc/geth.ex:129: EthereumJSONRPC.Geth.debug_trace_transaction_responses_to_internal_transactions_params/3
    (indexer 5.0.0) lib/indexer/fetcher/internal_transaction.ex:174: anonymous fn/3 in Indexer.Fetcher.InternalTransaction.fetch_block_internal_transactions_by_transactions/2
    (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
    (indexer 5.0.0) lib/indexer/fetcher/internal_transaction.ex:115: Indexer.Fetcher.InternalTransaction.run/2
    (elixir 1.14.3) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.3) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3

```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
