### PR TITLE
Take into account batch ERC-1155 transfers while paginating token tra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#6990](https://github.com/blockscout/blockscout/pull/6990) - Improved http requests logging, batch transfers pagination; New API v2 endpoint `/smart-contracts/counters`; And some refactoring
+
 ### Fixes
 
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link

--- a/apps/block_scout_web/.sobelow-conf
+++ b/apps/block_scout_web/.sobelow-conf
@@ -7,7 +7,6 @@
   format: "compact",
   ignore: ["Config.Headers", "Config.CSWH", "XSS.SendResp", "XSS.Raw"],
   ignore_files: [
-    "apps/block_scout_web/lib/block_scout_web/views/tokens/instance/overview_view.ex",
     "apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex"
   ]
 ]

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -48,6 +48,22 @@ config :logger, :block_scout_web,
        block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :block_scout_web]
 
+config :logger, :api,
+  # keep synced with `config/config.exs`
+  format: "$dateT$time $metadata[$level] $message\n",
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count shrunk import_id transaction_id)a,
+  metadata_filter: [application: :api]
+
+config :logger, :api_v2,
+  # keep synced with `config/config.exs`
+  format: "$dateT$time $metadata[$level] $message\n",
+  metadata:
+    ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count
+       block_number step count error_count shrunk import_id transaction_id)a,
+  metadata_filter: [application: :api_v2]
+
 config :prometheus, BlockScoutWeb.Prometheus.Instrumenter,
   # override default for Phoenix 1.4 compatibility
   # * `:transport_name` to `:transport`

--- a/apps/block_scout_web/config/dev.exs
+++ b/apps/block_scout_web/config/dev.exs
@@ -57,7 +57,12 @@ config :logger, :block_scout_web,
 config :logger, :api,
   level: :debug,
   path: Path.absname("logs/dev/api.log"),
-  metadata_filter: [fetcher: :api]
+  metadata_filter: [application: :api]
+
+config :logger, :api_v2,
+  level: :debug,
+  path: Path.absname("logs/dev/api_v2.log"),
+  metadata_filter: [application: :api_v2]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/apps/block_scout_web/config/prod.exs
+++ b/apps/block_scout_web/config/prod.exs
@@ -27,7 +27,13 @@ config :logger, :block_scout_web,
 config :logger, :api,
   level: :debug,
   path: Path.absname("logs/prod/api.log"),
-  metadata_filter: [fetcher: :api],
+  metadata_filter: [application: :api],
+  rotate: %{max_bytes: 52_428_800, keep: 19}
+
+config :logger, :api_v2,
+  level: :debug,
+  path: Path.absname("logs/prod/api_v2.log"),
+  metadata_filter: [application: :api_v2],
   rotate: %{max_bytes: 52_428_800, keep: 19}
 
 config :block_scout_web, :captcha_helper, BlockScoutWeb.CaptchaHelper

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -20,6 +20,7 @@ defmodule BlockScoutWeb.ApiRouter do
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(BlockScoutWeb.Plug.Logger, application: :api)
   end
 
   pipeline :account_api do
@@ -29,9 +30,11 @@ defmodule BlockScoutWeb.ApiRouter do
   end
 
   pipeline :api_v2 do
+    plug(:accepts, ["json"])
     plug(CheckApiV2)
     plug(:fetch_session)
     plug(:protect_from_forgery)
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
   end
 
   alias BlockScoutWeb.Account.Api.V1.{TagsController, UserController}
@@ -93,7 +96,6 @@ defmodule BlockScoutWeb.ApiRouter do
   end
 
   scope "/v2", as: :api_v2 do
-    pipe_through(:api)
     pipe_through(:api_v2)
 
     alias BlockScoutWeb.API.V2

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -477,9 +477,9 @@ defmodule BlockScoutWeb.Chain do
     Map.merge(params, paging_params(List.last(list)))
   end
 
-  def token_tranfers_next_page_params([], _list, _params), do: nil
+  def token_transfers_next_page_params([], _list, _params), do: nil
 
-  def token_tranfers_next_page_params(next_page, list, params) do
+  def token_transfers_next_page_params(next_page, list, params) do
     next_token_transfer = List.first(next_page)
     current_token_transfer = List.last(list)
 
@@ -488,7 +488,7 @@ defmodule BlockScoutWeb.Chain do
          next_token_transfer.transaction_hash == current_token_transfer.transaction_hash do
       new_params =
         list
-        |> last_token_trasfer_before_current(current_token_transfer)
+        |> last_token_transfer_before_current(current_token_transfer)
         |> (&if(is_nil(&1), do: %{}, else: paging_params(&1))).()
 
       params
@@ -504,7 +504,7 @@ defmodule BlockScoutWeb.Chain do
     end
   end
 
