### PR TITLE
Actualize docker-compose readme and use latest tags instead main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Chore
 
+- [#7449](https://github.com/blockscout/blockscout/pull/7449) - Actualize docker-compose readme and use latest tags instead main
 - [#7417](https://github.com/blockscout/blockscout/pull/7417) - Docker compose for frontend
 - [#7349](https://github.com/blockscout/blockscout/pull/7349) - Proxy pattern with getImplementation()
 - [#7360](https://github.com/blockscout/blockscout/pull/7360) - Manage visibility of indexing progress alert

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -14,11 +14,17 @@ Runs Blockscout locally in Docker containers with [docker-compose](https://githu
 docker-compose up --build
 ```
 
-This command uses by-default `docker-compose.yml`, which builds the explorer into the Docker image and runs 3 Docker containers:
+This command uses by-default `docker-compose.yml`, which builds the explorer into the Docker image and runs 6 Docker containers:
 
 - Postgres 14.x database, which will be available at port 7432 on localhost.
-- [Smart-contract-verifier](https://github.com/blockscout/blockscout-rs/) service, which will be available at port 8043 on localhost.
+- Redis database of latest version, which will be available at port 6379 on localhost.
 - Blockscout explorer at http://localhost:4000.
+
+and 3 Rust microservices:
+
+- [Smart-contract-verifier](https://github.com/blockscout/blockscout-rs/tree/main/smart-contract-verifier) service, which will be available at port 8150 on the host machine.
+- [Sig-provider](https://github.com/blockscout/blockscout-rs/tree/main/sig-provider) service, which will be available at port 8151 on the host machine.
+- [Sol2UML visualizer](https://github.com/blockscout/blockscout-rs/tree/main/visualizer) service, which will be available at port 8152 on the host machine.
 
 Note for Linux users: Linux users need to run the local node on http://0.0.0.0/ rather than http://127.0.0.1/
 
@@ -37,7 +43,7 @@ The repo contains built-in configs for different clients without needing to buil
 - Nethermind, OpenEthereum: `docker-compose -f docker-compose-no-build-nethermind up -d`
 - Ganache: `docker-compose -f docker-compose-no-build-ganache.yml up -d`
 - HardHat network: `docker-compose -f docker-compose-no-build-hardhat-network.yml up -d`
-- Running explorer only without DB: `docker-compose -f docker-compose-no-build-no-db-container.yml up -d`. In this case, one container is created - for the explorer itself. It assumes DB credentials are provided through the `DATABASE_URL` environment variable.
+- Running only explorer without DB: `docker-compose -f docker-compose-no-build-no-db-container.yml up -d`. In this case, one container is created - for the explorer itself. And it assumes that the DB credentials are provided through `DATABASE_URL` environment variable.
 
 All of the configs assume the Ethereum JSON RPC is running at http://localhost:8545.
 

--- a/docker-compose/services/docker-compose-sig-provider.yml
+++ b/docker-compose/services/docker-compose-sig-provider.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   sig-provider:
-    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-main}
+    image: ghcr.io/blockscout/sig-provider:${SIG_PROVIDER_DOCKER_TAG:-latest}
     pull_policy: always
     restart: always
     container_name: 'sig-provider'

--- a/docker-compose/services/docker-compose-smart-contract-verifier.yml
+++ b/docker-compose/services/docker-compose-smart-contract-verifier.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   smart-contract-verifier:
-    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-main}
+    image: ghcr.io/blockscout/smart-contract-verifier:${SMART_CONTRACT_VERIFIER_DOCKER_TAG:-latest}
     pull_policy: always
     restart: always
     container_name: 'smart-contract-verifier'

--- a/docker-compose/services/docker-compose-stats.yml
+++ b/docker-compose/services/docker-compose-stats.yml
@@ -16,7 +16,7 @@ services:
   stats:
     depends_on:
       - stats-db
-    image: ghcr.io/blockscout/stats:${STATS_DOCKER_TAG:-main}
+    image: ghcr.io/blockscout/stats:${STATS_DOCKER_TAG:-latest}
     pull_policy: always
     restart: always
     container_name: 'stats'


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/7440

## Motivation

Actualize docker-compose readme and use `latest` tags for Rust microservices instead `main`. Docs update is in https://github.com/blockscout/docs/pull/154.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
