### PR TITLE
Reset MissingRangesCollector min_fetched_block_number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#7270](https://github.com/blockscout/blockscout/pull/7270) - Fix default `TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL`
 - [#7276](https://github.com/blockscout/blockscout/pull/7276) - Convert 99+% of int txs indexing into 100% in order to hide top indexing banner
 - [#7282](https://github.com/blockscout/blockscout/pull/7282) - Add not found transaction error case
+- [#7305](https://github.com/blockscout/blockscout/pull/7305) - Reset MissingRangesCollector min_fetched_block_number
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -140,7 +140,15 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
       MissingBlockRange.save_batch(batch)
       {:noreply, %{state | min_fetched_block_number: new_min_number}}
     else
-      {:noreply, state}
+      Process.send_after(self(), :update_past, @past_check_interval * 100)
+      {:noreply, %{state | min_fetched_block_number: reset_min_fetched_block_number(state.max_fetched_block_number)}}
+    end
+  end
+
+  defp reset_min_fetched_block_number(max_fetched_block_number) do
+    case MissingBlockRange.fetch_min_max() do
+      %{min: nil} -> max_fetched_block_number
+      %{min: min} -> min
     end
   end
 


### PR DESCRIPTION
## Changelog

Reset `MissingRangesCollector` `min_fetched_block_number` in order to re-search missing blocks after bottom is reached.