-  defp last_token_trasfer_before_current(list, current_token_transfer) do
+  defp last_token_transfer_before_current(list, current_token_transfer) do
     Enum.reduce_while(list, nil, fn tt, acc ->
       if tt.log_index == current_token_transfer.log_index and tt.block_hash == current_token_transfer.block_hash and
            tt.transaction_hash == current_token_transfer.transaction_hash do

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -163,6 +163,55 @@ defmodule BlockScoutWeb.Chain do
     end
   end
 
+  def paging_options(%{
+        "block_number" => block_number_string,
+        "index" => index_string,
+        "batch_log_index" => batch_log_index_string,
+        "batch_block_hash" => batch_block_hash_string,
+        "batch_transaction_hash" => batch_transaction_hash_string,
+        "index_in_batch" => index_in_batch_string
+      }) do
+    with {block_number, ""} <- Integer.parse(block_number_string),
+         {index, ""} <- Integer.parse(index_string),
+         {index_in_batch, ""} <- Integer.parse(index_in_batch_string),
+         {:ok, batch_transaction_hash} <- string_to_transaction_hash(batch_transaction_hash_string),
+         {:ok, batch_block_hash} <- string_to_block_hash(batch_block_hash_string),
+         {batch_log_index, ""} <- Integer.parse(batch_log_index_string) do
+      [
+        paging_options: %{
+          @default_paging_options
+          | key: {block_number, index},
+            batch_key: {batch_block_hash, batch_transaction_hash, batch_log_index, index_in_batch}
+        }
+      ]
+    else
+      _ ->
+        [paging_options: @default_paging_options]
+    end
+  end
+
+  def paging_options(%{
+        "batch_log_index" => batch_log_index_string,
+        "batch_block_hash" => batch_block_hash_string,
+        "batch_transaction_hash" => batch_transaction_hash_string,
+        "index_in_batch" => index_in_batch_string
+      }) do
+    with {index_in_batch, ""} <- Integer.parse(index_in_batch_string),
+         {:ok, batch_transaction_hash} <- string_to_transaction_hash(batch_transaction_hash_string),
+         {:ok, batch_block_hash} <- string_to_block_hash(batch_block_hash_string),
+         {batch_log_index, ""} <- Integer.parse(batch_log_index_string) do
+      [
+        paging_options: %{
+          @default_paging_options
+          | batch_key: {batch_block_hash, batch_transaction_hash, batch_log_index, index_in_batch}
+        }
+      ]
+    else
+      _ ->
+        [paging_options: @default_paging_options]
+    end
+  end
+
   def paging_options(%{"block_number" => block_number_string, "index" => index_string}) do
     with {block_number, ""} <- Integer.parse(block_number_string),
          {index, ""} <- Integer.parse(index_string) do
@@ -364,6 +413,7 @@ defmodule BlockScoutWeb.Chain do
     %{"smart_contract_id" => smart_contract.id}
   end
 
+  # clause for search results pagination
   defp paging_params(%{
          address_hash: address_hash,
          tx_hash: tx_hash,
@@ -425,5 +475,43 @@ defmodule BlockScoutWeb.Chain do
 
   def unique_tokens_next_page(_, list, params) do
     Map.merge(params, paging_params(List.last(list)))
+  end
+
+  def token_tranfers_next_page_params([], _list, _params), do: nil
+
+  def token_tranfers_next_page_params(next_page, list, params) do
+    next_token_transfer = List.first(next_page)
+    current_token_transfer = List.last(list)
+
+    if next_token_transfer.log_index == current_token_transfer.log_index and
+         next_token_transfer.block_hash == current_token_transfer.block_hash and
+         next_token_transfer.transaction_hash == current_token_transfer.transaction_hash do
+      new_params =
+        list
+        |> last_token_trasfer_before_current(current_token_transfer)
+        |> (&if(is_nil(&1), do: %{}, else: paging_params(&1))).()
+
+      params
+      |> Map.merge(new_params)
+      |> Map.merge(%{
+        "batch_log_index" => current_token_transfer.log_index,
+        "batch_block_hash" => current_token_transfer.block_hash,
+        "batch_transaction_hash" => current_token_transfer.transaction_hash,
+        "index_in_batch" => current_token_transfer.index_in_batch
+      })
+    else
+      Map.merge(params, paging_params(List.last(list)))
+    end
+  end
+
+  defp last_token_trasfer_before_current(list, current_token_transfer) do
+    Enum.reduce_while(list, nil, fn tt, acc ->
+      if tt.log_index == current_token_transfer.log_index and tt.block_hash == current_token_transfer.block_hash and
+           tt.transaction_hash == current_token_transfer.transaction_hash do
+        {:halt, acc}
+      else
+        {:cont, tt}
+      end
+    end)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
@@ -18,7 +18,7 @@ defmodule BlockScoutWeb.AddressTokenController do
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
       token_balances_plus_one =
         address_hash
-        |> Chain.fetch_last_token_balances(paging_options(params))
+        |> Chain.fetch_paginated_last_token_balances(paging_options(params))
         |> Market.add_price()
 
       {tokens, next_page} = split_list_by_page(token_balances_plus_one)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/api_logger.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/api_logger.ex
@@ -4,22 +4,13 @@ defmodule BlockScoutWeb.API.APILogger do
   """
   require Logger
 
-  def log(conn) do
-    endpoint =
-      if conn.query_string do
-        "#{conn.request_path}?#{conn.query_string}"
-      else
-        conn.request_path
-      end
-
-    Logger.debug(endpoint,
-      fetcher: :api
-    )
-  end
+  @params [application: :api]
 
   def message(text) do
-    Logger.debug(text,
-      fetcher: :api
-    )
+    Logger.debug(text, @params)
+  end
+
+  def error(error) do
+    Logger.error(error, @params)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
@@ -35,7 +35,6 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
          true <- action_accessed?(action, write_actions),
          :ok <- AccessHelpers.check_rate_limit(conn),
          {:ok, conn} <- call_controller(conn, controller, action) do
-      APILogger.log(conn)
       conn
     else
       {:error, :no_action} ->
@@ -46,7 +45,9 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
         |> halt()
 
       {:error, error} ->
-        Logger.error(fn -> ["Error while calling RPC action", inspect(error)] end)
+        APILogger.error(fn ->
+          ["Error while calling RPC action", inspect(error, limit: :infinity, printable_limit: :infinity)]
+        end)
 
         conn
         |> put_status(500)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -35,11 +35,11 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
           key: nil,
           page_number: options_with_defaults.page_number,
           page_size: options_with_defaults.page_size
-        }
+        },
+        api?: true
       ]
 
-      from_api = true
-      token_holders = Chain.fetch_token_holders_from_token_hash(address_hash, from_api, options)
+      token_holders = Chain.fetch_token_holders_from_token_hash(address_hash, options)
       render(conn, "gettokenholders.json", %{token_holders: token_holders})
     else
       {:contractaddress_param, :error} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/transaction_controller.ex
@@ -6,14 +6,15 @@ defmodule BlockScoutWeb.API.RPC.TransactionController do
   alias Explorer.Chain
   alias Explorer.Chain.Transaction
 
+  @api_true [api?: true]
+
   def gettxinfo(conn, params) do
     with {:txhash_param, {:ok, txhash_param}} <- fetch_txhash(params),
          {:format, {:ok, transaction_hash}} <- to_transaction_hash(txhash_param),
          {:transaction, {:ok, %Transaction{revert_reason: revert_reason, error: error} = transaction}} <-
            transaction_from_hash(transaction_hash),
          paging_options <- paging_options(params) do
-      from_api = true
-      logs = Chain.transaction_to_logs(transaction_hash, from_api, paging_options)
+      logs = Chain.transaction_to_logs(transaction_hash, Keyword.merge(paging_options, @api_true))
       {logs, next_page} = split_list_by_page(logs)
 
       transaction_updated =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/decompiled_smart_contract_controller.ex
@@ -1,13 +1,10 @@
 defmodule BlockScoutWeb.API.V1.DecompiledSmartContractController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.API.APILogger
   alias Explorer.Chain
   alias Explorer.Chain.Hash.Address
 
   def create(conn, params) do
-    APILogger.log(conn)
-
     if auth_token(conn) == actual_token() do
       with {:ok, hash} <- validate_address_hash(params["address_hash"]),
            :ok <- Chain.check_address_exists(hash),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/health_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/health_controller.ex
@@ -1,13 +1,10 @@
 defmodule BlockScoutWeb.API.V1.HealthController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.API.APILogger
   alias Explorer.Chain
   alias Timex.Duration
 
   def health(conn, _) do
-    APILogger.log(conn)
-
     with {:ok, number, timestamp} <- Chain.last_db_block_status(),
          {:ok, cache_number, cache_timestamp} <- Chain.last_cache_block_status() do
       send_resp(conn, :ok, result(number, timestamp, cache_number, cache_timestamp))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/supply_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/supply_controller.ex
@@ -1,11 +1,9 @@
 defmodule BlockScoutWeb.API.V1.SupplyController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.API.APILogger
   alias Explorer.Chain
 
   def supply(conn, _) do
-    APILogger.log(conn)
     total_supply = Chain.total_supply()
     circulating_supply = Chain.circulating_supply()
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/verified_smart_contract_controller.ex
@@ -1,14 +1,11 @@
 defmodule BlockScoutWeb.API.V1.VerifiedSmartContractController do
   use BlockScoutWeb, :controller
 
-  alias BlockScoutWeb.API.APILogger
   alias Explorer.Chain
   alias Explorer.Chain.Hash.Address
   alias Explorer.SmartContract.Solidity.Publisher
 
   def create(conn, params) do
-    APILogger.log(conn)
-
     with {:ok, hash} <- validate_address_hash(params["address_hash"]),
          :ok <- Chain.check_address_exists(hash),
          {:contract, :not_found} <- {:contract, Chain.check_verified_smart_contract_exists(hash)} do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -28,7 +28,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       [created_contract_address: :smart_contract] => :optional,
       [from_address: :smart_contract] => :optional,
       [to_address: :smart_contract] => :optional
-    }
+    },
+    api?: true
   ]
 
   @token_transfer_necessity_by_association [
@@ -37,15 +38,29 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       :from_address => :optional,
       :block => :optional,
       :transaction => :optional
-    }
+    },
+    api?: true
   ]
+
+  @address_options [
+    necessity_by_association: %{
+      :contracts_creation_internal_transaction => :optional,
+      :names => :optional,
+      :smart_contract => :optional,
+      :token => :optional,
+      :contracts_creation_transaction => :optional
+    },
+    api?: true
+  ]
+
+  @api_true [api?: true]
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
   def address(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash)} do
+         {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash, @address_options)} do
       CoinBalanceOnDemand.trigger_fetch(address)
 
       conn
@@ -57,8 +72,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def counters(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash)} do
-      {validation_count} = Chain.address_counters(address)
+         {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
+      {validation_count} = Chain.address_counters(address, @api_true)
 
       transactions_from_db = address.transactions_count || 0
       token_transfers_from_db = address.token_transfers_count || 0
@@ -76,10 +91,10 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def token_balances(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       token_balances =
         address_hash
-        |> Chain.fetch_last_token_balances()
+        |> Chain.fetch_last_token_balances(@api_true)
 
       Task.start_link(fn ->
         TokenBalanceOnDemand.trigger_fetch(address_hash, token_balances)
@@ -98,7 +113,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def transactions(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       options =
         @transaction_necessity_by_association
         |> Keyword.merge(paging_options(params))
@@ -125,8 +140,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
          {:format, {:ok, token_address_hash}} <- {:format, Chain.string_to_address_hash(token_address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
          {:ok, false} <- AccessHelpers.restricted_access?(token_address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)},
-         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(token_address_hash)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)},
+         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(token_address_hash, @api_true)} do
       paging_options = paging_options(params)
 
       options =
@@ -140,6 +155,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           }
         ]
         |> Keyword.merge(paging_options)
+        |> Keyword.merge(@api_true)
 
       results =
         address_hash
@@ -167,7 +183,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def token_transfers(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       paging_options = paging_options(params)
 
       options =
@@ -199,7 +215,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def internal_transactions(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       full_options =
         [
           necessity_by_association: %{
@@ -213,6 +229,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         ]
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(current_filter(params))
+        |> Keyword.merge(@api_true)
 
       results_plus_one = Chain.address_to_internal_transactions(address_hash, full_options)
       {internal_transactions, next_page} = split_list_by_page(results_plus_one)
@@ -233,12 +250,14 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def logs(conn, %{"address_hash" => address_hash_string, "topic" => topic} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       prepared_topic = String.trim(topic)
 
       formatted_topic = if String.starts_with?(prepared_topic, "0x"), do: prepared_topic, else: "0x" <> prepared_topic
 
-      results_plus_one = Chain.address_to_logs(address_hash, topic: formatted_topic)
+      options = Keyword.merge([topic: formatted_topic], @api_true)
+
+      results_plus_one = Chain.address_to_logs(address_hash, options)
 
       {logs, next_page} = split_list_by_page(results_plus_one)
 
@@ -254,8 +273,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def logs(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
-      results_plus_one = Chain.address_to_logs(address_hash, paging_options(params))
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
+      options = params |> paging_options() |> Keyword.merge(@api_true)
+
+      results_plus_one = Chain.address_to_logs(address_hash, options)
+
       {logs, next_page} = split_list_by_page(results_plus_one)
 
       next_page_params = next_page |> next_page_params(logs, params) |> delete_parameters_from_next_page_params()
@@ -270,19 +292,18 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def blocks_validated(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       full_options =
-        Keyword.merge(
-          [
-            necessity_by_association: %{
-              miner: :required,
-              nephews: :optional,
-              transactions: :optional,
-              rewards: :optional
-            }
-          ],
-          paging_options(params)
-        )
+        [
+          necessity_by_association: %{
+            miner: :required,
+            nephews: :optional,
+            transactions: :optional,
+            rewards: :optional
+          }
+        ]
+        |> Keyword.merge(paging_options(params))
+        |> Keyword.merge(@api_true)
 
       results_plus_one = Chain.get_blocks_validated_by_address(full_options, address_hash)
       {blocks, next_page} = split_list_by_page(results_plus_one)
@@ -299,8 +320,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def coin_balance_history(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash)} do
-      full_options = paging_options(params)
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
+      full_options = params |> paging_options() |> Keyword.merge(@api_true)
 
       results_plus_one = Chain.address_to_coin_balances(address_hash, full_options)
 
@@ -318,10 +339,10 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def coin_balance_history_by_day(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       balances_by_day =
         address_hash
-        |> Chain.address_to_balances_by_day(true)
+        |> Chain.address_to_balances_by_day(@api_true)
 
       conn
       |> put_status(200)
@@ -332,14 +353,15 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def tokens(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, [], false)} do
+         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)} do
       results_plus_one =
         address_hash
-        |> Chain.fetch_last_token_balances(
+        |> Chain.fetch_paginated_last_token_balances(
           params
           |> delete_parameters_from_next_page_params()
           |> paging_options()
           |> Keyword.merge(token_transfers_types_options(params))
+          |> Keyword.merge(@api_true)
         )
         |> Market.add_price()
 
@@ -357,6 +379,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     {addresses, next_page} =
       params
       |> paging_options()
+      |> Keyword.merge(@api_true)
       |> Chain.list_top_addresses()
       |> split_list_by_page()
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
-      token_tranfers_next_page_params: 3,
+      token_transfers_next_page_params: 3,
       paging_options: 1,
       split_list_by_page: 1,
       current_filter: 1
@@ -154,7 +154,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       next_page_params =
         next_page
-        |> token_tranfers_next_page_params(token_transfers, params)
+        |> token_transfers_next_page_params(token_transfers, params)
         |> delete_parameters_from_next_page_params()
 
       conn
@@ -186,7 +186,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       next_page_params =
         next_page
-        |> token_tranfers_next_page_params(token_transfers, params)
+        |> token_transfers_next_page_params(token_transfers, params)
         |> delete_parameters_from_next_page_params()
 
       conn

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -22,6 +22,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     }
   ]
 
+  @api_true [api?: true]
+
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
   def block(conn, %{"block_hash_or_number" => block_hash_or_number}) do
@@ -33,7 +35,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
                :nephews => :optional,
                :rewards => :optional,
                :transactions => :optional
-             }
+             },
+             api?: true
            ) do
       conn
       |> put_status(200)
@@ -47,6 +50,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     blocks_plus_one =
       full_options
       |> Keyword.merge(paging_options(params))
+      |> Keyword.merge(@api_true)
       |> Chain.list_blocks()
 
     {blocks, next_page} = split_list_by_page(blocks_plus_one)
@@ -61,10 +65,9 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   def transactions(conn, %{"block_hash_or_number" => block_hash_or_number} = params) do
     with {:ok, block} <- BlockTransactionController.param_block_hash_or_number_to_block(block_hash_or_number, []) do
       full_options =
-        Keyword.merge(
-          @transaction_necessity_by_association,
-          put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true)
-        )
+        @transaction_necessity_by_association
+        |> Keyword.merge(put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true))
+        |> Keyword.merge(@api_true)
 
       transactions_plus_one = Chain.block_to_transactions(block.hash, full_options, false)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -7,9 +7,9 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
 
   def blocks(conn, _params) do
     blocks =
-      [paging_options: %PagingOptions{page_size: 4}]
+      [paging_options: %PagingOptions{page_size: 4}, api?: true]
       |> Chain.list_blocks()
-      |> Repo.preload([[miner: :names], :transactions, :rewards])
+      |> Repo.replica().preload([[miner: :names], :transactions, :rewards])
 
     conn
     |> put_status(200)
@@ -29,7 +29,8 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
           [from_address: :smart_contract] => :optional,
           [to_address: :smart_contract] => :optional
         },
-        paging_options: %PagingOptions{page_size: 6}
+        paging_options: %PagingOptions{page_size: 6},
+        api?: true
       )
 
     conn
@@ -44,7 +45,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
 
     json(conn, %{
       finished_indexing_blocks: finished_indexing_blocks,
-      finished_indexing: Chain.finished_indexing?(indexed_ratio_blocks),
+      finished_indexing: Chain.finished_indexing?(indexed_ratio_blocks, api?: true),
       indexed_blocks_ratio: indexed_ratio_blocks,
       indexed_internal_transactions_ratio: if(finished_indexing_blocks, do: Chain.indexed_ratio_internal_transactions())
     })

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.SearchController do
   use Phoenix.Controller
 
-  import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
+  import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1, from_param: 1]
 
   alias Explorer.Chain
 
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.API.V2.SearchController do
 
     search_results_plus_one =
       paging_options
-      |> Chain.joint_search(offset, query)
+      |> Chain.joint_search(offset, query, api?: true)
 
     {search_results, next_page} = split_list_by_page(search_results_plus_one)
 
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.API.V2.SearchController do
     result =
       query
       |> String.trim()
-      |> BlockScoutWeb.Chain.from_param()
+      |> from_param()
 
     conn
     |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -63,9 +63,9 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
          smart_contract <- Chain.address_hash_to_smart_contract(address_hash, @api_true),
          {:not_found, false} <- {:not_found, is_nil(smart_contract)} do
-      read_only_functions_from_abi = Reader.read_only_functions(address_hash, params["from"])
+      read_only_functions_from_abi = Reader.read_only_functions(smart_contract, address_hash, params["from"])
 
-      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet(address_hash)
+      read_functions_required_wallet_from_abi = Reader.read_functions_required_wallet(smart_contract)
 
       conn
       |> put_status(200)
@@ -91,7 +91,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:not_found, false} <- {:not_found, is_nil(smart_contract)} do
       conn
       |> put_status(200)
-      |> json(Writer.write_functions(address_hash))
+      |> json(Writer.write_functions(smart_contract))
     end
   end
 
@@ -110,7 +110,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       conn
       |> put_status(200)
       |> render(:read_functions, %{
-        functions: Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string)
+        functions: Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, nil, @api_true)
       })
     end
   end
@@ -129,7 +129,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(Writer.write_functions_proxy(implementation_address_hash_string))
+      |> json(Writer.write_functions_proxy(implementation_address_hash_string, @api_true))
     end
   end
 
@@ -168,7 +168,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
             address_hash,
             %{method_id: params["method_id"], args: prepare_args(args)},
             contract_type,
-            params["from"]
+            params["from"],
+            @api_true
           )
         end
 
@@ -197,6 +198,16 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
     conn
     |> put_status(200)
     |> render(:smart_contracts, %{smart_contracts: smart_contracts, next_page_params: next_page_params})
+  end
+
+  def smart_contracts_counters(conn, _params) do
+    conn
+    |> json(%{
+      smart_contracts: Chain.count_contracts_from_cache(@api_true),
+      new_smart_contracts_24h: Chain.count_new_contracts_from_cache(@api_true),
+      verified_smart_contracts: Chain.count_verified_contracts_from_cache(@api_true),
+      new_verified_smart_contracts_24h: Chain.count_new_verified_contracts_from_cache(@api_true)
+    })
   end
 
   def prepare_args(list) when is_list(list), do: list

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -20,8 +20,11 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       :contracts_creation_internal_transaction => :optional,
       :smart_contract => :optional,
       :contracts_creation_transaction => :optional
-    }
+    },
+    api?: true
   ]
+
+  @api_true [api?: true]
 
   @burn_address "0x0000000000000000000000000000000000000000"
 
@@ -58,7 +61,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   def methods_read(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         smart_contract <- Chain.address_hash_to_smart_contract(address_hash),
+         smart_contract <- Chain.address_hash_to_smart_contract(address_hash, @api_true),
          {:not_found, false} <- {:not_found, is_nil(smart_contract)} do
       read_only_functions_from_abi = Reader.read_only_functions(address_hash, params["from"])
 
@@ -84,7 +87,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   def methods_write(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         smart_contract <- Chain.address_hash_to_smart_contract(address_hash),
+         smart_contract <- Chain.address_hash_to_smart_contract(address_hash, @api_true),
          {:not_found, false} <- {:not_found, is_nil(smart_contract)} do
       conn
       |> put_status(200)
@@ -100,7 +103,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:not_found, false} <- {:not_found, is_nil(address.smart_contract)} do
       implementation_address_hash_string =
         address.smart_contract
-        |> SmartContract.get_implementation_address_hash()
+        |> SmartContract.get_implementation_address_hash(@api_true)
         |> Tuple.to_list()
         |> List.first() || @burn_address
 
@@ -120,7 +123,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:not_found, false} <- {:not_found, is_nil(address.smart_contract)} do
       implementation_address_hash_string =
         address.smart_contract
-        |> SmartContract.get_implementation_address_hash()
+        |> SmartContract.get_implementation_address_hash(@api_true)
         |> Tuple.to_list()
         |> List.first() || @burn_address
 
@@ -146,7 +149,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
             Chain.find_contract_address(address_hash,
               necessity_by_association: %{
                 :smart_contract => :optional
-              }
+              },
+              api?: true
             )},
          {:not_found, true} <-
            {:not_found,
@@ -180,6 +184,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(current_filter(params))
       |> Keyword.merge(search_query(params))
+      |> Keyword.merge(@api_true)
 
     smart_contracts_plus_one = Chain.verified_contracts(full_options)
     {smart_contracts, next_page} = split_list_by_page(smart_contracts_plus_one)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -169,6 +169,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
             %{method_id: params["method_id"], args: prepare_args(args)},
             contract_type,
             params["from"],
+            address.smart_contract.abi,
             @api_true
           )
         end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -12,6 +12,8 @@ defmodule BlockScoutWeb.API.V2.StatsController do
   alias Explorer.ExchangeRates.Token
   alias Timex.Duration
 
+  @api_true [api?: true]
+
   def stats(conn, _params) do
     market_cap_type =
       case Application.get_env(:explorer, :supply) do
@@ -41,7 +43,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
       conn,
       %{
         "total_blocks" => BlockCache.estimated_count() |> to_string(),
-        "total_addresses" => Chain.address_estimated_count() |> to_string(),
+        "total_addresses" => @api_true |> Chain.address_estimated_count() |> to_string(),
         "total_transactions" => TransactionCache.estimated_count() |> to_string(),
         "average_block_time" => AverageBlockTime.average_block_time() |> Duration.to_milliseconds(),
         "coin_price" => exchange_rate.usd_value,
@@ -75,7 +77,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
     latest = Date.add(today, -1)
     earliest = Date.add(latest, -1 * history_size)
 
-    date_range = TransactionStats.by_date_range(earliest, latest)
+    date_range = TransactionStats.by_date_range(earliest, latest, @api_true)
 
     transaction_history_data =
       date_range

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -21,10 +21,12 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
+  @api_true [api?: true]
+
   def token(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash)} do
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
       TokenTotalSupplyOnDemand.trigger_fetch(address_hash)
 
       conn
@@ -36,7 +38,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def counters(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(address_hash)} do
+         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
       {transfer_count, token_holder_count} = Chain.fetch_token_counters(address_hash, 30_000)
 
       json(conn, %{transfers_count: to_string(transfer_count), token_holders_count: to_string(token_holder_count)})
@@ -46,12 +48,12 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def transfers(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(address_hash)} do
+         {:not_found, {:ok, _}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
       paging_options = paging_options(params)
 
       results =
         address_hash
-        |> Chain.fetch_token_transfers_from_token_hash(paging_options)
+        |> Chain.fetch_token_transfers_from_token_hash(Keyword.merge(@api_true, paging_options))
         |> Chain.flat_1155_batch_token_transfers()
         |> Chain.paginate_1155_batch_token_transfers(paging_options)
 
@@ -70,12 +72,12 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   end
 
   def holders(conn, %{"address_hash" => address_hash_string} = params) do
-    from_api = true
-
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash)} do
-      results_plus_one = Chain.fetch_token_holders_from_token_hash(address_hash, from_api, paging_options(params))
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
+      results_plus_one =
+        Chain.fetch_token_holders_from_token_hash(address_hash, Keyword.merge(paging_options(params), @api_true))
+
       {token_balances, next_page} = split_list_by_page(results_plus_one)
 
       next_page_params =
@@ -90,9 +92,12 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def instances(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash)} do
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
       results_plus_one =
-        Chain.address_to_unique_tokens(token.contract_address_hash, unique_tokens_paging_options(params))
+        Chain.address_to_unique_tokens(
+          token.contract_address_hash,
+          Keyword.merge(unique_tokens_paging_options(params), @api_true)
+        )
 
       {token_instances, next_page} = split_list_by_page(results_plus_one)
 
@@ -108,26 +113,31 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def instance(conn, %{"address_hash" => address_hash_string, "token_id" => token_id} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash)},
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
          {:not_found, {:ok, token_instance}} <-
-           {:not_found, Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash)} do
+           {:not_found,
+            Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash, @api_true)} do
       conn
       |> put_status(200)
-      |> render(:token_instance, %{token_instance: token_instance |> Chain.put_owner_to_token_instance(), token: token})
+      |> render(:token_instance, %{
+        token_instance: token_instance |> Chain.put_owner_to_token_instance(@api_true),
+        token: token
+      })
     end
   end
 
   def transfers_by_instance(conn, %{"address_hash" => address_hash_string, "token_id" => token_id} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _token}} <- {:not_found, Chain.token_from_address_hash(address_hash)},
+         {:not_found, {:ok, _token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
          {:not_found, {:ok, _token_instance}} <-
-           {:not_found, Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash)} do
+           {:not_found,
+            Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash, @api_true)} do
       paging_options = paging_options(params)
 
       results =
         address_hash
-        |> Chain.fetch_token_transfers_from_token_hash_and_token_id(token_id, paging_options)
+        |> Chain.fetch_token_transfers_from_token_hash_and_token_id(token_id, Keyword.merge(paging_options, @api_true))
         |> Chain.flat_1155_batch_token_transfers(Decimal.new(token_id))
         |> Chain.paginate_1155_batch_token_transfers(paging_options)
 
@@ -148,24 +158,28 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def transfers_count_by_instance(conn, %{"address_hash" => address_hash_string, "token_id" => token_id} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, _token}} <- {:not_found, Chain.token_from_address_hash(address_hash)},
+         {:not_found, {:ok, _token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
          {:not_found, {:ok, _token_instance}} <-
-           {:not_found, Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash)} do
+           {:not_found,
+            Chain.erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, address_hash, @api_true)} do
       conn
       |> put_status(200)
-      |> json(%{transfers_count: Chain.count_token_transfers_from_token_hash_and_token_id(address_hash, token_id)})
+      |> json(%{
+        transfers_count: Chain.count_token_transfers_from_token_hash_and_token_id(address_hash, token_id, @api_true)
+      })
     end
   end
 
   def tokens_list(conn, params) do
     filter = params["q"]
 
-    paging_params =
+    options =
       params
       |> paging_options()
       |> Keyword.merge(token_transfers_types_options(params))
+      |> Keyword.merge(@api_true)
 
-    {tokens, next_page} = filter |> Chain.list_top_tokens(paging_params) |> Market.add_price() |> split_list_by_page()
+    {tokens, next_page} = filter |> Chain.list_top_tokens(options) |> Market.add_price() |> split_list_by_page()
 
     next_page_params = next_page |> next_page_params(tokens, params) |> delete_parameters_from_next_page_params()
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       split_list_by_page: 1,
       paging_options: 1,
       next_page_params: 3,
-      token_tranfers_next_page_params: 3,
+      token_transfers_next_page_params: 3,
       unique_tokens_paging_options: 1,
       unique_tokens_next_page: 3
     ]
@@ -59,7 +59,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
       next_page_params =
         next_page
-        |> token_tranfers_next_page_params(token_transfers, params)
+        |> token_transfers_next_page_params(token_transfers, params)
         |> delete_parameters_from_next_page_params()
 
       conn
@@ -135,7 +135,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
       next_page_params =
         next_page
-        |> token_tranfers_next_page_params(token_transfers, params)
+        |> token_transfers_next_page_params(token_transfers, params)
         |> delete_parameters_from_next_page_params()
 
       conn

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -61,18 +61,21 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     }
   ]
 
+  @api_true [api?: true]
+
   def transaction(conn, %{"transaction_hash" => transaction_hash_string} = params) do
     with {:format, {:ok, transaction_hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash_string)},
          {:not_found, {:ok, transaction}} <-
            {:not_found,
             Chain.hash_to_transaction(
               transaction_hash,
-              necessity_by_association: Map.put(@transaction_necessity_by_association, :transaction_actions, :optional)
+              necessity_by_association: Map.put(@transaction_necessity_by_association, :transaction_actions, :optional),
+              api?: true
             )},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params),
          preloaded <-
-           Chain.preload_token_transfers(transaction, @token_transfers_in_tx_necessity_by_association, false) do
+           Chain.preload_token_transfers(transaction, @token_transfers_in_tx_necessity_by_association, @api_true, false) do
       conn
       |> put_status(200)
       |> render(:transaction, %{transaction: preloaded})
@@ -89,6 +92,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       |> Keyword.merge(paging_options(params, filter_options))
       |> Keyword.merge(method_filter_options(params))
       |> Keyword.merge(type_filter_options(params))
+      |> Keyword.merge(@api_true)
 
     transactions_plus_one = Chain.recent_transactions(full_options, filter_options)
 
@@ -104,7 +108,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def raw_trace(conn, %{"transaction_hash" => transaction_hash_string} = params) do
     with {:format, {:ok, transaction_hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash_string)},
          {:not_found, {:ok, transaction}} <-
-           {:not_found, Chain.hash_to_transaction(transaction_hash)},
+           {:not_found, Chain.hash_to_transaction(transaction_hash, @api_true)},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
       if is_nil(transaction.block_number) do
@@ -112,7 +116,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         |> put_status(200)
         |> render(:raw_trace, %{internal_transactions: []})
       else
-        internal_transactions = Chain.all_transaction_to_internal_transactions(transaction_hash)
+        internal_transactions = Chain.all_transaction_to_internal_transactions(transaction_hash, @api_true)
 
         first_trace_exists =
           Enum.find_index(internal_transactions, fn trace ->
@@ -133,7 +137,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def token_transfers(conn, %{"transaction_hash" => transaction_hash_string} = params) do
     with {:format, {:ok, transaction_hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash_string)},
          {:not_found, {:ok, transaction}} <-
-           {:not_found, Chain.hash_to_transaction(transaction_hash)},
+           {:not_found, Chain.hash_to_transaction(transaction_hash, @api_true)},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
       paging_options = paging_options(params)
@@ -142,6 +146,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         [necessity_by_association: @token_transfers_necessity_by_association]
         |> Keyword.merge(paging_options)
         |> Keyword.merge(token_transfers_types_options(params))
+        |> Keyword.merge(@api_true)
 
       results =
         transaction_hash
@@ -165,14 +170,13 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def internal_transactions(conn, %{"transaction_hash" => transaction_hash_string} = params) do
     with {:format, {:ok, transaction_hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash_string)},
          {:not_found, {:ok, transaction}} <-
-           {:not_found, Chain.hash_to_transaction(transaction_hash)},
+           {:not_found, Chain.hash_to_transaction(transaction_hash, @api_true)},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
       full_options =
-        Keyword.merge(
-          @internal_transaction_necessity_by_association,
-          paging_options(params)
-        )
+        @internal_transaction_necessity_by_association
+        |> Keyword.merge(paging_options(params))
+        |> Keyword.merge(@api_true)
 
       internal_transactions_plus_one = Chain.transaction_to_internal_transactions(transaction_hash, full_options)
 
@@ -195,23 +199,21 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def logs(conn, %{"transaction_hash" => transaction_hash_string} = params) do
     with {:format, {:ok, transaction_hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash_string)},
          {:not_found, {:ok, transaction}} <-
-           {:not_found, Chain.hash_to_transaction(transaction_hash)},
+           {:not_found, Chain.hash_to_transaction(transaction_hash, @api_true)},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do
       full_options =
-        Keyword.merge(
-          [
-            necessity_by_association: %{
-              [address: :names] => :optional,
-              [address: :smart_contract] => :optional,
-              address: :optional
-            }
-          ],
-          paging_options(params)
-        )
+        [
+          necessity_by_association: %{
+            [address: :names] => :optional,
+            [address: :smart_contract] => :optional,
+            address: :optional
+          }
+        ]
+        |> Keyword.merge(paging_options(params))
+        |> Keyword.merge(@api_true)
 
-      from_api = true
-      logs_plus_one = Chain.transaction_to_logs(transaction_hash, from_api, full_options)
+      logs_plus_one = Chain.transaction_to_logs(transaction_hash, full_options)
 
       {logs, next_page} = split_list_by_page(logs_plus_one)
 
@@ -236,7 +238,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
            {:not_found,
             Chain.hash_to_transaction(transaction_hash,
               necessity_by_association:
-                Map.merge(@transaction_necessity_by_association, %{[block: [miner: :names]] => :optional})
+                Map.merge(@transaction_necessity_by_association, %{[block: [miner: :names]] => :optional}),
+              api?: true
             )},
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.from_address_hash), params),
          {:ok, false} <- AccessHelpers.restricted_access?(to_string(transaction.to_address_hash), params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Chain,
-    only: [next_page_params: 3, token_tranfers_next_page_params: 3, paging_options: 1, split_list_by_page: 1]
+    only: [next_page_params: 3, token_transfers_next_page_params: 3, paging_options: 1, split_list_by_page: 1]
 
   import BlockScoutWeb.PagingHelper,
     only: [
@@ -153,7 +153,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
       next_page_params =
         next_page
-        |> token_tranfers_next_page_params(token_transfers, params)
+        |> token_transfers_next_page_params(token_transfers, params)
         |> delete_parameters_from_next_page_params()
 
       conn

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/verification_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/verification_controller.ex
@@ -13,6 +13,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
+  @api_true [api?: true]
+
   def config(conn, _params) do
     evm_versions = CodeCompiler.allowed_evm_versions()
     solidity_compiler_versions = CompilerVersion.fetch_version_list(:solc)
@@ -45,7 +47,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
       ) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)} do
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)} do
       verification_params =
         %{
           "address_hash" => String.downcase(address_hash_string),
@@ -79,7 +82,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
       ) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)},
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)},
          files_array <- PublishHelper.prepare_files_array(files),
          {:no_json_file, %Plug.Upload{path: path}} <-
            {:no_json_file, PublishHelper.get_one_json(files_array)},
@@ -106,7 +110,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
            {:not_found, Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:enabled]},
          {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)},
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)},
          files_array <- PublishHelper.prepare_files_array(files),
          {:no_json_file, %Plug.Upload{path: _path}} <-
            {:no_json_file, PublishHelper.get_one_json(files_array)},
@@ -131,7 +136,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
     with {:not_found, true} <- {:not_found, RustVerifierInterface.enabled?()},
          {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)},
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)},
          libraries <- Map.get(params, "libraries", "{}"),
          {:libs_format, {:ok, json}} <- {:libs_format, Jason.decode(libraries)} do
       verification_params =
@@ -167,7 +173,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
       ) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)} do
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)} do
       verification_params =
         %{
           "address_hash" => String.downcase(address_hash_string),
@@ -193,7 +200,8 @@ defmodule BlockScoutWeb.API.V2.VerificationController do
     with {:not_found, true} <- {:not_found, RustVerifierInterface.enabled?()},
          {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params),
-         {:already_verified, false} <- {:already_verified, Chain.smart_contract_fully_verified?(address_hash)} do
+         {:already_verified, false} <-
+           {:already_verified, Chain.smart_contract_fully_verified?(address_hash, @api_true)} do
       verification_params =
         %{
           "address_hash" => String.downcase(address_hash_string),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -162,7 +162,7 @@ defmodule BlockScoutWeb.SmartContractController do
 
     with true <- ajax?(conn),
          {:ok, address_hash} <- Chain.string_to_address_hash(params["id"]),
-         {:ok, _address} <- Chain.find_contract_address(address_hash, address_options, true) do
+         {:ok, address} <- Chain.find_contract_address(address_hash, address_options, true) do
       contract_type = if params["type"] == "proxy", do: :proxy, else: :regular
 
       args =
@@ -190,7 +190,8 @@ defmodule BlockScoutWeb.SmartContractController do
             address_hash,
             %{method_id: params["method_id"], args: args},
             contract_type,
-            params["from"]
+            params["from"],
+            address.smart_contract && address.smart_contract.abi
           )
         end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -38,13 +38,13 @@ defmodule BlockScoutWeb.SmartContractController do
           if contract_type == "proxy" do
             Writer.write_functions_proxy(implementation_address_hash_string)
           else
-            Writer.write_functions(address_hash)
+            Writer.write_functions(address.smart_contract)
           end
         else
           if contract_type == "proxy" do
-            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string)
+            Reader.read_only_functions_proxy(address_hash, implementation_address_hash_string, nil)
           else
-            Reader.read_only_functions(address_hash, params["from"])
+            Reader.read_only_functions(address.smart_contract, address_hash, params["from"])
           end
         end
 
@@ -53,7 +53,7 @@ defmodule BlockScoutWeb.SmartContractController do
           if contract_type == "proxy" do
             Reader.read_functions_required_wallet_proxy(implementation_address_hash_string)
           else
-            Reader.read_functions_required_wallet(address_hash)
+            Reader.read_functions_required_wallet(address.smart_contract)
           end
         else
           []

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/holder_controller.ex
@@ -19,11 +19,9 @@ defmodule BlockScoutWeb.Tokens.HolderController do
     ]
 
   def index(conn, %{"token_id" => address_hash_string, "type" => "JSON"} = params) do
-    from_api = false
-
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, token} <- Chain.token_from_address_hash(address_hash),
-         token_balances <- Chain.fetch_token_holders_from_token_hash(address_hash, from_api, paging_options(params)),
+         token_balances <- Chain.fetch_token_holders_from_token_hash(address_hash, paging_options(params)),
          {:ok, false} <- AccessHelpers.restricted_access?(address_hash_string, params) do
       {token_balances_paginated, next_page} = split_list_by_page(token_balances)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_log_controller.ex
@@ -31,8 +31,7 @@ defmodule BlockScoutWeb.TransactionLogController do
           paging_options(params)
         )
 
-      from_api = false
-      logs_plus_one = Chain.transaction_to_logs(transaction_hash, from_api, full_options)
+      logs_plus_one = Chain.transaction_to_logs(transaction_hash, full_options)
 
       {logs, next_page} = split_list_by_page(logs_plus_one)
 

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -43,7 +43,6 @@ defmodule BlockScoutWeb.Endpoint do
   end
 
   plug(Plug.RequestId)
-  plug(Plug.Logger)
 
   plug(
     Plug.Parsers,

--- a/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
@@ -1,0 +1,71 @@
+defmodule BlockScoutWeb.Plug.Logger do
+  @moduledoc """
+    Extended version of Plug.Logger from https://github.com/elixir-plug/plug/blob/v1.14.0/lib/plug/logger.ex
+    Now it's possible to put parameters in order to log API v2 requests separately from API and others
+
+    Usage example:
+      `plug(BlockScoutWeb.Plug.Logger, application: :api_v2)`
+  """
+
+  require Logger
+  alias Plug.Conn
+  @behaviour Plug
+
+  @impl true
+  def init(opts) do
+    opts
+  end
+
+  @impl true
+  def call(conn, opts) do
+    level = Keyword.get(opts, :log, :info)
+    application = Keyword.get(opts, :application, :block_scout_web)
+
+    log(application, conn, level, opts)
+
+    start = System.monotonic_time()
+
+    Conn.register_before_send(conn, fn conn ->
+      Logger.log(
+        level,
+        fn ->
+          stop = System.monotonic_time()
+          diff = System.convert_time_unit(stop - start, :native, :microsecond)
+          status = Integer.to_string(conn.status)
+
+          [connection_type(conn), ?\s, status, " in ", formatted_diff(diff)]
+        end,
+        opts
+      )
+
+      conn
+    end)
+  end
+
+  defp log(:api, conn, level, opts) do
+    endpoint =
+      if conn.query_string do
+        "#{conn.request_path}?#{conn.query_string}"
+      else
+        conn.request_path
+      end
+
+    Logger.log(level, endpoint, opts)
+  end
+
+  defp log(_application, conn, level, opts) do
+    Logger.log(
+      level,
+      fn ->
+        [conn.method, ?\s, conn.request_path]
+      end,
+      opts
+    )
+  end
+
+  defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string(), "ms"]
+  defp formatted_diff(diff), do: [Integer.to_string(diff), "µs"]
+
+  defp connection_type(%{state: :set_chunked}), do: "Chunked"
+  defp connection_type(_), do: "Sent"
+end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -18,10 +18,12 @@ defmodule BlockScoutWeb.Router do
     plug(:fetch_flash)
     plug(:protect_from_forgery)
     plug(BlockScoutWeb.CSPHeader)
+    plug(BlockScoutWeb.Plug.Logger, application: :block_scout_web)
   end
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(BlockScoutWeb.Plug.Logger, application: :api)
   end
 
   forward("/api", ApiRouter)

--- a/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
@@ -6,17 +6,14 @@ defmodule BlockScoutWeb.SmartContractsApiV2Router do
   use BlockScoutWeb, :router
   alias BlockScoutWeb.Plug.CheckApiV2
 
-  pipeline :api do
-    plug(:accepts, ["json"])
-  end
-
   pipeline :api_v2_no_forgery_protect do
+    plug(:accepts, ["json"])
     plug(CheckApiV2)
     plug(:fetch_session)
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
   end
 
   scope "/", as: :api_v2 do
-    pipe_through(:api)
     pipe_through(:api_v2_no_forgery_protect)
 
     alias BlockScoutWeb.API.V2

--- a/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/smart_contracts_api_v2_router.ex
@@ -19,6 +19,7 @@ defmodule BlockScoutWeb.SmartContractsApiV2Router do
     alias BlockScoutWeb.API.V2
 
     get("/", V2.SmartContractController, :smart_contracts_list)
+    get("/counters", V2.SmartContractController, :smart_contracts_counters)
     get("/:address_hash", V2.SmartContractController, :smart_contract)
     get("/:address_hash/methods-read", V2.SmartContractController, :methods_read)
     get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -261,11 +261,13 @@ defmodule BlockScoutWeb.AddressView do
 
   def is_read_function?(function), do: Helper.queriable_method?(function) || Helper.read_with_wallet_method?(function)
 
-  def smart_contract_is_proxy?(%Address{smart_contract: %SmartContract{} = smart_contract}) do
-    SmartContract.proxy_contract?(smart_contract)
+  def smart_contract_is_proxy?(address, options \\ [])
+
+  def smart_contract_is_proxy?(%Address{smart_contract: %SmartContract{} = smart_contract}, options) do
+    SmartContract.proxy_contract?(smart_contract, options)
   end
 
-  def smart_contract_is_proxy?(%Address{smart_contract: nil}), do: false
+  def smart_contract_is_proxy?(%Address{smart_contract: nil}, _), do: false
 
   def smart_contract_with_write_functions?(%Address{smart_contract: %SmartContract{}} = address) do
     Enum.any?(

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -8,6 +8,8 @@ defmodule BlockScoutWeb.API.V2.AddressView do
   alias Explorer.Chain.{Address, SmartContract}
   alias Explorer.ExchangeRates.Token
 
+  @api_true [api?: true]
+
   def render("message.json", assigns) do
     ApiView.render("message.json", assigns)
   end
@@ -59,11 +61,11 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
   def prepare_address(address, conn \\ nil) do
     base_info = Helper.address_with_info(conn, address, address.hash)
-    is_proxy = AddressView.smart_contract_is_proxy?(address)
+    is_proxy = AddressView.smart_contract_is_proxy?(address, @api_true)
 
     {implementation_address, implementation_name} =
       with true <- is_proxy,
-           {address, name} <- SmartContract.get_implementation_address_hash(address.smart_contract),
+           {address, name} <- SmartContract.get_implementation_address_hash(address.smart_contract, @api_true),
            false <- is_nil(address),
            {:ok, address_hash} <- Chain.string_to_address_hash(address),
            checksummed_address <- Address.checksum(address_hash) do
@@ -94,15 +96,15 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "block_number_balance_updated_at" => address.fetched_coin_balance_block_number,
       "has_custom_methods_read" => read_custom_abi?,
       "has_custom_methods_write" => write_custom_abi?,
-      "has_methods_read" => AddressView.smart_contract_with_read_only_functions?(address) || read_custom_abi?,
-      "has_methods_write" => AddressView.smart_contract_with_write_functions?(address) || write_custom_abi?,
+      "has_methods_read" => AddressView.smart_contract_with_read_only_functions?(address),
+      "has_methods_write" => AddressView.smart_contract_with_write_functions?(address),
       "has_methods_read_proxy" => is_proxy,
       "has_methods_write_proxy" => AddressView.smart_contract_with_write_functions?(address) && is_proxy,
       "has_decompiled_code" => AddressView.has_decompiled_code?(address),
-      "has_validated_blocks" => Chain.check_if_validated_blocks_at_address(address.hash),
-      "has_logs" => Chain.check_if_logs_at_address(address.hash),
-      "has_tokens" => Chain.check_if_tokens_at_address(address.hash),
-      "has_token_transfers" => Chain.check_if_token_transfers_at_address(address.hash)
+      "has_validated_blocks" => Chain.check_if_validated_blocks_at_address(address.hash, @api_true),
+      "has_logs" => Chain.check_if_logs_at_address(address.hash, @api_true),
+      "has_tokens" => Chain.check_if_tokens_at_address(address.hash, @api_true),
+      "has_token_transfers" => Chain.check_if_token_transfers_at_address(address.hash, @api_true)
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -13,6 +13,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
 
   require Logger
 
+  @api_true [api?: true]
+
   def render("smart_contracts.json", %{smart_contracts: smart_contracts, next_page_params: next_page_params}) do
     %{"items" => Enum.map(smart_contracts, &prepare_smart_contract_for_list/1), "next_page_params" => next_page_params}
   end
@@ -42,7 +44,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
       {:error, %{code: code, message: message, data: data}} ->
         revert_reason = Chain.format_revert_reason_message(data)
 
-        case SmartContractView.decode_revert_reason(contract_address_hash, revert_reason) do
+        case SmartContractView.decode_revert_reason(contract_address_hash, revert_reason, @api_true) do
           {:ok, method_id, text, mapping} ->
             %{
               result:
@@ -127,14 +129,12 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
 
   # credo:disable-for-next-line
   def prepare_smart_contract(%Address{smart_contract: %SmartContract{}} = address) do
-    minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash)
-
-    metadata_for_verification =
-      minimal_proxy_template || Chain.get_address_verified_twin_contract(address.hash).verified_contract
-
+    minimal_proxy_template = Chain.get_minimal_proxy_template(address.hash, @api_true)
+    twin = Chain.get_address_verified_twin_contract(address.hash, @api_true)
+    metadata_for_verification = minimal_proxy_template || twin.verified_contract
     smart_contract_verified = AddressView.smart_contract_verified?(address)
-    additional_sources_from_twin = Chain.get_address_verified_twin_contract(address.hash).additional_sources
-    fully_verified = Chain.smart_contract_fully_verified?(address.hash)
+    additional_sources_from_twin = twin.additional_sources
+    fully_verified = Chain.smart_contract_fully_verified?(address.hash, @api_true)
 
     additional_sources =
       if smart_contract_verified, do: address.smart_contract_additional_sources, else: additional_sources_from_twin

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.API.V2.TokenView do
   alias Explorer.Chain
   alias Explorer.Chain.Address
 
+  @api_true [api?: true]
+
   def render("token.json", %{token: token}) do
     %{
       "address" => Address.checksum(token.contract_address_hash),
@@ -72,7 +74,8 @@ defmodule BlockScoutWeb.API.V2.TokenView do
       "animation_url" => instance.metadata && NFTHelpers.retrieve_image(instance.metadata["animation_url"]),
       "image_url" => instance.metadata && NFTHelpers.get_media_src(instance.metadata, false),
       "is_unique" =>
-        not (token.type == "ERC-1155") or Chain.token_id_1155_is_unique?(token.contract_address_hash, instance.token_id)
+        not (token.type == "ERC-1155") or
+          Chain.token_id_1155_is_unique?(token.contract_address_hash, instance.token_id, @api_true)
     }
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -17,6 +17,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
 
+  @api_true [api?: true]
+
   def render("message.json", assigns) do
     ApiView.render("message.json", assigns)
   end
@@ -242,7 +244,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "created_contract" =>
         Helper.address_with_info(conn, transaction.created_contract_address, transaction.created_contract_address_hash),
       "confirmations" =>
-        transaction.block |> Chain.confirmations(block_height: Chain.block_height()) |> format_confirmations(),
+        transaction.block |> Chain.confirmations(block_height: Chain.block_height(@api_true)) |> format_confirmations(),
       "confirmation_duration" => processing_time_duration(transaction),
       "value" => transaction.value,
       "fee" => transaction |> Chain.fee(:wei) |> format_fee(),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   def prepare_token_transfer(token_transfer, conn) do
-    decoded_input = token_transfer.transaction |> Transaction.decoded_input_data() |> format_decoded_input()
+    decoded_input = token_transfer.transaction |> Transaction.decoded_input_data(@api_true) |> format_decoded_input()
 
     %{
       "tx_hash" => token_transfer.transaction_hash,
@@ -196,7 +196,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   defp smart_contract_info(_), do: nil
 
   defp decode_log(log, %Transaction{} = tx) do
-    case log |> Log.decode(tx) |> format_decoded_log_input() do
+    case log |> Log.decode(tx, @api_true) |> format_decoded_log_input() do
       {:ok, method_id, text, mapping} ->
         render(__MODULE__, "decoded_log_input.json", method_id: method_id, text: text, mapping: mapping)
 
@@ -230,7 +230,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
     revert_reason = revert_reason(status, transaction)
 
-    decoded_input = transaction |> Transaction.decoded_input_data() |> format_decoded_input()
+    decoded_input = transaction |> Transaction.decoded_input_data(@api_true) |> format_decoded_input()
     decoded_input_data = decoded_input(decoded_input)
 
     %{
@@ -317,7 +317,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   defp revert_reason(status, transaction) do
     if is_binary(status) && status |> String.downcase() |> String.contains?("reverted") do
-      case TransactionView.transaction_revert_reason(transaction) do
+      case TransactionView.transaction_revert_reason(transaction, @api_true) do
         {:error, _contract_not_verified, candidates} when candidates != [] ->
           {:ok, method_id, text, mapping} = Enum.at(candidates, 0)
           render(__MODULE__, "decoded_input.json", method_id: method_id, text: text, mapping: mapping, error?: true)

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -270,7 +270,8 @@ defmodule BlockScoutWeb.SmartContractView do
 
     Transaction.decoded_revert_reason(
       %Transaction{to_address: %{smart_contract: smart_contract}, hash: to_address},
-      revert_reason
+      revert_reason,
+      options
     )
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -265,8 +265,8 @@ defmodule BlockScoutWeb.SmartContractView do
     end
   end
 
-  def decode_revert_reason(to_address, revert_reason) do
-    smart_contract = Chain.address_hash_to_smart_contract(to_address)
+  def decode_revert_reason(to_address, revert_reason, options \\ []) do
+    smart_contract = Chain.address_hash_to_smart_contract(to_address, options)
 
     Transaction.decoded_revert_reason(
       %Transaction{to_address: %{smart_contract: smart_contract}, hash: to_address},

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -340,8 +340,8 @@ defmodule BlockScoutWeb.TransactionView do
     Chain.transaction_to_status(transaction)
   end
 
-  def transaction_revert_reason(transaction) do
-    transaction |> Chain.transaction_to_revert_reason() |> decoded_revert_reason(transaction)
+  def transaction_revert_reason(transaction, options \\ []) do
+    transaction |> Chain.transaction_to_revert_reason() |> decoded_revert_reason(transaction, options)
   end
 
   def get_pure_transaction_revert_reason(nil), do: nil
@@ -385,11 +385,11 @@ defmodule BlockScoutWeb.TransactionView do
   end
 
   def decoded_input_data(transaction) do
-    Transaction.decoded_input_data(transaction)
+    Transaction.decoded_input_data(transaction, [])
   end
 
-  def decoded_revert_reason(revert_reason, transaction) do
-    Transaction.decoded_revert_reason(transaction, revert_reason)
+  def decoded_revert_reason(revert_reason, transaction, options) do
+    Transaction.decoded_revert_reason(transaction, revert_reason, options)
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/web_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/web_router.ex
@@ -14,6 +14,7 @@ defmodule BlockScoutWeb.WebRouter do
     plug(:protect_from_forgery)
     plug(BlockScoutWeb.CSPHeader)
     plug(BlockScoutWeb.ChecksumAddress)
+    plug(BlockScoutWeb.Plug.Logger, application: :block_scout_web)
   end
 
   pipeline :account do
@@ -24,6 +25,7 @@ defmodule BlockScoutWeb.WebRouter do
     plug(:protect_from_forgery)
     plug(BlockScoutWeb.CSPHeader)
     plug(BlockScoutWeb.ChecksumAddress)
+    plug(BlockScoutWeb.Plug.Logger, application: :block_scout_web)
   end
 
   if Mix.env() == :dev do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -487,7 +487,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:48
 #: lib/block_scout_web/templates/address/overview.html.eex:275
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:381
+#: lib/block_scout_web/views/address_view.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -582,13 +582,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:374
+#: lib/block_scout_web/views/address_view.ex:376
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:380
+#: lib/block_scout_web/views/address_view.ex:382
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Decoded"
 msgstr ""
 
-#: lib/block_scout_web/views/address_view.ex:375
+#: lib/block_scout_web/views/address_view.ex:377
 #, elixir-autogen, elixir-format
 msgid "Decompiled Code"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:371
+#: lib/block_scout_web/views/address_view.ex:373
 #: lib/block_scout_web/views/transaction_view.ex:528
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1621,7 +1621,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:382
+#: lib/block_scout_web/views/address_view.ex:384
 #: lib/block_scout_web/views/transaction_view.ex:529
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -2096,7 +2096,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:376
+#: lib/block_scout_web/views/address_view.ex:378
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -2104,7 +2104,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:377
+#: lib/block_scout_web/views/address_view.ex:379
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2730,7 +2730,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:373
+#: lib/block_scout_web/views/address_view.ex:375
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:110
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:527
@@ -2754,7 +2754,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:78
 #: lib/block_scout_web/templates/tokens/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:370
+#: lib/block_scout_web/views/address_view.ex:372
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -2916,7 +2916,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:213
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:372
+#: lib/block_scout_web/views/address_view.ex:374
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -3260,14 +3260,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:378
+#: lib/block_scout_web/views/address_view.ex:380
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:379
+#: lib/block_scout_web/views/address_view.ex:381
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -487,7 +487,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:48
 #: lib/block_scout_web/templates/address/overview.html.eex:275
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:381
+#: lib/block_scout_web/views/address_view.ex:383
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -582,13 +582,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:374
+#: lib/block_scout_web/views/address_view.ex:376
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:380
+#: lib/block_scout_web/views/address_view.ex:382
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Decoded"
 msgstr ""
 
-#: lib/block_scout_web/views/address_view.ex:375
+#: lib/block_scout_web/views/address_view.ex:377
 #, elixir-autogen, elixir-format
 msgid "Decompiled Code"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:371
+#: lib/block_scout_web/views/address_view.ex:373
 #: lib/block_scout_web/views/transaction_view.ex:528
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1621,7 +1621,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:382
+#: lib/block_scout_web/views/address_view.ex:384
 #: lib/block_scout_web/views/transaction_view.ex:529
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -2096,7 +2096,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:376
+#: lib/block_scout_web/views/address_view.ex:378
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -2104,7 +2104,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:377
+#: lib/block_scout_web/views/address_view.ex:379
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2730,7 +2730,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:373
+#: lib/block_scout_web/views/address_view.ex:375
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:110
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:527
@@ -2754,7 +2754,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:78
 #: lib/block_scout_web/templates/tokens/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:370
+#: lib/block_scout_web/views/address_view.ex:372
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -2916,7 +2916,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block_transaction/index.html.eex:10
 #: lib/block_scout_web/templates/chain/show.html.eex:213
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:372
+#: lib/block_scout_web/views/address_view.ex:374
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -3260,14 +3260,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:378
+#: lib/block_scout_web/views/address_view.ex:380
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:379
+#: lib/block_scout_web/views/address_view.ex:381
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -1547,6 +1547,19 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     end
   end
 
+  describe "/smart-contracts/counters" do
+    test "fetch counters", %{conn: conn} do
+      request = get(conn, "/api/v2/smart-contracts/counters")
+
+      assert %{
+               "smart_contracts" => _,
+               "new_smart_contracts_24h" => _,
+               "verified_smart_contracts" => _,
+               "new_verified_smart_contracts_24h" => _
+             } = json_response(request, 200)
+    end
+  end
+
   defp compare_item(%SmartContract{} = smart_contract, json) do
     assert smart_contract.compiler_version == json["compiler_version"]
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -142,6 +142,207 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       check_paginated_response(response, response_2nd_page, token_transfers)
     end
+
+    test "check that same token_ids within batch squashes", %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+
+      id = 0
+
+      insert(:token_instance, token_id: id, token_contract_address_hash: token.contract_address_hash)
+
+      tt =
+        for _ <- 0..50 do
+          tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          insert(:token_transfer,
+            transaction: tx,
+            block: tx.block,
+            block_number: tx.block_number,
+            token_contract_address: token.contract_address,
+            token_ids: Enum.map(0..50, fn _x -> id end),
+            amounts: Enum.map(0..50, fn x -> x end)
+          )
+        end
+
+      token_transfers =
+        for i <- tt do
+          %TokenTransfer{i | token_ids: [id], amount: Decimal.new(1275)}
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers", response["next_page_params"])
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers)
+    end
+
+    test "check that pagination works for 721 tokens", %{conn: conn} do
+      token = insert(:token, type: "ERC-721")
+
+      token_transfers =
+        for i <- 0..50 do
+          tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          insert(:token_transfer,
+            transaction: tx,
+            block: tx.block,
+            block_number: tx.block_number,
+            token_contract_address: token.contract_address,
+            token_ids: [i]
+          )
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers", response["next_page_params"])
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers)
+    end
+
+    test "check that pagination works fine with 1155 batches #1 (large batch)", %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+      tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt =
+        insert(:token_transfer,
+          transaction: tx,
+          block: tx.block,
+          block_number: tx.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(0..50, fn x -> x end),
+          amounts: Enum.map(0..50, fn x -> x end)
+        )
+
+      token_transfers =
+        for i <- 0..50 do
+          %TokenTransfer{tt | token_ids: [i], amount: i}
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers", response["next_page_params"])
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers)
+    end
+
+    test "check that pagination works fine with 1155 batches #2 some batches on the first page and one on the second",
+         %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+
+      tx_1 = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt_1 =
+        insert(:token_transfer,
+          transaction: tx_1,
+          block: tx_1.block,
+          block_number: tx_1.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(0..24, fn x -> x end),
+          amounts: Enum.map(0..24, fn x -> x end)
+        )
+
+      token_transfers_1 =
+        for i <- 0..24 do
+          %TokenTransfer{tt_1 | token_ids: [i], amount: i}
+        end
+
+      tx_2 = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt_2 =
+        insert(:token_transfer,
+          transaction: tx_2,
+          block: tx_2.block,
+          block_number: tx_2.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(25..49, fn x -> x end),
+          amounts: Enum.map(25..49, fn x -> x end)
+        )
+
+      token_transfers_2 =
+        for i <- 25..49 do
+          %TokenTransfer{tt_2 | token_ids: [i], amount: i}
+        end
+
+      tt_3 =
+        insert(:token_transfer,
+          transaction: tx_2,
+          block: tx_2.block,
+          block_number: tx_2.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: [50],
+          amounts: [50]
+        )
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers", response["next_page_params"])
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers_1 ++ token_transfers_2 ++ [tt_3])
+    end
+
+    test "check that pagination works fine with 1155 batches #3", %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+
+      tx_1 = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt_1 =
+        insert(:token_transfer,
+          transaction: tx_1,
+          block: tx_1.block,
+          block_number: tx_1.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(0..24, fn x -> x end),
+          amounts: Enum.map(0..24, fn x -> x end)
+        )
+
+      token_transfers_1 =
+        for i <- 0..24 do
+          %TokenTransfer{tt_1 | token_ids: [i], amount: i}
+        end
+
+      tx_2 = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt_2 =
+        insert(:token_transfer,
+          transaction: tx_2,
+          block: tx_2.block,
+          block_number: tx_2.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(25..50, fn x -> x end),
+          amounts: Enum.map(25..50, fn x -> x end)
+        )
+
+      token_transfers_2 =
+        for i <- 25..50 do
+          %TokenTransfer{tt_2 | token_ids: [i], amount: i}
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(conn, "/api/v2/tokens/#{token.contract_address.hash}/transfers", response["next_page_params"])
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers_1 ++ token_transfers_2)
+    end
   end
 
   describe "/tokens/{address_hash}/holders" do
@@ -393,6 +594,107 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
       check_paginated_response(response, response_2nd_page, transfers_0 ++ transfers_1)
     end
+
+    test "check that pagination works for 721 tokens", %{conn: conn} do
+      token = insert(:token, type: "ERC-721")
+      id = 0
+      insert(:token_instance, token_id: id, token_contract_address_hash: token.contract_address_hash)
+
+      token_transfers =
+        for _i <- 0..50 do
+          tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          insert(:token_transfer,
+            transaction: tx,
+            block: tx.block,
+            block_number: tx.block_number,
+            token_contract_address: token.contract_address,
+            token_ids: [id]
+          )
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{id}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(
+          conn,
+          "/api/v2/tokens/#{token.contract_address.hash}/instances/#{id}/transfers",
+          response["next_page_params"]
+        )
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers)
+    end
+
+    test "check that same token_ids within batch squashes", %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+
+      id = 0
+
+      insert(:token_instance, token_id: id, token_contract_address_hash: token.contract_address_hash)
+
+      tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt =
+        insert(:token_transfer,
+          transaction: tx,
+          block: tx.block,
+          block_number: tx.block_number,
+          token_contract_address: token.contract_address,
+          token_ids: Enum.map(0..50, fn _x -> id end),
+          amounts: Enum.map(0..50, fn x -> x end)
+        )
+
+      token_transfer = %TokenTransfer{tt | token_ids: [id], amount: Decimal.new(1275)}
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{id}/transfers")
+      assert %{"next_page_params" => nil, "items" => [item]} = json_response(request, 200)
+      compare_item(token_transfer, item)
+    end
+
+    test "check that pagination works fine with 1155 batches #1 (51 batch with twice repeated id. Repeated id squashed into one element)",
+         %{conn: conn} do
+      token = insert(:token, type: "ERC-1155")
+
+      id = 0
+      amount = 101
+      insert(:token_instance, token_id: id, token_contract_address_hash: token.contract_address_hash)
+
+      tx = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      tt =
+        for _ <- 0..50 do
+          insert(:token_transfer,
+            transaction: tx,
+            block: tx.block,
+            block_number: tx.block_number,
+            token_contract_address: token.contract_address,
+            token_ids: Enum.map(0..50, fn x -> x end) ++ [id],
+            amounts: Enum.map(1..51, fn x -> x end) ++ [amount]
+          )
+        end
+
+      token_transfers =
+        for i <- tt do
+          %TokenTransfer{i | token_ids: [id], amount: amount + 1}
+        end
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{id}/transfers")
+      assert response = json_response(request, 200)
+
+      request_2nd_page =
+        get(
+          conn,
+          "/api/v2/tokens/#{token.contract_address.hash}/instances/#{id}/transfers",
+          response["next_page_params"]
+        )
+
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      check_paginated_response(response, response_2nd_page, token_transfers)
+    end
   end
 
   describe "/tokens/{address_hash}/instances/{token_id}/transfers-count" do
@@ -491,8 +793,18 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     compare_item(Repo.preload(instance, [{:token, :contract_address}]).token, json["token"])
   end
 
-  def check_total(%Token{type: nft}, json, token_transfer) when nft in ["ERC-721", "ERC-1155"] do
+  def check_total(%Token{type: nft}, json, token_transfer) when nft in ["ERC-1155"] do
+    json["token_id"] in Enum.map(token_transfer.token_ids, fn x -> to_string(x) end) and
+      json["value"] == to_string(token_transfer.amount)
+  end
+
+  def check_total(%Token{type: nft}, json, token_transfer) when nft in ["ERC-721"] do
     json["token_id"] in Enum.map(token_transfer.token_ids, fn x -> to_string(x) end)
+  end
+
+  # with the current implementation no transfers should come with list in totals
+  def check_total(%Token{type: nft}, json, _token_transfer) when nft in ["ERC-721", "ERC-1155"] and is_list(json) do
+    false
   end
 
   def check_total(_, _, _), do: true

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -336,7 +336,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     end
 
     test "get token transfers by instance", %{conn: conn} do
-      token = insert(:token, type: "ERC-721")
+      token = insert(:token, type: "ERC-1155")
 
       for _ <- 0..50 do
         insert(:token_instance, token_id: 0)
@@ -354,14 +354,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       insert_list(100, :token_transfer,
         token_contract_address: token.contract_address,
         transaction: transaction,
-        token_ids: [id + 1]
+        token_ids: [id + 1],
+        amounts: [1]
       )
 
       transfers_0 =
         insert_list(26, :token_transfer,
           token_contract_address: token.contract_address,
           transaction: transaction,
-          token_ids: [id, id + 1]
+          token_ids: [id, id + 1],
+          amounts: [1, 2]
         )
 
       transfers_1 =

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -46,3 +46,4 @@ config :explorer, Explorer.ExchangeRates.Source.TransactionAndLog,
   secondary_source: Explorer.ExchangeRates.Source.OneCoinSource
 
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: false
+config :explorer, Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand, enabled: false

--- a/apps/explorer/lib/explorer/application/constants.ex
+++ b/apps/explorer/lib/explorer/application/constants.ex
@@ -4,7 +4,7 @@ defmodule Explorer.Application.Constants do
   """
 
   use Explorer.Schema
-  alias Explorer.Repo
+  alias Explorer.{Chain, Repo}
 
   @keys_manager_contract_address_key "keys_manager_contract_address"
 
@@ -28,10 +28,10 @@ defmodule Explorer.Application.Constants do
     |> validate_required(@required_attrs)
   end
 
-  def get_constant_by_key(key) do
+  def get_constant_by_key(key, options) do
     __MODULE__
     |> where([constant], constant.key == ^key)
-    |> Repo.one()
+    |> Chain.select_repo(options).one()
   end
 
   def insert_keys_manager_contract_address(value) do
@@ -40,7 +40,7 @@ defmodule Explorer.Application.Constants do
     |> Repo.insert!()
   end
 
-  def get_keys_manager_contract_address do
-    get_constant_by_key(@keys_manager_contract_address_key)
+  def get_keys_manager_contract_address(options \\ []) do
+    get_constant_by_key(@keys_manager_contract_address_key, options)
   end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2997,7 +2997,7 @@ defmodule Explorer.Chain do
     )
   end
 
-  def get_last_fetched_counter(type) do
+  def get_last_fetched_counter(type, options \\ []) do
     query =
       from(
         last_fetched_counter in LastFetchedCounter,
@@ -3005,7 +3005,7 @@ defmodule Explorer.Chain do
         select: last_fetched_counter.value
       )
 
-    Repo.one!(query) || Decimal.new(0)
+    select_repo(options).one(query) || Decimal.new(0)
   end
 
   defp block_status({number, timestamp}) do
@@ -5885,13 +5885,15 @@ defmodule Explorer.Chain do
     end
   end
 
-  def combine_proxy_implementation_abi(%SmartContract{abi: abi} = smart_contract) when not is_nil(abi) do
-    implementation_abi = get_implementation_abi_from_proxy(smart_contract)
+  def combine_proxy_implementation_abi(smart_contract, options \\ [])
+
+  def combine_proxy_implementation_abi(%SmartContract{abi: abi} = smart_contract, options) when not is_nil(abi) do
+    implementation_abi = get_implementation_abi_from_proxy(smart_contract, options)
 
     if Enum.empty?(implementation_abi), do: abi, else: implementation_abi ++ abi
   end
 
-  def combine_proxy_implementation_abi(_) do
+  def combine_proxy_implementation_abi(_, _) do
     []
   end
 
@@ -5928,12 +5930,15 @@ defmodule Explorer.Chain do
     end)
   end
 
-  def get_implementation_abi(implementation_address_hash_string) when not is_nil(implementation_address_hash_string) do
+  def get_implementation_abi(implementation_address_hash_string, options \\ [])
+
+  def get_implementation_abi(implementation_address_hash_string, options)
+      when not is_nil(implementation_address_hash_string) do
     case Chain.string_to_address_hash(implementation_address_hash_string) do
       {:ok, implementation_address_hash} ->
         implementation_smart_contract =
           implementation_address_hash
-          |> Chain.address_hash_to_smart_contract()
+          |> address_hash_to_smart_contract(options)
 
         if implementation_smart_contract do
           implementation_smart_contract
@@ -5947,17 +5952,20 @@ defmodule Explorer.Chain do
     end
   end
 
-  def get_implementation_abi(implementation_address_hash_string) when is_nil(implementation_address_hash_string) do
+  def get_implementation_abi(implementation_address_hash_string, _) when is_nil(implementation_address_hash_string) do
     []
   end
 
-  def get_implementation_abi_from_proxy(%SmartContract{address_hash: proxy_address_hash, abi: abi} = smart_contract)
+  def get_implementation_abi_from_proxy(
+        %SmartContract{address_hash: proxy_address_hash, abi: abi} = smart_contract,
+        options
+      )
       when not is_nil(proxy_address_hash) and not is_nil(abi) do
-    {implementation_address_hash_string, _name} = SmartContract.get_implementation_address_hash(smart_contract)
+    {implementation_address_hash_string, _name} = SmartContract.get_implementation_address_hash(smart_contract, options)
     get_implementation_abi(implementation_address_hash_string)
   end
 
-  def get_implementation_abi_from_proxy(_), do: []
+  def get_implementation_abi_from_proxy(_, _), do: []
 
   defp format_tx_first_trace(first_trace, block_hash, json_rpc_named_arguments) do
     {:ok, to_address_hash} =
@@ -6389,20 +6397,20 @@ defmodule Explorer.Chain do
     |> Repo.aggregate(:count, timeout: :infinity)
   end
 
-  def count_verified_contracts_from_cache do
-    VerifiedContractsCounter.fetch()
+  def count_verified_contracts_from_cache(options \\ []) do
+    VerifiedContractsCounter.fetch(options)
   end
 
-  def count_new_verified_contracts_from_cache do
-    NewVerifiedContractsCounter.fetch()
+  def count_new_verified_contracts_from_cache(options \\ []) do
+    NewVerifiedContractsCounter.fetch(options)
   end
 
-  def count_contracts_from_cache do
-    ContractsCounter.fetch()
+  def count_contracts_from_cache(options \\ []) do
+    ContractsCounter.fetch(options)
   end
 
-  def count_new_contracts_from_cache do
-    NewContractsCounter.fetch()
+  def count_new_contracts_from_cache(options \\ []) do
+    NewContractsCounter.fetch(options)
   end
 
   def address_counters(address, options \\ []) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -6467,4 +6467,66 @@ defmodule Explorer.Chain do
     end)
     |> List.to_tuple()
   end
