### PR TITLE
Delete pending block operations for empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#7246](https://github.com/blockscout/blockscout/pull/7246) - Fallback JSON RPC option
+- [#7329](https://github.com/blockscout/blockscout/pull/7329) - Delete pending block operations for empty blocks
 
 ### Fixes
 


### PR DESCRIPTION
## Motivation

In case when the chain has a lot of empty blocks, fetching internal transactions for each is useless.

## Changelog

Delete pending block operations for empty blocks since they don't have internal transactions.