### PR TITLE
Token balances refactoring: put token to preloads; fix pagination bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- [#7852](https://github.com/blockscout/blockscout/pull/7852) - Token balances refactoring & fixes
 - [#7872](https://github.com/blockscout/blockscout/pull/7872) - Fix pending gas price in pending tx
 - [#7875](https://github.com/blockscout/blockscout/pull/7875) - Fix twin compiler version
 - [#7825](https://github.com/blockscout/blockscout/pull/7825) - Fix nginx config for the new frontend websockets

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.Chain do
 
   import Explorer.Chain,
     only: [
-      balance_in_fiat: 1,
       find_or_insert_address_from_hash: 1,
       hash_to_block: 1,
       hash_to_transaction: 1,
@@ -502,7 +501,7 @@ defmodule BlockScoutWeb.Chain do
   end
 
   defp paging_params_with_fiat_value(%CurrentTokenBalance{id: id, value: value} = ctb) do
-    %{"fiat_value" => balance_in_fiat(ctb), "value" => value, "id" => id}
+    %{"fiat_value" => ctb.fiat_value, "value" => value, "id" => id}
   end
 
   defp block_or_transaction_from_param(param) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_controller.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.AddressTokenController do
   use BlockScoutWeb, :controller
 
-  import BlockScoutWeb.Chain, only: [next_page_params: 3, paging_options: 1, split_list_by_page: 1]
+  import BlockScoutWeb.Chain, only: [next_page_params: 4, paging_options: 1, split_list_by_page: 1]
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
   import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
 
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.AddressTokenController do
       {tokens, next_page} = split_list_by_page(token_balances_plus_one)
 
       next_page_path =
-        case next_page_params(next_page, tokens, params) do
+        case next_page_params(next_page, tokens, params, true) do
           nil ->
             nil
 
@@ -32,12 +32,12 @@ defmodule BlockScoutWeb.AddressTokenController do
 
       items =
         tokens
-        |> Enum.map(fn {token_balance, token} ->
+        |> Enum.map(fn token_balance ->
           View.render_to_string(
             AddressTokenView,
             "_tokens.html",
             token_balance: token_balance,
-            token: token,
+            token: token_balance.token,
             address: address,
             conn: conn
           )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
+      next_page_params: 4,
       token_transfers_next_page_params: 3,
       paging_options: 1,
       split_list_by_page: 1,
@@ -365,7 +366,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       {tokens, next_page} = split_list_by_page(results_plus_one)
 
-      next_page_params = next_page |> next_page_params(tokens, params) |> delete_parameters_from_next_page_params()
+      next_page_params =
+        next_page |> next_page_params(tokens, params, true) |> delete_parameters_from_next_page_params()
 
       conn
       |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token/_tokens.html.eex
@@ -40,7 +40,7 @@
   <td class="stakes-td">
     <%= if token_price && @token.decimals do %>
       <p class="mb-0 col-md-6 text-right">
-        <span data-selector="token-balance-usd" data-usd-value="<%= Chain.balance_in_fiat(@token_balance, @token) %>"><%= ChainView.format_usd_value(Chain.balance_in_fiat(@token_balance, @token)) %></span>
+        <span data-selector="token-balance-usd" data-usd-value="<%= Chain.balance_in_fiat(@token_balance) %>"><%= ChainView.format_usd_value(Chain.balance_in_fiat(@token_balance)) %></span>
       </p>
     <% end %>
   </td>

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
@@ -47,7 +47,7 @@
               placeholder: gettext("Search tokens")
             ) %>
       </div>
-      <%= if Enum.any?(@token_balances, fn {_token_balance, token} -> token.type == "ERC-721" end) do %>
+      <%= if Enum.any?(@token_balances, fn token_balance -> token_balance.token.type == "ERC-721" end) do %>
         <%= render(
               "_tokens.html",
               conn: @conn,
@@ -56,7 +56,7 @@
             ) %>
       <% end %>
 
-      <%= if Enum.any?(@token_balances, fn {_token_balance, token} -> token.type == "ERC-1155" end) do %>
+      <%= if Enum.any?(@token_balances, fn token_balance -> token_balance.token.type == "ERC-1155" end) do %>
         <%= render(
               "_tokens.html",
               conn: @conn,
@@ -65,7 +65,7 @@
             ) %>
       <% end %>
 
-      <%= if Enum.any?(@token_balances, fn {_token_balance, token} -> token.type == "ERC-20" end) do %>
+      <%= if Enum.any?(@token_balances, fn token_balance -> token_balance.token.type == "ERC-20" end) do %>
         <%= render(
               "_tokens.html",
               conn: @conn,

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_tokens.html.eex
@@ -3,17 +3,17 @@
     <%= @type %> (<span data-number-of-tokens-by-type="<%= @type %>"><%= Enum.count(@token_balances)%></span>)
   </h6>
 
-  <%= for {token_balance, token} <- @token_balances do %>
+  <%= for token_balance <- @token_balances do %>
     <div
       class="border-bottom"
       data-dropdown-token-balance-test
-      data-token-name="<%= token_name(token) %>"
-      data-token-symbol="<%= token_symbol(token) %>"
+      data-token-name="<%= token_name(token_balance.token) %>"
+      data-token-symbol="<%= token_symbol(token_balance.token) %>"
     >
       <% path = cond do
-          token_balance.token_type == "ERC-721" && !is_nil(token_balance.token_id) -> token_instance_path(@conn, :show, token.contract_address_hash, to_string(token_balance.token_id))
-          token_balance.token_type == "ERC-1155" && !is_nil(token_balance.token_id) -> token_instance_path(@conn, :show, token.contract_address_hash, to_string(token_balance.token_id))
-          true -> token_path(@conn, :show, to_string(token.contract_address_hash))
+          token_balance.token_type == "ERC-721" && !is_nil(token_balance.token_id) -> token_instance_path(@conn, :show, token_balance.token.contract_address_hash, to_string(token_balance.token_id))
+          token_balance.token_type == "ERC-1155" && !is_nil(token_balance.token_id) -> token_instance_path(@conn, :show, token_balance.token.contract_address_hash, to_string(token_balance.token_id))
+          true -> token_path(@conn, :show, to_string(token_balance.token.contract_address_hash))
         end
       %>
       <%= link(
@@ -23,7 +23,7 @@
         <div class="row dropdown-row wh-sp">
           <%= if Application.get_env(:block_scout_web, :display_token_icons) do %>
             <% chain_id_for_token_icon = Application.get_env(:block_scout_web, :chain_id) %>
-            <% address_hash = token.contract_address_hash %>
+            <% address_hash = token_balance.token.contract_address_hash %>
             <%=
               render BlockScoutWeb.TokensView,
               "_token_icon.html",
@@ -32,18 +32,18 @@
               additional_classes: ["token-wallet-icon"]
             %>
           <% end %>
-          <p class="mb-0 col-md-6 pl-0 pr-0 el-1 flex-grow-2 <%= if !Application.get_env(:block_scout_web, :display_token_icons), do: "ml-5px" %>"><%= token_name(token) %>
+          <p class="mb-0 col-md-6 pl-0 pr-0 el-1 flex-grow-2 <%= if !Application.get_env(:block_scout_web, :display_token_icons), do: "ml-5px" %>"><%= token_name(token_balance.token) %>
           </p>
-          <%= if token.fiat_value && token.decimals do %>
+          <%= if token_balance.token.fiat_value && token_balance.token.decimals do %>
             <p class="mb-0 col-md-6 text-right usd-total">
-              <span data-selector="token-balance-usd" data-usd-value="<%= Chain.balance_in_fiat(token_balance, token) %>"></span>
+              <span data-selector="token-balance-usd" data-usd-value="<%= Chain.balance_in_fiat(token_balance) %>"></span>
             </p>
           <% end %>
         </div>
         <div class="row dropdown-row wh-sp">
-          <%= if token.fiat_value do %>
+          <%= if token_balance.token.fiat_value do %>
             <p class="mb-0 text-right text-muted usd-rate">
-              <span data-selector="token-price" data-token-usd-value="<%= token.fiat_value %>"></span>
+              <span data-selector="token-price" data-token-usd-value="<%= token_balance.token.fiat_value %>"></span>
             </p>
           <% end %>
         </div>
@@ -52,7 +52,7 @@
             <%= if token_balance.token_type == "ERC-721" && !is_nil(token_balance.token_id) do %>
               1
             <% else %>
-              <%= format_according_to_decimals(token_balance.value, token.decimals) %> <%= token_symbol(token) %>
+              <%= format_according_to_decimals(token_balance.value, token_balance.token.decimals) %> <%= token_symbol(token_balance.token) %>
             <% end %>
             <%= if (token_balance.token_type == "ERC-721" && !is_nil(token_balance.token_id)) or token_balance.token_type == "ERC-1155" do %>
               <%= " TokenID " <> to_string(token_balance.token_id) %>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_token_balance_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_token_balance_view.ex
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.AddressTokenBalanceView do
   end
 
   def filter_by_type(token_balances, type) do
-    Enum.filter(token_balances, fn {_token_balance, token} -> token.type == type end)
+    Enum.filter(token_balances, fn token_balance -> token_balance.token.type == type end)
   end
 
   def address_tokens_usd_sum_cache(address, token_balances) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -111,17 +111,17 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     })
   end
 
-  def prepare_token_balance({token_balance, token}, fetch_token_instance? \\ false) do
+  def prepare_token_balance(token_balance, fetch_token_instance? \\ false) do
     %{
       "value" => token_balance.value,
-      "token" => TokenView.render("token.json", %{token: token}),
+      "token" => TokenView.render("token.json", %{token: token_balance.token}),
       "token_id" => token_balance.token_id,
       "token_instance" =>
         if(fetch_token_instance? && token_balance.token_id,
           do:
             fetch_and_render_token_instance(
               token_balance.token_id,
-              token,
+              token_balance.token,
               token_balance.address_hash
             )
         )

--- a/apps/block_scout_web/test/block_scout_web/views/address_token_balance_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_token_balance_view_test.exs
@@ -20,11 +20,9 @@ defmodule BlockScoutWeb.AddressTokenBalanceViewTest do
       token_balance_a = build(:token_balance, token: build(:token, type: "ERC-20"))
       token_balance_b = build(:token_balance, token: build(:token, type: "ERC-721"))
 
-      token_balances = [{token_balance_a, token_balance_a.token}, {token_balance_b, token_balance_b.token}]
+      token_balances = [token_balance_a, token_balance_b]
 
-      assert AddressTokenBalanceView.filter_by_type(token_balances, "ERC-20") == [
-               {token_balance_a, token_balance_a.token}
-             ]
+      assert AddressTokenBalanceView.filter_by_type(token_balances, "ERC-20") == [token_balance_a]
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -47,6 +47,7 @@ defmodule Explorer.Chain do
     Address.CurrentTokenBalance,
     Address.TokenBalance,
     Block,
+    CurrencyHelper,
     Data,
     DecompiledSmartContract,
     Hash,
@@ -2689,8 +2690,17 @@ defmodule Explorer.Chain do
   @doc """
   Return the balance in usd corresponding to this token. Return nil if the fiat_value of the token is not present.
   """
-  def balance_in_fiat(token_balance) do
+  def balance_in_fiat(%{fiat_value: fiat_value} = token_balance) when not is_nil(fiat_value) do
     token_balance.fiat_value
+  end
+
+  def balance_in_fiat(%{token: %{fiat_value: fiat_value, decimals: decimals}}) when nil in [fiat_value, decimals] do
+    nil
+  end
+
+  def balance_in_fiat(%{token: %{fiat_value: fiat_value, decimals: decimals}} = token_balance) do
+    tokens = CurrencyHelper.divide_decimals(token_balance.value, decimals)
+    Decimal.mult(tokens, fiat_value)
   end
 
   defp contract?(%{contract_code: nil}), do: false

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -47,7 +47,6 @@ defmodule Explorer.Chain do
     Address.CurrentTokenBalance,
     Address.TokenBalance,
     Block,
-    CurrencyHelper,
     Data,
     DecompiledSmartContract,
     Hash,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2690,24 +2690,8 @@ defmodule Explorer.Chain do
   @doc """
   Return the balance in usd corresponding to this token. Return nil if the fiat_value of the token is not present.
   """
-  def balance_in_fiat(_token_balance, %{fiat_value: fiat_value, decimals: decimals})
-      when nil in [fiat_value, decimals] do
-    nil
-  end
-
-  def balance_in_fiat(token_balance, %{fiat_value: fiat_value, decimals: decimals}) do
-    tokens = CurrencyHelper.divide_decimals(token_balance.value, decimals)
-    Decimal.mult(tokens, fiat_value)
-  end
-
-  def balance_in_fiat(%{token: %{fiat_value: nil}}) do
-    nil
-  end
-
   def balance_in_fiat(token_balance) do
-    tokens = CurrencyHelper.divide_decimals(token_balance.value, token_balance.token.decimals)
-    price = token_balance.token.fiat_value
-    Decimal.mult(tokens, price)
+    token_balance.fiat_value
   end
 
   defp contract?(%{contract_code: nil}), do: false

--- a/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
+++ b/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
@@ -53,9 +53,9 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
   @spec address_tokens_fiat_sum([{Address.CurrentTokenBalance, Explorer.Chain.Token}]) :: Decimal.t()
   defp address_tokens_fiat_sum(token_balances) do
     token_balances
-    |> Enum.reduce(Decimal.new(0), fn {token_balance, token}, acc ->
-      if token_balance.value && token.fiat_value && token.decimals do
-        Decimal.add(acc, Chain.balance_in_fiat(token_balance, token))
+    |> Enum.reduce(Decimal.new(0), fn token_balance, acc ->
+      if token_balance.value && token_balance.token.fiat_value && token_balance.token.decimals do
+        Decimal.add(acc, Chain.balance_in_fiat(token_balance))
       else
         acc
       end

--- a/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
@@ -157,7 +157,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalanceTest do
         address.hash
         |> CurrentTokenBalance.last_token_balances()
         |> Repo.all()
-        |> Enum.map(fn {token_balance, _} -> token_balance.address_hash end)
+        |> Enum.map(fn token_balance -> token_balance.address_hash end)
 
       assert token_balances == [current_token_balance.address_hash]
     end
@@ -195,7 +195,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalanceTest do
         address.hash
         |> CurrentTokenBalance.last_token_balances()
         |> Repo.all()
-        |> Enum.map(fn {token_balance, _} -> token_balance.address_hash end)
+        |> Enum.map(fn token_balance -> token_balance.address_hash end)
 
       assert token_balances == [current_token_balance_a.address_hash]
     end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -5080,7 +5080,7 @@ defmodule Explorer.ChainTest do
       token_balances =
         address.hash
         |> Chain.fetch_last_token_balances()
-        |> Enum.map(fn {token_balance, _} -> token_balance.address_hash end)
+        |> Enum.map(fn token_balance -> token_balance.address_hash end)
 
       assert token_balances == [current_token_balance.address_hash]
     end

--- a/apps/explorer/test/explorer/counters/addresses_tokens_usd_sum_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/addresses_tokens_usd_sum_counter_test.exs
@@ -19,15 +19,15 @@ defmodule Explorer.Counters.AddressTokenUsdSumTest do
       )
 
     AddressTokenUsdSum.fetch(address.hash, [
-      {address_current_token_balance, address_current_token_balance.token},
-      {address_current_token_balance_2, address_current_token_balance_2.token}
+      address_current_token_balance,
+      address_current_token_balance_2
     ])
 
     Process.sleep(200)
 
     assert AddressTokenUsdSum.fetch(address.hash, [
-             {address_current_token_balance, address_current_token_balance.token},
-             {address_current_token_balance_2, address_current_token_balance_2.token}
+             address_current_token_balance,
+             address_current_token_balance_2
            ]) ==
              Decimal.new(2_010_000)
   end


### PR DESCRIPTION
Close #7860 
## Motivation
- There was a bug in pagination in corner cases, when DB round fiat_value for ctb differently than elixir 

## Changelog
- Put fiat_value calculated in postgres to ctb in order to leave one point of truth

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
