### PR TITLE
Fix task restart in transaction actions fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#6859](https://github.com/blockscout/blockscout/pull/6859) - Fix task restart in transaction actions fetcher
 - [#6831](https://github.com/blockscout/blockscout/pull/6831) - Copy of [#6028](https://github.com/blockscout/blockscout/pull/6028)
 - [#6832](https://github.com/blockscout/blockscout/pull/6832) - Transaction actions fix
 - [#6827](https://github.com/blockscout/blockscout/pull/6827) - Fix handling unknown calls from `callTracer`

--- a/apps/indexer/lib/indexer/fetcher/transaction_action.ex
+++ b/apps/indexer/lib/indexer/fetcher/transaction_action.ex
@@ -88,13 +88,13 @@ defmodule Indexer.Fetcher.TransactionAction do
     else
       Logger.metadata(fetcher: :transaction_action)
       Logger.error(fn -> "Transaction action fetcher task exited due to #{inspect(reason)}. Rerunning..." end)
-      {:noreply, run_fetch(state)}
+      {:noreply, run_fetch(%__MODULE__{state | next_block: get_stage_block(@stage_next_block)})}
     end
   end
 
   defp run_fetch(state) do
     pid = self()
-    Process.send(pid, :fetch, [])
+    Process.send_after(pid, :fetch, 3000, [])
     %__MODULE__{state | task: nil, pid: pid}
   end
 
@@ -122,7 +122,7 @@ defmodule Indexer.Fetcher.TransactionAction do
 
       %{transaction_actions: transaction_actions} =
         query
-        |> Repo.all()
+        |> Repo.all(timeout: :infinity)
         |> TransactionActions.parse(protocols)
 
       addresses =


### PR DESCRIPTION
## Motivation

Sometimes the indexing task interrupts with timeout error when reading `log` table, and then starts from the block which already was handled. This PR fixes both issues.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
