### PR TITLE
Websocket v2 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - [#7490](https://github.com/blockscout/blockscout/pull/7490) - Fix pending txs is not a map
+- [#7474](https://github.com/blockscout/blockscout/pull/7474) - Websocket v2 improvements
 - [#7472](https://github.com/blockscout/blockscout/pull/7472) - Fix RE_CAPTCHA_DISABLED variable parsing
 - [#7391](https://github.com/blockscout/blockscout/pull/7391) - Fix: cannot read properties of null (reading 'value')
 - [#7377](https://github.com/blockscout/blockscout/pull/7377), [#7454](https://github.com/blockscout/blockscout/pull/7454) - API v2 improvements

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -267,18 +267,23 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   def handle_transaction(
-        %{address: _address, transaction: transaction},
+        %{transactions: transactions},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket,
         event
-      ) do
-    transaction_json = TransactionViewAPI.render("transaction.json", %{transaction: transaction, conn: nil})
+      )
+      when is_list(transactions) do
+    transaction_json = TransactionViewAPI.render("transactions.json", %{transactions: transactions, conn: nil})
 
-    push(socket, event, %{transaction: transaction_json})
+    push(socket, event, %{transactions: transaction_json})
 
     {:noreply, socket}
   end
 
-  def handle_transaction(%{address: address, transaction: transaction}, socket, event) do
+  def handle_transaction(
+        %{address: address, transaction: transaction},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocket} = socket,
+        event
+      ) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
     rendered =
@@ -298,6 +303,10 @@ defmodule BlockScoutWeb.AddressChannel do
       transaction_html: rendered
     })
 
+    {:noreply, socket}
+  end
+
+  def handle_transaction(_, socket, _event) do
     {:noreply, socket}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -311,18 +311,24 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   def handle_token_transfer(
-        %{address: _address, token_transfer: token_transfer},
+        %{token_transfers: token_transfers},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket,
         event
-      ) do
-    token_transfer_json = TransactionViewAPI.render("token_transfer.json", %{token_transfer: token_transfer, conn: nil})
+      )
+      when is_list(token_transfers) do
+    token_transfer_json =
+      TransactionViewAPI.render("token_transfers.json", %{token_transfers: token_transfers, conn: nil})
 
-    push(socket, event, %{token_transfer: token_transfer_json})
+    push(socket, event, %{token_transfers: token_transfer_json})
 
     {:noreply, socket}
   end
 
-  def handle_token_transfer(%{address: address, token_transfer: token_transfer}, socket, event) do
+  def handle_token_transfer(
+        %{address: address, token_transfer: token_transfer},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocket} = socket,
+        event
+      ) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
     transaction =
@@ -353,6 +359,10 @@ defmodule BlockScoutWeb.AddressChannel do
       token_transfer_html: rendered
     })
 
+    {:noreply, socket}
+  end
+
+  def handle_token_transfer(_, socket, _event) do
     {:noreply, socket}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/token_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/token_channel.ex
@@ -21,15 +21,20 @@ defmodule BlockScoutWeb.TokenChannel do
 
   def handle_out(
         "token_transfer",
-        %{token_transfer: _token_transfer},
+        %{token_transfers: token_transfers},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
-      ) do
-    push(socket, "token_transfer", %{token_transfer: 1})
+      )
+      when is_list(token_transfers) do
+    push(socket, "token_transfer", %{token_transfer: Enum.count(token_transfers)})
 
     {:noreply, socket}
   end
 
-  def handle_out("token_transfer", %{token_transfer: token_transfer}, socket) do
+  def handle_out(
+        "token_transfer",
+        %{token_transfer: token_transfer},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocket} = socket
+      ) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
     rendered_token_transfer =
@@ -47,6 +52,10 @@ defmodule BlockScoutWeb.TokenChannel do
       token_transfer_html: rendered_token_transfer
     })
 
+    {:noreply, socket}
+  end
+
+  def handle_out("token_transfer", _, socket) do
     {:noreply, socket}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
@@ -33,15 +33,20 @@ defmodule BlockScoutWeb.TransactionChannel do
 
   def handle_out(
         "pending_transaction",
-        %{transaction: _transaction},
+        %{transactions: transactions},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
-      ) do
-    push(socket, "pending_transaction", %{pending_transaction: 1})
+      )
+      when is_list(transactions) do
+    push(socket, "pending_transaction", %{pending_transaction: Enum.count(transactions)})
 
     {:noreply, socket}
   end
 
