### PR TITLE
Drop address foreign keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#8181](https://github.com/blockscout/blockscout/pull/8181) - Insert current token balances placeholders along with historical
+- [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop address foreign keys
 
 ### Fixes
 
@@ -30,7 +31,6 @@
 - [#6190](https://github.com/blockscout/blockscout/pull/6190) - Add EIP-1559 support to gas price oracle
 - [#7977](https://github.com/blockscout/blockscout/pull/7977) - GraphQL: extend schema with new field for existing objects
 - [#8158](https://github.com/blockscout/blockscout/pull/8158), [#8164](https://github.com/blockscout/blockscout/pull/8164) - Include unfetched balances in TokenBalanceOnDemand fetcher
-- [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop address foreign keys from logs, token transfers and transactions
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - [#6190](https://github.com/blockscout/blockscout/pull/6190) - Add EIP-1559 support to gas price oracle
 - [#7977](https://github.com/blockscout/blockscout/pull/7977) - GraphQL: extend schema with new field for existing objects
 - [#8158](https://github.com/blockscout/blockscout/pull/8158), [#8164](https://github.com/blockscout/blockscout/pull/8164) - Include unfetched balances in TokenBalanceOnDemand fetcher
-- [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop logs address_hash foreign key
+- [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop address foreign keys from logs, token transfers and transactions
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#6190](https://github.com/blockscout/blockscout/pull/6190) - Add EIP-1559 support to gas price oracle
 - [#7977](https://github.com/blockscout/blockscout/pull/7977) - GraphQL: extend schema with new field for existing objects
 - [#8158](https://github.com/blockscout/blockscout/pull/8158), [#8164](https://github.com/blockscout/blockscout/pull/8164) - Include unfetched balances in TokenBalanceOnDemand fetcher
+- [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop logs address_hash foreign key
 
 ### Fixes
 

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -155,7 +155,6 @@ defmodule Explorer.Chain.Address.CoinBalance do
     balance
     |> cast(params, @allowed_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:address_hash)
     |> unique_constraint(:block_number, name: :address_coin_balances_address_hash_block_number_index)
   end
 end

--- a/apps/explorer/lib/explorer/chain/address/coin_balance_daily.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance_daily.ex
@@ -69,7 +69,6 @@ defmodule Explorer.Chain.Address.CoinBalanceDaily do
     balance
     |> cast(params, @allowed_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:address_hash)
     |> unique_constraint(:day, name: :address_coin_balances_daily_address_hash_day_index)
   end
 end

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -74,7 +74,6 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     token_balance
     |> cast(attrs, @allowed_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:address_hash)
     |> foreign_key_constraint(:token_contract_address_hash)
   end
 

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -65,7 +65,6 @@ defmodule Explorer.Chain.Address.TokenBalance do
     token_balance
     |> cast(attrs, @allowed_fields)
     |> validate_required(@required_fields)
-    |> foreign_key_constraint(:address_hash)
     |> foreign_key_constraint(:token_contract_address_hash)
     |> unique_constraint(:block_number, name: :token_balances_address_hash_block_number_index)
   end

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -444,8 +444,6 @@ defmodule Explorer.Chain.InternalTransaction do
     |> validate_call_error_or_result()
     |> check_constraint(:call_type, message: ~S|can't be blank when type is 'call'|, name: :call_has_call_type)
     |> check_constraint(:input, message: ~S|can't be blank when type is 'call'|, name: :call_has_call_type)
-    |> foreign_key_constraint(:from_address_hash)
-    |> foreign_key_constraint(:to_address_hash)
     |> foreign_key_constraint(:transaction_hash)
     |> unique_constraint(:index)
   end
@@ -460,8 +458,6 @@ defmodule Explorer.Chain.InternalTransaction do
     |> validate_required(@create_required_fields)
     |> validate_create_error_or_result()
     |> check_constraint(:init, message: ~S|can't be blank when type is 'create'|, name: :create_has_init)
-    |> foreign_key_constraint(:created_contract_address_hash)
-    |> foreign_key_constraint(:from_address_hash)
     |> foreign_key_constraint(:transaction_hash)
     |> unique_constraint(:index)
   end
@@ -474,8 +470,6 @@ defmodule Explorer.Chain.InternalTransaction do
     changeset
     |> cast(attrs, @selfdestruct_allowed_fields)
     |> validate_required(@selfdestruct_required_fields)
-    |> foreign_key_constraint(:from_address_hash)
-    |> foreign_key_constraint(:to_address_hash)
     |> unique_constraint(:index)
   end
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -113,7 +113,6 @@ defmodule Explorer.Chain.Token do
     token
     |> cast(params, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
-    |> foreign_key_constraint(:contract_address)
     |> trim_name()
     |> sanitize_token_input(:name)
     |> sanitize_token_input(:symbol)

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -136,9 +136,6 @@ defmodule Explorer.Chain.TokenTransfer do
     struct
     |> cast(params, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
-    |> foreign_key_constraint(:from_address)
-    |> foreign_key_constraint(:to_address)
-    |> foreign_key_constraint(:token_contract_address)
     |> foreign_key_constraint(:transaction)
   end
 

--- a/apps/explorer/priv/repo/migrations/20230815131151_drop_logs_address_hash_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230815131151_drop_logs_address_hash_foreign_key.exs
@@ -1,0 +1,8 @@
+# cspell:ignore fkey
+defmodule Explorer.Repo.Migrations.DropLogsAddressHashForeignKey do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(constraint(:logs, :logs_address_hash_fkey))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20230816061723_drop_token_transfers_and_transactions_address_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230816061723_drop_token_transfers_and_transactions_address_foreign_key.exs
@@ -1,0 +1,13 @@
+# cspell:ignore fkey
+defmodule Explorer.Repo.Migrations.DropTokenTransfersAndTransactionsAddressForeignKey do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(constraint(:token_transfers, :token_transfers_from_address_hash_fkey))
+    drop_if_exists(constraint(:token_transfers, :token_transfers_to_address_hash_fkey))
+    drop_if_exists(constraint(:token_transfers, :token_transfers_token_contract_address_hash_fkey))
+    drop_if_exists(constraint(:transactions, :transactions_created_contract_address_hash_fkey))
+    drop_if_exists(constraint(:transactions, :transactions_from_address_hash_fkey))
+    drop_if_exists(constraint(:transactions, :transactions_to_address_hash_fkey))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20230817061317_drop_address_foreign_keys.exs
+++ b/apps/explorer/priv/repo/migrations/20230817061317_drop_address_foreign_keys.exs
@@ -1,0 +1,14 @@
+# cspell:ignore fkey
+defmodule Explorer.Repo.Migrations.DropAddressForeignKeys do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(constraint(:address_coin_balances, :address_coin_balances_address_hash_fkey))
+    drop_if_exists(constraint(:address_token_balances, :address_token_balances_address_hash_fkey))
+    drop_if_exists(constraint(:address_current_token_balances, :address_current_token_balances_address_hash_fkey))
+    drop_if_exists(constraint(:tokens, :tokens_contract_address_hash_fkey))
+    drop_if_exists(constraint(:internal_transactions, :internal_transactions_created_contract_address_hash_fkey))
+    drop_if_exists(constraint(:internal_transactions, :internal_transactions_from_address_hash_fkey))
+    drop_if_exists(constraint(:internal_transactions, :internal_transactions_to_address_hash_fkey))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20230821120625_drop_rest_address_foreign_keys.exs
+++ b/apps/explorer/priv/repo/migrations/20230821120625_drop_rest_address_foreign_keys.exs
@@ -1,0 +1,14 @@
+# cspell:ignore fkey
+defmodule Explorer.Repo.Migrations.DropRestAddressForeignKeys do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(constraint(:address_coin_balances_daily, :address_coin_balances_daily_address_hash_fkey))
+    drop_if_exists(constraint(:address_to_tags, :address_to_tags_address_hash_fkey))
+    drop_if_exists(constraint(:block_rewards, :block_rewards_address_hash_fkey))
+    drop_if_exists(constraint(:decompiled_smart_contracts, :decompiled_smart_contracts_address_hash_fkey))
+    drop_if_exists(constraint(:smart_contracts, :smart_contracts_address_hash_fkey))
+    drop_if_exists(constraint(:withdrawals, :withdrawals_address_hash_fkey))
+    drop_if_exists(constraint(:blocks, :blocks_miner_hash_fkey))
+  end
+end


### PR DESCRIPTION
## Changelog

Drop address foreign-keys from logs, token transfers, transactions, tokens, token balances, coin balances and internal transactions for performance reasons.