### PR TITLE
Add new ipfs clause; Decrease timeout for NFT metadata fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 
 - [#7635](https://github.com/blockscout/blockscout/pull/7635) - Fix single 1155 transfer displaying
+- [#7629](https://github.com/blockscout/blockscout/pull/7629) - Fix NFT fetcher
 - [#7611](https://github.com/blockscout/blockscout/pull/7611) - Fix tokens pagination
 - [#7566](https://github.com/blockscout/blockscout/pull/7566) - Account: check composed email beofre sending
 - [#7564](https://github.com/blockscout/blockscout/pull/7564) - Return contract type in address view

--- a/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/instance_metadata_retriever.ex
@@ -187,6 +187,10 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
     fetch_from_ipfs(right, hex_token_id)
   end
 
+  defp fetch_json_from_uri({:ok, ["ipfs/" <> right]}, hex_token_id) do
+    fetch_from_ipfs(right, hex_token_id)
+  end
+
   defp fetch_json_from_uri({:ok, [@ipfs_protocol <> right]}, hex_token_id) do
     fetch_from_ipfs(right, hex_token_id)
   end
@@ -240,8 +244,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
 
   def fetch_metadata_from_uri_inner(uri, hex_token_id) do
     case Application.get_env(:explorer, :http_adapter).get(uri, [],
-           timeout: 60_000,
-           recv_timeout: 60_000,
+           recv_timeout: 30_000,
            follow_redirect: true
          ) do
       {:ok, %Response{body: body, status_code: 200, headers: headers}} ->
@@ -263,7 +266,7 @@ defmodule Explorer.Token.InstanceMetadataRetriever do
           fetcher: :token_instances
         )
 
-        {:error, reason |> inspect(reason) |> truncate_error()}
+        {:error, reason |> inspect() |> truncate_error()}
     end
   rescue
     e ->


### PR DESCRIPTION
Close #7597 

## Changelog
- Add new ipfs clause (now supported `ipfs/{id}` uri)
- Decrease timeout for NFT metadata fetch
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
