### PR TITLE
Fix native coin exchange rate with `EXCHANGE_RATES_COINGECKO_COIN_ID`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#8915](https://github.com/blockscout/blockscout/pull/8915) - smart-contract: delete embeds_many relation on replace
 - [#8906](https://github.com/blockscout/blockscout/pull/8906) - Fix abi encoded string argument
 - [#8882](https://github.com/blockscout/blockscout/pull/8882) - Change order of proxy contracts patterns detection: existing popular EIPs to the top of the list
+- [#8707](https://github.com/blockscout/blockscout/pull/8707) - Fix native coin exchange rate with `EXCHANGE_RATES_COINGECKO_COIN_ID`
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
@@ -84,9 +84,11 @@ defmodule Explorer.ExchangeRates do
   @doc """
   Lists exchange rates for the tracked tickers.
   """
-  @spec list :: [Token.t()]
+  @spec list :: [Token.t()] | nil
   def list do
-    list_from_store(store())
+    if enabled?() do
+      list_from_store(store())
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -54,7 +54,7 @@ defmodule Explorer.Market do
   """
   @spec get_coin_exchange_rate() :: Token.t() | nil
   def get_coin_exchange_rate do
-    get_exchange_rate(Explorer.coin()) || get_native_coin_exchange_rate_from_db() || Token.null()
+    get_native_coin_exchange_rate_from_cache() || get_native_coin_exchange_rate_from_db() || Token.null()
   end
 
   @doc false
@@ -138,8 +138,11 @@ defmodule Explorer.Market do
     )
   end
 
-  @spec get_exchange_rate(String.t()) :: Token.t() | nil
-  defp get_exchange_rate(symbol) do
-    ExchangeRates.lookup(symbol)
+  @spec get_native_coin_exchange_rate_from_cache :: Token.t() | nil
+  defp get_native_coin_exchange_rate_from_cache do
+    case ExchangeRates.list() do
+      [native_coin] -> native_coin
+      _ -> nil
+    end
   end
 end


### PR DESCRIPTION
Fixes #8692 

## Motivation

Currently `EXCHANGE_RATES_COINGECKO_COIN_ID` is ignored at the point of retrieving exchange rate from the ETS in favor of `COIN_NAME`, while it is used to fetch exchange rate from CoinGecko API

## Changelog

Do not take into account `COIN_NAME` while querying ETS as it cannot store more than one entry by design

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
