### PR TITLE
Handle depositNonce key in transaction receipts for OpStack L2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#7764](https://github.com/blockscout/blockscout/pull/7764) - Fix missing ranges insertion and deletion logic
 - [#7843](https://github.com/blockscout/blockscout/pull/7843) - Fix created_contract_code_indexed_at updating
 - [#7855](https://github.com/blockscout/blockscout/pull/7855) - Handle internal transactions unique_violation
+- [#7904] (https://github.com/blockscout/blockscout/pull/7904) - Handle depositNonce key in receipts for OpStack
 
 ### Chore
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -309,6 +309,11 @@ defmodule EthereumJSONRPC.Receipt do
     :ignore
   end
 
+  # OpStack fields
+  defp entry_to_elixir({key, _}) when key in ~w(depositNonce) do
+    :ignore
+  end
+
   # GoQuorum specific transaction receipt fields
   defp entry_to_elixir({key, _}) when key in ~w(isPrivacyMarkerTransaction) do
     :ignore

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
@@ -29,6 +29,14 @@ defmodule EthereumJSONRPC.ReceiptTest do
     test ~s|"status" => nil is treated the same as no status| do
       assert Receipt.to_elixir(%{"status" => nil, "transactionHash" => "0x0"}) == %{"transactionHash" => "0x0"}
     end
+
+    test "ignore edge case fields" do
+      edge_case_fields = ~w(error returnData returnCode feeStats l1BlockNumber l1GasUsed l1GasPrice l1FeeScalar l1Fee isPrivacyMarkerTransaction depositNonce)
+
+      Enum.each(edge_case_fields, fn field ->
+        assert Receipt.to_elixir(%{field => nil, "transactionHash" => "0x0"}) == %{"transactionHash" => "0x0"}
+      end)
+    end
   end
 
   test "leaves nil if blockNumber is nil" do


### PR DESCRIPTION
## Motivation

I want to resolve `depositNonce` not being ignored which is causing the blockscout to fail at indexing Opstack L2s. Seems like others are also facing this issue [PR 7878](https://github.com/blockscout/blockscout/pull/7878).

## Changelog

Ignoring `depositNonce` extra key in Transaction Receipts from Opstack's L2.

```
** (ArgumentError) Could not convert receipt to elixir

Receipt:
  %{"blockHash" => "0xfaa1c25ae4ed8ce74b3017b107806f859f6edb77dc1519f3f2799510be974a50", "blockNumber" => "0x4c87", "contractAddress" => nil, "cumulativeGasUsed" => "0xf9d1", "depositNonce" => "0x4c86", "effectiveGasPrice" => "0x0", "from" => "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001", "gas" => 1000000, "gasUsed" => "0xf9d1", "logs" => [], "logsBloom" => "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "status" => "0x1", "to" => "0x4200000000000000000000000000000000000015", "transactionHash" => "0x5437342cb1e8e972ddf9ef4e47718d9135d042fd6f4780c272b5345937f0b273", "transactionIndex" => "0x0", "type" => "0x7e"}

Errors:
  {:unknown_key, %{key: "depositNonce", value: "0x4c86"}}
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
