### PR TITLE
Fix twin compiler version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 - [#7811](https://github.com/blockscout/blockscout/pull/7811) - Filter addresses before insertion
 
 ### Fixes
+
 - [#7872](https://github.com/blockscout/blockscout/pull/7872) - Fix pending gas price in pending tx
+- [#7875](https://github.com/blockscout/blockscout/pull/7875) - Fix twin compiler version
 - [#7825](https://github.com/blockscout/blockscout/pull/7825) - Fix nginx config for the new frontend websockets
 - [#7772](https://github.com/blockscout/blockscout/pull/7772) - Fix parsing of database password period(s)
 - [#7803](https://github.com/blockscout/blockscout/pull/7803) - Fix additional sources and interfaces, save names for vyper contracts

--- a/apps/block_scout_web/assets/js/pages/verification_form.js
+++ b/apps/block_scout_web/assets/js/pages/verification_form.js
@@ -127,9 +127,7 @@ if ($contractVerificationPage.length) {
   $(function () {
     initializeDropzone()
 
-    setTimeout(function () {
-      $('.nightly-builds-false').trigger('click')
-    }, 10)
+    filterNightlyBuilds(true, false)
 
     $('body').on('click', '.js-btn-add-contract-libraries', function () {
       $('.js-smart-contract-libraries-wrapper').show()


### PR DESCRIPTION
Close #6923

## Changelog
- Replace trigger('click') with appropriate function call
- Fix UI bug: 
![image](https://github.com/blockscout/blockscout/assets/32202610/2c926827-4fdc-4c9a-8145-0f4177b25d04)

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
