### PR TITLE
Extend `INDEXER_MEMORY_LIMIT` env parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Chore
 
+- [#6929](https://github.com/blockscout/blockscout/pull/6929) - Extend `INDEXER_MEMORY_LIMIT` env parsing
 - [#6902](https://github.com/blockscout/blockscout/pull/6902) - Increase verification timeout to 120 seconds for microservice verification
 
 <details>

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -7,14 +7,16 @@ indexer_memory_limit_default = 1
 indexer_memory_limit =
   "INDEXER_MEMORY_LIMIT"
   |> System.get_env(to_string(indexer_memory_limit_default))
+  |> String.downcase()
   |> Integer.parse()
   |> case do
-    {integer, ""} -> integer
-    _ -> indexer_memory_limit_default
+    {integer, g} when g in ["g", "gb", ""] -> integer <<< 30
+    {integer, m} when m in ["m", "mb"] -> integer <<< 20
+    _ -> indexer_memory_limit_default <<< 30
   end
 
 config :indexer,
-  memory_limit: indexer_memory_limit <<< 30
+  memory_limit: indexer_memory_limit
 
 indexer_empty_blocks_sanitizer_batch_size_default = 100
 


### PR DESCRIPTION
## Motivation

It's not obvious that value of `INDEXER_MEMORY_LIMIT` must be a single number (https://discord.com/channels/973915550965174292/992040622254997566/1072857553622540399)

## Changelog

Added possibility to set `INDEXER_MEMORY_LIMIT` with suffixes like `gb`, `g`, `mb`, `m` independently of letter case. With no suffix interpreted as gb as it was.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. (https://github.com/blockscout/docs/pull/119)
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
