### PR TITLE
Filter token transfers on coin balances updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#8180](https://github.com/blockscout/blockscout/pull/8180) - Deposits and Withdrawals for Polygon Edge
 - [#7996](https://github.com/blockscout/blockscout/pull/7996) - Add CoinBalance fetcher init query limit
 - [#8658](https://github.com/blockscout/blockscout/pull/8658) - Remove block consensus on import fail
+- [#8575](https://github.com/blockscout/blockscout/pull/8575) - Filter token transfers on coin balances updates
 
 ### Fixes
 

--- a/apps/indexer/lib/indexer/transform/address_coin_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances.ex
@@ -3,6 +3,8 @@ defmodule Indexer.Transform.AddressCoinBalances do
   Extracts `Explorer.Chain.Address.CoinBalance` params from other schema's params.
   """
 
+  alias Explorer.Chain.TokenTransfer
+
   def params_set(%{} = import_options) do
     Enum.reduce(import_options, MapSet.new(), &reducer/2)
   end
@@ -30,6 +32,7 @@ defmodule Indexer.Transform.AddressCoinBalances do
   defp reducer({:logs_params, logs_params}, acc) when is_list(logs_params) do
     # a log MUST have address_hash and block_number
     logs_params
+    |> Enum.reject(&(&1.first_topic == TokenTransfer.constant()))
     |> Enum.into(acc, fn
       %{address_hash: address_hash, block_number: block_number}
       when is_binary(address_hash) and is_integer(block_number) ->

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -110,6 +110,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
         |> Factory.params_for()
         |> Map.put(:block_number, block_number)
         |> Map.put(:address_hash, address_hash)
+        |> Map.put(:first_topic, nil)
 
       params_set = AddressCoinBalances.params_set(%{logs_params: [log_params]})
 
@@ -129,6 +130,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
         |> Factory.params_for()
         |> Map.put(:block_number, nil)
         |> Map.put(:address_hash, address_hash)
+        |> Map.put(:first_topic, nil)
         |> Map.put(:type, "pending")
 
       log_params2 =
@@ -136,6 +138,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
         |> Factory.params_for()
         |> Map.put(:block_number, block_number)
         |> Map.put(:address_hash, address_hash)
+        |> Map.put(:first_topic, nil)
 
       params_set = AddressCoinBalances.params_set(%{logs_params: [log_params1, log_params2]})
 


### PR DESCRIPTION
## Motivation

Currently we are updating coin balances for all addresses that present in logs on block import. But token transfers cannot change the coin balance of any address.

## Changelog

Filter token transfer logs from collecting addresses for coin balance update.