### PR TITLE
Convert 99+% of int txs indexing into 100% in order to hide top indexing banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
+- [#7276](https://github.com/blockscout/blockscout/pull/7276) - Convert 99+% of int txs indexing into 100% in order to hide top indexing banner
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2229,33 +2229,24 @@ defmodule Explorer.Chain do
   @spec indexed_ratio_blocks() :: Decimal.t()
   def indexed_ratio_blocks do
     if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] do
-      %{min: min, max: max} = BlockNumber.get_all()
+      %{min: min_saved_block_number, max: max_saved_block_number} = BlockNumber.get_all()
 
-      min_blockchain_block_number =
-        case Integer.parse(Application.get_env(:indexer, :first_block)) do
-          {block_number, _} -> block_number
-          _ -> 0
-        end
+      min_blockchain_block_number = min_block_number_from_config(:first_block)
 
-      case {min, max} do
+      case {min_saved_block_number, max_saved_block_number} do
         {0, 0} ->
           Decimal.new(0)
 
         _ ->
-          result =
-            BlockCache.estimated_count()
-            |> Decimal.div(max - min_blockchain_block_number + 1)
-            |> (&if(
-                  (Decimal.compare(&1, Decimal.from_float(0.99)) == :gt ||
-                     Decimal.compare(&1, Decimal.from_float(0.99)) == :eq) &&
-                    min <= min_blockchain_block_number,
-                  do: Decimal.new(1),
-                  else: &1
-                )).()
-
-          result
-          |> Decimal.round(2, :down)
-          |> Decimal.min(Decimal.new(1))
+          BlockCache.estimated_count()
+          |> Decimal.div(max_saved_block_number - min_blockchain_block_number + 1)
+          |> (&if(
+                greater_or_equal_0_99(&1) &&
+                  min_saved_block_number <= min_blockchain_block_number,
+                do: Decimal.new(1),
+                else: &1
+              )).()
+          |> format_indexed_ratio()
       end
     else
       Decimal.new(1)
@@ -2266,30 +2257,52 @@ defmodule Explorer.Chain do
   def indexed_ratio_internal_transactions do
     if Application.get_env(:indexer, Indexer.Supervisor)[:enabled] &&
          not Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)[:disabled?] do
-      %{max: max} = BlockNumber.get_all()
-      count = Repo.aggregate(PendingBlockOperation, :count, timeout: :infinity)
+      %{max: max_saved_block_number} = BlockNumber.get_all()
+      pbo_count = Repo.aggregate(PendingBlockOperation, :count, timeout: :infinity)
 
-      min_blockchain_trace_block_number =
-        case Integer.parse(Application.get_env(:indexer, :trace_first_block)) do
-          {block_number, _} -> block_number
-          _ -> 0
-        end
+      min_blockchain_trace_block_number = min_block_number_from_config(:trace_first_block)
 
-      case max do
+      case max_saved_block_number do
         0 ->
           Decimal.new(0)
 
         _ ->
-          full_blocks_range = max - min_blockchain_trace_block_number + 1
-          result = Decimal.div(full_blocks_range - count, full_blocks_range)
+          full_blocks_range = max_saved_block_number - min_blockchain_trace_block_number + 1
+          processed_int_txs_for_blocks_count = full_blocks_range - pbo_count
 
-          result
-          |> Decimal.round(2, :down)
-          |> Decimal.min(Decimal.new(1))
+          processed_int_txs_for_blocks_count
+          |> Decimal.div(full_blocks_range)
+          |> (&if(
+                greater_or_equal_0_99(&1),
+                do: Decimal.new(1),
+                else: &1
+              )).()
+          |> format_indexed_ratio()
       end
     else
       Decimal.new(1)
     end
+  end
+
+  @spec greater_or_equal_0_99(Decimal.t()) :: boolean()
+  defp greater_or_equal_0_99(value) do
+    Decimal.compare(value, Decimal.from_float(0.99)) == :gt ||
+      Decimal.compare(value, Decimal.from_float(0.99)) == :eq
+  end
+
+  @spec min_block_number_from_config(atom()) :: integer()
+  defp min_block_number_from_config(block_type) do
+    case Integer.parse(Application.get_env(:indexer, block_type)) do
+      {block_number, _} -> block_number
+      _ -> 0
+    end
+  end
+
+  @spec format_indexed_ratio(Decimal.t()) :: Decimal.t()
+  defp format_indexed_ratio(raw_ratio) do
+    raw_ratio
+    |> Decimal.round(2, :down)
+    |> Decimal.min(Decimal.new(1))
   end
 
   @spec fetch_min_block_number() :: non_neg_integer


### PR DESCRIPTION
## Motivation

99% of indexed internal transactions top banner may never disappear.

## Changelog

Convert 99+% into 100% in order to disable top indexin banner.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
