### PR TITLE
Add Base Mainnet support for tx actions

### DIFF
--- a/apps/indexer/lib/indexer/transform/transaction_actions.ex
+++ b/apps/indexer/lib/indexer/transform/transaction_actions.ex
@@ -18,6 +18,7 @@ defmodule Indexer.Transform.TransactionActions do
   @goerli 5
   @optimism 10
   @polygon 137
+  @base_mainnet 8453
   @base_goerli 84531
   # @gnosis 100
 
@@ -161,7 +162,7 @@ defmodule Indexer.Transform.TransactionActions do
   end
 
   defp parse_uniswap_v3(logs, actions, protocols_to_rewrite, chain_id) do
-    if Enum.member?([@mainnet, @goerli, @optimism, @polygon, @base_goerli], chain_id) and
+    if Enum.member?([@mainnet, @goerli, @optimism, @polygon, @base_mainnet, @base_goerli], chain_id) and
          (is_nil(protocols_to_rewrite) or Enum.empty?(protocols_to_rewrite) or
             Enum.member?(protocols_to_rewrite, "uniswap_v3")) do
       uniswap_v3_positions_nft =


### PR DESCRIPTION
## Motivation

Base Mainnet chain id wasn't added to transaction actions module.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
