### PR TITLE
Va fix optimism batches module

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -523,6 +523,10 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
         put_future_frame(current_channel_id, future_frame)
         {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}
 
+      frame.number == last_frame_number && frame.channel_id == current_channel_id ->
+        # ignore duplicated frame
+        {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}
+
       true ->
         {:halt,
          {:error,


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/7793.

## Motivation

This is a continuation of https://github.com/blockscout/blockscout/pull/7776. On some Optimism chains the Sequencer submits chunks of a batch sequence in incorrect order (e.g. chunk number 4 after number 2 and then number 3) through different L1 blocks. This PR adds a small memory buffer which keeps incorrect chunk in memory and uses it after correctly ordered chunk is caught (within the same "channel id"). The buffer is cleared right after the chunk is used.

I plan to rewrite the `Indexer.Fetcher.OptimismTxnBatch` module from scratch (to make its code simpler and clearer taking into account the latest found bugs with Sequencer behaviour on different Optimism chains) after more prioritized tasks are done.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
