### PR TITLE
Reduce ttl_check_interval for cache modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- [#6940](https://github.com/blockscout/blockscout/pull/6940) - Reduce ttl_check_interval for cache module
 - [#6912](https://github.com/blockscout/blockscout/pull/6912) - Docker compose fix exposed ports
 - [#6913](https://github.com/blockscout/blockscout/pull/6913) - Fix an error occurred when decoding base64 encoded json
 - [#6911](https://github.com/blockscout/blockscout/pull/6911) - Fix bugs in verification API v2

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -13,7 +13,7 @@ defmodule Explorer.Chain.Cache.Block do
     key: :count,
     key: :async_task,
     global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
-    ttl_check_interval: :timer.minutes(15),
+    ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
   require Logger

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -42,7 +42,7 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
     key: :gas_prices,
     key: :async_task,
     global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
-    ttl_check_interval: :timer.minutes(5),
+    ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
   def get_average_gas_price(num_of_blocks, safelow_percentile, average_percentile, fast_percentile) do

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.Cache.GasUsage do
     key: :sum,
     key: :async_task,
     global_ttl: cache_period(),
-    ttl_check_interval: :timer.minutes(15),
+    ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
   alias Explorer.Chain.Transaction

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Cache.Transaction do
     key: :count,
     key: :async_task,
     global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
-    ttl_check_interval: :timer.minutes(15),
+    ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
   require Logger


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6934

## Motivation

`CACHE_BLOCK_COUNT_PERIOD` is not actually period of update of "Block counter" cache because of higher `ttl_check_interval`.

## Changelog

Reduce `ttl_check_interval` to 1 sec for all cache modules, where it is set to > 1 min.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
