### PR TITLE
Tx actions: remove excess `delete_all` calls and remake a cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Chore
 
+- [#7107](https://github.com/blockscout/blockscout/pull/7107) - Tx actions: remove excess delete_all calls and remake a cache
 - [#7201](https://github.com/blockscout/blockscout/pull/7201) - Remove rust, cargo from dependencies since the latest version of ex_keccak is using precompiled rust
 
 ## 5.1.2-beta

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -70,6 +70,10 @@ config :explorer, Explorer.Chain.Cache.NewVerifiedContractsCounter,
   enable_consolidation: true,
   update_interval_in_milliseconds: update_interval_in_milliseconds_default
 
+config :explorer, Explorer.Chain.Cache.TransactionActionTokensData, enabled: true
+
+config :explorer, Explorer.Chain.Cache.TransactionActionUniswapPools, enabled: true
+
 config :explorer, Explorer.ExchangeRates,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_EXCHANGE_RATES_PERIOD", "10m")
 

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -90,6 +90,8 @@ defmodule Explorer.Application do
       configure(Explorer.Chain.Cache.NewContractsCounter),
       configure(Explorer.Chain.Cache.VerifiedContractsCounter),
       configure(Explorer.Chain.Cache.NewVerifiedContractsCounter),
+      configure(Explorer.Chain.Cache.TransactionActionTokensData),
+      configure(Explorer.Chain.Cache.TransactionActionUniswapPools),
       configure(Explorer.Chain.Transaction.History.Historian),
       configure(Explorer.Chain.Events.Listener),
       configure(Explorer.Counters.AddressesWithBalanceCounter),

--- a/apps/explorer/lib/explorer/chain/cache/transaction_action_tokens_data.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_action_tokens_data.ex
@@ -1,0 +1,71 @@
+defmodule Explorer.Chain.Cache.TransactionActionTokensData do
+  @moduledoc """
+  Caches tokens data for Indexer.Transform.TransactionActions.
+  """
+  use GenServer
+
+  @cache_name :tx_actions_tokens_data_cache
+  @default_max_cache_size 100_000
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    create_cache_table()
+    {:ok, %{}}
+  end
+
+  def create_cache_table do
+    if :ets.whereis(@cache_name) == :undefined do
+      :ets.new(@cache_name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+    end
+  end
+
+  def fetch_from_cache(address) do
+    with info when info != :undefined <- :ets.info(@cache_name),
+         [{_, value}] <- :ets.lookup(@cache_name, address) do
+      value
+    else
+      _ -> %{symbol: nil, decimals: nil}
+    end
+  end
+
+  def put_to_cache(address, data) do
+    if not :ets.member(@cache_name, address) do
+      # we need to add a new item to the cache, but don't exceed the limit
+      cache_size = :ets.info(@cache_name, :size)
+
+      how_many_to_remove = cache_size - get_max_token_cache_size() + 1
+
+      range = Range.new(1, how_many_to_remove, 1)
+
+      for _step <- range do
+        :ets.delete(@cache_name, :ets.first(@cache_name))
+      end
+    end
+
+    :ets.insert(@cache_name, {address, data})
+  end
+
+  defp get_max_token_cache_size do
+    case Application.get_env(:explorer, __MODULE__)[:max_cache_size] do
+      nil ->
+        @default_max_cache_size
+
+      "" ->
+        @default_max_cache_size
+
+      max_cache_size ->
+        if is_binary(max_cache_size), do: String.to_integer(max_cache_size), else: max_cache_size
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/cache/transaction_action_tokens_data.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_action_tokens_data.ex
@@ -5,7 +5,6 @@ defmodule Explorer.Chain.Cache.TransactionActionTokensData do
   use GenServer
 
   @cache_name :tx_actions_tokens_data_cache
-  @default_max_cache_size 100_000
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_) do
@@ -57,15 +56,6 @@ defmodule Explorer.Chain.Cache.TransactionActionTokensData do
   end
 
   defp get_max_token_cache_size do
-    case Application.get_env(:explorer, __MODULE__)[:max_cache_size] do
-      nil ->
-        @default_max_cache_size
-
-      "" ->
-        @default_max_cache_size
-
-      max_cache_size ->
-        if is_binary(max_cache_size), do: String.to_integer(max_cache_size), else: max_cache_size
-    end
+    Application.get_env(:explorer, __MODULE__)[:max_cache_size]
   end
 end

--- a/apps/explorer/lib/explorer/chain/cache/transaction_action_uniswap_pools.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction_action_uniswap_pools.ex
@@ -1,0 +1,44 @@
+defmodule Explorer.Chain.Cache.TransactionActionUniswapPools do
+  @moduledoc """
+  Caches Uniswap pools for Indexer.Transform.TransactionActions.
+  """
+  use GenServer
+
+  @cache_name :tx_actions_uniswap_pools_cache
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_args) do
+    create_cache_table()
+    {:ok, %{}}
+  end
+
+  def create_cache_table do
+    if :ets.whereis(@cache_name) == :undefined do
+      :ets.new(@cache_name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+    end
+  end
+
+  def fetch_from_cache(pool_address) do
+    with info when info != :undefined <- :ets.info(@cache_name),
+         [{_, value}] <- :ets.lookup(@cache_name, pool_address) do
+      value
+    else
+      _ -> nil
+    end
+  end
+
+  def put_to_cache(address, value) do
+    :ets.insert(@cache_name, {address, value})
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -355,6 +355,9 @@ config :explorer, :spandex,
 
 config :explorer, :datadog, port: ConfigHelper.parse_integer_env_var("DATADOG_PORT", 8126)
 
+config :explorer, Explorer.Chain.Cache.TransactionActionTokensData,
+  max_cache_size: System.get_env("INDEXER_TX_ACTIONS_MAX_TOKEN_CACHE_SIZE")
+
 ###############
 ### Indexer ###
 ###############

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -356,7 +356,7 @@ config :explorer, :spandex,
 config :explorer, :datadog, port: ConfigHelper.parse_integer_env_var("DATADOG_PORT", 8126)
 
 config :explorer, Explorer.Chain.Cache.TransactionActionTokensData,
-  max_cache_size: System.get_env("INDEXER_TX_ACTIONS_MAX_TOKEN_CACHE_SIZE")
+  max_cache_size: ConfigHelper.parse_integer_env_var("INDEXER_TX_ACTIONS_MAX_TOKEN_CACHE_SIZE", 100_000)
 
 ###############
 ### Indexer ###


### PR DESCRIPTION
## Motivation

This PR does two things:

1. Removes `DELETE FROM` sql requests if tx actions transformer is called by realtime or catchup indexer. In this case already existing actions will be rewritten using primary key conflicting.

2. Moves ETS cache from tx actions module to a separate GenServer module like it's done for other modules. It's needed to prevent losing the cache when the module is restarted (as ETS is destroyed if its parent process dies).

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