+
+  @spec flat_1155_batch_token_transfers([TokenTransfer.t()], Decimal.t() | nil) :: [TokenTransfer.t()]
+  def flat_1155_batch_token_transfers(token_transfers, token_id \\ nil) when is_list(token_transfers) do
+    Enum.reduce(token_transfers, [], fn tt, acc ->
+      case tt.token_ids do
+        [] ->
+          Enum.reverse([tt | Enum.reverse(acc)])
+
+        [_token_id] ->
+          Enum.reverse([tt | Enum.reverse(acc)])
+
+        token_ids when is_list(token_ids) ->
+          transfers = flat_1155_batch_token_transfer(tt, tt.amounts, token_ids, token_id)
+
+          acc ++ transfers
+
+        _ ->
+          Enum.reverse([tt | Enum.reverse(acc)])
+      end
+    end)
+  end
+
+  defp flat_1155_batch_token_transfer(tt, amounts, token_ids, token_id_to_filter) do
+    amounts
+    |> Enum.zip(token_ids)
+    |> Enum.with_index()
+    |> Enum.map(fn {{amount, token_id}, index} ->
+      if is_nil(token_id_to_filter) || token_id == token_id_to_filter do
+        %TokenTransfer{tt | token_ids: [token_id], amount: amount, amounts: nil, index_in_batch: index}
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @spec paginate_1155_batch_token_transfers([TokenTransfer.t()], [paging_options]) :: [TokenTransfer.t()]
+  def paginate_1155_batch_token_transfers(token_transfers, options) do
+    paging_options = options |> Keyword.get(:paging_options, nil)
+
+    case paging_options do
+      %PagingOptions{batch_key: batch_key} when not is_nil(batch_key) ->
+        filter_previous_page_transfers(token_transfers, batch_key)
+
+      _ ->
+        token_transfers
+    end
+  end
+
+  defp filter_previous_page_transfers(
+         token_transfers,
+         {batch_block_hash, batch_transaction_hash, batch_log_index, index_in_batch}
+       ) do
+    token_transfers
+    |> Enum.reverse()
+    |> Enum.reduce_while([], fn tt, acc ->
+      if tt.block_hash == batch_block_hash and tt.transaction_hash == batch_transaction_hash and
+           tt.log_index == batch_log_index and tt.index_in_batch == index_in_batch do
+        {:halt, acc}
+      else
+        {:cont, [tt | acc]}
+      end
+    end)
+  end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -192,7 +192,7 @@ defmodule Explorer.Chain do
     cached_value = AddressesCounter.fetch()
 
     if is_nil(cached_value) || cached_value == 0 do
-      count = CacheHelper.estimated_count_from("addresses")
+      count = CacheHelper.estimated_count_from("addresses", options)
 
       max(count, 0)
     else

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -172,6 +172,7 @@ defmodule Explorer.Chain do
   @typep necessity_by_association_option :: {:necessity_by_association, necessity_by_association}
   @typep paging_options :: {:paging_options, PagingOptions.t()}
   @typep balance_by_day :: %{date: String.t(), value: Wei.t()}
+  @typep api? :: {:api?, true | false}
 
   @doc """
   Gets from the cache the count of `t:Explorer.Chain.Address.t/0`'s where the `fetched_coin_balance` is > 0
@@ -187,7 +188,7 @@ defmodule Explorer.Chain do
   Estimated count of addresses.
   """
   @spec address_estimated_count() :: non_neg_integer()
-  def address_estimated_count do
+  def address_estimated_count(options \\ []) do
     cached_value = AddressesCounter.fetch()
 
     if is_nil(cached_value) || cached_value == 0 do
@@ -286,7 +287,7 @@ defmodule Explorer.Chain do
       |> common_where_limit_order(paging_options)
       |> preload(transaction: :block)
       |> join_associations(necessity_by_association)
-      |> Repo.all()
+      |> select_repo(options).all()
     else
       InternalTransaction
       |> InternalTransaction.where_nonpending_block()
@@ -295,7 +296,7 @@ defmodule Explorer.Chain do
       |> common_where_limit_order(paging_options)
       |> preload(transaction: :block)
       |> join_associations(necessity_by_association)
-      |> Repo.all()
+      |> select_repo(options).all()
     end
   end
 
@@ -377,7 +378,8 @@ defmodule Explorer.Chain do
           address_to_transactions_without_rewards(address_hash, options)
 
         address_has_rewards?(address_hash) ->
-          %{payout_key: block_miner_payout_address} = Reward.get_validator_payout_key_by_mining(address_hash)
+          %{payout_key: block_miner_payout_address} =
+            Reward.get_validator_payout_key_by_mining_from_db(address_hash, options)
 
           if block_miner_payout_address && address_hash == block_miner_payout_address do
             transactions_with_rewards_results(address_hash, options, paging_options)
@@ -397,7 +399,7 @@ defmodule Explorer.Chain do
     blocks_range = address_to_transactions_tasks_range_of_blocks(address_hash, options)
 
     rewards_task =
-      Task.async(fn -> Reward.fetch_emission_rewards_tuples(address_hash, paging_options, blocks_range) end)
+      Task.async(fn -> Reward.fetch_emission_rewards_tuples(address_hash, paging_options, blocks_range, options) end)
 
     [rewards_task | address_to_transactions_tasks(address_hash, options)]
     |> wait_for_address_transactions()
@@ -478,7 +480,7 @@ defmodule Explorer.Chain do
     |> where_block_number_in_period(from_block, to_block)
     |> join_associations(necessity_by_association)
     |> Transaction.matching_address_queries_list(direction, address_hash)
-    |> Enum.map(fn query -> Task.async(fn -> Repo.all(query) end) end)
+    |> Enum.map(fn query -> Task.async(fn -> select_repo(options).all(query) end) end)
   end
 
   defp address_to_mined_transactions_tasks(address_hash, options) do
@@ -579,7 +581,7 @@ defmodule Explorer.Chain do
     |> TokenTransfer.token_transfers_by_address_hash(address_hash, filters)
     |> join_associations(necessity_by_association)
     |> TokenTransfer.handle_paging_options(paging_options)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @spec address_hash_to_token_transfers_by_token_address_hash(
@@ -596,7 +598,7 @@ defmodule Explorer.Chain do
     |> TokenTransfer.token_transfers_by_address_hash_and_token_address_hash(token_address_hash)
     |> join_associations(necessity_by_association)
     |> TokenTransfer.handle_paging_options(paging_options)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -693,7 +695,7 @@ defmodule Explorer.Chain do
 
     base_query =
       base
-      |> filter_topic(options)
+      |> filter_topic(Keyword.get(options, :topic))
 
     wrapped_query =
       from(
@@ -709,19 +711,19 @@ defmodule Explorer.Chain do
 
     wrapped_query
     |> where_block_number_in_period(from_block, to_block)
-    |> Repo.all()
+    |> select_repo(options).all()
     |> Enum.take(paging_options.page_size)
   end
 
-  defp filter_topic(base_query, topic: topic) do
+  defp filter_topic(base_query, nil), do: base_query
+
+  defp filter_topic(base_query, topic) do
     from(log in base_query,
       where:
         log.first_topic == ^topic or log.second_topic == ^topic or log.third_topic == ^topic or
           log.fourth_topic == ^topic
     )
   end
-
-  defp filter_topic(base_query, _), do: base_query
 
   def where_block_number_in_period(base_query, from_block, to_block) when is_nil(from_block) and not is_nil(to_block) do
     from(q in base_query,
@@ -965,10 +967,11 @@ defmodule Explorer.Chain do
     |> where([_, block], block.hash == ^block_hash)
     |> join_associations(necessity_by_association)
     |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()
-    |> Repo.all()
+    |> select_repo(options).all()
     |> (&if(old_ui?,
           do: &1,
-          else: Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association) end)
+          else:
+            Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association, options) end)
         )).()
   end
 
