### PR TITLE
Set 404 on blocks which lose consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - [#7185](https://github.com/blockscout/blockscout/pull/7185) - Aave v3 transaction actions indexer
-- [#7148](https://github.com/blockscout/blockscout/pull/7148) - API v2 improvements: API rate limiting, `/tokens/{address_hash}/instances/{token_id}/holders` and other changes
+- [#7148](https://github.com/blockscout/blockscout/pull/7148), [#7244](https://github.com/blockscout/blockscout/pull/7244) - API v2 improvements: API rate limiting, `/tokens/{address_hash}/instances/{token_id}/holders` and other changes
 
 ### Fixes
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -81,6 +81,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
 
   def call(conn, {:lost_consensus, {:ok, block}}) do
     conn
+    |> put_status(:not_found)
     |> json(%{message: "Block lost consensus", hash: to_string(block.hash)})
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -206,7 +206,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       hash = to_string(block.hash)
 
       request_1 = get(conn, "/api/v2/blocks/#{block.number}")
-      assert %{"message" => "Block lost consensus", "hash" => ^hash} = json_response(request_1, 200)
+      assert %{"message" => "Block lost consensus", "hash" => ^hash} = json_response(request_1, 404)
     end
 
     test "get the same blocks by hash and number", %{conn: conn} do


### PR DESCRIPTION
## Motivation

## Changelog
- set 404 on reorg response added in https://github.com/blockscout/blockscout/pull/7148

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
