### PR TITLE
Fix for tvl update in market history when row already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- [#8765](https://github.com/blockscout/blockscout/pull/8765) - Fix for tvl update in market history when row already exists
 - [#8759](https://github.com/blockscout/blockscout/pull/8759) - Gnosis safe proxy via singleton input
 - [#8752](https://github.com/blockscout/blockscout/pull/8752) - Add `TOKEN_INSTANCE_OWNER_MIGRATION_ENABLED` env
 - [#8724](https://github.com/blockscout/blockscout/pull/8724) - Fix flaky account notifier test


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8764

## Motivation

tvl is not updated for historical dates when `market_history` table is previously filled.

## Changelog

Change update on conflict behavior from DO NOTHING to UPDATE with non-null positive values. This is applied to tvl, market_cap and prices.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
