### PR TITLE
Null round handling

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -8,7 +8,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
 
   alias Explorer.Chain.Transaction.StateChange
   alias Explorer.{Chain, PagingOptions}
-  alias Explorer.Chain.{Block, Transaction, Wei}
+  alias Explorer.Chain.{Block, NullRoundHeight, Transaction, Wei}
   alias Explorer.Chain.Cache.StateChanges
   alias Indexer.Fetcher.{CoinBalanceOnDemand, TokenBalanceOnDemand}
 
@@ -73,9 +73,11 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
         api?: Keyword.get(options, :api?, false)
       )
 
-    from_before_block = coin_balance(transaction.from_address_hash, block.number - 1, options)
-    to_before_block = coin_balance(transaction.to_address_hash, block.number - 1, options)
-    miner_before_block = coin_balance(block.miner_hash, block.number - 1, options)
+    previous_block_number = NullRoundHeight.previous_block_number(block.number)
+
+    from_before_block = coin_balance(transaction.from_address_hash, previous_block_number, options)
+    to_before_block = coin_balance(transaction.to_address_hash, previous_block_number, options)
+    miner_before_block = coin_balance(block.miner_hash, previous_block_number, options)
 
     {from_before_tx, to_before_tx, miner_before_tx} =
       StateChange.coin_balances_before(transaction, block_txs, from_before_block, to_before_block, miner_before_block)
@@ -146,7 +148,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
     from = transfer.from_address
     to = transfer.to_address
     token_hash = transfer.token_contract_address_hash
-    prev_block = transfer.block_number - 1
+    prev_block = NullRoundHeight.previous_block_number(transfer.block_number)
 
     balances
     |> case do

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -23,11 +23,9 @@ defmodule BlockScoutWeb.Notifier do
   alias Explorer.Chain.{Address, InternalTransaction, Transaction}
   alias Explorer.Chain.Supply.RSK
   alias Explorer.Chain.Transaction.History.TransactionStats
-  alias Explorer.Counters.{AverageBlockTime, Helper}
+  alias Explorer.Counters.AverageBlockTime
   alias Explorer.SmartContract.{CompilerVersion, Solidity.CodeCompiler}
   alias Phoenix.View
-
-  @check_broadcast_sequence_period 500
 
   def handle_event({:chain_event, :addresses, type, addresses}) when type in [:realtime, :on_demand] do
     Endpoint.broadcast("addresses:new_address", "count", %{count: Counters.address_estimated_count()})
@@ -105,13 +103,7 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :blocks, :realtime, blocks}) do
-    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
-
-    blocks
-    |> Enum.sort_by(& &1.number, :asc)
-    |> Enum.each(fn block ->
-      broadcast_latest_block?(block, last_broadcasted_block_number)
-    end)
+    Enum.each(blocks, &broadcast_block/1)
   end
 
   def handle_event({:chain_event, :zkevm_confirmed_batches, :realtime, batches}) do
@@ -294,35 +286,6 @@ defmodule BlockScoutWeb.Notifier do
       ratio: Decimal.to_string(ratio),
       finished: Chain.finished_indexing_from_ratio?(ratio)
     })
-  end
-
-  defp broadcast_latest_block?(block, last_broadcasted_block_number) do
-    cond do
-      last_broadcasted_block_number == 0 || last_broadcasted_block_number == block.number - 1 ||
-          last_broadcasted_block_number < block.number - 4 ->
-        broadcast_block(block)
-        :ets.insert(:last_broadcasted_block, {:number, block.number})
-
-      last_broadcasted_block_number > block.number - 1 ->
-        broadcast_block(block)
-
-      true ->
-        Task.start_link(fn ->
-          schedule_broadcasting(block)
-        end)
-    end
-  end
-
-  defp schedule_broadcasting(block) do
-    :timer.sleep(@check_broadcast_sequence_period)
-    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
-
-    if last_broadcasted_block_number == block.number - 1 do
-      broadcast_block(block)
-      :ets.insert(:last_broadcasted_block, {:number, block.number})
-    else
-      schedule_broadcasting(block)
-    end
   end
 
   defp broadcast_address_coin_balance(%{address_hash: address_hash, block_number: block_number}) do

--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -7,7 +7,6 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   alias BlockScoutWeb.Notifier
   alias Explorer.Chain.Events.Subscriber
-  alias Explorer.Counters.Helper
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -15,7 +14,6 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   @impl true
   def init([]) do
