### PR TITLE
Fix tokensupply API v1 endpoint: handle nil total_supply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#7317](https://github.com/blockscout/blockscout/pull/7317) - Fix tokensupply API v1 endpoint: handle nil total_supply
 - [#7290](https://github.com/blockscout/blockscout/pull/7290) - Allow nil gas price for pending tx (Erigon node case)
 - [#7288](https://github.com/blockscout/blockscout/pull/7288) - API v2 improvements: Fix tx type for pending contract creation; Remove owner for not unique ERC-1155 token instances
 - [#7283](https://github.com/blockscout/blockscout/pull/7283) - Fix status for dropped/replaced tx

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
          {:format, {:ok, address_hash}} <- to_address_hash(contractaddress_param),
          {:token, {:ok, token}} <- {:token, Chain.token_from_address_hash(address_hash)} do
-      render(conn, "tokensupply.json", total_supply: Decimal.to_string(token.total_supply))
+      render(conn, "tokensupply.json", total_supply: token.total_supply && Decimal.to_string(token.total_supply))
     else
       {:contractaddress_param, :error} ->
         render(conn, :error, error: "Query parameter contract address is required")
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
         render(conn, :error, error: "Invalid contract address format")
 
       {:token, {:error, :not_found}} ->
-        render(conn, :error, error: "contract address not found")
+        render(conn, :error, error: "Contract address not found")
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -17,7 +17,7 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
         render(conn, :error, error: "Invalid contract address hash")
 
       {:token, {:error, :not_found}} ->
-        render(conn, :error, error: "contract address not found")
+        render(conn, :error, error: "Contract address not found")
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -57,7 +57,7 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
                |> get("/api", params)
                |> json_response(200)
 
-      assert response["message"] =~ "contract address not found"
+      assert response["message"] =~ "Contract address not found"
       assert response["status"] == "0"
       assert Map.has_key?(response, "result")
       refute response["result"]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
                |> get("/api", params)
                |> json_response(200)
 
-      assert response["message"] =~ "contract address not found"
+      assert response["message"] =~ "Contract address not found"
       assert response["status"] == "0"
       assert Map.has_key?(response, "result")
       refute response["result"]

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -43,7 +43,7 @@ defmodule Explorer.Chain.Token do
   @type t :: %Token{
           name: String.t(),
           symbol: String.t(),
-          total_supply: Decimal.t(),
+          total_supply: Decimal.t() | nil,
           decimals: non_neg_integer(),
           type: String.t(),
           cataloged: boolean(),


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7315

## Motivation

tokensupply API v1 internal server error on tokens with nil total supply

## Changelog

Handle nil total supply in tokensupply API v1 endpoint.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