@@ -1272,8 +1275,8 @@ defmodule Explorer.Chain do
   Checks to see if the chain is down indexing based on the transaction from the
   oldest block and the pending operation
   """
-  @spec finished_internal_transactions_indexing?() :: boolean()
-  def finished_internal_transactions_indexing? do
+  @spec finished_internal_transactions_indexing?([api?]) :: boolean()
+  def finished_internal_transactions_indexing?(options \\ []) do
     internal_transactions_disabled? = System.get_env("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER", "false") == "true"
 
     if internal_transactions_disabled? do
@@ -1285,8 +1288,9 @@ defmodule Explorer.Chain do
       if variant == EthereumJSONRPC.Ganache || variant == EthereumJSONRPC.Arbitrum do
         true
       else
-        with {:transactions_exist, true} <- {:transactions_exist, Repo.exists?(Transaction)},
-             min_block_number when not is_nil(min_block_number) <- Repo.aggregate(Transaction, :min, :block_number) do
+        with {:transactions_exist, true} <- {:transactions_exist, select_repo(options).exists?(Transaction)},
+             min_block_number when not is_nil(min_block_number) <-
+               select_repo(options).aggregate(Transaction, :min, :block_number) do
           min_block_number =
             min_block_number
             |> Decimal.max(EthereumJSONRPC.first_block_to_fetch(:trace_first_block))
@@ -1299,7 +1303,7 @@ defmodule Explorer.Chain do
               where: b.consensus and b.number == ^min_block_number
             )
 
-          !Repo.exists?(query)
+          !select_repo(options).exists?(query)
         else
           {:transactions_exist, false} -> true
           nil -> false
@@ -1315,11 +1319,11 @@ defmodule Explorer.Chain do
   @doc """
   Checks if indexing of blocks and internal transactions finished aka full indexing
   """
-  @spec finished_indexing?(Decimal.t()) :: boolean()
-  def finished_indexing?(indexed_ratio_blocks) do
+  @spec finished_indexing?(Decimal.t(), [api?]) :: boolean()
+  def finished_indexing?(indexed_ratio_blocks, options \\ []) do
     case finished_blocks_indexing?(indexed_ratio_blocks) do
       false -> false
-      _ -> Chain.finished_internal_transactions_indexing?()
+      _ -> finished_internal_transactions_indexing?(options)
     end
   end
 
@@ -1357,7 +1361,7 @@ defmodule Explorer.Chain do
   Optionally it also accepts a boolean to fetch the `has_decompiled_code?` virtual field or not
 
   """
