### PR TITLE
Add configs for Uniswap v3 transaction actions to index them on Base Goerli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Chore
 
+- [#7312](https://github.com/blockscout/blockscout/pull/7312) - Add configs for Uniswap v3 transaction actions to index them on Base Goerli
 - [#7310](https://github.com/blockscout/blockscout/pull/7310) - Reducing resource consumption on bs-indexer-eth-goerli environment
 - [#7297](https://github.com/blockscout/blockscout/pull/7297) - Use tracing JSONRPC URL in case of debug_traceTransaction method
 - [#7292](https://github.com/blockscout/blockscout/pull/7292) - Allow Node 16+ version

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -47,7 +47,7 @@ defmodule ConfigHelper do
     end
   end
 
-  defp safe_get_env(env_var, default_value) do
+  def safe_get_env(env_var, default_value) do
     env_var
     |> System.get_env(default_value)
     |> case do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -402,7 +402,17 @@ config :indexer, Indexer.Fetcher.TransactionAction,
   reindex_first_block: System.get_env("INDEXER_TX_ACTIONS_REINDEX_FIRST_BLOCK"),
   reindex_last_block: System.get_env("INDEXER_TX_ACTIONS_REINDEX_LAST_BLOCK"),
   reindex_protocols: System.get_env("INDEXER_TX_ACTIONS_REINDEX_PROTOCOLS", ""),
-  aave_v3_pool: System.get_env("INDEXER_TX_ACTIONS_AAVE_V3_POOL_CONTRACT")
+  aave_v3_pool: System.get_env("INDEXER_TX_ACTIONS_AAVE_V3_POOL_CONTRACT"),
+  uniswap_v3_factory:
+    ConfigHelper.safe_get_env(
+      "INDEXER_TX_ACTIONS_UNISWAP_V3_FACTORY_CONTRACT",
+      "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+    ),
+  uniswap_v3_nft_position_manager:
+    ConfigHelper.safe_get_env(
+      "INDEXER_TX_ACTIONS_UNISWAP_V3_NFT_POSITION_MANAGER_CONTRACT",
+      "0xC36442b4a4522E871399CD717aBDD847Ab11FE88"
+    )
 
 config :indexer, Indexer.Fetcher.PendingTransaction.Supervisor,
   disabled?:


### PR DESCRIPTION
## Motivation

Transaction actions indexer has hardcoded contract addresses for Uniswap v3. To be able to index Uniswap's actions on Base Goerli, we need to configure the addresses through env variables. This PR adds two new env vars: `INDEXER_TX_ACTIONS_UNISWAP_V3_FACTORY_CONTRACT` and `INDEXER_TX_ACTIONS_UNISWAP_V3_NFT_POSITION_MANAGER_CONTRACT`. They have default values taken from https://docs.uniswap.org/contracts/v3/reference/deployments. Base Goerli chain has [other addresses](https://docs.base.org/contracts/) for those contracts, so now we will be able to define arbitrary addresses if they don't match the default ones.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR https://github.com/blockscout/docs/pull/142
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
