### PR TITLE
Move MissingRangesCollector init logic to handle_continue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#7516](https://github.com/blockscout/blockscout/pull/7516) - Fix shrinking logo in Safari
 - [#7590](https://github.com/blockscout/blockscout/pull/7590) - Drop genesis block in internal transactions fetcher
 - [#7639](https://github.com/blockscout/blockscout/pull/7639) - Fix contract creation transactions
+- [#7724](https://github.com/blockscout/blockscout/pull/7724) - Move MissingRangesCollector init logic to handle_continue
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -22,7 +22,12 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
 
   @impl true
   def init(_) do
-    {:ok, define_init()}
+    {:ok, %{min_fetched_block_number: nil, max_fetched_block_number: nil}, {:continue, :ok}}
+  end
+
+  @impl true
+  def handle_continue(:ok, _state) do
+    {:noreply, define_init()}
   end
 
   defp define_init do

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -8,7 +8,6 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
 
   alias Explorer.Chain.Block
   alias Explorer.Repo
-  alias Explorer.Utility.MissingRangesManipulator
   alias Indexer.BoundInterval
   alias Indexer.Block.Catchup
   alias Indexer.Block.Catchup.MissingRangesCollector
@@ -532,6 +531,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
 
       # from `setup :state`
       assert_received :catchup_index
+
+      Process.sleep(50)
 
       assert {:noreply,
               %Catchup.BoundIntervalSupervisor{fetcher: %Catchup.Fetcher{}, task: %Task{pid: pid, ref: ref}} =

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -285,6 +285,8 @@ defmodule Indexer.Block.Catchup.FetcherTest do
 
       assert count(Chain.Block) == 0
 
+      Process.sleep(50)
+
       assert %{first_block_number: ^block_number, last_block_number: 0, missing_block_count: 2, shrunk: false} =
                Fetcher.task(%Fetcher{
                  block_fetcher: %Block.Fetcher{
@@ -438,6 +440,8 @@ defmodule Indexer.Block.Catchup.FetcherTest do
 
       Process.register(pid, BlockReward)
 
+      Process.sleep(50)
+
       assert %{first_block_number: ^block_number, last_block_number: 0, missing_block_count: 2, shrunk: false} =
                Fetcher.task(%Fetcher{
                  block_fetcher: %Block.Fetcher{
@@ -585,6 +589,8 @@ defmodule Indexer.Block.Catchup.FetcherTest do
         end)
 
       Process.register(pid, BlockReward)
+
+      Process.sleep(50)
 
       assert %{first_block_number: ^block_number, last_block_number: 0, missing_block_count: 2, shrunk: false} =
                Fetcher.task(%Fetcher{


### PR DESCRIPTION
## Motivation

Missing ranges sanitizing may take a while which can lead to a failed launch of `MissingRangesCollector`.

## Changelog

Move sanitizing logic to `handle_continue` so GenServer will start immediately and perform necessary actions after initialization.