### PR TITLE
Refactoring queries with blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Chore
 
+- [#7468](https://github.com/blockscout/blockscout/pull/7468) - Refactoring queries with blocks
 - [#7435](https://github.com/blockscout/blockscout/pull/7435) - Add `.exs` and `.eex` checking in cspell
 - [#7450](https://github.com/blockscout/blockscout/pull/7450) - Resolve unresponsive navbar in verification form page
 - [#7449](https://github.com/blockscout/blockscout/pull/7449) - Actualize docker-compose readme and use latest tags instead main

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1354,9 +1354,9 @@ defmodule Explorer.Chain do
 
           query =
             from(
-              b in Block,
-              join: pending_ops in assoc(b, :pending_operations),
-              where: b.consensus and b.number == ^min_block_number
+              block in Block,
+              join: pending_ops in assoc(block, :pending_operations),
+              where: block.consensus and block.number == ^min_block_number
             )
 
           !select_repo(options).exists?(query)
@@ -2385,7 +2385,7 @@ defmodule Explorer.Chain do
       from(
         block in Block,
         where: block.number in ^block_numbers,
-        where: block.consensus,
+        where: block.consensus == true,
         select: block.number
       )
 

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -175,10 +175,10 @@ defmodule Explorer.Chain.Address.CoinBalance do
 
     from(
       cb in subquery(coin_balance_query),
-      inner_join: b in Block,
-      on: cb.block_number == b.number,
-      where: b.consensus,
-      select: %{timestamp: b.timestamp, value: cb.value}
+      inner_join: block in Block,
+      on: cb.block_number == block.number,
+      where: block.consensus,
+      select: %{timestamp: block.timestamp, value: cb.value}
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -124,8 +124,8 @@ defmodule Explorer.Chain.Block do
   def blocks_without_reward_query do
     consensus_blocks_query =
       from(
-        b in __MODULE__,
-        where: b.consensus == true
+        block in __MODULE__,
+        where: block.consensus == true
       )
 
     validator_rewards =

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -733,7 +733,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         end
       end)
 
-    where(invalid_neighbors_query, [b], b.consensus)
+    where(invalid_neighbors_query, [block], block.consensus)
   end
 
   defp filter_by_min_height(blocks, filter_func) do

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -281,11 +281,11 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
 
     query =
       from(
-        b in Block,
-        where: b.number in ^block_numbers and b.consensus,
-        select: b.hash,
+        block in Block,
+        where: block.number in ^block_numbers and block.consensus,
+        select: block.hash,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
-        order_by: [asc: b.hash],
+        order_by: [asc: block.hash],
         lock: "FOR UPDATE"
       )
 
@@ -671,10 +671,10 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     if Enum.count(invalid_block_numbers) > 0 do
       update_query =
         from(
-          b in Block,
-          where: b.number in ^invalid_block_numbers and b.consensus,
-          where: b.number > ^minimal_block,
-          select: b.hash,
+          block in Block,
+          where: block.number in ^invalid_block_numbers and block.consensus,
+          where: block.number > ^minimal_block,
+          select: block.hash,
           # ShareLocks order already enforced by `acquire_blocks` (see docs: sharelocks.md)
           update: [set: [consensus: false]]
         )

--- a/apps/explorer/lib/explorer/chain/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/withdrawal.ex
@@ -86,7 +86,7 @@ defmodule Explorer.Chain.Withdrawal do
       select: withdrawal,
       left_join: block in assoc(withdrawal, :block),
       where: withdrawal.address_hash == ^address_hash,
-      where: block.consensus,
+      where: block.consensus == true,
       preload: [block: block]
     )
   end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -151,8 +151,8 @@ defmodule Explorer.Etherscan do
 
     consensus_blocks =
       from(
-        b in Block,
-        where: b.consensus == true
+        block in Block,
+        where: block.consensus == true
       )
 
     if direction == nil do

--- a/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
+++ b/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
@@ -53,7 +53,7 @@ defmodule Indexer.Temporary.BlocksTransactionsMismatch do
     query =
       from(block in Block,
         left_join: transactions in assoc(block, :transactions),
-        where: block.consensus and block.refetch_needed,
+        where: block.consensus == true and block.refetch_needed,
         group_by: block.hash,
         select: {block.hash, count(transactions.hash)}
       )

--- a/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
+++ b/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
@@ -51,8 +51,8 @@ defmodule Indexer.Temporary.UnclesWithoutIndex do
   def init(initial, reducer, _) do
     query =
       from(bsdr in SecondDegreeRelation,
-        join: b in assoc(bsdr, :nephew),
-        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and b.consensus,
+        join: block in assoc(bsdr, :nephew),
+        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and block.consensus,
         select: bsdr.nephew_hash,
         group_by: bsdr.nephew_hash
       )


### PR DESCRIPTION
## Motivation

Refactoring for the sake of consistency.

## Changelog

- Use `block` instead `b` in queries
- Set `block.consensus == true` in queries explicitly

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
