### PR TITLE
Fix missing range insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#8040](https://github.com/blockscout/blockscout/pull/8040) - Resolve issue with Docker image for Mac M1/M2
 - [#8060](https://github.com/blockscout/blockscout/pull/8060) - Fix eth_getLogs API endpoint
 - [#8082](https://github.com/blockscout/blockscout/pull/8082), [#8088](https://github.com/blockscout/blockscout/pull/8088) - Fix Rootstock charts API
+- [#7992](https://github.com/blockscout/blockscout/pull/7992) - Fix missing range insert
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -61,6 +61,7 @@ defmodule Explorer.Utility.MissingBlockRange do
         update_range(range_1, %{from_number: range_2.from_number})
 
       _ ->
+        delete_ranges_between(max_number, min_number)
         insert_range(%{from_number: max_number, to_number: min_number})
     end
   end


### PR DESCRIPTION
## Changelog
Fix missing range insertion logic in case when the inserted range doesn't fall with its bounds into any of the existing. We should delete all ranges between the bounds of new range before inserting.