### PR TITLE
Block reorg fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#7055](https://github.com/blockscout/blockscout/pull/7055) - Set updated_at on token update even if there are no changes
 - [#7080](https://github.com/blockscout/blockscout/pull/7080) - Deduplicate second degree relations before insert
 - [#7161](https://github.com/blockscout/blockscout/pull/7161) - Treat "" as empty value while parsing env vars
+- [#7135](https://github.com/blockscout/blockscout/pull/7135) - Block reorg fixes
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2310,6 +2310,18 @@ defmodule Explorer.Chain do
     Repo.get(Block, block_hash)
   end
 
+  def filter_consensus_block_numbers(block_numbers) do
+    query =
+      from(
+        block in Block,
+        where: block.number in ^block_numbers,
+        where: block.consensus,
+        select: block.number
+      )
+
+    Repo.all(query)
+  end
+
   @doc """
   The number of `t:Explorer.Chain.InternalTransaction.t/0`.
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   require Ecto.Query
 
-  import Ecto.Query, only: [from: 2, subquery: 1]
+  import Ecto.Query, only: [from: 2, where: 3, subquery: 1]
 
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.{Address, Block, Import, PendingBlockOperation, Transaction}
@@ -714,23 +714,26 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp where_invalid_neighbor(blocks_changes) when is_list(blocks_changes) do
     initial = from(b in Block, where: false)
 
-    Enum.reduce(blocks_changes, initial, fn %{
-                                              consensus: consensus,
-                                              hash: hash,
-                                              parent_hash: parent_hash,
-                                              number: number
-                                            },
-                                            acc ->
-      if consensus do
-        from(
-          block in acc,
-          or_where: block.number == ^(number - 1) and block.hash != ^parent_hash,
-          or_where: block.number == ^(number + 1) and block.parent_hash != ^hash
-        )
-      else
-        acc
-      end
-    end)
+    invalid_neighbors_query =
+      Enum.reduce(blocks_changes, initial, fn %{
+                                                consensus: consensus,
+                                                hash: hash,
+                                                parent_hash: parent_hash,
+                                                number: number
+                                              },
+                                              acc ->
+        if consensus do
+          from(
+            block in acc,
+            or_where: block.number == ^(number - 1) and block.hash != ^parent_hash,
+            or_where: block.number == ^(number + 1) and block.parent_hash != ^hash
+          )
+        else
+          acc
+        end
+      end)
+
+    where(invalid_neighbors_query, [b], b.consensus)
   end
 
   defp filter_by_min_height(blocks, filter_func) do

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -330,8 +330,16 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
          %{consensus_block: %{number: block_number} = block, options: options} do
       block1 = params_for(:block, consensus: true, miner_hash: insert(:address).hash)
 
-      run_block_consensus_change(block, false, options)
-      run_block_consensus_change(block1, true, options)
+      block2 =
+        params_for(:block,
+          consensus: true,
+          miner_hash: insert(:address).hash,
+          parent_hash: block1.hash,
+          number: block.number + 1
+        )
+
+      insert_block(block, options)
+      insert_block(block2, options)
 
       assert %{from_number: ^block_number, to_number: ^block_number} = Repo.one(MissingBlockRange)
     end
@@ -350,6 +358,26 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
         |> Repo.transaction()
 
       assert %{block_number: ^number, block_hash: ^hash} = Repo.one(PendingBlockOperation)
+    end
+  end
+
+  describe "lose_consensus/5" do
+    test "loses consensus only for consensus=true blocks" do
+      insert(:block, consensus: true, number: 0)
+      insert(:block, consensus: true, number: 1)
+      insert(:block, consensus: false, number: 2)
+
+      new_block0 = params_for(:block, miner_hash: insert(:address).hash, number: 0)
+      new_block1 = params_for(:block, miner_hash: insert(:address).hash, parent_hash: new_block0.hash, number: 1)
+
+      %Ecto.Changeset{valid?: true, changes: new_block1_changes} = Block.changeset(%Block{}, new_block1)
+
+      opts = %{
+        timeout: 60_000,
+        timestamps: %{updated_at: DateTime.utc_now()}
+      }
+
+      assert {:ok, [{0, _}, {1, _}]} = Blocks.lose_consensus(Repo, [], [1], [new_block1_changes], opts)
     end
   end
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -41,8 +41,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
   @minimum_safe_polling_period :timer.seconds(1)
 
-  @blocks_concurrency 100
-
   @shutdown_after :timer.minutes(1)
 
   @enforce_keys ~w(block_fetcher)a
@@ -50,8 +48,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
   defstruct block_fetcher: nil,
             subscription: nil,
             previous_number: nil,
-            timer: nil,
-            blocks_concurrency: @blocks_concurrency
+            timer: nil
 
   @type t :: %__MODULE__{
           block_fetcher: %Block.Fetcher{
@@ -63,8 +60,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
           },
           subscription: Subscription.t(),
           previous_number: pos_integer() | nil,
-          timer: reference(),
-          blocks_concurrency: pos_integer()
+          timer: reference()
         }
 
   def start_link([arguments, gen_server_options]) do
@@ -92,8 +88,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
           block_fetcher: %Block.Fetcher{} = block_fetcher,
           subscription: %Subscription{} = subscription,
           previous_number: previous_number,
-          timer: timer,
-          blocks_concurrency: blocks_concurrency
+          timer: timer
         } = state
       )
       when is_binary(quantity) do
@@ -105,7 +100,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
 
     # Subscriptions don't support getting all the blocks and transactions data,
     # so we need to go back and get the full block
-    start_fetch_and_import(number, block_fetcher, blocks_concurrency, previous_number)
+    start_fetch_and_import(number, block_fetcher, previous_number)
 
     Process.cancel_timer(timer)
     new_timer = schedule_polling()
@@ -123,14 +118,13 @@ defmodule Indexer.Block.Realtime.Fetcher do
         :poll_latest_block_number,
         %__MODULE__{
           block_fetcher: %Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = block_fetcher,
-          previous_number: previous_number,
-          blocks_concurrency: blocks_concurrency
+          previous_number: previous_number
         } = state
       ) do
     new_previous_number =
       case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
         {:ok, number} when is_nil(previous_number) or number != previous_number ->
-          start_fetch_and_import(number, block_fetcher, blocks_concurrency, previous_number)
+          start_fetch_and_import(number, block_fetcher, previous_number)
 
           number
 
@@ -241,19 +235,14 @@ defmodule Indexer.Block.Realtime.Fetcher do
     {:ok, []}
   end
 
-  defp start_fetch_and_import(number, block_fetcher, blocks_concurrency, previous_number) do
+  def start_fetch_and_import(number, block_fetcher, previous_number) do
     start_at = determine_start_at(number, previous_number)
     is_reorg = reorg?(number, previous_number)
 
-    TaskSupervisor
-    |> Task.Supervisor.async_stream(
-      start_at..number,
-      &fetch_and_import_block(&1, block_fetcher, is_reorg),
-      max_concurrency: blocks_concurrency,
-      timeout: :infinity,
-      shutdown: @shutdown_after
-    )
-    |> Stream.run()
+    for block_number_to_fetch <- start_at..number do
+      args = [block_number_to_fetch, block_fetcher, is_reorg]
+      Task.Supervisor.start_child(TaskSupervisor, __MODULE__, :fetch_and_import_block, args, shutdown: @shutdown_after)
+    end
   end
 
   defp determine_start_at(number, nil), do: number

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -90,7 +90,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
               tracer: Tracer
             )
   def run(block_numbers, json_rpc_named_arguments) do
-    unique_numbers = Enum.uniq(block_numbers)
+    unique_numbers =
+      block_numbers
+      |> Enum.uniq()
+      |> Chain.filter_consensus_block_numbers()
 
     filtered_unique_numbers =
       EthereumJSONRPC.block_numbers_in_range(unique_numbers) --

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -91,7 +91,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
             )
   def run(block_numbers, json_rpc_named_arguments) do
     unique_numbers = Enum.uniq(block_numbers)
-    filtered_unique_numbers = EthereumJSONRPC.block_numbers_in_range(unique_numbers)
+
+    filtered_unique_numbers =
+      EthereumJSONRPC.block_numbers_in_range(unique_numbers) --
+        [EthereumJSONRPC.first_block_to_fetch(:trace_first_block)]
 
     filtered_unique_numbers_count = Enum.count(filtered_unique_numbers)
     Logger.metadata(count: filtered_unique_numbers_count)
@@ -124,6 +127,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
           error_count: filtered_unique_numbers_count
         )
 
+        handle_not_found_transaction(reason)
+
         # re-queue the de-duped entries
         {:retry, filtered_unique_numbers}
 
@@ -134,6 +139,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
           end,
           error_count: filtered_unique_numbers_count
         )
+
+        handle_not_found_transaction(reason)
 
         # re-queue the de-duped entries
         {:retry, filtered_unique_numbers}
@@ -298,6 +305,26 @@ defmodule Indexer.Fetcher.InternalTransaction do
       ]
     end)
   end
+
+  defp handle_not_found_transaction(errors) when is_list(errors) do
+    Enum.each(errors, &handle_not_found_transaction/1)
+  end
+
+  defp handle_not_found_transaction(error) do
+    case error do
+      %{data: data, message: "historical backend error" <> _} -> invalidate_block_from_error(data)
+      %{data: data, message: "genesis is not traceable"} -> invalidate_block_from_error(data)
+      _ -> :ok
+    end
+  end
+
+  defp invalidate_block_from_error(%{"blockNumber" => block_number}),
+    do: BlocksRunner.invalidate_consensus_blocks([block_number])
+
+  defp invalidate_block_from_error(%{block_number: block_number}),
+    do: BlocksRunner.invalidate_consensus_blocks([block_number])
+
+  defp invalidate_block_from_error(_error_data), do: :ok
 
   defp defaults do
     [

--- a/apps/indexer/lib/indexer/fetcher/uncle_block.ex
+++ b/apps/indexer/lib/indexer/fetcher/uncle_block.ex
@@ -35,8 +35,12 @@ defmodule Indexer.Fetcher.UncleBlock do
   """
   @spec async_fetch_blocks([%{required(:nephew_hash) => Hash.Full.t(), required(:index) => non_neg_integer()}]) :: :ok
   def async_fetch_blocks(relations) when is_list(relations) do
-    entries = Enum.map(relations, &entry/1)
-    BufferedTask.buffer(__MODULE__, entries)
+    if UncleBlock.Supervisor.disabled?() do
+      :ok
+    else
+      entries = Enum.map(relations, &entry/1)
+      BufferedTask.buffer(__MODULE__, entries)
+    end
   end
 
   @doc false

--- a/apps/indexer/lib/indexer/fetcher/uncle_block.ex
+++ b/apps/indexer/lib/indexer/fetcher/uncle_block.ex
@@ -16,6 +16,7 @@ defmodule Indexer.Fetcher.UncleBlock do
   alias Explorer.Chain.Hash
   alias Indexer.{Block, BufferedTask, Tracer}
   alias Indexer.Fetcher.UncleBlock
+  alias Indexer.Fetcher.UncleBlock.Supervisor, as: UncleBlockSupervisor
   alias Indexer.Transform.Addresses
 
   @behaviour Block.Fetcher
@@ -35,7 +36,7 @@ defmodule Indexer.Fetcher.UncleBlock do
   """
   @spec async_fetch_blocks([%{required(:nephew_hash) => Hash.Full.t(), required(:index) => non_neg_integer()}]) :: :ok
   def async_fetch_blocks(relations) when is_list(relations) do
-    if UncleBlock.Supervisor.disabled?() do
+    if UncleBlockSupervisor.disabled?() do
       :ok
     else
       entries = Enum.map(relations, &entry/1)

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -35,9 +35,6 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       json_rpc_named_arguments: core_json_rpc_named_arguments
     }
 
-    initial_env = Application.get_all_env(:indexer)
-    on_exit(fn -> Application.put_all_env([{:indexer, initial_env}]) end)
-
     TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
     %{block_fetcher: block_fetcher, json_rpc_named_arguments: core_json_rpc_named_arguments}
@@ -1061,6 +1058,13 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       block_fetcher: block_fetcher,
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
+      initial_env = Application.get_all_env(:indexer)
+
+      on_exit(fn ->
+        Application.delete_env(:indexer, UncleBlock.Supervisor)
+        Application.put_all_env([{:indexer, initial_env}])
+      end)
+
       Application.put_env(:indexer, :fetch_rewards_way, "manual")
       Application.put_env(:indexer, InternalTransaction.Supervisor, disabled?: true)
       Application.put_env(:indexer, UncleBlock.Supervisor, disabled?: true)

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -35,6 +35,9 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       json_rpc_named_arguments: core_json_rpc_named_arguments
     }
 
+    initial_env = Application.get_all_env(:indexer)
+    on_exit(fn -> Application.put_all_env([{:indexer, initial_env}]) end)
+
     TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
     %{block_fetcher: block_fetcher, json_rpc_named_arguments: core_json_rpc_named_arguments}
@@ -1059,6 +1062,8 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
       Application.put_env(:indexer, :fetch_rewards_way, "manual")
+      Application.put_env(:indexer, InternalTransaction.Supervisor, disabled?: true)
+      Application.put_env(:indexer, UncleBlock.Supervisor, disabled?: true)
 
       {:ok, sequence} = Sequence.start_link(ranges: [], step: 2)
       Sequence.cap(sequence)
@@ -1068,12 +1073,6 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 
       ContractCode.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
-
-      InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
-
-      UncleBlock.Supervisor.Case.start_supervised!(
-        block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
-      )
 
       ReplacedTransaction.Supervisor.Case.start_supervised!()
 

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -1051,4 +1051,211 @@ defmodule Indexer.Block.Realtime.FetcherTest do
       Application.put_env(:indexer, :fetch_rewards_way, nil)
     end
   end
+
+  describe "start_fetch_and_import" do
+    @tag :no_geth
+    test "reorg", %{
+      block_fetcher: block_fetcher,
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      Application.put_env(:indexer, :fetch_rewards_way, "manual")
+
+      {:ok, sequence} = Sequence.start_link(ranges: [], step: 2)
+      Sequence.cap(sequence)
+
+      start_supervised!({Task.Supervisor, name: Realtime.TaskSupervisor})
+
+      Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      ContractCode.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      UncleBlock.Supervisor.Case.start_supervised!(
+        block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+      )
+
+      ReplacedTransaction.Supervisor.Case.start_supervised!()
+
+      block_1_data = %{
+        "author" => "0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2",
+        "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+        "extraData" => "0xd583010b088650617269747986312e32372e32826c69",
+        "gasLimit" => "0x7a1200",
+        "gasUsed" => "0x2886e",
+        "hash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+        "logsBloom" =>
+          "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "miner" => "0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2",
+        "number" => "0x3c365f",
+        "parentHash" => "0x57f6d66e07488defccd5216c4d2968dd6afd3bd32415e284de3b02af6535e8dc",
+        "receiptsRoot" => "0x111be72e682cea9c93e02f1ef503fb64aa821b2ef510fd9177c49b37d0af98b5",
+        "sealFields" => [
+          "0x841246c63f",
+          "0xb841ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700"
+        ],
+        "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "signature" =>
+          "ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700",
+        "size" => "0x33e",
+        "stateRoot" => "0x7f73f5fb9f891213b671356126c31e9795d038844392c7aa8800ed4f52307209",
+        "step" => "306628159",
+        "timestamp" => "0x5b61df3b",
+        "totalDifficulty" => "0x3c365effffffffffffffffffffffffed7f0362",
+        "transactions" => [],
+        "transactionsRoot" => "0xd7c39a93eafe0bdcbd1324c13dcd674bed8c9fa8adbf8f95bf6a59788985da6f",
+        "uncles" => ["0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cd"]
+      }
+
+      block_2_data = %{
+        "author" => "0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3",
+        "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+        "extraData" => "0xd583010a068650617269747986312e32362e32826c69",
+        "gasLimit" => "0x7a1200",
+        "gasUsed" => "0x0",
+        "hash" => "0xfb483e511d316fa4072694da3f7abc94b06286406af45061e5e681395bdc6815",
+        "logsBloom" =>
+          "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "miner" => "0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3",
+        "number" => "0x3c3660",
+        "parentHash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+        "receiptsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        "sealFields" => [
+          "0x841246c640",
+          "0xb84114db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800"
+        ],
+        "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "signature" =>
+          "14db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800",
+        "size" => "0x243",
+        "stateRoot" => "0x3174c461989e9f99e08fa9b4ffb8bce8d9a281c8fc9f80694bb9d3acd4f15559",
+        "step" => "306628160",
+        "timestamp" => "0x5b61df40",
+        "totalDifficulty" => "0x3c365fffffffffffffffffffffffffed7f0360",
+        "transactions" => [],
+        "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+        "uncles" => []
+      }
+
+      reorg_block_1_data =
+        Map.put(block_1_data, "hash", "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cd")
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, 6, fn
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBlockByNumber",
+              params: ["0x3C365F", true]
+            }
+          ],
+          _ ->
+            {:ok,
+             [
+               %{
+                 id: 0,
+                 jsonrpc: "2.0",
+                 result: block_1_data
+               }
+             ]}
+
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBlockByNumber",
+              params: ["0x3C3660", true]
+            }
+          ],
+          _ ->
+            {:ok,
+             [
+               %{
+                 id: 0,
+                 jsonrpc: "2.0",
+                 result: block_2_data
+               }
+             ]}
+
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBalance",
+              params: ["0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2", "0x3C365F"]
+            }
+          ],
+          _ ->
+            {:ok, [%{id: 0, jsonrpc: "2.0", result: "0x53474fa377a46000"}]}
+
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBalance",
+              params: ["0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3", "0x3C3660"]
+            }
+          ],
+          _ ->
+            {:ok, [%{id: 0, jsonrpc: "2.0", result: "0x53507afe51f28000"}]}
+        end)
+        |> expect(:json_rpc, 3, fn
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBlockByNumber",
+              params: ["0x3C365F", true]
+            }
+          ],
+          _ ->
+            {:ok,
+             [
+               %{
+                 id: 0,
+                 jsonrpc: "2.0",
+                 result: reorg_block_1_data
+               }
+             ]}
+
+          [
+            %{
+              id: 0,
+              jsonrpc: "2.0",
+              method: "eth_getBalance",
+              params: ["0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2", "0x3C365F"]
+            }
+          ],
+          _ ->
+            {:ok, [%{id: 0, jsonrpc: "2.0", result: "0x53474fa377a46000"}]}
+        end)
+      end
+
+      Realtime.Fetcher.start_fetch_and_import(3_946_080, block_fetcher, 3_946_078)
+      Process.sleep(1000)
+
+      result_blocks = Explorer.Repo.all(Chain.Block)
+      assert [%{consensus: true}, %{consensus: true}] = result_blocks
+
+      block_1 = Enum.find(result_blocks, fn block -> block.number == 3_946_079 end)
+      block_2 = Enum.find(result_blocks, fn block -> block.number == 3_946_080 end)
+      assert to_string(block_1.hash) == block_1_data["hash"]
+      assert to_string(block_2.hash) == block_2_data["hash"]
+
+      Realtime.Fetcher.start_fetch_and_import(3_946_079, block_fetcher, 3_946_080)
+      Process.sleep(6000)
+
+      result_blocks = Explorer.Repo.all(Chain.Block)
+      assert Enum.count(result_blocks) == 3
+
+      block_1_old = Enum.find(result_blocks, fn block -> to_string(block.hash) == block_1_data["hash"] end)
+      block_2_old = Enum.find(result_blocks, fn block -> to_string(block.hash) == block_2_data["hash"] end)
+      block_1_new = Enum.find(result_blocks, fn block -> to_string(block.hash) == reorg_block_1_data["hash"] end)
+      assert %{consensus: false} = block_1_old
+      assert %{consensus: false} = block_2_old
+      assert %{consensus: true} = block_1_new
+    end
+  end
 end


### PR DESCRIPTION
Resolves #7125 

## Motivation

Currently realtime fetcher schedules next poll only after the current one is done, which may cause delays on new blocks detecting and reorgs missing.

## Changelog

- Changed realtime fetcher logic to schedule next run immediately
- Added a test to check if realtime fetcher handles reorg correctly
- Invalidate block consensus if internal transactions fetcher encounters the associated error