-  @spec hash_to_address(Hash.Address.t(), [necessity_by_association_option], boolean()) ::
+  @spec hash_to_address(Hash.Address.t(), [necessity_by_association_option | api?], boolean()) ::
           {:ok, Address.t()} | {:error, :not_found}
   def hash_to_address(
         %Hash{byte_count: unquote(Hash.Address.byte_count())} = hash,
@@ -1384,7 +1388,7 @@ defmodule Explorer.Chain do
       query
       |> join_associations(necessity_by_association)
       |> with_decompiled_code_flag(hash, query_decompiled_code_flag)
-      |> Repo.one()
+      |> select_repo(options).one()
 
     address_updated_result =
       case address_result do
@@ -1393,8 +1397,8 @@ defmodule Explorer.Chain do
             address_result
           else
             address_verified_twin_contract =
-              Chain.get_minimal_proxy_template(hash) ||
-                Chain.get_address_verified_twin_contract(hash).verified_contract
+              get_minimal_proxy_template(hash, options) ||
+                get_address_verified_twin_contract(hash, options).verified_contract
 
             if address_verified_twin_contract do
               address_verified_twin_contract_updated =
@@ -1601,7 +1605,7 @@ defmodule Explorer.Chain do
     end
   end
 
-  def joint_search(paging_options, offset, raw_string) do
+  def joint_search(paging_options, offset, raw_string, options \\ []) do
     string = String.trim(raw_string)
 
     case prepare_search_term(string) do
@@ -1648,7 +1652,7 @@ defmodule Explorer.Chain do
           ordered_query
           |> page_search_results(paging_options)
 
-        search_results = Repo.all(paginated_ordered_query)
+        search_results = select_repo(options).all(paginated_ordered_query)
 
         search_results
         |> Enum.map(fn result ->
@@ -1905,7 +1909,7 @@ defmodule Explorer.Chain do
       query
       |> join_associations(necessity_by_association)
       |> with_decompiled_code_flag(hash, query_decompiled_code_flag)
-      |> Repo.one()
+      |> select_repo(options).one()
 
     address_updated_result =
       case address_result do
@@ -1915,8 +1919,8 @@ defmodule Explorer.Chain do
             address_result
           else
             address_verified_twin_contract =
-              Chain.get_minimal_proxy_template(hash) ||
-                Chain.get_address_verified_twin_contract(hash).verified_contract
+              get_minimal_proxy_template(hash, options) ||
+                get_address_verified_twin_contract(hash, options).verified_contract
 
             if address_verified_twin_contract do
               address_verified_twin_contract_updated =
@@ -1997,14 +2001,15 @@ defmodule Explorer.Chain do
       `t:Explorer.Chain.Block.t/0` will not be included in the page `entries`.
 
   """
-  @spec hash_to_block(Hash.Full.t(), [necessity_by_association_option]) :: {:ok, Block.t()} | {:error, :not_found}
+  @spec hash_to_block(Hash.Full.t(), [necessity_by_association_option | api?]) ::
+          {:ok, Block.t()} | {:error, :not_found}
   def hash_to_block(%Hash{byte_count: unquote(Hash.Full.byte_count())} = hash, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
     Block
     |> where(hash: ^hash)
     |> join_associations(necessity_by_association)
-    |> Repo.one()
+    |> select_repo(options).one()
     |> case do
       nil ->
         {:error, :not_found}
@@ -2066,7 +2071,7 @@ defmodule Explorer.Chain do
       `:required`, and the `t:Explorer.Chain.Transaction.t/0` has no associated record for that association, then the
       `t:Explorer.Chain.Transaction.t/0` will not be included in the page `entries`.
   """
-  @spec hash_to_transaction(Hash.Full.t(), [necessity_by_association_option]) ::
+  @spec hash_to_transaction(Hash.Full.t(), [necessity_by_association_option | api?]) ::
           {:ok, Transaction.t()} | {:error, :not_found}
   def hash_to_transaction(
         %Hash{byte_count: unquote(Hash.Full.byte_count())} = hash,
@@ -2078,7 +2083,7 @@ defmodule Explorer.Chain do
     Transaction
     |> where(hash: ^hash)
     |> join_associations(necessity_by_association)
-    |> Repo.one()
+    |> select_repo(options).one()
     |> case do
       nil ->
         {:error, :not_found}
@@ -2092,6 +2097,7 @@ defmodule Explorer.Chain do
   def preload_token_transfers(
         %Transaction{hash: tx_hash, block_hash: block_hash} = transaction,
         necessity_by_association,
+        options,
         preload_to_detect_tt? \\ true
       ) do
     token_transfers =
@@ -2108,7 +2114,7 @@ defmodule Explorer.Chain do
       |> limit(^if(preload_to_detect_tt?, do: 1, else: @token_transfers_per_transaction_preview + 1))
       |> order_by([token_transfer], asc: token_transfer.log_index)
       |> join_associations(necessity_by_association)
-      |> Repo.all()
+      |> select_repo(options).all()
 
     %Transaction{transaction | token_transfers: token_transfers}
   end
@@ -2298,7 +2304,7 @@ defmodule Explorer.Chain do
     * ':block_type' - use to filter by type of block; Uncle`, `Reorg`, or `Block` (default).
 
   """
-  @spec list_blocks([paging_options | necessity_by_association_option]) :: [Block.t()]
+  @spec list_blocks([paging_options | necessity_by_association_option | api?]) :: [Block.t()]
   def list_blocks(options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options) || @default_paging_options
@@ -2306,20 +2312,20 @@ defmodule Explorer.Chain do
 
     cond do
       block_type == "Block" && !paging_options.key ->
-        block_from_cache(block_type, paging_options, necessity_by_association)
+        block_from_cache(block_type, paging_options, necessity_by_association, options)
 
       block_type == "Uncle" && !paging_options.key ->
-        uncles_from_cache(block_type, paging_options, necessity_by_association)
+        uncles_from_cache(block_type, paging_options, necessity_by_association, options)
 
       true ->
-        fetch_blocks(block_type, paging_options, necessity_by_association)
+        fetch_blocks(block_type, paging_options, necessity_by_association, options)
     end
   end
 
-  defp block_from_cache(block_type, paging_options, necessity_by_association) do
+  defp block_from_cache(block_type, paging_options, necessity_by_association, options) do
     case Blocks.take_enough(paging_options.page_size) do
       nil ->
-        elements = fetch_blocks(block_type, paging_options, necessity_by_association)
+        elements = fetch_blocks(block_type, paging_options, necessity_by_association, options)
 
         Blocks.update(elements)
 
@@ -2330,10 +2336,10 @@ defmodule Explorer.Chain do
     end
   end
 
-  def uncles_from_cache(block_type, paging_options, necessity_by_association) do
+  def uncles_from_cache(block_type, paging_options, necessity_by_association, options) do
     case Uncles.take_enough(paging_options.page_size) do
       nil ->
-        elements = fetch_blocks(block_type, paging_options, necessity_by_association)
+        elements = fetch_blocks(block_type, paging_options, necessity_by_association, options)
 
         Uncles.update(elements)
 
@@ -2344,14 +2350,14 @@ defmodule Explorer.Chain do
     end
   end
 
-  defp fetch_blocks(block_type, paging_options, necessity_by_association) do
+  defp fetch_blocks(block_type, paging_options, necessity_by_association, options) do
     Block
     |> Block.block_type_filter(block_type)
     |> page_blocks(paging_options)
     |> limit(^paging_options.page_size)
     |> order_by(desc: :number)
     |> join_associations(necessity_by_association)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -2390,7 +2396,7 @@ defmodule Explorer.Chain do
       |> Accounts.take_enough()
       |> case do
         nil ->
-          accounts_with_n = fetch_top_addresses(paging_options)
+          accounts_with_n = fetch_top_addresses(options)
 
           accounts_with_n
           |> Enum.map(fn {address, _n} -> address end)
@@ -2410,11 +2416,13 @@ defmodule Explorer.Chain do
           )
       end
     else
-      fetch_top_addresses(paging_options)
+      fetch_top_addresses(options)
     end
   end
 
-  defp fetch_top_addresses(paging_options) do
+  defp fetch_top_addresses(options) do
+    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+
     base_query =
       from(a in Address,
         where: a.fetched_coin_balance > ^0,
@@ -2426,7 +2434,7 @@ defmodule Explorer.Chain do
     base_query
     |> page_addresses(paging_options)
     |> limit(^paging_options.page_size)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -2438,10 +2446,10 @@ defmodule Explorer.Chain do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
     token_type = Keyword.get(options, :token_type, nil)
 
-    fetch_top_tokens(filter, paging_options, token_type)
+    fetch_top_tokens(filter, paging_options, token_type, options)
   end
 
-  defp fetch_top_tokens(filter, paging_options, token_type) do
+  defp fetch_top_tokens(filter, paging_options, token_type, options) do
     base_query = base_token_query(token_type)
 
     base_query_with_paging =
@@ -2464,7 +2472,7 @@ defmodule Explorer.Chain do
       end
 
     query
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   defp base_token_query(empty_type) when empty_type in [nil, []] do
@@ -2526,15 +2534,15 @@ defmodule Explorer.Chain do
     |> page_blocks(paging_options)
     |> limit(^paging_options.page_size)
     |> order_by(desc: :number)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
-  def check_if_validated_blocks_at_address(address_hash) do
-    Repo.exists?(from(b in Block, where: b.miner_hash == ^address_hash))
+  def check_if_validated_blocks_at_address(address_hash, options \\ []) do
+    select_repo(options).exists?(from(b in Block, where: b.miner_hash == ^address_hash))
   end
 
-  def check_if_logs_at_address(address_hash) do
-    Repo.exists?(from(l in Log, where: l.address_hash == ^address_hash))
+  def check_if_logs_at_address(address_hash, options \\ []) do
+    select_repo(options).exists?(from(l in Log, where: l.address_hash == ^address_hash))
   end
 
   def check_if_internal_transactions_at_address(address_hash) do
@@ -2551,19 +2559,19 @@ defmodule Explorer.Chain do
       internal_transactions_exists_by_to_address_hash
   end
 
-  def check_if_token_transfers_at_address(address_hash) do
+  def check_if_token_transfers_at_address(address_hash, options \\ []) do
     token_transfers_exists_by_from_address_hash =
-      Repo.exists?(from(tt in TokenTransfer, where: tt.from_address_hash == ^address_hash))
+      select_repo(options).exists?(from(tt in TokenTransfer, where: tt.from_address_hash == ^address_hash))
 
     token_transfers_exists_by_to_address_hash =
-      Repo.exists?(from(tt in TokenTransfer, where: tt.to_address_hash == ^address_hash))
+      select_repo(options).exists?(from(tt in TokenTransfer, where: tt.to_address_hash == ^address_hash))
 
     token_transfers_exists_by_from_address_hash ||
       token_transfers_exists_by_to_address_hash
   end
 
-  def check_if_tokens_at_address(address_hash) do
-    Repo.exists?(
+  def check_if_tokens_at_address(address_hash, options \\ []) do
+    select_repo(options).exists?(
       from(
         tb in CurrentTokenBalance,
         where: tb.address_hash == ^address_hash,
@@ -2591,11 +2599,11 @@ defmodule Explorer.Chain do
   @doc """
   Counts the number of `t:Explorer.Chain.Block.t/0` validated by the address with the given `hash`.
   """
-  @spec address_to_validation_count(Hash.Address.t()) :: non_neg_integer()
-  def address_to_validation_count(hash) do
+  @spec address_to_validation_count(Hash.Address.t(), [api?]) :: non_neg_integer()
+  def address_to_validation_count(hash, options) do
     query = from(block in Block, where: block.miner_hash == ^hash, select: fragment("COUNT(*)"))
 
-    Repo.one(query)
+    select_repo(options).one(query)
   end
 
   @spec address_to_transaction_count(Address.t()) :: non_neg_integer()
@@ -2944,10 +2952,10 @@ defmodule Explorer.Chain do
   end
 
   @spec block_height() :: block_height()
-  def block_height do
+  def block_height(options \\ []) do
     query = from(block in Block, select: coalesce(max(block.number), 0), where: block.consensus == true)
 
-    Repo.one!(query)
+    select_repo(options).one!(query)
   end
 
   def last_db_block_status do
@@ -3191,7 +3199,7 @@ defmodule Explorer.Chain do
       `t:Explorer.Chain.Block.t/0` will not be included in the page `entries`.
 
   """
-  @spec number_to_block(Block.block_number(), [necessity_by_association_option]) ::
+  @spec number_to_block(Block.block_number(), [necessity_by_association_option | api?]) ::
           {:ok, Block.t()} | {:error, :not_found}
   def number_to_block(number, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
@@ -3199,7 +3207,7 @@ defmodule Explorer.Chain do
     Block
     |> where(consensus: true, number: ^number)
     |> join_associations(necessity_by_association)
-    |> Repo.one()
+    |> select_repo(options).one()
     |> case do
       nil -> {:error, :not_found}
       block -> {:ok, block}
@@ -3312,7 +3320,7 @@ defmodule Explorer.Chain do
       the `block_number` and `index` that are passed.
 
   """
-  @spec recent_collated_transactions(true | false, [paging_options | necessity_by_association_option]) :: [
+  @spec recent_collated_transactions(true | false, [paging_options | necessity_by_association_option | api?]) :: [
           Transaction.t()
         ]
   def recent_collated_transactions(old_ui?, options \\ [])
@@ -3327,7 +3335,8 @@ defmodule Explorer.Chain do
       paging_options,
       necessity_by_association,
       method_id_filter,
-      type_filter
+      type_filter,
+      options
     )
   end
 
@@ -3391,7 +3400,8 @@ defmodule Explorer.Chain do
         paging_options,
         necessity_by_association,
         method_id_filter,
-        type_filter
+        type_filter,
+        options
       ) do
     paging_options
     |> fetch_transactions()
@@ -3400,10 +3410,11 @@ defmodule Explorer.Chain do
     |> apply_filter_by_tx_type_to_transactions(type_filter)
     |> join_associations(necessity_by_association)
     |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()
-    |> Repo.all()
+    |> select_repo(options).all()
     |> (&if(old_ui?,
           do: &1,
-          else: Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association) end)
+          else:
+            Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association, options) end)
         )).()
   end
 
@@ -3450,10 +3461,11 @@ defmodule Explorer.Chain do
     |> order_by([transaction], desc: transaction.inserted_at, asc: transaction.hash)
     |> join_associations(necessity_by_association)
     |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()
-    |> Repo.all()
+    |> select_repo(options).all()
     |> (&if(old_ui?,
           do: &1,
-          else: Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association) end)
+          else:
+            Enum.map(&1, fn tx -> preload_token_transfers(tx, @token_transfers_necessity_by_association, options) end)
         )).()
   end
 
@@ -3580,7 +3592,9 @@ defmodule Explorer.Chain do
 
   """
 
-  @spec all_transaction_to_internal_transactions(Hash.Full.t(), [paging_options | necessity_by_association_option]) :: [
+  @spec all_transaction_to_internal_transactions(Hash.Full.t(), [
+          paging_options | necessity_by_association_option | api?
+        ]) :: [
           InternalTransaction.t()
         ]
   def all_transaction_to_internal_transactions(hash, options \\ []) when is_list(options) do
@@ -3595,12 +3609,13 @@ defmodule Explorer.Chain do
     |> limit(^paging_options.page_size)
     |> order_by([internal_transaction], asc: internal_transaction.index)
     |> preload(:transaction)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
-  @spec transaction_to_internal_transactions(Hash.Full.t(), [paging_options | necessity_by_association_option]) :: [
-          InternalTransaction.t()
-        ]
+  @spec transaction_to_internal_transactions(Hash.Full.t(), [paging_options | necessity_by_association_option | api?]) ::
+          [
+            InternalTransaction.t()
+          ]
   def transaction_to_internal_transactions(hash, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
@@ -3615,7 +3630,7 @@ defmodule Explorer.Chain do
     |> limit(^paging_options.page_size)
     |> order_by([internal_transaction], asc: internal_transaction.index)
     |> preload(:transaction)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -3631,8 +3646,8 @@ defmodule Explorer.Chain do
       the `index` that are passed.
 
   """
-  @spec transaction_to_logs(Hash.Full.t(), boolean(), [paging_options | necessity_by_association_option]) :: [Log.t()]
-  def transaction_to_logs(transaction_hash, from_api, options \\ []) when is_list(options) do
+  @spec transaction_to_logs(Hash.Full.t(), [paging_options | necessity_by_association_option | api?]) :: [Log.t()]
+  def transaction_to_logs(transaction_hash, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
@@ -3652,13 +3667,8 @@ defmodule Explorer.Chain do
       |> order_by([log], asc: log.index)
       |> join_associations(necessity_by_association)
 
-    if from_api do
-      query
-      |> Repo.replica().all()
-    else
-      query
-      |> Repo.all()
-    end
+    query
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -3696,7 +3706,7 @@ defmodule Explorer.Chain do
     |> limit(^paging_options.page_size)
     |> order_by([token_transfer], asc: token_transfer.log_index)
     |> join_associations(necessity_by_association)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   @doc """
@@ -4200,7 +4210,7 @@ defmodule Explorer.Chain do
     |> repo.insert(on_conflict: :nothing, conflict_target: [:address_hash, :name])
   end
 
-  def get_verified_twin_contract(%Explorer.Chain.Address{} = target_address) do
+  def get_verified_twin_contract(%Explorer.Chain.Address{} = target_address, options \\ []) do
     case target_address do
       %{contract_code: %Chain.Data{bytes: contract_code_bytes}} ->
         target_address_hash = target_address.hash
@@ -4217,7 +4227,7 @@ defmodule Explorer.Chain do
           )
 
         verified_contract_twin_query
-        |> Repo.one(timeout: 10_000)
+        |> select_repo(options).one(timeout: 10_000)
 
       _ ->
         nil
@@ -4228,19 +4238,21 @@ defmodule Explorer.Chain do
   Finds metadata for verification of a contract from verified twins: contracts with the same bytecode
   which were verified previously, returns a single t:SmartContract.t/0
   """
-  def get_address_verified_twin_contract(hash) when is_binary(hash) do
+  def get_address_verified_twin_contract(hash, options \\ [])
+
+  def get_address_verified_twin_contract(hash, options) when is_binary(hash) do
     case string_to_address_hash(hash) do
-      {:ok, address_hash} -> get_address_verified_twin_contract(address_hash)
+      {:ok, address_hash} -> get_address_verified_twin_contract(address_hash, options)
       _ -> %{:verified_contract => nil, :additional_sources => nil}
     end
   end
 
-  def get_address_verified_twin_contract(%Explorer.Chain.Hash{} = address_hash) do
-    with target_address <- Repo.get(Address, address_hash),
+  def get_address_verified_twin_contract(%Explorer.Chain.Hash{} = address_hash, options) do
+    with target_address <- select_repo(options).get(Address, address_hash),
          false <- is_nil(target_address) do
-      verified_contract_twin = get_verified_twin_contract(target_address)
+      verified_contract_twin = get_verified_twin_contract(target_address, options)
 
-      verified_contract_twin_additional_sources = get_contract_additional_sources(verified_contract_twin)
+      verified_contract_twin_additional_sources = get_contract_additional_sources(verified_contract_twin, options)
 
       %{
         :verified_contract => verified_contract_twin,
@@ -4252,9 +4264,9 @@ defmodule Explorer.Chain do
     end
   end
 
-  def get_minimal_proxy_template(address_hash) do
+  def get_minimal_proxy_template(address_hash, options \\ []) do
     minimal_proxy_template =
-      case Repo.get(Address, address_hash) do
+      case select_repo(options).get(Address, address_hash) do
         nil ->
           nil
 
@@ -4265,7 +4277,7 @@ defmodule Explorer.Chain do
             %Chain.Data{bytes: contract_code_bytes} ->
               contract_bytecode = Base.encode16(contract_code_bytes, case: :lower)
 
-              get_minimal_proxy_from_template_code(contract_bytecode)
+              get_minimal_proxy_from_template_code(contract_bytecode, options)
 
             _ ->
               nil
@@ -4275,7 +4287,7 @@ defmodule Explorer.Chain do
     minimal_proxy_template
   end
 
-  defp get_minimal_proxy_from_template_code(contract_bytecode) do
+  defp get_minimal_proxy_from_template_code(contract_bytecode, options) do
     case contract_bytecode do
       "363d3d373d3d3d363d73" <> <<template_address::binary-size(40)>> <> _ ->
         template_address = "0x" <> template_address
@@ -4289,7 +4301,7 @@ defmodule Explorer.Chain do
 
         template =
           query
-          |> Repo.one(timeout: 10_000)
+          |> select_repo(options).one(timeout: 10_000)
 
         template
 
@@ -4298,7 +4310,7 @@ defmodule Explorer.Chain do
     end
   end
 
-  defp get_contract_additional_sources(verified_contract_twin) do
+  defp get_contract_additional_sources(verified_contract_twin, options) do
     if verified_contract_twin do
       verified_contract_twin_additional_sources_query =
         from(
@@ -4307,28 +4319,28 @@ defmodule Explorer.Chain do
         )
 
       verified_contract_twin_additional_sources_query
-      |> Repo.all()
+      |> select_repo(options).all()
     else
       []
     end
   end
 
-  @spec address_hash_to_smart_contract(Hash.Address.t()) :: SmartContract.t() | nil
-  def address_hash_to_smart_contract(address_hash) do
+  @spec address_hash_to_smart_contract(Hash.Address.t(), [api?]) :: SmartContract.t() | nil
+  def address_hash_to_smart_contract(address_hash, options \\ []) do
     query =
       from(
         smart_contract in SmartContract,
         where: smart_contract.address_hash == ^address_hash
       )
 
-    current_smart_contract = Repo.one(query)
+    current_smart_contract = select_repo(options).one(query)
 
     if current_smart_contract do
       current_smart_contract
     else
       address_verified_twin_contract =
-        Chain.get_minimal_proxy_template(address_hash) ||
-          Chain.get_address_verified_twin_contract(address_hash).verified_contract
+        get_minimal_proxy_template(address_hash, options) ||
+          get_address_verified_twin_contract(address_hash, options).verified_contract
 
       if address_verified_twin_contract do
         address_verified_twin_contract
@@ -4343,39 +4355,41 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec address_hash_to_smart_contract_without_twin(Hash.Address.t()) :: SmartContract.t() | nil
-  def address_hash_to_smart_contract_without_twin(address_hash) do
+  @spec address_hash_to_smart_contract_without_twin(Hash.Address.t(), [api?]) :: SmartContract.t() | nil
+  def address_hash_to_smart_contract_without_twin(address_hash, options) do
     query =
       from(
         smart_contract in SmartContract,
         where: smart_contract.address_hash == ^address_hash
       )
 
-    Repo.one(query)
+    select_repo(options).one(query)
   end
 
-  def smart_contract_fully_verified?(address_hash_str) when is_binary(address_hash_str) do
+  def smart_contract_fully_verified?(address_hash, options \\ [])
+
+  def smart_contract_fully_verified?(address_hash_str, options) when is_binary(address_hash_str) do
     case string_to_address_hash(address_hash_str) do
       {:ok, address_hash} ->
-        check_fully_verified(address_hash)
+        check_fully_verified(address_hash, options)
 
       _ ->
         false
     end
   end
 
-  def smart_contract_fully_verified?(address_hash) do
-    check_fully_verified(address_hash)
+  def smart_contract_fully_verified?(address_hash, options) do
+    check_fully_verified(address_hash, options)
   end
 
-  defp check_fully_verified(address_hash) do
+  defp check_fully_verified(address_hash, options) do
     query =
       from(
         smart_contract in SmartContract,
         where: smart_contract.address_hash == ^address_hash
       )
 
-    result = Repo.one(query)
+    result = select_repo(options).one(query)
 
     if result, do: !result.partially_verified, else: false
   end
@@ -4709,11 +4723,12 @@ defmodule Explorer.Chain do
     )
   end
 
+  def page_current_token_balances(query, keyword) when is_list(keyword),
+    do: page_current_token_balances(query, Keyword.get(keyword, :paging_options))
+
   def page_current_token_balances(query, %PagingOptions{key: nil}), do: query
 
-  def page_current_token_balances(query, paging_options: %PagingOptions{key: nil}), do: query
-
-  def page_current_token_balances(query, paging_options: %PagingOptions{key: {name, type, value}}) do
+  def page_current_token_balances(query, %PagingOptions{key: {name, type, value}}) do
     where(
       query,
       [ctb, t],
@@ -4916,7 +4931,7 @@ defmodule Explorer.Chain do
       `:required`, and the `t:Token.t/0` has no associated record for that association,
       then the `t:Token.t/0` will not be included in the list.
   """
-  @spec token_from_address_hash(Hash.Address.t(), [necessity_by_association_option]) ::
+  @spec token_from_address_hash(Hash.Address.t(), [necessity_by_association_option | api?]) ::
           {:ok, Token.t()} | {:error, :not_found}
   def token_from_address_hash(
         %Hash{byte_count: unquote(Hash.Address.byte_count())} = hash,
@@ -4934,7 +4949,7 @@ defmodule Explorer.Chain do
     query
     |> join_associations(necessity_by_association)
     |> preload(:contract_address)
-    |> Repo.one()
+    |> select_repo(options).one()
     |> case do
       nil ->
         {:error, :not_found}
@@ -4962,9 +4977,9 @@ defmodule Explorer.Chain do
     TokenTransfer.count_token_transfers_from_token_hash(token_address_hash)
   end
 
-  @spec count_token_transfers_from_token_hash_and_token_id(Hash.t(), binary()) :: non_neg_integer()
-  def count_token_transfers_from_token_hash_and_token_id(token_address_hash, token_id) do
-    TokenTransfer.count_token_transfers_from_token_hash_and_token_id(token_address_hash, token_id)
+  @spec count_token_transfers_from_token_hash_and_token_id(Hash.t(), binary(), [api?]) :: non_neg_integer()
+  def count_token_transfers_from_token_hash_and_token_id(token_address_hash, token_id, options \\ []) do
+    TokenTransfer.count_token_transfers_from_token_hash_and_token_id(token_address_hash, token_id, options)
   end
 
   @spec transaction_has_token_transfers?(Hash.t()) :: boolean()
@@ -5125,31 +5140,31 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec fetch_last_token_balances(Hash.Address.t()) :: []
-  def fetch_last_token_balances(address_hash) do
+  @spec fetch_last_token_balances(Hash.Address.t(), [api?]) :: []
+  def fetch_last_token_balances(address_hash, options \\ []) do
     address_hash
     |> CurrentTokenBalance.last_token_balances()
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
-  @spec fetch_last_token_balances(Hash.Address.t(), [paging_options]) :: []
-  def fetch_last_token_balances(address_hash, options) do
+  @spec fetch_paginated_last_token_balances(Hash.Address.t(), [paging_options]) :: []
+  def fetch_paginated_last_token_balances(address_hash, options) do
     filter = Keyword.get(options, :token_type)
     options = Keyword.delete(options, :token_type)
 
     address_hash
     |> CurrentTokenBalance.last_token_balances(options, filter)
     |> page_current_token_balances(options)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
-  @spec erc721_or_erc1155_token_instance_from_token_id_and_token_address(binary(), Hash.Address.t()) ::
+  @spec erc721_or_erc1155_token_instance_from_token_id_and_token_address(binary(), Hash.Address.t(), [api?]) ::
           {:ok, Instance.t()} | {:error, :not_found}
-  def erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, token_contract_address) do
+  def erc721_or_erc1155_token_instance_from_token_id_and_token_address(token_id, token_contract_address, options \\ []) do
     query =
       from(i in Instance, where: i.token_contract_address_hash == ^token_contract_address and i.token_id == ^token_id)
 
-    case Repo.one(query) do
+    case select_repo(options).one(query) do
       nil -> {:error, :not_found}
       token_instance -> {:ok, token_instance}
     end
@@ -5187,7 +5202,7 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec address_to_coin_balances(Hash.Address.t(), [paging_options]) :: []
+  @spec address_to_coin_balances(Hash.Address.t(), [paging_options | api?]) :: []
   def address_to_coin_balances(address_hash, options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
@@ -5195,7 +5210,7 @@ defmodule Explorer.Chain do
       address_hash
       |> fetch_coin_balances(paging_options)
       |> page_coin_balances(paging_options)
-      |> Repo.all()
+      |> select_repo(options).all()
 
     if Enum.empty?(balances_raw) do
       balances_raw
@@ -5214,8 +5229,8 @@ defmodule Explorer.Chain do
         |> Enum.max_by(fn balance -> balance.block_number end, fn -> %{} end)
         |> Map.get(:block_number)
 
-      min_block_timestamp = find_block_timestamp(min_block_number)
-      max_block_timestamp = find_block_timestamp(max_block_number)
+      min_block_timestamp = find_block_timestamp(min_block_number, options)
+      max_block_timestamp = find_block_timestamp(max_block_number, options)
 
       min_block_unix_timestamp =
         min_block_timestamp
@@ -5268,19 +5283,19 @@ defmodule Explorer.Chain do
     Repo.one(query)
   end
 
-  @spec address_to_balances_by_day(Hash.Address.t(), true | false) :: [balance_by_day]
-  def address_to_balances_by_day(address_hash, api? \\ false) do
+  @spec address_to_balances_by_day(Hash.Address.t(), [api?]) :: [balance_by_day]
+  def address_to_balances_by_day(address_hash, options \\ []) do
     latest_block_timestamp =
       address_hash
       |> CoinBalance.last_coin_balance_timestamp()
-      |> Repo.one()
+      |> select_repo(options).one()
 
     address_hash
     |> CoinBalanceDaily.balances_by_day()
-    |> Repo.all()
+    |> select_repo(options).all()
     |> Enum.sort_by(fn %{date: d} -> {d.year, d.month, d.day} end)
     |> replace_last_value(latest_block_timestamp)
-    |> normalize_balances_by_day(api?)
+    |> normalize_balances_by_day(Keyword.get(options, :api?, false))
   end
 
   # https://github.com/blockscout/blockscout/issues/2658
@@ -5306,19 +5321,14 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec fetch_token_holders_from_token_hash(Hash.Address.t(), boolean(), [paging_options]) :: [TokenBalance.t()]
-  def fetch_token_holders_from_token_hash(contract_address_hash, from_api, options \\ []) do
+  @spec fetch_token_holders_from_token_hash(Hash.Address.t(), [paging_options | api?]) :: [TokenBalance.t()]
+  def fetch_token_holders_from_token_hash(contract_address_hash, options \\ []) do
     query =
       contract_address_hash
       |> CurrentTokenBalance.token_holders_ordered_by_value(options)
 
-    if from_api do
-      query
-      |> Repo.replica().all()
-    else
-      query
-      |> Repo.all()
-    end
+    query
+    |> select_repo(options).all()
   end
 
   def fetch_token_holders_from_token_hash_and_token_id(contract_address_hash, token_id, options \\ []) do
@@ -5327,10 +5337,13 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
-  def token_id_1155_is_unique?(_, nil), do: false
+  def token_id_1155_is_unique?(contract_address_hash, token_id, options \\ [])
 
-  def token_id_1155_is_unique?(contract_address_hash, token_id) do
-    result = contract_address_hash |> CurrentTokenBalance.token_balances_by_id_limit_2(token_id) |> Repo.all()
+  def token_id_1155_is_unique?(_, nil, _), do: false
+
+  def token_id_1155_is_unique?(contract_address_hash, token_id, options) do
+    result =
+      contract_address_hash |> CurrentTokenBalance.token_balances_by_id_limit_2(token_id) |> select_repo(options).all()
 
     if length(result) == 1 do
       Decimal.compare(Enum.at(result, 0), 1) == :eq
@@ -5355,7 +5368,7 @@ defmodule Explorer.Chain do
     Repo.one!(query, timeout: :infinity)
   end
 
-  @spec address_to_unique_tokens(Hash.Address.t(), [paging_options]) :: [Instance.t()]
+  @spec address_to_unique_tokens(Hash.Address.t(), [paging_options | api?]) :: [Instance.t()]
   def address_to_unique_tokens(contract_address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
@@ -5363,15 +5376,15 @@ defmodule Explorer.Chain do
     |> Instance.address_to_unique_token_instances()
     |> Instance.page_token_instance(paging_options)
     |> limit(^paging_options.page_size)
-    |> Repo.all()
-    |> Enum.map(&put_owner_to_token_instance/1)
+    |> select_repo(options).all()
+    |> Enum.map(&put_owner_to_token_instance(&1, options))
   end
 
-  def put_owner_to_token_instance(%Instance{} = token_instance) do
+  def put_owner_to_token_instance(%Instance{} = token_instance, options \\ []) do
     owner =
       token_instance
       |> Instance.owner_query()
-      |> Repo.one()
+      |> select_repo(options).one()
 
     %{token_instance | owner: owner}
   end
@@ -6061,12 +6074,12 @@ defmodule Explorer.Chain do
     end
   end
 
-  defp find_block_timestamp(number) do
+  defp find_block_timestamp(number, options) do
     Block
     |> where([b], b.number == ^number)
     |> select([b], b.timestamp)
     |> limit(1)
-    |> Repo.one()
+    |> select_repo(options).one()
   end
 
   @spec get_token_transfer_type(TokenTransfer.t()) ::
@@ -6294,7 +6307,10 @@ defmodule Explorer.Chain do
   end
 
   @spec verified_contracts([
-          paging_options | necessity_by_association_option | {:filter, :solidity | :vyper} | {:search, String.t()}
+          paging_options
+          | necessity_by_association_option
+          | {:filter, :solidity | :vyper}
+          | {:search, String.t() | {:api?, true | false}}
         ]) :: [SmartContract.t()]
   def verified_contracts(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
@@ -6309,7 +6325,7 @@ defmodule Explorer.Chain do
     |> search_contracts(search_string)
     |> handle_verified_contracts_paging_options(paging_options)
     |> join_associations(necessity_by_association)
-    |> Repo.all()
+    |> select_repo(options).all()
   end
 
   defp search_contracts(basic_query, nil), do: basic_query
@@ -6389,10 +6405,10 @@ defmodule Explorer.Chain do
     NewContractsCounter.fetch()
   end
 
-  def address_counters(address) do
+  def address_counters(address, options \\ []) do
     validation_count_task =
       Task.async(fn ->
-        address_to_validation_count(address.hash)
+        address_to_validation_count(address.hash, options)
       end)
 
     Task.start_link(fn ->
@@ -6544,5 +6560,13 @@ defmodule Explorer.Chain do
         {:cont, [tt | acc]}
       end
     end)
+  end
+
+  def select_repo(options) do
+    if Keyword.get(options, :api?, false) do
+      Repo.replica()
+    else
+      Repo
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/block/reward.ex
+++ b/apps/explorer/lib/explorer/chain/block/reward.ex
@@ -6,11 +6,10 @@ defmodule Explorer.Chain.Block.Reward do
   use Explorer.Schema
 
   alias Explorer.Application.Constants
-  alias Explorer.Chain
+  alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.Block.Reward.AddressType
   alias Explorer.Chain.{Address, Block, Hash, Validator, Wei}
   alias Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand
-  alias Explorer.{PagingOptions, Repo}
   alias Explorer.SmartContract.Reader
 
   @required_attrs ~w(address_hash address_type block_hash reward)a
@@ -94,10 +93,15 @@ defmodule Explorer.Chain.Block.Reward do
   Returns a list of tuples representing rewards by the EmissionFunds on POA chains.
   The tuples have the format {EmissionFunds, Validator}
   """
-  def fetch_emission_rewards_tuples(address_hash, paging_options, %{
-        min_block_number: min_block_number,
-        max_block_number: max_block_number
-      }) do
+  def fetch_emission_rewards_tuples(
+        address_hash,
+        paging_options,
+        %{
+          min_block_number: min_block_number,
+          max_block_number: max_block_number
+        },
+        options
+      ) do
     address_rewards =
       __MODULE__
       |> join_associations()
@@ -106,7 +110,7 @@ defmodule Explorer.Chain.Block.Reward do
       |> order_by([_, block], desc: block.number)
       |> where([reward], reward.address_hash == ^address_hash)
       |> address_rewards_blocks_ranges_clause(min_block_number, max_block_number, paging_options)
-      |> Repo.all()
+      |> Chain.select_repo(options).all()
 
     case List.first(address_rewards) do
       nil ->
@@ -130,7 +134,7 @@ defmodule Explorer.Chain.Block.Reward do
           |> order_by([_, block], desc: block.number)
           |> where([reward], reward.address_type == ^other_type)
           |> where([reward], reward.block_hash in ^block_hashes)
-          |> Repo.all()
+          |> Chain.select_repo(options).all()
 
         if other_type == :emission_funds do
           Enum.zip(other_rewards, address_rewards)
@@ -154,8 +158,8 @@ defmodule Explorer.Chain.Block.Reward do
     end
   end
 
-  def get_validator_payout_key_by_mining_from_db(mining_key) do
-    contract_address_from_db = Constants.get_keys_manager_contract_address()
+  def get_validator_payout_key_by_mining_from_db(mining_key, options \\ []) do
+    contract_address_from_db = Constants.get_keys_manager_contract_address(options)
 
     contract_address_from_env =
       Application.get_env(:explorer, Explorer.Chain.Block.Reward, %{})[:keys_manager_contract_address]
@@ -170,7 +174,7 @@ defmodule Explorer.Chain.Block.Reward do
 
       contract_address_from_db.value |> String.downcase() == contract_address_from_env |> String.downcase() ->
         FetchValidatorInfoOnDemand.trigger_fetch(mining_key)
-        validator = Validator.get_validator_by_address_hash(mining_key)
+        validator = Validator.get_validator_by_address_hash(mining_key, options)
         is_validator = validator && validator.is_validator
 
         with {:is_validator, true} <- {:is_validator, is_validator},

--- a/apps/explorer/lib/explorer/chain/cache/contracts_counter.ex
+++ b/apps/explorer/lib/explorer/chain/cache/contracts_counter.ex
@@ -62,8 +62,8 @@ defmodule Explorer.Chain.Cache.ContractsCounter do
   @doc """
   Fetches the value for a `#{@counter_type}` counter type from the `last_fetched_counters` table.
   """
-  def fetch do
-    Chain.get_last_fetched_counter(@counter_type)
+  def fetch(options) do
+    Chain.get_last_fetched_counter(@counter_type, options)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/cache/helper.ex
+++ b/apps/explorer/lib/explorer/chain/cache/helper.ex
@@ -2,11 +2,13 @@ defmodule Explorer.Chain.Cache.Helper do
   @moduledoc """
   Common helper functions for cache modules
   """
-  alias Explorer.Repo
+  alias Explorer.Chain
 
-  def estimated_count_from(table_name) do
+  def estimated_count_from(table_name, options \\ []) do
     %Postgrex.Result{rows: [[count]]} =
-      Repo.query!("SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname = '#{table_name}';")
+      Chain.select_repo(options).query!(
+        "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname = '#{table_name}';"
+      )
 
     count
   end

--- a/apps/explorer/lib/explorer/chain/cache/new_contracts_counter.ex
+++ b/apps/explorer/lib/explorer/chain/cache/new_contracts_counter.ex
@@ -63,8 +63,8 @@ defmodule Explorer.Chain.Cache.NewContractsCounter do
   @doc """
   Fetches the value for a `#{@counter_type}` counter type from the `last_fetched_counters` table.
   """
-  def fetch do
-    Chain.get_last_fetched_counter(@counter_type)
+  def fetch(options) do
+    Chain.get_last_fetched_counter(@counter_type, options)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/cache/new_verified_contracts_counter.ex
+++ b/apps/explorer/lib/explorer/chain/cache/new_verified_contracts_counter.ex
@@ -63,8 +63,8 @@ defmodule Explorer.Chain.Cache.NewVerifiedContractsCounter do
   @doc """
   Fetches the value for a `#{@counter_type}` counter type from the `last_fetched_counters` table.
   """
-  def fetch do
-    Chain.get_last_fetched_counter(@counter_type)
+  def fetch(options) do
+    Chain.get_last_fetched_counter(@counter_type, options)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/cache/verified_contracts_counter.ex
+++ b/apps/explorer/lib/explorer/chain/cache/verified_contracts_counter.ex
@@ -62,8 +62,8 @@ defmodule Explorer.Chain.Cache.VerifiedContractsCounter do
   @doc """
   Fetches the value for a `#{@counter_type}` counter type from the `last_fetched_counters` table.
   """
-  def fetch do
-    Chain.get_last_fetched_counter(@counter_type)
+  def fetch(options) do
+    Chain.get_last_fetched_counter(@counter_type, options)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -65,7 +65,8 @@ defmodule Explorer.Chain.TokenTransfer do
           transaction_hash: Hash.Full.t(),
           log_index: non_neg_integer(),
           amounts: [Decimal.t()] | nil,
-          token_ids: [non_neg_integer()] | nil
+          token_ids: [non_neg_integer()] | nil,
+          index_in_batch: non_neg_integer() | nil
         }
 
   @typep paging_options :: {:paging_options, PagingOptions.t()}
@@ -84,6 +85,7 @@ defmodule Explorer.Chain.TokenTransfer do
     field(:token_id, :decimal)
     field(:amounts, {:array, :decimal})
     field(:token_ids, {:array, :decimal})
+    field(:index_in_batch, :integer, virtual: true)
 
     belongs_to(:from_address, Address, foreign_key: :from_address_hash, references: :hash, type: Hash.Address)
     belongs_to(:to_address, Address, foreign_key: :to_address_hash, references: :hash, type: Hash.Address)

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -162,7 +162,7 @@ defmodule Explorer.Chain.TokenTransfer do
         tt in TokenTransfer,
         where: tt.token_contract_address_hash == ^token_address_hash and not is_nil(tt.block_number),
         preload: [{:transaction, :block}, :token, :from_address, :to_address],
-        order_by: [desc: tt.block_number]
+        order_by: [desc: tt.block_number, desc: tt.log_index]
       )
 
     query
@@ -182,7 +182,7 @@ defmodule Explorer.Chain.TokenTransfer do
         where: fragment("? @> ARRAY[?::decimal]", tt.token_ids, ^Decimal.new(token_id)),
         where: not is_nil(tt.block_number),
         preload: [{:transaction, :block}, :token, :from_address, :to_address],
-        order_by: [desc: tt.block_number]
+        order_by: [desc: tt.block_number, desc: tt.log_index]
       )
 
     query

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -642,13 +642,14 @@ defmodule Explorer.Chain.Transaction do
     if transaction.created_contract_address_hash do
       nil
     else
-      case Transaction.decoded_input_data(
+      case decoded_input_data(
              %__MODULE__{
                to_address: %{smart_contract: nil},
                input: transaction.input,
                hash: transaction.hash
              },
-             true
+             true,
+             []
            ) do
         {:error, :contract_not_verified, [{:ok, _method_id, decoded_func, _}]} ->
           parse_method_name(decoded_func)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Transaction do
   alias Ecto.Association.NotLoaded
   alias Ecto.Changeset
 
-  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain
 
   alias Explorer.Chain.{
     Address,
@@ -443,26 +443,32 @@ defmodule Explorer.Chain.Transaction do
     preload(query, [tt], token_transfers: ^token_transfers_query)
   end
 
-  def decoded_revert_reason(transaction, revert_reason) do
-    case revert_reason do
-      "0x" <> hex_part ->
-        process_hex_revert_reason(hex_part, transaction)
+  def decoded_revert_reason(transaction, revert_reason, options \\ []) do
+    hex =
+      case revert_reason do
+        "0x" <> hex_part ->
+          hex_part
 
-      hex_part ->
-        process_hex_revert_reason(hex_part, transaction)
-    end
+        hex ->
+          hex
+      end
+
+    process_hex_revert_reason(hex, transaction, options)
   end
 
-  defp process_hex_revert_reason(hex_revert_reason, %__MODULE__{to_address: smart_contract, hash: hash}) do
+  defp process_hex_revert_reason(hex_revert_reason, %__MODULE__{to_address: smart_contract, hash: hash}, options) do
     case Integer.parse(hex_revert_reason, 16) do
       {number, ""} ->
         binary_revert_reason = :binary.encode_unsigned(number)
 
-        decoded_input_data(%Transaction{
-          to_address: smart_contract,
-          hash: hash,
-          input: %Data{bytes: binary_revert_reason}
-        })
+        decoded_input_data(
+          %Transaction{
+            to_address: smart_contract,
+            hash: hash,
+            input: %Data{bytes: binary_revert_reason}
+          },
+          options
+        )
 
       _ ->
         hex_revert_reason
@@ -470,14 +476,16 @@ defmodule Explorer.Chain.Transaction do
   end
 
   # Because there is no contract association, we know the contract was not verified
-  def decoded_input_data(tx, extract_names? \\ false)
+  def decoded_input_data(tx, extract_names? \\ false, options)
 
-  def decoded_input_data(%__MODULE__{to_address: nil}, _), do: {:error, :no_to_address}
-  def decoded_input_data(%NotLoaded{}, _), do: {:error, :not_loaded}
-  def decoded_input_data(%__MODULE__{input: %{bytes: bytes}}, _) when bytes in [nil, <<>>], do: {:error, :no_input_data}
+  def decoded_input_data(%__MODULE__{to_address: nil}, _, _), do: {:error, :no_to_address}
+  def decoded_input_data(%NotLoaded{}, _, _), do: {:error, :not_loaded}
+
+  def decoded_input_data(%__MODULE__{input: %{bytes: bytes}}, _, _) when bytes in [nil, <<>>],
+    do: {:error, :no_input_data}
 
   if not Application.compile_env(:explorer, :decode_not_a_contract_calls) do
-    def decoded_input_data(%__MODULE__{to_address: %{contract_code: nil}}, _), do: {:error, :not_a_contract_call}
+    def decoded_input_data(%__MODULE__{to_address: %{contract_code: nil}}, _, _), do: {:error, :not_a_contract_call}
   end
 
   def decoded_input_data(
@@ -486,7 +494,8 @@ defmodule Explorer.Chain.Transaction do
           input: input,
           hash: hash
         },
-        extract_names?
+        extract_names?,
+        options
       ) do
     decoded_input_data(
       %__MODULE__{
@@ -494,7 +503,8 @@ defmodule Explorer.Chain.Transaction do
         input: input,
         hash: hash
       },
-      extract_names?
+      extract_names?,
+      options
     )
   end
 
@@ -504,7 +514,8 @@ defmodule Explorer.Chain.Transaction do
           input: input,
           hash: hash
         },
-        extract_names?
+        extract_names?,
+        options
       ) do
     decoded_input_data(
       %__MODULE__{
@@ -512,7 +523,8 @@ defmodule Explorer.Chain.Transaction do
         input: input,
         hash: hash
       },
-      extract_names?
+      extract_names?,
+      options
     )
   end
 
@@ -522,7 +534,8 @@ defmodule Explorer.Chain.Transaction do
           input: %{bytes: <<method_id::binary-size(4), _::binary>> = data} = input,
           hash: hash
         },
-        extract_names?
+        extract_names?,
+        options
       ) do
     candidates_query =
       from(
@@ -533,9 +546,9 @@ defmodule Explorer.Chain.Transaction do
 
     candidates =
       candidates_query
-      |> Repo.all()
+      |> Chain.select_repo(options).all()
       |> Enum.flat_map(fn candidate ->
-        case do_decoded_input_data(data, %SmartContract{abi: [candidate.abi], address_hash: nil}, hash) do
+        case do_decoded_input_data(data, %SmartContract{abi: [candidate.abi], address_hash: nil}, hash, options) do
           {:ok, _, _, _} = decoded -> [decoded]
           _ -> []
         end
@@ -545,7 +558,7 @@ defmodule Explorer.Chain.Transaction do
      if(candidates == [], do: decode_function_call_via_sig_provider(input, hash, extract_names?), else: candidates)}
   end
 
-  def decoded_input_data(%__MODULE__{to_address: %{smart_contract: nil}}, _) do
+  def decoded_input_data(%__MODULE__{to_address: %{smart_contract: nil}}, _, _) do
     {:error, :contract_not_verified, []}
   end
 
@@ -555,9 +568,10 @@ defmodule Explorer.Chain.Transaction do
           to_address: %{smart_contract: smart_contract},
           hash: hash
         },
-        extract_names?
+        extract_names?,
+        options
       ) do
-    case do_decoded_input_data(data, smart_contract, hash) do
+    case do_decoded_input_data(data, smart_contract, hash, options) do
       # In some cases transactions use methods of some unpredictable contracts, so we can try to look up for method in a whole DB
       {:error, :could_not_decode} ->
         case decoded_input_data(
@@ -566,7 +580,8 @@ defmodule Explorer.Chain.Transaction do
                  input: input,
                  hash: hash
                },
-               extract_names?
+               extract_names?,
+               options
              ) do
           {:error, :contract_not_verified, []} ->
             decode_function_call_via_sig_provider_wrapper(input, hash, extract_names?)
@@ -593,8 +608,8 @@ defmodule Explorer.Chain.Transaction do
     end
   end
 
-  defp do_decoded_input_data(data, smart_contract, hash) do
-    full_abi = Chain.combine_proxy_implementation_abi(smart_contract)
+  defp do_decoded_input_data(data, smart_contract, hash, options) do
+    full_abi = Chain.combine_proxy_implementation_abi(smart_contract, options)
 
     with {:ok, {selector, values}} <- find_and_decode(full_abi, data, hash),
          {:ok, mapping} <- selector_mapping(selector, values, hash),
@@ -610,7 +625,8 @@ defmodule Explorer.Chain.Transaction do
          true <- is_list(result),
          false <- Enum.empty?(result),
          abi <- [result |> List.first() |> Map.put("outputs", []) |> Map.put("type", "function")],
-         {:ok, _, _, _} = candidate <- do_decoded_input_data(data, %SmartContract{abi: abi, address_hash: nil}, hash) do
+         {:ok, _, _, _} = candidate <-
+           do_decoded_input_data(data, %SmartContract{abi: abi, address_hash: nil}, hash, []) do
       [candidate]
     else
       _ ->

--- a/apps/explorer/lib/explorer/chain/transaction/history/transaction_stats.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/transaction_stats.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Transaction.History.TransactionStats do
 
   use Explorer.Schema
 
-  alias Explorer.Repo
+  alias Explorer.Chain
 
   @derive {Jason.Encoder,
            except: [
@@ -36,7 +36,7 @@ defmodule Explorer.Chain.Transaction.History.TransactionStats do
         }
 
   @spec by_date_range(Date.t(), Date.t()) :: [__MODULE__]
-  def by_date_range(earliest, latest) do
+  def by_date_range(earliest, latest, options \\ []) do
     # Create a query
     query =
       from(stat in __MODULE__,
@@ -44,6 +44,6 @@ defmodule Explorer.Chain.Transaction.History.TransactionStats do
         order_by: [desc: :date]
       )
 
-    Repo.all(query)
+    Chain.select_repo(options).all(query)
   end
 end

--- a/apps/explorer/lib/explorer/chain/validator.ex
+++ b/apps/explorer/lib/explorer/chain/validator.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Validator do
 
   use Explorer.Schema
   alias Explorer.Chain.Hash.Address
-  alias Explorer.Repo
+  alias Explorer.{Chain, Repo}
 
   @primary_key false
   schema "validators" do
@@ -43,10 +43,10 @@ defmodule Explorer.Chain.Validator do
     |> unique_constraint(:address_hash)
   end
 
-  def get_validator_by_address_hash(address_hash) do
+  def get_validator_by_address_hash(address_hash, options \\ []) do
     __MODULE__
     |> where([validator], validator.address_hash == ^address_hash)
-    |> Repo.one()
+    |> Chain.select_repo(options).one()
   end
 
   def drop_all_validators do

--- a/apps/explorer/lib/explorer/paging_options.ex
+++ b/apps/explorer/lib/explorer/paging_options.ex
@@ -10,7 +10,8 @@ defmodule Explorer.PagingOptions do
           page_number: page_number,
           is_pending_tx: is_pending_tx,
           is_index_in_asc_order: is_index_in_asc_order,
-          asc_order: asc_order
+          asc_order: asc_order,
+          batch_key: batch_key
         }
 
   @typep key :: any()
@@ -19,6 +20,15 @@ defmodule Explorer.PagingOptions do
   @typep is_pending_tx :: atom()
   @typep is_index_in_asc_order :: atom()
   @typep asc_order :: atom()
+  @typep batch_key :: any()
 
-  defstruct [:key, :page_size, page_number: 1, is_pending_tx: false, is_index_in_asc_order: false, asc_order: false]
+  defstruct [
+    :key,
+    :page_size,
+    page_number: 1,
+    is_pending_tx: false,
+    is_index_in_asc_order: false,
+    asc_order: false,
+    batch_key: nil
+  ]
 end

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -32,6 +32,8 @@ defmodule Explorer.SmartContract.Reader do
           {:json_rpc_named_arguments, EthereumJSONRPC.json_rpc_named_arguments()}
         ]
 
+  @typep api? :: {:api?, true | false}
+
   @doc """
   Queries the contract functions on the blockchain and returns the call results.
 
@@ -184,7 +186,7 @@ defmodule Explorer.SmartContract.Reader do
 
   ## Examples
 
-    $ Explorer.SmartContract.Reader.read_only_functions("0x798465571ae21a184a272f044f991ad1d5f87a3f")
+    $ Explorer.SmartContract.Reader.read_only_functions(%SmartContract{...})
     => [
         %{
           "constant" => true,
@@ -206,13 +208,8 @@ defmodule Explorer.SmartContract.Reader do
         }
       ]
   """
-  @spec read_only_functions(Hash.t()) :: [%{}]
-  def read_only_functions(contract_address_hash, from \\ nil) do
-    abi =
-      contract_address_hash
-      |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi)
-
+  @spec read_only_functions(SmartContract.t(), Hash.t(), String.t() | nil) :: [%{}]
+  def read_only_functions(%SmartContract{abi: abi}, contract_address_hash, from) do
     case abi do
       nil ->
         []
@@ -222,8 +219,10 @@ defmodule Explorer.SmartContract.Reader do
     end
   end
 
-  def read_only_functions_proxy(contract_address_hash, implementation_address_hash_string, from \\ nil) do
-    implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string)
+  def read_only_functions(nil, _, _), do: []
+
+  def read_only_functions_proxy(contract_address_hash, implementation_address_hash_string, from, options \\ []) do
+    implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string, options)
 
     case implementation_abi do
       nil ->
@@ -253,13 +252,8 @@ defmodule Explorer.SmartContract.Reader do
   @doc """
     Returns abi for not queriable functions of the smart contract which can be considered as read-only
   """
-  @spec read_functions_required_wallet(Hash.t()) :: [%{}]
-  def read_functions_required_wallet(contract_address_hash) do
-    abi =
-      contract_address_hash
-      |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi)
-
+  @spec read_functions_required_wallet(SmartContract.t()) :: [%{}]
+  def read_functions_required_wallet(%SmartContract{abi: abi}) do
     case abi do
       nil ->
         []
@@ -268,6 +262,8 @@ defmodule Explorer.SmartContract.Reader do
         read_functions_required_wallet_from_abi(abi)
     end
   end
+
+  def read_functions_required_wallet(nil), do: []
 
   def read_only_functions_from_abi_with_sender([_ | _] = abi, contract_address_hash, from) do
     abi_with_method_id = get_abi_with_method_id(abi)
@@ -367,11 +363,12 @@ defmodule Explorer.SmartContract.Reader do
           Hash.t(),
           %{method_id: String.t(), args: [term()] | nil},
           atom(),
-          String.t()
+          String.t() | nil,
+          [api?]
         ) :: %{:names => [any()], :output => [%{}]}
-  def query_function_with_names(contract_address_hash, %{method_id: method_id, args: args}, type, from) do
-    outputs = query_function(contract_address_hash, %{method_id: method_id, args: args}, type, from, true)
-    names = parse_names_from_abi(get_abi(contract_address_hash, type), method_id)
+  def query_function_with_names(contract_address_hash, %{method_id: method_id, args: args}, type, from, options \\ []) do
+    outputs = query_function(contract_address_hash, %{method_id: method_id, args: args}, type, from, true, options)
+    names = parse_names_from_abi(get_abi(contract_address_hash, type, options), method_id)
     %{output: outputs, names: names}
   end
 
@@ -397,31 +394,43 @@ defmodule Explorer.SmartContract.Reader do
   @doc """
   Fetches the blockchain value of a function that requires arguments.
   """
-  @spec query_function(String.t(), %{method_id: String.t(), args: nil}, atom(), true | false) :: [%{}]
-  def query_function(contract_address_hash, %{method_id: method_id, args: nil}, type, leave_error_as_map) do
-    query_function(contract_address_hash, %{method_id: method_id, args: []}, type, leave_error_as_map)
+  def query_function(contract_address_hash, params, type, leave_error_as_map, options \\ [])
+
+  @spec query_function(String.t(), %{method_id: String.t(), args: nil}, atom(), true | false, [api?]) :: [%{}]
+  def query_function(contract_address_hash, %{method_id: method_id, args: nil}, type, leave_error_as_map, options) do
+    query_function(contract_address_hash, %{method_id: method_id, args: []}, type, leave_error_as_map, options)
   end
 
-  @spec query_function(Hash.t(), %{method_id: String.t(), args: [term()]}, atom(), true | false) :: [%{}]
-  def query_function(contract_address_hash, %{method_id: method_id, args: args}, type, leave_error_as_map) do
-    query_function_inner(contract_address_hash, method_id, args, type, nil, leave_error_as_map)
+  @spec query_function(Hash.t(), %{method_id: String.t(), args: [term()]}, atom(), true | false, [api?]) :: [%{}]
+  def query_function(contract_address_hash, %{method_id: method_id, args: args}, type, leave_error_as_map, options) do
+    query_function_inner(contract_address_hash, method_id, args, type, nil, leave_error_as_map, options)
   end
 
-  @spec query_function(String.t(), %{method_id: String.t(), args: nil}, atom(), String.t() | nil, true | false) :: [%{}]
-  def query_function(contract_address_hash, %{method_id: method_id, args: nil}, type, from, leave_error_as_map) do
-    query_function(contract_address_hash, %{method_id: method_id, args: []}, type, from, leave_error_as_map)
+  @spec query_function(String.t(), %{method_id: String.t(), args: nil}, atom(), String.t() | nil, true | false, [api?]) ::
+          [%{}]
+  def query_function(contract_address_hash, %{method_id: method_id, args: nil}, type, from, leave_error_as_map, options) do
+    query_function(contract_address_hash, %{method_id: method_id, args: []}, type, from, leave_error_as_map, options)
   end
 
-  @spec query_function(Hash.t(), %{method_id: String.t(), args: [term()]}, atom(), String.t() | nil, true | false) :: [
+  @spec query_function(Hash.t(), %{method_id: String.t(), args: [term()]}, atom(), String.t() | nil, true | false, [
+          api?
+        ]) :: [
           %{}
         ]
-  def query_function(contract_address_hash, %{method_id: method_id, args: args}, type, from, leave_error_as_map) do
-    query_function_inner(contract_address_hash, method_id, args, type, from, leave_error_as_map)
+  def query_function(
+        contract_address_hash,
+        %{method_id: method_id, args: args},
+        type,
+        from,
+        leave_error_as_map,
+        options
+      ) do
+    query_function_inner(contract_address_hash, method_id, args, type, from, leave_error_as_map, options)
   end
 
-  @spec query_function_inner(Hash.t(), String.t(), [term()], atom(), String.t() | nil, true | false) :: [%{}]
-  defp query_function_inner(contract_address_hash, method_id, args, type, from, leave_error_as_map) do
-    abi = get_abi(contract_address_hash, type)
+  @spec query_function_inner(Hash.t(), String.t(), [term()], atom(), String.t() | nil, true | false, [api?]) :: [%{}]
+  defp query_function_inner(contract_address_hash, method_id, args, type, from, leave_error_as_map, options) do
+    abi = get_abi(contract_address_hash, type, options)
 
     parsed_final_abi =
       abi
@@ -527,11 +536,11 @@ defmodule Explorer.SmartContract.Reader do
     |> link_outputs_and_values(outputs, method_id)
   end
 
-  defp get_abi(contract_address_hash, type) do
+  defp get_abi(contract_address_hash, type, options) do
     contract = Chain.address_hash_to_smart_contract(contract_address_hash)
 
     if type == :proxy do
-      Chain.get_implementation_abi_from_proxy(contract)
+      Chain.get_implementation_abi_from_proxy(contract, options)
     else
       contract.abi
     end

--- a/apps/explorer/lib/explorer/smart_contract/writer.ex
+++ b/apps/explorer/lib/explorer/smart_contract/writer.ex
@@ -4,16 +4,11 @@ defmodule Explorer.SmartContract.Writer do
   """
 
   alias Explorer.Chain
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Hash, SmartContract}
   alias Explorer.SmartContract.Helper
 
-  @spec write_functions(Hash.t()) :: [%{}]
-  def write_functions(contract_address_hash) do
-    abi =
-      contract_address_hash
-      |> Chain.address_hash_to_smart_contract()
-      |> Map.get(:abi)
-
+  @spec write_functions(SmartContract.t()) :: [%{}]
+  def write_functions(%SmartContract{abi: abi}) do
     case abi do
       nil ->
         []
@@ -25,8 +20,8 @@ defmodule Explorer.SmartContract.Writer do
   end
 
   @spec write_functions_proxy(Hash.t() | String.t()) :: [%{}]
-  def write_functions_proxy(implementation_address_hash_string) do
-    implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string)
+  def write_functions_proxy(implementation_address_hash_string, options \\ []) do
+    implementation_abi = Chain.get_implementation_abi(implementation_address_hash_string, options)
 
     case implementation_abi do
       nil ->

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -247,7 +247,7 @@ defmodule Explorer.Chain.TransactionTest do
     test "that a transaction that is not a contract call returns a commensurate error" do
       transaction = insert(:transaction)
 
-      assert Transaction.decoded_input_data(transaction) == {:error, :not_a_contract_call}
+      assert Transaction.decoded_input_data(transaction, []) == {:error, :not_a_contract_call}
     end
 
     test "that a contract call transaction that has no verified contract returns a commensurate error" do
@@ -256,7 +256,7 @@ defmodule Explorer.Chain.TransactionTest do
         |> insert(to_address: insert(:contract_address))
         |> Repo.preload(to_address: :smart_contract)
 
-      assert Transaction.decoded_input_data(transaction) == {:error, :contract_not_verified, []}
+      assert Transaction.decoded_input_data(transaction, []) == {:error, :contract_not_verified, []}
     end
 
     test "that a contract call transaction that has a verified contract returns the decoded input data" do
@@ -267,7 +267,8 @@ defmodule Explorer.Chain.TransactionTest do
 
       get_eip1967_implementation()
 
-      assert Transaction.decoded_input_data(transaction) == {:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 50}]}
+      assert Transaction.decoded_input_data(transaction, []) ==
+               {:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 50}]}
     end
 
     test "that a contract call will look up a match in contract_methods table" do
