### PR TITLE
Fix eth_getLogs API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#8040](https://github.com/blockscout/blockscout/pull/8040) - Resolve issue with Docker image for Mac M1/M2
+- [#8060](https://github.com/blockscout/blockscout/pull/8060) - Fix eth_getLogs API endpoint
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -296,17 +296,14 @@ defmodule Explorer.EthRPC do
   defp paging_options(%{
          "paging_options" => %{
            "logIndex" => log_index,
-           "transactionIndex" => transaction_index,
            "blockNumber" => block_number
          }
-       })
-       when is_integer(transaction_index) do
+       }) do
     with {:ok, parsed_block_number} <- to_number(block_number, "invalid block number"),
          {:ok, parsed_log_index} <- to_number(log_index, "invalid log index") do
       {:ok,
        %{
          log_index: parsed_log_index,
-         transaction_index: transaction_index,
          block_number: parsed_block_number
        }}
     end

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -248,16 +248,14 @@ defmodule Explorer.Etherscan.Logs do
 
   defp where_multiple_topics_match(query, _, _, _), do: query
 
-  defp page_logs(query, %{block_number: nil, transaction_index: nil, log_index: nil}) do
+  defp page_logs(query, %{block_number: nil, log_index: nil}) do
     query
   end
 
-  defp page_logs(query, %{block_number: block_number, transaction_index: transaction_index, log_index: log_index}) do
+  defp page_logs(query, %{block_number: block_number, log_index: log_index}) do
     from(
       data in query,
-      where:
-        data.index > ^log_index and data.block_number >= ^block_number and
-          data.transaction_index >= ^transaction_index
+      where: data.index > ^log_index and data.block_number >= ^block_number
     )
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8059

## Motivation

`eth_getLogs` pagination function is broken.

## Changelog

Remove unused in query and expected in paging options `transaction_index`.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
