### PR TITLE
Fix API v2 for OP Withdrawals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- [#8364](https://github.com/blockscout/blockscout/pull/8364) - Fix API v2 for OP Withdrawals
 - [#8350](https://github.com/blockscout/blockscout/pull/8350) - Add Base Mainnet support for tx actions
 - [#8282](https://github.com/blockscout/blockscout/pull/8282) - NFT fetcher improvements
 - [#8287](https://github.com/blockscout/blockscout/pull/8287) - Add separate hackney pool for TokenInstance fetchers

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -115,7 +115,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
 
           msg_nonce_version = Bitwise.bsr(Decimal.to_integer(w.msg_nonce), 240)
 
-          from_address =
+          {from_address, from_address_hash} =
             with false <- is_nil(w.from),
                  {:ok, address} <-
                    Chain.hash_to_address(
@@ -123,9 +123,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
                      [necessity_by_association: %{:names => :optional, :smart_contract => :optional}, api?: true],
                      false
                    ) do
-              address
+              {address, address.hash}
             else
-              _ -> nil
+              _ -> {nil, nil}
             end
 
           {status, challenge_period_end} = withdrawal_status(w)
@@ -134,7 +134,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
             "msg_nonce_raw" => Decimal.to_string(w.msg_nonce, :normal),
             "msg_nonce" => msg_nonce,
             "msg_nonce_version" => msg_nonce_version,
-            "from" => Helper.address_with_info(conn, from_address, from_address.hash, w.from),
+            "from" => Helper.address_with_info(conn, from_address, from_address_hash, w.from),
             "l2_tx_hash" => w.l2_transaction_hash,
             "l2_timestamp" => w.l2_timestamp,
             "status" => status,


### PR DESCRIPTION
## Motivation

`BlockScoutWeb.API.V2.OptimismView` module doesn't take into account null `from` field (in case of L2 transaction is not indexed yet). Because of that there can be errors like this:

```
2023-08-31 14:36:13.496	
        (block_scout_web 5.2.2) lib/block_scout_web/controllers/api/v2/optimism_controller.ex:1: BlockScoutWeb.API.V2.OptimismController.phoenix_controller_pipeline/2

2023-08-31 14:36:13.496	
        (block_scout_web 5.2.2) lib/block_scout_web/controllers/api/v2/optimism_controller.ex:1: BlockScoutWeb.API.V2.OptimismController.action/2
2023-08-31 14:36:13.496	
        (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
2023-08-31 14:36:13.496	
        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
2023-08-31 14:36:13.496	
        (block_scout_web 5.2.2) lib/block_scout_web/views/api/v2/optimism_view.ex:109: BlockScoutWeb.API.V2.OptimismView.render/2
2023-08-31 14:36:13.496	
        (elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
2023-08-31 14:36:13.496	
        (elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
2023-08-31 14:36:13.496	
        (block_scout_web 5.2.2) lib/block_scout_web/views/api/v2/optimism_view.ex:137: anonymous fn/2 in BlockScoutWeb.API.V2.OptimismView.render/2
2023-08-31 14:36:13.496	
    ** (KeyError) key :hash not found in: nil. If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
2023-08-31 14:36:13.496	
** (exit) an exception was raised:
2023-08-31 14:36:13.496	
Request: GET /api/v2/optimism/withdrawals
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
