### PR TITLE
Remove repos_list (default value for ecto repos) from Explorer.ReleaseTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#8728](https://github.com/blockscout/blockscout/pull/8728) - Remove repos_list (default value for ecto repos) from Explorer.ReleaseTasks
+
 <details>
   <summary>Dependencies version bumps</summary>
 </details>

--- a/apps/explorer/lib/release_tasks.ex
+++ b/apps/explorer/lib/release_tasks.ex
@@ -15,20 +15,7 @@ defmodule Explorer.ReleaseTasks do
   ]
 
   def repos do
-    base_repos_list = [
-      Explorer.Repo,
-      Explorer.Repo.Account
-    ]
-
-    repos_list =
-      case System.get_env("CHAIN_TYPE") do
-        "polygon_edge" -> [Explorer.Repo.PolygonEdge | base_repos_list]
-        "polygon_zkevm" -> [Explorer.Repo.PolygonZkevm | base_repos_list]
-        "suave" -> [Explorer.Repo.Suave | base_repos_list]
-        _ -> base_repos_list
-      end
-
-    Application.get_env(:explorer, :ecto_repos, repos_list)
+    Application.get_env(:explorer, :ecto_repos)
   end
 
   def create_and_migrate do


### PR DESCRIPTION
## Motivation

Redundant default value `repos_list` for explorer.ecto_repos in Explorer.ReleaseTasks


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
