### PR TITLE
Instance metadata retriever mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link
-- [#7007](https://github.com/blockscout/blockscout/pull/7007), [#7031](https://github.com/blockscout/blockscout/pull/7031), [#7058](https://github.com/blockscout/blockscout/pull/7058) - Token instance fetcher fixes
+- [#7007](https://github.com/blockscout/blockscout/pull/7007), [#7031](https://github.com/blockscout/blockscout/pull/7031), [#7058](https://github.com/blockscout/blockscout/pull/7058), [#7061](https://github.com/blockscout/blockscout/pull/7061) - Token instance fetcher fixes
 - [#7009](https://github.com/blockscout/blockscout/pull/7009) - Fix updating coin balances with empty value
 
 ### Chore

--- a/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/instance_metadata_retriever_test.exs
@@ -151,19 +151,21 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
     end
 
     test "fetches json with latin1 encoding", %{bypass: bypass} do
+      path = "/api/card/55265"
+
       json = """
       {
         "name": "Sérgio Mendonça"
       }
       """
 
-      Bypass.expect(bypass, "GET", "/api/card/55265", fn conn ->
+      Bypass.expect(bypass, "GET", path, fn conn ->
         Conn.resp(conn, 200, json)
       end)
 
       assert {:ok, %{metadata: %{"name" => "Sérgio Mendonça"}}} ==
                InstanceMetadataRetriever.fetch_json(%{
-                 "c87b56dd" => {:ok, ["http://localhost:#{bypass.port}/api/card/55265"]}
+                 "c87b56dd" => {:ok, ["http://localhost:#{bypass.port}#{path}"]}
                })
     end
 
@@ -174,18 +176,34 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
       assert Map.get(metadata, "name") == "KittyBlue_2_Lemonade"
     end
 
-    test "fetches json metadata when HTTP status 301" do
-      {:ok, %{metadata: metadata}} =
-        InstanceMetadataRetriever.fetch_metadata_from_uri("https://metadata.billyli.workers.dev/1302")
+    test "fetches json metadata when HTTP status 301", %{bypass: bypass} do
+      path = "/1302"
 
-      assert Map.get(metadata, "attributes") == [
-               %{"trait_type" => "Mouth", "value" => "Discomfort"},
-               %{"trait_type" => "Background", "value" => "Army Green"},
-               %{"trait_type" => "Eyes", "value" => "Wide Eyed"},
-               %{"trait_type" => "Fur", "value" => "Black"},
-               %{"trait_type" => "Earring", "value" => "Silver Hoop"},
-               %{"trait_type" => "Hat", "value" => "Sea Captain's Hat"}
-             ]
+      attributes = """
+      [
+        {"trait_type": "Mouth", "value": "Discomfort"},
+        {"trait_type": "Background", "value": "Army Green"},
+        {"trait_type": "Eyes", "value": "Wide Eyed"},
+        {"trait_type": "Fur", "value": "Black"},
+        {"trait_type": "Earring", "value": "Silver Hoop"},
+        {"trait_type": "Hat", "value": "Sea Captain's Hat"}
+      ]
+      """
+
+      json = """
+      {
+        "attributes": #{attributes}
+      }
+      """
+
+      Bypass.expect(bypass, "GET", path, fn conn ->
+        Conn.resp(conn, 200, json)
+      end)
+
+      {:ok, %{metadata: metadata}} =
+        InstanceMetadataRetriever.fetch_metadata_from_uri("http://localhost:#{bypass.port}#{path}")
+
+      assert Map.get(metadata, "attributes") == Jason.decode!(attributes)
     end
 
     test "replace {id} with actual token_id", %{bypass: bypass} do
@@ -347,12 +365,24 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
                 }}
     end
 
-    test "fetches image from ipfs link directly" do
+    test "fetches image from ipfs link directly", %{bypass: bypass} do
+      path = "/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"
+
+      json = """
+      {
+        "image": "https://ipfs.io/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"
+      }
+      """
+
+      Bypass.expect(bypass, "GET", path, fn conn ->
+        Conn.resp(conn, 200, json)
+      end)
+
       data = %{
         "c87b56dd" =>
           {:ok,
            [
-             "ipfs://bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"
+             "http://localhost:#{bypass.port}#{path}"
            ]}
       }
 
@@ -364,12 +394,24 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
               }} == InstanceMetadataRetriever.fetch_json(data)
     end
 
-    test "Fetches metadata from ipfs" do
+    test "Fetches metadata from ipfs", %{bypass: bypass} do
+      path = "/ipfs/bafybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json"
+
+      json = """
+      {
+        "image": "ipfs://bafybeihxuj3gxk7x5p36amzootyukbugmx3pw7dyntsrohg3se64efkuga/51.png"
+      }
+      """
+
+      Bypass.expect(bypass, "GET", path, fn conn ->
+        Conn.resp(conn, 200, json)
+      end)
+
       data = %{
         "c87b56dd" =>
           {:ok,
            [
-             "ipfs://bafybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json"
+             "http://localhost:#{bypass.port}#{path}"
            ]}
       }
 


### PR DESCRIPTION
## Motivation

Add mocks for external URLs requests in instance metadata retriever tests

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
