### PR TITLE
Add method_id to write methods in API v2 response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Chore
 
+- [#8146](https://github.com/blockscout/blockscout/pull/8146) - Add method_id to write methods in API v2 response
 - [#8105](https://github.com/blockscout/blockscout/pull/8105) - Extend API v1 with endpoints used by new UI
 - [#8104](https://github.com/blockscout/blockscout/pull/8104) - remove "TODO" from API v2 response
 - [#8100](https://github.com/blockscout/blockscout/pull/8100), [#8103](https://github.com/blockscout/blockscout/pull/8103) - Extend docker-compose configs with new config when front is running externally

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:not_found, true} <- {:not_found, AddressView.check_custom_abi_for_having_write_functions(custom_abi)} do
       conn
       |> put_status(200)
-      |> json(Writer.filter_write_functions(custom_abi.abi))
+      |> json(custom_abi.abi |> Writer.filter_write_functions() |> Reader.get_abi_with_method_id())
     end
   end
 
@@ -95,7 +95,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
          {:not_found, false} <- {:not_found, is_nil(smart_contract)} do
       conn
       |> put_status(200)
-      |> json(Writer.write_functions(smart_contract))
+      |> json(smart_contract |> Writer.write_functions() |> Reader.get_abi_with_method_id())
     end
   end
 
@@ -135,7 +135,11 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
 
       conn
       |> put_status(200)
-      |> json(Writer.write_functions_proxy(implementation_address_hash_string, @api_true))
+      |> json(
+        implementation_address_hash_string
+        |> Writer.write_functions_proxy(@api_true)
+        |> Reader.get_abi_with_method_id()
+      )
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -1205,6 +1205,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       assert [
                %{
+                 "method_id" => "49ba1b49",
                  "type" => "function",
                  "stateMutability" => "nonpayable",
                  "outputs" => [],
@@ -1271,7 +1272,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "stateMutability" => "nonpayable",
                  "outputs" => [],
                  "name" => "disableWhitelist",
-                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}],
+                 "method_id" => "49ba1b49"
                }
              ] == response
     end
@@ -1912,7 +1914,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "stateMutability" => "nonpayable",
                  "outputs" => [],
                  "name" => "disableWhitelist",
-                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}]
+                 "inputs" => [%{"type" => "bool", "name" => "disable", "internalType" => "bool"}],
+                 "method_id" => "49ba1b49"
                }
              ] == response
     end


### PR DESCRIPTION
Close #7924 

## Changelog
- Add method_id to write methods in API v2 response

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
