### PR TITLE
Optimizing bs-indexer-eth-goerli resource consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Chore
 
+- [#7310](https://github.com/blockscout/blockscout/pull/7310) - Reducing resource consumption on bs-indexer-eth-goerli environment
 - [#7297](https://github.com/blockscout/blockscout/pull/7297) - Use tracing JSONRPC URL in case of debug_traceTransaction method
 - [#7292](https://github.com/blockscout/blockscout/pull/7292) - Allow Node 16+ version
 

--- a/deploy/testing/eth-goerli/values.yaml
+++ b/deploy/testing/eth-goerli/values.yaml
@@ -25,9 +25,9 @@ blockscout:
         _default: "3"
     requests:
       memory:
-        _default: "8Gi"
+        _default: "6Gi"
       cpu:
-        _default: "3"
+        _default: "2"
 
   # node label
   nodeSelector:
@@ -156,14 +156,14 @@ frontend:
   resources:
     limits:
       memory:
-        _default: "7Gi"
+        _default: "2Gi"
       cpu:
-        _default: "4"
+        _default: "2"
     requests:
       memory:
-        _default: "7Gi"
+        _default: "512Mi"
       cpu:
-        _default: "4"
+        _default: "250m"
   # node label
   nodeSelector:
     enabled: true
@@ -237,14 +237,14 @@ stats:
   resources:
     limits:
       memory:
-        _default: "0.1Gi"
+        _default: 128Mi
       cpu:
-        _default: "0.1"
+        _default: 100m
     requests:
       memory:
-        _default: "0.1Gi"
+        _default: 128Mi
       cpu:
-        _default: "0.1"
+        _default: 100m
 
   # node label
   nodeSelector:
@@ -283,6 +283,7 @@ postgres:
     mountPath: /docker-entrypoint-initdb.d
 
   persistence: true
+  storage: 500Gi
 
   resources:
     limits:
@@ -310,14 +311,14 @@ scVerifier:
   resources:
     limits:
       memory:
-        _default: "0.5Gi"
+        _default: 512Mi
       cpu:
-        _default: "0.25"
+        _default: 250m
     requests:
       memory:
-        _default: "0.5Gi"
+        _default: 512Mi
       cpu:
-        _default: "0.25"
+        _default: 250m
   # probes
   livenessProbe:
     enabled: true
@@ -384,14 +385,14 @@ visualizer:
   resources:
     limits:
       memory:
-        _default: "0.05Gi"
+        _default: 64Mi
       cpu:
-        _default: "0.05"
+        _default: 50m
     requests:
       memory:
-        _default: "0.05Gi"
+        _default: 64Mi
       cpu:
-        _default: "0.05"
+        _default: 50m
 
   # node label
   nodeSelector:


### PR DESCRIPTION

## Motivation

Reduce resource consumption on bs-indexer-eth-goerli environment

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
