### PR TITLE
Allow hyphen in DB username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Chore
 
+- [#7543](https://github.com/blockscout/blockscout/pull/7543) - Allow hyphen in DB username
+
 <details>
   <summary>Dependencies version bumps</summary>
 

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -36,7 +36,7 @@ defmodule Explorer.Repo.ConfigHelper do
 
   # sobelow_skip ["DOS.StringToAtom"]
   defp extract_parameters(database_url) do
-    ~r/\w*:\/\/(?<username>\w+):(?<password>[a-zA-Z0-9-*#!%^&$_]*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>[a-zA-Z0-9_-]*)/
+    ~r/\w*:\/\/(?<username>[a-zA-Z0-9_-]*):(?<password>[a-zA-Z0-9-*#!%^&$_]*)?@(?<hostname>(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])):(?<port>\d+)\/(?<database>[a-zA-Z0-9_-]*)/
     |> Regex.named_captures(database_url)
     |> Keyword.new(fn {k, v} -> {String.to_atom(k), v} end)
     |> Keyword.put(:url, database_url)

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -40,6 +40,18 @@ defmodule Explorer.Repo.ConfigHelperTest do
       assert result[:database] == "test-database"
     end
 
+    test "parse params from database url with hyphen in database user name" do
+      database_url = "postgresql://test-username:password@hostname.test.com:7777/database"
+
+      result = ConfigHelper.get_db_config(%{url: database_url, env_func: fn _ -> nil end})
+
+      assert result[:username] == "test-username"
+      assert result[:password] == "password"
+      assert result[:hostname] == "hostname.test.com"
+      assert result[:port] == "7777"
+      assert result[:database] == "database"
+    end
+
     test "parse params from database url with special characters in password" do
       database_url = "postgresql://test_username:awN!l#W*g$P%t-l^q&d@hostname.test.com:7777/test_database"
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7504

## Changelog

Fix regexp in order to allow hyphen in DB username.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
