### PR TITLE
Insert current token balances placeholders along with historical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#8181](https://github.com/blockscout/blockscout/pull/8181) - Insert current token balances placeholders along with historical
+
 ### Fixes
 
 - [#8240](https://github.com/blockscout/blockscout/pull/8240) - Refactor and fix paging params in API v2

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -273,11 +273,12 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
         ]
       ],
       where:
-        fragment("? < EXCLUDED.block_number", current_token_balance.block_number) or
-          (fragment("? = EXCLUDED.block_number", current_token_balance.block_number) and
-             fragment("EXCLUDED.value IS NOT NULL") and
-             (is_nil(current_token_balance.value_fetched_at) or
-                fragment("? < EXCLUDED.value_fetched_at", current_token_balance.value_fetched_at)))
+        fragment("EXCLUDED.value_fetched_at IS NOT NULL") and
+          (fragment("? < EXCLUDED.block_number", current_token_balance.block_number) or
+             (fragment("? = EXCLUDED.block_number", current_token_balance.block_number) and
+                fragment("EXCLUDED.value IS NOT NULL") and
+                (is_nil(current_token_balance.value_fetched_at) or
+                   fragment("? < EXCLUDED.value_fetched_at", current_token_balance.value_fetched_at))))
     )
   end
 

--- a/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
@@ -218,7 +218,8 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
           address_hash: address.hash,
           block_number: 2,
           token_contract_address_hash: token.contract_address_hash,
-          value: Decimal.new(200)
+          value: Decimal.new(200),
+          value_fetched_at: DateTime.utc_now()
         },
         options
       )
@@ -300,7 +301,8 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                    address_hash: address_hash,
                    token_contract_address_hash: token_contract_address_hash,
                    block_number: block_number,
-                   value: value
+                   value: value,
+                   value_fetched_at: DateTime.utc_now()
                  },
                  options
                )
@@ -344,7 +346,8 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                    address_hash: address_hash,
                    token_contract_address_hash: token_contract_address_hash,
                    block_number: block_number,
-                   value: value
+                   value: value,
+                   value_fetched_at: DateTime.utc_now()
                  },
                  options
                )
@@ -404,13 +407,15 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
                      address_hash: non_holder_becomes_holder_address_hash,
                      token_contract_address_hash: token_contract_address_hash,
                      block_number: block_number,
-                     value: non_holder_becomes_holder_value
+                     value: non_holder_becomes_holder_value,
+                     value_fetched_at: DateTime.utc_now()
                    },
                    %{
                      address_hash: holder_becomes_non_holder_address_hash,
                      token_contract_address_hash: token_contract_address_hash,
                      block_number: block_number,
-                     value: holder_becomes_non_holder_value
+                     value: holder_becomes_non_holder_value,
+                     value_fetched_at: DateTime.utc_now()
                    }
                  ],
                  options

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -29,7 +29,7 @@ defmodule Indexer.Block.Fetcher do
     UncleBlock
   }
 
-  alias Indexer.{Prometheus, Tracer}
+  alias Indexer.{Prometheus, TokenBalances, Tracer}
 
   alias Indexer.Transform.{
     AddressCoinBalances,
@@ -182,6 +182,9 @@ defmodule Indexer.Block.Fetcher do
                address_coin_balances: %{params: coin_balances_params_set},
                address_coin_balances_daily: %{params: coin_balances_params_daily_set},
                address_token_balances: %{params: address_token_balances},
+               address_current_token_balances: %{
+                 params: address_token_balances |> MapSet.to_list() |> TokenBalances.to_address_current_token_balances()
+               },
                blocks: %{params: blocks},
                block_second_degree_relations: %{params: block_second_degree_relations_params},
                block_rewards: %{errors: beneficiaries_errors, params: beneficiaries_with_gas_payment},


### PR DESCRIPTION
#8157 

## Changelog

Insert current token balances placeholders along with historical balances so `TokenBalanceOnDemand` fetcher will update balances more accurately