### PR TITLE
Withdrawals fixes and improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Fixes
 
-- [](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)
+- [#7537](https://github.com/blockscout/blockscout/pull/7537) - Withdrawals fixes and improvements
+- [#7546](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)
 - [#7545](https://github.com/blockscout/blockscout/pull/7545) - API v2: Check if cached exchange rate is empty before replacing DB value in stats API
 - [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -35,7 +35,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       :uncles => :optional,
       :nephews => :optional,
       :rewards => :optional,
-      :transactions => :optional
+      :transactions => :optional,
+      :withdrawals => :optional
     },
     api?: true
   ]

--- a/apps/block_scout_web/lib/block_scout_web/templates/withdrawal/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/withdrawal/index.html.eex
@@ -8,7 +8,7 @@
         <%= render BlockScoutWeb.CommonComponentsView, "_pagination_container.html", position: "top", cur_page_number: @page_number, show_pagination_limit: true, data_next_page_button: true, data_prev_page_button: true %>
       </div>
       
-      <p><%= gettext("There are %{withdrawals_count} withdrawals total that withdrawn %{withdrawals_sum}", withdrawals_count: BlockScoutWeb.Cldr.Number.to_string!(@withdrawals_count, format: "#,###"), withdrawals_sum: format_wei_value(@withdrawals_sum, :ether)) %></p> 
+      <p><%= gettext("%{withdrawals_count} withdrawals processed and %{withdrawals_sum} withdrawn.", withdrawals_count: BlockScoutWeb.Cldr.Number.to_string!(@withdrawals_count, format: "#,###"), withdrawals_sum: format_wei_value(@withdrawals_sum, :ether)) %></p> 
 
       <button data-error-message class="alert alert-danger col-12 text-left" style="display: none;">
         <span href="#" class="alert-link"><%= gettext("Something went wrong, click to reload.") %></span>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -7,8 +7,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   alias Explorer.Chain.Block
   alias Explorer.Counters.BlockPriorityFeeCounter
 
-  @api_true [api?: true]
-
   def render("message.json", assigns) do
     ApiView.render("message.json", assigns)
   end
@@ -61,8 +59,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "burnt_fees_percentage" => burnt_fees_percentage(burned_fee, tx_fees),
       "type" => block |> BlockView.block_type() |> String.downcase(),
       "tx_fees" => tx_fees,
-      "has_beacon_chain_withdrawals" =>
-        if(single_block?, do: Chain.check_if_withdrawals_in_block(block.hash, @api_true), else: nil)
+      "withdrawals_count" => count_withdrawals(block)
     }
   end
 
@@ -107,4 +104,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
 
   def count_transactions(%Block{transactions: txs}) when is_list(txs), do: Enum.count(txs)
   def count_transactions(_), do: nil
+
+  def count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
+  def count_withdrawals(_), do: nil
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -2642,11 +2642,6 @@ msgstr ""
 msgid "The total gas amount used in the block and its percentage of gas filled in the block."
 msgstr ""
 
-#: lib/block_scout_web/templates/withdrawal/index.html.eex:11
-#, elixir-autogen, elixir-format
-msgid "There are %{withdrawals_count} withdrawals total that withdrawn %{withdrawals_sum}"
-msgstr ""
-
 #: lib/block_scout_web/templates/address_validation/index.html.eex:16
 #, elixir-autogen, elixir-format
 msgid "There are no blocks validated by this address."
@@ -3663,4 +3658,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:5
 #, elixir-autogen, elixir-format
 msgid "New Smart Contract Verification via metadata JSON"
+msgstr ""
+
+#: lib/block_scout_web/templates/withdrawal/index.html.eex:11
+#, elixir-autogen, elixir-format
+msgid "%{withdrawals_count} withdrawals processed and %{withdrawals_sum} withdrawn."
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -2642,11 +2642,6 @@ msgstr ""
 msgid "The total gas amount used in the block and its percentage of gas filled in the block."
 msgstr ""
 
-#: lib/block_scout_web/templates/withdrawal/index.html.eex:11
-#, elixir-autogen, elixir-format
-msgid "There are %{withdrawals_count} withdrawals total that withdrawn %{withdrawals_sum}"
-msgstr ""
-
 #: lib/block_scout_web/templates/address_validation/index.html.eex:16
 #, elixir-autogen, elixir-format
 msgid "There are no blocks validated by this address."
@@ -3663,4 +3658,9 @@ msgstr ""
 #: lib/block_scout_web/templates/address_contract_verification_via_json/new.html.eex:5
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New Smart Contract Verification via metadata JSON"
+msgstr ""
+
+#: lib/block_scout_web/templates/withdrawal/index.html.eex:11
+#, elixir-autogen, elixir-format, fuzzy
+msgid "%{withdrawals_count} withdrawals processed and %{withdrawals_sum} withdrawn."
 msgstr ""

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawal.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawal.ex
@@ -45,7 +45,7 @@ defmodule EthereumJSONRPC.Withdrawal do
       ...> )
       %{
         address_hash: "0x388ea662ef2c223ec0b047d41bf3c0f362142ad5",
-        amount: 4040000000000,
+        amount: 4040000000000000000000,
         block_hash: "0x7f035c5f3c0678250853a1fde6027def7cac1812667bd0d5ab7ccb94eb8b6f3a",
         block_number: 3,
         index: 3867,
@@ -67,7 +67,7 @@ defmodule EthereumJSONRPC.Withdrawal do
       address_hash: address_hash,
       block_hash: block_hash,
       block_number: block_number,
-      amount: amount
+      amount: amount * 1_000_000_000
     }
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawals.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawals.ex
@@ -26,7 +26,7 @@ defmodule EthereumJSONRPC.Withdrawals do
       [
         %{
           address_hash: "0x388ea662ef2c223ec0b047d41bf3c0f362142ad5",
-          amount: 4040000000000,
+          amount: 4040000000000000000000,
           block_hash: "0x7f035c5f3c0678250853a1fde6027def7cac1812667bd0d5ab7ccb94eb8b6f3a",
           index: 3867,
           validator_index: 1721,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -6871,7 +6871,7 @@ defmodule Explorer.Chain do
   end
 
   def sum_withdrawals do
-    Repo.aggregate(Withdrawal, :max, :index, timeout: :infinity)
+    Repo.aggregate(Withdrawal, :sum, :amount, timeout: :infinity)
   end
 
   def upsert_count_withdrawals(index) do

--- a/apps/explorer/lib/explorer/chain/cache/withdrawals_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/withdrawals_sum.ex
@@ -12,6 +12,7 @@ defmodule Explorer.Chain.Cache.WithdrawalsSum do
   use GenServer
 
   alias Explorer.Chain
+  alias Explorer.Chain.Wei
 
   @counter_type "withdrawals_sum"
 
@@ -68,7 +69,7 @@ defmodule Explorer.Chain.Cache.WithdrawalsSum do
 
     params = %{
       counter_type: @counter_type,
-      value: withdrawals_sum
+      value: withdrawals_sum |> Wei.to(:wei)
     }
 
     Chain.upsert_last_fetched_counter(params)

--- a/apps/explorer/priv/repo/migrations/20230522130735_withdrawals_gwei_amount_to_wei_amount.exs
+++ b/apps/explorer/priv/repo/migrations/20230522130735_withdrawals_gwei_amount_to_wei_amount.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.WithdrawalsGweiAmountToWeiAmount do
+  use Ecto.Migration
+
+  def change do
+    execute("UPDATE withdrawals SET amount = amount * 1000000000")
+  end
+end


### PR DESCRIPTION
Close #7531

## Motivation

Currently withdrawal amount displayed in wei however it returned in gwei from the node
Also, sum counter does not work properly

## Changelog

- Convert withdrawal amount to wei
- Add `withdrawals_count` field to block structure and **_!remove `has_beacon_chain_withdrawals`!_**
- Fix sum counter

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
