### PR TITLE
Clear missing block ranges after every success import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#7355](https://github.com/blockscout/blockscout/pull/7355) - Add endpoint for token info import
 - [#7393](https://github.com/blockscout/blockscout/pull/7393) - Realtime fetcher max gap
 - [#7436](https://github.com/blockscout/blockscout/pull/7436) - TokenBalanceOnDemand ERC-1155 support
+- [#7469](https://github.com/blockscout/blockscout/pull/7469) - Clear missing block ranges after every success import
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -185,6 +185,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
       {:ok, %{inserted: inserted, errors: errors}} ->
         errors = cap_seq(sequence, errors)
         retry(sequence, errors)
+        clear_missing_ranges(range, errors)
 
         {:ok, inserted: inserted}
 
@@ -270,6 +271,14 @@ defmodule Indexer.Block.Catchup.Fetcher do
     |> Enum.map(&push_back(sequence, &1))
   end
 
+  defp clear_missing_ranges(initial_range, errors) do
+    success_numbers = Enum.to_list(initial_range) -- Enum.map(errors, &block_error_to_number/1)
+
+    success_numbers
+    |> numbers_to_ranges()
+    |> Enum.map(&MissingBlockRange.delete_range/1)
+  end
+
   defp block_errors_to_block_number_ranges(block_errors) when is_list(block_errors) do
     block_errors
     |> Enum.map(&block_error_to_number/1)
@@ -295,7 +304,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
         number, range ->
           {:cont, range, number..number}
       end,
-      fn range -> {:cont, range} end
+      fn range -> {:cont, range, nil} end
     )
   end
 


### PR DESCRIPTION
## Motivation

Currently, catchup fetcher clears the batch of `missing_block_ranges` only after the whole batch has been processed. Since this batch can contain a large amount of blocks, it can take a lot of time for process and, if there will be any error on import (such as db disconnect), the batch will not be cleared, and therefore, the same batch will be processed on the next step.

## Changelog

Clear batch after every successful import