### PR TITLE
Check if cached exchange rate is empty before replacing DB value in stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#7545](https://github.com/blockscout/blockscout/pull/7545) - Check if cached exchange rate is empty before replacing DB value in stats API
 - [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari
 
 ### Chore

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -99,7 +99,13 @@ defmodule BlockScoutWeb.API.V2.StatsController do
       recent_market_history
       |> case do
         [today | the_rest] ->
-          [%{today | closing_price: exchange_rate.usd_value} | the_rest]
+          [
+            %{
+              today
+              | closing_price: if(exchange_rate.usd_value, do: exchange_rate.usd_value, else: today.closing_price)
+            }
+            | the_rest
+          ]
 
         data ->
           data


### PR DESCRIPTION
## Motivation

<img width="893" alt="Screenshot 2023-05-24 at 13 43 03" src="https://github.com/blockscout/blockscout/assets/4341812/5b58719f-27c2-49f4-a9fe-ffeabec3dfc2">

## Changelog

Check if cached in memory exchange rate is empty before replacing DB value in stats API.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
