### PR TITLE
Hotfix for optimism_withdrawal_transaction_status function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- [#8822](https://github.com/blockscout/blockscout/pull/8822) - Hotfix for optimism_withdrawal_transaction_status function
 - [#8813](https://github.com/blockscout/blockscout/pull/8813) - Force verify twin contracts on `/api/v2/import/smart-contracts/{address_hash}`
 - [#8811](https://github.com/blockscout/blockscout/pull/8811) - Consider consensus block only when retrieving OP withdrawal transaction status
 - [#8784](https://github.com/blockscout/blockscout/pull/8784) - Fix Indexer.Transform.Addresses for non-Suave setup

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2224,7 +2224,8 @@ defmodule Explorer.Chain do
             hash: w.hash,
             l2_timestamp: l2_block.timestamp,
             l1_transaction_hash: we.l1_transaction_hash
-          }
+          },
+          limit: 1
         )
       )
 


### PR DESCRIPTION
## Motivation

This change fixes the following error:

```
Request: GET /api/v2/transactions/0xc2f1dc7be06c8580bb233e97a736b1fd15cb5cd4274ffd21e1119cf7f3e076d0
** (exit) an exception was raised:
    ** (Ecto.MultipleResultsError) expected at most one result but got 2 in query:

from o0 in Explorer.Chain.OptimismWithdrawal,
  left_join: b1 in Explorer.Chain.Block,
  on: o0.l2_block_number == b1.number,
  left_join: o2 in Explorer.Chain.OptimismWithdrawalEvent,
  on: o2.withdrawal_hash == o0.hash and o2.l1_event_type == :WithdrawalFinalized,
  where: o0.l2_transaction_hash ==
  ^%Explorer.Chain.Hash{byte_count: 32, bytes: <<194, 241, 220, 123, 224, 108, 133, 128, 187, 35, 62, 151, 167, 54, 177, 253, 21, 203, 92, 212, 39, 79, 253, 33, 225, 17, 156, 247, 243, 224, 118, 208>>},
  select: %{hash: o0.hash, l2_timestamp: b1.timestamp, l1_transaction_hash: o2.l1_transaction_hash}

        (ecto 3.10.3) lib/ecto/repo/queryable.ex:154: Ecto.Repo.Queryable.one/3
        (explorer 5.3.1) lib/explorer/chain.ex:2216: Explorer.Chain.optimism_withdrawal_transaction_status/1
        (block_scout_web 5.3.1) lib/block_scout_web/views/api/v2/transaction_view.ex:574: BlockScoutWeb.API.V2.TransactionView.add_optimism_fields/3
        (block_scout_web 5.3.1) lib/block_scout_web/views/api/v2/transaction_view.ex:429: BlockScoutWeb.API.V2.TransactionView.prepare_transaction/6
        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
        (block_scout_web 5.3.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.action/2
        (block_scout_web 5.3.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.phoenix_controller_pipeline/2
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
