### PR TITLE
Ignore invalid frame by OP transaction batches module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,8 @@
 
 ### Fixes
 
-<<<<<<< HEAD
 - [#7776](https://github.com/blockscout/blockscout/pull/7776) - Fix transactions ordering in Indexer.Fetcher.OptimismTxnBatch
-=======
 - [#8187](https://github.com/blockscout/blockscout/pull/8187) - API v1 500 error convert to 404, if requested path is incorrect
->>>>>>> origin/master
 - [#7852](https://github.com/blockscout/blockscout/pull/7852) - Token balances refactoring & fixes
 - [#7872](https://github.com/blockscout/blockscout/pull/7872) - Fix pending gas price in pending tx
 - [#7875](https://github.com/blockscout/blockscout/pull/7875) - Fix twin compiler version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- [#8208](https://github.com/blockscout/blockscout/pull/8208) - Ignore invalid frame by OP transaction batches module
 - [#8122](https://github.com/blockscout/blockscout/pull/8122) - Ignore previously handled frame by OP transaction batches module
 - [#8147](https://github.com/blockscout/blockscout/pull/8147) - Switch sourcify tests from POA Sokol to Gnosis Chiado
 - [#8145](https://github.com/blockscout/blockscout/pull/8145) - Handle negative holders count in API v2

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -494,6 +494,7 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
     end)
   end
 
+  # credo:disable-for-next-line /Complexity/
   defp handle_invalid_frame_number(
          last_frame_number,
          frame,
@@ -508,6 +509,8 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
       frame.number == 0 ->
         # the new frame rewrites the previous frame sequence
         # todo: handle last frame (when frame.is_last == true)
+        clear_future_frames()
+
         {:cont,
          {:ok, batches, sequences,
           %{bytes: frame.data, last_frame_number: frame.number, l1_transaction_hashes: [tx.hash]}, last_channel_id,
@@ -517,10 +520,14 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
         # ignore duplicated frame with the number greater than 0
         {:cont, {:ok, batches, sequences, empty_incomplete_frame_sequence(), last_channel_id, current_channel_id}}
 
-      frame.number > last_frame_number && frame.channel_id == current_channel_id ->
-        # temporarily save future frame to handle that later
-        future_frame = %{frame: frame, l1_tx_hash: tx.hash, l1_timestamp: l1_timestamp}
-        put_future_frame(current_channel_id, future_frame)
+      frame.number > last_frame_number ->
+        if frame.channel_id == current_channel_id do
+          # temporarily save future frame to handle that later
+          future_frame = %{frame: frame, l1_tx_hash: tx.hash, l1_timestamp: l1_timestamp}
+          put_future_frame(current_channel_id, future_frame)
+        end
+
+        # ignore invalid frame
         {:cont, {:ok, batches, sequences, incomplete_frame_sequence, last_channel_id, current_channel_id}}
 
       frame.number < last_frame_number && frame.channel_id == current_channel_id &&
@@ -961,11 +968,15 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
     end
   end
 
+  defp clear_future_frames do
+    :ets.delete_all_objects(@future_frames_table_name)
+  end
+
   defp get_future_frames(channel_id, clear \\ false) do
     with info when info != :undefined <- :ets.info(@future_frames_table_name),
          [{_, value}] <- :ets.lookup(@future_frames_table_name, channel_id) do
       if clear do
-        :ets.delete_all_objects(@future_frames_table_name)
+        clear_future_frames()
       end
 
       value


### PR DESCRIPTION
## Motivation

This is a continuation of https://github.com/blockscout/blockscout/pull/7827 for the cases like this:

```
2023-08-15T08:08:43.235 fetcher=optimism_txn_batches [error] GenServer Indexer.Fetcher.OptimismTxnBatch terminating
** (MatchError) no match of right hand side value: {:error, "Invalid frame sequence. Last frame number: 2. Next frame number: 4. Tx hash: 0xafde0199e602cde34fd5d71792abcb971dcfe49309cec61e08f241ab2e21292f."}
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:173: anonymous fn/9 in Indexer.Fetcher.OptimismTxnBatch.handle_info/2
    (elixir 1.14.5) lib/range.ex:392: Enumerable.Range.reduce/5
    (elixir 1.14.5) lib/enum.ex:2514: Enum.reduce_while/3
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:163: Indexer.Fetcher.OptimismTxnBatch.handle_info/2
    (stdlib 4.3.1.2) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3.1.2) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.3.1.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: :continue
State: %{batch_inbox: "0xff00000000000000000000000000000000000420", batch_submitter: "0x7431310e026b69bfc676c0013e12a1a11411eec9", block_check_interval: 7920, chunk_size: 4, current_channel_id: "", end_block: 9521012, incomplete_frame_sequence: %{bytes: "", l1_transaction_hashes: [], last_frame_number: -1}, ...
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
