### PR TITLE
Fix custom ABI loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- [#7091](https://github.com/blockscout/blockscout/pull/7091) - Fix custom ABI
 - [#7062](https://github.com/blockscout/blockscout/pull/7062) - Save block count in the DB when calculated in Cache module
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link
 - [#7007](https://github.com/blockscout/blockscout/pull/7007), [#7031](https://github.com/blockscout/blockscout/pull/7031), [#7058](https://github.com/blockscout/blockscout/pull/7058), [#7061](https://github.com/blockscout/blockscout/pull/7061), [#7067](https://github.com/blockscout/blockscout/pull/7067) - Token instance fetcher fixes

--- a/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
+++ b/apps/block_scout_web/assets/js/lib/smart_contract/functions.js
@@ -101,19 +101,19 @@ const readWriteFunction = (element) => {
 const container = $('[data-smart-contract-functions]')
 
 if (container.length) {
-  getWalletAndLoadFunctions()
+  getWalletAndLoadFunctions(false, container)
 }
 
 const customABIContainer = $('[data-smart-contract-functions-custom]')
 
 if (customABIContainer.length) {
-  getWalletAndLoadFunctions()
+  getWalletAndLoadFunctions(true, customABIContainer)
 }
 
-function getWalletAndLoadFunctions () {
+function getWalletAndLoadFunctions (isCustomABI, container) {
   getCurrentAccountPromise(window.web3 && window.web3.currentProvider).then((currentAccount) => {
-    loadFunctions(container, false, currentAccount)
+    loadFunctions(container, isCustomABI, currentAccount)
   }, () => {
-    loadFunctions(container, false, null)
+    loadFunctions(container, isCustomABI, null)
   })
 }


### PR DESCRIPTION
## Motivation

If you will try to access any custom ABI tab you will see only infinite loader 

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/32202610/225713040-320857bd-50f1-4dcb-91be-36b67a63d211.png">

## Changelog
- Fix `loadFunctions()` usage

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
