### PR TITLE
Manage visibility of indexing progress alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#7360](https://github.com/blockscout/blockscout/pull/7360) - Manage visibility of indexing progress alert
+
 ## 5.1.4-beta
 
 ### Features

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -70,22 +70,25 @@
       <!-- -->
       <% show_maintenance_alert = Application.get_env(:block_scout_web, BlockScoutWeb.Chain)[:show_maintenance_alert] %>
       <%= if show_maintenance_alert do %>
-        <div class="alert alert-warning text-center mb-0 p-3" data-selector="indexed-status">
+        <div class="alert alert-warning text-center mb-0 p-3">
           <%= raw(System.get_env("MAINTENANCE_ALERT_MESSAGE")) %>
         </div>
       <% end %>
-      <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
-      <% indexed_ratio =
-      case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
-       false -> indexed_ratio_blocks
-       _ -> Chain.indexed_ratio_internal_transactions()
-      end %>
-      <%= if not Chain.finished_indexing_from_ratio?(indexed_ratio) do %>
-        <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
-          <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
-          <span data-indexed-ratio-blocks="<%= indexed_ratio_blocks %>" data-indexed-ratio="<%= indexed_ratio %>"></span>
-          <%= gettext("- We're indexing this chain right now. Some of the counts may be inaccurate.") %>
-        </div>
+      <% hide_indexing_progress_alert = Application.get_env(:indexer, :hide_indexing_progress_alert) %>
+      <%= unless hide_indexing_progress_alert do %>
+        <% indexed_ratio_blocks = Chain.indexed_ratio_blocks() %>
+        <% indexed_ratio =
+        case Chain.finished_indexing_from_ratio?(indexed_ratio_blocks) do
+        false -> indexed_ratio_blocks
+        _ -> Chain.indexed_ratio_internal_transactions()
+        end %>
+        <%= if not Chain.finished_indexing_from_ratio?(indexed_ratio) do %>
+          <div class="alert alert-warning text-center mb-0 p-3" data-seindexed_ratiolector="indexed-status">
+            <%= render BlockScoutWeb.CommonComponentsView, "_loading_spinner.html" %>
+            <span data-indexed-ratio-blocks="<%= indexed_ratio_blocks %>" data-indexed-ratio="<%= indexed_ratio %>"></span>
+            <%= gettext("- We're indexing this chain right now. Some of the counts may be inaccurate.") %>
+          </div>
+        <% end %>
       <% end %>
       <%= render BlockScoutWeb.LayoutView, "_topnav.html", current_user: Conn.get_session(@conn, :current_user), conn: @conn %>
 

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -81,7 +81,7 @@ msgstr ""
 msgid ") may be added for each contract. Click the Add Library button to add an additional one."
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:87
+#: lib/block_scout_web/templates/layout/app.html.eex:89
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -81,7 +81,7 @@ msgstr ""
 msgid ") may be added for each contract. Click the Add Library button to add an additional one."
 msgstr ""
 
-#: lib/block_scout_web/templates/layout/app.html.eex:87
+#: lib/block_scout_web/templates/layout/app.html.eex:89
 #, elixir-autogen, elixir-format
 msgid "- We're indexing this chain right now. Some of the counts may be inaccurate."
 msgstr ""

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -395,7 +395,8 @@ config :indexer,
   fetch_rewards_way: System.get_env("FETCH_REWARDS_WAY", "trace_block"),
   memory_limit: ConfigHelper.indexer_memory_limit(),
   receipts_batch_size: ConfigHelper.parse_integer_env_var("INDEXER_RECEIPTS_BATCH_SIZE", 250),
-  receipts_concurrency: ConfigHelper.parse_integer_env_var("INDEXER_RECEIPTS_CONCURRENCY", 10)
+  receipts_concurrency: ConfigHelper.parse_integer_env_var("INDEXER_RECEIPTS_CONCURRENCY", 10),
+  hide_indexing_progress_alert: ConfigHelper.parse_bool_env_var("INDEXER_HIDE_INDEXING_PROGRESS_ALERT")
 
 config :indexer, Indexer.Supervisor, enabled: !ConfigHelper.parse_bool_env_var("DISABLE_INDEXER")
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7035


## Changelog

`INDEXER_HIDE_INDEXING_PROGRESS_ALERT` runtime env variable is added to manage visibility of indexing status alert.

Docs update in https://github.com/blockscout/docs/pull/148.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
