### PR TITLE
Add Smart-Contract-Verifier in Docker-compose

### DIFF
--- a/docker-compose/docker-compose-no-build-erigon.yml
+++ b/docker-compose/docker-compose-no-build-erigon.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -25,6 +26,11 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-external-backend.yml
+++ b/docker-compose/docker-compose-no-build-external-backend.yml
@@ -11,6 +11,11 @@ services:
       file: ./services/docker-compose-db.yml
       service: db
 
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
+
   visualizer:
     extends:
       file: ./services/docker-compose-visualizer.yml

--- a/docker-compose/docker-compose-no-build-external-frontend.yml
+++ b/docker-compose/docker-compose-no-build-external-frontend.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -29,6 +30,11 @@ services:
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-ganache.yml
+++ b/docker-compose/docker-compose-no-build-ganache.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -28,6 +29,11 @@ services:
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
+++ b/docker-compose/docker-compose-no-build-geth-clique-consensus.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -26,6 +27,11 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-geth.yml
+++ b/docker-compose/docker-compose-no-build-geth.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -25,6 +26,11 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-hardhat-network.yml
+++ b/docker-compose/docker-compose-no-build-hardhat-network.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -26,6 +27,11 @@ services:
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-nethermind.yml
+++ b/docker-compose/docker-compose-no-build-nethermind.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -25,6 +26,11 @@ services:
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose-no-build-no-db-container.yml
+++ b/docker-compose/docker-compose-no-build-no-db-container.yml
@@ -8,6 +8,7 @@ services:
 
   backend:
     depends_on:
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -16,6 +17,11 @@ services:
         ETHEREUM_JSONRPC_VARIANT: 'geth'
         ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:5432/blockscout?ssl=false
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   backend:
     depends_on:
       - db
+      - smart-contract-verifier
       - redis_db
     extends:
       file: ./services/docker-compose-backend.yml
@@ -38,6 +39,11 @@ services:
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         DATABASE_URL: postgresql://postgres:@host.docker.internal:7432/blockscout?ssl=false
         CHAIN_ID: '1337'
+
+  smart-contract-verifier:
+    extends:
+      file: ./services/docker-compose-smart-contract-verifier.yml
+      service: smart-contract-verifier
 
   visualizer:
     extends:


### PR DESCRIPTION
This update adds a Smart Contract verifier, because there was no smart contract verifier before. in file docker-compose.yml

## Motivation

I added a smart contract verifier because the latest version does not have a smart contract verifier.
