### PR TITLE
CoinBalanceHistory tab: show also tx with gasPrice & gasUsed > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 - [#8714](https://github.com/blockscout/blockscout/pull/8714) - Fix sourcify check 
+- [#8708](https://github.com/blockscout/blockscout/pull/8708) - CoinBalanceHistory tab: show also tx with gasPrice & gasUsed > 0
 - [#8706](https://github.com/blockscout/blockscout/pull/8706) - Add address name updating on contract re-verification
 - [#8705](https://github.com/blockscout/blockscout/pull/8705) - Fix sourcify enabled flag
 - [#8695](https://github.com/blockscout/blockscout/pull/8695) - Don't override internal transaction error if it's present already

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4975,7 +4975,7 @@ defmodule Explorer.Chain do
           Transaction
           |> where(
             [tx],
-            tx.block_number == ^balance.block_number and tx.value > ^0 and
+            tx.block_number == ^balance.block_number and (tx.value > ^0 or (tx.gas_price > ^0 and tx.gas_used > ^0)) and
               (tx.to_address_hash == ^balance.address_hash or tx.from_address_hash == ^balance.address_hash)
           )
           |> select([tx], tx.hash)


### PR DESCRIPTION
Close #8621 

## Changelog
- Extend query condition in `preload_transactions/2`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
