### PR TITLE
Conceal secondary ports in docker compose setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#8501](https://github.com/blockscout/blockscout/pull/8501) - Conceal secondary ports in docker compose setup
+
 ## 5.2.3-beta
 
 ### Features

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -11,19 +11,25 @@ Runs Blockscout locally in Docker containers with [docker-compose](https://githu
 ## Building Docker containers from source
 
 ```bash
+cd ./docker-compose
 docker-compose up --build
 ```
 
-This command uses by-default `docker-compose.yml`, which builds the explorer into the Docker image and runs 5 Docker containers:
+Note: if you don't need to make backend customizations, you can run `docker-compose up` in order to launch from pre-build backend Docker image. This will be much faster.
 
-- Postgres 14.x database, which will be available at port 7432 on localhost.
-- Redis database of latest version, which will be available at port 6379 on localhost.
-- Blockscout explorer at http://localhost:4000.
+This command uses `docker-compose.yml` by-default, which builds the backend of the explorer into the Docker image and runs 9 Docker containers:
 
-and 2 microservices (written in Rust):
+- Postgres 14.x database, which will be available at port 7432 on the host machine.
+- Redis database of the latest version.
+- Blockscout backend with api at /api path.
+- Nginx proxy to bind backend, frontend and microservices.
+- Blockscout explorer at http://localhost.
 
-- [Sig-provider](https://github.com/blockscout/blockscout-rs/tree/main/sig-provider) service, which will be available at port 8151 on the host machine.
-- [Sol2UML visualizer](https://github.com/blockscout/blockscout-rs/tree/main/visualizer) service, which will be available at port 8152 on the host machine.
+and 4 containers for microservices (written in Rust):
+
+- [Stats](https://github.com/blockscout/blockscout-rs/tree/main/stats) service with a separate Postgres 14 DB.
+- [Sol2UML visualizer](https://github.com/blockscout/blockscout-rs/tree/main/visualizer) service.
+- [Sig-provider](https://github.com/blockscout/blockscout-rs/tree/main/sig-provider) service.
 
 Note for Linux users: Linux users need to run the local node on http://0.0.0.0/ rather than http://127.0.0.1/
 
@@ -32,16 +38,26 @@ Note for Linux users: Linux users need to run the local node on http://0.0.0.0/ 
 The repo contains built-in configs for different JSON RPC clients without need to build the image.
 
 - Erigon: `docker-compose -f docker-compose-no-build-erigon.yml up -d`
-- Geth: `docker-compose -f docker-compose-no-build-geth.yml up -d`
+- Geth (suitable for Reth as well): `docker-compose -f docker-compose-no-build-geth.yml up -d`
+- Geth Clique: `docker-compose -f docker-compose-no-build-geth-clique-consensus.yml up -d`
 - Nethermind, OpenEthereum: `docker-compose -f docker-compose-no-build-nethermind up -d`
 - Ganache: `docker-compose -f docker-compose-no-build-ganache.yml up -d`
 - HardHat network: `docker-compose -f docker-compose-no-build-hardhat-network.yml up -d`
 - Running only explorer without DB: `docker-compose -f docker-compose-no-build-no-db-container.yml up -d`. In this case, one container is created - for the explorer itself. And it assumes that the DB credentials are provided through `DATABASE_URL` environment variable.
+- Running explorer with external backend: `docker-compose -f docker-compose-no-build-external-backend.yml up -d`
+- Running explorer with external frontend: `docker-compose -f docker-compose-no-build-external-frontend.yml up -d`
 
 All of the configs assume the Ethereum JSON RPC is running at http://localhost:8545.
 
-Explorer UI will be available at http://localhost.
-
 In order to stop launched containers, run `docker-compose -d -f config_file.yml down`, replacing `config_file.yml` with the file name of the config which was previously launched.
 
-You can adjust BlockScout environment variables from `./envs/common-blockscout.env`. Descriptions of the ENVs are available in [the docs](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
+You can adjust BlockScout environment variables:
+
+- for backend in `./envs/common-blockscout.env`
+- for frontend in `./envs/common-frontend.env`
+- for stats service in `./envs/common-stats.env`
+- for visualizer in `./envs/common-visualizer.env`
+
+Descriptions of the ENVs are available
+-  for [backend](https://docs.blockscout.com/for-developers/information-and-settings/env-variables)
+-  for [frontend](https://github.com/blockscout/frontend/blob/main/docs/ENVS.md).

--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -32,8 +32,6 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-external-frontend.yml
+++ b/docker-compose/docker-compose-no-build-external-frontend.yml
@@ -36,8 +36,6 @@ services:
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -35,8 +35,6 @@ services:
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
+++ b/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
@@ -33,8 +33,6 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -32,8 +32,6 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -33,8 +33,6 @@ services:
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -32,8 +32,6 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -23,8 +23,6 @@ services:
         ETHEREUM_JSONRPC_VARIANT: 'geth'
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:5432/blockscout?ssl=false
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -45,8 +45,6 @@ services:
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
-    ports:
-      - 4000:4000
     volumes:
       - ./logs/:/app/logs/
 

--- a/docker-compose/envs/common-frontend.env
+++ b/docker-compose/envs/common-frontend.env
@@ -1,20 +1,17 @@
 NEXT_PUBLIC_API_HOST=localhost
 NEXT_PUBLIC_API_PROTOCOL=http
 NEXT_PUBLIC_STATS_API_HOST=http://localhost:8080
-NEXT_PUBLIC_NETWORK_NAME=Göerli
-NEXT_PUBLIC_NETWORK_SHORT_NAME=Göerli
+NEXT_PUBLIC_NETWORK_NAME=Awesome chain
+NEXT_PUBLIC_NETWORK_SHORT_NAME=Awesome chain
 NEXT_PUBLIC_NETWORK_ID=5
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=Ether
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=ETH
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
 NEXT_PUBLIC_API_BASE_PATH=/
-NEXT_PUBLIC_FEATURED_NETWORKS=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/featured-networks/eth-goerli.json
 NEXT_PUBLIC_APP_HOST=localhost
 NEXT_PUBLIC_APP_PROTOCOL=http
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
 NEXT_PUBLIC_VISUALIZE_API_HOST=http://localhost:8081
 NEXT_PUBLIC_IS_TESTNET=true
-NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-logos/goerli.svg
-NEXT_PUBLIC_NETWORK_ICON=https://raw.githubusercontent.com/blockscout/frontend-configs/main/configs/network-icons/goerli.svg
-NEXT_PUBLIC_HOMEPAGE_PLATE_TEXT_COLOR=rgb(255, 255, 255)
 NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
+NEXT_PUBLIC_API_SPEC_URL: https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml

--- a/docker-compose/services/docker-compose-frontend.yml
+++ b/docker-compose/services/docker-compose-frontend.yml
@@ -9,5 +9,3 @@ services:
     container_name: 'frontend'
     env_file:
       -  ../envs/common-frontend.env
-    ports:
-      - 3000:3000

--- a/docker-compose/services/docker-compose-redis.yml
+++ b/docker-compose/services/docker-compose-redis.yml
@@ -3,8 +3,6 @@ version: '3.8'
 services:
   redis_db:
     image: 'redis:alpine'
-    ports:
-      - 6379:6379
     container_name: redis_db
     command: redis-server
     volumes:

--- a/docker-compose/services/docker-compose-sig-provider.yml
+++ b/docker-compose/services/docker-compose-sig-provider.yml
@@ -7,5 +7,3 @@ services:
     platform: linux/amd64
     restart: always
     container_name: 'sig-provider'
-    ports:
-      - 8151:8050

--- a/docker-compose/services/docker-compose-smart-contract-verifier.yml
+++ b/docker-compose/services/docker-compose-smart-contract-verifier.yml
@@ -9,5 +9,3 @@ services:
     container_name: 'smart-contract-verifier'
     env_file:
       -  ../envs/common-smart-contract-verifier.env
-    ports:
-      - 8150:8050

--- a/docker-compose/services/docker-compose-stats.yml
+++ b/docker-compose/services/docker-compose-stats.yml
@@ -30,5 +30,3 @@ services:
       - STATS__BLOCKSCOUT_DB_URL=postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
       - STATS__CREATE_DATABASE=true
       - STATS__RUN_MIGRATIONS=true
-    ports:
-      - 8153:8050

--- a/docker-compose/services/docker-compose-visualizer.yml
+++ b/docker-compose/services/docker-compose-visualizer.yml
@@ -9,5 +9,3 @@ services:
     container_name: 'visualizer'
     env_file:
       -  ../envs/common-visualizer.env
-    ports:
-      - 8152:8050


### PR DESCRIPTION
## Motivation

Ports from Redis, old UI, microservices are exposed to the outside in the docker-compose setup.

## Changelog

Conceal those ports.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
