### PR TITLE
Add release announcement in Slack

### DIFF
--- a/.github/workflows/publish-docker-image-release.yml
+++ b/.github/workflows/publish-docker-image-release.yml
@@ -69,44 +69,56 @@ jobs:
             BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
-  merge-master-after-release:
-    name: Merge 'master' to specific branch after release
-    runs-on: ubuntu-latest
-    env:
-      BRANCHES: |
-        production-core-stg
-        production-sokol-stg
-        production-eth-stg-experimental
-        production-eth-goerli-stg
-        production-lukso-stg
-        production-xdai-stg
-        production-polygon-supernets-stg
-        production-rsk-stg
-        production-immutable-stg
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set Git config
-      run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "Github Actions"
-    - name: Merge master back after release
-      run: |
-          git fetch --unshallow
-          touch errors.txt
-          for branch in $BRANCHES;
-          do
-            git reset --merge
-            git checkout master
-            git fetch origin
-            echo $branch
-            git ls-remote --exit-code --heads origin $branch || { echo $branch >> errors.txt; continue; }
-            echo "Merge 'master' to $branch"
-            git checkout $branch
-            git pull || { echo $branch >> errors.txt; continue; }
-            git merge --no-ff master -m "Auto-merge master back to $branch" || { echo $branch >> errors.txt; continue; }
-            git push || { echo $branch >> errors.txt; continue; }
-            git checkout master;
-          done
-          [ -s errors.txt ] && echo "There are problems with merging 'master' to branches:" || echo "Errors file is empty"
-          cat errors.txt
-          [ ! -s errors.txt ]
+      - name: Send release announcement to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "release-version": "${{ env.RELEASE_VERSION }}",
+              "release-link": "https://github.com/blockscout/blockscout/releases/tag/v${{ env.RELEASE_VERSION }}-beta"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  # merge-master-after-release:
+  #   name: Merge 'master' to specific branch after release
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     BRANCHES: |
+  #       production-core-stg
+  #       production-sokol-stg
+  #       production-eth-stg-experimental
+  #       production-eth-goerli-stg
+  #       production-lukso-stg
+  #       production-xdai-stg
+  #       production-polygon-supernets-stg
+  #       production-rsk-stg
+  #       production-immutable-stg
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set Git config
+  #     run: |
+  #         git config --local user.email "actions@github.com"
+  #         git config --local user.name "Github Actions"
+  #   - name: Merge master back after release
+  #     run: |
+  #         git fetch --unshallow
+  #         touch errors.txt
+  #         for branch in $BRANCHES;
+  #         do
+  #           git reset --merge
+  #           git checkout master
+  #           git fetch origin
+  #           echo $branch
+  #           git ls-remote --exit-code --heads origin $branch || { echo $branch >> errors.txt; continue; }
+  #           echo "Merge 'master' to $branch"
+  #           git checkout $branch
+  #           git pull || { echo $branch >> errors.txt; continue; }
+  #           git merge --no-ff master -m "Auto-merge master back to $branch" || { echo $branch >> errors.txt; continue; }
+  #           git push || { echo $branch >> errors.txt; continue; }
+  #           git checkout master;
+  #         done
+  #         [ -s errors.txt ] && echo "There are problems with merging 'master' to branches:" || echo "Errors file is empty"
+  #         cat errors.txt
+  #         [ ! -s errors.txt ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Chore
 
+- [#8494](https://github.com/blockscout/blockscout/pull/8494) - Add release announcement in Slack
 - [#8493](https://github.com/blockscout/blockscout/pull/8493) - Fix arm docker image build
 - [#8478](https://github.com/blockscout/blockscout/pull/8478) - Set integration with Blockscout's eth bytecode DB endpoint by default and other enhancements
 - [#8442](https://github.com/blockscout/blockscout/pull/8442) - Unify burn address definition


### PR DESCRIPTION
## Motivation

Automate interal release announcements

## Changelog

- Add release announcement to the Slack
- Disable branches updates on release since it works imperfect

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
