### PR TITLE
Token instance fetcher fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#7007](https://github.com/blockscout/blockscout/pull/7007) - Token instance fetcher fixes
+
 ### Chore
 
 - [#6989](https://github.com/blockscout/blockscout/pull/6989) - Update bitwalker/alpine-elixir-phoenix: 1.13 -> 1.14

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -64,8 +64,8 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
   @erc1155_token_id_placeholder "{id}"
 
   def fetch_metadata(unquote(@cryptokitties_address_hash), token_id) do
-    %{"tokenURI" => {:ok, ["https://api.cryptokitties.co/kitties/#{token_id}"]}}
-    |> fetch_json()
+    %{@token_uri => {:ok, ["https://api.cryptokitties.co/kitties/{id}"]}}
+    |> fetch_json(to_string(token_id))
   end
 
   def fetch_metadata(contract_address_hash, token_id) do
@@ -207,24 +207,20 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
       {:error, base64_encoded_json}
   end
 
-  def fetch_json(%{@token_uri => {:ok, ["ipfs://ipfs/" <> ipfs_uid]}}, hex_token_id) do
-    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
-    fetch_metadata_inner(ipfs_url, hex_token_id)
+  def fetch_json(%{@token_uri => {:ok, ["ipfs://ipfs/" <> right]}}, hex_token_id) do
+    fetch_from_ipfs(right, hex_token_id)
   end
 
-  def fetch_json(%{@uri => {:ok, ["ipfs://ipfs/" <> ipfs_uid]}}, hex_token_id) do
-    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
-    fetch_metadata_inner(ipfs_url, hex_token_id)
+  def fetch_json(%{@uri => {:ok, ["ipfs://ipfs/" <> right]}}, hex_token_id) do
+    fetch_from_ipfs(right, hex_token_id)
   end
 
-  def fetch_json(%{@token_uri => {:ok, ["ipfs://" <> ipfs_uid]}}, hex_token_id) do
-    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
-    fetch_metadata_inner(ipfs_url, hex_token_id)
+  def fetch_json(%{@token_uri => {:ok, ["ipfs://" <> right]}}, hex_token_id) do
+    fetch_from_ipfs(right, hex_token_id)
   end
 
-  def fetch_json(%{@uri => {:ok, ["ipfs://" <> ipfs_uid]}}, hex_token_id) do
-    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
-    fetch_metadata_inner(ipfs_url, hex_token_id)
+  def fetch_json(%{@uri => {:ok, ["ipfs://" <> right]}}, hex_token_id) do
+    fetch_from_ipfs(right, hex_token_id)
   end
 
   def fetch_json(%{@token_uri => {:ok, [json]}}, hex_token_id) do
@@ -259,13 +255,31 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     {:error, result}
   end
 
+  defp fetch_from_ipfs(right, hex_token_id) do
+    ipfs_uid = right |> String.split("/") |> List.first()
+    ipfs_url = "https://ipfs.io/ipfs/" <> ipfs_uid
+    fetch_metadata_inner(ipfs_url, hex_token_id)
+  end
+
   defp fetch_metadata_inner(uri, hex_token_id) do
     prepared_uri = substitute_token_id_to_token_uri(uri, hex_token_id)
+    fetch_metadata_from_uri(prepared_uri, hex_token_id)
+  rescue
+    e ->
+      Logger.debug(
+        ["Could not prepare token uri #{inspect(uri)}.", Exception.format(:error, e, __STACKTRACE__)],
+        fetcher: :token_instances
+      )
 
-    case HTTPoison.get(prepared_uri) do
-      {:ok, %Response{body: body, status_code: 200, headers: headers}} ->
+      {:error, :request_error}
+  end
+
+  def fetch_metadata_from_uri(uri, hex_token_id \\ nil) do
+    case HTTPoison.get(uri, [], timeout: 60_000, recv_timeout: 60_000, follow_redirect: true) do
+      {:ok, %Response{body: body, status_code: status_code, headers: headers}}
+      when status_code in [200, 301, 302, 307] ->
         if Enum.member?(headers, {"Content-Type", "image/png"}) do
-          json = %{"image" => prepared_uri}
+          json = %{"image" => uri}
 
           check_type(json, nil)
         else
@@ -273,11 +287,6 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
 
           check_type(json, hex_token_id)
         end
-
-      {:ok, %Response{body: body, status_code: 301}} ->
-        {:ok, json} = decode_json(body)
-
-        check_type(json, hex_token_id)
 
       {:ok, %Response{body: body}} ->
         {:error, body}

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -276,8 +276,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
 
   def fetch_metadata_from_uri(uri, hex_token_id \\ nil) do
     case HTTPoison.get(uri, [], timeout: 60_000, recv_timeout: 60_000, follow_redirect: true) do
-      {:ok, %Response{body: body, status_code: status_code, headers: headers}}
-      when status_code in [200, 301, 302, 307] ->
+      {:ok, %Response{body: body, status_code: 200, headers: headers}} ->
         if Enum.member?(headers, {"Content-Type", "image/png"}) do
           json = %{"image" => uri}
 

--- a/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
@@ -167,6 +167,27 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
                })
     end
 
