### PR TITLE
Don't override internal transaction error if it's present already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ### Fixes
 
-- [#8678](https://github.com/blockscout/blockscout/pull/8678) - Fix `is_verified` for `/addresses` and `/smart-contracts`
+- [#8695](https://github.com/blockscout/blockscout/pull/8695) - Don't override internal transaction error if it's present already
 - [#8685](https://github.com/blockscout/blockscout/pull/8685) - Fix db pool size exceeds Postgres max connections
+- [#8678](https://github.com/blockscout/blockscout/pull/8678) - Fix `is_verified` for `/addresses` and `/smart-contracts`
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -306,7 +306,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
         |> Map.delete(:created_contract_code)
         |> Map.delete(:gas_used)
         |> Map.delete(:output)
-        |> Map.put(:error, failed_parent[:error])
+        |> Map.put_new(:error, failed_parent[:error])
       else
         internal_transaction_param
       end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8623

## Motivation

If there is an error in parent internal transactions, all child errors will be the same, which means that if child internal transaction have its own error, it will be overridden.

## Changelog

Put parent's error in child internal transactions only if there is no error yet.