### PR TITLE
Split range on catchup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#7952](https://github.com/blockscout/blockscout/pull/7952) - Add parsing constructor arguments for sourcify contracts
 - [#6190](https://github.com/blockscout/blockscout/pull/6190) - Add EIP-1559 support to gas price oracle
 - [#7977](https://github.com/blockscout/blockscout/pull/7977) - GraphQL: extend schema with new field for existing objects
+- [#8151](https://github.com/blockscout/blockscout/pull/8151) - Split range on catchup failure
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -199,7 +199,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
         Prometheus.Instrumenter.import_errors()
         Logger.error(fn -> [inspect(reason), ". Retrying."] end, step: step)
 
-        push_back(sequence, range)
+        split_and_push_back(sequence, range)
 
         error
 
@@ -223,7 +223,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
           step: step
         )
 
-        push_back(sequence, range)
+        split_and_push_back(sequence, range)
 
         error
     end
@@ -231,7 +231,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
     exception ->
       Logger.error(fn -> [Exception.format(:error, exception, __STACKTRACE__), ?\n, ?\n, "Retrying."] end)
 
-      push_back(sequence, range)
+      split_and_push_back(sequence, range)
 
       {:error, exception}
   end
@@ -254,6 +254,20 @@ defmodule Indexer.Block.Catchup.Fetcher do
     end
 
     other_errors
+  end
+
+  defp split_and_push_back(sequence, same_number..same_number = range) do
+    Logger.error("Range #{inspect(range)} is at its minimum size and cannot be split")
+
+    push_back(sequence, range)
+  end
+
+  defp split_and_push_back(sequence, from..to) do
+    middle_left = div(from + to, 2)
+    middle_right = if from > to, do: middle_left - 1, else: middle_left + 1
+
+    push_back(sequence, from..middle_left)
+    push_back(sequence, middle_right..to)
   end
 
   defp push_back(sequence, range) do


### PR DESCRIPTION
## Motivation

There are cases when catchup fetcher fails on import by timeout. It makes sense to split range on such fail so the next try will be lighter.

## Changelog

Split range before pushing back to sequence after catchup failure.