### PR TITLE
Add token balances info to watchlist address response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#7888](https://github.com/blockscout/blockscout/pull/7888) - Add token balances info to watchlist address response
 - [#7898](https://github.com/blockscout/blockscout/pull/7898) - Add possibility to add extra headers with JSON RPC URL
 - [#7836](https://github.com/blockscout/blockscout/pull/7836) - Improve unverified email flow
 - [#7784](https://github.com/blockscout/blockscout/pull/7784) - Search improvements: Add new fields, light refactoring

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
@@ -8,12 +8,13 @@ defmodule BlockScoutWeb.Account.Api.V1.UserController do
   alias Explorer.Account.Api.Key, as: ApiKey
   alias Explorer.Account.CustomABI
   alias Explorer.Account.{Identity, PublicTagsRequest, TagAddress, TagTransaction, WatchlistAddress}
-  alias Explorer.{Market, Repo}
+  alias Explorer.{Chain, Market, PagingOptions, Repo}
   alias Plug.CSRFProtection
 
   action_fallback(BlockScoutWeb.Account.Api.V1.FallbackController)
 
   @ok_message "OK"
+  @token_balances_amount 150
 
   def info(conn, _params) do
     with {:auth, %{id: uid}} <- {:auth, current_user(conn)},
@@ -30,11 +31,34 @@ defmodule BlockScoutWeb.Account.Api.V1.UserController do
          {:watchlist, %{watchlists: [watchlist | _]}} <-
            {:watchlist, Repo.account_repo().preload(identity, :watchlists)},
          watchlist_with_addresses <- preload_watchlist_addresses(watchlist) do
+      watchlist_addresses =
+        Enum.map(watchlist_with_addresses.watchlist_addresses, fn wa ->
+          balances =
+            Chain.fetch_paginated_last_token_balances(wa.address_hash,
+              paging_options: %PagingOptions{page_size: @token_balances_amount + 1}
+            )
+
+          count = Enum.count(balances)
+          overflow? = count > @token_balances_amount
+
+          fiat_sum =
+            balances
+            |> Enum.take(@token_balances_amount)
+            |> Enum.reduce(Decimal.new(0), fn tb, acc -> Decimal.add(acc, tb.fiat_value) end)
+
+          %WatchlistAddress{
+            wa
+            | tokens_fiat_value: fiat_sum,
+              tokens_count: min(count, @token_balances_amount),
+              tokens_overflow: overflow?
+          }
+        end)
+
       conn
       |> put_status(200)
       |> render(:watchlist_addresses, %{
         exchange_rate: Market.get_coin_exchange_rate(),
-        watchlist_addresses: watchlist_with_addresses.watchlist_addresses
+        watchlist_addresses: watchlist_addresses
       })
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
@@ -44,7 +44,7 @@ defmodule BlockScoutWeb.Account.Api.V1.UserController do
           fiat_sum =
             balances
             |> Enum.take(@token_balances_amount)
-            |> Enum.reduce(Decimal.new(0), fn tb, acc -> Decimal.add(acc, tb.fiat_value) end)
+            |> Enum.reduce(Decimal.new(0), fn tb, acc -> Decimal.add(acc, tb.fiat_value || 0) end)
 
           %WatchlistAddress{
             wa

--- a/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/user_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/user_view.ex
@@ -102,7 +102,10 @@ defmodule BlockScoutWeb.Account.Api.V1.UserView do
       },
       "notification_methods" => %{
         "email" => watchlist.notify_email
-      }
+      },
+      "tokens_fiat_value" => watchlist.tokens_fiat_value,
+      "tokens_count" => watchlist.tokens_count,
+      "tokens_overflow" => watchlist.tokens_overflow
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.Account.Api.V1.UserControllerTest do
   use BlockScoutWeb.ConnCase
 
+  alias Explorer.Repo
   alias Explorer.Chain.Address
   alias BlockScoutWeb.Models.UserFromAuth
 
@@ -571,6 +572,70 @@ defmodule BlockScoutWeb.Account.Api.V1.UserControllerTest do
              )
              |> doc(description: "Example of error on editing watchlist address")
              |> json_response(422) == %{"errors" => %{"watchlist_id" => ["Address already added to the watch list"]}}
+    end
+
+    test "watchlist address returns with token balances info", %{conn: conn} do
+      watchlist_address_map = build(:watchlist_address)
+
+      conn
+      |> post(
+        "/api/account/v1/user/watchlist",
+        watchlist_address_map
+      )
+      |> json_response(200)
+
+      watchlist_address_map_1 = build(:watchlist_address)
+
+      conn
+      |> post(
+        "/api/account/v1/user/watchlist",
+        watchlist_address_map_1
+      )
+      |> json_response(200)
+
+      values =
+        for _i <- 0..149 do
+          ctb =
+            insert(:address_current_token_balance_with_token_id,
+              address: Repo.get_by(Address, hash: watchlist_address_map["address_hash"])
+            )
+            |> Repo.preload([:token])
+
+          Decimal.div(
+            Decimal.mult(ctb.value, ctb.token.fiat_value),
+            Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals))
+          )
+        end
+
+      values_1 =
+        for _i <- 0..200 do
+          ctb =
+            insert(:address_current_token_balance_with_token_id,
+              address: Repo.get_by(Address, hash: watchlist_address_map_1["address_hash"])
+            )
+            |> Repo.preload([:token])
+
+          Decimal.div(
+            Decimal.mult(ctb.value, ctb.token.fiat_value),
+            Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals))
+          )
+        end
+        |> Enum.sort(fn x1, x2 -> Decimal.compare(x1, x2) in [:gt, :eq] end)
+        |> Enum.take(150)
+
+      [wa2, wa1] = conn |> get("/api/account/v1/user/watchlist") |> json_response(200)
+
+      assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(14) ==
+               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(14)
+
+      assert wa1["tokens_count"] == 150
+      assert wa1["tokens_overflow"] == false
+
+      assert wa2["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(14) ==
+               values_1 |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(14)
+
+      assert wa2["tokens_count"] == 150
+      assert wa2["tokens_overflow"] == true
     end
 
     test "post api key", %{conn: conn} do

--- a/apps/explorer/lib/explorer/account/watchlist_address.ex
+++ b/apps/explorer/lib/explorer/account/watchlist_address.ex
@@ -38,6 +38,9 @@ defmodule Explorer.Account.WatchlistAddress do
     field(:notify_inapp, :boolean)
 
     field(:fetched_coin_balance, Wei, virtual: true)
+    field(:tokens_fiat_value, :decimal, virtual: true)
+    field(:tokens_count, :integer, virtual: true)
+    field(:tokens_overflow, :boolean, virtual: true)
 
     timestamps()
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -895,7 +895,7 @@ defmodule Explorer.Factory do
       address: build(:address),
       token_contract_address_hash: insert(:token).contract_address_hash,
       block_number: block_number(),
-      value: Enum.random(1..100_000),
+      value: Enum.random(1_000_000_000_000_000_000..10_000_000_000_000_000_000),
       value_fetched_at: DateTime.utc_now(),
       token_id: token_id,
       token_type: token_type


### PR DESCRIPTION
Close #7887

## Changelog
- Add `tokens_fiat_value`, `tokens_count` and `tokens_overflow` to watchlist address model

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
