### PR TITLE
Add Optimism BedRock Deposits to the main page in API

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -157,6 +157,7 @@ defmodule BlockScoutWeb.ApiRouter do
 
     scope "/main-page" do
       get("/blocks", V2.MainPageController, :blocks)
+      get("/optimism-deposits", V2.MainPageController, :optimism_deposits)
       get("/transactions", V2.MainPageController, :transactions)
       get("/indexing-status", V2.MainPageController, :indexing_status)
     end

--- a/apps/block_scout_web/lib/block_scout_web/channels/optimism_deposit_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/optimism_deposit_channel.ex
@@ -1,0 +1,22 @@
+defmodule BlockScoutWeb.OptimismDepositChannel do
+  @moduledoc """
+  Establishes pub/sub channel for live updates of Optimism deposit events.
+  """
+  use BlockScoutWeb, :channel
+
+  intercept(["deposit"])
+
+  def join("optimism_deposits:new_deposit", _params, socket) do
+    {:ok, %{}, socket}
+  end
+
+  def handle_out(
+        "deposit",
+        %{deposit: _deposit},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
+      ) do
+    push(socket, "deposit", %{deposit: 1})
+
+    {:noreply, socket}
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/channels/user_socket.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/user_socket.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.UserSocket do
   channel("addresses:*", BlockScoutWeb.AddressChannel)
   channel("blocks:*", BlockScoutWeb.BlockChannel)
   channel("exchange_rate:*", BlockScoutWeb.ExchangeRateChannel)
+  channel("optimism_deposits:*", BlockScoutWeb.OptimismDepositChannel)
   channel("rewards:*", BlockScoutWeb.RewardChannel)
   channel("transactions:*", BlockScoutWeb.TransactionChannel)
   channel("tokens:*", BlockScoutWeb.TokenChannel)

--- a/apps/block_scout_web/lib/block_scout_web/channels/user_socket_v2.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/user_socket_v2.ex
@@ -7,6 +7,7 @@ defmodule BlockScoutWeb.UserSocketV2 do
   channel("addresses:*", BlockScoutWeb.AddressChannel)
   channel("blocks:*", BlockScoutWeb.BlockChannel)
   channel("exchange_rate:*", BlockScoutWeb.ExchangeRateChannel)
+  channel("optimism_deposits:*", BlockScoutWeb.OptimismDepositChannel)
   channel("rewards:*", BlockScoutWeb.RewardChannel)
   channel("transactions:*", BlockScoutWeb.TransactionChannel)
   channel("tokens:*", BlockScoutWeb.TokenChannel)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -2,7 +2,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
   use Phoenix.Controller
 
   alias Explorer.{Chain, PagingOptions}
-  alias BlockScoutWeb.API.V2.{BlockView, TransactionView}
+  alias BlockScoutWeb.API.V2.{BlockView, OptimismView, TransactionView}
   alias Explorer.{Chain, Repo}
 
   def blocks(conn, _params) do
@@ -15,6 +15,19 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     |> put_status(200)
     |> put_view(BlockView)
     |> render(:blocks, %{blocks: blocks})
+  end
+
+  def optimism_deposits(conn, _params) do
+    recent_deposits =
+      Chain.list_optimism_deposits(
+        paging_options: %PagingOptions{page_size: 6},
+        api?: true
+      )
+
+    conn
+    |> put_status(200)
+    |> put_view(OptimismView)
+    |> render(:optimism_deposits, %{deposits: recent_deposits})
   end
 
   def transactions(conn, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -225,6 +225,12 @@ defmodule BlockScoutWeb.Notifier do
     Endpoint.broadcast("addresses:#{to_string(address_hash)}", "changed_bytecode", %{})
   end
 
+  def handle_event({:chain_event, :optimism_deposits, :realtime, deposits}) do
+    Enum.each(deposits, fn deposit ->
+      broadcast_optimism_deposit(deposit, "optimism_deposits:new_deposit", "deposit")
+    end)
+  end
+
   def handle_event(_), do: nil
 
   def fetch_compiler_version(compiler) do
@@ -397,6 +403,10 @@ defmodule BlockScoutWeb.Notifier do
         transaction: transaction
       })
     end
