### PR TITLE
Unify burn address definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Chore
 
+- [#8442](https://github.com/blockscout/blockscout/pull/8442) - Unify burn address definition
 - [#8321](https://github.com/blockscout/blockscout/pull/8321) - Add curl into resulting Docker image
 - [#8319](https://github.com/blockscout/blockscout/pull/8319) - Add MIX_ENV: 'prod' to docker-compose
 - [#8281](https://github.com/blockscout/blockscout/pull/8281) - Planned removal of duplicate API endpoints: for CSV export and GraphQL

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.AddressChannel do
   """
   use BlockScoutWeb, :channel
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias BlockScoutWeb.API.V2.AddressView, as: AddressViewAPI
   alias BlockScoutWeb.API.V2.SmartContractView, as: SmartContractViewAPI
   alias BlockScoutWeb.API.V2.TransactionView, as: TransactionViewAPI
@@ -32,7 +34,7 @@ defmodule BlockScoutWeb.AddressChannel do
     "address_current_token_balances"
   ])
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
   @current_token_balances_limit 50
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/token_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/token_channel.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.TokenChannel do
   """
   use BlockScoutWeb, :channel
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias BlockScoutWeb.{CurrencyHelper, TokensView}
   alias BlockScoutWeb.Tokens.TransferView
   alias Explorer.Chain
@@ -12,7 +14,7 @@ defmodule BlockScoutWeb.TokenChannel do
 
   intercept(["token_transfer", "token_total_supply"])
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def join("tokens:" <> _transaction_hash, _params, socket) do

--- a/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/transaction_channel.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.TransactionChannel do
   """
   use BlockScoutWeb, :channel
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias BlockScoutWeb.API.V2.TransactionView, as: TransactionViewV2
   alias BlockScoutWeb.{TransactionRawTraceView, TransactionView}
   alias Explorer.Chain
@@ -12,7 +14,7 @@ defmodule BlockScoutWeb.TransactionChannel do
 
   intercept(["pending_transaction", "transaction", "raw_trace"])
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def join("transactions:new_transaction", _params, socket) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_transfer_controller.ex
@@ -13,6 +13,8 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
   import BlockScoutWeb.Chain,
     only: [current_filter: 1, next_page_params: 3, paging_options: 1, split_list_by_page: 1]
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   @transaction_necessity_by_association [
     necessity_by_association: %{
       [created_contract_address: :names] => :optional,
@@ -29,7 +31,7 @@ defmodule BlockScoutWeb.AddressTokenTransferController do
     }
   ]
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -6,10 +6,9 @@ defmodule BlockScoutWeb.AddressTransactionController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
-
   import BlockScoutWeb.Chain, only: [current_filter: 1, paging_options: 1, next_page_params: 3, split_list_by_page: 1]
-
   import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{AccessHelper, Controller, TransactionView}
   alias Explorer.{Chain, Market}
@@ -40,7 +39,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
     }
   ]
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   import BlockScoutWeb.PagingHelper,
     only: [current_filter: 1, delete_parameters_from_next_page_params: 1, search_query: 1]
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
   import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
 
   alias BlockScoutWeb.{AccessHelper, AddressView}
@@ -25,8 +26,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   ]
 
   @api_true [api?: true]
-
-  @burn_address "0x0000000000000000000000000000000000000000"
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -109,7 +108,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
         address.smart_contract
         |> SmartContract.get_implementation_address_hash(@api_true)
         |> Tuple.to_list()
-        |> List.first() || @burn_address
+        |> List.first() || burn_address_hash_string()
 
       conn
       |> put_status(200)
@@ -131,7 +130,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
         address.smart_contract
         |> SmartContract.get_implementation_address_hash(@api_true)
         |> Tuple.to_list()
-        |> List.first() || @burn_address
+        |> List.first() || burn_address_hash_string()
 
       conn
       |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/block_transaction_controller.ex
@@ -11,12 +11,13 @@ defmodule BlockScoutWeb.BlockTransactionController do
     ]
 
   import Explorer.Chain, only: [hash_to_block: 2, number_to_block: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{Controller, TransactionView}
   alias Explorer.Chain
   alias Phoenix.View
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"block_hash_or_number" => formatted_block_hash_or_number, "type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
@@ -2,12 +2,13 @@ defmodule BlockScoutWeb.PendingTransactionController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{Controller, TransactionView}
   alias Explorer.Chain
   alias Phoenix.View
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/recent_transactions_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/recent_transactions_controller.ex
@@ -1,11 +1,13 @@
 defmodule BlockScoutWeb.RecentTransactionsController do
   use BlockScoutWeb, :controller
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.Hash
   alias Phoenix.View
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -7,8 +7,7 @@ defmodule BlockScoutWeb.SmartContractController do
   alias Explorer.SmartContract.{Reader, Writer}
 
   import Explorer.SmartContract.Solidity.Verifier, only: [parse_boolean: 1]
-
-  @burn_address "0x0000000000000000000000000000000000000000"
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   def index(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action} = params) do
     address_options = [
@@ -30,9 +29,9 @@ defmodule BlockScoutWeb.SmartContractController do
           address.smart_contract
           |> SmartContract.get_implementation_address_hash()
           |> Tuple.to_list()
-          |> List.first() || @burn_address
+          |> List.first() || burn_address_hash_string()
         else
-          @burn_address
+          burn_address_hash_string()
         end
 
       functions =
@@ -137,7 +136,7 @@ defmodule BlockScoutWeb.SmartContractController do
         address: %{hash: address_hash},
         custom_abi: true,
         contract_abi: contract_abi,
-        implementation_address: @burn_address,
+        implementation_address: burn_address_hash_string(),
         implementation_abi: [],
         contract_type: contract_type,
         action: action

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/instance/transfer_controller.ex
@@ -8,8 +8,9 @@ defmodule BlockScoutWeb.Tokens.Instance.TransferController do
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"token_id" => token_address_hash, "instance_id" => token_id_str, "type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/transfer_controller.ex
@@ -12,8 +12,9 @@ defmodule BlockScoutWeb.Tokens.TransferController do
   alias Phoenix.View
 
   import BlockScoutWeb.Chain, only: [split_list_by_page: 1, paging_options: 1, next_page_params: 3]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"token_id" => address_hash_string, "type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -14,6 +14,7 @@ defmodule BlockScoutWeb.TransactionController do
 
   import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
   import BlockScoutWeb.Models.GetTransactionTags, only: [get_transaction_with_addresses_tags: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{
     AccessHelper,
@@ -36,7 +37,7 @@ defmodule BlockScoutWeb.TransactionController do
     :token_transfers => :optional
   }
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   @default_options [

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
@@ -16,8 +16,9 @@ defmodule BlockScoutWeb.TransactionStateController do
   import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
   import BlockScoutWeb.Models.GetTransactionTags, only: [get_transaction_with_addresses_tags: 2]
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
 
   @burn_address_hash burn_address_hash
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -5,12 +5,13 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
   import BlockScoutWeb.Chain, only: [paging_options: 1, next_page_params: 3, split_list_by_page: 1]
   import BlockScoutWeb.Models.GetAddressTags, only: [get_address_tags: 2]
   import BlockScoutWeb.Models.GetTransactionTags, only: [get_transaction_with_addresses_tags: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{AccessHelper, Controller, TransactionController, TransactionTokenTransferView}
   alias Explorer.{Chain, Market}
   alias Phoenix.View
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def index(conn, %{"transaction_id" => transaction_hash_string, "type" => "JSON"} = params) do

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -4,13 +4,15 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
   """
 
   import BlockScoutWeb.Chain, only: [default_paging_options: 0]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias Explorer.Chain.Transaction.StateChange
   alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.{Block, Transaction, Wei}
   alias Explorer.Chain.Cache.StateChanges
   alias Indexer.Fetcher.{CoinBalanceOnDemand, TokenBalanceOnDemand}
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   def state_changes(transaction, options \\ [])

--- a/apps/explorer/lib/explorer/account/notifier/forbidden_address.ex
+++ b/apps/explorer/lib/explorer/account/notifier/forbidden_address.ex
@@ -3,8 +3,10 @@ defmodule Explorer.Account.Notifier.ForbiddenAddress do
     Check if address is forbidden to notify
   """
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   @blacklist [
-    "0x0000000000000000000000000000000000000000",
+    burn_address_hash_string(),
     "0x000000000000000000000000000000000000dEaD"
   ]
 

--- a/apps/explorer/lib/explorer/account/notifier/summary.ex
+++ b/apps/explorer/lib/explorer/account/notifier/summary.ex
@@ -3,6 +3,8 @@ defmodule Explorer.Account.Notifier.Summary do
     Compose a summary from transactions
   """
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias Explorer
   alias Explorer.Account.Notifier.Summary
   alias Explorer.{Chain, Repo}
@@ -154,10 +156,8 @@ defmodule Explorer.Account.Notifier.Summary do
 
   def fetch_summary(_, _), do: :nothing
 
-  @burn_address "0x0000000000000000000000000000000000000000"
-
   def method(%{from_address_hash: from, to_address_hash: to}) do
-    {:ok, burn_address} = format_address(@burn_address)
+    {:ok, burn_address} = format_address(burn_address_hash_string())
 
     cond do
       burn_address == from -> "mint"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -26,6 +26,7 @@ defmodule Explorer.Chain do
     ]
 
   import EthereumJSONRPC, only: [integer_to_quantity: 1, fetch_block_internal_transactions: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   require Logger
 
@@ -121,8 +122,6 @@ defmodule Explorer.Chain do
   @revert_msg_prefix_5 "execution reverted: "
   # keccak256("Error(string)")
   @revert_error_method_id "08c379a0"
-
-  @burn_address_hash_str "0x0000000000000000000000000000000000000000"
 
   @limit_showing_transactions 10_000
   @default_page_size 50
@@ -5805,7 +5804,7 @@ defmodule Explorer.Chain do
   @spec get_token_transfer_type(TokenTransfer.t()) ::
           :token_burning | :token_minting | :token_spawning | :token_transfer
   def get_token_transfer_type(transfer) do
-    {:ok, burn_address_hash} = Chain.string_to_address_hash(@burn_address_hash_str)
+    {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
 
     cond do
       transfer.to_address_hash == burn_address_hash && transfer.from_address_hash !== burn_address_hash ->

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
 
   import Ecto.Changeset
   import Ecto.Query, only: [from: 2, limit: 2, offset: 2, order_by: 3, preload: 2, dynamic: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, Hash, Token}
@@ -76,7 +77,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     |> validate_required(@required_fields)
   end
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -9,6 +9,8 @@ defmodule Explorer.Chain.Address.TokenBalance do
 
   use Explorer.Schema
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias Explorer.Chain
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.{Address, Block, Hash, Token}
@@ -68,7 +70,7 @@ defmodule Explorer.Chain.Address.TokenBalance do
     |> unique_constraint(:block_number, name: :token_balances_address_hash_block_number_index)
   end
 
-  {:ok, burn_address_hash} = Chain.string_to_address_hash("0x0000000000000000000000000000000000000000")
+  {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
   @burn_address_hash burn_address_hash
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/block/reward.ex
+++ b/apps/explorer/lib/explorer/chain/block/reward.ex
@@ -5,6 +5,8 @@ defmodule Explorer.Chain.Block.Reward do
 
   use Explorer.Schema
 
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
   alias Explorer.Application.Constants
   alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.Block.Reward.AddressType
@@ -33,8 +35,6 @@ defmodule Explorer.Chain.Block.Reward do
     "inputs" => [%{"type" => "address", "name" => ""}],
     "constant" => true
   }
-
-  @empty_address "0x0000000000000000000000000000000000000000"
 
   @typedoc """
   The validation reward given related to a block.
@@ -218,7 +218,7 @@ defmodule Explorer.Chain.Block.Reward do
       payout_key_hash =
         call_contract(keys_manager_contract_address, @get_payout_by_mining_abi, get_payout_by_mining_params)
 
-      if payout_key_hash == @empty_address do
+      if payout_key_hash == burn_address_hash_string() do
         mining_key
       else
         choose_key(payout_key_hash, mining_key)
@@ -248,7 +248,7 @@ defmodule Explorer.Chain.Block.Reward do
 
     case Reader.query_contract(address, abi, params, false) do
       %{^method_id => {:ok, [result]}} -> result
-      _ -> @empty_address
+      _ -> burn_address_hash_string()
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -21,8 +21,26 @@ defmodule Explorer.Chain.SmartContract do
   alias Explorer.SmartContract.Reader
   alias Timex.Duration
 
-  @burn_address_hash_str "0x0000000000000000000000000000000000000000"
-  @burn_address_hash_str_32 "0x0000000000000000000000000000000000000000000000000000000000000000"
+  # supported signatures:
+  # 5c60da1b = keccak256(implementation())
+  @implementation_signature "5c60da1b"
+  # aaf10f42 = keccak256(getImplementation())
+  @get_implementation_signature "aaf10f42"
+
+  @burn_address_hash_string "0x0000000000000000000000000000000000000000"
+  @burn_address_hash_string_32 "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+  defguard is_burn_signature(term) when term in ["0x", "0x0", @burn_address_hash_string_32]
+  defguard is_burn_signature_or_nil(term) when is_burn_signature(term) or term == nil
+  defguard is_burn_signature_extended(term) when is_burn_signature(term) or term == @burn_address_hash_string
+
+  @doc """
+    Returns burn address hash
+  """
+  @spec burn_address_hash_string() :: String.t()
+  def burn_address_hash_string do
+    @burn_address_hash_string
+  end
 
   @typep api? :: {:api?, true | false}
 
@@ -699,10 +717,10 @@ defmodule Explorer.Chain.SmartContract do
     implementation_address =
       cond do
         implementation_method_abi ->
-          get_implementation_address_hash_basic("5c60da1b", proxy_address_hash, abi)
+          get_implementation_address_hash_basic(@implementation_signature, proxy_address_hash, abi)
 
         get_implementation_method_abi ->
-          get_implementation_address_hash_basic("aaf10f42", proxy_address_hash, abi)
+          get_implementation_address_hash_basic(@get_implementation_signature, proxy_address_hash, abi)
 
         master_copy_method_abi ->
           get_implementation_address_hash_from_master_copy_pattern(proxy_address_hash)
@@ -732,7 +750,7 @@ defmodule Explorer.Chain.SmartContract do
              json_rpc_named_arguments
            ) do
         {:ok, empty_address}
-        when empty_address in ["0x", "0x0", @burn_address_hash_str_32, nil] ->
+        when is_burn_signature_or_nil(empty_address) ->
           fetch_beacon_proxy_implementation(proxy_address_hash, json_rpc_named_arguments)
 
         {:ok, implementation_logic_address} ->
@@ -768,13 +786,13 @@ defmodule Explorer.Chain.SmartContract do
            json_rpc_named_arguments
          ) do
       {:ok, empty_address}
-      when empty_address in ["0x", "0x0", @burn_address_hash_str_32, nil] ->
+      when is_burn_signature_or_nil(empty_address) ->
         fetch_openzeppelin_proxy_implementation(proxy_address_hash, json_rpc_named_arguments)
 
       {:ok, beacon_contract_address} ->
         case beacon_contract_address
              |> abi_decode_address_output()
-             |> get_implementation_address_hash_basic("5c60da1b", implementation_method_abi) do
+             |> get_implementation_address_hash_basic(@implementation_signature, implementation_method_abi) do
           <<implementation_address::binary-size(42)>> ->
             {:ok, implementation_address}
 
@@ -799,7 +817,7 @@ defmodule Explorer.Chain.SmartContract do
            json_rpc_named_arguments
          ) do
       {:ok, empty_address}
-      when empty_address in ["0x", "0x0", @burn_address_hash_str_32] ->
+      when is_burn_signature(empty_address) ->
         {:ok, "0x"}
 
       {:ok, logic_contract_address} ->
@@ -811,9 +829,6 @@ defmodule Explorer.Chain.SmartContract do
   end
 
   defp get_implementation_address_hash_basic(signature, proxy_address_hash, abi) do
-    # supported signatures:
-    # 5c60da1b = keccak256(implementation())
-    # aaf10f42 = keccak256(getImplementation())
     implementation_address =
       case Reader.query_contract(
              proxy_address_hash,
@@ -843,7 +858,7 @@ defmodule Explorer.Chain.SmartContract do
              json_rpc_named_arguments
            ) do
         {:ok, empty_address}
-        when empty_address in ["0x", "0x0", @burn_address_hash_str_32] ->
+        when is_burn_signature(empty_address) ->
           {:ok, "0x"}
 
         {:ok, logic_contract_address} ->
@@ -859,12 +874,7 @@ defmodule Explorer.Chain.SmartContract do
   defp save_implementation_data(nil, _, _, _), do: {nil, nil}
 
   defp save_implementation_data(empty_address_hash_string, proxy_address_hash, metadata_from_verified_twin, options)
-       when empty_address_hash_string in [
-              "0x",
-              "0x0",
-              @burn_address_hash_str_32,
-              @burn_address_hash_str
-            ] do
+       when is_burn_signature_extended(empty_address_hash_string) do
     if is_nil(metadata_from_verified_twin) or !metadata_from_verified_twin do
       proxy_address_hash
       |> Chain.address_hash_to_smart_contract_without_twin(options)
@@ -932,7 +942,7 @@ defmodule Explorer.Chain.SmartContract do
 
   defp abi_decode_address_output(nil), do: nil
 
-  defp abi_decode_address_output("0x"), do: @burn_address_hash_str
+  defp abi_decode_address_output("0x"), do: burn_address_hash_string()
 
   defp abi_decode_address_output(address) when is_binary(address) do
     if String.length(address) > 42 do

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -4,6 +4,7 @@ defmodule Explorer.Etherscan do
   """
 
   import Ecto.Query, only: [from: 2, where: 3, or_where: 3, union: 2, subquery: 1, order_by: 3]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias Explorer.Etherscan.Logs
   alias Explorer.{Chain, Repo}
@@ -20,8 +21,6 @@ defmodule Explorer.Etherscan do
     start_timestamp: nil,
     end_timestamp: nil
   }
-
-  @burn_address_hash_str "0x0000000000000000000000000000000000000000"
 
   @doc """
   Returns the maximum allowed page size number.
@@ -585,7 +584,7 @@ defmodule Explorer.Etherscan do
 
   @spec fetch_sum_coin_total_supply_minus_burnt() :: non_neg_integer
   def fetch_sum_coin_total_supply_minus_burnt do
-    {:ok, burn_address_hash} = Chain.string_to_address_hash(@burn_address_hash_str)
+    {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
 
     query =
       from(

--- a/apps/indexer/lib/indexer/transform/address_token_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_token_balances.ex
@@ -3,7 +3,7 @@ defmodule Indexer.Transform.AddressTokenBalances do
   Extracts `Explorer.Address.TokenBalance` params from other schema's params.
   """
 
-  @burn_address "0x0000000000000000000000000000000000000000"
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   def params_set(%{} = import_options) do
     Enum.reduce(import_options, MapSet.new(), &reducer/2)
@@ -35,7 +35,7 @@ defmodule Indexer.Transform.AddressTokenBalances do
     Enum.filter(token_transfers_params, &do_filter_burn_address/1)
   end
 
-  defp add_token_balance_address(map_set, unquote(@burn_address), _, _, _, _), do: map_set
+  defp add_token_balance_address(map_set, unquote(burn_address_hash_string()), _, _, _, _), do: map_set
 
   defp add_token_balance_address(map_set, address, token_contract_address, token_id, token_type, block_number) do
     MapSet.put(map_set, %{
@@ -47,7 +47,7 @@ defmodule Indexer.Transform.AddressTokenBalances do
     })
   end
 
-  def do_filter_burn_address(%{to_address_hash: unquote(@burn_address), token_type: "ERC-721"}) do
+  def do_filter_burn_address(%{to_address_hash: unquote(burn_address_hash_string()), token_type: "ERC-721"}) do
     false
   end
 

--- a/apps/indexer/lib/indexer/transform/transaction_actions.ex
+++ b/apps/indexer/lib/indexer/transform/transaction_actions.ex
@@ -6,6 +6,7 @@ defmodule Indexer.Transform.TransactionActions do
   require Logger
 
   import Ecto.Query, only: [from: 2]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias ABI.TypeDecoder
   alias Explorer.Chain.Cache.NetVersion
@@ -22,7 +23,6 @@ defmodule Indexer.Transform.TransactionActions do
   @base_goerli 84531
   # @gnosis 100
 
-  @burn_address "0x0000000000000000000000000000000000000000"
   @uniswap_v3_factory_abi [
     %{
       "inputs" => [
@@ -450,7 +450,7 @@ defmodule Indexer.Transform.TransactionActions do
           from = truncate_address_hash(log.second_topic)
 
           # credo:disable-for-next-line
-          if from == @burn_address do
+          if from == burn_address_hash_string() do
             to = truncate_address_hash(log.third_topic)
             [token_id] = decode_data(log.fourth_topic, [{:uint, 256}])
             mint_nft_ids = Map.put_new(acc, to, %{ids: [], log_index: log.index})
@@ -651,8 +651,8 @@ defmodule Indexer.Transform.TransactionActions do
         end
       end)
       |> Enum.map(fn {pool_address, pool} ->
-        token0 = if is_address_correct?(pool.token0), do: String.downcase(pool.token0), else: @burn_address
-        token1 = if is_address_correct?(pool.token1), do: String.downcase(pool.token1), else: @burn_address
+        token0 = if is_address_correct?(pool.token0), do: String.downcase(pool.token0), else: burn_address_hash_string()
+        token1 = if is_address_correct?(pool.token1), do: String.downcase(pool.token1), else: burn_address_hash_string()
         fee = if pool.fee == "", do: 0, else: pool.fee
 
         # we will call getPool(token0, token1, fee) public getter
@@ -999,7 +999,7 @@ defmodule Indexer.Transform.TransactionActions do
     if is_nil(first_topic), do: "", else: String.downcase(first_topic)
   end
 
-  defp truncate_address_hash(nil), do: @burn_address
+  defp truncate_address_hash(nil), do: burn_address_hash_string()
 
   defp truncate_address_hash("0x000000000000000000000000" <> truncated_hash) do
     "0x#{truncated_hash}"


### PR DESCRIPTION
## Motivation

Burn address is defined multiple times.

## Changelog

Define burn address once and re-use in other modules.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
