### PR TITLE
Add tokens sorting by market cap and fiat value; Add priority to sear…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#7970](https://github.com/blockscout/blockscout/pull/7970) - Search improvements: add sorting
 - [#7771](https://github.com/blockscout/blockscout/pull/7771) - CSV export: speed up
 - [#7962](https://github.com/blockscout/blockscout/pull/7962) - Allow indicate CMC id of the coin through env var
 - [#7946](https://github.com/blockscout/blockscout/pull/7946) - API v2 rate limit: Put token to cookies & change /api/v2/key method

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -28,7 +28,9 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "token_type" => search_result.token_type,
       "is_smart_contract_verified" => search_result.verified,
       "exchange_rate" => search_result.exchange_rate && to_string(search_result.exchange_rate),
-      "total_supply" => search_result.total_supply
+      "total_supply" => search_result.total_supply,
+      "circulating_market_cap" =>
+        search_result.circulating_market_cap && to_string(search_result.circulating_market_cap)
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
@@ -672,8 +672,8 @@ defmodule BlockScoutWeb.Account.Api.V1.UserControllerTest do
 
       [wa1] = conn |> get("/api/account/v1/user/watchlist") |> json_response(200)
 
-      assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(14) ==
-               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(14)
+      assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
+               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
 
       assert wa1["tokens_count"] == 150
       assert wa1["tokens_overflow"] == false

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1513,7 +1513,9 @@ defmodule Explorer.Chain do
         timestamp: fragment("NULL::timestamp without time zone"),
         verified: not is_nil(smart_contract),
         exchange_rate: nil,
-        total_supply: nil
+        total_supply: nil,
+        circulating_market_cap: nil,
+        priority: 1
       }
     )
   end
@@ -1538,7 +1540,9 @@ defmodule Explorer.Chain do
         timestamp: fragment("NULL::timestamp without time zone"),
         verified: not is_nil(smart_contract),
         exchange_rate: token.fiat_value,
-        total_supply: token.total_supply
+        total_supply: token.total_supply,
+        circulating_market_cap: token.circulating_market_cap,
+        priority: 0
       }
     )
   end
@@ -1563,7 +1567,9 @@ defmodule Explorer.Chain do
         timestamp: fragment("NULL::timestamp without time zone"),
         verified: true,
         exchange_rate: nil,
-        total_supply: nil
+        total_supply: nil,
+        circulating_market_cap: nil,
+        priority: 0
       }
     )
   end
@@ -1597,7 +1603,9 @@ defmodule Explorer.Chain do
             timestamp: fragment("NULL::timestamp without time zone"),
             verified: address.verified,
             exchange_rate: nil,
-            total_supply: nil
+            total_supply: nil,
+            circulating_market_cap: nil,
+            priority: 0
           }
         )
 
@@ -1628,7 +1636,9 @@ defmodule Explorer.Chain do
             timestamp: block.timestamp,
             verified: nil,
             exchange_rate: nil,
-            total_supply: nil
+            total_supply: nil,
+            circulating_market_cap: nil,
+            priority: 0
           }
         )
 
@@ -1657,7 +1667,9 @@ defmodule Explorer.Chain do
             timestamp: block.timestamp,
             verified: nil,
             exchange_rate: nil,
-            total_supply: nil
+            total_supply: nil,
+            circulating_market_cap: nil,
+            priority: 0
           }
         )
 
@@ -1681,7 +1693,9 @@ defmodule Explorer.Chain do
                 timestamp: block.timestamp,
                 verified: nil,
                 exchange_rate: nil,
-                total_supply: nil
+                total_supply: nil,
+                circulating_market_cap: nil,
+                priority: 0
               }
             )
 
@@ -1731,7 +1745,14 @@ defmodule Explorer.Chain do
 
         ordered_query =
           from(items in subquery(query),
-            order_by: [desc_nulls_last: items.holder_count, asc: items.name, desc: items.inserted_at],
+            order_by: [
+              desc: items.priority,
+              desc_nulls_last: items.circulating_market_cap,
+              desc_nulls_last: items.exchange_rate,
+              desc_nulls_last: items.holder_count,
+              asc: items.name,
+              desc: items.inserted_at
+            ],
             limit: ^paging_options.page_size,
             offset: ^offset
           )


### PR DESCRIPTION
…ch results

## Motivation
https://github.com/blockscout/blockscout/issues/7971
## Changelog
- Add tokens sorting by market cap and fiat value etc. Now ordering is:
```
              desc: items.priority,
              desc_nulls_last: items.circulating_market_cap,
              desc_nulls_last: items.exchange_rate,
              desc_nulls_last: items.holder_count,
              asc: items.name,
              desc: items.inserted_at
```
- Add priority to search results
- Add `circulating_market_cap` to token search result

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
