### PR TITLE
Generalize available_supply function across application versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [#8040](https://github.com/blockscout/blockscout/pull/8040) - Resolve issue with Docker image for Mac M1/M2
 - [#8060](https://github.com/blockscout/blockscout/pull/8060) - Fix eth_getLogs API endpoint
-- [#8082](https://github.com/blockscout/blockscout/pull/8082) - Fix Rootstock charts API
+- [#8082](https://github.com/blockscout/blockscout/pull/8082), [#8088](https://github.com/blockscout/blockscout/pull/8088) - Fix Rootstock charts API
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -94,7 +94,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
     exchange_rate = Market.get_coin_exchange_rate()
 
     recent_market_history = Market.fetch_recent_history()
-    current_total_supply = available_supply(Chain.supply_for_days(), exchange_rate)
+    current_total_supply = MarketHistoryChartController.available_supply(Chain.supply_for_days(), exchange_rate)
 
     price_history_data =
       recent_market_history
@@ -121,24 +121,5 @@ defmodule BlockScoutWeb.API.V2.StatsController do
       # todo: remove when new frontend is ready to use data from chart_data property only
       available_supply: current_total_supply
     })
-  end
-
-  defp available_supply(:ok, exchange_rate), do: exchange_rate.available_supply || 0
-
-  defp available_supply({:ok, supply_for_days}, _exchange_rate) do
-    supply_for_days
-    |> Jason.encode()
-    |> case do
-      {:ok, _data} ->
-        current_date =
-          supply_for_days
-          |> Map.keys()
-          |> Enum.max(Date)
-
-        Map.get(supply_for_days, current_date)
-
-      _ ->
-        nil
-    end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain/market_history_chart_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain/market_history_chart_controller.ex
@@ -29,16 +29,22 @@ defmodule BlockScoutWeb.Chain.MarketHistoryChartController do
     end
   end
 
-  defp available_supply(:ok, exchange_rate) do
-    to_string(exchange_rate.available_supply || 0)
-  end
+  def available_supply(:ok, exchange_rate), do: exchange_rate.available_supply || 0
 
-  defp available_supply({:ok, supply_for_days}, _exchange_rate) do
+  def available_supply({:ok, supply_for_days}, _exchange_rate) do
     supply_for_days
     |> Jason.encode()
     |> case do
-      {:ok, data} -> data
-      _ -> []
+      {:ok, _data} ->
+        current_date =
+          supply_for_days
+          |> Map.keys()
+          |> Enum.max(Date)
+
+        Map.get(supply_for_days, current_date)
+
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/8082

## Motivation

`available_supply` is defined twice: in API v2 and in the controller for an old UI.

## Changelog

Define generalized `available_supply` function.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
