### PR TITLE
Don't push back to sequence on catchup exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#8181](https://github.com/blockscout/blockscout/pull/8181) - Insert current token balances placeholders along with historical
 - [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop address foreign keys
 - [#8292](https://github.com/blockscout/blockscout/pull/8292) - Add ETHEREUM_JSONRPC_WAIT_PER_TIMEOUT env var
+- [#8269](https://github.com/blockscout/blockscout/pull/8269) - Don't push back to sequence on catchup exception
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -247,9 +247,6 @@ defmodule Indexer.Block.Catchup.Fetcher do
   rescue
     exception ->
       Logger.error(fn -> [Exception.format(:error, exception, __STACKTRACE__), ?\n, ?\n, "Retrying."] end)
-
-      push_back(sequence, range)
-
       {:error, exception}
   end
 


### PR DESCRIPTION
## Motivation

Currently, if a range handled by catchup fetcher throws an exception constantly, the sequence will never be empty and therefore catchup fetcher will not fetch other missing blocks.

## Changelog

Removed pushing back to sequence on catchup exception so other missing blocks will be processed even if some of them throws an exception on every try.