### PR TITLE
Limit TokenBalance fetcher timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#8869](https://github.com/blockscout/blockscout/pull/8869) - Limit TokenBalance fetcher timeout
 - [#8855](https://github.com/blockscout/blockscout/pull/8855) - All transactions count at top addresses page
 - [#8836](https://github.com/blockscout/blockscout/pull/8836) - Safe token update
 - [#8814](https://github.com/blockscout/blockscout/pull/8814) - Improve performance for EOA addresses in `/api/v2/addresses/{address_hash}`

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -28,6 +28,8 @@ defmodule Indexer.Fetcher.TokenBalance do
   @default_max_batch_size 100
   @default_max_concurrency 10
 
+  @timeout :timer.minutes(10)
+
   @max_retries 3
 
   @spec async_fetch([
@@ -156,7 +158,7 @@ defmodule Indexer.Fetcher.TokenBalance do
       address_current_token_balances: %{
         params: TokenBalances.to_address_current_token_balances(formatted_token_balances_params)
       },
-      timeout: :infinity
+      timeout: @timeout
     }
 
     case Chain.import(import_params) do


### PR DESCRIPTION
## Motivation

Queries inserting token balances may be long-running and since they are keeping locks that conflict with queries from block fetchers, it may cause block fetchers to fail because of timeout.

## Changelog

Set an increased but not infinity limit for token balances fetcher.