### PR TITLE
Add release link or commit hash to docker images

### DIFF
--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -7,7 +7,7 @@ on:
 env:
   OTP_VERSION: '25.2.1'
   ELIXIR_VERSION: '1.14.3'
-  NEXT_RELEASE_VERSION: 5.1.1
+  RELEASE_VERSION: 5.1.1
 
 jobs:
   push_to_registry:
@@ -55,7 +55,7 @@ jobs:
           push: true
           cache-from: type=registry,ref=blockscout/blockscout:buildcache
           cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
-          tags: blockscout/blockscout:latest, blockscout/blockscout:${{ env.NEXT_RELEASE_VERSION }}-prerelease-${{ env.SHORT_SHA }}
+          tags: blockscout/blockscout:latest, blockscout/blockscout:${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             DISABLE_READ_API=false
@@ -65,6 +65,7 @@ jobs:
             WOBSERVER_ENABLED=false
             ADMIN_PANEL_ENABLED=false
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            BLOCKSCOUT_VERSION=v{{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
 
       - name: Build and push Docker image for frontend
         uses: docker/build-push-action@v3

--- a/.github/workflows/publish-docker-image-release.yml
+++ b/.github/workflows/publish-docker-image-release.yml
@@ -62,6 +62,7 @@ jobs:
             WOBSERVER_ENABLED=false
             ADMIN_PANEL_ENABLED=
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            BLOCKSCOUT_VERSION=v{{ env.RELEASE_VERSION }}-beta
 
   merge-master-after-release:
     name: Merge 'master' to specific branch after release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Chore
 
+- [#7136](https://github.com/blockscout/blockscout/pull/7136) - Add release link or commit hash to docker images
 - [#7072](https://github.com/blockscout/blockscout/pull/7072) - Add a separate docker compose for geth with clique consensus
 - [#7056](https://github.com/blockscout/blockscout/pull/7056) - Add path_helper in interact.js
 - [#7040](https://github.com/blockscout/blockscout/pull/7040) - Use alias BlockScoutWeb.Cldr.Number

--- a/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/layout_view.ex
@@ -109,25 +109,34 @@ defmodule BlockScoutWeb.LayoutView do
     BlockScoutWeb.version()
   end
 
+  def release_link(""), do: ""
+  def release_link(nil), do: ""
+
   def release_link(version) do
     release_link_env_var = Application.get_env(:block_scout_web, :release_link)
 
     release_link =
-      cond do
-        version == "" || version == nil ->
-          nil
-
-        release_link_env_var == "" || release_link_env_var == nil ->
-          "https://github.com/blockscout/blockscout/releases/tag/" <> version
-
-        true ->
-          release_link_env_var
+      if release_link_env_var == "" || release_link_env_var == nil do
+        release_link_from_version(version)
+      else
+        release_link_env_var
       end
 
-    if release_link == nil do
-      ""
+    html_escape({:safe, "<a href=\"#{release_link}\" class=\"footer-link\" target=\"_blank\">#{version}</a>"})
+  end
+
+  def release_link_from_version(version) do
+    repo = "https://github.com/blockscout/blockscout"
+
+    if String.contains?(version, "+commit.") do
+      commit_hash =
+        version
+        |> String.split("+commit.")
+        |> List.last()
+
+      repo <> "/commit/" <> commit_hash
     else
-      html_escape({:safe, "<a href=\"#{release_link}\" class=\"footer-link\" target=\"_blank\">#{version}</a>"})
+      repo <> "/releases/tag/" <> version
     end
   end
 


### PR DESCRIPTION
## Motivation

Add release link or commit hash to generated by CI docker images

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
