### PR TITLE
Fix ABI read functions filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- [#7636](https://github.com/blockscout/blockscout/pull/7636) - Remove receive from read methods
 - [#7635](https://github.com/blockscout/blockscout/pull/7635) - Fix single 1155 transfer displaying
 - [#7629](https://github.com/blockscout/blockscout/pull/7629) - Fix NFT fetcher
 - [#7614](https://github.com/blockscout/blockscout/pull/7614) - API and smart-contracts fixes and improvements

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -463,6 +463,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
         },
         %{"type" => "fallback"},
+        %{"type" => "receive"},
         %{
           "type" => "function",
           "stateMutability" => "view",
@@ -626,6 +627,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
              } in response
 
       refute %{"type" => "fallback"} in response
+      refute %{"type" => "receive"} in response
     end
 
     test "get array of addresses within read-methods", %{conn: conn} do

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -12,8 +12,6 @@ defmodule Explorer.SmartContract.Helper do
 
   def constructor?(function), do: function["type"] == "constructor"
 
-  def fallback?(function), do: function["type"] == "fallback"
-
   def event?(function), do: function["type"] == "event"
 
   def error?(function), do: function["type"] == "error"
@@ -24,13 +22,12 @@ defmodule Explorer.SmartContract.Helper do
   @spec read_with_wallet_method?(%{}) :: true | false
   def read_with_wallet_method?(function),
     do:
-      !error?(function) && !event?(function) && !constructor?(function) && !fallback?(function) &&
-        nonpayable?(function) &&
+      !error?(function) && !event?(function) && !constructor?(function) && nonpayable?(function) &&
         !empty_outputs?(function)
 
-  def empty_inputs?(function), do: function["inputs"] == []
+  def empty_inputs?(function), do: is_nil(function["inputs"]) || function["inputs"] == []
 
-  def empty_outputs?(function), do: function["outputs"] == []
+  def empty_outputs?(function), do: is_nil(function["outputs"]) || function["outputs"] == []
 
   def payable?(function), do: function["stateMutability"] == "payable" || function["payable"]
 

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -25,8 +25,6 @@ defmodule Explorer.SmartContract.Helper do
       !error?(function) && !event?(function) && !constructor?(function) && nonpayable?(function) &&
         !empty_outputs?(function)
 
-  def empty_inputs?(function), do: is_nil(function["inputs"]) || function["inputs"] == []
-
   def empty_outputs?(function), do: is_nil(function["outputs"]) || function["outputs"] == []
 
   def payable?(function), do: function["stateMutability"] == "payable" || function["payable"]


### PR DESCRIPTION
Continuation of https://github.com/blockscout/blockscout/pull/7562

## Motivation
Receive function was not filtered

## Changelog
- Filter all functions with empty output

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
