### PR TITLE
Increase verification timeout to 120 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Chore
 
+- [#6902](https://github.com/blockscout/blockscout/pull/6902) - Increase verification timeout to 120 seconds for microservice verification
+
 <details>
   <summary>Dependencies version bumps</summary>
 </details>

--- a/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface.ex
@@ -6,7 +6,7 @@ defmodule Explorer.SmartContract.RustVerifierInterface do
   alias HTTPoison.Response
   require Logger
 
-  @post_timeout :timer.seconds(30)
+  @post_timeout :timer.seconds(120)
   @request_error_msg "Error while sending request to verification microservice"
 
   def verify_multi_part(


### PR DESCRIPTION
## Motivation
Some heavy contracts consume more than 30 seconds for verification.

## Changelog
- Increase verification timeout to 120 seconds

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
