### PR TITLE
Fix address contract code update

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -249,7 +249,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
     imports =
       Chain.import(%{
-        addresses: %{params: addresses_params},
+        addresses: %{params: addresses_params, on_conflict: :update_contract_code},
         internal_transactions: %{params: internal_transactions_and_empty_block_numbers, with: :blockless_changeset},
         timeout: :infinity
       })


### PR DESCRIPTION
## Motivation

Internal transactions fetcher may update the address contract code so it needs to explicitly define `:on_conflict`
