### PR TITLE
Change tx actions warning importance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#6987](https://github.com/blockscout/blockscout/pull/6987) - Change tx actions warning importance
+
 <details>
   <summary>Dependencies version bumps</summary>
 </details>
@@ -40,7 +42,6 @@
 
 ### Chore
 
-- [#6987](https://github.com/blockscout/blockscout/pull/6987) - Change tx actions warning importance
 - [#6981](https://github.com/blockscout/blockscout/pull/6981) - Token instance fetcher batch size and concurrency env vars
 - [#6954](https://github.com/blockscout/blockscout/pull/6954), [#6979](https://github.com/blockscout/blockscout/pull/6979) - Move some compile time vars to runtime
 - [#6952](https://github.com/blockscout/blockscout/pull/6952) - Manage BlockReward fetcher params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Chore
 
+- [#6987](https://github.com/blockscout/blockscout/pull/6987) - Change tx actions warning importance
 - [#6981](https://github.com/blockscout/blockscout/pull/6981) - Token instance fetcher batch size and concurrency env vars
 - [#6954](https://github.com/blockscout/blockscout/pull/6954), [#6979](https://github.com/blockscout/blockscout/pull/6979) - Move some compile time vars to runtime
 - [#6952](https://github.com/blockscout/blockscout/pull/6952) - Manage BlockReward fetcher params

--- a/apps/indexer/lib/indexer/fetcher/transaction_action.ex
+++ b/apps/indexer/lib/indexer/fetcher/transaction_action.ex
@@ -191,41 +191,41 @@ defmodule Indexer.Fetcher.TransactionAction do
     first_block = parse_integer(first_block)
     last_block = parse_integer(last_block)
 
-    cond do
-      is_nil(first_block) or is_nil(last_block) or first_block <= 0 or last_block <= 0 or first_block > last_block ->
-        {:stop, "Correct block range must be provided to #{__MODULE__}."}
+    if is_nil(first_block) or is_nil(last_block) or first_block <= 0 or last_block <= 0 or first_block > last_block do
+      {:stop, "Correct block range must be provided to #{__MODULE__}."}
+    else
+      max_block_number = Chain.fetch_max_block_number()
 
-      true ->
-        if last_block > (max_block_number = Chain.fetch_max_block_number()) do
-          Logger.warning(
-            "Note, that the last block number (#{last_block}) provided to #{__MODULE__} exceeds max block number available in DB (#{max_block_number})."
-          )
-        end
+      if last_block > max_block_number do
+        Logger.warning(
+          "Note, that the last block number (#{last_block}) provided to #{__MODULE__} exceeds max block number available in DB (#{max_block_number})."
+        )
+      end
 
-        supported_protocols =
-          TransactionAction.supported_protocols()
-          |> Enum.map(&Atom.to_string(&1))
+      supported_protocols =
+        TransactionAction.supported_protocols()
+        |> Enum.map(&Atom.to_string(&1))
 
-        protocols =
-          opts
-          |> Keyword.get(:reindex_protocols, "")
-          |> String.trim()
-          |> String.split(",")
-          |> Enum.map(&String.trim(&1))
-          |> Enum.filter(&Enum.member?(supported_protocols, &1))
+      protocols =
+        opts
+        |> Keyword.get(:reindex_protocols, "")
+        |> String.trim()
+        |> String.split(",")
+        |> Enum.map(&String.trim(&1))
+        |> Enum.filter(&Enum.member?(supported_protocols, &1))
 
-        next_block = get_next_block(first_block, last_block, protocols)
+      next_block = get_next_block(first_block, last_block, protocols)
 
-        state =
-          %__MODULE__{
-            first_block: first_block,
-            next_block: next_block,
-            last_block: last_block,
-            protocols: protocols
-          }
-          |> run_fetch()
+      state =
+        %__MODULE__{
+          first_block: first_block,
+          next_block: next_block,
+          last_block: last_block,
+          protocols: protocols
+        }
+        |> run_fetch()
 
-        {:ok, state}
+      {:ok, state}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/transaction_action.ex
+++ b/apps/indexer/lib/indexer/fetcher/transaction_action.ex
@@ -195,11 +195,13 @@ defmodule Indexer.Fetcher.TransactionAction do
       is_nil(first_block) or is_nil(last_block) or first_block <= 0 or last_block <= 0 or first_block > last_block ->
         {:stop, "Correct block range must be provided to #{__MODULE__}."}
 
-      last_block > (max_block_number = Chain.fetch_max_block_number()) ->
-        {:stop,
-         "The last block number (#{last_block}) provided to #{__MODULE__} is incorrect as it exceeds max block number available in DB (#{max_block_number})."}
-
       true ->
+        if last_block > (max_block_number = Chain.fetch_max_block_number()) do
+          Logger.warning(
+            "Note, that the last block number (#{last_block}) provided to #{__MODULE__} exceeds max block number available in DB (#{max_block_number})."
+          )
+        end
+
         supported_protocols =
           TransactionAction.supported_protocols()
           |> Enum.map(&Atom.to_string(&1))


### PR DESCRIPTION
## Motivation

The current implementation doesn't allow setting `INDEXER_TX_ACTIONS_REINDEX_LAST_BLOCK` to the block that is not yet indexed. This PR fixes it.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
