### PR TITLE
Update receipt.ex fixing Errors: unknown_key depositNonce

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -253,7 +253,7 @@ defmodule EthereumJSONRPC.Receipt do
   # hash format
   # gas is passed in from the `t:EthereumJSONRPC.Transaction.params/0` to allow pre-Byzantium status to be derived
   defp entry_to_elixir({key, _} = entry)
-       when key in ~w(blockHash contractAddress from gas logsBloom root to transactionHash revertReason type effectiveGasPrice),
+       when key in ~w(blockHash contractAddress from gas logsBloom root to transactionHash revertReason type effectiveGasPrice, depositNonce),
        do: {:ok, entry}
 
   defp entry_to_elixir({key, quantity})


### PR DESCRIPTION
I'm trying to run blockscout for a L2 chain created with op-stack. I followed this guide: https://stack.optimism.io/docs/build/explorer/#

I can see below error on console where blockscout is running and due to this error blockscout is unable to sync with op-chain L2:


blockscout                 |
blockscout                 | Errors:
blockscout                 |   {:unknown_key, %{key: "depositNonce", value: "0x3fdb"}}
blockscout                 |
blockscout                 |     (ethereum_jsonrpc 5.2.0) lib/ethereum_jsonrpc/receipt.ex:236: EthereumJSONRPC.Receipt.ok!/2
blockscout                 |     (elixir 1.14.0) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
blockscout                 |     (ethereum_jsonrpc 5.2.0) lib/ethereum_jsonrpc/receipts.ex:138: EthereumJSONRPC.Receipts.fetch/2
blockscout                 |     (elixir 1.14.0) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
blockscout                 |     (elixir 1.14.0) lib/task/supervised.ex:34: Task.Supervised.reply/4
blockscout                 |     (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
blockscout                 | Function: &:erlang.apply/2


By adding `"depositNonce"` to the list of recognized keys in the `entry_to_elixir/1` function, the error should be resolved.

Here's the modified code with the fix:

```elixir
defmodule EthereumJSONRPC.Receipt do
  # ...

  defp entry_to_elixir({key, _} = entry)
       when key in ~w(blockHash contractAddress from gas logsBloom root to transactionHash revertReason type effectiveGasPrice depositNonce),
       do: {:ok, entry}

  # ...

end
```
