### PR TITLE
Update Docker image tag `latest` with release only

### DIFF
--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -55,7 +55,7 @@ jobs:
           push: true
           cache-from: type=registry,ref=blockscout/blockscout:buildcache
           cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
-          tags: blockscout/blockscout:latest, blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
+          tags: blockscout/blockscout:master, blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
           build-args: |
             CACHE_EXCHANGE_RATES_PERIOD=
             DISABLE_READ_API=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Chore
 
+- [#7328](https://github.com/blockscout/blockscout/pull/7328) - Update Docker image tag latest with release only
 - [#7312](https://github.com/blockscout/blockscout/pull/7312) - Add configs for Uniswap v3 transaction actions to index them on Base Goerli
 - [#7310](https://github.com/blockscout/blockscout/pull/7310) - Reducing resource consumption on bs-indexer-eth-goerli environment
 - [#7297](https://github.com/blockscout/blockscout/pull/7297) - Use tracing JSONRPC URL in case of debug_traceTransaction method

--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
+++ b/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -7,7 +7,6 @@ services:
       service: redis_db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - smart-contract-verifier
       - redis_db

--- a/docker-compose/docker-compose-no-rust-services.yml
+++ b/docker-compose/docker-compose-no-rust-services.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - redis_db

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       service: db
 
   blockscout:
-    platform: linux/x86_64
     depends_on:
       - db
       - smart-contract-verifier

--- a/docker-compose/services/docker-compose-sig-provider.yml
+++ b/docker-compose/services/docker-compose-sig-provider.yml
@@ -2,7 +2,6 @@ version: '3.8'
 
 services:
   sig-provider:
-    platform: linux/x86_64
     image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
     pull_policy: always
     restart: always

--- a/docker-compose/services/docker-compose-smart-contract-verifier.yml
+++ b/docker-compose/services/docker-compose-smart-contract-verifier.yml
@@ -2,7 +2,6 @@ version: '3.8'
 
 services:
   smart-contract-verifier:
-    platform: linux/x86_64
     image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-main}
     pull_policy: always
     restart: always

--- a/docker-compose/services/docker-compose-stats.yml
+++ b/docker-compose/services/docker-compose-stats.yml
@@ -14,7 +14,6 @@ services:
       - 7433:5432
 
   stats:
-    platform: linux/x86_64
     depends_on:
       - stats-db
     image: ghcr.io/blockscout/stats:${STATS_DOCKER_TAG:-main}

--- a/docker-compose/services/docker-compose-visualizer.yml
+++ b/docker-compose/services/docker-compose-visualizer.yml
@@ -2,7 +2,6 @@ version: '3.8'
 
 services:
   visualizer:
-    platform: linux/x86_64
     image: ghcr.io/blockscout/visualizer:${VISUALIZER_DOCKER_TAG:-latest}
     pull_policy: always
     restart: always


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/6787

## Motivation

Currently `latest` docker image tag is updated on every push to master branch and every release issuance. But, update from every push to master is built only for linux/amd64 arch whereas release-based images are multi-platform.

## Changelog

- Update `latest` Docker image tag only from release issuance.
- With every push to master branch update `master` Docker image tag.
- Remove platform param from docker-compose configs.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