@@ -289,7 +290,8 @@ defmodule Explorer.Chain.TransactionTest do
 
       get_eip1967_implementation()
 
-      assert Transaction.decoded_input_data(transaction) == {:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 10}]}
+      assert Transaction.decoded_input_data(transaction, []) ==
+               {:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 10}]}
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -591,9 +591,13 @@ defmodule Explorer.ChainTest do
         keys_manager_contract_address: "0x0000000000000000000000000000000000000006"
       )
 
+      consumer_pid = start_supervised!(Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand)
+      :erlang.trace(consumer_pid, true, [:receive])
+
       block = insert(:block)
 
       block_miner_hash_string = Base.encode16(block.miner_hash.bytes, case: :lower)
+      block_miner_hash = block.miner_hash
 
       insert(
         :reward,
@@ -629,8 +633,10 @@ defmodule Explorer.ChainTest do
       )
 
       res = Chain.address_to_transactions_with_rewards(block.miner.hash)
-
       assert [{_, _}] = res
+
+      assert_receive {:trace, ^consumer_pid, :receive, {:"$gen_cast", {:fetch_or_update, ^block_miner_hash}}}, 1000
+      :timer.sleep(500)
 
       on_exit(fn ->
         Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
@@ -650,9 +656,13 @@ defmodule Explorer.ChainTest do
         keys_manager_contract_address: "0x0000000000000000000000000000000000000006"
       )
 
