### PR TITLE
Fix MissingRangesCollector max block number fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#7210](https://github.com/blockscout/blockscout/pull/7210) - Fix Makefile docker image build
 - [#7203](https://github.com/blockscout/blockscout/pull/7203) - Fix write contract functionality for multidimensional arrays case
 - [#7186](https://github.com/blockscout/blockscout/pull/7186) - Fix build from Dockerfile
+- [#7255](https://github.com/blockscout/blockscout/pull/7255) - Fix MissingRangesCollector max block number fetching
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -194,8 +194,11 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
     case BlockNumber.get_max() do
       0 ->
         json_rpc_named_arguments = Application.get_env(:indexer, :json_rpc_named_arguments)
-        {:ok, number} = EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments)
-        number
+
+        case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
+          {:ok, number} -> number
+          _ -> 0
+        end
 
       number ->
         number


### PR DESCRIPTION
Resolves #6975 #7217 

## Changelog

Set `MissingRangesCollector` max block number to 0 if node is not responding.