### PR TITLE
[FEAT] Add support for DEPOSIT and WITHDRAW token transfer event in older contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#7653](https://github.com/blockscout/blockscout/pull/7653) - Add support for DEPOSIT and WITHDRAW token transfer event in older contracts
 - [#7628](https://github.com/blockscout/blockscout/pull/7628) - Support partially verified property from verifier MS; Add property to track contracts automatically verified via eth-bytecode-db
 - [#7603](https://github.com/blockscout/blockscout/pull/7603) - Add Polygon Edge and optimism genesis files support
 - [#7513](https://github.com/blockscout/blockscout/pull/7513) - Add Polygon Edge support

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -74,6 +74,8 @@ defmodule Explorer.Chain.TokenTransfer do
   @typep api? :: {:api?, true | false}
 
   @constant "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  @weth_deposit_signature "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c"
+  @weth_withdrawal_signature "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
   @erc1155_single_transfer_signature "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62"
   @erc1155_batch_transfer_signature "0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb"
 
@@ -145,6 +147,10 @@ defmodule Explorer.Chain.TokenTransfer do
   `first_topic` field.
   """
   def constant, do: @constant
+
+  def weth_deposit_signature, do: @weth_deposit_signature
+
+  def weth_withdrawal_signature, do: @weth_withdrawal_signature
 
   def erc1155_single_transfer_signature, do: @erc1155_single_transfer_signature
 

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -7,7 +7,7 @@ defmodule Indexer.Transform.TokenTransfersTest do
 
   describe "parse/1" do
     test "parse/1 parses logs for tokens and token transfers" do
-      [log_1, _log_2, log_3] =
+      [log_1, _log_2, log_3, weth_deposit_log, weth_withdrawal_log] =
         logs = [
           %{
             address_hash: "0xf2eec76e45b328df99a34fa696320a262cb92154",
@@ -47,6 +47,32 @@ defmodule Indexer.Transform.TokenTransfersTest do
             third_topic: "0x000000000000000000000000dccb72afee70e60b0c1226288fe86c01b953e8ac",
             transaction_hash: "0x4011d9a930a3da620321589a54dc0ca3b88216b4886c7a7c3aaad1fb17702d35",
             type: "mined"
+          },
+          %{
+            address_hash: "0x0BE9e53fd7EDaC9F859882AfdDa116645287C629",
+            block_number: 23_704_638,
+            block_hash: "0x8f61c99b0dd1196714ffda5bf979a282e6a62fdd3cff25c291284e6b57de2106",
+            data: "0x00000000000000000000000000000000000000000000002be19edfcf6b480000",
+            first_topic: "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c",
+            second_topic: "0x000000000000000000000000fb76e9e7d88e308ab530330ed90e84a952570319",
+            third_topic: nil,
+            fourth_topic: nil,
+            index: 1,
+            transaction_hash: "0x185889bc91372106ecf114a4e23f4ee615e131ae3e698078bd5d2ed7e3f55a49",
+            type: "mined"
+          },
+          %{
+            address_hash: "0x0BE9e53fd7EDaC9F859882AfdDa116645287C629",
+            block_number: 23_704_608,
+            block_hash: "0x5a5e69984f78d65fc6d92e18058d21a9b114f1d56d06ca7aa017b3d87bf0491a",
+            data: "0x00000000000000000000000000000000000000000000000000e1315e1ebd28e8",
+            first_topic: "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65",
+            second_topic: "0x000000000000000000000000e3f85aad0c8dd7337427b9df5d0fb741d65eeeb5",
+            third_topic: nil,
+            fourth_topic: nil,
+            index: 1,
+            transaction_hash: "0x07510dbfddbac9064f7d607c2d9a14aa26fa19cdfcd578c0b585ff2395df543f",
+            type: "mined"
           }
         ]
 
@@ -58,6 +84,10 @@ defmodule Indexer.Transform.TokenTransfersTest do
           },
           %{
             contract_address_hash: log_1.address_hash,
+            type: "ERC-20"
+          },
+          %{
+            contract_address_hash: weth_withdrawal_log.address_hash,
             type: "ERC-20"
           }
         ],
@@ -84,6 +114,30 @@ defmodule Indexer.Transform.TokenTransfersTest do
             transaction_hash: log_1.transaction_hash,
             token_type: "ERC-20",
             block_hash: log_1.block_hash
+          },
+          %{
+            amount: Decimal.new("63386150072297704"),
+            block_hash: weth_withdrawal_log.block_hash,
+            block_number: weth_withdrawal_log.block_number,
+            from_address_hash: truncated_hash(weth_withdrawal_log.second_topic),
+            log_index: 1,
+            to_address_hash: "0x0000000000000000000000000000000000000000",
+            token_contract_address_hash: weth_withdrawal_log.address_hash,
+            token_ids: nil,
+            token_type: "ERC-20",
+            transaction_hash: weth_withdrawal_log.transaction_hash
+          },
+          %{
+            amount: Decimal.new("809467672956315893760"),
+            block_hash: weth_deposit_log.block_hash,
+            block_number: weth_deposit_log.block_number,
+            from_address_hash: "0x0000000000000000000000000000000000000000",
+            log_index: 1,
+            to_address_hash: truncated_hash(weth_deposit_log.second_topic),
+            token_contract_address_hash: weth_deposit_log.address_hash,
+            token_ids: nil,
+            token_type: "ERC-20",
+            transaction_hash: weth_deposit_log.transaction_hash
           }
         ]
       }


### PR DESCRIPTION
Resolves #7652 

## Changelog

### Enhancements
Add support for DEPOSIT and WITHDRAW token transfer event in older contracts

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
