### PR TITLE
Switch sourcify tests from POA Sokol to Gnosis Chiado

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -625,7 +625,7 @@ jobs:
           PGUSER: postgres
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Nethermind.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
-          CHAIN_ID: "77"
+          CHAIN_ID: "10200"
           API_RATE_LIMIT_DISABLED: "true"
           ADMIN_PANEL_ENABLED: "true"
           ACCOUNT_ENABLED: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- [#8147](https://github.com/blockscout/blockscout/pull/8147) - Switch sourcify tests from POA Sokol to Gnosis Chiado
 - [#8145](https://github.com/blockscout/blockscout/pull/8145) - Handle negative holders count in API v2
 - [#8040](https://github.com/blockscout/blockscout/pull/8040) - Resolve issue with Docker image for Mac M1/M2
 - [#8060](https://github.com/blockscout/blockscout/pull/8060) - Fix eth_getLogs API endpoint

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -712,7 +712,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       params = %{
         "module" => "contract",
         "action" => "verify_via_sourcify",
-        "addressHash" => "0x18d89C12e9463Be6343c35C9990361bA4C42AfC2"
+        "addressHash" => "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1"
       }
 
       response =
@@ -732,14 +732,14 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       _created_contract_address =
         insert(
           :address,
-          hash: "0x18d89C12e9463Be6343c35C9990361bA4C42AfC2",
+          hash: "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1",
           contract_code: smart_contract_bytecode
         )
 
       params = %{
         "module" => "contract",
         "action" => "verify_via_sourcify",
-        "addressHash" => "0x18d89C12e9463Be6343c35C9990361bA4C42AfC2"
+        "addressHash" => "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1"
       }
 
       get_implementation()

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
@@ -222,7 +222,7 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
     end
 
     test "verify contract from sourcify repo", %{conn: conn} do
-      address = "0x18d89C12e9463Be6343c35C9990361bA4C42AfC2"
+      address = "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1"
 
       _contract = insert(:address, hash: address, contract_code: "0x01")
 


### PR DESCRIPTION
Close #8139

## Changelog
- Switch sourcify tests from POA Sokol to Gnosis Chiado

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