+    test "fetches json metadata for kitties" do
+      {:ok, %{metadata: metadata}} =
+        InstanceMetadataRetriever.fetch_metadata("0x06012c8cf97bead5deae237070f9587f8e7a266d", 100_500)
+
+      assert Map.get(metadata, "name") == "KittyBlue_2_Lemonade"
+    end
+
+    test "fetches json metadata when HTTP status 301" do
+      {:ok, %{metadata: metadata}} =
+        InstanceMetadataRetriever.fetch_metadata_from_uri("https://metadata.billyli.workers.dev/1302")
+
+      assert Map.get(metadata, "attributes") == [
+               %{"trait_type" => "Mouth", "value" => "Discomfort"},
+               %{"trait_type" => "Background", "value" => "Army Green"},
+               %{"trait_type" => "Eyes", "value" => "Wide Eyed"},
+               %{"trait_type" => "Fur", "value" => "Black"},
+               %{"trait_type" => "Earring", "value" => "Silver Hoop"},
+               %{"trait_type" => "Hat", "value" => "Sea Captain's Hat"}
+             ]
+    end
+
     test "replace {id} with actual token_id", %{bypass: bypass} do
       json = """
       {
@@ -324,6 +345,22 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
                     "description" => "Punk Domains digital identity ï. Visit https://punk.domains/"
                   }
                 }}
+    end
+
+    test "fetches json metadata from ipfs://${uid}/something" do
+      data = %{
+        "c87b56dd" =>
+          {:ok,
+           [
+             "ipfs://bafkreigvdbls327yodd77iinrijqdfhyrtvfav6xwl2i3r7pjl6q4qmqgm/1732.json"
+           ]}
+      }
+
+      {:ok, %{metadata: metadata}} = InstanceMetadataRetriever.fetch_json(data)
+
+      assert metadata
+             |> Map.get("links")
+             |> Map.get("website") == "https://base.org/"
     end
   end
 end


### PR DESCRIPTION
## Motivation

Different token instance fetcher errors in the logs:
- error kind 1:
`12:11:36.604 [debug] failed to fetch token instance metadata for {"0xe513ca43714e13ba611750a001b8d099d970e282", 2084}: {:error, "ipfs resolve -r /ipfs/bafkreigvdbls327yodd77iinrijqdfhyrtvfav6xwl2i3r7pjl6q4qmqgm/2084.json: func called on wrong kind: \"LookupBySegment\" called on a bytes node (kind: bytes), but only makes sense on map or list\n"}`
- error kind 2: HTTP status code 301 redirect in token URI handled improperly
- Cryptokitties case handled improperly

## Changelog

- Process ipfs link, when after UID, custom path is added.
- Add handling of HTTP status code 301: find redirect location and request metadata from it.
- Properly add handling of Cryptokitties contract.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
