### PR TITLE
Remove block consensus on import fail

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -321,6 +321,18 @@ defmodule Explorer.Chain.Import do
     runner_to_changes_list
     |> runner_to_changes_list_to_multis(options)
     |> logged_import(options)
+    |> case do
+      {:ok, result} ->
+        {:ok, result}
+
+      error ->
+        remove_consensus_from_partially_imported_blocks(options)
+        error
+    end
+  rescue
+    exception ->
+      remove_consensus_from_partially_imported_blocks(options)
+      reraise exception, __STACKTRACE__
   end
 
   defp logged_import(multis, options) when is_list(multis) and is_map(options) do
@@ -347,6 +359,14 @@ defmodule Explorer.Chain.Import do
   defp import_transaction(multi, options) when is_map(options) do
     Repo.logged_transaction(multi, timeout: Map.get(options, :timeout, @transaction_timeout))
   end
+
+  defp remove_consensus_from_partially_imported_blocks(%{blocks: %{params: blocks_params}}) do
+    blocks_params
+    |> Enum.map(& &1.number)
+    |> Import.Runner.Blocks.invalidate_consensus_blocks()
+  end
+
+  defp remove_consensus_from_partially_imported_blocks(_options), do: :ok
 
   @spec timestamps() :: timestamps
   def timestamps do

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -350,6 +350,19 @@ defmodule Explorer.Chain.ImportTest do
               }} = Import.all(@import_data)
     end
 
+    test "block consensus removed if there was an exception in further steps" do
+      not_existing_block_hash = "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471db"
+
+      incorrect_data =
+        update_in(@import_data, [:transactions, :params], fn params ->
+          [&1 |> Enum.at(0) |> Map.put(:block_hash, not_existing_block_hash)]
+        end)
+
+      assert_raise(Postgrex.Error, fn -> Import.all(incorrect_data) end)
+      assert [] = Repo.all(Transaction)
+      assert %{consensus: false} = Repo.one(Block)
+    end
+
     test "inserts a token_balance" do
       params = %{
         addresses: %{


### PR DESCRIPTION
## Motivation

Currently, block import stages runs in separate transactions which means that if a later transaction fails, previous ones will not be rolled back. For example, the stage containing blocks runner located before the stage containing transactions runner, so if there was an error on transactions import, there will be consensus block in database with zero transactions.

## Changelog

Remove consensus from blocks that were imported in the stage that was failed after.