### PR TITLE
Treat "" as empty value while parsing env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#7009](https://github.com/blockscout/blockscout/pull/7009) - Fix updating coin balances with empty value
 - [#7055](https://github.com/blockscout/blockscout/pull/7055) - Set updated_at on token update even if there are no changes
 - [#7080](https://github.com/blockscout/blockscout/pull/7080) - Deduplicate second degree relations before insert
+- [#7161](https://github.com/blockscout/blockscout/pull/7161) - Treat "" as empty value while parsing env vars
 
 ### Chore
 


### PR DESCRIPTION
## Motivation

If env variable is set to an empty string, it doesn't use the default value which may cause unpredictable behaviour.

## Changelog

Use default value if env variable is set to an empty string.