### PR TITLE
Fix sourcify check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- [#8714](https://github.com/blockscout/blockscout/pull/8714) - Fix sourcify check 
 - [#8705](https://github.com/blockscout/blockscout/pull/8705) - Fix sourcify enabled flag
 - [#8695](https://github.com/blockscout/blockscout/pull/8695) - Don't override internal transaction error if it's present already
 - [#8685](https://github.com/blockscout/blockscout/pull/8685) - Fix db pool size exceeds Postgres max connections

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.AddressContractController do
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         _ <- PublishHelper.check_and_verify(address_hash_string),
+         _ <- PublishHelper.sourcify_check(address_hash_string),
          {:ok, address} <- Chain.find_contract_address(address_hash, address_options, true) do
       render(
         conn,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -14,6 +14,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   alias Explorer.Chain
   alias Explorer.Chain.SmartContract
   alias Explorer.SmartContract.{Reader, Writer}
+  alias Explorer.SmartContract.Solidity.PublishHelper
 
   @smart_contract_address_options [
     necessity_by_association: %{
@@ -31,6 +32,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   def smart_contract(conn, %{"address_hash" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
+         _ <- PublishHelper.sourcify_check(address_hash_string),
          {:not_found, {:ok, address}} <-
            {:not_found, Chain.find_contract_address(address_hash, @smart_contract_address_options, false)} do
       conn

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publish_helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publish_helper.ex
@@ -162,6 +162,22 @@ defmodule Explorer.SmartContract.Solidity.PublishHelper do
     end
   end
 
+  def sourcify_check(address_hash_string) do
+    cond do
+      Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)[:eth_bytecode_db?] ->
+        {:error, :eth_bytecode_db_enabled}
+
+      Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:enabled] ->
+        check_by_address_in_sourcify(
+          SmartContract.select_partially_verified_by_address_hash(address_hash_string),
+          address_hash_string
+        )
+
+      true ->
+        {:error, :sourcify_disabled}
+    end
+  end
+
   defp check_by_address_in_sourcify(false, _address_hash_string) do
     {:ok, :already_fully_verified}
   end


### PR DESCRIPTION
Close #8710 

## Changelog
- Add new function that purely go to sourcify, and do not trigger eth_bytecode_db

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
