### PR TITLE
Set infinity timeout in timestamp_to_block_number query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - [#7096](https://github.com/blockscout/blockscout/pull/7096) - Hide indexing alert, if indexer disabled
+- [#7102](https://github.com/blockscout/blockscout/pull/7102) - Set infinity timeout timestamp_to_block_number query
 - [#7091](https://github.com/blockscout/blockscout/pull/7091) - Fix custom ABI
 - [#7087](https://github.com/blockscout/blockscout/pull/7087) - Allow URI special symbols in `DATABASE_URL`
 - [#7062](https://github.com/blockscout/blockscout/pull/7062) - Save block count in the DB when calculated in Cache module

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3254,16 +3254,10 @@ defmodule Explorer.Chain do
         limit: 1
       )
 
-    response =
-      if from_api do
-        query
-        |> Repo.replica().one()
-      else
-        query
-        |> Repo.one()
-      end
+    repo = if from_api, do: Repo.replica(), else: Repo
 
-    response
+    query
+    |> repo.one(timeout: :infinity)
     |> case do
       nil ->
         {:error, :not_found}

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -52,29 +52,34 @@ defmodule Explorer.Chain.Transaction.History.Historian do
         compile_records(num_days - 1, records)
       else
         _ ->
+          Logger.info(
+            "tx/per day chart: timestamp cannot be converted to min/max blocks, trying to find min/max blocks through a fallback option}"
+          )
+
           min_max_block_query =
             from(block in Block,
               where: block.timestamp >= ^earliest and block.timestamp <= ^latest,
               select: {min(block.number), max(block.number)}
             )
 
-          {min_block, max_block} = Repo.one(min_max_block_query, timeout: :infinity)
+          case Repo.one(min_max_block_query, timeout: :infinity) do
+            {min_block, max_block} ->
+              record =
+                min_block
+                |> compile_records_in_range(max_block)
+                |> Map.put(:date, day_to_fetch)
 
-          if min_block && max_block do
-            record =
-              min_block
-              |> compile_records_in_range(max_block)
-              |> Map.put(:date, day_to_fetch)
+              records = [
+                record
+                | records
+              ]
 
-            records = [
-              record
-              | records
-            ]
+              compile_records(num_days - 1, records)
 
-            compile_records(num_days - 1, records)
-          else
-            records = [%{date: day_to_fetch, number_of_transactions: 0, gas_used: 0, total_fee: 0} | records]
-            compile_records(num_days - 1, records)
+            _ ->
+              Logger.warning("tx/per day chart: failed to get min/max blocks through a fallback option}")
+              records = [%{date: day_to_fetch, number_of_transactions: 0, gas_used: 0, total_fee: 0} | records]
+              compile_records(num_days - 1, records)
           end
       end
     end

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -64,25 +64,34 @@ defmodule Explorer.Chain.Transaction.History.Historian do
 
           case Repo.one(min_max_block_query, timeout: :infinity) do
             {min_block, max_block} ->
-              record =
-                min_block
-                |> compile_records_in_range(max_block)
-                |> Map.put(:date, day_to_fetch)
+              if min_block && max_block do
+                record =
+                  min_block
+                  |> compile_records_in_range(max_block)
+                  |> Map.put(:date, day_to_fetch)
 
-              records = [
-                record
-                | records
-              ]
+                records = [
+                  record
+                  | records
+                ]
 
-              compile_records(num_days - 1, records)
+                compile_records(num_days - 1, records)
+              else
+                Logger.warning("tx/per day chart: min_block or/and max_block is null}")
+                empty_records_for_day(day_to_fetch, records, num_days)
+              end
 
             _ ->
               Logger.warning("tx/per day chart: failed to get min/max blocks through a fallback option}")
-              records = [%{date: day_to_fetch, number_of_transactions: 0, gas_used: 0, total_fee: 0} | records]
-              compile_records(num_days - 1, records)
+              empty_records_for_day(day_to_fetch, records, num_days)
           end
       end
     end
+  end
+
+  defp empty_records_for_day(day_to_fetch, records, num_days) do
+    records = [%{date: day_to_fetch, number_of_transactions: 0, gas_used: 0, total_fee: 0} | records]
+    compile_records(num_days - 1, records)
   end
 
   defp compile_records_in_range(min_block, max_block) do


### PR DESCRIPTION
## Motivation

Tx stats chart sometimes stops to show new data (0 txs on the chart for current and some previous days).

## Changelog

Set infinity timeout timestamp_to_block_number query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
