### PR TITLE
Output L1 fields in API v2 for transaction and fix transaction fee calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#7219](https://github.com/blockscout/blockscout/pull/7219) - Output L1 fields in API v2 for transaction page and fix transaction fee calculation
+
 ### Chore
 
 ## 5.1.2-beta

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -233,7 +233,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     decoded_input = transaction |> Transaction.decoded_input_data(@api_true) |> format_decoded_input()
     decoded_input_data = decoded_input(decoded_input)
 
-    %{
+    result = %{
       "hash" => transaction.hash,
       "result" => status,
       "status" => transaction.status,
@@ -270,6 +270,19 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "tx_types" => tx_types(transaction),
       "tx_tag" => GetTransactionTags.get_transaction_tags(transaction.hash, current_user(conn))
     }
+
+    result
+    |> add_optional_transaction_field(transaction, :l1_fee)
+    |> add_optional_transaction_field(transaction, :l1_fee_scalar)
+    |> add_optional_transaction_field(transaction, :l1_gas_price)
+    |> add_optional_transaction_field(transaction, :l1_gas_used)
+  end
+
+  defp add_optional_transaction_field(result, transaction, field) do
+    case Map.get(transaction, field) do
+      nil -> result
+      value -> Map.put(result, Atom.to_string(field), value)
+    end
   end
 
   def token_transfers(_, _conn, false), do: nil


### PR DESCRIPTION
This PR adds the following fields to transaction in API v2:
- L1 fee
- L1 fee scalar
- L1 gas price
- L1 gas used by Txn

These fields are contained in `eth_getTransactionReceipt` response. If some field doesn't exist, it won't be included into API v2 response.

Also, this PR adds `L1 fee` to the `fee` so that `fee` equals to `l2_execution_fee + l1_data_fee` as described in https://community.optimism.io/docs/developers/build/transaction-fees/. For L1 chains `L1 fee` will be zero and the fee will be calculated as usual, so this change is backward compatible.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
