### PR TITLE
Drop genesis block in internal transactions fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#7546](https://github.com/blockscout/blockscout/pull/7546) - API v2: fix today coin price (use in-memory or cached in DB value)
 - [#7545](https://github.com/blockscout/blockscout/pull/7545) - API v2: Check if cached exchange rate is empty before replacing DB value in stats API
 - [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari
+- [#7590](https://github.com/blockscout/blockscout/pull/7590) - Drop genesis block in internal transactions fetcher
 
 ### Chore
 


### PR DESCRIPTION
## Motivation

Internal transactions fetcher currently drops first block to fetch from process since genesis block is not traceable. But first block is not always a genesis block, so in that case it shouldn't be dropped.

## Changelog

Drop first block from internal transactions fetcher process only if it is a genesis.