### PR TITLE
Fix transactions ordering in Indexer.Fetcher.OptimismTxnBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#7776](https://github.com/blockscout/blockscout/pull/7776) - Fix transactions ordering in Indexer.Fetcher.OptimismTxnBatch
+
 ### Chore
 
 <details>

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -749,23 +749,16 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
     end)
   end
 
-  # credo:disable-for-next-line /Complexity/
-  defp txs_filter_sort_fn(direction, t1, t2) do
+  defp txs_filter_sort_fn(:asc, t1, t2) do
+    txs_filter_sort_fn(:desc, t2, t1)
+  end
+
+  defp txs_filter_sort_fn(_direction, t1, t2) do
     cond do
-      direction == :asc and t1.block_number < t2.block_number ->
+      t1.block_number > t2.block_number ->
         true
 
-      direction == :asc and t1.block_number == t2.block_number ->
-        t1_frame = input_to_frame(t1.input)
-        t2_frame = input_to_frame(t2.input)
-
-        (t1_frame.channel_id != t2_frame.channel_id and t1.transaction_index < t2.transaction_index) or
-          (t1_frame.channel_id == t2_frame.channel_id and t1_frame.number < t2_frame.number)
-
-      direction != :asc and t1.block_number > t2.block_number ->
-        true
-
-      direction != :asc and t1.block_number == t2.block_number ->
+      t1.block_number == t2.block_number ->
         t1_frame = input_to_frame(t1.input)
         t2_frame = input_to_frame(t2.input)
 

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -745,14 +745,36 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
       end
     end)
     |> Enum.sort(fn t1, t2 ->
-      if direction == :asc do
-        t1.block_number < t2.block_number or
-          (t1.block_number == t2.block_number and t1.transaction_index < t2.transaction_index)
-      else
-        t1.block_number > t2.block_number or
-          (t1.block_number == t2.block_number and t1.transaction_index > t2.transaction_index)
-      end
+      txs_filter_sort_fn(direction, t1, t2)
     end)
+  end
+
+  # credo:disable-for-next-line /Complexity/
+  defp txs_filter_sort_fn(direction, t1, t2) do
+    cond do
+      direction == :asc and t1.block_number < t2.block_number ->
+        true
+
+      direction == :asc and t1.block_number == t2.block_number ->
+        t1_frame = input_to_frame(t1.input)
+        t2_frame = input_to_frame(t2.input)
+
+        (t1_frame.channel_id != t2_frame.channel_id and t1.transaction_index < t2.transaction_index) or
+          (t1_frame.channel_id == t2_frame.channel_id and t1_frame.number < t2_frame.number)
+
+      direction != :asc and t1.block_number > t2.block_number ->
+        true
+
+      direction != :asc and t1.block_number == t2.block_number ->
+        t1_frame = input_to_frame(t1.input)
+        t2_frame = input_to_frame(t2.input)
+
+        (t1_frame.channel_id != t2_frame.channel_id and t1.transaction_index > t2.transaction_index) or
+          (t1_frame.channel_id == t2_frame.channel_id and t1_frame.number > t2_frame.number)
+
+      true ->
+        false
+    end
   end
 
   defp zlib_decompress(bytes) do


### PR DESCRIPTION
## Motivation

`OptimismTxnBatch` fetcher stops indexing batches due to incorrect transactions ordering when L1 transactions are in the same block.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
