### PR TITLE
Fix indexed blocks value in "Indexing tokens" banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#6912](https://github.com/blockscout/blockscout/pull/6912) - Docker compose fix exposed ports
 - [#6911](https://github.com/blockscout/blockscout/pull/6911) - Fix bugs in verification API v2
+- [#6903](https://github.com/blockscout/blockscout/pull/6903) - Fix indexed blocks value in "Indexing tokens" banner
 - [#6891](https://github.com/blockscout/blockscout/pull/6891) - Fix read contract for geth
 - [#6889](https://github.com/blockscout/blockscout/pull/6889) - Fix Internal Server Error on tx input decoding
 - [#6893](https://github.com/blockscout/blockscout/pull/6893) - Fix token type definition for multiple interface tokens

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -77,6 +77,8 @@ defmodule Explorer.Chain do
     VerifiedContractsCounter
   }
 
+  alias Explorer.Chain.Cache.Block, as: BlockCache
+
   alias Explorer.Chain.Import.Runner
   alias Explorer.Chain.InternalTransaction.{CallType, Type}
 
@@ -2209,13 +2211,6 @@ defmodule Explorer.Chain do
   @doc """
   The percentage of indexed blocks on the chain.
 
-      iex> for index <- 5..9 do
-      ...>   insert(:block, number: index)
-      ...>   Process.sleep(200)
-      ...> end
-      iex> Explorer.Chain.indexed_ratio_blocks()
-      Decimal.new(1, 50, -2)
-
   If there are no blocks, the percentage is 0.
 
       iex> Explorer.Chain.indexed_ratio_blocks()
@@ -2237,7 +2232,7 @@ defmodule Explorer.Chain do
         Decimal.new(0)
 
       _ ->
-        result = Decimal.div(max - min + 1, max - min_blockchain_block_number + 1)
+        result = Decimal.div(BlockCache.estimated_count(), max - min_blockchain_block_number + 1)
 
         result
         |> Decimal.round(2, :down)

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -3,8 +3,6 @@ defmodule Explorer.Chain.Cache.Block do
   Cache for block count.
   """
 
-  @default_cache_period :timer.hours(2)
-
   import Ecto.Query,
     only: [
       from: 2
@@ -14,7 +12,7 @@ defmodule Explorer.Chain.Cache.Block do
     name: :block_count,
     key: :count,
     key: :async_task,
-    global_ttl: cache_period(),
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
     ttl_check_interval: :timer.minutes(15),
     callback: &async_task_on_deletion(&1)
 
@@ -77,16 +75,6 @@ defmodule Explorer.Chain.Cache.Block do
   defp async_task_on_deletion({:delete, _, :count}), do: get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
-
-  defp cache_period do
-    "CACHE_BLOCK_COUNT_PERIOD"
-    |> System.get_env("")
-    |> Integer.parse()
-    |> case do
-      {integer, ""} -> :timer.seconds(integer)
-      _ -> @default_cache_period
-    end
-  end
 
   @spec fetch_count_consensus_block() :: non_neg_integer
   defp fetch_count_consensus_block do

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -17,8 +17,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
 
   alias Explorer.Repo
 
-  @default_cache_period :timer.seconds(30)
-
   @num_of_blocks (case Integer.parse(System.get_env("GAS_PRICE_ORACLE_NUM_OF_BLOCKS", "200")) do
                     {integer, ""} -> integer
                     _ -> 200
@@ -43,7 +41,7 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
     name: :gas_price,
     key: :gas_prices,
     key: :async_task,
-    global_ttl: cache_period(),
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
     ttl_check_interval: :timer.minutes(5),
     callback: &async_task_on_deletion(&1)
 
@@ -155,14 +153,4 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
   defp async_task_on_deletion({:delete, _, :gas_prices}), do: get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
-
-  defp cache_period do
-    "GAS_PRICE_ORACLE_CACHE_PERIOD"
-    |> System.get_env("")
-    |> Integer.parse()
-    |> case do
-      {integer, ""} -> :timer.seconds(integer)
-      _ -> @default_cache_period
-    end
-  end
 end

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -3,13 +3,11 @@ defmodule Explorer.Chain.Cache.Transaction do
   Cache for estimated transaction count.
   """
 
-  @default_cache_period :timer.hours(2)
-
   use Explorer.Chain.MapCache,
     name: :transaction_count,
     key: :count,
     key: :async_task,
-    global_ttl: cache_period(),
+    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
     ttl_check_interval: :timer.minutes(15),
     callback: &async_task_on_deletion(&1)
 
@@ -74,14 +72,4 @@ defmodule Explorer.Chain.Cache.Transaction do
   defp async_task_on_deletion({:delete, _, :count}), do: get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
-
-  defp cache_period do
-    "CACHE_TXS_COUNT_PERIOD"
-    |> System.get_env("")
-    |> Integer.parse()
-    |> case do
-      {integer, ""} -> :timer.seconds(integer)
-      _ -> @default_cache_period
-    end
-  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -28,6 +28,7 @@ defmodule Explorer.ChainTest do
   }
 
   alias Explorer.{Chain, Etherscan}
+  alias Explorer.Chain.Cache.Block, as: BlockCache
   alias Explorer.Chain.Cache.Transaction, as: TransactionCache
   alias Explorer.Chain.InternalTransaction.Type
 
@@ -1475,6 +1476,9 @@ defmodule Explorer.ChainTest do
 
   describe "indexed_ratio_blocks/0" do
     setup do
+      Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Block.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Block.child_id())
+
       on_exit(fn ->
         Application.put_env(:indexer, :first_block, "")
       end)
@@ -1482,8 +1486,10 @@ defmodule Explorer.ChainTest do
 
     test "returns indexed ratio" do
       for index <- 5..9 do
-        insert(:block, number: index)
+        insert(:block, number: index, consensus: true)
       end
+
+      BlockCache.estimated_count()
 
       assert Decimal.compare(Chain.indexed_ratio_blocks(), Decimal.from_float(0.5)) == :eq
     end
@@ -1494,9 +1500,11 @@ defmodule Explorer.ChainTest do
 
     test "returns 1.0 if fully indexed blocks" do
       for index <- 0..9 do
-        insert(:block, number: index)
+        insert(:block, number: index, consensus: true)
         Process.sleep(200)
       end
+
+      BlockCache.estimated_count()
 
       assert Decimal.compare(Chain.indexed_ratio_blocks(), 1) == :eq
     end
@@ -1505,9 +1513,11 @@ defmodule Explorer.ChainTest do
       Application.put_env(:indexer, :first_block, "5")
 
       for index <- 5..9 do
-        insert(:block, number: index)
+        insert(:block, number: index, consensus: true)
         Process.sleep(200)
       end
+
+      BlockCache.estimated_count()
 
       assert Decimal.compare(Chain.indexed_ratio_blocks(), 1) == :eq
     end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -255,6 +255,42 @@ config :explorer, Explorer.Chain.Cache.AddressSum, global_ttl: address_sum_globa
 
 config :explorer, Explorer.Chain.Cache.AddressSumMinusBurnt, global_ttl: address_sum_global_ttl
 
+block_count_global_ttl =
+  "CACHE_BLOCK_COUNT_PERIOD"
+  |> System.get_env("")
+  |> Integer.parse()
+  |> case do
+    {integer, ""} -> integer
+    _ -> 7200
+  end
+  |> :timer.seconds()
+
+config :explorer, Explorer.Chain.Cache.Block, global_ttl: block_count_global_ttl
+
+transaction_count_global_ttl =
+  "CACHE_TXS_COUNT_PERIOD"
+  |> System.get_env("")
+  |> Integer.parse()
+  |> case do
+    {integer, ""} -> integer
+    _ -> 7200
+  end
+  |> :timer.seconds()
+
+config :explorer, Explorer.Chain.Cache.Transaction, global_ttl: transaction_count_global_ttl
+
+gas_price_oracle_global_ttl =
+  "GAS_PRICE_ORACLE_CACHE_PERIOD"
+  |> System.get_env("")
+  |> Integer.parse()
+  |> case do
+    {integer, ""} -> integer
+    _ -> 30
+  end
+  |> :timer.seconds()
+
+config :explorer, Explorer.Chain.Cache.GasPriceOracle, global_ttl: gas_price_oracle_global_ttl
+
 config :explorer, Explorer.ExchangeRates,
   store: :ets,
   enabled: System.get_env("DISABLE_EXCHANGE_RATES") != "true",


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/6899

## Motivation

Inaccurate calculation of indexed blocks.

## Changelog

Rely on  actual `BlockCache.estimated_count()` in calculation rather than `max - min` since not all blocks can be indexed in the range.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
