### PR TITLE
Add delay to Indexer.Fetcher.OptimismTxnBatch module initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chore
 
 - [#8702](https://github.com/blockscout/blockscout/pull/8702) - Add OP withdrawal status to transaction page in API
+- [#8739](https://github.com/blockscout/blockscout/pull/8739) - Add delay to Indexer.Fetcher.OptimismTxnBatch module initialization
 
 <details>
   <summary>Dependencies version bumps</summary>

--- a/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism_txn_batch.ex
@@ -43,14 +43,19 @@ defmodule Indexer.Fetcher.OptimismTxnBatch do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments_l2 = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments_l2}}
+    {:ok, %{json_rpc_named_arguments_l2: args[:json_rpc_named_arguments]}, {:continue, nil}}
   end
 
   @impl GenServer
-  def handle_continue(json_rpc_named_arguments_l2, state) do
+  def handle_continue(_, state) do
     Logger.metadata(fetcher: @fetcher_name)
+    # two seconds pause needed to avoid exceeding Supervisor restart intensity when DB issues
+    Process.send_after(self(), :init_with_delay, 2000)
+    {:noreply, state}
+  end
 
+  @impl GenServer
+  def handle_info(:init_with_delay, %{json_rpc_named_arguments_l2: json_rpc_named_arguments_l2} = state) do
     env = Application.get_all_env(:indexer)[__MODULE__]
 
     with {:start_block_l1_undefined, false} <- {:start_block_l1_undefined, is_nil(env[:start_block_l1])},


### PR DESCRIPTION
## Motivation

This small change adds 2-second delay to Indexer.Fetcher.OptimismTxnBatch module when its starting to avoid exceeding Supervisor restart intensity (in case of DB issues).

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
