### PR TITLE
Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
+
 ### Chore
 
 <details>
@@ -24,7 +26,6 @@
 
 ### Fixes
 
-- [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
 - [#7242](https://github.com/blockscout/blockscout/pull/7242) - Fix daily txs chart
 - [#7210](https://github.com/blockscout/blockscout/pull/7210) - Fix Makefile docker image build
 - [#7203](https://github.com/blockscout/blockscout/pull/7203) - Fix write contract functionality for multidimensional arrays case

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixes
 
+- [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
 - [#7242](https://github.com/blockscout/blockscout/pull/7242) - Fix daily txs chart
 - [#7210](https://github.com/blockscout/blockscout/pull/7210) - Fix Makefile docker image build
 - [#7203](https://github.com/blockscout/blockscout/pull/7203) - Fix write contract functionality for multidimensional arrays case

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -260,7 +260,7 @@ config :explorer, Explorer.ExchangeRates.Source.CoinGecko,
 config :explorer, Explorer.ExchangeRates.TokenExchangeRates,
   enabled: !ConfigHelper.parse_bool_env_var("DISABLE_TOKEN_EXCHANGE_RATE", "true"),
   interval: ConfigHelper.parse_time_env_var("TOKEN_EXCHANGE_RATE_INTERVAL", "5s"),
-  refetch_interval: ConfigHelper.parse_time_env_var("TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL", nil),
+  refetch_interval: ConfigHelper.parse_time_env_var("TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL", "1h"),
   max_batch_size: ConfigHelper.parse_integer_env_var("TOKEN_EXCHANGE_RATE_MAX_BATCH_SIZE", 150)
 
 config :explorer, Explorer.Market.History.Cataloger, enabled: !disable_indexer?


### PR DESCRIPTION
## Motivation

At the moment we have 0 default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL` value that can cause exhausting coin gecko api use

## Changelog

Set default `1h` for `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
