### PR TITLE
Fixed wrong TX url in email notifications for mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#7843](https://github.com/blockscout/blockscout/pull/7843) - Fix created_contract_code_indexed_at updating
 - [#7855](https://github.com/blockscout/blockscout/pull/7855) - Handle internal transactions unique_violation
 - [#7899](https://github.com/blockscout/blockscout/pull/7899) - Fix catchup numbers_to_ranges function
+- [#7951](https://github.com/blockscout/blockscout/pull/7951) - Fix TX url in email notifications on mainnet
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/account/notifier/email.ex
+++ b/apps/explorer/lib/explorer/account/notifier/email.ex
@@ -134,11 +134,7 @@ defmodule Explorer.Account.Notifier.Email do
   end
 
   defp host do
-    if System.get_env("MIX_ENV") == "prod" do
-      "blockscout.com"
-    else
-      Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-    end
+    Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
   end
 
   defp path do


### PR DESCRIPTION
Fixes #7938 

## Motivation

Currently, email notifications on mainnet contain wrong tx address, e.g.:
`https://blockscout.com/tx/0x8ae7becf6abe11ff4eec490537f26e9cac228af37dbc3503e9bc030162e42b79` instead of `https://eth.blockscout.com/tx/0x8ae7becf6abe11ff4eec490537f26e9cac228af37dbc3503e9bc030162e42b79`

### Bug Fixes
The url-building logic contained redundant check for `prod` environment that led to wrong hostname substitution. According to the docs, the environment should have correct value in `BLOCKSCOUT_HOST` ENV variable.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
