### PR TITLE
Handle ':error.types/0 is undefined' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- [#8515](https://github.com/blockscout/blockscout/pull/8515) - Fix `:error.types/0 is undefined` warning
 - [#7959](https://github.com/blockscout/blockscout/pull/7959) - Fix empty batch transfers handling
 - [#8513](https://github.com/blockscout/blockscout/pull/8513) - Don't override transaction status
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -756,12 +756,12 @@ defmodule Explorer.Chain.Transaction do
   end
 
   defp find_and_decode(abi, data, hash) do
-    result =
-      abi
-      |> ABI.parse_specification()
-      |> ABI.find_and_decode(data)
-
-    {:ok, result}
+    with {%FunctionSelector{}, _mapping} = result <-
+           abi
+           |> ABI.parse_specification()
+           |> ABI.find_and_decode(data) do
+      {:ok, result}
+    end
   rescue
     e ->
       Logger.warn(fn ->


### PR DESCRIPTION
Close #7529 

## Changelog
- Fix the root cause of the warning

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
