### PR TITLE
API v2: Pass backend version to the frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Chore
 
+- [#7496](https://github.com/blockscout/blockscout/pull/7496) - API v2: Pass backend version to the frontend
 - [#7468](https://github.com/blockscout/blockscout/pull/7468) - Refactoring queries with blocks
 - [#7435](https://github.com/blockscout/blockscout/pull/7435) - Add `.exs` and `.eex` checking in cspell
 - [#7450](https://github.com/blockscout/blockscout/pull/7450) - Resolve unresponsive navbar in verification form page

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -128,6 +128,7 @@ defmodule BlockScoutWeb.ApiRouter do
 
     scope "/config" do
       get("/json-rpc-url", V2.ConfigController, :json_rpc_url)
+      get("/backend-version", V2.ConfigController, :backend_version)
     end
 
     scope "/transactions" do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -8,4 +8,12 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
     |> put_status(200)
     |> render(:json_rpc_url, %{url: json_rpc_url})
   end
+
+  def backend_version(conn, _params) do
+    backend_version = Application.get_env(:block_scout_web, :version)
+
+    conn
+    |> put_status(200)
+    |> render(:backend_version, %{version: backend_version})
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/config_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/config_view.ex
@@ -4,4 +4,10 @@ defmodule BlockScoutWeb.API.V2.ConfigView do
       "json_rpc_url" => url
     }
   end
+
+  def render("backend_version.json", %{version: version}) do
+    %{
+      "backend_version" => version
+    }
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7484

## Changelog

```
/api/v2/config/backend-version
```

Response example:
```
{
    "backend_version": "v5.1.4-beta"
}
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
