### PR TITLE
Fix tokens pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- [#7611](https://github.com/blockscout/blockscout/pull/7611) - Fix tokens pagination
 - [#7566](https://github.com/blockscout/blockscout/pull/7566) - Account: check composed email beofre sending
 - [#7564](https://github.com/blockscout/blockscout/pull/7564) - Return contract type in address view
 - [#7562](https://github.com/blockscout/blockscout/pull/7562) - Remove fallback from Read methods

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -16,7 +16,8 @@ defmodule BlockScoutWeb.API.V2.TokenView do
       "holders" => token.holder_count && to_string(token.holder_count),
       "exchange_rate" => exchange_rate(token),
       "total_supply" => token.total_supply,
-      "icon_url" => token.icon_url
+      "icon_url" => token.icon_url,
+      "circulating_market_cap" => token.circulating_market_cap
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -393,26 +393,170 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
   end
 
   describe "/tokens" do
+    defp check_tokens_pagination(tokens, conn) do
+      request = get(conn, "/api/v2/tokens")
+      assert response = json_response(request, 200)
+      request_2nd_page = get(conn, "/api/v2/tokens", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+      check_paginated_response(response, response_2nd_page, tokens)
+    end
+
     test "get empty list", %{conn: conn} do
       request = get(conn, "/api/v2/tokens")
 
       assert %{"items" => [], "next_page_params" => nil} = json_response(request, 200)
     end
 
-    test "check pagination", %{conn: conn} do
+    # these tests that tokens paginates by each parameter separately and by any combination of them
+    test "pagination by address", %{conn: conn} do
       tokens =
         for i <- 0..50 do
+          insert(:token, name: nil)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by name", %{conn: conn} do
+      tokens =
+        for i <- 0..48 do
           insert(:token, holder_count: i)
         end
 
-      request = get(conn, "/api/v2/tokens")
-      assert response = json_response(request, 200)
+      empty_named_token = insert(:token, name: "")
+      named_token = insert(:token)
 
-      request_2nd_page = get(conn, "/api/v2/tokens", response["next_page_params"])
+      tokens = [named_token, empty_named_token | tokens]
 
-      assert response_2nd_page = json_response(request_2nd_page, 200)
+      check_tokens_pagination(tokens, conn)
+    end
 
-      check_paginated_response(response, response_2nd_page, tokens)
+    test "pagination by holders", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, holder_count: i, name: nil)
+        end
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, circulating_market_cap: i, name: nil)
+        end
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by name and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by holders and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, holder_count: 1, name: nil)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, circulating_market_cap: 1, name: nil)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by holders and name", %{conn: conn} do
+      tokens =
+        for i <- 1..51 do
+          insert(:token, holder_count: 1, name: List.to_string([i]))
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap and name", %{conn: conn} do
+      tokens =
+        for i <- 1..51 do
+          insert(:token, circulating_market_cap: 1, name: List.to_string([i]))
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap and holders", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, circulating_market_cap: 1, holder_count: i, name: nil)
+        end
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by holders, name and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, holder_count: 1)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap, name and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, circulating_market_cap: 1)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap, holders and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, circulating_market_cap: 1, holder_count: 1, name: nil)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap, holders and name", %{conn: conn} do
+      tokens =
+        for i <- 1..51 do
+          insert(:token, circulating_market_cap: 1, holder_count: 1, name: List.to_string([i]))
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
+    end
+
+    test "pagination by circulating_market_cap, holders, name and address", %{conn: conn} do
+      tokens =
+        for i <- 0..50 do
+          insert(:token, holder_count: 1, circulating_market_cap: 1)
+        end
+        |> Enum.reverse()
+
+      check_tokens_pagination(tokens, conn)
     end
 
     test "check nil", %{conn: conn} do


### PR DESCRIPTION
## Motivation

- Pagination fails in case of null or the same token names, holders and market cap
- Nullable fields are not handled correctly

## Changelog

- Add token contract address hash to pagination key for uniqueness 
- Handle each nullable field individually
- Add `circulating_market_cap` field to /api/v2/tokens/ response

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
