### PR TITLE
Add block_number index for address_coin_balances table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Chore
 
+- [#7699](https://github.com/blockscout/blockscout/pull/7699) - Add block_number index for address_coin_balances table
 - [#7666](https://github.com/blockscout/blockscout/pull/7666) - Search label query
 - [#7644](https://github.com/blockscout/blockscout/pull/7644) - Publish docker images CI for prod/staging branches
 - [#7594](https://github.com/blockscout/blockscout/pull/7594) - Stats service support in docker-compose config with new frontend

--- a/apps/explorer/priv/repo/migrations/20230613181244_address_coin_balances_block_number_index.exs
+++ b/apps/explorer/priv/repo/migrations/20230613181244_address_coin_balances_block_number_index.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.AddressCoinBalancesBlockNumberIndex do
+  use Ecto.Migration
+
+  def up do
+    create(index(:address_coin_balances, [:block_number]))
+  end
+
+  def down do
+    drop(index(:address_coin_balances, [:block_number]))
+  end
+end


### PR DESCRIPTION
## Motivation

It should significantly speed up queries like this for stats microservice (coin total supply calculation):
```
SELECT DISTINCT on (address_hash) address_hash, value
FROM address_coin_balances
WHERE last_previous_day_bn < block_number AND block_number <= last_current_day_bn
ORDER BY address_hash, block_number DESC;
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
