### PR TITLE
Save GasPriceOracle old prices as a fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#8717](https://github.com/blockscout/blockscout/pull/8717) - Save GasPriceOracle old prices as a fallback
 - [#8696](https://github.com/blockscout/blockscout/pull/8696) - Support tokenSymbol and tokenName in `/api/v2/import/token-info`
 - [#8673](https://github.com/blockscout/blockscout/pull/8673) - Add a window for balances fetching from non-archive node
 - [#8651](https://github.com/blockscout/blockscout/pull/8651) - Add `stability_fee` for CHAIN_TYPE=stability


### PR DESCRIPTION
## Motivation

Gas prices update task takes several seconds to complete during which `get_gas_prices()` returns `nil`.

## Changelog

Save prices value as old value before deletion as a fallback for `get_gas_prices()`.