### PR TITLE
Return contract type in address view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current
 
 ### Features
+
 - [#7513](https://github.com/blockscout/blockscout/pull/7513) - Add Polygon Edge support
 
 - [#7532](https://github.com/blockscout/blockscout/pull/7532) - Handle empty id in json rpc responses
@@ -10,6 +11,7 @@
 
 ### Fixes
 
+- [#7564](https://github.com/blockscout/blockscout/pull/7564) - Return contract type in address view
 - [#7562](https://github.com/blockscout/blockscout/pull/7562) - Remove fallback from Read methods
 - [#7537](https://github.com/blockscout/blockscout/pull/7537), [#7553](https://github.com/blockscout/blockscout/pull/7553) - Withdrawals fixes and improvements
 - [#7546](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -108,7 +108,8 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "has_tokens" => Chain.check_if_tokens_at_address(address.hash, @api_true),
       "has_token_transfers" => Chain.check_if_token_transfers_at_address(address.hash, @api_true),
       "watchlist_address_id" => Chain.select_watchlist_address_id(get_watchlist_id(conn), address.hash),
-      "has_beacon_chain_withdrawals" => Chain.check_if_withdrawals_at_address(address.hash, @api_true)
+      "has_beacon_chain_withdrawals" => Chain.check_if_withdrawals_at_address(address.hash, @api_true),
+      "contract_type" => contract_type(address)
     })
   end
 
@@ -169,5 +170,20 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       end
 
     TokenView.render("token_instance.json", %{token_instance: token_instance, token: token})
+  end
+
+  @spec contract_type(term) :: nil | :solidity | :vyper | :yul
+  def contract_type(%Address{smart_contract: nil}), do: nil
+
+  def contract_type(%Address{smart_contract: %SmartContract{}} = address) do
+    if address.smart_contract.is_vyper_contract do
+      :vyper
+    else
+      if address.smart_contract.abi do
+        :solidity
+      else
+        :yul
+      end
+    end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -67,7 +67,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "has_tokens" => false,
         "has_token_transfers" => false,
         "watchlist_address_id" => nil,
-        "has_beacon_chain_withdrawals" => false
+        "has_beacon_chain_withdrawals" => false,
+        "contract_type" => nil
       }
 
       request = get(conn, "/api/v2/addresses/#{Address.checksum(address.hash)}")


### PR DESCRIPTION
## Motivation

![Screenshot 2023-05-24 at 16 22 56](https://github.com/blockscout/blockscout/assets/4341812/5e47c3d7-3925-461a-b68c-0536ac344d94)


## Changelog

return `contract_type` property in API v2 `api/v2/addresses/_hash_` endpoint.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
