### PR TITLE
Fix for eth_getbalance API v1 endpoint when requesting latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - [#8784](https://github.com/blockscout/blockscout/pull/8784) - Fix Indexer.Transform.Addresses for non-Suave setup
+- [#8770](https://github.com/blockscout/blockscout/pull/8770) - Fix for eth_getbalance API v1 endpoint when requesting latest tag
 - [#8765](https://github.com/blockscout/blockscout/pull/8765) - Fix for tvl update in market history when row already exists
 - [#8759](https://github.com/blockscout/blockscout/pull/8759) - Gnosis safe proxy via singleton input
 - [#8752](https://github.com/blockscout/blockscout/pull/8752) - Add `TOKEN_INSTANCE_OWNER_MIGRATION_ENABLED` env

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -400,9 +400,7 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
     test "with a valid address that has a balance", %{conn: conn, api_params: api_params} do
       block = insert(:block)
-      address = insert(:address)
-
-      insert(:fetched_balance, block_number: block.number, address_hash: address.hash, value: 1)
+      address = insert(:address, fetched_coin_balance: 1, fetched_coin_balance_block_number: block.number)
 
       assert response =
                conn


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8769

## Motivation

`eth_get_balance` API returns the latest value found in coin balance history for block number equal or less then latest indexed. However, this can be fragile when fetcher of internal transactions didn't finished initial index.

## Changelog

Get balance for a latest tag from `fetched_coin_balance` in `addresses` table for the given address.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
