### PR TITLE
Add block_type to search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#8530](https://github.com/blockscout/blockscout/pull/8530) - Add `block_type` to search results
 - [#8180](https://github.com/blockscout/blockscout/pull/8180) - Deposits and Withdrawals for Polygon Edge
 - [#7996](https://github.com/blockscout/blockscout/pull/7996) - Add CoinBalance fetcher init query limit
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -1,7 +1,8 @@
 defmodule BlockScoutWeb.API.V2.SearchView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.Endpoint
+  alias BlockScoutWeb.{BlockView, Endpoint}
+  alias Explorer.Chain
   alias Explorer.Chain.{Address, Block, Hash, Transaction}
 
   def render("search_results.json", %{search_results: search_results, next_page_params: next_page_params}) do
@@ -53,12 +54,21 @@ defmodule BlockScoutWeb.API.V2.SearchView do
   def prepare_search_result(%{type: "block"} = search_result) do
     block_hash = hash_to_string(search_result.block_hash)
 
+    {:ok, block} =
+      Chain.hash_to_block(hash(search_result.block_hash),
+        necessity_by_association: %{
+          :nephews => :optional
+        },
+        api?: true
+      )
+
     %{
       "type" => search_result.type,
       "block_number" => search_result.block_number,
       "block_hash" => block_hash,
       "url" => block_path(Endpoint, :show, block_hash),
-      "timestamp" => search_result.timestamp
+      "timestamp" => search_result.timestamp,
+      "block_type" => block |> BlockView.block_type() |> String.downcase()
     }
   end
 
@@ -75,6 +85,14 @@ defmodule BlockScoutWeb.API.V2.SearchView do
 
   defp hash_to_string(%Hash{bytes: bytes}), do: hash_to_string(bytes)
   defp hash_to_string(hash), do: "0x" <> Base.encode16(hash, case: :lower)
+
+  defp hash(%Hash{} = hash), do: hash
+
+  defp hash(bytes),
+    do: %Hash{
+      byte_count: 32,
+      bytes: bytes
+    }
 
   defp redirect_search_results(%Address{} = item) do
     %{"type" => "address", "parameter" => Address.checksum(item.hash)}


### PR DESCRIPTION
Close #8270 

## Changelog
- Add `block_type` to search results with `type=block`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
