### PR TITLE
Use tracing JSONRPC URL in case of debug_traceTransaction method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Chore
 
+- [#7297](https://github.com/blockscout/blockscout/pull/7297) - Use tracing JSONRPC URL in case of debug_traceTransaction method
 - [#7254](https://github.com/blockscout/blockscout/pull/7254) - Rename env vars related for the integration with microservices
 - [#7107](https://github.com/blockscout/blockscout/pull/7107) - Tx actions: remove excess delete_all calls and remake a cache
 - [#7201](https://github.com/blockscout/blockscout/pull/7201) - Remove rust, cargo from dependencies since the latest version of ex_keccak is using precompiled rust

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -14,6 +14,10 @@ config :explorer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      method_to_url: [
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+      ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -14,6 +14,10 @@ config :explorer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      method_to_url: [
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+      ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -19,6 +19,10 @@ config :indexer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      method_to_url: [
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+      ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -19,6 +19,10 @@ config :indexer,
       http: EthereumJSONRPC.HTTP.HTTPoison,
       url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      method_to_url: [
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+      ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
     variant: EthereumJSONRPC.Geth


### PR DESCRIPTION
## Motivation

Currently we use `ETHEREUM_JSONRPC_TRACE_URL` for tracing methods in case of `nethermind`/`erigon` json rpc variants, but not in case of `geth`.

## Changelog

Use `ETHEREUM_JSONRPC_TRACE_URL` in case of `debug_traceTransaction` method. 

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