-  def handle_out("pending_transaction", %{transaction: transaction}, socket) do
+  def handle_out(
+        "pending_transaction",
+        %{transaction: transaction},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocket} = socket
+      ) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
     rendered_transaction =
@@ -61,17 +66,26 @@ defmodule BlockScoutWeb.TransactionChannel do
     {:noreply, socket}
   end
 
+  def handle_out("pending_transaction", _, socket) do
+    {:noreply, socket}
+  end
+
   def handle_out(
         "transaction",
-        %{transaction: _transaction},
+        %{transactions: transactions},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
-      ) do
-    push(socket, "transaction", %{transaction: 1})
+      )
+      when is_list(transactions) do
+    push(socket, "transaction", %{transactions: Enum.count(transactions)})
 
     {:noreply, socket}
   end
 
-  def handle_out("transaction", %{transaction: transaction}, socket) do
+  def handle_out(
+        "transaction",
+        %{transaction: transaction},
+        %Phoenix.Socket{handler: BlockScoutWeb.UserSocket} = socket
+      ) do
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
     rendered_transaction =
@@ -88,6 +102,10 @@ defmodule BlockScoutWeb.TransactionChannel do
       transaction_html: rendered_transaction
     })
 
+    {:noreply, socket}
+  end
+
+  def handle_out("transaction", _, socket) do
     {:noreply, socket}
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
@@ -76,7 +76,7 @@ defmodule BlockScoutWeb.TransactionChannel do
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
       )
       when is_list(transactions) do
-    push(socket, "transaction", %{transactions: Enum.count(transactions)})
+    push(socket, "transaction", %{transaction: Enum.count(transactions)})
 
     {:noreply, socket}
   end

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.Endpoint do
   end
 
   socket("/socket", BlockScoutWeb.UserSocket, websocket: [timeout: 45_000])
-  socket("/socket/v2", BlockScoutWeb.UserSocketV2, websocket: [timeout: :infinity])
+  socket("/socket/v2", BlockScoutWeb.UserSocketV2, websocket: [timeout: 45_000])
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.Endpoint do
   end
 
   socket("/socket", BlockScoutWeb.UserSocket, websocket: [timeout: 45_000])
-  socket("/socket/v2", BlockScoutWeb.UserSocketV2, websocket: [timeout: 45_000])
+  socket("/socket/v2", BlockScoutWeb.UserSocketV2, websocket: [timeout: :infinity])
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/address_channel_test.exs
@@ -80,7 +80,11 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [pending]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload},
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "pending_transaction",
+                       payload: %{transaction: _} = payload
+                     },
                      :timer.seconds(5)
 
       assert payload.address.hash == address.hash
@@ -95,7 +99,13 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "transaction",
+                       payload: %{transaction: _} = payload
+                     },
+                     :timer.seconds(5)
+
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
     end
@@ -108,7 +118,13 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "transaction",
+                       payload: %{transaction: _} = payload
+                     },
+                     :timer.seconds(5)
+
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
     end
@@ -121,11 +137,19 @@ defmodule BlockScoutWeb.AddressChannelTest do
 
       Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
 
-      assert_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload}, :timer.seconds(5)
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "transaction",
+                       payload: %{transaction: _} = payload
+                     },
+                     :timer.seconds(5)
+
       assert payload.address.hash == address.hash
       assert payload.transaction.hash == transaction.hash
 
-      refute_receive _, 100, "Received duplicate broadcast."
+      refute_receive %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: %{transaction: _}},
+                     100,
+                     "Received duplicate broadcast."
     end
 
     test "notified of new_internal_transaction for matching from_address", %{address: address, topic: topic} do

--- a/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/transaction_channel_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.TransactionChannelTest do
   use BlockScoutWeb.ChannelCase
 
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Hash, Import, Transaction}
   alias BlockScoutWeb.Notifier
 
   test "subscribed user is notified of new_transaction topic" do
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.TransactionChannelTest do
     Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
 
     receive do
-      %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: payload} ->
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "transaction", payload: %{transaction: _transaction} = payload} ->
         assert payload.transaction.hash == transaction.hash
     after
       :timer.seconds(5) ->
