### PR TITLE
Fix reorgs query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#8240](https://github.com/blockscout/blockscout/pull/8240) - Refactor and fix paging params in API v2
 - [#8242](https://github.com/blockscout/blockscout/pull/8242) - Fixing visualizer service CORS issue when running docker-compose
 - [#8355](https://github.com/blockscout/blockscout/pull/8355) - Fix current token balances redefining
+- [#8338](https://github.com/blockscout/blockscout/pull/8338) - Fix reorgs query
 
 ### Chore
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -103,6 +103,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         |> insert_list(:block, consensus: false)
         |> Enum.reverse()
 
+      Enum.each(reorgs, fn b -> insert(:block, number: b.number, consensus: true) end)
+
       request = get(conn, "/api/v2/blocks", %{"type" => "reorg"})
 
       assert response = json_response(request, 200)
@@ -118,6 +120,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       reorgs =
         51
         |> insert_list(:block, consensus: false)
+
+      Enum.each(reorgs, fn b -> insert(:block, number: b.number, consensus: true) end)
 
       filter = %{"type" => "reorg"}
       request = get(conn, "/api/v2/blocks", filter)

--- a/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/block_controller_test.exs
@@ -134,7 +134,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
     test "returns all reorgs", %{conn: conn} do
       4
       |> insert_list(:block, consensus: false)
-      |> Enum.map(& &1.hash)
+      |> Enum.each(fn b -> insert(:block, number: b.number, consensus: true) end)
 
       conn = get(conn, reorg_path(conn, :reorg), %{"type" => "JSON"})
 
@@ -146,7 +146,7 @@ defmodule BlockScoutWeb.BlockControllerTest do
     test "does not include blocks or uncles", %{conn: conn} do
       4
       |> insert_list(:block, consensus: false)
-      |> Enum.map(& &1.hash)
+      |> Enum.each(fn b -> insert(:block, number: b.number, consensus: true) end)
 
       insert(:block)
       uncle = insert(:block, consensus: false)

--- a/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/viewing_blocks_test.exs
@@ -174,7 +174,8 @@ defmodule BlockScoutWeb.ViewingBlocksTest do
 
   describe "viewing reorg blocks list" do
     test "lists uncle blocks", %{session: session} do
-      [reorg | _] = insert_list(10, :block, consensus: false)
+      [reorg | _] = blocks = insert_list(10, :block, consensus: false)
+      Enum.each(blocks, fn b -> insert(:block, number: b.number, consensus: true) end)
 
       session
       |> BlockListPage.visit_reorgs_page()


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/8209

## Motivation

Since blocks can lost consensus not only because there was a reorg (according to application logic), the current reorgs query is not quite correct.

## Changelog

Fix reorgs query so it checks if there is a block with the same number and `consensus: true`