### PR TITLE
Fix market cap in /stats endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#8382](https://github.com/blockscout/blockscout/pull/8382) - Add sitemap.xml
 - [#8313](https://github.com/blockscout/blockscout/pull/8313) - Add batches to TokenInstance fetchers
-- [#8285](https://github.com/blockscout/blockscout/pull/8285) - Add CG/CMC coin price sources
+- [#8285](https://github.com/blockscout/blockscout/pull/8285), [#8399](https://github.com/blockscout/blockscout/pull/8399) - Add CG/CMC coin price sources
 - [#8181](https://github.com/blockscout/blockscout/pull/8181) - Insert current token balances placeholders along with historical
 - [#8210](https://github.com/blockscout/blockscout/pull/8210) - Drop address foreign keys
 - [#8292](https://github.com/blockscout/blockscout/pull/8292) - Add ETHEREUM_JSONRPC_WAIT_PER_TIMEOUT env var

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -104,17 +104,13 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def is_verified(%Address{smart_contract: %NotLoaded{}}), do: nil
   def is_verified(%Address{smart_contract: _}), do: true
 
-  def market_cap(:standard, %{available_supply: available_supply, usd_value: usd_value})
+  def market_cap(:standard, %{available_supply: available_supply, usd_value: usd_value, market_cap_usd: market_cap_usd})
       when is_nil(available_supply) or is_nil(usd_value) do
-    Decimal.new(0)
+    max(Decimal.new(0), market_cap_usd)
   end
 
   def market_cap(:standard, %{available_supply: available_supply, usd_value: usd_value}) do
     Decimal.mult(available_supply, usd_value)
-  end
-
-  def market_cap(:standard, exchange_rate) do
-    exchange_rate.market_cap_usd
   end
 
   def market_cap(module, exchange_rate) do


### PR DESCRIPTION
## Motivation

`/api/v2/stats` API endpoint returns 0 market cap:
```
{
    "average_block_time": 5020.0,
    "coin_price": "1.018",
    "gas_prices": {
        "average": 1.71,
        "fast": 2.07,
        "slow": 1.55
    },
    "gas_used_today": "65263362659",
    "market_cap": "0",
    "network_utilization_percentage": 11.9133755,
    "static_gas_price": null,
    "total_addresses": "1117657",
    "total_blocks": "473390",
    "total_gas_used": "0",
    "total_transactions": "1098480",
    "transactions_today": "124792"
}
```

Despite market cap extracted from the source and retuned in `/api/v2/stats/charts/market`

```
{
    "available_supply": 0,
    "chart_data": [
        {
            "closing_price": "1.018",
            "date": "2023-09-05",
            "market_cap": "234074505"
        }
    ]
}
```

## Changelog

Take market cap from `market_cap_usd`, if it is returned.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
