### PR TITLE
Fix Rootstock charts API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#8040](https://github.com/blockscout/blockscout/pull/8040) - Resolve issue with Docker image for Mac M1/M2
 - [#8060](https://github.com/blockscout/blockscout/pull/8060) - Fix eth_getLogs API endpoint
+- [#8082](https://github.com/blockscout/blockscout/pull/8082) - Fix Rootstock charts API
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -125,5 +125,20 @@ defmodule BlockScoutWeb.API.V2.StatsController do
 
   defp available_supply(:ok, exchange_rate), do: exchange_rate.available_supply || 0
 
-  defp available_supply({:ok, supply_for_days}, _exchange_rate), do: supply_for_days
+  defp available_supply({:ok, supply_for_days}, _exchange_rate) do
+    supply_for_days
+    |> Jason.encode()
+    |> case do
+      {:ok, _data} ->
+        current_date =
+          supply_for_days
+          |> Map.keys()
+          |> Enum.max(Date)
+
+        Map.get(supply_for_days, current_date)
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/chain/supply/rsk.ex
+++ b/apps/explorer/lib/explorer/chain/supply/rsk.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Supply.RSK do
 
   use Explorer.Chain.Supply
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, subquery: 1]
   import EthereumJSONRPC, only: [integer_to_quantity: 1]
 
   alias EthereumJSONRPC.FetchedBalances
@@ -16,7 +16,9 @@ defmodule Explorer.Chain.Supply.RSK do
 
   @cache_name :rsk_balance
   @balance_key :balance
+  @rsk_bridge_contract_address "0x0000000000000000000000000000000001000006"
 
+  @spec market_cap(any()) :: Decimal.t()
   def market_cap(%{usd_value: usd_value}) when not is_nil(usd_value) do
     btc = circulating()
 
@@ -25,31 +27,32 @@ defmodule Explorer.Chain.Supply.RSK do
 
   def market_cap(_), do: Decimal.new(0)
 
-  @doc "Equivalent to getting the circulating value "
+  @doc "Equivalent to getting the circulating value"
   def supply_for_days(days) do
     now = Timex.now()
 
-    balances_query =
+    base_query =
       from(balance in CoinBalance,
         join: block in Block,
         on: block.number == balance.block_number,
         where: block.consensus == true,
-        where: balance.address_hash == ^"0x0000000000000000000000000000000001000006",
-        where: block.timestamp > ^Timex.shift(now, days: -days),
-        distinct: fragment("date_trunc('day', ?)", block.timestamp),
-        select: {block.timestamp, balance.value}
+        where: balance.address_hash == ^@rsk_bridge_contract_address,
+        select: %{timestamp: block.timestamp, value: balance.value}
+      )
+
+    balances_query =
+      from(q in subquery(base_query),
+        where: q.timestamp > ^Timex.shift(now, days: -days),
+        distinct: fragment("date_trunc('day', ?)", q.timestamp),
+        select: {q.timestamp, q.value}
       )
 
     balance_before_query =
-      from(balance in CoinBalance,
-        join: block in Block,
-        on: block.number == balance.block_number,
-        where: block.consensus == true,
-        where: balance.address_hash == ^"0x0000000000000000000000000000000001000006",
-        where: block.timestamp <= ^Timex.shift(Timex.now(), days: -days),
-        order_by: [desc: block.timestamp],
+      from(q in subquery(base_query),
+        where: q.timestamp <= ^Timex.shift(Timex.now(), days: -days),
+        order_by: [desc: q.timestamp],
         limit: 1,
-        select: balance.value
+        select: q.value
       )
 
     by_day =
@@ -105,7 +108,7 @@ defmodule Explorer.Chain.Supply.RSK do
     max_number = BlockNumber.get_max()
 
     params = [
-      %{block_quantity: integer_to_quantity(max_number), hash_data: "0x0000000000000000000000000000000001000006"}
+      %{block_quantity: integer_to_quantity(max_number), hash_data: @rsk_bridge_contract_address}
     ]
 
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
@@ -116,7 +119,7 @@ defmodule Explorer.Chain.Supply.RSK do
          errors: [],
          params_list: [
            %{
-             address_hash: "0x0000000000000000000000000000000001000006",
+             address_hash: @rsk_bridge_contract_address,
              value: value
            }
          ]


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8083

## Motivation

`/api/v2/stats/charts/market` returns 500 error in case of Rootstock supply module (`SUPPLY_MODULE=rsk`)

## Changelog

Correctly parse current available supply in case of Rootstock.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
