### PR TITLE
Fix TokenBalance fetcher retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#7959](https://github.com/blockscout/blockscout/pull/7959) - Fix empty batch transfers handling
 - [#8513](https://github.com/blockscout/blockscout/pull/8513) - Don't override transaction status
 - [#8620](https://github.com/blockscout/blockscout/pull/8620) - Fix the display of icons
+- [#8594](https://github.com/blockscout/blockscout/pull/8594) - Fix TokenBalance fetcher retry logic
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -117,17 +117,21 @@ defmodule Indexer.Fetcher.TokenBalance do
     %{fetched_token_balances: fetched_token_balances, failed_token_balances: _failed_token_balances} =
       1..@max_retries
       |> Enum.reduce_while(%{fetched_token_balances: [], failed_token_balances: retryable_params_list}, fn _x, acc ->
-        {:ok,
-         %{fetched_token_balances: _fetched_token_balances, failed_token_balances: failed_token_balances} =
-           token_balances} = TokenBalances.fetch_token_balances_from_blockchain(acc.failed_token_balances)
+        {:ok, %{fetched_token_balances: fetched_token_balances, failed_token_balances: failed_token_balances}} =
+          TokenBalances.fetch_token_balances_from_blockchain(acc.failed_token_balances)
+
+        all_token_balances = %{
+          fetched_token_balances: acc.fetched_token_balances ++ fetched_token_balances,
+          failed_token_balances: failed_token_balances
+        }
 
         if Enum.empty?(failed_token_balances) do
-          {:halt, token_balances}
+          {:halt, all_token_balances}
         else
           failed_token_balances = increase_retries_count(failed_token_balances)
 
           token_balances_updated_retries_count =
-            token_balances
+            all_token_balances
             |> Map.put(:failed_token_balances, failed_token_balances)
 
           {:cont, token_balances_updated_retries_count}


### PR DESCRIPTION
## Changelog

Fixed a TokenBalance fetcher bug that we are ignoring all successfully fetched balances if there is at least one failed