### PR TITLE
Transaction actions import fix

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -204,10 +204,15 @@ defmodule Indexer.Block.Fetcher do
                token_transfers: %{params: token_transfers},
                tokens: %{on_conflict: :nothing, params: tokens},
                transactions: %{params: transactions_with_receipts},
-               transaction_actions: %{params: transaction_actions},
                withdrawals: %{params: withdrawals_params}
              }
-           ) do
+           ),
+         {:ok, inserted_tx_actions} <-
+           Chain.import(%{
+             transaction_actions: %{params: transaction_actions},
+             timeout: :infinity
+           }) do
+      inserted = Map.merge(inserted, inserted_tx_actions)
       Logger.info(["### fetch_and_import_range FINALIZED ", inspect(range), " ###"])
       Prometheus.Instrumenter.block_batch_fetch(fetch_time, callback_module)
       result = {:ok, %{inserted: inserted, errors: blocks_errors}}

--- a/apps/indexer/lib/indexer/fetcher/transaction_action.ex
+++ b/apps/indexer/lib/indexer/fetcher/transaction_action.ex
@@ -136,6 +136,8 @@ defmodule Indexer.Fetcher.TransactionAction do
           Map.put(action, :data, Map.delete(action.data, :block_number))
         end)
 
+      Logger.warn("tx_actions = #{inspect(tx_actions)}")
+
       {:ok, _} =
         Chain.import(%{
           addresses: %{params: addresses, on_conflict: :nothing},


### PR DESCRIPTION
This PR contains two important fixes for transaction actions module: 1) the import now will be executed after transactions are imported; 2) only consensus blocks will be handled while analizing logs.

## Checklist for your Pull Request (PR)

  - [] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
