### PR TITLE
Hide indexing alert, if indexer disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- [#7096](https://github.com/blockscout/blockscout/pull/7096) - Hide indexing alert, if indexer disabled
 - [#7091](https://github.com/blockscout/blockscout/pull/7091) - Fix custom ABI
 - [#7062](https://github.com/blockscout/blockscout/pull/7062) - Save block count in the DB when calculated in Cache module
 - [#7008](https://github.com/blockscout/blockscout/pull/7008) - Fetch image/video content from IPFS link

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -41,11 +41,11 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
 
   def indexing_status(conn, _params) do
     indexed_ratio_blocks = Chain.indexed_ratio_blocks()
-    finished_indexing_blocks = Chain.finished_blocks_indexing?(indexed_ratio_blocks)
+    finished_indexing_blocks = Chain.finished_indexing_from_ratio?(indexed_ratio_blocks)
 
     json(conn, %{
       finished_indexing_blocks: finished_indexing_blocks,
-      finished_indexing: Chain.finished_indexing?(indexed_ratio_blocks, api?: true),
+      finished_indexing: Chain.finished_indexing?(api?: true),
       indexed_blocks_ratio: indexed_ratio_blocks,
       indexed_internal_transactions_ratio: if(finished_indexing_blocks, do: Chain.indexed_ratio_internal_transactions())
     })

--- a/apps/block_scout_web/lib/block_scout_web/counters/internal_transactions_indexed_counter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/counters/internal_transactions_indexed_counter.ex
@@ -36,11 +36,9 @@ defmodule BlockScoutWeb.Counters.InternalTransactionsIndexedCounter do
   end
 
   def calculate_internal_transactions_indexed do
-    indexed_ratio_internal_transactions = Chain.indexed_ratio_internal_transactions()
+    ratio = Chain.indexed_ratio_internal_transactions()
 
-    finished? = Chain.finished_indexing?(indexed_ratio_internal_transactions)
-
-    Notifier.broadcast_internal_transactions_indexed_ratio(indexed_ratio_internal_transactions, finished?)
+    Notifier.broadcast_indexed_ratio("blocks:indexing_internal_transactions", ratio)
   end
 
   defp schedule_next_consolidation do

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -264,22 +264,14 @@ defmodule BlockScoutWeb.Notifier do
     do: Map.has_key?(params, "verification_type") && Map.get(params, "verification_type") == type
 
   @doc """
-  Broadcast the percentage of blocks indexed so far.
+  Broadcast the percentage of blocks or pending block operations indexed so far.
   """
-  def broadcast_blocks_indexed_ratio(ratio, finished?) do
-    Endpoint.broadcast("blocks:indexing", "index_status", %{
+  @spec broadcast_indexed_ratio(String.t(), Decimal.t()) ::
+          :ok | {:error, term()}
+  def broadcast_indexed_ratio(msg, ratio) do
+    Endpoint.broadcast(msg, "index_status", %{
       ratio: Decimal.to_string(ratio),
-      finished: finished?
-    })
-  end
-
-  @doc """
-  Broadcast the percentage of pending block operations indexed so far.
-  """
-  def broadcast_internal_transactions_indexed_ratio(ratio, finished?) do
-    Endpoint.broadcast("blocks:indexing_internal_transactions", "index_status", %{
-      ratio: Decimal.to_string(ratio),
-      finished: finished?
+      finished: Chain.finished_indexing_from_ratio?(ratio)
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -74,11 +74,11 @@
       <% end %>
       <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
       <% indexed_ratio =
-        case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
-        false -> indexed_ratio_blocks
-        _ -> Chain.indexed_ratio_internal_transactions()
-        end %>
-         <%= if not Chain.finished_indexing_from_ratio?(indexed_ratio) do %>
+      case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
+       false -> indexed_ratio_blocks
+       _ -> Chain.indexed_ratio_internal_transactions()
+      end %>
+      <%= if not Chain.finished_indexing_from_ratio?(indexed_ratio) do %>
         <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
           <span data-indexed-ratio-blocks="<%= indexed_ratio_blocks %>" data-indexed-ratio="<%= indexed_ratio %>"></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -72,13 +72,13 @@
           <%= raw(System.get_env("MAINTENANCE_ALERT_MESSAGE")) %>
         </div>
       <% end %>
-      <%= if not Chain.finished_indexing?() do %>
-        <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
-        <% indexed_ratio =
+      <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
+      <% indexed_ratio =
         case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
         false -> indexed_ratio_blocks
         _ -> Chain.indexed_ratio_internal_transactions()
         end %>
+         <%= if not Chain.finished_indexing_from_ratio?(indexed_ratio) do %>
         <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
           <span data-indexed-ratio-blocks="<%= indexed_ratio_blocks %>" data-indexed-ratio="<%= indexed_ratio %>"></span>

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -72,13 +72,13 @@
           <%= raw(System.get_env("MAINTENANCE_ALERT_MESSAGE")) %>
         </div>
       <% end %>
-      <% indexed_ratio_blocks = Explorer.Chain.indexed_ratio_blocks() %>
-      <% indexed_ratio =
-      case Chain.finished_blocks_indexing?(indexed_ratio_blocks) do
-       false -> indexed_ratio_blocks
-       _ -> Explorer.Chain.indexed_ratio_internal_transactions()
-      end %>
-      <%= if not Explorer.Chain.finished_indexing?(indexed_ratio_blocks) do %>
+      <%= if not Chain.finished_indexing?() do %>
+        <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
+        <% indexed_ratio =
+        case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
+        false -> indexed_ratio_blocks
+        _ -> Chain.indexed_ratio_internal_transactions()
+        end %>
         <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
           <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
           <span data-indexed-ratio-blocks="<%= indexed_ratio_blocks %>" data-indexed-ratio="<%= indexed_ratio %>"></span>

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1277,7 +1277,9 @@ defmodule Explorer.Chain do
   """
   @spec finished_indexing_internal_transactions?([api?]) :: boolean()
   def finished_indexing_internal_transactions?(options \\ []) do
-    internal_transactions_disabled? = System.get_env("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER", "false") == "true"
+    internal_transactions_disabled? =
+      Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)[:disabled?] or
+        not Application.get_env(:indexer, Indexer.Supervisor)[:enabled]
 
     if internal_transactions_disabled? do
       true

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1275,8 +1275,8 @@ defmodule Explorer.Chain do
   Checks to see if the chain is down indexing based on the transaction from the
   oldest block and the pending operation
   """
-  @spec finished_internal_transactions_indexing?([api?]) :: boolean()
-  def finished_internal_transactions_indexing?(options \\ []) do
+  @spec finished_indexing_internal_transactions?([api?]) :: boolean()
+  def finished_indexing_internal_transactions?(options \\ []) do
     internal_transactions_disabled? = System.get_env("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER", "false") == "true"
 
     if internal_transactions_disabled? do
@@ -1312,19 +1312,21 @@ defmodule Explorer.Chain do
     end
   end
 
-  def finished_blocks_indexing?(indexed_ratio_blocks) do
-    Decimal.compare(indexed_ratio_blocks, 1) !== :lt
+  def finished_indexing_from_ratio?(ratio) do
+    Decimal.compare(ratio, 1) !== :lt
   end
 
   @doc """
   Checks if indexing of blocks and internal transactions finished aka full indexing
   """
-  @spec finished_indexing?(Decimal.t(), [api?]) :: boolean()
-  def finished_indexing?(indexed_ratio_blocks, options \\ []) do
+  @spec finished_indexing?([api?]) :: boolean()
+  def finished_indexing?(options \\ []) do
     if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] do
-      case finished_blocks_indexing?(indexed_ratio_blocks) do
+      indexed_ratio = indexed_ratio_blocks()
+
+      case finished_indexing_from_ratio?(indexed_ratio) do
         false -> false
-        _ -> finished_internal_transactions_indexing?(options)
+        _ -> finished_indexing_internal_transactions?(options)
       end
     else
       true
@@ -2185,58 +2187,66 @@ defmodule Explorer.Chain do
   """
   @spec indexed_ratio_blocks() :: Decimal.t()
   def indexed_ratio_blocks do
-    %{min: min, max: max} = BlockNumber.get_all()
+    if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] do
+      %{min: min, max: max} = BlockNumber.get_all()
 
-    min_blockchain_block_number =
-      case Integer.parse(Application.get_env(:indexer, :first_block)) do
-        {block_number, _} -> block_number
-        _ -> 0
+      min_blockchain_block_number =
+        case Integer.parse(Application.get_env(:indexer, :first_block)) do
+          {block_number, _} -> block_number
+          _ -> 0
+        end
+
+      case {min, max} do
+        {0, 0} ->
+          Decimal.new(0)
+
+        _ ->
+          result =
+            BlockCache.estimated_count()
+            |> Decimal.div(max - min_blockchain_block_number + 1)
+            |> (&if(
+                  (Decimal.compare(&1, Decimal.from_float(0.99)) == :gt ||
+                     Decimal.compare(&1, Decimal.from_float(0.99)) == :eq) &&
+                    min <= min_blockchain_block_number,
+                  do: Decimal.new(1),
+                  else: &1
+                )).()
+
+          result
+          |> Decimal.round(2, :down)
+          |> Decimal.min(Decimal.new(1))
       end
-
-    case {min, max} do
-      {0, 0} ->
-        Decimal.new(0)
-
-      _ ->
-        result =
-          BlockCache.estimated_count()
-          |> Decimal.div(max - min_blockchain_block_number + 1)
-          |> (&if(
-                (Decimal.compare(&1, Decimal.from_float(0.99)) == :gt ||
-                   Decimal.compare(&1, Decimal.from_float(0.99)) == :eq) &&
-                  min <= min_blockchain_block_number,
-                do: Decimal.new(1),
-                else: &1
-              )).()
-
-        result
-        |> Decimal.round(2, :down)
-        |> Decimal.min(Decimal.new(1))
+    else
+      Decimal.new(1)
     end
   end
 
   @spec indexed_ratio_internal_transactions() :: Decimal.t()
   def indexed_ratio_internal_transactions do
-    %{max: max} = BlockNumber.get_all()
-    count = Repo.aggregate(PendingBlockOperation, :count, timeout: :infinity)
+    if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] do
+      %{max: max} = BlockNumber.get_all()
+      count = Repo.aggregate(PendingBlockOperation, :count, timeout: :infinity)
 
-    min_blockchain_trace_block_number =
-      case Integer.parse(Application.get_env(:indexer, :trace_first_block)) do
-        {block_number, _} -> block_number
-        _ -> 0
+      min_blockchain_trace_block_number =
+        case Integer.parse(Application.get_env(:indexer, :trace_first_block)) do
+          {block_number, _} -> block_number
+          _ -> 0
+        end
+
+      case max do
+        0 ->
+          Decimal.new(0)
+
+        _ ->
+          full_blocks_range = max - min_blockchain_trace_block_number + 1
+          result = Decimal.div(full_blocks_range - count, full_blocks_range)
+
+          result
+          |> Decimal.round(2, :down)
+          |> Decimal.min(Decimal.new(1))
       end
-
-    case max do
-      0 ->
-        Decimal.new(0)
-
-      _ ->
-        full_blocks_range = max - min_blockchain_trace_block_number + 1
-        result = Decimal.div(full_blocks_range - count, full_blocks_range)
-
-        result
-        |> Decimal.round(2, :down)
-        |> Decimal.min(Decimal.new(1))
+    else
+      Decimal.new(1)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1321,9 +1321,13 @@ defmodule Explorer.Chain do
   """
   @spec finished_indexing?(Decimal.t(), [api?]) :: boolean()
   def finished_indexing?(indexed_ratio_blocks, options \\ []) do
-    case finished_blocks_indexing?(indexed_ratio_blocks) do
-      false -> false
-      _ -> finished_internal_transactions_indexing?(options)
+    if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] do
+      case finished_blocks_indexing?(indexed_ratio_blocks) do
+        false -> false
+        _ -> finished_internal_transactions_indexing?(options)
+      end
+    else
+      true
     end
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1206,7 +1206,7 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "finished_internal_transactions_indexing?/0" do
+  describe "finished_indexing_internal_transactions?/0" do
     test "finished indexing" do
       block = insert(:block, number: 1)
 
@@ -1214,11 +1214,11 @@ defmodule Explorer.ChainTest do
       |> insert()
       |> with_block(block)
 
-      assert Chain.finished_internal_transactions_indexing?()
+      assert Chain.finished_indexing_internal_transactions?()
     end
 
     test "finished indexing (no txs)" do
-      assert Chain.finished_internal_transactions_indexing?()
+      assert Chain.finished_indexing_internal_transactions?()
     end
 
     test "not finished indexing" do
@@ -1230,7 +1230,7 @@ defmodule Explorer.ChainTest do
 
       insert(:pending_block_operation, block: block, block_number: block.number)
 
-      refute Chain.finished_internal_transactions_indexing?()
+      refute Chain.finished_indexing_internal_transactions?()
     end
   end
 


### PR DESCRIPTION
## Motivation

https://blockscout.com/poa/sokol/
![Screenshot 2023-03-16 at 23 18 28](https://user-images.githubusercontent.com/4341812/225743007-00582edd-aafd-4e13-a8c0-1402bec12add.png)


## Changelog

Check value of `DISABLE_INDEXER` in `finished_indexing?/2` function

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
