### PR TITLE
API v2: Add block_hash to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 - [#7863](https://github.com/blockscout/blockscout/pull/7863) - Add max_age for account sessions
 - [#7841](https://github.com/blockscout/blockscout/pull/7841) - CORS setup for docker-compose config with new frontend
-- [#7832](https://github.com/blockscout/blockscout/pull/7832) - API v2: Add block_number to logs
+- [#7832](https://github.com/blockscout/blockscout/pull/7832), [#7891](https://github.com/blockscout/blockscout/pull/7891) - API v2: Add block_number, block_hash to logs
 - [#7789](https://github.com/blockscout/blockscout/pull/7789) - Fix test warnings; Fix name of `MICROSERVICE_ETH_BYTECODE_DB_INTERVAL_BETWEEN_LOOKUPS` env variable
 - [#7819](https://github.com/blockscout/blockscout/pull/7819) - Add logging for unknown error verification result
 - [#7781](https://github.com/blockscout/blockscout/pull/7781) - Add `/api/v1/health/liveness` and `/api/v1/health/readiness`

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -285,7 +285,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "index" => log.index,
       "decoded" => decoded,
       "smart_contract" => smart_contract_info(transaction_or_hash),
-      "block_number" => log.block_number
+      "block_number" => log.block_number,
+      "block_hash" => log.block_hash
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1729,6 +1729,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     assert Address.checksum(log.address_hash) == json["address"]["hash"]
     assert to_string(log.transaction_hash) == json["tx_hash"]
     assert json["block_number"] == log.block_number
+    assert json["block_hash"] == to_string(log.block_hash)
   end
 
   defp compare_item(%Withdrawal{} = withdrawal, json) do


### PR DESCRIPTION
## Changelog
- Add `block_hash` to logs entity

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
