### PR TITLE
Allow Node 16+ version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Chore
 
+- [#7292](https://github.com/blockscout/blockscout/pull/7292) - Allow Node 16+ version
+
 <details>
   <summary>Dependencies version bumps</summary>
 

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -96,8 +96,8 @@
         "webpack-cli": "^5.0.1"
       },
       "engines": {
-        "node": "18.x",
-        "npm": "8.x"
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       }
     },
     "../../../deps/phoenix": {

--- a/apps/block_scout_web/assets/package.json
+++ b/apps/block_scout_web/assets/package.json
@@ -8,8 +8,8 @@
   "author": "Blockscout",
   "license": "GPL-3.0",
   "engines": {
-    "node": "18.x",
-    "npm": "8.x"
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
   },
   "scripts": {
     "deploy": "webpack --mode production",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6924

## Motivation

Warning in docker container:
> npm WARN EBADENGINE required: { node: '18.x', npm: '8.x' },
=> => # npm WARN EBADENGINE current: { node: 'v16.13.1', npm: '8.3.0' }


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
