### PR TITLE
Move OnDemand fetchers from indexer supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#6541](https://github.com/blockscout/blockscout/pull/6541) - Integrate sig provider
 - [#6712](https://github.com/blockscout/blockscout/pull/6712), [#6798](https://github.com/blockscout/blockscout/pull/6798) - API v2 update
 - [#6582](https://github.com/blockscout/blockscout/pull/6582) - Transaction actions indexer
+- [#6863](https://github.com/blockscout/blockscout/pull/6863) - Move OnDemand fetchers from indexer supervisor
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -5,6 +5,7 @@ defmodule Indexer.Application do
 
   use Application
 
+  alias Indexer.Fetcher.{CoinBalanceOnDemand, TokenTotalSupplyOnDemand}
   alias Indexer.Memory
   alias Indexer.Prometheus.PendingBlockOperationsCollector
   alias Prometheus.Registry
@@ -21,8 +22,12 @@ defmodule Indexer.Application do
 
     memory_monitor_name = Memory.Monitor
 
+    json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
+
     base_children = [
-      {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]}
+      {Memory.Monitor, [memory_monitor_options, [name: memory_monitor_name]]},
+      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]}
     ]
 
     children =

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -16,7 +16,6 @@ defmodule Indexer.Supervisor do
   alias Indexer.Fetcher.{
     BlockReward,
     CoinBalance,
-    CoinBalanceOnDemand,
     ContractCode,
     EmptyBlocksSanitizer,
     InternalTransaction,
@@ -26,7 +25,6 @@ defmodule Indexer.Supervisor do
     Token,
     TokenBalance,
     TokenInstance,
-    TokenTotalSupplyOnDemand,
     TokenUpdater,
     TransactionAction,
     UncleBlock
@@ -131,9 +129,7 @@ defmodule Indexer.Supervisor do
         {ReplacedTransaction.Supervisor, [[memory_monitor: memory_monitor]]},
 
         # Out-of-band fetchers
-        {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
         {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
-        {TokenTotalSupplyOnDemand.Supervisor, [json_rpc_named_arguments]},
         {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
 
         # Temporary workers


### PR DESCRIPTION
## Motivation

In a setup when the indexer and the web app are running in separate instances, web app cannot trigger OnDemand fetchers because indexer supervisor is disabled, so some data may be inaccurate. It's reasonable to move those fetchers from indexer supervisor so they are started every time regardless of whether the indexer is disabled.

## Changelog

Moved OnDemand fetchers from `Indexer.Supervisor` to `Indexer.Application`.