### PR TITLE
Update NETWORK_PATH env usage to use runtime env

### DIFF
--- a/apps/block_scout_web/assets/js/lib/autocomplete.js
+++ b/apps/block_scout_web/assets/js/lib/autocomplete.js
@@ -145,7 +145,9 @@ const autoCompleteJSMobile = document.querySelector('#main-search-autocomplete-m
 const selection = (event) => {
   const selectionValue = event.detail.selection.value
 
-  const commonPath = process.env.NETWORK_PATH
+  const pathObj = document.getElementById('network-path')
+  // @ts-ignore
+  const commonPath = (pathObj && pathObj.value) || ''
 
   if (selectionValue.type === 'contract' || selectionValue.type === 'address' || selectionValue.type === 'label') {
     window.location.href = `${commonPath}/address/${selectionValue.address_hash}`

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -74,7 +74,10 @@ if ($('[data-page="address-logs"]').length) {
     const topic = $('[data-search-field]').val()
     const addressHashPlain = store.getState().addressHash
     const addressHashChecksum = addressHashPlain && utils.toChecksumAddress(addressHashPlain)
-    const path = `${process.env.NETWORK_PATH}/search-logs?topic=${topic}&address_id=${addressHashChecksum}`
+    const pathObj = document.getElementById('network-path')
+    // @ts-ignore
+    const commonPath = (pathObj && pathObj.value) || ''
+    const path = `${commonPath}/search-logs?topic=${topic}&address_id=${addressHashChecksum}`
     loadPage(store, path)
   }
 

--- a/apps/block_scout_web/assets/js/pages/layout.js
+++ b/apps/block_scout_web/assets/js/pages/layout.js
@@ -174,8 +174,12 @@ const search = (value) => {
 
   analytics.trackEvent(eventName, eventProperties)
 
+  const pathObj = document.getElementById('network-path')
+  // @ts-ignore
+  const path = (pathObj && pathObj.value) || ''
+
   if (value) {
-    window.location.href = `${process.env.NETWORK_PATH}/search?q=${value}`
+    window.location.href = `${path}/search?q=${value}`
   }
 }
 

--- a/apps/block_scout_web/assets/js/pages/transaction.js
+++ b/apps/block_scout_web/assets/js/pages/transaction.js
@@ -110,7 +110,10 @@ if ($transactionDetailsPage.length) {
           params: [txParams]
         })
           .then(function (txHash) {
-            const successMsg = `<a href="${process.env.NETWORK_PATH}/tx/${txHash}">Canceling transaction</a> successfully sent to the network. The current one will change the status once canceling transaction will be confirmed.`
+            const pathObj = document.getElementById('network-path')
+            // @ts-ignore
+            const path = (pathObj && pathObj.value) || ''
+            const successMsg = `<a href="${path}/tx/${txHash}">Canceling transaction</a> successfully sent to the network. The current one will change the status once canceling transaction will be confirmed.`
             Swal.fire({
               title: 'Success',
               html: successMsg,


### PR DESCRIPTION
## Motivation
At the moment we cannot use `NETWORK_PATH` env in some places in the UI, it leads to situations when search, for instance, points to url like this `.../undefined/address/...`

## Changelog
Update `NETWORK_PATH` env usage in the UI

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
