### PR TITLE
Fix created_contract_code_indexed_at updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#7803](https://github.com/blockscout/blockscout/pull/7803) - Fix additional sources and interfaces, save names for vyper contracts
 - [#7758](https://github.com/blockscout/blockscout/pull/7758) - Remove limit for configurable fetchers
 - [#7764](https://github.com/blockscout/blockscout/pull/7764) - Fix missing ranges insertion and deletion logic
+- [#7843](https://github.com/blockscout/blockscout/pull/7843) - Fix created_contract_code_indexed_at updating
 
 ### Chore
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7300

## Motivation

Currently on the import of addresses, field `created_contract_code_indexed_at` for transactions is updated every time an address that has a `contract_code` was updated, regardless of whether the contract code was indexed for the first time or not.

## Changelog

Check if `contract_code` was indexed for the first time and update `created_contract_code_indexed_at` only if it is true.