### PR TITLE
Improve locks acquiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#7859](https://github.com/blockscout/blockscout/pull/7859) - Add TokenTotalSupplyUpdater
 - [#7873](https://github.com/blockscout/blockscout/pull/7873) - Chunk realtime balances requests
 - [#7927](https://github.com/blockscout/blockscout/pull/7927) - Delete token balances only for blocks that lost consensus
+- [#7947](https://github.com/blockscout/blockscout/pull/7947) - Decrease locks level
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [#7859](https://github.com/blockscout/blockscout/pull/7859) - Add TokenTotalSupplyUpdater
 - [#7873](https://github.com/blockscout/blockscout/pull/7873) - Chunk realtime balances requests
 - [#7927](https://github.com/blockscout/blockscout/pull/7927) - Delete token balances only for blocks that lost consensus
-- [#7947](https://github.com/blockscout/blockscout/pull/7947) - Decrease locks level
+- [#7947](https://github.com/blockscout/blockscout/pull/7947) - Improve locks acquiring
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4221,7 +4221,7 @@ defmodule Explorer.Chain do
         where: address_name.address_hash == ^address_hash,
         # Enforce Name ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: :address_hash, asc: :name],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     repo.update_all(
@@ -5159,7 +5159,7 @@ defmodule Explorer.Chain do
       )
       # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
       |> order_by(asc: :hash)
-      |> lock("FOR UPDATE")
+      |> lock("FOR NO KEY UPDATE")
 
     hashes = Enum.map(transactions, & &1.hash)
 
@@ -5204,7 +5204,7 @@ defmodule Explorer.Chain do
         end)
         # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
         |> order_by(asc: :hash)
-        |> lock("FOR UPDATE")
+        |> lock("FOR NO KEY UPDATE")
 
       Repo.update_all(
         from(t in Transaction, join: s in subquery(query), on: t.hash == s.hash),

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -107,35 +107,13 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
       |> Map.put_new(:timeout, @timeout)
       |> Map.put(:timestamps, timestamps)
 
-    # Enforce ShareLocks tables order (see docs: sharelocks.md)
-    run_func = fn repo ->
-      token_contract_address_hashes_and_ids =
-        changes_list
-        |> Enum.map(fn change ->
-          token_id = get_token_id(change)
-
-          {change.token_contract_address_hash, token_id}
-        end)
-        |> Enum.uniq()
-
-      Tokens.acquire_contract_address_tokens(repo, token_contract_address_hashes_and_ids)
-    end
-
     multi
-    |> Multi.run(:acquire_contract_address_tokens, fn repo, _ ->
-      Instrumenter.block_import_stage_runner(
-        fn -> run_func.(repo) end,
-        :block_following,
-        :current_token_balances,
-        :acquire_contract_address_tokens
-      )
-    end)
     |> Multi.run(:address_current_token_balances, fn repo, _ ->
       Instrumenter.block_import_stage_runner(
         fn -> insert(repo, changes_list, insert_options) end,
         :block_following,
         :current_token_balances,
-        :acquire_contract_address_tokens
+        :address_current_token_balances
       )
     end)
     |> Multi.run(:address_current_token_balances_update_token_holder_counts, fn repo,
@@ -156,13 +134,9 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
         end,
         :block_following,
         :current_token_balances,
-        :acquire_contract_address_tokens
+        :address_current_token_balances_update_token_holder_counts
       )
     end)
-  end
-
-  defp get_token_id(change) do
-    if Map.has_key?(change, :token_id), do: change.token_id, else: nil
   end
 
   @impl Import.Runner

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -243,7 +243,7 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
           where: t.created_contract_address_hash in ^ordered_created_contract_hashes,
           # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
           order_by: t.hash,
-          lock: "FOR UPDATE"
+          lock: "FOR NO KEY UPDATE"
         )
 
       try do

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -232,7 +232,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         select: transaction,
         # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: :hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     update_query =
@@ -378,7 +378,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         select: block.hash,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: block.hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     {_, removed_consensus_block_hashes} =
@@ -683,7 +683,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         where: bsdr.uncle_hash in ^uncle_hashes,
         # Enforce SeconDegreeRelation ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: :nephew_hash, asc: :uncle_hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     update_query =

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -286,7 +286,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         select: block.hash,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: block.hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     {:ok, repo.all(query)}
@@ -314,7 +314,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         select: map(t, [:hash, :block_hash, :block_number, :cumulative_gas_used]),
         # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: t.hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     {:ok, repo.all(query)}

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -215,7 +215,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           where: block.hash in ^block_hashes,
           # Enforce Block ShareLocks order (see docs: sharelocks.md)
           order_by: [asc: block.hash],
-          lock: "FOR UPDATE"
+          lock: "FOR NO KEY UPDATE"
         )
 
       try do

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -142,7 +142,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
       order_by: [asc: block.hash],
       limit: ^limit,
       offset: 1000,
-      lock: "FOR UPDATE"
+      lock: "FOR NO KEY UPDATE"
     )
   end
 

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -68,19 +68,15 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   end
 
   defp sanitize_empty_blocks(json_rpc_named_arguments) do
-    unprocessed_non_empty_blocks_from_db = unprocessed_non_empty_blocks_query_list(limit())
+    unprocessed_non_empty_blocks_query = unprocessed_non_empty_blocks_query(limit())
 
-    uniq_block_hashes = unprocessed_non_empty_blocks_from_db
-
-    if Enum.count(uniq_block_hashes) > 0 do
-      Repo.update_all(
-        from(
-          block in Block,
-          where: block.hash in ^uniq_block_hashes
-        ),
-        set: [is_empty: false, updated_at: Timex.now()]
-      )
-    end
+    Repo.update_all(
+      from(
+        block in Block,
+        where: block.hash in subquery(unprocessed_non_empty_blocks_query)
+      ),
+      set: [is_empty: false, updated_at: Timex.now()]
+    )
 
     unprocessed_empty_blocks_from_db = unprocessed_empty_blocks_query_list(limit())
 
@@ -141,25 +137,20 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
       where: block.consensus == true,
       order_by: [asc: block.hash],
       limit: ^limit,
-      offset: 1000,
-      lock: "FOR NO KEY UPDATE"
+      offset: 1000
     )
   end
 
-  defp unprocessed_non_empty_blocks_query_list(limit) do
+  defp unprocessed_non_empty_blocks_query(limit) do
     blocks_query = consensus_blocks_with_nil_is_empty_query(limit)
 
-    query =
-      from(q in subquery(blocks_query),
-        inner_join: transaction in Transaction,
-        on: q.number == transaction.block_number,
-        select: q.hash,
-        distinct: q.hash,
-        order_by: [asc: q.hash]
-      )
-
-    query
-    |> Repo.all(timeout: :infinity)
+    from(q in subquery(blocks_query),
+      inner_join: transaction in Transaction,
+      on: q.number == transaction.block_number,
+      select: q.hash,
+      order_by: [asc: q.hash],
+      lock: fragment("FOR NO KEY UPDATE OF ?", q)
+    )
   end
 
   defp unprocessed_empty_blocks_query_list(limit) do

--- a/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
+++ b/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex
@@ -136,7 +136,7 @@ defmodule Indexer.Temporary.BlocksTransactionsMismatch do
         where: block.hash in ^hashes,
         # Enforce Block ShareLocks order (see docs: sharelocks.md)
         order_by: [asc: block.hash],
-        lock: "FOR UPDATE"
+        lock: "FOR NO KEY UPDATE"
       )
 
     Repo.update_all(


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/6755
Resolves https://github.com/blockscout/blockscout/issues/6734

## Motivation

Currently we are using `FOR UPDATE` locks in every lock queries, but there is no need to use this lock type for queries that are not going to delete or modify primary key. In these cases it's better to use `FOR NO KEY UPDATE` to avoid unnecessary locks.

Also, there are several locks that hold data not meant to be updated.

## Changelog

- Change lock type from `FOR UPDATE` to `FOR NO KEY UPDATE` for queries that are not going to delete data or modify PK
- Move tokens lock acquiring from `Blocks` and `CurrentTokenBalances` runners to update token holders function since this lock is only needed for insert ordering
- Upgrade lock acquiring in `EmptyBlockSanitizer` so it doesn't conflict with general block fetchers