### PR TITLE
Fix token type definition for multiple interface tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#6891](https://github.com/blockscout/blockscout/pull/6891) - Fix read contract for geth
 - [#6889](https://github.com/blockscout/blockscout/pull/6889) - Fix Internal Server Error on tx input decoding
+- [#6893](https://github.com/blockscout/blockscout/pull/6893) - Fix token type definition for multiple interface tokens
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -31,8 +31,10 @@ defmodule Indexer.Transform.TokenTransfers do
       end)
       |> Enum.reduce(initial_acc, &do_parse(&1, &2, :erc1155))
 
-    tokens = erc1155_token_transfers.tokens ++ erc20_and_erc721_token_transfers.tokens
-    token_transfers = erc1155_token_transfers.token_transfers ++ erc20_and_erc721_token_transfers.token_transfers
+    rough_tokens = erc1155_token_transfers.tokens ++ erc20_and_erc721_token_transfers.tokens
+    rough_token_transfers = erc1155_token_transfers.token_transfers ++ erc20_and_erc721_token_transfers.token_transfers
+
+    {tokens, token_transfers} = sanitize_token_types(rough_tokens, rough_token_transfers)
 
     token_transfers
     |> Enum.filter(fn token_transfer ->
@@ -52,6 +54,60 @@ defmodule Indexer.Transform.TokenTransfers do
     }
 
     token_transfers_from_logs_uniq
+  end
+
+  defp sanitize_token_types(tokens, token_transfers) do
+    existing_token_types_map =
+      tokens
+      |> Enum.reduce([], fn %{contract_address_hash: address_hash}, acc ->
+        case Repo.get_by(Token, contract_address_hash: address_hash) do
+          %{type: type} -> [{address_hash, type} | acc]
+          _ -> acc
+        end
+      end)
+      |> Map.new()
+
+    existing_tokens =
+      existing_token_types_map
+      |> Map.keys()
+      |> Enum.map(&to_string/1)
+
+    new_tokens_token_transfers = Enum.filter(token_transfers, &(&1.token_contract_address_hash not in existing_tokens))
+
+    new_token_types_map =
+      new_tokens_token_transfers
+      |> Enum.group_by(& &1.token_contract_address_hash)
+      |> Enum.map(fn {contract_address_hash, transfers} ->
+        {contract_address_hash, define_token_type(transfers)}
+      end)
+      |> Map.new()
+
+    actual_token_types_map = Map.merge(new_token_types_map, existing_token_types_map)
+
+    actual_tokens =
+      Enum.map(tokens, fn %{contract_address_hash: hash} = token ->
+        Map.put(token, :type, actual_token_types_map[hash])
+      end)
+
+    actual_token_transfers =
+      Enum.map(token_transfers, fn %{token_contract_address_hash: hash} = tt ->
+        Map.put(tt, :token_type, actual_token_types_map[hash])
+      end)
+
+    {actual_tokens, actual_token_transfers}
+  end
+
+  defp define_token_type(token_transfers) do
+    Enum.reduce(token_transfers, nil, fn %{token_type: token_type}, acc ->
+      if token_type_priority(token_type) > token_type_priority(acc), do: token_type, else: acc
+    end)
+  end
+
+  defp token_type_priority(nil), do: -1
+
+  @token_types_priority_order ["ERC-20", "ERC-721", "ERC-1155"]
+  defp token_type_priority(token_type) do
+    Enum.find_index(@token_types_priority_order, &(&1 == token_type))
   end
 
   defp do_parse(log, %{tokens: tokens, token_transfers: token_transfers} = acc, type \\ :erc20_erc721) do


### PR DESCRIPTION
Resolves #6483 

## Changelog

- Token type in the database is the precedence type
- If there are two or more transfers with different token types, the highest priority type will be selected for all