### PR TITLE
Fix market cap calculation in case of CMC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#8446](https://github.com/blockscout/blockscout/pull/8446) - Fix market cap calculation in case of CMC
 - [#8431](https://github.com/blockscout/blockscout/pull/8431) - Fix contracts' output decoding
 - [#8354](https://github.com/blockscout/blockscout/pull/8354) - Hotfix for proper addresses' tokens displaying
 - [#8350](https://github.com/blockscout/blockscout/pull/8350) - Add Base Mainnet support for tx actions

--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_market_cap.ex
@@ -107,7 +107,11 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCap do
          true <- Enum.count(token_values_list) > 0,
          token_values <- token_values_list |> Enum.at(0),
          true <- Enum.count(token_values) > 0 do
-      token_values |> Enum.at(0)
+      if is_list(token_values) do
+        token_values |> Enum.at(0)
+      else
+        token_values
+      end
     else
       _ -> %{}
     end

--- a/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/coin_market_cap_test.exs
@@ -34,4 +34,103 @@ defmodule Explorer.ExchangeRates.Source.CoinMarketCapTest do
                CoinMarketCap.source_url("ETH")
     end
   end
+
+  @token_properties %{
+    "circulating_supply" => 0,
+    "cmc_rank" => 2977,
+    "date_added" => "2021-12-06T11:25:31.000Z",
+    "id" => 15658,
+    "infinite_supply" => false,
+    "is_active" => 1,
+    "is_fiat" => 0,
+    "last_updated" => "2023-09-12T09:03:00.000Z",
+    "max_supply" => 210_240_000,
+    "name" => "Qitmeer Network",
+    "num_market_pairs" => 10,
+    "platform" => nil,
+    "quote" => %{
+      "USD" => %{
+        "fully_diluted_market_cap" => 27_390_222.61,
+        "last_updated" => "2023-09-12T09:03:00.000Z",
+        "market_cap" => 0,
+        "market_cap_dominance" => 0,
+        "percent_change_1h" => -0.14807635,
+        "percent_change_24h" => -4.05784287,
+        "percent_change_30d" => -20.18918329,
+        "percent_change_60d" => 85.21384726,
+        "percent_change_7d" => -5.49776979,
+        "percent_change_90d" => 22.27442093,
+        "price" => 0.13028073920022334,
+        "tvl" => nil,
+        "volume_24h" => 93766.09652096,
+        "volume_change_24h" => -0.9423
+      }
+    },
+    "self_reported_circulating_supply" => 71_348_557,
+    "self_reported_market_cap" => 9_295_342.74682927,
+    "slug" => "qitmeer-network",
+    "symbol" => "MEER",
+    "tags" => [],
+    "total_supply" => 71_348_557,
+    "tvl_ratio" => nil
+  }
+
+  @market_data_multiple_tokens %{
+    "MEER" => [
+      @token_properties,
+      %{
+        "circulating_supply" => nil,
+        "cmc_rank" => nil,
+        "date_added" => "2023-05-12T15:52:05.000Z",
+        "id" => 25240,
+        "infinite_supply" => false,
+        "is_active" => 0,
+        "is_fiat" => 0,
+        "last_updated" => "2023-09-12T09:05:15.725Z",
+        "max_supply" => 210_240_000,
+        "name" => "Meer Coin",
+        "num_market_pairs" => nil,
+        "platform" => nil,
+        "quote" => %{
+          "USD" => %{
+            "fully_diluted_market_cap" => nil,
+            "last_updated" => "2023-09-12T09:05:15.725Z",
+            "market_cap" => nil,
+            "market_cap_dominance" => nil,
+            "percent_change_1h" => nil,
+            "percent_change_24h" => nil,
+            "percent_change_30d" => nil,
+            "percent_change_60d" => nil,
+            "percent_change_7d" => nil,
+            "percent_change_90d" => nil,
+            "price" => 0,
+            "tvl" => nil,
+            "volume_24h" => nil,
+            "volume_change_24h" => nil
+          }
+        },
+        "self_reported_circulating_supply" => nil,
+        "self_reported_market_cap" => nil,
+        "slug" => "meer-coin",
+        "symbol" => "MEER",
+        "tags" => [],
+        "total_supply" => nil,
+        "tvl_ratio" => nil
+      }
+    ]
+  }
+
+  @market_data_single_token %{
+    "15658" => @token_properties
+  }
+
+  describe "get_token_properties/1" do
+    test "returns a single token property, when market_data contains multiple tokens" do
+      assert CoinMarketCap.get_token_properties(@market_data_multiple_tokens) == @token_properties
+    end
+
+    test "returns a single token property, when market_data contains a single token" do
+      assert CoinMarketCap.get_token_properties(@market_data_single_token) == @token_properties
+    end
+  end
 end

--- a/cspell.json
+++ b/cspell.json
@@ -522,7 +522,9 @@
         "secp",
         "qwertyuioiuytrewertyuioiuytrertyuio",
         "urlset",
-        "lastmod"
+        "lastmod",
+        "qitmeer",
+        "meer",
     ],
     "enableFiletypes": [
         "dotenv",


### PR DESCRIPTION
## Motivation

An error arises in native coin market cap calculation when `EXCHANGE_RATES_COINMARKETCAP_COIN_ID` is provided:
```
2023-09-10T03:23:37.990 [error] Task #PID<0.4384.0> started from Explorer.Market.History.Cataloger terminating
** (FunctionClauseError) no function clause matching in Access.get/3
    (elixir 1.14.5) lib/access.ex:286: Access.get({"circulating_supply", 0}, "last_updated", nil)
    (explorer 5.2.2) lib/explorer/exchange_rates/source/coin_market_cap.ex:145: Explorer.ExchangeRates.Source.CoinMarketCap.get_last_updated/1
    (explorer 5.2.2) lib/explorer/market/history/source/price/coin_market_cap.ex:42: Explorer.Market.History.Source.Price.CoinMarketCap.format_data/1
    (explorer 5.2.2) lib/explorer/market/history/source/price/coin_market_cap.ex:21: Explorer.Market.History.Source.Price.CoinMarketCap.fetch_price_history/1
    (explorer 5.2.2) lib/explorer/market/history/cataloger.ex:140: anonymous fn/2 in Explorer.Market.History.Cataloger.fetch_price_history/2
    (elixir 1.14.5) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.5) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 4.3.1.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: #Function<2.12386946/0 in Explorer.Market.History.Cataloger.fetch_price_history/2>
    Args: []
```

## Changelog

Check, if the list of coins or a single coin properties returned from CoinMarketCap API.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
