### PR TITLE
Fix Indexer.Fetcher.OptimismTxnBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- [#8229](https://github.com/blockscout/blockscout/pull/8229) - Fix Indexer.Fetcher.OptimismTxnBatch
 - [#8208](https://github.com/blockscout/blockscout/pull/8208) - Ignore invalid frame by OP transaction batches module
 - [#8122](https://github.com/blockscout/blockscout/pull/8122) - Ignore previously handled frame by OP transaction batches module
 - [#8147](https://github.com/blockscout/blockscout/pull/8147) - Switch sourcify tests from POA Sokol to Gnosis Chiado

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -439,6 +439,8 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
 
         with {:new_channel_id, true} <- {:new_channel_id, frame.channel_id != last_channel_id},
              {:frame_number_valid, true} <- {:frame_number_valid, frame.number == last_frame_number + 1},
+             {:channel_id_valid, true} <-
+               {:channel_id_valid, frame.channel_id == current_channel_id or current_channel_id == <<>>},
              {:frame_is_last, true} <- {:frame_is_last, frame.is_last},
              l1_timestamp = get_block_timestamp_by_number(t.block_number, blocks_params),
              {batches_parsed, seq} =
@@ -472,6 +474,10 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
               {last_channel_id, current_channel_id},
               incomplete_frame_sequence_acc
             )
+
+          {:channel_id_valid, false} ->
+            # ignore invalid frame
+            {:cont, {:ok, batches, sequences, incomplete_frame_sequence_acc, last_channel_id, current_channel_id}}
 
           {:frame_is_last, false} ->
             handle_not_last_valid_frame(


### PR DESCRIPTION
## Motivation

This is a continuation of https://github.com/blockscout/blockscout/pull/7827 for the cases like this:

```
2023-08-16T13:56:52.534 fetcher=optimism_txn_batches [error] GenServer Indexer.Fetcher.OptimismTxnBatch terminating
** (MatchError) no match of right hand side value: {:error, "Invalid RLP in frame sequence. Tx hash of the last frame: 0xdfd9b119af3e28d65a15a29cecee889aa20ec5a086336904ca11e85cc751d693. Compressed bytes of the sequence: 0x78da7c5c555895ed16a4bb43ba414a90ee92ee9f06e9ee0691ee6e9410a4a4bbbb4140ba4b1ae96e693cb7fbbd39e7ee3cf3fcb8bffdbdef5ab36666edd62744a88727d85c04d89f9df0deb405138517be4d6e9eb86e611d5e2835771afd9932ccc8b2c97921f121c6b9128df80cac7911d7d847706f3a55b023df51f1d2a8b99a2e2458f47cf20fb9780935afa18d7f786c6c7dac7b78ac0e26930efd90580e150acdce0295acf1a81a00bf45f1187153c774e09734d1d3b7b815d8fa28a99c3e4f0ef5ffff47f9ff61c429c8ff77ae2f924263aa6992cc445fe1ec22e985f869251e12ff205b5d784cda9f1aa60af3aa03dda3de33163804894b8f5511a6da8aec372b0c8fcb3d7a2ae55eb2c942e2235f7705a3ef7b6f89240a154c709bb42c6ab9452171f4c1b58701aecb0d7df294db2dc5667e6f9f100f485ce5d414e781994d85919a5d2674603f923b6bb50d1297a40bea501d7cfd74a66f685b2cfe31d4cf940d78daf472f49d5d475a85362c9801a6e4e8364215163e48fca1ff8b3c3449fa064e67f87a574ea5bb83ea9d1c24be4269e987d04397841a99dbd8f74fdf61bd8f05f8fb9c311397683118c6153ae92109bf0893eef0b6a821f1f19c1354b943c10db8e94feb018f442bdd1dd8e390385c7157f127674db27da36ee6aeb6a507c675fc6a48fce505b602bbaee5ebd6fb411814e4c4427289e540e0f9d37e899557ba642dbd0968fe5cb9e3449025067c7fc4a6bbf6fc179829dd3c0ad795f948a29a191dbf207172a223d9739d209aebc563792e7c0c99482a35e001cb4850df5ded3d3378229cbb1bea76d175ac042f43e27c56bf7f8e181ba47e29f58da243c21df229cac386c4db7c9c8d0d39350e9cc206182713f273705ab45120f15fa9a5cb83fe45226ad155f467c1306f7f951e3342e2b46843c33f9a63177873c7926e2238eb5b59240520714deec6abd73763fe0eea14fc261c2ca9cb01dac8903885de6995be78a75061db5878c60ff18b366f46e0f35fa7b434eb34fd79150ff83513f49a733b65fb2b12129f9491adcebad8ccf0b17087cbf7346187c1229384c4fbff1cae1711d21ccae757557f2de9abcbbf43c080c445d854259f5eb7f23b46e1530992862586136e3921f1ce9141b2d57e4e227f9361f6d5ed91fe184bae66485c59b38684631316adb72b2cf0ba688396f4d22303128729b21493260e37552b27652dcb71792fc7cb087cfeccd255a65efdc8b739b872bdeabe5bee5996ef6c2171537f9fb5001a965282a3277f92baafea550be5789038fd05a1a5602b1da93223dcad7da7939df118512524cef068238bc9f4791a7eaf74ae22e7fcc56d561ff8fbf28f77aaeb9b3479818a07a6f87e5959fe87664b90b8e07446754bad4581ad95652dcf82b8d1df3967e07efe1727d7bf72d6585b5dc7bba1f8094ec3c0872401120fdaf434f4160b66fb86f366f37e9a3d5d73eb17f0f9f95805824b16f1e902a24f91d0504dc7e766b5378162595bfd24c53e1398fffa4385a3c3d90befd1a90bb8dfd62e8b59ce623d25af763ca181aa5752b2b38990b8061d5a0b56403f4f9b8f5203bd06bdf63a250129241ef2d9504f5350382e95e7148926874bc510393b16121f4869a56195d63ce7b27a4e14a02b4947e68106ea8f9c6a134dd3b6fd5c8b47614123d50e2deae62717481c3a4ba47d4669f338fc1b6b3f4a30816cfd7f2df690b82e4758f429870eb441b595eb3d1dd787cb5f17c0f3d37bdf0d15280a2b28d13015b78920e190b028027f3f4b821e3ec694268cfb1311b37d1e4f0c7b617d04244ed3410eadf3854f2eacf75e5f42ad9f3704aa650212df4970e36f108bfd1efda2f373571759beb3ba420bacff701aecc9afa9e68ca92573b42dd61af42a75c0fbd1671f97ebc22c1165a7e9a4d4dc7bebe2a8fa1712bf09f6ddc3f610c950cfd1de7efe7054fbc3411fa89ff3ef88aec3a4706bd7d35fc47d57175d243fd502f579593a3a8245423e69b1e439d493a9fffb8b0e14703eebbc3fa1b8962275f684b771e2ec10c3904f8df600f513ef8f0b2ee74ac7a10aa9fca5f0283e7474030ed0bfd28511e91cd96374e65979e1dac682ebf57b85207105a6b0c57cba78dad4a31de93bf25abb9cf5ae76483c97e1798e75b8fe79f69b0345c7bc2805e635373b242ede365a5a8267db367e334d3e1a2122c79ef74a069cdfc3ebde0fcb383593f9328d3319835c2d3534407d7fdc9962b8dc4d46f3bd1e3dd04231d159b5d507f805dca17e44434b49ad916be68516a1b334a333563124ae46a19010586dc8c21943e19a6e43cecbd85eae0489c3932ff0ffb0f10c749baffb80b4179b2cc11d0ef4a7945ea9ffdc23254fab38d62a3e0ed990fdabc35b00fa37d5aa3e99aceccd7dfd5104c3c27649ff50d62a24ce1da9da8c71705559263873f81c6f4eec972608f01b69bf0f245b0a814f48239e5edefaf68e7e02d4407f40277a8f9f83209e6dadd3818fc5db784f8be8e10b89ff8581f6ed153ef8a4886846123537fc1ffbe68b38505f7871bc4a6f1ef2636bc4cd7bae1a4bb830f4712171d109233cff2599039dfa0251acdec9d59abaca23e07c0a0fcdc104e3fba61bfd23c1fd891e78763501f02b0aa737c646ca6217d20a587822ef025c494cbe02cfc7d7e0e7bbbd80aa6a180dab01337cda5b38456600894be97d1b14a41e959e22be938a1cba677f1fad1400892b5d4d7986bf8b36b18bc92f9c6089d9b0945b7d0f89db62" <> ...}
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:173: anonymous fn/9 in Indexer.Fetcher.OptimismTxnBatch.handle_info/2
    (elixir 1.14.5) lib/range.ex:392: Enumerable.Range.reduce/5
    (elixir 1.14.5) lib/enum.ex:2514: Enum.reduce_while/3
    (indexer 5.2.1) lib/indexer/fetcher/optimism_txn_batch.ex:163: Indexer.Fetcher.OptimismTxnBatch.handle_info/2
    (stdlib 4.3.1.2) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3.1.2) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.3.1.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: :continue
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