-    Helper.create_cache_table(:last_broadcasted_block)
     Subscriber.to(:address_coin_balances, :realtime)
     Subscriber.to(:addresses, :realtime)
     Subscriber.to(:block_rewards, :realtime)

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -13,6 +13,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     Address,
     Block,
     Import,
+    NullRoundHeight,
     PendingBlockOperation,
     Token,
     Token.Instance,
@@ -875,11 +876,14 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
                                                 number: number
                                               },
                                               acc ->
+        previous_block_number = NullRoundHeight.previous_block_number(number)
+        next_block_number = NullRoundHeight.next_block_number(number)
+
         if consensus do
           from(
             block in acc,
-            or_where: block.number == ^(number - 1) and block.hash != ^parent_hash,
-            or_where: block.number == ^(number + 1) and block.parent_hash != ^hash
+            or_where: block.number == ^previous_block_number and block.hash != ^parent_hash,
+            or_where: block.number == ^next_block_number and block.parent_hash != ^hash
           )
         else
           acc

--- a/apps/explorer/lib/explorer/chain/null_round_height.ex
+++ b/apps/explorer/lib/explorer/chain/null_round_height.ex
@@ -1,0 +1,82 @@
+defmodule Explorer.Chain.NullRoundHeight do
+  @moduledoc """
+  A null round is formed when a block at height N links to a block at height N-2 instead of N-1
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Repo
+
+  @primary_key false
+  schema "null_round_heights" do
+    field(:height, :integer, primary_key: true)
+  end
+
+  def changeset(null_round_height \\ %__MODULE__{}, params) do
+    null_round_height
+    |> cast(params, [:height])
+    |> validate_required([:height])
+    |> unique_constraint(:height)
+  end
+
+  def total do
+    Repo.aggregate(__MODULE__, :count)
+  end
+
+  def insert_heights(heights) do
+    params =
+      heights
+      |> Enum.uniq()
+      |> Enum.map(&%{height: &1})
+
+    Repo.insert_all(__MODULE__, params, on_conflict: :nothing)
+  end
+
+  def previous_block_number(number), do: neighbor_block_number(number, :previous)
+
+  def next_block_number(number), do: neighbor_block_number(number, :next)
+
+  @batch_size 5
+  def neighbor_block_number(number, direction) do
+    number
+    |> neighbors_query(direction)
+    |> select([nrh], nrh.height)
+    |> Repo.all()
+    |> case do
+      [] -> move_by_one(number, direction)
+      previous_null_rounds -> find_neighbor_from_previous(previous_null_rounds, number, direction)
+    end
+  end
+
+  defp find_neighbor_from_previous(previous_null_rounds, number, direction) do
+    previous_null_rounds
+    |> Enum.reduce_while({number, nil}, fn height, {curr, _result} ->
+      if height == move_by_one(curr, direction) do
+        {:cont, {height, nil}}
+      else
+        {:halt, {nil, move_by_one(curr, direction)}}
+      end
+    end)
+    |> elem(1)
+    |> case do
+      nil ->
+        previous_null_rounds
+        |> List.last()
+        |> neighbor_block_number(direction)
+
+      number ->
+        number
+    end
+  end
+
+  defp move_by_one(number, :previous), do: number - 1
+  defp move_by_one(number, :next), do: number + 1
+
+  defp neighbors_query(number, :previous) do
+    from(nrh in __MODULE__, where: nrh.height < ^number, order_by: [desc: :height], limit: @batch_size)
+  end
+
+  defp neighbors_query(number, :next) do
+    from(nrh in __MODULE__, where: nrh.height > ^number, order_by: [asc: :height], limit: @batch_size)
+  end
+end

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -4,6 +4,7 @@ defmodule Explorer.Utility.MissingBlockRange do
   """
   use Explorer.Schema
 
+  alias Explorer.Chain.NullRoundHeight
   alias Explorer.Repo
 
   @default_returning_batch_size 10
@@ -76,21 +77,29 @@ defmodule Explorer.Utility.MissingBlockRange do
     case {lower_range, higher_range} do
       {%__MODULE__{} = same_range, %__MODULE__{} = same_range} ->
         Repo.delete(same_range)
