### PR TITLE
Fix db pool size exceeds Postgres max connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#8685](https://github.com/blockscout/blockscout/pull/8685) - Fix db pool size exceeds Postgres max connections
+
 ### Chore
 
 <details>

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -46,6 +46,7 @@ defmodule Explorer.Application do
     # Children to start in all environments
     base_children = [
       Explorer.Repo,
+      Explorer.Repo.Replica1,
       Explorer.Vault,
       Supervisor.child_spec({SpandexDatadog.ApiServer, datadog_opts()}, id: SpandexDatadog.ApiServer),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.HistoryTaskSupervisor}, id: Explorer.HistoryTaskSupervisor),
@@ -128,7 +129,7 @@ defmodule Explorer.Application do
       ]
       |> List.flatten()
 
-    repos_by_chain_type() ++ account_repo() ++ replica_repo() ++ configurable_children_set
+    repos_by_chain_type() ++ account_repo() ++ configurable_children_set
   end
 
   defp repos_by_chain_type do
@@ -142,14 +143,6 @@ defmodule Explorer.Application do
   defp account_repo do
     if System.get_env("ACCOUNT_DATABASE_URL") || Mix.env() == :test do
       [Explorer.Repo.Account]
-    else
-      []
-    end
-  end
-
-  defp replica_repo do
-    if System.get_env("DATABASE_READ_ONLY_API_URL") do
-      [Explorer.Repo.Replica1]
     else
       []
     end

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -74,14 +74,18 @@ config :explorer, Explorer.Repo.PolygonEdge,
   database: database,
   hostname: hostname,
   url: System.get_env("DATABASE_URL"),
-  pool_size: ConfigHelper.parse_integer_env_var("POLYGON_EDGE_POOL_SIZE", 10)
+  # actually this repo is not started, and its pool size remains unused.
+  # separating repos for different CHAIN_TYPE is implemented only for the sake of keeping DB schema update relevant to the current chain type
+  pool_size: 1
 
 # Configure Rootstock database
 config :explorer, Explorer.Repo.RSK,
   database: database,
   hostname: hostname,
   url: System.get_env("DATABASE_URL"),
-  pool_size: pool_size
+  # actually this repo is not started, and its pool size remains unused.
+  # separating repos for different CHAIN_TYPE is implemented only for the sake of keeping DB schema update relevant to the current chain type
+  pool_size: 1
 
 variant = Variant.get()
 

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -27,10 +27,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
 ### Explorer ###
 ################
 
-pool_size =
-  if System.get_env("DATABASE_READ_ONLY_API_URL"),
-    do: ConfigHelper.parse_integer_env_var("POOL_SIZE", 50),
-    else: ConfigHelper.parse_integer_env_var("POOL_SIZE", 40)
+pool_size = ConfigHelper.parse_integer_env_var("POOL_SIZE", 50)
 
 # Configures the database
 config :explorer, Explorer.Repo,
@@ -38,15 +35,10 @@ config :explorer, Explorer.Repo,
   pool_size: pool_size,
   ssl: ExplorerConfigHelper.ssl_enabled?()
 
-pool_size_api =
-  if System.get_env("DATABASE_READ_ONLY_API_URL"),
-    do: ConfigHelper.parse_integer_env_var("POOL_SIZE_API", 50),
-    else: ConfigHelper.parse_integer_env_var("POOL_SIZE_API", 10)
-
 # Configures API the database
 config :explorer, Explorer.Repo.Replica1,
   url: ExplorerConfigHelper.get_api_db_url(),
-  pool_size: pool_size_api,
+  pool_size: ConfigHelper.parse_integer_env_var("POOL_SIZE_API", 50),
   ssl: ExplorerConfigHelper.ssl_enabled?()
 
 # Configures Account database
@@ -58,13 +50,17 @@ config :explorer, Explorer.Repo.Account,
 # Configures PolygonEdge database
 config :explorer, Explorer.Repo.PolygonEdge,
   url: System.get_env("DATABASE_URL"),
-  pool_size: ConfigHelper.parse_integer_env_var("POLYGON_EDGE_POOL_SIZE", 50),
+  # actually this repo is not started, and its pool size remains unused.
+  # separating repos for different CHAIN_TYPE is implemented only for the sake of keeping DB schema update relevant to the current chain type
+  pool_size: 1,
   ssl: ExplorerConfigHelper.ssl_enabled?()
 
 # Configures Rootstock database
 config :explorer, Explorer.Repo.RSK,
   url: System.get_env("DATABASE_URL"),
-  pool_size: pool_size,
+  # actually this repo is not started, and its pool size remains unused.
+  # separating repos for different CHAIN_TYPE is implemented only for the sake of keeping DB schema update relevant to the current chain type
+  pool_size: 1,
   ssl: ExplorerConfigHelper.ssl_enabled?()
 
 variant = Variant.get()


### PR DESCRIPTION
## Motivation

Setting pool size=50 leads to number of connections to DB > 200.

## Changelog

Exclude repos which are supposed to be operated by the same DB (like RSK and PolygonEdge repos) for the application children except tests. Currently, all pool sizes are concatenated, resulting high total pool size.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
