### PR TITLE
Fix shrinking logo in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari
+
 ### Chore
 
 <details>

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -12,7 +12,7 @@ $header-textfield-background-color: #f5f6fa !default;
 $header-textfield-magnifier-color: $header-links-color !default;
 $header-link-horizontal-padding: 0.71rem;
 $navbar-logo-height: auto !default;
-$navbar-logo-width: 100% !default;
+$navbar-logo-width: auto !default;
 $header-logo-text-color: #333 !default;
 
 .navbar.navbar-primary {


### PR DESCRIPTION
Part of #6437 

## Motivation

.png images were shrinking in Safari browser

## Changelog

Changed default `width` value for logo from `100%` to `auto`

before:
<img width="892" alt="image" src="https://github.com/blockscout/blockscout/assets/53992153/51d1a933-ddeb-4d73-b404-a91016aec3ac">
after:
<img width="888" alt="image" src="https://github.com/blockscout/blockscout/assets/53992153/61248989-9ffa-40b9-8f02-2eb64bb08263">



## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