@@ -33,7 +33,11 @@ defmodule BlockScoutWeb.TransactionChannelTest do
     Notifier.handle_event({:chain_event, :transactions, :realtime, [pending]})
 
     receive do
-      %Phoenix.Socket.Broadcast{topic: ^topic, event: "pending_transaction", payload: payload} ->
+      %Phoenix.Socket.Broadcast{
+        topic: ^topic,
+        event: "pending_transaction",
+        payload: %{transaction: _transaction} = payload
+      } ->
         assert payload.transaction.hash == pending.hash
     after
       :timer.seconds(5) ->

--- a/apps/block_scout_web/test/block_scout_web/channels/websocket_v2_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/websocket_v2_test.exs
@@ -1,0 +1,393 @@
+defmodule BlockScoutWeb.WebsocketV2Test do
+  use BlockScoutWeb.ChannelCase, async: false
+
+  alias BlockScoutWeb.Notifier
+  alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Chain.{Address, Import, InternalTransaction, Log, Token, TokenTransfer, Transaction}
+  alias Explorer.Repo
+
+  describe "websocket v2" do
+    @import_data %{
+      blocks: %{
+        params: [
+          %{
+            consensus: true,
+            difficulty: 340_282_366_920_938_463_463_374_607_431_768_211_454,
+            gas_limit: 6_946_336,
+            gas_used: 50450,
+            hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            miner_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            nonce: 0,
+            number: 37,
+            parent_hash: "0xc37bbad7057945d1bf128c1ff009fb1ad632110bf6a000aac025a80f7766b66e",
+            size: 719,
+            timestamp: Timex.parse!("2017-12-15T21:06:30.000000Z", "{ISO:Extended:Z}"),
+            total_difficulty: 12_590_447_576_074_723_148_144_860_474_975_121_280_509
+          }
+        ],
+        timeout: 5
+      },
+      broadcast: :realtime,
+      logs: %{
+        params: [
+          %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            fourth_topic: nil,
+            index: 0,
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
+            type: "mined"
+          },
+          %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            fourth_topic: nil,
+            index: 1,
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
+            type: "mined"
+          },
+          %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            fourth_topic: nil,
+            index: 2,
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
+            type: "mined"
+          }
+        ],
+        timeout: 5
+      },
+      transactions: %{
+        params: [
+          %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            block_number: 37,
+            cumulative_gas_used: 50450,
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            gas: 4_700_000,
+            gas_price: 100_000_000_000,
+            gas_used: 50450,
+            hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
+            index: 0,
+            input: "0x10855269000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
+            nonce: 4,
+            public_key:
+              "0xe5d196ad4ceada719d9e592f7166d0c75700f6eab2e3c3de34ba751ea786527cb3f6eb96ad9fdfdb9989ff572df50f1c42ef800af9c5207a38b929aff969b5c9",
+            r: 0xA7F8F45CCE375BB7AF8750416E1B03E0473F93C256DA2285D1134FC97A700E01,
+            s: 0x1F87A076F13824F4BE8963E3DFFD7300DAE64D5F23C9A062AF0C6EAD347C135F,
+            standard_v: 1,
+            status: :ok,
+            to_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            v: 0xBE,
+            value: 0
+          },
+          %{
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            block_number: 37,
+            cumulative_gas_used: 50450,
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            gas: 4_700_000,
+            gas_price: 100_000_000_000,
+            gas_used: 50450,
+            hash: "0x00bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e1",
+            index: 1,
+            input: "0x10855269000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
+            nonce: 5,
+            public_key:
+              "0xe5d196ad4ceada719d9e592f7166d0c75700f6eab2e3c3de34ba751ea786527cb3f6eb96ad9fdfdb9989ff572df50f1c42ef800af9c5207a38b929aff969b5c9",
+            r: 0xA7F8F45CCE375BB7AF8750416E1B03E0473F93C256DA2285D1134FC97A700E09,
+            s: 0x1F87A076F13824F4BE8963E3DFFD7300DAE64D5F23C9A062AF0C6EAD347C1354,
+            standard_v: 1,
+            status: :ok,
+            to_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            v: 0xBE,
+            value: 0
+          },
+          %{
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            gas: 4_700_000,
+            gas_price: 100_000_000_000,
+            hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e0",
+            input: "0x10855269000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
+            nonce: 6,
+            public_key:
+              "0xe5d196ad4ceada719d9e592f7166d0c75700f6eab2e3c3de34ba751ea786527cb3f6eb96ad9fdfdb9989ff572df50f1c42ef800af9c5207a38b929aff969b5c9",
+            r: 0xA7F8F45CCE375BB7AF8750416E1B03E0473F93C256DA2285D1134FC97A700E09,
+            s: 0x1F87A076F13824F4BE8963E3DFFD7300DAE64D5F23C9A062AF0C6EAD347C1354,
+            standard_v: 1,
+            to_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            v: 0xBE,
+            value: 0
+          },
+          %{
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            gas: 4_700_000,
+            gas_price: 100_000_000_000,
+            hash: "0x00bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd43312",
+            input: "0x10855269000000000000000000000000862d67cb0773ee3f8ce7ea89b328ffea861ab3ef",
+            nonce: 7,
+            public_key:
+              "0xe5d196ad4ceada719d9e592f7166d0c75700f6eab2e3c3de34ba751ea786527cb3f6eb96ad9fdfdb9989ff572df50f1c42ef800af9c5207a38b929aff969b5c9",
+            r: 0xA7F8F45CCE375BB7AF8750416E1B03E0473F93C256DA2285D1134FC97A700E09,
+            s: 0x1F87A076F13824F4BE8963E3DFFD7300DAE64D5F23C9A062AF0C6EAD347C1354,
+            standard_v: 1,
+            to_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            v: 0xBE,
+            value: 0
+          }
+        ],
+        timeout: 5
+      },
+      addresses: %{
+        params: [
+          %{hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"},
+          %{hash: "0x00f38d4764929064f2d4d3a56520a76ab3df4151"},
+          %{hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"},
+          %{hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"}
+        ],
+        timeout: 5
+      },
+      tokens: %{
+        on_conflict: :nothing,
+        params: [
+          %{
+            contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            type: "ERC-20"
+          },
+          %{
+            contract_address_hash: "0x00f38d4764929064f2d4d3a56520a76ab3df4151",
+            type: "ERC-20"
+          }
+        ],
+        timeout: 5
+      },
+      token_transfers: %{
+        params: [
+          %{
+            amount: Decimal.new(1_000_000_000_000_000_000),
+            block_number: 37,
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            log_index: 0,
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            to_address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5"
+          },
+          %{
+            amount: Decimal.new(1_000_000_000_000_000_000),
+            block_number: 37,
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            log_index: 1,
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            to_address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5"
+          },
+          %{
+            amount: Decimal.new(1_000_000_000_000_000_000),
+            block_number: 37,
+            block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
+            log_index: 2,
+            from_address_hash: "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
+            to_address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            token_contract_address_hash: "0x00f38d4764929064f2d4d3a56520a76ab3df4151",
+            transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5"
+          }
+        ],
+        timeout: 5
+      }
+    }
+
+    test "broadcasted several transactions in one message" do
+      topic = "transactions:new_transaction"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic)
+
+      topic_pending = "transactions:new_pending_transaction"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic_pending)
+
+      Subscriber.to(:transactions, :realtime)
+      Import.all(@import_data)
+      assert_receive {:chain_event, :transactions, :realtime, txs}, :timer.seconds(5)
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, txs})
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{transaction: 2},
+                       event: "transaction",
+                       topic: ^topic
+                     },
+                     :timer.seconds(5)
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{pending_transaction: 2},
+                       event: "pending_transaction",
+                       topic: ^topic_pending
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "broadcast token transfers" do
+      topic_token = "tokens:0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic_token)
+
+      Subscriber.to(:token_transfers, :realtime)
+
+      Import.all(@import_data)
+
+      assert_receive {:chain_event, :token_transfers, :realtime, token_transfers}, :timer.seconds(5)
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, token_transfers})
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{token_transfer: 2},
+                       event: "token_transfer",
+                       topic: ^topic_token
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "broadcast array of txs to address" do
+      topic = "addresses:0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic)
+
+      Subscriber.to(:transactions, :realtime)
+      Import.all(@import_data)
+
+      assert_receive {:chain_event, :transactions, :realtime, txs}, :timer.seconds(5)
+      Notifier.handle_event({:chain_event, :transactions, :realtime, txs})
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{transactions: [tx_1, tx_2]},
+                       event: "transaction",
+                       topic: ^topic
+                     },
+                     :timer.seconds(5)
+
+      tx_1 = tx_1 |> Jason.encode!() |> Jason.decode!()
+      compare_item(Repo.get_by(Transaction, %{hash: tx_1["hash"]}), tx_1)
+
+      tx_2 = tx_2 |> Jason.encode!() |> Jason.decode!()
+      compare_item(Repo.get_by(Transaction, %{hash: tx_2["hash"]}), tx_2)
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{transactions: [tx_1, tx_2]},
+                       event: "pending_transaction",
+                       topic: ^topic
+                     },
+                     :timer.seconds(5)
+
+      tx_1 = tx_1 |> Jason.encode!() |> Jason.decode!()
+      compare_item(Repo.get_by(Transaction, %{hash: tx_1["hash"]}), tx_1)
+
+      tx_2 = tx_2 |> Jason.encode!() |> Jason.decode!()
+      compare_item(Repo.get_by(Transaction, %{hash: tx_2["hash"]}), tx_2)
+    end
+
+    test "broadcast array of transfers to address" do
+      topic = "addresses:0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic)
+
+      topic_1 = "addresses:0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic_1)
+
+      Subscriber.to(:token_transfers, :realtime)
+      Import.all(@import_data)
+
+      assert_receive {:chain_event, :token_transfers, :realtime, token_transfers}, :timer.seconds(5)
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, token_transfers})
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{token_transfers: [_, _, _] = transfers},
+                       event: "token_transfer",
+                       topic: ^topic
+                     },
+                     :timer.seconds(5)
+
+      token_transfers
+      |> Enum.zip(transfers)
+      |> Enum.each(fn {transfer, json} -> compare_item(transfer, json |> Jason.encode!() |> Jason.decode!()) end)
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{token_transfers: [_, _, _] = transfers},
+                       event: "token_transfer",
+                       topic: ^topic_1
+                     },
+                     :timer.seconds(5)
+
+      token_transfers
+      |> Enum.zip(transfers)
+      |> Enum.each(fn {transfer, json} -> compare_item(transfer, json |> Jason.encode!() |> Jason.decode!()) end)
+    end
+  end
+
+  defp compare_item(%TokenTransfer{} = token_transfer, json) do
+    assert Address.checksum(token_transfer.from_address_hash) == json["from"]["hash"]
+    assert Address.checksum(token_transfer.to_address_hash) == json["to"]["hash"]
+    assert to_string(token_transfer.transaction_hash) == json["tx_hash"]
+    assert json["timestamp"] != nil
+    assert json["method"] != nil
+    assert to_string(token_transfer.block_hash) == json["block_hash"]
+    assert to_string(token_transfer.log_index) == json["log_index"]
+    assert check_total(Repo.preload(token_transfer, [{:token, :contract_address}]).token, json["total"], token_transfer)
+  end
+
+  defp compare_item(%Transaction{} = transaction, json) do
+    assert to_string(transaction.hash) == json["hash"]
+    assert transaction.block_number == json["block"]
+    assert to_string(transaction.value.value) == json["value"]
+    assert Address.checksum(transaction.from_address_hash) == json["from"]["hash"]
+    assert Address.checksum(transaction.to_address_hash) == json["to"]["hash"]
+  end
+
+  defp check_total(%Token{type: nft}, json, token_transfer) when nft in ["ERC-1155"] do
+    json["token_id"] in Enum.map(token_transfer.token_ids, fn x -> to_string(x) end) and
+      json["value"] == to_string(token_transfer.amount)
+  end
+
+  defp check_total(%Token{type: nft}, json, token_transfer) when nft in ["ERC-721"] do
+    json["token_id"] in Enum.map(token_transfer.token_ids, fn x -> to_string(x) end)
+  end
+
+  # with the current implementation no transfers should come with list in totals
+  defp check_total(%Token{type: nft}, json, _token_transfer) when nft in ["ERC-721", "ERC-1155"] and is_list(json) do
+    false
+  end
+
+  defp check_total(_, _, _), do: true
+end


### PR DESCRIPTION
Close #7202 

## Changelog
- Now websocket v2 groups and sends several updates in one message (for transactions and token transfers)

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
