### PR TITLE
Add JSON_RPC to CSP header

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -3,30 +3,16 @@
 :0: Unknown type 'Elixir.Map':t/0
 :0: Unknown type 'Elixir.Hash':t/0
 :0: Unknown type 'Elixir.Address':t/0
-apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex:400: Function timestamp_to_datetime/1 has no local return
 lib/ethereum_jsonrpc/rolling_window.ex:173
-lib/explorer/repo/prometheus_logger.ex:8
 lib/explorer/smart_contract/solidity/publisher_worker.ex:1
 lib/explorer/smart_contract/vyper/publisher_worker.ex:1
 lib/explorer/smart_contract/solidity/publisher_worker.ex:6
 lib/explorer/smart_contract/vyper/publisher_worker.ex:6
-apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: Function microseconds_time/1 has no local return
-apps/explorer/lib/explorer/repo/prometheus_logger.ex:8: The call 'Elixir.System':convert_time_unit(__@1::any(),'native','microseconds') breaks the contract (integer(),time_unit() | 'native',time_unit() | 'native') -> integer()
 lib/block_scout_web/router.ex:1
 lib/block_scout_web/schema/types.ex:31
 lib/phoenix/router.ex:324
 lib/phoenix/router.ex:402
-lib/block_scout_web/views/layout_view.ex:145: The call 'Elixir.Poison.Parser':'parse!'
-lib/block_scout_web/views/layout_view.ex:237: The call 'Elixir.Poison.Parser':'parse!'
 lib/explorer/smart_contract/reader.ex:435
 lib/indexer/fetcher/token_total_supply_on_demand.ex:16
 lib/explorer/exchange_rates/source.ex:116
 lib/explorer/exchange_rates/source.ex:119
-lib/block_scout_web/templates/address_contract/index.html.eex:158
-lib/block_scout_web/templates/address_contract/index.html.eex:195
-lib/block_scout_web/views/transaction_view.ex:137
-lib/block_scout_web/views/transaction_view.ex:152
-lib/block_scout_web/views/transaction_view.ex:197
-lib/indexer/buffered_task.ex:402
-lib/indexer/buffered_task.ex:451
-lib/indexer/memory/monitor.ex:160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - [#6859](https://github.com/blockscout/blockscout/pull/6859) - Fix task restart in transaction actions fetcher
+- [#6860](https://github.com/blockscout/blockscout/pull/6860) - JSON RPC to CSP header
 - [#6831](https://github.com/blockscout/blockscout/pull/6831) - Copy of [#6028](https://github.com/blockscout/blockscout/pull/6028)
 - [#6832](https://github.com/blockscout/blockscout/pull/6832) - Transaction actions fix
 - [#6827](https://github.com/blockscout/blockscout/pull/6827) - Fix handling unknown calls from `callTracer`

--- a/apps/block_scout_web/lib/block_scout_web/csp_header.ex
+++ b/apps/block_scout_web/lib/block_scout_web/csp_header.ex
@@ -10,17 +10,23 @@ defmodule BlockScoutWeb.CSPHeader do
 
   def call(conn, _opts) do
     config = Application.get_env(:block_scout_web, __MODULE__)
+    google_url = "https://www.google.com"
+    czilladx_url = "https://request-global.czilladx.com"
+    coinzillatag_url = "https://coinzillatag.com"
+    trustwallet_url = "https://raw.githubusercontent.com/trustwallet/assets/"
+    walletconnect_urls = "wss://*.bridge.walletconnect.org https://registry.walletconnect.org/data/wallets.json"
+    json_rpc_url = Application.get_env(:block_scout_web, :json_rpc)
 
     Controller.put_secure_browser_headers(conn, %{
       "content-security-policy" => "\
-        connect-src 'self' #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} wss://*.bridge.walletconnect.org/ https://request-global.czilladx.com/ https://raw.githubusercontent.com/trustwallet/assets/ https://registry.walletconnect.org/data/wallets.json https://*.poa.network;\
+        connect-src 'self' #{json_rpc_url} #{config[:mixpanel_url]} #{config[:amplitude_url]} #{websocket_endpoints(conn)} #{czilladx_url} #{trustwallet_url} #{walletconnect_urls};\
         default-src 'self';\
-        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://coinzillatag.com https://www.google.com https://www.gstatic.com;\
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' #{coinzillatag_url} #{google_url} https://www.gstatic.com;\
         style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com;\
         img-src 'self' * data:;\
         media-src 'self' * data:;\
         font-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.gstatic.com data:;\
-        frame-src 'self' 'unsafe-inline' 'unsafe-eval' https://request-global.czilladx.com/ https://www.google.com;\
+        frame-src 'self' 'unsafe-inline' 'unsafe-eval' #{czilladx_url} #{google_url};\
       "
     })
   end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6236

## Motivation

> When setting JSON_RPC env we are getting CSP browser errors after connecting the wallet.

## Changelog

Add value of `JSONRPC` env var to CSP header.

Chore: remove obsolete code lines from `.dialyzer-ignore`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
