### PR TITLE
Add MainPageRealtimeEventHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#8848](https://github.com/blockscout/blockscout/pull/8848) - Add MainPageRealtimeEventHandler
 - [#8795](https://github.com/blockscout/blockscout/pull/8795) - Disable catchup indexer by env
 - [#8768](https://github.com/blockscout/blockscout/pull/8768) - Add possibility to search tokens by address hash
 - [#8750](https://github.com/blockscout/blockscout/pull/8750) - Support new eth-bytecode-db request metadata fields

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -8,7 +8,7 @@ defmodule BlockScoutWeb.Application do
   alias BlockScoutWeb.API.APILogger
   alias BlockScoutWeb.Counters.{BlocksIndexedCounter, InternalTransactionsIndexedCounter}
   alias BlockScoutWeb.{Endpoint, Prometheus}
-  alias BlockScoutWeb.RealtimeEventHandler
+  alias BlockScoutWeb.{MainPageRealtimeEventHandler, RealtimeEventHandler}
 
   def start(_type, _args) do
     import Supervisor
@@ -34,6 +34,7 @@ defmodule BlockScoutWeb.Application do
       {Phoenix.PubSub, name: BlockScoutWeb.PubSub},
       child_spec(Endpoint, []),
       {Absinthe.Subscription, Endpoint},
+      {MainPageRealtimeEventHandler, name: MainPageRealtimeEventHandler},
       {RealtimeEventHandler, name: RealtimeEventHandler},
       {BlocksIndexedCounter, name: BlocksIndexedCounter},
       {InternalTransactionsIndexedCounter, name: InternalTransactionsIndexedCounter}

--- a/apps/block_scout_web/lib/block_scout_web/main_page_realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/main_page_realtime_event_handler.ex
@@ -1,0 +1,29 @@
+defmodule BlockScoutWeb.MainPageRealtimeEventHandler do
+  @moduledoc """
+  Subscribing process for main page broadcast events from realtime.
+  """
+
+  use GenServer
+
+  alias BlockScoutWeb.Notifier
+  alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Counters.Helper
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init([]) do
+    Helper.create_cache_table(:last_broadcasted_block)
+    Subscriber.to(:blocks, :realtime)
+    Subscriber.to(:transactions, :realtime)
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_info(event, state) do
+    Notifier.handle_event(event)
+    {:noreply, state}
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -7,7 +7,6 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   alias BlockScoutWeb.Notifier
   alias Explorer.Chain.Events.Subscriber
-  alias Explorer.Counters.Helper
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -15,15 +14,12 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
 
   @impl true
   def init([]) do
-    Helper.create_cache_table(:last_broadcasted_block)
     Subscriber.to(:address_coin_balances, :realtime)
     Subscriber.to(:addresses, :realtime)
     Subscriber.to(:block_rewards, :realtime)
-    Subscriber.to(:blocks, :realtime)
     Subscriber.to(:internal_transactions, :realtime)
     Subscriber.to(:internal_transactions, :on_demand)
     Subscriber.to(:token_transfers, :realtime)
-    Subscriber.to(:transactions, :realtime)
     Subscriber.to(:addresses, :on_demand)
     Subscriber.to(:address_coin_balances, :on_demand)
     Subscriber.to(:address_current_token_balances, :on_demand)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8736

## Motivation

Main page events are the most important of all since they are visible by every user from the very beginning of using app.

## Changelog

Move main page events to a separate handler so they won't be slowed down by other events.