### PR TITLE
Allow URI special symbols in `DATABASE_URL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [#7096](https://github.com/blockscout/blockscout/pull/7096) - Hide indexing alert, if indexer disabled
 - [#7091](https://github.com/blockscout/blockscout/pull/7091) - Fix custom ABI
+- [#7087](https://github.com/blockscout/blockscout/pull/7087) - Allow URI special symbols in `DATABASE_URL`
 - [#7062](https://github.com/blockscout/blockscout/pull/7062) - Save block count in the DB when calculated in Cache module
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link
 - [#7007](https://github.com/blockscout/blockscout/pull/7007), [#7031](https://github.com/blockscout/blockscout/pull/7031), [#7058](https://github.com/blockscout/blockscout/pull/7058), [#7061](https://github.com/blockscout/blockscout/pull/7061), [#7067](https://github.com/blockscout/blockscout/pull/7067) - Token instance fetcher fixes

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -17,7 +17,8 @@ defmodule Explorer.Repo.ConfigHelper do
   ]
 
   def get_db_config(opts) do
-    url = opts[:url] || System.get_env("DATABASE_URL")
+    url_encoded = opts[:url] || System.get_env("DATABASE_URL")
+    url = url_encoded && URI.decode(url_encoded)
     env_function = opts[:env_func] || (&System.get_env/1)
 
     @postgrex_env_vars

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -28,7 +28,7 @@ defmodule Explorer.Repo.ConfigHelperTest do
       assert result[:database] == "test_database"
     end
 
-    test "parse params from database url with hyphen in databasename" do
+    test "parse params from database url with hyphen in database name" do
       database_url = "postgresql://test_username:test_password@host-name.test.com:7777/test-database"
 
       result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
@@ -47,6 +47,18 @@ defmodule Explorer.Repo.ConfigHelperTest do
 
       assert result[:username] == "test_username"
       assert result[:password] == "awN!l#W*g$P%t-l^q&d"
+      assert result[:hostname] == "hostname.test.com"
+      assert result[:port] == "7777"
+      assert result[:database] == "test_database"
+    end
+
+    test "parse params from database url with encoded special characters in password" do
+      database_url = "postgresql://test_username:pass%23@hostname.test.com:7777/test_database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test_username"
+      assert result[:password] == "pass#"
       assert result[:hostname] == "hostname.test.com"
       assert result[:port] == "7777"
       assert result[:database] == "test_database"


### PR DESCRIPTION
## Motivation
Now we cannot have special symbols like `#` in `DATABASE_URL`. If we leave it as it is ecto struggling to parse `DATABASE_URL`, if we encode it like `%23` ecto parses it fine, but config helper adds it to the password as is. For instance we can encode password `pass#` in `DATABASE_URL` like `pass%23` ecto wil decode it as `pass#` but config helper will parse `pass%23` thus in some places we will get authentication error.


## Changelog
Add `URI.decode()` before parsing in config helper

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
