### PR TITLE
fix response of get_token_properties(market_data)

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -107,7 +107,7 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
          true <- Enum.count(token_values_list) > 0,
          token_values <- token_values_list |> Enum.at(0),
          true <- Enum.count(token_values) > 0 do
-      token_values |> Enum.at(0)
+      token_values
     else
       _ -> %{}
     end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*
Fix response of get_token_properties(market_data) to let data from CMC works well.
## Changelog
Edit function get_token_properties(market_data) at apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex.
Change `token_values |> Enum.at(0)` to `token_values` as return.
### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

this bug happended when I try to set EXCHANGE_RATES_MARKET_CAP_SOURCE, EXCHANGE_RATES_PRICE_SOURCE to coin_market_cap to get the price and market cap from CoinMarket Cap. But it failed on backend and I saw this errors in log: 

> 2023-09-10T03:23:37.990 [error] Task #PID<0.4384.0> started from Explorer.Market.History.Cataloger terminating
** (FunctionClauseError) no function clause matching in Access.get/3
    (elixir 1.14.5) lib/access.ex:286: Access.get({"circulating_supply", 0}, "last_updated", nil)
    (explorer 5.2.2) lib/explorer/exchange_rates/source/coin_market_cap.ex:145: Explorer.ExchangeRates.Source.CoinMarketCap.get_last_updated/1
    (explorer 5.2.2) lib/explorer/market/history/source/price/coin_market_cap.ex:42: Explorer.Market.History.Source.Price.CoinMarketCap.format_data/1
    (explorer 5.2.2) lib/explorer/market/history/source/price/coin_market_cap.ex:21: Explorer.Market.History.Source.Price.CoinMarketCap.fetch_price_history/1
    (explorer 5.2.2) lib/explorer/market/history/cataloger.ex:140: anonymous fn/2 in Explorer.Market.History.Cataloger.fetch_price_history/2
    (elixir 1.14.5) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.5) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 4.3.1.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: #Function<2.12386946/0 in Explorer.Market.History.Cataloger.fetch_price_history/2>
    Args: []

And then I found it due to the wrong token_properties by use this function get_token_properties(market_data).

As a example, the input data 'market_data' is 

> {
    "15658": {
      "id": 15658,
      "name": "Qitmeer Network",
      "symbol": "MEER",
      "slug": "qitmeer-network",
      "num_market_pairs": 10,
      "date_added": "2021-12-06T11:25:31.000Z",
      "tags": [        
      ],
      "max_supply": 210240000,
      "circulating_supply": 0,
      "total_supply": 71348557,
      "is_active": 1,
      "infinite_supply": false,
      "platform": null,
      "cmc_rank": 2858,
      "is_fiat": 0,
      "self_reported_circulating_supply": 71348557,
      "self_reported_market_cap": 9302630.377115801,
      "tvl_ratio": null,
      "last_updated": "2023-09-10T03:30:00.000Z",
      "quote": {
        "USD": {
          "price": 0.1303828804430593,
          "volume_24h": 101674.65467653,
          "volume_change_24h": 5.9644,
          "percent_change_1h": -0.53351534,
          "percent_change_24h": -0.08012403,
          "percent_change_7d": -2.70172899,
          "percent_change_30d": 12.51300838,
          "percent_change_60d": 93.66511639,
          "percent_change_90d": 78.07149161,
          "market_cap": 0,
          "market_cap_dominance": 0,
          "fully_diluted_market_cap": 27411696.78,
          "tvl": null,
          "last_updated": "2023-09-10T03:30:00.000Z"
        }
      }
    }
  }. 

And the response of get_token_properties(market_data) should be

> {
      "id": 15658,
      "name": "Qitmeer Network",
      "symbol": "MEER",
      "slug": "qitmeer-network",
      "num_market_pairs": 10,
      "date_added": "2021-12-06T11:25:31.000Z",
      "tags": [        
      ],
      "max_supply": 210240000,
      "circulating_supply": 0,
      "total_supply": 71348557,
      "is_active": 1,
      "infinite_supply": false,
      "platform": null,
      "cmc_rank": 2858,
      "is_fiat": 0,
      "self_reported_circulating_supply": 71348557,
      "self_reported_market_cap": 9302630.377115801,
      "tvl_ratio": null,
      "last_updated": "2023-09-10T03:30:00.000Z",
      "quote": {
        "USD": {
          "price": 0.1303828804430593,
          "volume_24h": 101674.65467653,
          "volume_change_24h": 5.9644,
          "percent_change_1h": -0.53351534,
          "percent_change_24h": -0.08012403,
          "percent_change_7d": -2.70172899,
          "percent_change_30d": 12.51300838,
          "percent_change_60d": 93.66511639,
          "percent_change_90d": 78.07149161,
          "market_cap": 0,
          "market_cap_dominance": 0,
          "fully_diluted_market_cap": 27411696.78,
          "tvl": null,
          "last_updated": "2023-09-10T03:30:00.000Z"
        }
      }
    }

But actually, it was `{"circulating_supply", 0}`, caused by the error operations at the end of  get_token_properties(market_data) and then caused the error when it was used in `last_updated = get_last_updated(token_properties)`.

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
