### PR TITLE
Allow nil gas price for pending tx (Erigon node case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#7290](https://github.com/blockscout/blockscout/pull/7290) - Allow nil gas price for pending tx (Erigon node case)
 - [#7283](https://github.com/blockscout/blockscout/pull/7283) - Fix status for dropped/replaced tx
 - [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
 - [#7276](https://github.com/blockscout/blockscout/pull/7276) - Convert 99+% of int txs indexing into 100% in order to hide top indexing banner

--- a/apps/explorer/priv/repo/migrations/20230417093914_allow_nil_tx_gas_price.exs
+++ b/apps/explorer/priv/repo/migrations/20230417093914_allow_nil_tx_gas_price.exs
@@ -1,0 +1,17 @@
+defmodule Explorer.Repo.Migrations.AllowNilTxGasPrice do
+  use Ecto.Migration
+
+  def change do
+    alter table(:transactions) do
+      modify(:gas_price, :numeric, precision: 100, null: true)
+    end
+
+    create(
+      constraint(
+        :transactions,
+        :collated_gas_price,
+        check: "block_hash IS NULL OR gas_price IS NOT NULL"
+      )
+    )
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6672
Resolves https://github.com/blockscout/blockscout/issues/6644

## Motivation

Erigon node returns empty gas price for pending txs in the request of `txpool_content` method.

## Changelog

Add new DB migration, which:
- allows null values for `gas_price` column in the `transactions` table
- adds `collated_gas_price` constraint, which claims, that gas_price shouldn't be null for transactions included into the block.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