+      consumer_pid = start_supervised!(Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand)
+      :erlang.trace(consumer_pid, true, [:receive])
+
       block = insert(:block)
 
       block_miner_hash_string = Base.encode16(block.miner_hash.bytes, case: :lower)
+      block_miner_hash = block.miner_hash
 
       insert(
         :reward,
@@ -693,6 +703,9 @@ defmodule Explorer.ChainTest do
       )
 
       assert [_, {_, _}] = Chain.address_to_transactions_with_rewards(block.miner.hash, direction: :to)
+
+      assert_receive {:trace, ^consumer_pid, :receive, {:"$gen_cast", {:fetch_or_update, ^block_miner_hash}}}, 1000
+      :timer.sleep(500)
 
       on_exit(fn ->
         Application.put_env(:block_scout_web, BlockScoutWeb.Chain, has_emission_funds: false)
@@ -3250,7 +3263,7 @@ defmodule Explorer.ChainTest do
     test "without logs" do
       transaction = insert(:transaction)
 
-      assert [] = Chain.transaction_to_logs(transaction.hash, false)
+      assert [] = Chain.transaction_to_logs(transaction.hash)
     end
 
     test "with logs" do
@@ -3262,8 +3275,7 @@ defmodule Explorer.ChainTest do
       %Log{transaction_hash: transaction_hash, index: index} =
         insert(:log, transaction: transaction, block: transaction.block, block_number: transaction.block_number)
 
-      assert [%Log{transaction_hash: ^transaction_hash, index: ^index}] =
-               Chain.transaction_to_logs(transaction.hash, false)
+      assert [%Log{transaction_hash: ^transaction_hash, index: ^index}] = Chain.transaction_to_logs(transaction.hash)
     end
 
     test "with logs can be paginated" do
@@ -3294,7 +3306,7 @@ defmodule Explorer.ChainTest do
 
       assert second_page_indexes ==
                transaction.hash
-               |> Chain.transaction_to_logs(false, paging_options: %PagingOptions{key: {log.index}, page_size: 50})
+               |> Chain.transaction_to_logs(paging_options: %PagingOptions{key: {log.index}, page_size: 50})
                |> Enum.map(& &1.index)
     end
 
@@ -3309,7 +3321,6 @@ defmodule Explorer.ChainTest do
       assert [%Log{address: %Address{}, transaction: %Transaction{}}] =
                Chain.transaction_to_logs(
                  transaction.hash,
-                 false,
                  necessity_by_association: %{
                    address: :optional,
                    transaction: :optional
@@ -3321,7 +3332,7 @@ defmodule Explorer.ChainTest do
                  address: %Ecto.Association.NotLoaded{},
                  transaction: %Ecto.Association.NotLoaded{}
                }
-             ] = Chain.transaction_to_logs(transaction.hash, false)
+             ] = Chain.transaction_to_logs(transaction.hash)
     end
   end
 
