### PR TITLE
Save block count in the DB when calculated in Cache module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#7062](https://github.com/blockscout/blockscout/pull/7062) - Save block count in the DB when calculated in Cache module
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link
 - [#7007](https://github.com/blockscout/blockscout/pull/7007), [#7031](https://github.com/blockscout/blockscout/pull/7031), [#7058](https://github.com/blockscout/blockscout/pull/7058), [#7061](https://github.com/blockscout/blockscout/pull/7061), [#7067](https://github.com/blockscout/blockscout/pull/7067) - Token instance fetcher fixes
 - [#7009](https://github.com/blockscout/blockscout/pull/7009) - Fix updating coin balances with empty value

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -18,9 +18,11 @@ defmodule Explorer.Chain.Cache.Block do
 
   require Logger
 
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Block
   alias Explorer.Chain.Cache.Helper
-  alias Explorer.Repo
+
+  @cache_key "block_count"
 
   @doc """
   Estimated count of `t:Explorer.Chain.Block.t/0`.
@@ -29,14 +31,23 @@ defmodule Explorer.Chain.Cache.Block do
   """
   @spec estimated_count() :: non_neg_integer()
   def estimated_count do
-    cached_value = __MODULE__.get_count()
+    cached_value_from_ets = __MODULE__.get_count()
 
-    if is_nil(cached_value) do
-      count = Helper.estimated_count_from("blocks")
+    if is_nil(cached_value_from_ets) do
+      cached_value_from_db =
+        @cache_key
+        |> Chain.get_last_fetched_counter()
+        |> Decimal.to_integer()
 
-      trunc(count * 0.90)
+      if cached_value_from_db === 0 do
+        count = Helper.estimated_count_from("blocks")
+
+        trunc(count * 0.90)
+      else
+        cached_value_from_db
+      end
     else
-      cached_value
+      cached_value_from_ets
     end
   end
 
@@ -55,6 +66,13 @@ defmodule Explorer.Chain.Cache.Block do
       Task.start(fn ->
         try do
           result = fetch_count_consensus_block()
+
+          params = %{
+            counter_type: @cache_key,
+            value: result
+          }
+
+          Chain.upsert_last_fetched_counter(params)
 
           set_count(result)
         rescue


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7032

## Motivation

On application restart ETS cache is empty and blocks indexed ratio is based on estimated count from `reltuples` from `pg_class` query. Thus indexing banner may appear on every restart. We need to keep status of indexing in the DB as well.

## Changelog

On every calculated from DB count of blocks from `Explorer.Chain.Cache.Block` module, save the counter value in `last_fetched_counters` table and use it, if ETS cache is empty.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
