### PR TITLE
Explicitly set consensus == true in queries (convenient for search)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Chore
 
+- [#7934](https://github.com/blockscout/blockscout/pull/7934) - Explicitly set consensus == true in queries (convenient for search)
 - [#7901](https://github.com/blockscout/blockscout/pull/7901) - Fix Docker image build
 - [#7890](https://github.com/blockscout/blockscout/pull/7890), [#7918](https://github.com/blockscout/blockscout/pull/7918) - Resolve warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
 - [#7863](https://github.com/blockscout/blockscout/pull/7863) - Add max_age for account sessions

--- a/apps/explorer/lib/explorer/account/notifier/summary.ex
+++ b/apps/explorer/lib/explorer/account/notifier/summary.ex
@@ -3,8 +3,6 @@ defmodule Explorer.Account.Notifier.Summary do
     Compose a summary from transactions
   """
 
-  require Logger
-
   alias Explorer
   alias Explorer.Account.Notifier.Summary
   alias Explorer.{Chain, Repo}

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -764,7 +764,7 @@ defmodule Explorer.Chain do
   def block_reward(block_number) do
     block_hash =
       Block
-      |> where([block], block.number == ^block_number and block.consensus)
+      |> where([block], block.number == ^block_number and block.consensus == true)
       |> select([block], block.hash)
       |> Repo.one!()
 
@@ -784,7 +784,7 @@ defmodule Explorer.Chain do
             left_join: transaction in assoc(block, :transactions),
             inner_join: emission_reward in EmissionReward,
             on: fragment("? <@ ?", block.number, emission_reward.block_range),
-            where: block.number == ^block_number and block.consensus,
+            where: block.number == ^block_number and block.consensus == true,
             group_by: [emission_reward.reward, block.hash],
             select: %Wei{
               value: coalesce(sum(transaction.gas_used * transaction.gas_price), 0) + emission_reward.reward
@@ -6373,8 +6373,8 @@ defmodule Explorer.Chain do
 
   defp find_block_timestamp(number, options) do
     Block
-    |> where([b], b.number == ^number)
-    |> select([b], b.timestamp)
+    |> where([block], block.number == ^number)
+    |> select([block], block.timestamp)
     |> limit(1)
     |> select_repo(options).one()
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -282,7 +282,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     query =
       from(
         block in Block,
-        where: block.number in ^block_numbers and block.consensus,
+        where: block.number in ^block_numbers and block.consensus == true,
         select: block.hash,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: block.hash],
@@ -672,7 +672,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       update_query =
         from(
           block in Block,
-          where: block.number in ^invalid_block_numbers and block.consensus,
+          where: block.number in ^invalid_block_numbers and block.consensus == true,
           where: block.number > ^minimal_block,
           select: block.hash,
           # ShareLocks order already enforced by `acquire_blocks` (see docs: sharelocks.md)

--- a/apps/explorer/lib/explorer/smart_contract/vyper/code_compiler.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/code_compiler.ex
@@ -5,8 +5,6 @@ defmodule Explorer.SmartContract.Vyper.CodeCompiler do
 
   alias Explorer.SmartContract.VyperDownloader
 
-  require Logger
-
   @spec run(Keyword.t()) :: {:ok, map} | {:error, :compilation | :name}
   def run(params) do
     compiler_version = Keyword.fetch!(params, :compiler_version)

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -97,7 +97,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
 
         if transactions_count > 0 do
           Logger.info(
-            "Block with number #{block_number} and hash #{to_string(block_hash)} is full of transactions. We should set consensus=false for it in order to refetch.",
+            "Block with number #{block_number} and hash #{to_string(block_hash)} is full of transactions. We should set consensus = false for it in order to refetch.",
             fetcher: :empty_blocks_to_refetch
           )
 

--- a/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
+++ b/apps/indexer/lib/indexer/temporary/uncles_without_index.ex
@@ -52,7 +52,7 @@ defmodule Indexer.Temporary.UnclesWithoutIndex do
     query =
       from(bsdr in SecondDegreeRelation,
         join: block in assoc(bsdr, :nephew),
-        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and block.consensus,
+        where: is_nil(bsdr.index) and is_nil(bsdr.uncle_fetched_at) and block.consensus == true,
         select: bsdr.nephew_hash,
         group_by: bsdr.nephew_hash
       )


### PR DESCRIPTION
## Motivation

Explicitly set consensus == true in queries (convenient for search)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
