### PR TITLE
Fix Dockerfile build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN mix do deps.get, local.rebar --force, deps.compile
 ADD apps ./apps
 ADD config ./config
 ADD rel ./rel
-ADD *.exs .
+ADD *.exs ./
 
 RUN apk add --update nodejs npm
 


### PR DESCRIPTION
Fix error while building Docker image
`Step 29/47 : ADD *.exs .
When using ADD with more than one source file, the destination must be a directory and end with a /`