### PR TITLE
Add new metadata fields and add x-api-key header to eth-bytecode-db r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#8795](https://github.com/blockscout/blockscout/pull/8795) - Disable catchup indexer by env
+- [#8750](https://github.com/blockscout/blockscout/pull/8750) - Support new eth-bytecode-db request metadata fields
 
 ### Fixes
 

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -181,6 +181,7 @@ defmodule BlockScoutWeb.ApiRouter do
     pipe_through(:api_v2_no_session)
 
     post("/token-info", V2.ImportController, :import_token_info)
+    get("/smart-contracts/:address_hash_param", V2.ImportController, :try_to_search_contract)
   end
 
   scope "/v2", as: :api_v2 do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -130,7 +130,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> render(:message, %{message: @restricted_access})
   end
 
-  def call(conn, {:already_verified, true}) do
+  def call(conn, {:already_verified, _}) do
     Logger.error(fn ->
       ["#{@verification_failed}: #{@already_verified}"]
     end)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3484,47 +3484,6 @@ defmodule Explorer.Chain do
     end
   end
 
-  def smart_contract_creation_tx_with_bytecode(address_hash) do
-    creation_tx_query =
-      from(
-        tx in Transaction,
-        left_join: a in Address,
-        on: tx.created_contract_address_hash == a.hash,
-        where: tx.created_contract_address_hash == ^address_hash,
-        where: tx.status == ^1
-      )
-
-    tx =
-      creation_tx_query
-      |> Repo.one()
-
-    if tx do
-      with %{init: input, created_contract_code: created_contract_code} <- tx do
-        %{init: Data.to_string(input), created_contract_code: Data.to_string(created_contract_code), tx: tx}
-      end
-    else
-      creation_int_tx_query =
-        from(
-          itx in InternalTransaction,
-          join: t in assoc(itx, :transaction),
-          where: itx.created_contract_address_hash == ^address_hash,
-          where: t.status == ^1
-        )
-
-      internal_tx = creation_int_tx_query |> Repo.one()
-
-      case internal_tx do
-        %{init: init, created_contract_code: created_contract_code} ->
-          init_str = Data.to_string(init)
-          created_contract_code_str = Data.to_string(created_contract_code)
-          %{init: init_str, created_contract_code: created_contract_code_str, internal_tx: internal_tx}
-
-        _ ->
-          nil
-      end
-    end
-  end
-
   @doc """
   Checks if an address is a contract
   """

--- a/apps/explorer/lib/explorer/smart_contract/eth_bytecode_db_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/eth_bytecode_db_interface.ex
@@ -17,6 +17,15 @@ defmodule Explorer.SmartContract.EthBytecodeDBInterface do
     end
   end
 
+  @doc """
+    Function to search smart contracts in eth-bytecode-db, similar to `search_contract/2` but
+      this function uses only `/api/v2/bytecodes/sources:search` method
+  """
+  @spec search_contract_in_eth_bytecode_internal_db(map()) :: {:error, any} | {:ok, any}
+  def search_contract_in_eth_bytecode_internal_db(%{"bytecode" => _, "bytecodeType" => _} = body) do
+    http_post_request(bytecode_search_sources_url(), body)
+  end
+
   def process_verifier_response(%{"sourcifySources" => [src | _]}) do
     {:ok, Map.put(src, "sourcify?", true)}
   end

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -4,6 +4,7 @@ defmodule Explorer.SmartContract.Helper do
   """
 
   alias Explorer.Chain
+  alias Explorer.Chain.{Hash, SmartContract}
   alias Phoenix.HTML
 
   def queriable_method?(method) do
@@ -136,20 +137,36 @@ defmodule Explorer.SmartContract.Helper do
     end
   end
 
+  @doc """
+    Returns a tuple: `{creation_bytecode, deployed_bytecode, metadata}` where `metadata` is a map:
+      {
+        "blockNumber": "string",
+        "chainId": "string",
+        "contractAddress": "string",
+        "creationCode": "string",
+        "deployer": "string",
+        "runtimeCode": "string",
+        "transactionHash": "string",
+        "transactionIndex": "string"
+      }
+
+    Metadata will be sent to a verifier microservice
+  """
+  @spec fetch_data_for_verification(binary() | Hash.t()) :: {binary() | nil, binary(), map()}
   def fetch_data_for_verification(address_hash) do
     deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
 
     metadata = %{
-      "contractAddress" => address_hash,
-      "runtimeCode" => deployed_bytecode,
+      "contractAddress" => to_string(address_hash),
+      "runtimeCode" => to_string(deployed_bytecode),
       "chainId" => Application.get_env(:block_scout_web, :chain_id)
     }
 
-    case Chain.smart_contract_creation_tx_with_bytecode(address_hash) do
-      %{init: init, created_contract_code: _, tx: tx} ->
+    case SmartContract.creation_tx_with_bytecode(address_hash) do
+      %{init: init, tx: tx} ->
         {init, deployed_bytecode, tx |> tx_to_metadata(init) |> Map.merge(metadata)}
 
-      %{init: init, created_contract_code: _, internal_tx: internal_tx} ->
+      %{init: init, internal_tx: internal_tx} ->
         {init, deployed_bytecode, internal_tx |> internal_tx_to_metadata(init) |> Map.merge(metadata)}
 
       _ ->
@@ -159,21 +176,21 @@ defmodule Explorer.SmartContract.Helper do
 
   defp tx_to_metadata(tx, init) do
     %{
-      "blockNumber" => tx.block_number,
-      "transactionHash" => tx.hash,
-      "transactionIndex" => tx.index,
-      "deployer" => tx.from_address_hash,
-      "creationCode" => init
+      "blockNumber" => to_string(tx.block_number),
+      "transactionHash" => to_string(tx.hash),
+      "transactionIndex" => to_string(tx.index),
+      "deployer" => to_string(tx.from_address_hash),
+      "creationCode" => to_string(init)
     }
   end
 
   defp internal_tx_to_metadata(internal_tx, init) do
     %{
-      "blockNumber" => internal_tx.block_number,
-      "transactionHash" => internal_tx.transaction_hash,
-      "transactionIndex" => internal_tx.transaction_index,
-      "deployer" => internal_tx.from_address_hash,
-      "creationCode" => init
+      "blockNumber" => to_string(internal_tx.block_number),
+      "transactionHash" => to_string(internal_tx.transaction_hash),
+      "transactionIndex" => to_string(internal_tx.transaction_index),
+      "deployer" => to_string(internal_tx.from_address_hash),
+      "creationCode" => to_string(init)
     }
   end
 end

--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -9,9 +9,13 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
   """
 
   import Explorer.SmartContract.Helper,
-    only: [cast_libraries: 1, prepare_bytecode_for_microservice: 3, contract_creation_input: 1]
+    only: [
+      cast_libraries: 1,
+      fetch_data_for_verification: 1,
+      prepare_bytecode_for_microservice: 3,
+      contract_creation_input: 1
+    ]
 
-  # import  Explorer.Chain.SmartContract, only: [:function_description]
   alias ABI.{FunctionSelector, TypeDecoder}
   alias Explorer.Chain
   alias Explorer.Chain.{Data, Hash, SmartContract}
@@ -40,9 +44,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
   end
 
   defp evaluate_authenticity_inner(true, address_hash, params) do
-    deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
-
-    creation_tx_input = contract_creation_input(address_hash)
+    {creation_tx_input, deployed_bytecode, verifier_metadata} = fetch_data_for_verification(address_hash)
 
     %{}
     |> prepare_bytecode_for_microservice(creation_tx_input, deployed_bytecode)
@@ -54,7 +56,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
     |> Map.put("optimizationRuns", prepare_optimization_runs(params["optimization"], params["optimization_runs"]))
     |> Map.put("evmVersion", Map.get(params, "evm_version", "default"))
     |> Map.put("compilerVersion", params["compiler_version"])
-    |> RustVerifierInterface.verify_multi_part(address_hash)
+    |> RustVerifierInterface.verify_multi_part(verifier_metadata)
   end
 
   defp evaluate_authenticity_inner(false, address_hash, params) do
@@ -124,14 +126,12 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
   end
 
   def evaluate_authenticity_via_standard_json_input_inner(true, address_hash, params, json_input) do
-    deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
-
-    creation_tx_input = contract_creation_input(address_hash)
+    {creation_tx_input, deployed_bytecode, verifier_metadata} = fetch_data_for_verification(address_hash)
 
     %{"compilerVersion" => params["compiler_version"]}
     |> prepare_bytecode_for_microservice(creation_tx_input, deployed_bytecode)
     |> Map.put("input", json_input)
-    |> RustVerifierInterface.verify_standard_json_input(address_hash)
+    |> RustVerifierInterface.verify_standard_json_input(verifier_metadata)
   end
 
   def evaluate_authenticity_via_standard_json_input_inner(false, address_hash, params, json_input) do
@@ -139,9 +139,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
   end
 
   def evaluate_authenticity_via_multi_part_files(address_hash, params, files) do
-    deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
-
-    creation_tx_input = contract_creation_input(address_hash)
+    {creation_tx_input, deployed_bytecode, verifier_metadata} = fetch_data_for_verification(address_hash)
 
     %{}
     |> prepare_bytecode_for_microservice(creation_tx_input, deployed_bytecode)
@@ -150,7 +148,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
     |> Map.put("optimizationRuns", prepare_optimization_runs(params["optimization"], params["optimization_runs"]))
     |> Map.put("evmVersion", Map.get(params, "evm_version", "default"))
     |> Map.put("compilerVersion", params["compiler_version"])
-    |> RustVerifierInterface.verify_multi_part(address_hash)
+    |> RustVerifierInterface.verify_multi_part(verifier_metadata)
   end
 
   defp verify(address_hash, params, json_input) do

--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -12,8 +12,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
     only: [
       cast_libraries: 1,
       fetch_data_for_verification: 1,
-      prepare_bytecode_for_microservice: 3,
-      contract_creation_input: 1
+      prepare_bytecode_for_microservice: 3
     ]
 
   alias ABI.{FunctionSelector, TypeDecoder}

--- a/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
@@ -12,7 +12,9 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
   alias Explorer.Chain
   alias Explorer.SmartContract.Vyper.CodeCompiler
   alias Explorer.SmartContract.RustVerifierInterface
-  import Explorer.SmartContract.Helper, only: [prepare_bytecode_for_microservice: 3, contract_creation_input: 1]
+
+  import Explorer.SmartContract.Helper,
+    only: [fetch_data_for_verification: 1, prepare_bytecode_for_microservice: 3, contract_creation_input: 1]
 
   def evaluate_authenticity(_, %{"contract_source_code" => ""}),
     do: {:error, :contract_source_code}
@@ -34,7 +36,7 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
   def evaluate_authenticity(address_hash, params, files) do
     try do
       if RustVerifierInterface.enabled?() do
-        vyper_verify_multipart(params, fetch_bytecode(address_hash), params["evm_version"], files, address_hash)
+        vyper_verify_multipart(params, params["evm_version"], files, address_hash)
       end
     rescue
       exception ->
@@ -50,7 +52,7 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
   def evaluate_authenticity_standard_json(%{"address_hash" => address_hash} = params) do
     try do
       if RustVerifierInterface.enabled?() do
-        vyper_verify_standard_json(params, fetch_bytecode(address_hash), address_hash)
+        vyper_verify_standard_json(params, address_hash)
       end
     rescue
       exception ->
@@ -66,7 +68,6 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
   defp evaluate_authenticity_inner(true, address_hash, params) do
     vyper_verify_multipart(
       params,
-      fetch_bytecode(address_hash),
       params["evm_version"],
       %{
         "#{params["name"]}.vy" => params["contract_source_code"]
@@ -77,13 +78,6 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
 
   defp evaluate_authenticity_inner(false, address_hash, params) do
     verify(address_hash, params)
-  end
-
-  def fetch_bytecode(address_hash) do
-    deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
-    creation_tx_input = contract_creation_input(address_hash)
-
-    prepare_bytecode_for_microservice(%{}, creation_tx_input, deployed_bytecode)
   end
 
   defp verify(address_hash, params) do
@@ -123,19 +117,25 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
     end
   end
 
-  defp vyper_verify_multipart(params, bytecode_map, evm_version, files, address_hash) do
-    bytecode_map
+  defp vyper_verify_multipart(params, evm_version, files, address_hash) do
+    {creation_tx_input, deployed_bytecode, verifier_metadata} = fetch_data_for_verification(address_hash)
+
+    %{}
+    |> prepare_bytecode_for_microservice(creation_tx_input, deployed_bytecode)
     |> Map.put("evmVersion", evm_version)
     |> Map.put("sourceFiles", files)
     |> Map.put("compilerVersion", params["compiler_version"])
     |> Map.put("interfaces", params["interfaces"] || %{})
-    |> RustVerifierInterface.vyper_verify_multipart(address_hash)
+    |> RustVerifierInterface.vyper_verify_multipart(verifier_metadata)
   end
 
-  defp vyper_verify_standard_json(params, bytecode_map, address_hash) do
-    bytecode_map
+  defp vyper_verify_standard_json(params, address_hash) do
+    {creation_tx_input, deployed_bytecode, verifier_metadata} = fetch_data_for_verification(address_hash)
+
+    %{}
+    |> prepare_bytecode_for_microservice(creation_tx_input, deployed_bytecode)
     |> Map.put("compilerVersion", params["compiler_version"])
     |> Map.put("input", params["input"])
-    |> RustVerifierInterface.vyper_verify_standard_json(address_hash)
+    |> RustVerifierInterface.vyper_verify_standard_json(verifier_metadata)
   end
 end

--- a/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/verifier.ex
@@ -9,7 +9,6 @@ defmodule Explorer.SmartContract.Vyper.Verifier do
   """
   require Logger
 
-  alias Explorer.Chain
   alias Explorer.SmartContract.Vyper.CodeCompiler
   alias Explorer.SmartContract.RustVerifierInterface
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -379,7 +379,8 @@ config :explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour,
   service_url: System.get_env("MICROSERVICE_SC_VERIFIER_URL") || "https://eth-bytecode-db.services.blockscout.com/",
   enabled: enabled?,
   type: type,
-  eth_bytecode_db?: enabled? && type == "eth_bytecode_db"
+  eth_bytecode_db?: enabled? && type == "eth_bytecode_db",
+  api_key: System.get_env("MICROSERVICE_SC_VERIFIER_API_KEY")
 
 config :explorer, Explorer.Visualize.Sol2uml,
   service_url: System.get_env("MICROSERVICE_VISUALIZE_SOL2UML_URL"),


### PR DESCRIPTION
…equest

Close #8720 

## Changelog
- Support new metadata format
```
"metadata": {
    "blockNumber": "string",
    "chainId": "string",
    "contractAddress": "string",
    "creationCode": "string",
    "deployer": "string",
    "runtimeCode": "string",
    "transactionHash": "string",
    "transactionIndex": "string"
  }
```
- Add `x-api-key` header
- New env `MICROSERVICE_SC_VERIFIER_API_KEY` (API key for verification that metadata sent to verifier microservice from a trusted source)
https://github.com/blockscout/docs/pull/194
- Add `/api/v2/import/smart-contracts/{address_hash}` endpoint


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
