### PR TITLE
Remove fallback from Read methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- [#7562](https://github.com/blockscout/blockscout/pull/7562) - Remove fallback from Read methods
 - [#7537](https://github.com/blockscout/blockscout/pull/7537), [#7553](https://github.com/blockscout/blockscout/pull/7553) - Withdrawals fixes and improvements
 - [#7546](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)
 - [#7545](https://github.com/blockscout/blockscout/pull/7545) - API v2: Check if cached exchange rate is empty before replacing DB value in stats API

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -461,8 +461,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           "outputs" => [],
           "name" => "disableWhitelist",
           "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
-        },
-        %{"type" => "fallback"}
+        }
       ]
 
       target_contract = insert(:smart_contract, abi: abi)
@@ -496,8 +495,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}],
                "method_id" => "c683630d"
              } in response
-
-      assert %{"type" => "fallback"} in response
     end
 
     test "get array of addresses within read-methods", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -461,7 +461,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           "outputs" => [],
           "name" => "disableWhitelist",
           "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
-        }
+        },
+        %{"type" => "fallback"}
       ]
 
       target_contract = insert(:smart_contract, abi: abi)
@@ -495,6 +496,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                "inputs" => [%{"type" => "address", "name" => "_address", "internalType" => "address"}],
                "method_id" => "c683630d"
              } in response
+
+      refute %{"type" => "fallback"} in response
     end
 
     test "get array of addresses within read-methods", %{conn: conn} do

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -12,6 +12,8 @@ defmodule Explorer.SmartContract.Helper do
 
   def constructor?(function), do: function["type"] == "constructor"
 
+  def fallback?(function), do: function["type"] == "fallback"
+
   def event?(function), do: function["type"] == "event"
 
   def error?(function), do: function["type"] == "error"
@@ -22,7 +24,7 @@ defmodule Explorer.SmartContract.Helper do
   @spec read_with_wallet_method?(%{}) :: true | false
   def read_with_wallet_method?(function),
     do:
-      !error?(function) && !event?(function) && !constructor?(function) && nonpayable?(function) &&
+      !error?(function) && !event?(function) && !constructor?(function) && !fallback?(function) && nonpayable?(function) &&
         !empty_outputs?(function)
 
   def empty_inputs?(function), do: function["inputs"] == []


### PR DESCRIPTION
## Motivation

https://eth.blockscout.com/address/0xd9db270c1b5e3bd161e8c8503c55ceabee709552?tab=read_contract

<img width="885" alt="Screenshot 2023-05-26 at 13 05 53" src="https://github.com/blockscout/blockscout/assets/4341812/f364dbdc-bbca-4fec-a2ae-2b5f1da88124">


## Changelog

Remove `fallback` type from read methods. It should populate Write tab instead.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
