### PR TITLE
Support basic auth in JSON RPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#6897](https://github.com/blockscout/blockscout/pull/6897) - Support basic auth in JSON RPC endpoint
+
 ### Fixes
 
 - [#6891](https://github.com/blockscout/blockscout/pull/6891) - Fix read contract for geth

--- a/apps/explorer/config/dev/arbitrum.exs
+++ b/apps/explorer/config/dev/arbitrum.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/arbitrum.exs
+++ b/apps/explorer/config/dev/arbitrum.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/arbitrum.exs
+++ b/apps/explorer/config/dev/arbitrum.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/arbitrum.exs
+++ b/apps/explorer/config/prod/arbitrum.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/arbitrum.exs
+++ b/apps/explorer/config/prod/arbitrum.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/arbitrum.exs
+++ b/apps/explorer/config/prod/arbitrum.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :explorer,
   json_rpc_named_arguments: [

--- a/apps/indexer/config/dev/arbitrum.exs
+++ b/apps/indexer/config/dev/arbitrum.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/arbitrum.exs
+++ b/apps/indexer/config/dev/arbitrum.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/arbitrum.exs
+++ b/apps/indexer/config/dev/arbitrum.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +22,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Arbitrum
   ],

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -17,7 +28,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -17,7 +28,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +22,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -17,7 +28,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Nethermind
   ],
@@ -33,7 +44,7 @@ config :indexer,
   #         trace_block: System.get_env("ETHEREUM_JSONRPC_REALTIME_TRACE_URL") || "http://localhost:8545",
   #         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_REALTIME_TRACE_URL") || "http://localhost:8545"
   #       ],
-  #       http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+  #       http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
   #     ],
   #     variant: EthereumJSONRPC.Nethermind
   #   ]

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   blocks_concurrency: 1,
@@ -18,7 +29,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
         trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/indexer/config/prod/arbitrum.exs
+++ b/apps/indexer/config/prod/arbitrum.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/arbitrum.exs
+++ b/apps/indexer/config/prod/arbitrum.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/arbitrum.exs
+++ b/apps/indexer/config/prod/arbitrum.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +22,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      http_options: [recv_timeout: :timer.minutes(5), timeout: :timer.minutes(5), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(5), timeout: :timer.minutes(5), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Arbitrum
   ],

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -16,7 +27,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -16,7 +27,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -11,7 +22,7 @@ config :indexer,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(1), timeout: :timer.minutes(1), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Ganache
   ],

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,13 +1,15 @@
 import Config
 
-hackney_opts_base = [pool: :ethereum_jsonrpc]
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
 
 hackney_opts =
-  if System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true" do
-    [:insecure] ++ hackney_opts_base
-  else
-    hackney_opts_base
-  end
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   json_rpc_named_arguments: [
@@ -16,7 +27,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -1,12 +1,12 @@
 import Config
 
 basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
 hackney_opts =
   [pool: :ethereum_jsonrpc]
   |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
         do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
         else: &1
       )).()

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -1,15 +1,10 @@
 import Config
 
-basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+~w(config config_helper.exs)
+|> Path.join()
+|> Code.eval_file()
 
-hackney_opts =
-  [pool: :ethereum_jsonrpc]
-  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
-  |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-        else: &1
-      )).()
+hackney_opts = ConfigHelper.hackney_options()
 
 config :indexer,
   block_interval: :timer.seconds(5),

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -1,5 +1,16 @@
 import Config
 
+basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", "")
+
+hackney_opts =
+  [pool: :ethereum_jsonrpc]
+  |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+  |> (&if(basic_auth_user != "" && basic_auth_pass != "",
+        do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+        else: &1
+      )).()
+
 config :indexer,
   block_interval: :timer.seconds(5),
   blocks_concurrency: 1,
@@ -18,7 +29,7 @@ config :indexer,
         trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
         trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
-      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: [pool: :ethereum_jsonrpc]]
+      http_options: [recv_timeout: :timer.minutes(10), timeout: :timer.minutes(10), hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -1,0 +1,14 @@
+defmodule ConfigHelper do
+  def hackney_options() do
+    basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+    basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+
+    hackney_opts =
+      [pool: :ethereum_jsonrpc]
+      |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+      |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
+            do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+            else: &1
+          )).()
+  end
+end

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -71,7 +71,7 @@ end
 # will be used by default
 
 release :blockscout do
-  set version: "1.2.0-beta"
+  set version: "5.1.0-beta"
   set applications: [
     :runtime_tools,
     block_scout_web: :permanent,


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/3501

## Motivation

Blockscout doesn't support JSON RPC endpoints with basic auth.

## Changelog

Support basic auth in JSON RPC endpoints by adding hackney params: `[basic_auth: {"user", "pass"}]`.
`ETHEREUM_JSONRPC_USER ` and `ETHEREUM_JSONRPC_PASSWORD` are for basic auth management.

Docs update in https://github.com/blockscout/docs/pull/114.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
