### PR TITLE
Ignore depositReceiptVersion from optimism receipts

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -315,7 +315,7 @@ defmodule EthereumJSONRPC.Receipt do
   end
 
   # Optimism specific transaction receipt fields
-  defp entry_to_elixir({key, _}) when key in ~w(depositNonce) do
+  defp entry_to_elixir({key, _}) when key in ~w(depositNonce depositReceiptVersion) do
     :ignore
   end
 


### PR DESCRIPTION
## Motivation

Optimism [canyon](https://blog.oplabs.co/canyon-hardfork/) upgrade [introduces](https://github.com/ethereum-optimism/op-geth/blob/ed8e9f54ed0a5069e77ea34895ff12a9ac4ca17f/core/state_processor.go#L150-L152) a new depositReceiptVersion field in receipts and blockscout indexing breaks because of the extra field in the receipt.

## Changelog

### Bug Fixes
Ignore depositReceiptVersion field from optimism txs receipts

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
