### PR TITLE
Define common function for "reltuples" query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Chore
 
 - [#7040](https://github.com/blockscout/blockscout/pull/7040) - Use alias BlockScoutWeb.Cldr.Number
+- [#7037](https://github.com/blockscout/blockscout/pull/7037) - Define common function for "reltuples" query
 - [#7034](https://github.com/blockscout/blockscout/pull/7034) - Resolve "Unexpected var, use let or const instead"
 - [#7014](https://github.com/blockscout/blockscout/pull/7014), [#7036](https://github.com/blockscout/blockscout/pull/7036) - Fix spell in namings, add spell checking in CI
 - [#7012](https://github.com/blockscout/blockscout/pull/7012) - Refactor socket.js

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -77,6 +77,7 @@ defmodule Explorer.Chain do
   }
 
   alias Explorer.Chain.Cache.Block, as: BlockCache
+  alias Explorer.Chain.Cache.Helper, as: CacheHelper
   alias Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand
   alias Explorer.Chain.Import.Runner
   alias Explorer.Chain.InternalTransaction.{CallType, Type}
@@ -190,7 +191,7 @@ defmodule Explorer.Chain do
     cached_value = AddressesCounter.fetch()
 
     if is_nil(cached_value) || cached_value == 0 do
-      %Postgrex.Result{rows: [[count]]} = Repo.query!("SELECT reltuples FROM pg_class WHERE relname = 'addresses';")
+      count = CacheHelper.estimated_count_from("addresses")
 
       max(count, 0)
     else

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Cache.Block do
   require Logger
 
   alias Explorer.Chain.Block
+  alias Explorer.Chain.Cache.Helper
   alias Explorer.Repo
 
   @doc """
@@ -31,7 +32,7 @@ defmodule Explorer.Chain.Cache.Block do
     cached_value = __MODULE__.get_count()
 
     if is_nil(cached_value) do
-      %Postgrex.Result{rows: [[count]]} = Repo.query!("SELECT reltuples FROM pg_class WHERE relname = 'blocks';")
+      count = Helper.estimated_count_from("blocks")
 
       trunc(count * 0.90)
     else

--- a/apps/explorer/lib/explorer/chain/cache/helper.ex
+++ b/apps/explorer/lib/explorer/chain/cache/helper.ex
@@ -1,0 +1,13 @@
+defmodule Explorer.Chain.Cache.Helper do
+  @moduledoc """
+  Common helper functions for cache modules
+  """
+  alias Explorer.Repo
+
+  def estimated_count_from(table_name) do
+    %Postgrex.Result{rows: [[count]]} =
+      Repo.query!("SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname = '#{table_name}';")
+
+    count
+  end
+end

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -13,7 +13,7 @@ defmodule Explorer.Chain.Cache.Transaction do
 
   require Logger
 
-  alias Ecto.Adapters.SQL
+  alias Explorer.Chain.Cache.Helper
   alias Explorer.Chain.Transaction
   alias Explorer.Repo
 
@@ -27,10 +27,9 @@ defmodule Explorer.Chain.Cache.Transaction do
     cached_value = __MODULE__.get_count()
 
     if is_nil(cached_value) do
-      %Postgrex.Result{rows: [[rows]]} =
-        SQL.query!(Repo, "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='transactions'")
+      count = Helper.estimated_count_from("blocks")
 
-      max(rows, 0)
+      max(count, 0)
     else
       cached_value
     end

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.Cache.Transaction do
     cached_value = __MODULE__.get_count()
 
     if is_nil(cached_value) do
-      count = Helper.estimated_count_from("blocks")
+      count = Helper.estimated_count_from("transactions")
 
       max(count, 0)
     else


### PR DESCRIPTION
## Motivation

Define common function for calculation estimated rows count from Postgres DB, which is used by caching functionality.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
