### PR TITLE
API v2: check base_fee_per_gas property exists before requesting its value for pending tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#7466](https://github.com/blockscout/blockscout/pull/7466) - API v2: check base_fee_per_gas property exists before requesting its value for pending tx
 - [#7391](https://github.com/blockscout/blockscout/pull/7391) - Fix: cannot read properties of null (reading 'value')
 - [#7377](https://github.com/blockscout/blockscout/pull/7377), [#7454](https://github.com/blockscout/blockscout/pull/7454) - API v2 improvements
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -236,7 +236,9 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   defp prepare_transaction(%Transaction{} = transaction, conn, single_tx?, watchlist_names \\ nil) do
-    base_fee_per_gas = transaction.block && transaction.block.base_fee_per_gas
+    base_fee_per_gas =
+      transaction.block && Map.has_key?(transaction.block, :base_fee_per_gas) && transaction.block.base_fee_per_gas
+
     max_priority_fee_per_gas = transaction.max_priority_fee_per_gas
     max_fee_per_gas = transaction.max_fee_per_gas
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7463

## Motivation

when broadcasting pending tx in api v2 through websocket block property doesn't exit. Then we shouldn't request :base_fee_per_gas of block.

## Changelog

Check if the block contains :base_fee_per_gas property before requesting it.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
