### PR TITLE
Fix reorg transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#8355](https://github.com/blockscout/blockscout/pull/8355) - Fix current token balances redefining
 - [#8338](https://github.com/blockscout/blockscout/pull/8338) - Fix reorgs query
 - [#8413](https://github.com/blockscout/blockscout/pull/8413) - Put error in last call for STOP opcode
+- [#8447](https://github.com/blockscout/blockscout/pull/8447) - Fix reorg transactions
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -226,6 +226,9 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
             index: nil,
             status: nil,
             error: nil,
+            max_priority_fee_per_gas: nil,
+            max_fee_per_gas: nil,
+            type: nil,
             updated_at: ^updated_at
           ]
         ],

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -218,11 +218,41 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           lock: "FOR NO KEY UPDATE"
         )
 
+      transactions_query =
+        from(
+          transaction in Transaction,
+          where: transaction.block_hash in ^block_hashes,
+          # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+          order_by: [asc: :hash],
+          lock: "FOR NO KEY UPDATE"
+        )
+
+      transactions_replacements = [
+        block_hash: nil,
+        block_number: nil,
+        gas_used: nil,
+        cumulative_gas_used: nil,
+        index: nil,
+        status: nil,
+        error: nil,
+        max_priority_fee_per_gas: nil,
+        max_fee_per_gas: nil,
+        type: nil,
+        updated_at: updated_at
+      ]
+
       try do
         {_, result} =
           repo.update_all(
             from(b in Block, join: s in subquery(query), on: b.hash == s.hash, select: b.number),
             [set: [consensus: false, updated_at: updated_at]],
+            timeout: timeout
+          )
+
+        {_, _transactions_result} =
+          repo.update_all(
+            from(t in Transaction, join: s in subquery(transactions_query), on: t.hash == s.hash),
+            [set: transactions_replacements],
             timeout: timeout
           )
 

--- a/apps/explorer/test/explorer/chain/import/runner/transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/transactions_test.exs
@@ -2,7 +2,7 @@ defmodule Explorer.Chain.Import.Runner.TransactionsTest do
   use Explorer.DataCase
 
   alias Ecto.Multi
-  alias Explorer.Chain.{Address, Transaction}
+  alias Explorer.Chain.{Address, Block, Transaction}
   alias Explorer.Chain.Import.Runner.Transactions
 
   describe "run/1" do
@@ -36,6 +36,47 @@ defmodule Explorer.Chain.Import.Runner.TransactionsTest do
       assert {:ok, _} = run_transactions([non_indexed_transaction_params])
 
       assert is_nil(Repo.get(Transaction, transaction.hash).created_contract_code_indexed_at)
+    end
+
+    test "recollated transactions replaced with empty data" do
+      reorg = insert(:block)
+      reorg_transaction = :transaction |> insert() |> with_block(reorg)
+      transaction = :transaction |> insert() |> with_block(reorg)
+      reorg |> Block.changeset(%{consensus: false}) |> Repo.update()
+      block = insert(:block, consensus: true, number: reorg.number)
+
+      transaction_params = %{
+        block_hash: block.hash,
+        block_number: block.number,
+        gas_used: transaction.gas_used,
+        cumulative_gas_used: transaction.cumulative_gas_used,
+        index: transaction.index,
+        from_address_hash: transaction.from_address.hash,
+        gas: transaction.gas,
+        gas_price: transaction.gas_price,
+        hash: transaction.hash,
+        input: transaction.input,
+        nonce: transaction.nonce,
+        r: transaction.r,
+        s: transaction.s,
+        to_address_hash: transaction.to_address.hash,
+        v: transaction.v,
+        value: transaction.value
+      }
+
+      assert {:ok, _} = run_transactions([transaction_params])
+
+      assert %{
+               block_hash: nil,
+               block_number: nil,
+               gas_used: nil,
+               cumulative_gas_used: nil,
+               index: nil,
+               status: nil,
+               error: nil
+             } = Repo.get_by(Transaction, hash: reorg_transaction.hash)
+
+      assert not is_nil(Repo.get_by(Transaction, hash: transaction.hash).block_hash)
     end
   end
 


### PR DESCRIPTION
## Motivation
There are cases when a block is imported later than the transactions of its reorg, so transactions related to the reorg will not be cleared and therefore reorg may have non-zero transactions.

## Changelog
Clear transactions of a reorg in transactions runner if there are any.