### PR TITLE
Add parsing constructor arguments for sourcify contracts

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -98,6 +98,7 @@ defmodule Explorer.Chain do
   alias Explorer.Market.MarketHistoryCache
   alias Explorer.{PagingOptions, Repo}
   alias Explorer.SmartContract.Helper
+  alias Explorer.SmartContract.Solidity.Verifier
   alias Explorer.Tags.{AddressTag, AddressToTag}
 
   alias Dataloader.Ecto, as: DataloaderEcto
@@ -1889,7 +1890,7 @@ defmodule Explorer.Chain do
           if smart_contract do
             CheckBytecodeMatchingOnDemand.trigger_check(address_result, smart_contract)
             LookUpSmartContractSourcesOnDemand.trigger_fetch(address_result, smart_contract)
-            address_result
+            check_and_update_constructor_args(address_result)
           else
             LookUpSmartContractSourcesOnDemand.trigger_fetch(address_result, nil)
 
@@ -1911,6 +1912,35 @@ defmodule Explorer.Chain do
       address -> {:ok, address}
     end
   end
+
+  defp check_and_update_constructor_args(
+         %SmartContract{address_hash: address_hash, constructor_arguments: nil} = smart_contract
+       ) do
+    if args = Verifier.parse_constructor_arguments_for_sourcify_contract(address_hash, smart_contract.abi) do
+      smart_contract |> SmartContract.changeset(%{constructor_arguments: args}) |> Repo.update()
+      %SmartContract{smart_contract | constructor_arguments: args}
+    else
+      smart_contract
+    end
+  end
+
+  defp check_and_update_constructor_args(
+         %Address{
+           hash: address_hash,
+           contract_code: deployed_bytecode,
+           smart_contract: %SmartContract{constructor_arguments: nil} = smart_contract
+         } = address
+       ) do
+    if args =
+         Verifier.parse_constructor_arguments_for_sourcify_contract(address_hash, smart_contract.abi, deployed_bytecode) do
+      smart_contract |> SmartContract.changeset(%{constructor_arguments: args}) |> Repo.update()
+      %Address{address | smart_contract: %SmartContract{smart_contract | constructor_arguments: args}}
+    else
+      address
+    end
+  end
+
+  defp check_and_update_constructor_args(other), do: other
 
   defp add_twin_info_to_contract(address_result, address_verified_twin_contract, _hash)
        when is_nil(address_verified_twin_contract),
@@ -4311,7 +4341,7 @@ defmodule Explorer.Chain do
       verified_contract_twin_additional_sources = get_contract_additional_sources(verified_contract_twin, options)
 
       %{
-        :verified_contract => verified_contract_twin,
+        :verified_contract => check_and_update_constructor_args(verified_contract_twin),
         :additional_sources => verified_contract_twin_additional_sources
       }
     else


### PR DESCRIPTION
Close #6986

## Changelog
- Add parsing constructor arguments for sourcify contracts

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
