### PR TITLE
Add volume for Postgres Docker containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ dump.rdb
 # mix phx.gen.cert self-signed certs for dev
 /apps/block_scout_web/priv/cert
 
-/docker-compose/postgres-data
-/docker-compose/redis-data
+/docker-compose/services/blockscout-db-data
+/docker-compose/services/stats-db-data
+/docker-compose/services/redis-data
 /docker-compose/tmp
 /docker-compose/logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Chore
 
+- [#7332](https://github.com/blockscout/blockscout/pull/7332) - Add volume for Postgres Docker containers DB
 - [#7328](https://github.com/blockscout/blockscout/pull/7328) - Update Docker image tag latest with release only
 - [#7312](https://github.com/blockscout/blockscout/pull/7312) - Add configs for Uniswap v3 transaction actions to index them on Base Goerli
 - [#7310](https://github.com/blockscout/blockscout/pull/7310) - Reducing resource consumption on bs-indexer-eth-goerli environment

--- a/docker-compose/services/docker-compose-db.yml
+++ b/docker-compose/services/docker-compose-db.yml
@@ -12,3 +12,5 @@ services:
         POSTGRES_HOST_AUTH_METHOD: 'trust'
     ports:
       - 7432:5432
+    volumes:
+      - ./blockscout-db-data:/var/lib/postgresql/data/

--- a/docker-compose/services/docker-compose-stats.yml
+++ b/docker-compose/services/docker-compose-stats.yml
@@ -30,3 +30,5 @@ services:
       - STATS__RUN_MIGRATIONS=true
     ports:
       - 8153:8050
+    volumes:
+      - ./stats-db-data:/var/lib/postgresql/data/


### PR DESCRIPTION
## Motivation

DB containers doesn't use persistent volumes.

## Changelog

Add volumes for explorer and stats Postgres Docker containers DBs

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
