### PR TITLE
Refactor optimism fetchers init

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
@@ -4,6 +4,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   """
 
   use GenServer
+  require Logger
 
   alias EthereumJSONRPC.Utility.EndpointAvailabilityObserver
 
@@ -32,7 +33,9 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
       Enum.reduce(unavailable_endpoints_arguments, [], fn json_rpc_named_arguments, acc ->
         case fetch_latest_block_number(json_rpc_named_arguments) do
           {:ok, _number} ->
-            EndpointAvailabilityObserver.enable_endpoint(json_rpc_named_arguments[:transport_options][:url])
+            url = json_rpc_named_arguments[:transport_options][:url]
+            EndpointAvailabilityObserver.enable_endpoint(url)
+            Logger.info("URL #{inspect(url)} is available now, switching back to it")
             acc
 
           _ ->

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
@@ -5,6 +5,8 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
 
   use GenServer
 
+  require Logger
+
   alias EthereumJSONRPC.Utility.EndpointAvailabilityChecker
 
   @max_error_count 3
@@ -60,6 +62,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
 
         current_count + 1 >= @max_error_count ->
           EndpointAvailabilityChecker.add_endpoint(put_in(json_rpc_named_arguments[:transport_options][:url], url))
+          Logger.warning("URL #{inspect(url)} is unavailable, switching to fallback url")
           %{state | error_counts: Map.delete(error_counts, url), unavailable_endpoints: [url | unavailable_endpoints]}
 
         true ->

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -62,13 +62,17 @@ defmodule Indexer.Fetcher.Optimism do
 
       json_rpc_named_arguments = json_rpc_named_arguments(optimism_l1_rpc)
 
-      {:ok, block_check_interval, _} = get_block_check_interval(json_rpc_named_arguments)
-
-      Process.send(self(), :reorg_monitor, [])
-
-      {:ok,
-       %{block_check_interval: block_check_interval, json_rpc_named_arguments: json_rpc_named_arguments, prev_latest: 0}}
+      {:ok, %{}, {:continue, json_rpc_named_arguments}}
     end
+  end
+
+  @impl GenServer
+  def handle_continue(json_rpc_named_arguments, _state) do
+    {:ok, block_check_interval, _} = get_block_check_interval(json_rpc_named_arguments)
+    Process.send(self(), :reorg_monitor, [])
+
+    {:noreply,
+     %{block_check_interval: block_check_interval, json_rpc_named_arguments: json_rpc_named_arguments, prev_latest: 0}}
   end
 
   @impl GenServer
@@ -200,7 +204,7 @@ defmodule Indexer.Fetcher.Optimism do
     ]
   end
 
-  def init(env, contract_address, caller)
+  def init_continue(env, contract_address, caller)
       when caller in [Indexer.Fetcher.OptimismWithdrawalEvent, Indexer.Fetcher.OptimismOutputRoot] do
     {contract_name, table_name, start_block_note} =
       if caller == Indexer.Fetcher.OptimismWithdrawalEvent do
@@ -230,7 +234,7 @@ defmodule Indexer.Fetcher.Optimism do
 
       Process.send(self(), :continue, [])
 
-      {:ok,
+      {:noreply,
        %{
          contract_address: contract_address,
          block_check_interval: block_check_interval,
@@ -241,41 +245,41 @@ defmodule Indexer.Fetcher.Optimism do
     else
       {:start_block_l1_undefined, true} ->
         # the process shouldn't start if the start block is not defined
-        :ignore
+        {:stop, :normal, %{}}
 
       {:reorg_monitor_started, false} ->
         Logger.error("Cannot start this process as reorg monitor in Indexer.Fetcher.Optimism is not started.")
-        :ignore
+        {:stop, :normal, %{}}
 
       {:rpc_l1_undefined, true} ->
         Logger.error("L1 RPC URL is not defined.")
-        :ignore
+        {:stop, :normal, %{}}
 
       {:contract_is_valid, false} ->
         Logger.error("#{contract_name} contract address is invalid or not defined.")
-        :ignore
+        {:stop, :normal, %{}}
 
       {:start_block_l1_valid, false} ->
         Logger.error("Invalid L1 Start Block value. Please, check the value and #{table_name} table.")
-        :ignore
+        {:stop, :normal, %{}}
 
       {:error, error_data} ->
         Logger.error(
           "Cannot get last L1 transaction from RPC by its hash, last safe block, or block timestamp by its number due to RPC error: #{inspect(error_data)}"
         )
 
-        :ignore
+        {:stop, :normal, %{}}
 
       {:l1_tx_not_found, true} ->
         Logger.error(
           "Cannot find last L1 transaction from RPC by its hash. Probably, there was a reorg on L1 chain. Please, check #{table_name} table."
         )
 
-        :ignore
+        {:stop, :normal, %{}}
 
       _ ->
         Logger.error("#{start_block_note} Start Block is invalid or zero.")
-        :ignore
+        {:stop, :normal, %{}}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/optimism_output_root.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_output_root.ex
@@ -38,11 +38,16 @@ defmodule Indexer.Fetcher.OptimismOutputRoot do
 
   @impl GenServer
   def init(_args) do
+    {:ok, %{}, {:continue, :ok}}
+  end
+
+  @impl GenServer
+  def handle_continue(:ok, _state) do
     Logger.metadata(fetcher: @fetcher_name)
 
     env = Application.get_all_env(:indexer)[__MODULE__]
 
-    Optimism.init(env, env[:output_oracle], __MODULE__)
+    Optimism.init_continue(env, env[:output_oracle], __MODULE__)
   end
 
   @impl GenServer

--- a/apps/indexer/lib/indexer/fetcher/optimism_withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_withdrawal.ex
@@ -40,9 +40,14 @@ defmodule Indexer.Fetcher.OptimismWithdrawal do
 
   @impl GenServer
   def init(args) do
+    json_rpc_named_arguments = args[:json_rpc_named_arguments]
+    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+  end
+
+  @impl GenServer
+  def handle_continue(json_rpc_named_arguments, state) do
     Logger.metadata(fetcher: @fetcher_name)
 
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
     env = Application.get_all_env(:indexer)[__MODULE__]
 
     with {:start_block_l2_undefined, false} <- {:start_block_l2_undefined, is_nil(env[:start_block_l2])},
@@ -59,7 +64,7 @@ defmodule Indexer.Fetcher.OptimismWithdrawal do
          {:l2_tx_not_found, false} <- {:l2_tx_not_found, !is_nil(last_l2_transaction_hash) && is_nil(last_l2_tx)} do
       Process.send(self(), :continue, [])
 
-      {:ok,
+      {:noreply,
        %{
          start_block: max(start_block_l2, last_l2_block_number),
          start_block_l2: start_block_l2,
@@ -70,31 +75,31 @@ defmodule Indexer.Fetcher.OptimismWithdrawal do
     else
       {:start_block_l2_undefined, true} ->
         # the process shouldn't start if the start block is not defined
-        :ignore
+        {:stop, :normal, state}
 
       {:message_passer_valid, false} ->
         Logger.error("L2ToL1MessagePasser contract address is invalid or not defined.")
-        :ignore
+        {:stop, :normal, state}
 
       {:start_block_l2_valid, false} ->
         Logger.error("Invalid L2 Start Block value. Please, check the value and op_withdrawals table.")
-        :ignore
+        {:stop, :normal, state}
 
       {:error, error_data} ->
         Logger.error("Cannot get last L2 transaction from RPC by its hash due to RPC error: #{inspect(error_data)}")
 
-        :ignore
+        {:stop, :normal, state}
 
       {:l2_tx_not_found, true} ->
         Logger.error(
           "Cannot find last L2 transaction from RPC by its hash. Probably, there was a reorg on L2 chain. Please, check op_withdrawals table."
         )
 
-        :ignore
+        {:stop, :normal, state}
 
       _ ->
         Logger.error("Withdrawals L2 Start Block is invalid or zero.")
-        :ignore
+        {:stop, :normal, state}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/optimism_withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_withdrawal_event.ex
@@ -43,12 +43,17 @@ defmodule Indexer.Fetcher.OptimismWithdrawalEvent do
 
   @impl GenServer
   def init(_args) do
+    {:ok, %{}, {:continue, :ok}}
+  end
+
+  @impl GenServer
+  def handle_continue(:ok, _state) do
     Logger.metadata(fetcher: @fetcher_name)
 
     env = Application.get_all_env(:indexer)[__MODULE__]
     optimism_l1_portal = Application.get_all_env(:indexer)[Indexer.Fetcher.Optimism][:optimism_l1_portal]
 
-    Optimism.init(env, optimism_l1_portal, __MODULE__)
+    Optimism.init_continue(env, optimism_l1_portal, __MODULE__)
   end
 
   @impl GenServer


### PR DESCRIPTION
## Motivation

In cases when the node is unavailable, fetchers that make requests in the `init` function will cause the `Indexer.Supervisor` to crash, but the application should start even on an unavailable node.

## Changelog

Move requests to node from `init` to `handle_continue` so `Indexer.Supervisor` won't crash if node is unavailable.