### PR TITLE
Fix RE_CAPTCHA_DISABLED variable parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#7472](https://github.com/blockscout/blockscout/pull/7472) - Fix RE_CAPTCHA_DISABLED variable parsing
 - [#7391](https://github.com/blockscout/blockscout/pull/7391) - Fix: cannot read properties of null (reading 'value')
 - [#7377](https://github.com/blockscout/blockscout/pull/7377), [#7454](https://github.com/blockscout/blockscout/pull/7454) - API v2 improvements
 

--- a/apps/block_scout_web/assets/js/lib/csv_download.js
+++ b/apps/block_scout_web/assets/js/lib/csv_download.js
@@ -33,7 +33,8 @@ $button.on('click', () => {
   const reCaptchaV3ClientKey = document.getElementById('js-re-captcha-v3-client-key').value
   // @ts-ignore
   // eslint-disable-next-line
-  const reCaptchaDisabled = document.getElementById('js-re-captcha-disabled').value
+  const reCaptchaDisabledRaw = document.getElementById('js-re-captcha-disabled').value
+  const reCaptchaDisabled = reCaptchaDisabledRaw && reCaptchaDisabledRaw.toLowerCase() === 'true'
   const addressHash = $button.data('address-hash')
   const from = $('.js-datepicker-from').val()
   const to = $('.js-datepicker-to').val()


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7470#issuecomment-1545863177

## Motivation

RE_CAPTCHA_DISABLED is incorrectly parsed in JS.

## Changelog

Convert string into boolean in the parsing of RE_CAPTCHA_DISABLED env variable in JS.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
