### PR TITLE
Docker compose fix exposed ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- [#6912](https://github.com/blockscout/blockscout/pull/6912) - Docker compose fix exposed ports
 - [#6891](https://github.com/blockscout/blockscout/pull/6891) - Fix read contract for geth
 - [#6889](https://github.com/blockscout/blockscout/pull/6889) - Fix Internal Server Error on tx input decoding
 - [#6893](https://github.com/blockscout/blockscout/pull/6893) - Fix token type definition for multiple interface tokens

--- a/docker-compose/services/docker-compose-sig-provider.yml
+++ b/docker-compose/services/docker-compose-sig-provider.yml
@@ -8,4 +8,4 @@ services:
     restart: always
     container_name: 'sig-provider'
     ports:
-      - 8051:8050
+      - 8151:8050

--- a/docker-compose/services/docker-compose-smart-contract-verifier.yml
+++ b/docker-compose/services/docker-compose-smart-contract-verifier.yml
@@ -10,4 +10,4 @@ services:
     env_file:
       -  ../envs/common-smart-contract-verifier.env
     ports:
-      - 8050:8050
+      - 8150:8050

--- a/docker-compose/services/docker-compose-visualizer.yml
+++ b/docker-compose/services/docker-compose-visualizer.yml
@@ -10,4 +10,4 @@ services:
     env_file:
       -  ../envs/common-visualizer.env
     ports:
-      - 8050:8050
+      - 8152:8050


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6910

## Motivation

Exposed ports for sc-verifier and visualiser services are the same.

## Changelog

Expose different ports for Rust microservices.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