+  end
+
+  defp broadcast_optimism_deposit(deposit, deposit_channel, event) do
+    Endpoint.broadcast(deposit_channel, event, %{deposit: deposit})
   end
 
   defp broadcast_token_transfer(token_transfer) do

--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -22,6 +22,7 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
     Subscriber.to(:blocks, :realtime)
     Subscriber.to(:internal_transactions, :realtime)
     Subscriber.to(:internal_transactions, :on_demand)
+    Subscriber.to(:optimism_deposits, :realtime)
     Subscriber.to(:token_transfers, :realtime)
     Subscriber.to(:transactions, :realtime)
     Subscriber.to(:addresses, :on_demand)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -87,6 +87,17 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  def render("optimism_deposits.json", %{deposits: deposits}) do
+    Enum.map(deposits, fn deposit ->
+      %{
+        "l1_block_number" => deposit.l1_block_number,
+        "l1_block_timestamp" => deposit.l1_block_timestamp,
+        "l1_tx_hash" => deposit.l1_transaction_hash,
+        "l2_tx_hash" => deposit.l2_transaction_hash
+      }
+    end)
+  end
+
   def render("optimism_withdrawals.json", %{
         withdrawals: withdrawals,
         next_page_params: next_page_params,

--- a/apps/explorer/lib/explorer/chain/events/publisher.ex
+++ b/apps/explorer/lib/explorer/chain/events/publisher.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Publisher do
   Publishes events related to the Chain context.
   """
 
-  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number optimism_reorg_block token_transfers transactions contract_verification_result token_total_supply changed_bytecode)a
+  @allowed_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number optimism_deposits optimism_reorg_block token_transfers transactions contract_verification_result token_total_supply changed_bytecode)a
 
   def broadcast(_data, false), do: :ok
 

--- a/apps/explorer/lib/explorer/chain/events/subscriber.ex
+++ b/apps/explorer/lib/explorer/chain/events/subscriber.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Events.Subscriber do
   Subscribes to events related to the Chain context.
   """
 
-  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number optimism_reorg_block token_transfers transactions contract_verification_result token_total_supply changed_bytecode)a
+  @allowed_broadcast_events ~w(addresses address_coin_balances address_token_balances blocks block_rewards internal_transactions last_block_number optimism_deposits optimism_reorg_block token_transfers transactions contract_verification_result token_total_supply changed_bytecode)a
 
   @allowed_broadcast_types ~w(catchup realtime on_demand contract_verification_result)a
 

--- a/apps/indexer/lib/indexer/fetcher/optimism_deposit.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_deposit.ex
@@ -16,6 +16,7 @@ defmodule Indexer.Fetcher.OptimismDeposit do
   alias EthereumJSONRPC.Block.ByNumber
   alias EthereumJSONRPC.Blocks
   alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.Events.Publisher
   alias Explorer.Chain.OptimismDeposit
   alias Indexer.Fetcher.Optimism
   alias Indexer.Helper
@@ -161,6 +162,8 @@ defmodule Indexer.Fetcher.OptimismDeposit do
          deposits = events_to_deposits(logs, json_rpc_named_arguments),
          {:import, {:ok, _imported}} <-
            {:import, Chain.import(%{optimism_deposits: %{params: deposits}, timeout: :infinity})} do
+      Publisher.broadcast(%{optimism_deposits: deposits}, :realtime)
+
       Optimism.log_blocks_chunk_handling(
         from_block,
         to_block,
@@ -355,6 +358,8 @@ defmodule Indexer.Fetcher.OptimismDeposit do
     unless Enum.empty?(logs_to_parse) do
       deposits = events_to_deposits(logs_to_parse, json_rpc_named_arguments)
       {:ok, _imported} = Chain.import(%{optimism_deposits: %{params: deposits}, timeout: :infinity})
+
+      Publisher.broadcast(%{optimism_deposits: deposits}, :realtime)
 
       Optimism.log_blocks_chunk_handling(
         min_block,


### PR DESCRIPTION
## Motivation

We need to display latest deposits on the main page and display `N more transactions have come in` string above the latest items. Created instead of https://github.com/blockscout/blockscout/pull/7146.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
