### PR TITLE
Disable market history cataloger fetcher when exchange rates are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#8614](https://github.com/blockscout/blockscout/pull/8614) - Disable market history cataloger fetcher when exchange rates are disabled
 - [#8572](https://github.com/blockscout/blockscout/pull/8572) - Refactor docker-compose config
 - [#8552](https://github.com/blockscout/blockscout/pull/8552) - Add CHAIN_TYPE build arg to Dockerfile
 - [#8550](https://github.com/blockscout/blockscout/pull/8550) - Sanitize paging params

--- a/apps/explorer/lib/explorer/market/history/cataloger.ex
+++ b/apps/explorer/lib/explorer/market/history/cataloger.ex
@@ -22,9 +22,13 @@ defmodule Explorer.Market.History.Cataloger do
 
   @impl GenServer
   def init(:ok) do
-    send(self(), {:fetch_price_history, 365})
+    if Application.get_env(:explorer, __MODULE__)[:enabled] do
+      send(self(), {:fetch_price_history, 365})
 
-    {:ok, %{}}
+      {:ok, %{}}
+    else
+      :ignore
+    end
   end
 
   @impl GenServer

--- a/apps/explorer/test/explorer/market/history/cataloger_test.exs
+++ b/apps/explorer/test/explorer/market/history/cataloger_test.exs
@@ -12,6 +12,7 @@ defmodule Explorer.Market.History.CatalogerTest do
 
   setup do
     Application.put_env(:explorer, Cataloger, source: TestSource)
+    Application.put_env(:explorer, Cataloger, enabled: true)
     :ok
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -178,6 +178,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
 
 disable_indexer? = ConfigHelper.parse_bool_env_var("DISABLE_INDEXER")
 disable_webapp? = ConfigHelper.parse_bool_env_var("DISABLE_WEBAPP")
+disable_exchange_rates? = ConfigHelper.parse_bool_env_var("DISABLE_EXCHANGE_RATES")
 
 checksum_function = System.get_env("CHECKSUM_FUNCTION")
 exchange_rates_coin = System.get_env("EXCHANGE_RATES_COIN")
@@ -273,7 +274,7 @@ config :explorer, Explorer.Counters.AddressTokenTransfersCounter,
 
 config :explorer, Explorer.ExchangeRates,
   store: :ets,
-  enabled: !ConfigHelper.parse_bool_env_var("DISABLE_EXCHANGE_RATES"),
+  enabled: !disable_exchange_rates?,
   fetch_btc_value: ConfigHelper.parse_bool_env_var("EXCHANGE_RATES_FETCH_BTC_VALUE")
 
 config :explorer, Explorer.ExchangeRates.Source,
@@ -296,7 +297,7 @@ config :explorer, Explorer.ExchangeRates.TokenExchangeRates,
   refetch_interval: ConfigHelper.parse_time_env_var("TOKEN_EXCHANGE_RATE_REFETCH_INTERVAL", "1h"),
   max_batch_size: ConfigHelper.parse_integer_env_var("TOKEN_EXCHANGE_RATE_MAX_BATCH_SIZE", 150)
 
-config :explorer, Explorer.Market.History.Cataloger, enabled: !disable_indexer?
+config :explorer, Explorer.Market.History.Cataloger, enabled: !disable_indexer? && !disable_exchange_rates?
 
 config :explorer, Explorer.Chain.Transaction.History.Historian,
   enabled: ConfigHelper.parse_bool_env_var("TXS_STATS_ENABLED", "true"),


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8535

## Motivation

Setting `DISABLE_EXCHANGE_RATES=true` doesn't disable market history cataloger.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
