### PR TITLE
Fix pending txs is not a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#7490](https://github.com/blockscout/blockscout/pull/7490) - Fix pending txs is not a map
 - [#7472](https://github.com/blockscout/blockscout/pull/7472) - Fix RE_CAPTCHA_DISABLED variable parsing
 - [#7391](https://github.com/blockscout/blockscout/pull/7391) - Fix: cannot read properties of null (reading 'value')
 - [#7377](https://github.com/blockscout/blockscout/pull/7377), [#7454](https://github.com/blockscout/blockscout/pull/7454) - API v2 improvements

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/pending_transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/pending_transaction.ex
@@ -13,7 +13,8 @@ defmodule EthereumJSONRPC.PendingTransaction do
           {:ok, [Transaction.params()]} | {:error, reason :: term}
   def fetch_pending_transactions_geth(json_rpc_named_arguments) do
     with {:ok, transaction_data} <-
-           %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments) do
+           %{id: 1, method: "txpool_content", params: []} |> request() |> json_rpc(json_rpc_named_arguments),
+         {:transaction_data_is_map, true} <- {:transaction_data_is_map, is_map(transaction_data)} do
       transactions_params =
         transaction_data["pending"]
         |> Enum.flat_map(fn {_address, nonce_transactions_map} ->
@@ -31,6 +32,9 @@ defmodule EthereumJSONRPC.PendingTransaction do
         end)
 
       {:ok, transactions_params}
+    else
+      {:error, _} = error -> error
+      {:transaction_data_is_map, false} -> {:ok, []}
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7483

## Motivation

`txpool_content` may return a list instead of a map in the result (LightLink example, see linked issue).

## Changelog

Check if a map is returned from the node in `fetch_pending_transactions_geth` function

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
