### PR TITLE
Apply block filters before pagination in token transfers list query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#8868](https://github.com/blockscout/blockscout/pull/8868) - Apply block filters before pagination in token transfers list query
+
 ### Chore
 
 ## 5.3.2-beta

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -464,6 +464,8 @@ defmodule Explorer.Etherscan do
 
     tt_specific_token_query =
       tt_query
+      |> where_token_transfers_start_block_match(options)
+      |> where_token_transfers_end_block_match(options)
       |> where_contract_address_match(contract_address_hash)
 
     wrapped_query =
@@ -501,8 +503,6 @@ defmodule Explorer.Etherscan do
       )
 
     wrapped_query
-    |> where_start_block_match(options)
-    |> where_end_block_match(options)
     |> Repo.replica().all()
   end
 
@@ -534,6 +534,18 @@ defmodule Explorer.Etherscan do
 
   defp where_contract_address_match(query, contract_address_hash) do
     where(query, [tt, _], tt.token_contract_address_hash == ^contract_address_hash)
+  end
+
+  defp where_token_transfers_start_block_match(query, %{start_block: nil}), do: query
+
+  defp where_token_transfers_start_block_match(query, %{start_block: start_block}) do
+    where(query, [tt, _], tt.block_number >= ^start_block)
+  end
+
+  defp where_token_transfers_end_block_match(query, %{end_block: nil}), do: query
+
+  defp where_token_transfers_end_block_match(query, %{end_block: end_block}) do
+    where(query, [tt, _], tt.block_number <= ^end_block)
   end
 
   defp offset(options), do: (options.page_number - 1) * options.page_size

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1363,7 +1363,8 @@ defmodule Explorer.EtherscanTest do
 
       options = %{
         start_block: second_block.number,
-        end_block: third_block.number
+        end_block: third_block.number,
+        page_size: 2
       }
 
       found_token_transfers = Etherscan.list_token_transfers(address.hash, nil, options)


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

Since the introduction of https://github.com/blockscout/blockscout/commit/21ca08b8994e56f1b329900e79d9927ee52d9351, `start_block` and `end_block` filters are applied after pagination (via `page` and `offset`) is done.

The subquery will fetch `options.page_size` results, the main query will then do a join, and the blocks filters will be applied on this query.
So assuming an address with more token transfers than `page_size`, if the `start_block` is after the block of the last token transfer of the first page, the query would return an empty result, while setting `page` to a different number might result the result if hitting the correct page.

This changes the behavior to apply the blocks filters on the subquery.

## Changelog

### Bug Fixes

* `start_block` and `end_block` filters on the token transfers endpoint are now working as expected for addresses with more transfers than the `page_size`. It's now the same behavior as the other endpoints.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
