### PR TITLE
Fix css-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#8515](https://github.com/blockscout/blockscout/pull/8515) - Fix `:error.types/0 is undefined` warning
 - [#7959](https://github.com/blockscout/blockscout/pull/7959) - Fix empty batch transfers handling
 - [#8513](https://github.com/blockscout/blockscout/pull/8513) - Don't override transaction status
+- [#8620](https://github.com/blockscout/blockscout/pull/8620) - Fix the display of icons
 
 ### Chore
 

--- a/apps/block_scout_web/assets/webpack.config.js
+++ b/apps/block_scout_web/assets/webpack.config.js
@@ -108,7 +108,10 @@ const appJs =
                 esModule: false,
               },
             }, {
-              loader: 'css-loader'
+              loader: 'css-loader',
+              options: {
+                esModule: false,
+              },
             }, {
               loader: 'postcss-loader'
             }, {


### PR DESCRIPTION
After these changes https://github.com/blockscout/blockscout/commit/917555f092b786bd3e36e048a727247d40f0627a

https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#notes

Icons from font awesome are not displayed in the explorer:
![bs-before](https://github.com/blockscout/blockscout/assets/1568885/c08b944c-f44a-48b4-814b-f647fd8b1e0b)


With `esModule: false` option icons are displayed correctly:
![bs-after](https://github.com/blockscout/blockscout/assets/1568885/3b93ad88-847f-404e-9527-ecad19d99cf3)


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
