### PR TITLE
Fix withdrawals sum count on empty database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- [#7537](https://github.com/blockscout/blockscout/pull/7537) - Withdrawals fixes and improvements
+- [#7537](https://github.com/blockscout/blockscout/pull/7537), [#7553](https://github.com/blockscout/blockscout/pull/7553) - Withdrawals fixes and improvements
 - [#7546](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)
 - [#7545](https://github.com/blockscout/blockscout/pull/7545) - API v2: Check if cached exchange rate is empty before replacing DB value in stats API
 - [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari

--- a/apps/explorer/lib/explorer/chain/cache/withdrawals_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/withdrawals_sum.ex
@@ -69,7 +69,7 @@ defmodule Explorer.Chain.Cache.WithdrawalsSum do
 
     params = %{
       counter_type: @counter_type,
-      value: withdrawals_sum |> Wei.to(:wei)
+      value: (withdrawals_sum && Wei.to(withdrawals_sum, :wei)) || 0
     }
 
     Chain.upsert_last_fetched_counter(params)


### PR DESCRIPTION

## Motivation

```
2023-05-25T17:34:07.299 [error] GenServer Explorer.Chain.Cache.WithdrawalsSum terminating
** (FunctionClauseError) no function clause matching in Explorer.Chain.Wei.to/2
    (explorer 5.1.5) lib/explorer/chain/wei.ex:251: Explorer.Chain.Wei.to(nil, :wei)
    (explorer 5.1.5) lib/explorer/chain/cache/withdrawals_sum.ex:72: Explorer.Chain.Cache.WithdrawalsSum.consolidate/0
    (explorer 5.1.5) lib/explorer/chain/cache/withdrawals_sum.ex:38: Explorer.Chain.Cache.WithdrawalsSum.handle_continue/2
    (stdlib 5.0) gen_server.erl:1067: :gen_server.try_handle_continue/3
    (stdlib 5.0) gen_server.erl:977: :gen_server.loop/7
    (stdlib 5.0) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:continue, :ok}
State: %{consolidate?: true}
```

## Changelog

Add handling of nil response from aggregate query

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
