### PR TITLE
Add OP withdrawal status to transaction page in API

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -25,4 +25,4 @@ lib/indexer/fetcher/zkevm/transaction_batch.ex:156
 lib/indexer/fetcher/zkevm/transaction_batch.ex:252
 lib/block_scout_web/views/api/v2/transaction_view.ex:431
 lib/block_scout_web/views/api/v2/transaction_view.ex:472
-lib/explorer/chain/transaction.ex:166
+lib/explorer/chain/transaction.ex:167

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#8702](https://github.com/blockscout/blockscout/pull/8702) - Add OP withdrawal status to transaction page in API
+
 <details>
   <summary>Dependencies version bumps</summary>
 </details>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.TransactionView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
+  alias BlockScoutWeb.API.V2.{ApiView, Helper, OptimismView, TokenView}
   alias BlockScoutWeb.{ABIEncodedValueView, TransactionView}
   alias BlockScoutWeb.Models.GetTransactionTags
   alias BlockScoutWeb.Tokens.Helper, as: TokensHelper
@@ -426,6 +426,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     |> add_optional_transaction_field(transaction, :l1_fee_scalar)
     |> add_optional_transaction_field(transaction, :l1_gas_price)
     |> add_optional_transaction_field(transaction, :l1_gas_used)
+    |> add_optimism_fields(transaction.hash, single_tx?)
     |> chain_type_fields(transaction, single_tx?, conn, watchlist_names)
     |> maybe_put_stability_fee(transaction)
   end
@@ -566,6 +567,18 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   defp sanitize_log_first_topic(first_topic) do
     if is_nil(first_topic), do: "", else: String.downcase(first_topic)
+  end
+
+  defp add_optimism_fields(result, transaction_hash, single_tx?) do
+    if single_tx? do
+      {op_withdrawal_status, op_l1_transaction_hash} = OptimismView.withdrawal_transaction_status(transaction_hash)
+
+      result
+      |> Map.put("op_withdrawal_status", op_withdrawal_status)
+      |> Map.put("op_l1_transaction_hash", op_l1_transaction_hash)
+    else
+      result
+    end
   end
 
   def token_transfers(_, _conn, false), do: nil

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.TransactionView do
   use BlockScoutWeb, :view
 
-  alias BlockScoutWeb.API.V2.{ApiView, Helper, OptimismView, TokenView}
+  alias BlockScoutWeb.API.V2.{ApiView, Helper, TokenView}
   alias BlockScoutWeb.{ABIEncodedValueView, TransactionView}
   alias BlockScoutWeb.Models.GetTransactionTags
   alias BlockScoutWeb.Tokens.Helper, as: TokensHelper
@@ -571,7 +571,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   defp add_optimism_fields(result, transaction_hash, single_tx?) do
     if single_tx? do
-      {op_withdrawal_status, op_l1_transaction_hash} = OptimismView.withdrawal_transaction_status(transaction_hash)
+      {op_withdrawal_status, op_l1_transaction_hash} = Chain.optimism_withdrawal_transaction_status(transaction_hash)
 
       result
       |> Map.put("op_withdrawal_status", op_withdrawal_status)

--- a/apps/explorer/priv/repo/migrations/20231025102325_add_op_withdrawal_index.exs
+++ b/apps/explorer/priv/repo/migrations/20231025102325_add_op_withdrawal_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddOpWithdrawalIndex do
+  use Ecto.Migration
+
+  def change do
+    create(index(:op_withdrawals, :l2_transaction_hash))
+  end
+end


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/8598.

## Motivation

We need to display Withdrawal status on transaction page.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