@@ -5120,7 +5131,7 @@ defmodule Explorer.ChainTest do
 
       token_holders_count =
         contract_address_hash
-        |> Chain.fetch_token_holders_from_token_hash(false, [])
+        |> Chain.fetch_token_holders_from_token_hash([])
         |> Enum.count()
 
       assert token_holders_count == 2

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -6030,7 +6030,10 @@ defmodule Explorer.ChainTest do
     test "get_implementation_abi_from_proxy/2 returns empty [] abi if proxy abi is null" do
       proxy_contract_address = insert(:contract_address)
 
-      assert Chain.get_implementation_abi_from_proxy(%SmartContract{address_hash: proxy_contract_address.hash, abi: nil}) ==
+      assert Chain.get_implementation_abi_from_proxy(
+               %SmartContract{address_hash: proxy_contract_address.hash, abi: nil},
+               []
+             ) ==
                []
     end
 
@@ -6051,7 +6054,7 @@ defmodule Explorer.ChainTest do
       smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: @proxy_abi, contract_code_md5: "123")
 
-      assert Chain.get_implementation_abi_from_proxy(smart_contract) == []
+      assert Chain.get_implementation_abi_from_proxy(smart_contract, []) == []
     end
 
     test "get_implementation_abi_from_proxy/2 returns implementation abi if implementation is verified" do
@@ -6086,7 +6089,7 @@ defmodule Explorer.ChainTest do
         end
       )
 
-      implementation_abi = Chain.get_implementation_abi_from_proxy(smart_contract)
+      implementation_abi = Chain.get_implementation_abi_from_proxy(smart_contract, [])
 
       assert implementation_abi == @implementation_abi
     end
@@ -6125,7 +6128,7 @@ defmodule Explorer.ChainTest do
         end
       )
 
-      implementation_abi = Chain.get_implementation_abi_from_proxy(smart_contract)
+      implementation_abi = Chain.get_implementation_abi_from_proxy(smart_contract, [])
 
       assert implementation_abi == @implementation_abi
     end

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -118,7 +118,7 @@ defmodule Explorer.SmartContract.ReaderTest do
   end
 
   describe "read_only_functions/1" do
-    test "fetches the smart contract read only functions with the blockchain value" do
+    test "fetches the smart contract read only functions with the blockchain value with provided smart_contract" do
       smart_contract =
         insert(
           :smart_contract,
@@ -146,7 +146,7 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       blockchain_get_function_mock()
 
-      response = Reader.read_only_functions(smart_contract.address_hash)
+      response = Reader.read_only_functions(smart_contract, smart_contract.address_hash, nil)
 
       assert [
                %{
@@ -229,7 +229,8 @@ defmodule Explorer.SmartContract.ReaderTest do
       response =
         Reader.read_only_functions_proxy(
           proxy_smart_contract.address_hash,
-          "0x" <> implementation_contract_address_hash_string
+          "0x" <> implementation_contract_address_hash_string,
+          nil
         )
 
       assert [

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -261,18 +261,6 @@ defmodule Explorer.SmartContract.ReaderTest do
       smart_contract = insert(:smart_contract, contract_code_md5: "123")
 
       blockchain_get_function_mock()
-
-      assert [
-               %{
-                 "type" => "uint256",
-                 "value" => 0
-               }
-             ] = Reader.query_function(smart_contract.address_hash, %{method_id: "6d4ce63c", args: []}, :regular, false)
-    end
-
-    test "nil arguments is treated as []" do
-      smart_contract = insert(:smart_contract, contract_code_md5: "123")
-
       blockchain_get_function_mock()
 
       assert [
@@ -281,7 +269,62 @@ defmodule Explorer.SmartContract.ReaderTest do
                  "value" => 0
                }
              ] =
-               Reader.query_function(smart_contract.address_hash, %{method_id: "6d4ce63c", args: nil}, :regular, false)
+               Reader.query_function(
+                 smart_contract.address_hash,
+                 %{method_id: "6d4ce63c", args: []},
+                 :regular,
+                 nil,
+                 false
+               )
+
+      assert [
+               %{
+                 "type" => "uint256",
+                 "value" => 0
+               }
+             ] =
+               Reader.query_function_with_custom_abi(
+                 smart_contract.address_hash,
+                 %{method_id: "6d4ce63c", args: []},
+                 nil,
+                 false,
+                 smart_contract.abi
+               )
+    end
+
+    test "nil arguments is treated as []" do
+      smart_contract = insert(:smart_contract, contract_code_md5: "123")
+
+      blockchain_get_function_mock()
+      blockchain_get_function_mock()
+
+      assert [
+               %{
+                 "type" => "uint256",
+                 "value" => 0
+               }
+             ] =
+               Reader.query_function(
+                 smart_contract.address_hash,
+                 %{method_id: "6d4ce63c", args: nil},
+                 :regular,
+                 nil,
+                 false
+               )
+
+      assert [
+               %{
+                 "type" => "uint256",
+                 "value" => 0
+               }
+             ] =
+               Reader.query_function_with_custom_abi(
+                 smart_contract.address_hash,
+                 %{method_id: "6d4ce63c", args: []},
+                 nil,
+                 false,
+                 smart_contract.abi
+               )
     end
   end
 

--- a/apps/explorer/test/explorer/smart_contract/writer_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/writer_test.exs
@@ -230,14 +230,14 @@ defmodule Explorer.SmartContract.WriterTest do
   setup :verify_on_exit!
 
   describe "write_functions/1" do
-    test "fetches the smart contract write functions" do
+    test "fetches the smart contract write functions with provided smart_contract" do
       smart_contract =
         insert(
           :smart_contract,
           abi: @abi
         )
 
-      response = Writer.write_functions(smart_contract.address_hash)
+      response = Writer.write_functions(smart_contract)
 
       assert [
                %{

--- a/config/config.exs
+++ b/config/config.exs
@@ -36,7 +36,8 @@ config :logger,
     {LoggerFileBackend, :empty_blocks_to_refetch},
     {LoggerFileBackend, :api},
     {LoggerFileBackend, :block_import_timings},
-    {LoggerFileBackend, :account}
+    {LoggerFileBackend, :account},
+    {LoggerFileBackend, :api_v2}
   ]
 
 config :logger, :console,


### PR DESCRIPTION
…nsfers

Close #6919 
Close #6841 
Close #6842 

## Changelog
- Refactor http requests logger: Now `api`, `api_v2` and `block_scout_web` logs saved separately
- Pagination for token transfers takes into account batch ERC-1155 transfers (+ squashes the same token ids)
- Add `/smart-contracts/counters`
- Refactor functions such as: `query_function_with_names`, `read_only_functions`, `read_only_functions_required_wallet` and some others in order to avoid fetching the same smart contract several times from a DB
- Redirect all the DB read interaction from the API v2 to the read replica

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
