### PR TITLE
Fix bugs in verification API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#6912](https://github.com/blockscout/blockscout/pull/6912) - Docker compose fix exposed ports
+- [#6911](https://github.com/blockscout/blockscout/pull/6911) - Fix bugs in verification API v2
 - [#6891](https://github.com/blockscout/blockscout/pull/6891) - Fix read contract for geth
 - [#6889](https://github.com/blockscout/blockscout/pull/6889) - Fix Internal Server Error on tx input decoding
 - [#6893](https://github.com/blockscout/blockscout/pull/6893) - Fix token type definition for multiple interface tokens

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/verification_controller.ex
@@ -113,7 +113,10 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
          files_content <- PublishHelper.read_files(files_array) do
       chosen_contract = params["chosen_contract_index"]
 
-      Que.add(SolidityPublisherWorker, {"sourcify_api_v2", address_hash_string, files_content, conn, chosen_contract})
+      Que.add(
+        SolidityPublisherWorker,
+        {"sourcify_api_v2", String.downcase(address_hash_string), files_content, conn, chosen_contract}
+      )
 
       conn
       |> put_view(ApiView)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
@@ -183,7 +183,7 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
 
       _contract = insert(:address, hash: address, contract_code: "0x01")
 
-      topic = "addresses:#{address}"
+      topic = "addresses:#{String.downcase(address)}"
 
       {:ok, _reply, _socket} =
         UserSocketV2

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publish_helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publish_helper.ex
@@ -94,15 +94,29 @@ defmodule Explorer.SmartContract.Solidity.PublishHelper do
 
   def get_one_json(files_array) do
     files_array
-    |> Enum.filter(fn file -> file.content_type == "application/json" end)
+    |> Enum.filter(fn file ->
+      case file do
+        %Plug.Upload{content_type: content_type} ->
+          content_type == "application/json"
+
+        _ ->
+          false
+      end
+    end)
     |> Enum.at(0)
   end
 
   # sobelow_skip ["Traversal.FileModule"]
   def read_files(plug_uploads) do
-    Enum.reduce(plug_uploads, %{}, fn %Plug.Upload{path: path, filename: file_name}, acc ->
-      {:ok, file_content} = File.read(path)
-      Map.put(acc, file_name, file_content)
+    Enum.reduce(plug_uploads, %{}, fn file, acc ->
+      case file do
+        %Plug.Upload{path: path, filename: file_name} ->
+          {:ok, file_content} = File.read(path)
+          Map.put(acc, file_name, file_content)
+
+        _ ->
+          acc
+      end
     end)
   end
 


### PR DESCRIPTION
## Motivation
There was some bugs in API v2 `/verification`:
1. Missed `String.downcase()` in sourcify verification
2.  
  ```
  2023-02-16T10:52:42.834 [error] #PID<0.1751.0> running BlockScoutWeb.Endpoint (connection #PID<0.1750.0>, stream id 1) terminated
  Server: localhost:80 (http)
  Request: POST /api/v2/smart-contracts/0x030f7c7dbd472864220bcf9e37ede1b8a3125970/verification/via/sourcify
  ** (exit) an exception was raised:
      ** (KeyError) key :content_type not found in: "". If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
          (explorer 5.1.0) lib/explorer/smart_contract/solidity/publish_helper.ex:97: anonymous fn/1 in Explorer.SmartContract.Solidity.PublishHelper.get_one_json/1
          (elixir 1.14.3) lib/enum.ex:4197: Enum.filter_list/2
          (explorer 5.1.0) lib/explorer/smart_contract/solidity/publish_helper.ex:97: Explorer.SmartContract.Solidity.PublishHelper.get_one_json/1
          (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:118: BlockScoutWeb.API.V2.VerificationController.verification_via_sourcify/2
          (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:1: BlockScoutWeb.API.V2.VerificationController.action/2
          (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:1: BlockScoutWeb.API.V2.VerificationController.phoenix_controller_pipeline/2
          (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
          (phoenix 1.5.13) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
          (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
          (phoenix 1.5.13) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
          (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
          (block_scout_web 5.1.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
          (block_scout_web 5.1.0) lib/plug/debugger.ex:136: BlockScoutWeb.Endpoint."call (overridable 3)"/2
          (block_scout_web 5.1.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
          (block_scout_web 5.1.0) lib/spandex_phoenix.ex:151: BlockScoutWeb.Endpoint.call/2
          (phoenix 1.5.13) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
          (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
          (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
          (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
          (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
  
  ``` 
3. 
```
2023-02-16T11:36:45.793 [error] #PID<0.1686.0> running BlockScoutWeb.Endpoint (connection #PID<0.1685.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: POST /api/v2/smart-contracts/0x030f7c7dbd472864220bcf9e37ede1b8a3125970/verification/via/multi-part
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Explorer.SmartContract.Solidity.PublishHelper.read_files/1
        (explorer 5.1.0) lib/explorer/smart_contract/solidity/publish_helper.ex:111: anonymous fn("", %{}) in Explorer.SmartContract.Solidity.PublishHelper.read_files/1
        (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
        (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:153: BlockScoutWeb.API.V2.VerificationController.verification_via_multi_part/2
        (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:1: BlockScoutWeb.API.V2.VerificationController.action/2
        (block_scout_web 5.1.0) lib/block_scout_web/controllers/api/v2/verification_controller.ex:1: BlockScoutWeb.API.V2.VerificationController.phoenix_controller_pipeline/2
        (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.13) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.13) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.13) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 5.1.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 5.1.0) lib/plug/debugger.ex:136: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 5.1.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 5.1.0) lib/spandex_phoenix.ex:151: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.13) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:306: :cowboy_stream_h.execute/3
        (cowboy 2.9.0) /Users/nikitosing/work/blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:295: :cowboy_stream_h.request_process/3
        (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
