### PR TITLE
Add polygon edge support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current
 
 ### Features
+- [#7513](https://github.com/blockscout/blockscout/pull/7513) - Add Polygon Edge support
 
 ### Fixes
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -8,7 +8,7 @@ defmodule EthereumJSONRPC.Geth do
   import EthereumJSONRPC, only: [id_to_params: 1, integer_to_quantity: 1, json_rpc: 2, request: 1]
 
   alias EthereumJSONRPC.{FetchedBalance, FetchedCode, PendingTransaction, Utility.CommonHelper}
-  alias EthereumJSONRPC.Geth.{Calls, Tracer}
+  alias EthereumJSONRPC.Geth.{Calls, PolygonTracer, Tracer}
 
   @behaviour EthereumJSONRPC.Variant
 
@@ -94,14 +94,25 @@ defmodule EthereumJSONRPC.Geth do
 
     tracer =
       case Application.get_env(:ethereum_jsonrpc, __MODULE__)[:tracer] do
-        "js" -> @tracer
-        "call_tracer" -> "callTracer"
+        "js" ->
+          %{"tracer" => @tracer}
+
+        "call_tracer" ->
+          %{"tracer" => "callTracer"}
+
+        _ ->
+          %{
+            "enableMemory" => true,
+            "disableStack" => false,
+            "disableStorage" => true,
+            "enableReturnData" => false
+          }
       end
 
     request(%{
       id: id,
       method: "debug_traceTransaction",
-      params: [hash_data, %{tracer: tracer, timeout: debug_trace_transaction_timeout}]
+      params: [hash_data, %{timeout: debug_trace_transaction_timeout} |> Map.merge(tracer)]
     })
   end
 
@@ -126,10 +137,15 @@ defmodule EthereumJSONRPC.Geth do
       receipts_map = Enum.into(receipts, %{}, fn %{id: id, result: receipt} -> {id, receipt} end)
       txs_map = Enum.into(txs, %{}, fn %{id: id, result: tx} -> {id, tx} end)
 
+      tracer =
+        if Application.get_env(:ethereum_jsonrpc, __MODULE__)[:tracer] == "polygon_edge",
+          do: PolygonTracer,
+          else: Tracer
+
       responses
       |> Enum.map(fn %{id: id, result: %{"structLogs" => _} = result} ->
         debug_trace_transaction_response_to_internal_transactions_params(
-          %{id: id, result: Tracer.replay(result, Map.fetch!(receipts_map, id), Map.fetch!(txs_map, id))},
+          %{id: id, result: tracer.replay(result, Map.fetch!(receipts_map, id), Map.fetch!(txs_map, id))},
           id_to_params
         )
       end)
@@ -158,7 +174,7 @@ defmodule EthereumJSONRPC.Geth do
              {id, %{created_contract_address_hash: address, block_number: block_number}} ->
                FetchedCode.request(%{id: id, block_quantity: integer_to_quantity(block_number), address: address})
 
-             {id, %{type: "selfdestruct", from: hash_data, block_number: block_number}} ->
+             {id, %{type: "selfdestruct", from_address_hash: hash_data, block_number: block_number}} ->
                FetchedBalance.request(%{id: id, block_quantity: integer_to_quantity(block_number), hash_data: hash_data})
 
              _ ->
@@ -244,7 +260,7 @@ defmodule EthereumJSONRPC.Geth do
   def prepare_calls(calls) do
     case Application.get_env(:ethereum_jsonrpc, __MODULE__)[:tracer] do
       "call_tracer" -> {calls, 0} |> parse_call_tracer_calls([], [], false) |> Enum.reverse()
-      "js" -> calls
+      _ -> calls
     end
   end
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -558,6 +558,7 @@ defmodule Indexer.Block.Fetcher do
            hash: hash
          } = address_params
        ) do
-    {{hash, fetched_coin_balance_block_number}, Map.delete(address_params, :fetched_coin_balance_block_number)}
+    {{String.downcase(hash), fetched_coin_balance_block_number},
+     Map.delete(address_params, :fetched_coin_balance_block_number)}
   end
 end

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -485,7 +485,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
             block_number
 
           _ ->
-            Map.fetch!(address_hash_to_block_number, address_hash)
+            Map.fetch!(address_hash_to_block_number, String.downcase(address_hash))
         end
 
       %{hash_data: address_hash, block_quantity: integer_to_quantity(block_number)}

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -220,7 +220,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
     address_hash_to_block_number =
       Enum.into(addresses_params, %{}, fn %{fetched_coin_balance_block_number: block_number, hash: hash} ->
-        {hash, block_number}
+        {String.downcase(hash), block_number}
       end)
 
     empty_block_numbers =


### PR DESCRIPTION
Fix #7090 

## Motivation

It turned out that Polygon edge trace is very different from geth trace, so it does not work now

## Changelog

Added separate tracer for geth to work with polygon.

There are some limitations:
- call ops are very strange in polygon edge, example:
```
{
                "pc": 3132,
                "op": "CALL",
                "gas": 492083345,
                "gasCost": 7400,
                "depth": 2,
                "stack": [],
                "memory": [],
                "storage": {}
}
```
so, `to` field in these cases is `0x0000000000000000000000000000000000000000`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs (https://github.com/blockscout/docs/pull/158)
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
