### PR TITLE
CSV export filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#7532](https://github.com/blockscout/blockscout/pull/7532) - Handle empty id in json rpc responses
 - [#7544](https://github.com/blockscout/blockscout/pull/7544) - Add ERC-1155 signatures to uncataloged_token_transfer_block_numbers
+- [#7363](https://github.com/blockscout/blockscout/pull/7363) - CSV export filters
 
 ### Fixes
 
@@ -41,7 +42,6 @@
 - [#7422](https://github.com/blockscout/blockscout/pull/7422) - Refactor state changes
 - [#7416](https://github.com/blockscout/blockscout/pull/7416) - Add option to disable reCAPTCHA
 - [#6694](https://github.com/blockscout/blockscout/pull/6694) - Add withdrawals support (EIP-4895)
-- [#7363](https://github.com/blockscout/blockscout/pull/7363) - CSV export filters
 - [#7355](https://github.com/blockscout/blockscout/pull/7355) - Add endpoint for token info import
 - [#7393](https://github.com/blockscout/blockscout/pull/7393) - Realtime fetcher max gap
 - [#7436](https://github.com/blockscout/blockscout/pull/7436) - TokenBalanceOnDemand ERC-1155 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [#7422](https://github.com/blockscout/blockscout/pull/7422) - Refactor state changes
 - [#7416](https://github.com/blockscout/blockscout/pull/7416) - Add option to disable reCAPTCHA
 - [#6694](https://github.com/blockscout/blockscout/pull/6694) - Add withdrawals support (EIP-4895)
+- [#7363](https://github.com/blockscout/blockscout/pull/7363) - CSV export filters
 - [#7355](https://github.com/blockscout/blockscout/pull/7355) - Add endpoint for token info import
 - [#7393](https://github.com/blockscout/blockscout/pull/7393) - Realtime fetcher max gap
 - [#7436](https://github.com/blockscout/blockscout/pull/7436) - TokenBalanceOnDemand ERC-1155 support

--- a/apps/block_scout_web/assets/css/components/_transaction.scss
+++ b/apps/block_scout_web/assets/css/components/_transaction.scss
@@ -8,7 +8,7 @@
 	}
 }
 
-.download-all-transactions {
+.download-all-items {
 	text-align: center;
 	color: #a3a9b5;
 	font-size: 13px;
@@ -16,7 +16,7 @@
 	@media (min-width: 768px) {
 		margin-top: 30px;
 	}
-	.download-all-transactions-link {
+	.download-all-items-link {
 		display: inline-flex;
 		align-items: center;
 		text-decoration: none;

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -413,7 +413,7 @@ $header-links-background-color-dark-mode: $dark-light !default;
 	}
 
 	// download csv button
-	.download-all-transactions .download-all-transactions-link svg path {
+	.download-all-items .download-all-items-link svg path {
 		fill: $dark-primary;
 	}
 

--- a/apps/block_scout_web/assets/css/theme/custom_contracts/_circles-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/custom_contracts/_circles-theme.scss
@@ -272,7 +272,7 @@ $c-dark-text-color: #8a8dba;
 	}
 
 	// download csv button
-	.download-all-transactions .download-all-transactions-link svg path {
+	.download-all-items .download-all-items-link svg path {
 		fill: $c-primary;
 	}
 

--- a/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/custom_contracts/_dark-forest-theme.scss
@@ -424,7 +424,7 @@ $dark-primary-alternate: $dark-primary;
 	}
 
 	// download csv button
-	.download-all-transactions .download-all-transactions-link svg path {
+	.download-all-items .download-all-items-link svg path {
 		fill: $dark-primary;
 	}
 

--- a/apps/block_scout_web/assets/js/lib/csv_download.js
+++ b/apps/block_scout_web/assets/js/lib/csv_download.js
@@ -38,10 +38,12 @@ $button.on('click', () => {
   const addressHash = $button.data('address-hash')
   const from = $('.js-datepicker-from').val()
   const to = $('.js-datepicker-to').val()
+  const urlParams = new URLSearchParams(window.location.search)
+  const filterType = urlParams.get('filter_type')
+  const filterValue = urlParams.get('filter_value')
+  const baseURL = `${$button.data('link')}?address_id=${addressHash}&from_period=${from}&to_period=${to}&filter_type=${filterType}&filter_value=${filterValue}`
   if (reCaptchaDisabled) {
-    const url = `${$button.data('link')}?address_id=${addressHash}&from_period=${from}&to_period=${to}`
-
-    download(url)
+    download(baseURL)
   } else if (reCaptchaV3ClientKey) {
     disableBtnWithSpinner()
     // @ts-ignore
@@ -51,7 +53,7 @@ $button.on('click', () => {
       // eslint-disable-next-line
       grecaptcha.execute(reCaptchaV3ClientKey, { action: 'login' })
         .then(function (token) {
-          const url = `${$button.data('link')}?address_id=${addressHash}&from_period=${from}&to_period=${to}&recaptcha_response=${token}`
+          const url = `${baseURL}&recaptcha_response=${token}`
 
           download(url)
         })
@@ -62,7 +64,7 @@ $button.on('click', () => {
   const recaptchaResponse = grecaptcha.getResponse()
     if (recaptchaResponse) {
       disableBtnWithSpinner()
-      const url = `${$button.data('link')}?address_id=${addressHash}&from_period=${from}&to_period=${to}&recaptcha_response=${recaptchaResponse}`
+      const url = `${baseURL}&recaptcha_response=${recaptchaResponse}`
 
       download(url, true, true)
     }
@@ -88,7 +90,13 @@ $button.on('click', () => {
           const downloadUrl = URL.createObjectURL(blob)
           const a = document.createElement('a')
           a.href = downloadUrl
-          a.download = `${$button.data('type')}_for_${addressHash}_from_${from}_to_${to}.csv`
+          let fileName = `${$button.data('type')}_for_${addressHash}_from_${from}_to_${to}`
+          if (filterType && filterValue) {
+            fileName = `${fileName}_with_filter_type_${filterType}_value_${filterValue}.csv`
+          } else {
+            fileName = `${fileName}.csv`
+          }
+          a.download = fileName
           document.body.appendChild(a)
           a.click()
 

--- a/apps/block_scout_web/assets/js/pages/address/logs.js
+++ b/apps/block_scout_web/assets/js/pages/address/logs.js
@@ -3,6 +3,7 @@ import omit from 'lodash.omit'
 import { connectElements } from '../../lib/redux_helpers.js'
 import { createAsyncLoadStore, loadPage } from '../../lib/async_listing_load'
 import { commonPath } from '../../lib/path_helper'
+import { escapeHtml } from '../../lib/utils'
 import '../address'
 // @ts-ignore
 import { utils } from 'web3'
@@ -76,7 +77,20 @@ if ($('[data-page="address-logs"]').length) {
     const addressHashPlain = store.getState().addressHash
     const addressHashChecksum = addressHashPlain && utils.toChecksumAddress(addressHashPlain)
     const path = `${commonPath}/search-logs?topic=${topic}&address_id=${addressHashChecksum}`
+    changeDownloadButtonHref(topic)
     loadPage(store, path)
+  }
+
+  function changeDownloadButtonHref (filter) {
+    const currentHref = $('a.download-all-items-link').attr('href')
+    if (currentHref) {
+      let hrefWithTopic = currentHref
+      if (currentHref.includes('filter_type=&')) {
+        hrefWithTopic = currentHref.replace(/filter_type=.*?&/, 'filter_type=topic&')
+      }
+      const href = hrefWithTopic.replace(/filter_value=.*?&/, `filter_value=${escapeHtml(filter)}&`)
+      $('a.download-all-items-link').attr('href', href)
+    }
   }
 
   store.dispatch({

--- a/apps/block_scout_web/assets/package-lock.json
+++ b/apps/block_scout_web/assets/package-lock.json
@@ -101,10 +101,11 @@
       }
     },
     "../../../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.13",
+      "license": "MIT"
     },
     "../../../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.0.4"
     },
     "node_modules/@amplitude/analytics-browser": {
       "version": "1.10.3",

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
@@ -110,6 +110,7 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
         address: address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(address),
         exchange_rate: Market.get_exchange_rate(Explorer.coin()) || Token.null(),
+        filter: params["filter"],
         current_path: Controller.current_full_path(conn),
         token: token,
         counters_path: address_path(conn, :address_counters, %{"id" => Address.checksum(address_hash)}),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -187,15 +187,18 @@ defmodule BlockScoutWeb.AddressTransactionController do
            "from_period" => from_period,
            "to_period" => to_period,
            "recaptcha_response" => recaptcha_response
-         },
+         } = params,
          csv_export_module
        )
        when is_binary(address_hash_string) do
+    filter_type = Map.get(params, "filter_type")
+    filter_value = Map.get(params, "filter_value")
+
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, address} <- Chain.hash_to_address(address_hash),
          {:recaptcha, true} <- {:recaptcha, captcha_helper().recaptcha_passed?(recaptcha_response)} do
       address
-      |> csv_export_module.export(from_period, to_period)
+      |> csv_export_module.export(from_period, to_period, filter_type, filter_value)
       |> Enum.reduce_while(put_resp_params(conn), fn chunk, conn ->
         case Conn.chunk(conn, chunk) do
           {:ok, conn} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/csv_export_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/csv_export_controller.ex
@@ -8,8 +8,15 @@ defmodule BlockScoutWeb.CsvExportController do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          :ok <- Chain.check_address_exists(address_hash),
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         true <- supported_export_type(type) do
-      render(conn, "index.html", address_hash_string: address_hash_string, type: type)
+         true <- supported_export_type(type),
+         filter_type <- Map.get(params, "filter_type"),
+         filter_value <- Map.get(params, "filter_value") do
+      render(conn, "index.html",
+        address_hash_string: address_hash_string,
+        type: type,
+        filter_type: filter_type && String.downcase(filter_type),
+        filter_value: filter_value && String.downcase(filter_value)
+      )
     else
       _ ->
         not_found(conn)

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_internal_transaction/index.html.eex
@@ -60,7 +60,7 @@
         </div>
 
         <div class="transaction-bottom-panel">
-          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "internal-transactions", conn: @conn %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "internal-transactions", filter_type: :address, filter_value: @filter, conn: @conn %>
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_transfer/index.html.eex
@@ -64,7 +64,7 @@
         </div>
 
         <div class="transaction-bottom-panel">
-          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "token-transfers", conn: @conn %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "token-transfers", filter_type: :address, filter_value: @filter, conn: @conn %>
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_transaction/index.html.eex
@@ -61,7 +61,7 @@
         </div>
 
         <div class="transaction-bottom-panel">
-          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "transactions", conn: @conn %>
+          <%= render BlockScoutWeb.CommonComponentsView, "_csv_export_button.html", address: Address.checksum(@address.hash), type: "transactions", filter_type: :address, filter_value: @filter, conn: @conn %>
           <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "bottom", cur_page_number: "1", show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
         </div>
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_csv_export_button.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_csv_export_button.html.eex
@@ -1,5 +1,7 @@
-<div csv-download class="download-all-transactions">
-    Download <a class="download-all-transactions-link" href=<%= csv_export_path(@conn, :index, %{"address" => @address, "type" => @type }) %>><%= gettext("CSV") %></span>
+<% filter_type = if assigns[:filter_type], do: @filter_type, else: "" %>
+<% filter_value = if assigns[:filter_value], do: @filter_value, else: "" %>
+<div csv-download class="download-all-items">
+    Download <a class="download-all-items-link" href=<%= csv_export_path(@conn, :index, %{"address" => @address, "type" => @type, "filter_type" => filter_type, "filter_value" => filter_value }) %>><%= gettext("CSV") %></span>
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
             <path fill="#333333" fill-rule="evenodd" d="M13 16H1c-.999 0-1-1-1-1V1s-.004-1 1-1h6l7 7v8s-.032 1-1 1zm-1-8c0-.99-1-1-1-1H8s-1 .001-1-1V3c0-.999-1-1-1-1H2v12h10V8z"/>
         </svg>

--- a/apps/block_scout_web/lib/block_scout_web/templates/common_components/_csv_export_button.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/common_components/_csv_export_button.html.eex
@@ -1,7 +1,7 @@
 <% filter_type = if assigns[:filter_type], do: @filter_type, else: "" %>
 <% filter_value = if assigns[:filter_value], do: @filter_value, else: "" %>
 <div csv-download class="download-all-items">
-    Download <a class="download-all-items-link" href=<%= csv_export_path(@conn, :index, %{"address" => @address, "type" => @type, "filter_type" => filter_type, "filter_value" => filter_value }) %>><%= gettext("CSV") %></span>
+    <%= gettext("Download") %> <a class="download-all-items-link" href=<%= csv_export_path(@conn, :index, %{"address" => @address, "type" => @type, "filter_type" => filter_type, "filter_value" => filter_value }) %>><%= gettext("CSV") %></span>
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
             <path fill="#333333" fill-rule="evenodd" d="M13 16H1c-.999 0-1-1-1-1V1s-.004-1 1-1h6l7 7v8s-.032 1-1 1zm-1-8c0-.99-1-1-1-1H8s-1 .001-1-1V3c0-.999-1-1-1-1H2v12h10V8z"/>
         </svg>

--- a/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
@@ -10,10 +10,11 @@
       <h1 class="card-title list-title-description"><%= gettext "Export Data" %></h1>
 
       <div>
+        <% filter_text = if Helper.is_valid_filter?(@filter_type, @filter_value, @type), do: " with applied filter by #{@filter_type} (#{@filter_value})", else: ""  %>
         <p class="card-subtitle list-title-description">Export <%= type_display_name(@type) %> for address <%= link(
               @address_hash_string,
               to: address_path(@conn, :show, @address_hash_string)
-            ) %> to CSV file</p>
+            ) %><%= filter_text %> to CSV file</p>
 	    </div>
 
       <div class="dates-container">

--- a/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/csv_export/index.html.eex
@@ -11,10 +11,10 @@
 
       <div>
         <% filter_text = if Helper.is_valid_filter?(@filter_type, @filter_value, @type), do: " with applied filter by #{@filter_type} (#{@filter_value})", else: ""  %>
-        <p class="card-subtitle list-title-description">Export <%= type_display_name(@type) %> for address <%= link(
+        <p class="card-subtitle list-title-description"><%= gettext("Export") %> <%= type_display_name(@type) %> <%= gettext("for address") %> <%= link(
               @address_hash_string,
               to: address_path(@conn, :show, @address_hash_string)
-            ) %><%= filter_text %> to CSV file</p>
+            ) %><%= filter_text %> <%= gettext("to CSV file") %></p>
 	    </div>
 
       <div class="dates-container">

--- a/apps/block_scout_web/lib/block_scout_web/views/csv_export.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/csv_export.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.CsvExportView do
 
   alias Explorer.Chain
   alias Explorer.Chain.Address
+  alias Explorer.Chain.CSVExport.Helper
 
   defp type_display_name(type) do
     case type do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -587,7 +587,7 @@ msgstr ""
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:2
+#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:4
 #, elixir-autogen, elixir-format
 msgid "CSV"
 msgstr ""
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/csv_export/index.html.eex:32
+#: lib/block_scout_web/templates/csv_export/index.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1145,6 +1145,7 @@ msgstr ""
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
+#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:4
 #: lib/block_scout_web/templates/csv_export/index.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Download"
@@ -3663,4 +3664,19 @@ msgstr ""
 #: lib/block_scout_web/templates/withdrawal/index.html.eex:11
 #, elixir-autogen, elixir-format
 msgid "%{withdrawals_count} withdrawals processed and %{withdrawals_sum} withdrawn."
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:14
+#, elixir-autogen, elixir-format
+msgid "Export"
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:14
+#, elixir-autogen, elixir-format
+msgid "for address"
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:17
+#, elixir-autogen, elixir-format
+msgid "to CSV file"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -587,7 +587,7 @@ msgstr ""
 msgid "CRC Worth"
 msgstr ""
 
-#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:2
+#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:4
 #, elixir-autogen, elixir-format
 msgid "CSV"
 msgstr ""
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
-#: lib/block_scout_web/templates/csv_export/index.html.eex:32
+#: lib/block_scout_web/templates/csv_export/index.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1145,6 +1145,7 @@ msgstr ""
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
 
+#: lib/block_scout_web/templates/common_components/_csv_export_button.html.eex:4
 #: lib/block_scout_web/templates/csv_export/index.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Download"
@@ -3663,4 +3664,19 @@ msgstr ""
 #: lib/block_scout_web/templates/withdrawal/index.html.eex:11
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{withdrawals_count} withdrawals processed and %{withdrawals_sum} withdrawn."
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:14
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Export"
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:14
+#, elixir-autogen, elixir-format, fuzzy
+msgid "for address"
+msgstr ""
+
+#: lib/block_scout_web/templates/csv_export/index.html.eex:17
+#, elixir-autogen, elixir-format
+msgid "to CSV file"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
@@ -62,7 +62,7 @@ defmodule BlockScoutWeb.API.V2.MainPageControllerTest do
     end
 
     test "get last 6 txs", %{conn: conn} do
-      txs = insert_list(10, :transaction) |> with_block()
+      insert_list(10, :transaction) |> with_block()
 
       auth = build(:auth)
       {:ok, user} = UserFromAuth.find_or_create(auth)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -633,74 +633,6 @@ defmodule Explorer.Chain do
     |> select_repo(options).all()
   end
 
-  @doc """
-  address_hash_to_token_transfers_including_contract/2 function returns token transfers on address (to/from/contract).
-  It is used by CSV export of token transfers button.
-  """
-  @spec address_hash_to_token_transfers_including_contract(Hash.Address.t(), Keyword.t()) :: [TokenTransfer.t()]
-  def address_hash_to_token_transfers_including_contract(address_hash, options \\ []) do
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    from_block = Keyword.get(options, :from_block)
-    to_block = Keyword.get(options, :to_block)
-
-    query =
-      from_block
-      |> query_address_hash_to_token_transfers_including_contract(to_block, address_hash)
-      |> order_by([token_transfer], asc: token_transfer.block_number, asc: token_transfer.log_index)
-
-    query
-    |> handle_token_transfer_paging_options(paging_options)
-    |> preload(transaction: :block)
-    |> preload(:token)
-    |> Repo.all()
-  end
-
-  defp query_address_hash_to_token_transfers_including_contract(nil, to_block, address_hash)
-       when not is_nil(to_block) do
-    from(
-      token_transfer in TokenTransfer,
-      where:
-        (token_transfer.to_address_hash == ^address_hash or
-           token_transfer.from_address_hash == ^address_hash or
-           token_transfer.token_contract_address_hash == ^address_hash) and
-          token_transfer.block_number <= ^to_block
-    )
-  end
-
-  defp query_address_hash_to_token_transfers_including_contract(from_block, nil, address_hash)
-       when not is_nil(from_block) do
-    from(
-      token_transfer in TokenTransfer,
-      where:
-        (token_transfer.to_address_hash == ^address_hash or
-           token_transfer.from_address_hash == ^address_hash or
-           token_transfer.token_contract_address_hash == ^address_hash) and
-          token_transfer.block_number >= ^from_block
-    )
-  end
-
-  defp query_address_hash_to_token_transfers_including_contract(from_block, to_block, address_hash)
-       when not is_nil(from_block) and not is_nil(to_block) do
-    from(
-      token_transfer in TokenTransfer,
-      where:
-        (token_transfer.to_address_hash == ^address_hash or
-           token_transfer.from_address_hash == ^address_hash or
-           token_transfer.token_contract_address_hash == ^address_hash) and
-          (token_transfer.block_number >= ^from_block and token_transfer.block_number <= ^to_block)
-    )
-  end
-
-  defp query_address_hash_to_token_transfers_including_contract(_, _, address_hash) do
-    from(
-      token_transfer in TokenTransfer,
-      where:
-        token_transfer.to_address_hash == ^address_hash or
-          token_transfer.from_address_hash == ^address_hash or
-          token_transfer.token_contract_address_hash == ^address_hash
-    )
-  end
-
   @spec address_to_logs(Hash.Address.t(), Keyword.t()) :: [Log.t()]
   def address_to_logs(address_hash, options \\ []) when is_list(options) do
     paging_options = Keyword.get(options, :paging_options) || %PagingOptions{page_size: 50}
@@ -4636,14 +4568,6 @@ defmodule Explorer.Chain do
   defp handle_verified_contracts_paging_options(query, paging_options) do
     query
     |> page_verified_contracts(paging_options)
-    |> limit(^paging_options.page_size)
-  end
-
-  defp handle_token_transfer_paging_options(query, nil), do: query
-
-  defp handle_token_transfer_paging_options(query, paging_options) do
-    query
-    |> TokenTransfer.page_token_transfer(paging_options)
     |> limit(^paging_options.page_size)
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -260,7 +260,7 @@ defmodule Explorer.Chain do
 
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    if direction == nil do
+    if direction == nil || direction == "" do
       query_to_address_hash_wrapped =
         InternalTransaction
         |> InternalTransaction.where_nonpending_block()
@@ -749,6 +749,8 @@ defmodule Explorer.Chain do
   end
 
   defp filter_topic(base_query, nil), do: base_query
+
+  defp filter_topic(base_query, ""), do: base_query
 
   defp filter_topic(base_query, topic) do
     from(log in base_query,

--- a/apps/explorer/lib/explorer/chain/csv_export/address_log_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/address_log_csv_exporter.ex
@@ -9,22 +9,23 @@ defmodule Explorer.Chain.CSVExport.AddressLogCsvExporter do
 
   @paging_options %PagingOptions{page_size: Helper.page_size() + 1}
 
-  @spec export(Address.t(), String.t(), String.t()) :: Enumerable.t()
-  def export(address, from_period, to_period) do
+  @spec export(Address.t(), String.t(), String.t(), String.t() | nil, String.t() | nil) :: Enumerable.t()
+  def export(address, from_period, to_period, filter_type \\ nil, filter_value \\ nil) do
     {from_block, to_block} = Helper.block_from_period(from_period, to_period)
 
     address.hash
-    |> fetch_all_logs(from_block, to_block, @paging_options)
+    |> fetch_all_logs(from_block, to_block, filter_type, filter_value, @paging_options)
     |> to_csv_format()
     |> Helper.dump_to_stream()
   end
 
-  defp fetch_all_logs(address_hash, from_block, to_block, paging_options, acc \\ []) do
+  defp fetch_all_logs(address_hash, from_block, to_block, filter_type, filter_value, paging_options, acc \\ []) do
     options =
       []
       |> Keyword.put(:paging_options, paging_options)
       |> Keyword.put(:from_block, from_block)
       |> Keyword.put(:to_block, to_block)
+      |> Keyword.put(:topic, filter_value)
 
     logs = Chain.address_to_logs(address_hash, options)
 
@@ -33,7 +34,7 @@ defmodule Explorer.Chain.CSVExport.AddressLogCsvExporter do
     case Enum.split(logs, Helper.page_size()) do
       {_logs, [%Log{block_number: block_number, transaction: %Transaction{index: transaction_index}, index: index}]} ->
         new_paging_options = %{@paging_options | key: {block_number, transaction_index, index}}
-        fetch_all_logs(address_hash, from_block, to_block, new_paging_options, new_acc)
+        fetch_all_logs(address_hash, from_block, to_block, filter_type, filter_value, new_paging_options, new_acc)
 
       {_, []} ->
         new_acc

--- a/apps/explorer/lib/explorer/chain/csv_export/address_token_transfer_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/address_token_transfer_csv_exporter.ex
@@ -3,37 +3,64 @@ defmodule Explorer.Chain.CSVExport.AddressTokenTransferCsvExporter do
   Exports token transfers to a csv file.
   """
 
-  alias Explorer.{Chain, PagingOptions}
-  alias Explorer.Chain.{Address, TokenTransfer}
+  import Ecto.Query,
+    only: [
+      limit: 2,
+      preload: 2,
+      order_by: 3,
+      where: 3
+    ]
+
+  alias Explorer.{Chain, PagingOptions, Repo}
+  alias Explorer.Chain.{Address, Hash, TokenTransfer}
   alias Explorer.Chain.CSVExport.Helper
 
   @paging_options %PagingOptions{page_size: Helper.page_size() + 1, asc_order: true}
 
-  @spec export(Address.t(), String.t(), String.t()) :: Enumerable.t()
-  def export(address, from_period, to_period) do
+  @spec export(Address.t(), String.t(), String.t(), String.t() | nil, String.t() | nil) :: Enumerable.t()
+  def export(address, from_period, to_period, filter_type \\ nil, filter_value \\ nil) do
     {from_block, to_block} = Helper.block_from_period(from_period, to_period)
 
     address.hash
-    |> fetch_all_token_transfers(from_block, to_block, @paging_options)
+    |> fetch_all_token_transfers(from_block, to_block, filter_type, filter_value, @paging_options)
     |> to_csv_format(address)
     |> Helper.dump_to_stream()
   end
 
-  def fetch_all_token_transfers(address_hash, from_block, to_block, paging_options, acc \\ []) do
+  def fetch_all_token_transfers(
+        address_hash,
+        from_block,
+        to_block,
+        filter_type,
+        filter_value,
+        paging_options,
+        acc \\ []
+      ) do
     options =
       []
       |> Keyword.put(:paging_options, paging_options)
       |> Keyword.put(:from_block, from_block)
       |> Keyword.put(:to_block, to_block)
+      |> Keyword.put(:filter_type, filter_type)
+      |> Keyword.put(:filter_value, filter_value)
 
-    token_transfers = Chain.address_hash_to_token_transfers_including_contract(address_hash, options)
+    token_transfers = address_hash_to_token_transfers_including_contract(address_hash, options)
 
     new_acc = acc ++ token_transfers
 
     case Enum.split(token_transfers, Helper.page_size()) do
       {_token_transfers, [%TokenTransfer{block_number: block_number, log_index: log_index}]} ->
         new_paging_options = %{@paging_options | key: {block_number, log_index}}
-        fetch_all_token_transfers(address_hash, from_block, to_block, new_paging_options, new_acc)
+
+        fetch_all_token_transfers(
+          address_hash,
+          from_block,
+          to_block,
+          filter_type,
+          filter_value,
+          new_paging_options,
+          new_acc
+        )
 
       {_, []} ->
         new_acc
@@ -91,5 +118,75 @@ defmodule Explorer.Chain.CSVExport.AddressTokenTransferCsvExporter do
       {:actual, value} -> value
       {:maximum, value} -> "Max of #{value}"
     end
+  end
+
+  @doc """
+  address_hash_to_token_transfers_including_contract/2 function returns token transfers on address (to/from/contract).
+  It is used by CSV export of token transfers button.
+  """
+  @spec address_hash_to_token_transfers_including_contract(Hash.Address.t(), Keyword.t()) :: [TokenTransfer.t()]
+  def address_hash_to_token_transfers_including_contract(address_hash, options \\ []) do
+    paging_options = Keyword.get(options, :paging_options, Helper.default_paging_options())
+    from_block = Keyword.get(options, :from_block)
+    to_block = Keyword.get(options, :to_block)
+    filter_type = Keyword.get(options, :filter_type)
+    filter_value = Keyword.get(options, :filter_value)
+
+    query =
+      from_block
+      |> query_address_hash_to_token_transfers_including_contract(to_block, address_hash, filter_type, filter_value)
+      |> order_by([token_transfer], asc: token_transfer.block_number, asc: token_transfer.log_index)
+
+    query
+    |> handle_token_transfer_paging_options(paging_options)
+    |> preload(transaction: :block)
+    |> preload(:token)
+    |> Repo.all()
+  end
+
+  defp query_address_hash_to_token_transfers_including_contract(nil, to_block, address_hash, filter_type, filter_value)
+       when not is_nil(to_block) do
+    TokenTransfer
+    |> Helper.where_address_hash(address_hash, filter_type, filter_value)
+    |> where([token_transfer], token_transfer.block_number <= ^to_block)
+  end
+
+  defp query_address_hash_to_token_transfers_including_contract(
+         from_block,
+         nil,
+         address_hash,
+         filter_type,
+         filter_value
+       )
+       when not is_nil(from_block) do
+    TokenTransfer
+    |> Helper.where_address_hash(address_hash, filter_type, filter_value)
+    |> where([token_transfer], token_transfer.block_number >= ^from_block)
+  end
+
+  defp query_address_hash_to_token_transfers_including_contract(
+         from_block,
+         to_block,
+         address_hash,
+         filter_type,
+         filter_value
+       )
+       when not is_nil(from_block) and not is_nil(to_block) do
+    TokenTransfer
+    |> Helper.where_address_hash(address_hash, filter_type, filter_value)
+    |> where([token_transfer], token_transfer.block_number >= ^from_block and token_transfer.block_number <= ^to_block)
+  end
+
+  defp query_address_hash_to_token_transfers_including_contract(_, _, address_hash, filter_type, filter_value) do
+    TokenTransfer
+    |> Helper.where_address_hash(address_hash, filter_type, filter_value)
+  end
+
+  defp handle_token_transfer_paging_options(query, nil), do: query
+
+  defp handle_token_transfer_paging_options(query, paging_options) do
+    query
+    |> TokenTransfer.page_token_transfer(paging_options)
+    |> limit(^paging_options.page_size)
   end
 end

--- a/apps/explorer/lib/explorer/chain/csv_export/address_transaction_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/address_transaction_csv_exporter.ex
@@ -29,23 +29,28 @@ defmodule Explorer.Chain.CSVExport.AddressTransactionCsvExporter do
 
   @paging_options %PagingOptions{page_size: Helper.page_size() + 1}
 
-  @spec export(Address.t(), String.t(), String.t()) :: Enumerable.t()
-  def export(address, from_period, to_period) do
+  @spec export(Address.t(), String.t(), String.t(), String.t() | nil, String.t() | nil) :: Enumerable.t()
+  def export(address, from_period, to_period, filter_type \\ nil, filter_value \\ nil) do
     {from_block, to_block} = Helper.block_from_period(from_period, to_period)
     exchange_rate = Market.get_exchange_rate(Explorer.coin()) || Token.null()
 
     address.hash
-    |> fetch_all_transactions(from_block, to_block, @paging_options)
+    |> fetch_all_transactions(from_block, to_block, filter_type, filter_value, @paging_options)
     |> to_csv_format(address, exchange_rate)
     |> Helper.dump_to_stream()
   end
 
-  def fetch_all_transactions(address_hash, from_block, to_block, paging_options, acc \\ []) do
+  # sobelow_skip ["DOS.StringToAtom"]
+  def fetch_all_transactions(address_hash, from_block, to_block, filter_type, filter_value, paging_options, acc \\ []) do
     options =
       @necessity_by_association
       |> Keyword.put(:paging_options, paging_options)
       |> Keyword.put(:from_block, from_block)
       |> Keyword.put(:to_block, to_block)
+      |> (&if(Helper.is_valid_filter?(filter_type, filter_value, "transactions"),
+            do: &1 |> Keyword.put(:direction, String.to_atom(filter_value)),
+            else: &1
+          )).()
 
     transactions = Chain.address_to_transactions_without_rewards(address_hash, options)
     new_acc = transactions ++ acc
@@ -53,7 +58,16 @@ defmodule Explorer.Chain.CSVExport.AddressTransactionCsvExporter do
     case Enum.split(transactions, Helper.page_size()) do
       {_transactions, [%Transaction{block_number: block_number, index: index}]} ->
         new_paging_options = %{@paging_options | key: {block_number, index}}
-        fetch_all_transactions(address_hash, from_block, to_block, new_paging_options, new_acc)
+
+        fetch_all_transactions(
+          address_hash,
+          from_block,
+          to_block,
+          filter_type,
+          filter_value,
+          new_paging_options,
+          new_acc
+        )
 
       {_, []} ->
         new_acc

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -4,6 +4,7 @@ defmodule Explorer.Chain.CSVExport.Helper do
   """
 
   alias Explorer.{Chain, PagingOptions}
+  alias Explorer.Chain.Hash.Full, as: Hash
   alias NimbleCSV.RFC4180
 
   import Ecto.Query,
@@ -97,10 +98,18 @@ defmodule Explorer.Chain.CSVExport.Helper do
   end
 
   defp is_valid_filter_value(filter_type, filter_value) do
-    if filter_type === "address" do
-      filter_value in supported_address_filter_values()
-    else
-      true
+    case filter_type do
+      "address" ->
+        filter_value in supported_address_filter_values()
+
+      "topic" ->
+        case Hash.cast(filter_value) do
+          {:ok, _} -> true
+          _ -> false
+        end
+
+      _ ->
+        true
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -3,10 +3,16 @@ defmodule Explorer.Chain.CSVExport.Helper do
   CSV export helper functions.
   """
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, PagingOptions}
   alias NimbleCSV.RFC4180
 
+  import Ecto.Query,
+    only: [
+      where: 3
+    ]
+
   @page_size 150
+  @default_paging_options %PagingOptions{page_size: 50}
 
   def dump_to_stream(items) do
     res =
@@ -16,14 +22,68 @@ defmodule Explorer.Chain.CSVExport.Helper do
     res
   end
 
-  def page_size do
-    @page_size
-  end
+  def page_size, do: @page_size
+
+  def default_paging_options, do: @default_paging_options
 
   def block_from_period(from_period, to_period) do
     from_block = Chain.convert_date_to_min_block(from_period)
     to_block = Chain.convert_date_to_max_block(to_period)
 
     {from_block, to_block}
+  end
+
+  def where_address_hash(query, address_hash, filter_type, filter_value) do
+    if filter_type == "address" do
+      case filter_value do
+        "to" -> where_address_hash_to(query, address_hash)
+        "from" -> where_address_hash_from(query, address_hash)
+        _ -> where_address_hash_all(query, address_hash)
+      end
+    else
+      where_address_hash_all(query, address_hash)
+    end
+  end
+
+  defp where_address_hash_to(query, address_hash) do
+    query
+    |> where(
+      [item],
+      item.to_address_hash == ^address_hash
+    )
+  end
+
+  defp where_address_hash_from(query, address_hash) do
+    query
+    |> where(
+      [item],
+      item.from_address_hash == ^address_hash
+    )
+  end
+
+  defp where_address_hash_all(query, address_hash) do
+    query
+    |> where(
+      [item],
+      item.to_address_hash == ^address_hash or
+        item.from_address_hash == ^address_hash or
+        item.token_contract_address_hash == ^address_hash
+    )
+  end
+
+  @spec supported_filters(String.t()) :: [String.t()]
+  def supported_filters(type) do
+    case type do
+      "internal-transactions" -> ["address"]
+      "transactions" -> ["address"]
+      "token-transfers" -> ["address"]
+      "logs" -> ["topic"]
+      _ -> []
+    end
+  end
+
+  @spec is_valid_filter?(String.t(), String.t(), String.t()) :: boolean()
+  def is_valid_filter?(filter_type, filter_value, item_type) do
+    filter_type in supported_filters(item_type) && filter_value && filter_value !== ""
   end
 end

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.CSVExport.Helper do
     ]
 
   @page_size 150
-  @default_paging_options %PagingOptions{page_size: 50}
+  @default_paging_options %PagingOptions{page_size: @page_size}
 
   def dump_to_stream(items) do
     res =

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -82,8 +82,25 @@ defmodule Explorer.Chain.CSVExport.Helper do
     end
   end
 
+  @spec supported_address_filter_values() :: [String.t()]
+  def supported_address_filter_values do
+    ["to", "from"]
+  end
+
   @spec is_valid_filter?(String.t(), String.t(), String.t()) :: boolean()
   def is_valid_filter?(filter_type, filter_value, item_type) do
+    is_valid_filter_type(filter_type, filter_value, item_type) && is_valid_filter_value(filter_type, filter_value)
+  end
+
+  defp is_valid_filter_type(filter_type, filter_value, item_type) do
     filter_type in supported_filters(item_type) && filter_value && filter_value !== ""
+  end
+
+  defp is_valid_filter_value(filter_type, filter_value) do
+    if filter_type === "address" do
+      filter_value in supported_address_filter_values()
+    else
+      true
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -542,15 +542,6 @@ defmodule Explorer.Chain.InternalTransaction do
     where(query, [t], t.from_address_hash == ^address_hash)
   end
 
-  def where_address_fields_match(query, address_hash, nil) do
-    where(
-      query,
-      [it],
-      it.to_address_hash == ^address_hash or it.from_address_hash == ^address_hash or
-        it.created_contract_address_hash == ^address_hash
-    )
-  end
-
   def where_address_fields_match(query, address_hash, :to_address_hash) do
     where(query, [it], it.to_address_hash == ^address_hash)
   end
@@ -561,6 +552,19 @@ defmodule Explorer.Chain.InternalTransaction do
 
   def where_address_fields_match(query, address_hash, :created_contract_address_hash) do
     where(query, [it], it.created_contract_address_hash == ^address_hash)
+  end
+
+  def where_address_fields_match(query, address_hash, _) do
+    base_address_where(query, address_hash)
+  end
+
+  defp base_address_where(query, address_hash) do
+    where(
+      query,
+      [it],
+      it.to_address_hash == ^address_hash or it.from_address_hash == ^address_hash or
+        it.created_contract_address_hash == ^address_hash
+    )
   end
 
   def where_is_different_from_parent_transaction(query) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6041

## Motivation

Applied filters on the items list are not accounted while exporting data to CSV.

## Changelog

Apply selected filters (by address: to/from/created contract or by log topic) to CSV export as well: transactions, token transfers, internal transactions and logs.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
