### PR TITLE
Update Nginx to proxy all frontend paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Chore
 
+- [#8573](https://github.com/blockscout/blockscout/pull/8573) - Update Nginx to proxy all frontend paths
 - [#8290](https://github.com/blockscout/blockscout/pull/8290) - Update Chromedriver version
 - [#8536](https://github.com/blockscout/blockscout/pull/8536), [#8537](https://github.com/blockscout/blockscout/pull/8537), [#8540](https://github.com/blockscout/blockscout/pull/8540), [#8557](https://github.com/blockscout/blockscout/pull/8557) - New issue template
 - [#8529](https://github.com/blockscout/blockscout/pull/8529) - Move PolygonEdge-related migration to the corresponding ecto repository

--- a/docker-compose/proxy/default.conf.template
+++ b/docker-compose/proxy/default.conf.template
@@ -9,7 +9,7 @@ server {
     server_name  localhost;
     proxy_http_version 1.1;
 
-    location / {
+    location ~ ^/(api|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
         proxy_pass            ${BACK_PROXY_PASS};
         proxy_http_version    1.1;
         proxy_set_header      Host "$host";
@@ -20,18 +20,7 @@ server {
         proxy_set_header      Connection $connection_upgrade;
         proxy_cache_bypass    $http_upgrade;
     }
-    location = / {
-        proxy_pass            ${FRONT_PROXY_PASS};
-        proxy_http_version    1.1;
-        proxy_set_header      Host "$host";
-        proxy_set_header      X-Real-IP "$remote_addr";
-        proxy_set_header      X-Forwarded-For "$proxy_add_x_forwarded_for";
-        proxy_set_header      X-Forwarded-Proto "$scheme";
-        proxy_set_header      Upgrade "$http_upgrade";
-        proxy_set_header      Connection $connection_upgrade;
-        proxy_cache_bypass    $http_upgrade;
-    }
-    location ~ ^/(_next|node-api|apps|account|accounts|favicon|static|auth/profile|auth/unverified-email|txs|tx|blocks|block|login|address|stats|search-results|token|tokens|visualize|api-docs|csv-export|verified-contracts|graphiql|withdrawals) {
+    location / {
         proxy_pass            ${FRONT_PROXY_PASS};
         proxy_http_version    1.1;
         proxy_set_header      Host "$host";


### PR DESCRIPTION
## Motivation

Currently, proxy works in such a way, that it opens all backend paths and proxy specified frontend paths. Since backend paths are rather stable and are no supposed to be changed or extended, but in the other hand, there can bew new paths appeared on the frontend. It is make more sense to switch: use all frontend paths and proxy list of known paths from backend.

## Changelog

Nginx template modification:
- Proxy all frontend paths by default
- Proxy known backend paths

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
