### PR TITLE
Extract Docker-compose services into separate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Chore
 
+- [#6845](https://github.com/blockscout/blockscout/pull/6845) - Extract Docker-compose services into separate files
 - [#6834](https://github.com/blockscout/blockscout/pull/6834) - Take into account FIRST_BLOCK in "Total blocks" counter on the main page
 - [#6340](https://github.com/blockscout/blockscout/pull/6340) - Rollback to websocket_client 1.3.0
 - [#6786](https://github.com/blockscout/blockscout/pull/6786) - Refactor `try rescue` statements to keep stacktrace

--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -2,26 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64
@@ -53,32 +41,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -2,24 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64
@@ -54,32 +44,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -2,26 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64
@@ -53,32 +41,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -2,24 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64
@@ -52,32 +42,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -2,26 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    volumes:
-      - ./postgres-data:/var/lib/postgresql/data
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64
@@ -53,32 +41,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -2,13 +2,9 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   blockscout:
     platform: linux/x86_64
@@ -36,32 +32,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/docker-compose-no-rust-services.yml
+++ b/docker-compose/docker-compose-no-rust-services.yml
@@ -2,24 +2,14 @@ version: '3.8'
 
 services:
   redis_db:
-    image: 'redis:alpine'
-    ports:
-      - 6379:6379
-    container_name: redis_db
-    command: redis-server
-    volumes:
-      - ./redis-data:/data
+    extends:
+      file: ./services/docker-compose-redis.yml
+      service: redis_db
 
   db:
-    image: postgres:14
-    restart: always
-    container_name: 'postgres'
-    environment:
-        POSTGRES_PASSWORD: ''
-        POSTGRES_USER: 'postgres'
-        POSTGRES_HOST_AUTH_METHOD: 'trust'
-    ports:
-      - 7432:5432
+    extends:
+      file: ./services/docker-compose-db.yml
+      service: db
 
   blockscout:
     platform: linux/x86_64

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -58,32 +58,16 @@ services:
       - ./logs/:/app/logs/
 
   smart-contract-verifier:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'smart-contract-verifier'
-    env_file:
-      -  ./envs/common-smart-contract-verifier.env
-    ports:
-      - 8043:8043
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
-    pull_policy: always
-    restart: always
-    container_name: 'visualizer'
-    env_file:
-      -  ./envs/common-visualizer.env
-    ports:
-      - 8050:8050
+    extends:
+      file: ./services/docker-compose-visualizer.yml
+      service: visualizer
 
   sig-provider:
-    platform: linux/x86_64
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
-    pull_policy: always
-    restart: always
-    container_name: 'sig-provider'
-    ports:
-      - 8051:8050
+    extends:
+      file: ./services/docker-compose-sig-provider.yml
+      service: sig-provider

--- a/docker-compose/services/docker-compose-db.yml
+++ b/docker-compose/services/docker-compose-db.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:14
+    restart: always
+    container_name: 'postgres'
+    environment:
+        POSTGRES_PASSWORD: ''
+        POSTGRES_USER: 'postgres'
+        POSTGRES_HOST_AUTH_METHOD: 'trust'
+    ports:
+      - 7432:5432

--- a/docker-compose/services/docker-compose-redis.yml
+++ b/docker-compose/services/docker-compose-redis.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  redis_db:
+    image: 'redis:alpine'
+    ports:
+      - 6379:6379
+    container_name: redis_db
+    command: redis-server
+    volumes:
+      - ./redis-data:/data

--- a/docker-compose/services/docker-compose-sig-provider.yml
+++ b/docker-compose/services/docker-compose-sig-provider.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  sig-provider:
+    platform: linux/x86_64
+    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
+    pull_policy: always
+    restart: always
+    container_name: 'sig-provider'
+    ports:
+      - 8051:8050

--- a/docker-compose/services/docker-compose-smart-contract-verifier.yml
+++ b/docker-compose/services/docker-compose-smart-contract-verifier.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  smart-contract-verifier:
+    platform: linux/x86_64
+    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
+    pull_policy: always
+    restart: always
+    container_name: 'smart-contract-verifier'
+    env_file:
+      -  ../envs/common-smart-contract-verifier.env
+    ports:
+      - 8043:8043

--- a/docker-compose/services/docker-compose-visualizer.yml
+++ b/docker-compose/services/docker-compose-visualizer.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  visualizer:
+    platform: linux/x86_64
+    image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
+    pull_policy: always
+    restart: always
+    container_name: 'visualizer'
+    env_file:
+      -  ../envs/common-visualizer.env
+    ports:
+      - 8050:8050


### PR DESCRIPTION
## Motivation

In docker-compose configs for different RPC clients we repeat the same services: sc-verifier, visualizer, sig-provider etc.

## Changelog

Extract repeating services into separate docker-compose configs.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
