### PR TITLE
Ignore previously handled frame by OP transaction batches module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#8122](https://github.com/blockscout/blockscout/pull/8122) - Ignore previously handled frame by OP transaction batches module
+
 ### Chore
 
 <details>

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -523,6 +523,11 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
         put_future_frame(current_channel_id, future_frame)
         {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}
 
+      frame.number < last_frame_number && frame.channel_id == current_channel_id &&
+          :binary.match(incomplete_frame_sequence.bytes, frame.data) != :nomatch ->
+        # ignore the frame (with the same channel id) which has already been concatenated before
+        {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}
+
       frame.number == last_frame_number && frame.channel_id == current_channel_id ->
         # ignore duplicated frame
         {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}


### PR DESCRIPTION
## Motivation

This is a continuation of https://github.com/blockscout/blockscout/pull/7827 for the cases like this:

```
2023-08-04 16:32:16.666	
State: %{batch_inbox: "0xff00000000000000000000000000000000000010", batch_submitter: "0x6887246668a3b87f54deb3b94ba47a6f63f32985", block_check_interval: 6180, chunk_size: 4, current_channel_id: "", end_block: 17841935, incomplete_frame_sequence: %{bytes: "", l1_transaction_hashes: [], last_frame_number: -1}, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "http://65.108.234.142:8545", http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]]], json_rpc_named_arguments_l2: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: "http://65.108.226.30:8545", fallback_url: "https://mainnet.optimism.io", fallback_trace_url: "https://mainnet.optimism.io", method_to_url: [debug_traceTransaction: "http://65.108.226.30:8545"], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Geth], last_channel_id: "", start_block: 17767692}
2023-08-04 16:32:16.666	
Last message: :continue
2023-08-04 16:32:16.666	
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
2023-08-04 16:32:16.666	
    (stdlib 4.0.1) gen_server.erl:1197: :gen_server.handle_msg/6
2023-08-04 16:32:16.666	
    (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
2023-08-04 16:32:16.666	
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:163: Indexer.Fetcher.OptimismTxnBatch.handle_info/2
2023-08-04 16:32:16.666	
    (elixir 1.14.0) lib/enum.ex:2514: Enum.reduce_while/3
2023-08-04 16:32:16.666	
    (elixir 1.14.0) lib/range.ex:383: Enumerable.Range.reduce/5
2023-08-04 16:32:16.666	
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:173: anonymous fn/9 in Indexer.Fetcher.OptimismTxnBatch.handle_info/2
2023-08-04 16:32:16.666	
** (MatchError) no match of right hand side value: {:error, "Invalid frame sequence. Last frame number: 4. Next frame number: 3. Tx hash: 0xb3bcf780372953b41dc46626c1874e5b9c6e975ff32e37449587e823df4fccaf."}
```

This error occured on Optimism Mainnet.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