-        insert_if_needed(%{from_number: same_range.from_number, to_number: max_number + 1})
-        insert_if_needed(%{from_number: min_number - 1, to_number: same_range.to_number})
+
+        insert_if_needed(%{
+          from_number: same_range.from_number,
+          to_number: NullRoundHeight.next_block_number(max_number)
+        })
+
+        insert_if_needed(%{
+          from_number: NullRoundHeight.previous_block_number(min_number),
+          to_number: same_range.to_number
+        })
 
       {%__MODULE__{} = range, nil} ->
         delete_ranges_between(max_number, range.from_number)
-        update_from_number_or_delete_range(range, min_number - 1)
+        update_from_number_or_delete_range(range, NullRoundHeight.previous_block_number(min_number))
 
       {nil, %__MODULE__{} = range} ->
         delete_ranges_between(range.to_number, min_number)
-        update_to_number_or_delete_range(range, max_number + 1)
+        update_to_number_or_delete_range(range, NullRoundHeight.next_block_number(max_number))
 
       {%__MODULE__{} = range_1, %__MODULE__{} = range_2} ->
         delete_ranges_between(range_2.to_number, range_1.from_number)
-        update_from_number_or_delete_range(range_1, min_number - 1)
-        update_to_number_or_delete_range(range_2, max_number + 1)
+        update_from_number_or_delete_range(range_1, NullRoundHeight.previous_block_number(min_number))
+        update_to_number_or_delete_range(range_2, NullRoundHeight.next_block_number(max_number))
 
       _ ->
         delete_ranges_between(max_number, min_number)

--- a/apps/explorer/priv/repo/migrations/20231109104957_create_null_round_heights.exs
+++ b/apps/explorer/priv/repo/migrations/20231109104957_create_null_round_heights.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.CreateNullRoundHeights do
+  use Ecto.Migration
+
+  def change do
+    create table(:null_round_heights, primary_key: false) do
+      add(:height, :integer, primary_key: true)
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -23,6 +23,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
   alias Ecto.Changeset
   alias Explorer.Chain
+  alias Explorer.Chain.NullRoundHeight
   alias Explorer.Utility.MissingRangesManipulator
   alias Indexer.{Block, Tracer}
   alias Indexer.Block.Catchup.{Sequence, TaskSupervisor}
@@ -198,7 +199,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
 
     case result do
       {:ok, %{inserted: inserted, errors: errors}} ->
-        errors = cap_seq(sequence, errors)
+        valid_errors = handle_null_rounds(errors)
+        errors = cap_seq(sequence, valid_errors)
         retry(sequence, errors)
         clear_missing_ranges(range, errors)
 
@@ -248,6 +250,20 @@ defmodule Indexer.Block.Catchup.Fetcher do
     exception ->
       Logger.error(fn -> [Exception.format(:error, exception, __STACKTRACE__), ?\n, ?\n, "Retrying."] end)
       {:error, exception}
+  end
+
+  defp handle_null_rounds(errors) do
+    {null_rounds, other_errors} =
+      Enum.split_with(errors, fn
+        %{message: "requested epoch was a null round"} -> true
+        _ -> false
+      end)
+
+    null_rounds
+    |> Enum.map(&block_error_to_number/1)
+    |> NullRoundHeight.insert_heights()
+
+    other_errors
   end
 
   defp cap_seq(seq, errors) do

--- a/apps/indexer/lib/indexer/fetcher/transaction_action.ex
+++ b/apps/indexer/lib/indexer/fetcher/transaction_action.ex
@@ -15,7 +15,7 @@ defmodule Indexer.Fetcher.TransactionAction do
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Helper, as: ExplorerHelper
-  alias Explorer.Chain.{Block, Log, TransactionAction}
+  alias Explorer.Chain.{Block, Log, NullRoundHeight, TransactionAction}
   alias Indexer.Transform.{Addresses, TransactionActions}
 
   @stage_first_block "tx_action_first_block"
@@ -157,7 +157,7 @@ defmodule Indexer.Fetcher.TransactionAction do
         |> Decimal.round(2)
         |> Decimal.to_string()
 
-      next_block_new = block_number - 1
+      next_block_new = NullRoundHeight.previous_block_number(block_number)
 
       Logger.info(
         "Block #{block_number} handled successfully. Progress: #{progress_percentage}%. Initial block range: #{first_block}..#{last_block}." <>


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8803

## Changelog

- Added `NullRoundHeight` entity that stores non-existent block numbers.
- Fill `NullRoundHeight` with block numbers from requests with error message `requested epoch was a null round`.
- Don't count null rounds as missing blocks.
- Refactored places that use previous or next block number to use it in accordance with possible null rounds.