### PR TITLE
API v2 rate limit: Put token to cookies & change /api/v2/key method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#7946](https://github.com/blockscout/blockscout/pull/7946) - API v2 rate limit: Put token to cookies & change /api/v2/key method
 - [#7888](https://github.com/blockscout/blockscout/pull/7888) - Add token balances info to watchlist address response
 - [#7898](https://github.com/blockscout/blockscout/pull/7898) - Add possibility to add extra headers with JSON RPC URL
 - [#7836](https://github.com/blockscout/blockscout/pull/7836) - Improve unverified email flow

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -13,7 +13,7 @@ config :block_scout_web,
   # 604800 seconds, 1 week
   session_cookie_ttl: 60 * 60 * 24 * 7,
   invalid_session_key: "invalid_session",
-  api_v2_temp_token_key: "api_v2_temp_client_key"
+  api_v2_temp_token_key: "api_v2_temp_token"
 
 config :block_scout_web,
   admin_panel_enabled: System.get_env("ADMIN_PANEL_ENABLED", "") == "true"

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -12,7 +12,8 @@ config :block_scout_web,
   cookie_domain: System.get_env("SESSION_COOKIE_DOMAIN"),
   # 604800 seconds, 1 week
   session_cookie_ttl: 60 * 60 * 24 * 7,
-  invalid_session_key: "invalid_session"
+  invalid_session_key: "invalid_session",
+  api_v2_temp_token_key: "api_v2_temp_client_key"
 
 config :block_scout_web,
   admin_panel_enabled: System.get_env("ADMIN_PANEL_ENABLED", "") == "true"

--- a/apps/block_scout_web/lib/block_scout_web/api_key_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_key_v2_router.ex
@@ -9,8 +9,6 @@ defmodule BlockScoutWeb.APIKeyV2Router do
     plug(Logger, application: :api_v2)
     plug(:accepts, ["json"])
     plug(CheckApiV2)
-    plug(:fetch_session)
-    plug(:protect_from_forgery)
   end
 
   scope "/", as: :api_v2 do
@@ -18,6 +16,6 @@ defmodule BlockScoutWeb.APIKeyV2Router do
 
     alias BlockScoutWeb.API.V2
 
-    get("/", V2.APIKeyController, :get_key)
+    post("/", V2.APIKeyController, :get_key)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
@@ -9,6 +9,10 @@ defmodule BlockScoutWeb.API.V2.APIKeyController do
 
   plug(:fetch_cookies, signed: [@api_v2_temp_token_key])
 
+  @doc """
+    Function to handle POST requests to `/api/v2/key` endpoint. It expects body with `recaptcha_response`. And puts cookie with temporary API v2 token. Which is handled here: https://github.com/blockscout/blockscout/blob/cd19739347f267d8a6ad81bbba2dbdad08bcc134/apps/block_scout_web/lib/block_scout_web/views/access_helper.ex#L170
+  """
+  @spec get_key(Plug.Conn.t(), nil | map) :: {:recaptcha, any} | Plug.Conn.t()
   def get_key(conn, params) do
     helper = Application.get_env(:block_scout_web, :captcha_helper)
     ttl = Application.get_env(:block_scout_web, :api_rate_limit)[:api_v2_token_ttl_seconds]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
@@ -2,9 +2,12 @@ defmodule BlockScoutWeb.API.V2.APIKeyController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.AccessHelper
-  alias Plug.Crypto
+
+  @api_v2_temp_token_key Application.compile_env(:block_scout_web, :api_v2_temp_token_key)
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  plug(:fetch_cookies, signed: [@api_v2_temp_token_key])
 
   def get_key(conn, params) do
     helper = Application.get_env(:block_scout_web, :captcha_helper)
@@ -14,11 +17,14 @@ defmodule BlockScoutWeb.API.V2.APIKeyController do
          {:recaptcha, false} <- {:recaptcha, is_nil(recaptcha_response)},
          {:recaptcha, true} <- {:recaptcha, helper.recaptcha_passed?(recaptcha_response)} do
       conn
+      |> put_resp_cookie(@api_v2_temp_token_key, %{ip: AccessHelper.conn_to_ip_string(conn)},
+        max_age: ttl,
+        sign: true,
+        same_site: "Lax",
+        domain: Application.get_env(:block_scout_web, :cookie_domain)
+      )
       |> json(%{
-        key:
-          Crypto.sign(conn.secret_key_base, conn.secret_key_base, %{ip: AccessHelper.conn_to_ip_string(conn)},
-            max_age: ttl
-          )
+        message: "OK"
       })
     end
   end


### PR DESCRIPTION
Close #7945 

## Changelog
- Put API v2 rate limit token to cookies
- Change `/api/v2/key` method from GET to POST

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
