### PR TITLE
Do not ignore twin contracts on /api/v2/import/smart-contracts/{address_hash}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- [#8813](https://github.com/blockscout/blockscout/pull/8813) - Force verify twin contracts on `/api/v2/import/smart-contracts/{address_hash}`
 - [#8784](https://github.com/blockscout/blockscout/pull/8784) - Fix Indexer.Transform.Addresses for non-Suave setup
 - [#8770](https://github.com/blockscout/blockscout/pull/8770) - Fix for eth_getbalance API v1 endpoint when requesting latest tag
 - [#8765](https://github.com/blockscout/blockscout/pull/8765) - Fix for tvl update in market history when row already exists

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
@@ -54,7 +54,7 @@ defmodule BlockScoutWeb.API.V2.ImportController do
 
   @doc """
     Function to handle request at:
-      `/api/v2/smart-contracts/{address_hash_param}`
+      `/api/v2/import/smart-contracts/{address_hash_param}`
 
     Needed to try to import unverified smart contracts via eth-bytecode-db (`/api/v2/bytecodes/sources:search` method).
     Protected by `x-api-key` header.
@@ -73,7 +73,7 @@ defmodule BlockScoutWeb.API.V2.ImportController do
          {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:not_found, {:ok, address}} <- {:not_found, Chain.hash_to_address(address_hash, @api_true, false)},
          {:already_verified, smart_contract} when is_nil(smart_contract) <-
-           {:already_verified, Chain.address_hash_to_smart_contract(address_hash, @api_true)} do
+           {:already_verified, Chain.address_hash_to_smart_contract_without_twin(address_hash, @api_true)} do
       creation_tx_input = contract_creation_input(address.hash)
 
       with {:ok, %{"sourceType" => type} = source} <-

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3912,13 +3912,6 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec address_hash_to_smart_contract(Hash.Address.t()) :: SmartContract.t() | nil
-  def address_hash_to_one_smart_contract(hash) do
-    SmartContract
-    |> where([sc], sc.address_hash == ^hash)
-    |> Repo.one()
-  end
-
   @spec address_hash_to_smart_contract_without_twin(Hash.Address.t(), [api?]) :: SmartContract.t() | nil
   def address_hash_to_smart_contract_without_twin(address_hash, options) do
     query =


### PR DESCRIPTION
## Motivation 
We send `already verified` error message on `/api/v2/import/smart-contracts/{address_hash}` if the contract has twin, but desired behavior is to verify such contracts

## Changelog
- do not ignore twin contracts on `/api/v2/import/smart-contracts/{address_hash}`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
