### PR TITLE
Revert "Remove /api/account/v1 path"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 
 ### Chore
 
-- [#8843](https://github.com/blockscout/blockscout/pull/8843) - Remove /api/account/v1 path
 - [#8832](https://github.com/blockscout/blockscout/pull/8832) - Log more details in regards 413 error
 - [#8807](https://github.com/blockscout/blockscout/pull/8807) - Smart-contract proxy detection refactoring
 - [#8802](https://github.com/blockscout/blockscout/pull/8802) - Enable API v2 by default

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -46,8 +46,73 @@ defmodule BlockScoutWeb.ApiRouter do
     plug(RateLimit)
   end
 
-  alias BlockScoutWeb.Account.Api.V2.{AuthenticateController, EmailController, TagsController, UserController}
+  alias BlockScoutWeb.Account.Api.V1.{AuthenticateController, EmailController, TagsController, UserController}
   alias BlockScoutWeb.API.V2
+
+  # TODO: Remove /account/v1 paths
+  scope "/account/v1", as: :account_v1 do
+    pipe_through(:api)
+    pipe_through(:account_api)
+
+    get("/authenticate", AuthenticateController, :authenticate_get)
+    post("/authenticate", AuthenticateController, :authenticate_post)
+
+    get("/get_csrf", UserController, :get_csrf)
+
+    scope "/email" do
+      get("/resend", EmailController, :resend_email)
+    end
+
+    scope "/user" do
+      get("/info", UserController, :info)
+
+      get("/watchlist", UserController, :watchlist_old)
+      delete("/watchlist/:id", UserController, :delete_watchlist)
+      post("/watchlist", UserController, :create_watchlist)
+      put("/watchlist/:id", UserController, :update_watchlist)
+
+      get("/api_keys", UserController, :api_keys)
+      delete("/api_keys/:api_key", UserController, :delete_api_key)
+      post("/api_keys", UserController, :create_api_key)
+      put("/api_keys/:api_key", UserController, :update_api_key)
+
+      get("/custom_abis", UserController, :custom_abis)
+      delete("/custom_abis/:id", UserController, :delete_custom_abi)
+      post("/custom_abis", UserController, :create_custom_abi)
+      put("/custom_abis/:id", UserController, :update_custom_abi)
+
+      get("/public_tags", UserController, :public_tags_requests)
+      delete("/public_tags/:id", UserController, :delete_public_tags_request)
+      post("/public_tags", UserController, :create_public_tags_request)
+      put("/public_tags/:id", UserController, :update_public_tags_request)
+
+      scope "/tags" do
+        get("/address/", UserController, :tags_address_old)
+        get("/address/:id", UserController, :tags_address)
+        delete("/address/:id", UserController, :delete_tag_address)
+        post("/address/", UserController, :create_tag_address)
+        put("/address/:id", UserController, :update_tag_address)
+
+        get("/transaction/", UserController, :tags_transaction_old)
+        get("/transaction/:id", UserController, :tags_transaction)
+        delete("/transaction/:id", UserController, :delete_tag_transaction)
+        post("/transaction/", UserController, :create_tag_transaction)
+        put("/transaction/:id", UserController, :update_tag_transaction)
+      end
+    end
+  end
+
+  # TODO: Remove /account/v1 paths
+  scope "/account/v1" do
+    pipe_through(:api)
+    pipe_through(:account_api)
+
+    scope "/tags" do
+      get("/address/:address_hash", TagsController, :tags_address)
+
+      get("/transaction/:transaction_hash", TagsController, :tags_transaction)
+    end
+  end
 
   scope "/account/v2", as: :account_v2 do
     pipe_through(:api)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/authenticate_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/authenticate_controller.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.AuthenticateController do
+defmodule BlockScoutWeb.Account.Api.V1.AuthenticateController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/email_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/email_controller.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.EmailController do
+defmodule BlockScoutWeb.Account.Api.V1.EmailController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.Models.UserFromAuth

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/fallback_controller.ex
@@ -1,7 +1,7 @@
-defmodule BlockScoutWeb.Account.Api.V2.FallbackController do
+defmodule BlockScoutWeb.Account.Api.V1.FallbackController do
   use Phoenix.Controller
 
-  alias BlockScoutWeb.Account.Api.V2.UserView
+  alias BlockScoutWeb.Account.Api.V1.UserView
   alias Ecto.Changeset
 
   def call(conn, {:identity, _}) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/tags_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/tags_controller.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.TagsController do
+defmodule BlockScoutWeb.Account.Api.V1.TagsController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v1/user_controller.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.UserController do
+defmodule BlockScoutWeb.Account.Api.V1.UserController do
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserController do
   alias Explorer.{Chain, Market, PagingOptions, Repo}
   alias Plug.CSRFProtection
 
-  action_fallback(BlockScoutWeb.Account.Api.V2.FallbackController)
+  action_fallback(BlockScoutWeb.Account.Api.V1.FallbackController)
 
   @ok_message "OK"
   @token_balances_amount 150

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/app.html.eex
@@ -94,7 +94,7 @@
       <% session = Explorer.Account.enabled?() && Plug.Conn.get_session(@conn, :current_user) %>
       <%= render BlockScoutWeb.LayoutView, "_topnav.html", current_user: session, conn: @conn %>
       <%= if session && !session[:email_verified] do %>
-        <p class="alert alert-warning" role="alert" style="margin-bottom: 0"><%= gettext("Please confirm your email address to use the My Account feature.") %> <%= gettext("A confirmation email was sent to") %> <a href="mailto:<%= session[:email] %>"><%=session[:email] %></a> <%= gettext "on sign up. Didn’t receive?" %> <a href="/api/account/v2/email/resend" class="ajax"><%= gettext "Resend verification email" %></a>.</p>
+        <p class="alert alert-warning" role="alert" style="margin-bottom: 0"><%= gettext("Please confirm your email address to use the My Account feature.") %> <%= gettext("A confirmation email was sent to") %> <a href="mailto:<%= session[:email] %>"><%=session[:email] %></a> <%= gettext "on sign up. Didn’t receive?" %> <a href="/api/account/v1/email/resend" class="ajax"><%= gettext "Resend verification email" %></a>.</p>
       <% else %>
         <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
       <% end %>

--- a/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/account_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/account_view.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.AccountView do
+defmodule BlockScoutWeb.Account.Api.V1.AccountView do
   def render("message.json", %{message: message}) do
     %{
       "message" => message

--- a/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/tags_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/tags_view.ex
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.TagsView do
+defmodule BlockScoutWeb.Account.Api.V1.TagsView do
   def render("address_tags.json", %{tags_map: tags_map}) do
     tags_map
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/user_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/account/api/v1/user_view.ex
@@ -1,5 +1,5 @@
-defmodule BlockScoutWeb.Account.Api.V2.UserView do
-  alias BlockScoutWeb.Account.Api.V2.AccountView
+defmodule BlockScoutWeb.Account.Api.V1.UserView do
+  alias BlockScoutWeb.Account.Api.V1.AccountView
   alias BlockScoutWeb.API.V2.Helper
   alias Ecto.Changeset
   alias Explorer.Chain

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v1/user_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
+defmodule BlockScoutWeb.Account.Api.V1.UserControllerTest do
   use BlockScoutWeb.ConnCase
 
   alias Explorer.Account.{
@@ -19,11 +19,11 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
     {:ok, user: user, conn: Plug.Test.init_test_session(conn, current_user: user)}
   end
 
-  describe "Test account/api/v2/user" do
+  describe "Test account/api/v1/user" do
     test "get user info", %{conn: conn, user: user} do
       result_conn =
         conn
-        |> get("/api/account/v2/user/info")
+        |> get("/api/account/v1/user/info")
         |> doc(description: "Get info about user")
 
       assert json_response(result_conn, 200) == %{
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
     test "post private address tag", %{conn: conn} do
       tag_address_response =
         conn
-        |> post("/api/account/v2/user/tags/address", %{
+        |> post("/api/account/v1/user/tags/address", %{
           "address_hash" => "0x3e9ac8f16c92bc4f093357933b5befbf1e16987b",
           "name" => "MyName"
         })
@@ -45,7 +45,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         |> json_response(200)
 
       conn
-      |> get("/api/account/v2/tags/address/0x3e9ac8f16c92bc4f093357933b5befbf1e16987b")
+      |> get("/api/account/v1/tags/address/0x3e9ac8f16c92bc4f093357933b5befbf1e16987b")
       |> doc(description: "Get tags for address")
       |> json_response(200)
 
@@ -69,11 +69,11 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       end
 
       assert conn
-             |> post("/api/account/v2/user/tags/address", build(:tag_address))
+             |> post("/api/account/v1/user/tags/address", build(:tag_address))
              |> json_response(200)
 
       assert conn
-             |> post("/api/account/v2/user/tags/address", build(:tag_address))
+             |> post("/api/account/v1/user/tags/address", build(:tag_address))
              |> json_response(422)
 
       Application.put_env(:explorer, Explorer.Account, old_env)
@@ -103,12 +103,12 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       tag_address_response =
         conn
-        |> post("/api/account/v2/user/tags/address", address_tag)
+        |> post("/api/account/v1/user/tags/address", address_tag)
         |> json_response(200)
 
       _response =
         conn
-        |> get("/api/account/v2/user/tags/address")
+        |> get("/api/account/v1/user/tags/address")
         |> json_response(200) == [tag_address_response]
 
       assert tag_address_response["address_hash"] == address_tag["address_hash"]
@@ -119,7 +119,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       new_tag_address_response =
         conn
-        |> put("/api/account/v2/user/tags/address/#{tag_address_response["id"]}", new_address_tag)
+        |> put("/api/account/v1/user/tags/address/#{tag_address_response["id"]}", new_address_tag)
         |> doc(description: "Edit private address tag")
         |> json_response(200)
 
@@ -137,7 +137,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         Enum.map(zipped, fn {addr, name} ->
           id =
             (conn
-             |> post("/api/account/v2/user/tags/address", %{
+             |> post("/api/account/v1/user/tags/address", %{
                "address_hash" => addr,
                "name" => name
              })
@@ -164,7 +164,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert Enum.all?(created, fn {addr, map_tag, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/address/#{addr}")
+                 |> get("/api/account/v1/tags/address/#{addr}")
                  |> json_response(200)
 
                response["personal_tags"] == [map_tag]
@@ -172,10 +172,9 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       response =
         conn
-        |> get("/api/account/v2/user/tags/address")
+        |> get("/api/account/v1/user/tags/address")
         |> doc(description: "Get private addresses tags")
         |> json_response(200)
-        |> Map.get("items")
 
       assert Enum.all?(created, fn {_, _, map} -> map in response end)
     end
@@ -189,7 +188,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         Enum.map(zipped, fn {addr, name} ->
           id =
             (conn
-             |> post("/api/account/v2/user/tags/address", %{
+             |> post("/api/account/v1/user/tags/address", %{
                "address_hash" => addr,
                "name" => name
              })
@@ -216,7 +215,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert Enum.all?(created, fn {addr, map_tag, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/address/#{addr}")
+                 |> get("/api/account/v1/tags/address/#{addr}")
                  |> json_response(200)
 
                response["personal_tags"] == [map_tag]
@@ -224,31 +223,32 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       response =
         conn
-        |> get("/api/account/v2/user/tags/address")
+        |> get("/api/account/v1/user/tags/address")
         |> json_response(200)
-        |> Map.get("items")
 
       assert Enum.all?(created, fn {_, _, map} -> map in response end)
 
       {_, _, %{"id" => id}} = Enum.at(created, 0)
 
       assert conn
-             |> delete("/api/account/v2/user/tags/address/#{id}")
+             |> delete("/api/account/v1/user/tags/address/#{id}")
              |> doc("Delete private address tag")
              |> json_response(200) == %{"message" => "OK"}
 
       assert Enum.all?(Enum.drop(created, 1), fn {_, _, %{"id" => id}} ->
                conn
-               |> delete("/api/account/v2/user/tags/address/#{id}")
+               |> delete("/api/account/v1/user/tags/address/#{id}")
                |> json_response(200) == %{"message" => "OK"}
              end)
 
-      assert conn |> get("/api/account/v2/user/tags/address") |> json_response(200) |> Map.get("items") == []
+      assert conn
+             |> get("/api/account/v1/user/tags/address")
+             |> json_response(200) == []
 
       assert Enum.all?(created, fn {addr, _, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/address/#{addr}")
+                 |> get("/api/account/v1/tags/address/#{addr}")
                  |> json_response(200)
 
                response["personal_tags"] == []
@@ -260,7 +260,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       tx_hash = to_string(insert(:transaction).hash)
 
       assert conn
-             |> post("/api/account/v2/user/tags/transaction", %{
+             |> post("/api/account/v1/user/tags/transaction", %{
                "transaction_hash" => tx_hash_non_existing,
                "name" => "MyName"
              })
@@ -269,7 +269,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       tag_transaction_response =
         conn
-        |> post("/api/account/v2/user/tags/transaction", %{
+        |> post("/api/account/v1/user/tags/transaction", %{
           "transaction_hash" => tx_hash,
           "name" => "MyName"
         })
@@ -277,7 +277,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         |> json_response(200)
 
       conn
-      |> get("/api/account/v2/tags/transaction/#{tx_hash}")
+      |> get("/api/account/v1/tags/transaction/#{tx_hash}")
       |> doc(description: "Get tags for transaction")
       |> json_response(200)
 
@@ -301,11 +301,11 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       end
 
       assert conn
-             |> post("/api/account/v2/user/tags/transaction", build(:tag_transaction))
+             |> post("/api/account/v1/user/tags/transaction", build(:tag_transaction))
              |> json_response(200)
 
       assert conn
-             |> post("/api/account/v2/user/tags/transaction", build(:tag_transaction))
+             |> post("/api/account/v1/user/tags/transaction", build(:tag_transaction))
              |> json_response(422)
 
       Application.put_env(:explorer, Explorer.Account, old_env)
@@ -335,12 +335,12 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       tag_response =
         conn
-        |> post("/api/account/v2/user/tags/transaction", tx_tag)
+        |> post("/api/account/v1/user/tags/transaction", tx_tag)
         |> json_response(200)
 
       _response =
         conn
-        |> get("/api/account/v2/user/tags/transaction")
+        |> get("/api/account/v1/user/tags/transaction")
         |> json_response(200) == [tag_response]
 
       assert tag_response["address_hash"] == tx_tag["address_hash"]
@@ -351,7 +351,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       new_tag_response =
         conn
-        |> put("/api/account/v2/user/tags/transaction/#{tag_response["id"]}", new_tx_tag)
+        |> put("/api/account/v1/user/tags/transaction/#{tag_response["id"]}", new_tx_tag)
         |> doc(description: "Edit private transaction tag")
         |> json_response(200)
 
@@ -369,7 +369,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         Enum.map(zipped, fn {tx_hash, name} ->
           id =
             (conn
-             |> post("/api/account/v2/user/tags/transaction", %{
+             |> post("/api/account/v1/user/tags/transaction", %{
                "transaction_hash" => tx_hash,
                "name" => name
              })
@@ -381,7 +381,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert Enum.all?(created, fn {tx_hash, map_tag, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/transaction/#{tx_hash}")
+                 |> get("/api/account/v1/tags/transaction/#{tx_hash}")
                  |> json_response(200)
 
                response["personal_tx_tag"] == map_tag
@@ -389,10 +389,9 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       response =
         conn
-        |> get("/api/account/v2/user/tags/transaction")
+        |> get("/api/account/v1/user/tags/transaction")
         |> doc(description: "Get private transactions tags")
         |> json_response(200)
-        |> Map.get("items")
 
       assert Enum.all?(created, fn {_, _, map} -> map in response end)
     end
@@ -406,7 +405,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         Enum.map(zipped, fn {tx_hash, name} ->
           id =
             (conn
-             |> post("/api/account/v2/user/tags/transaction", %{
+             |> post("/api/account/v1/user/tags/transaction", %{
                "transaction_hash" => tx_hash,
                "name" => name
              })
@@ -418,15 +417,15 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert Enum.all?(created, fn {tx_hash, map_tag, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/transaction/#{tx_hash}")
+                 |> get("/api/account/v1/tags/transaction/#{tx_hash}")
                  |> json_response(200)
 
                response["personal_tx_tag"] == map_tag
              end)
 
-      %{"items" => response, "next_page_params" => nil} =
+      response =
         conn
-        |> get("/api/account/v2/user/tags/transaction")
+        |> get("/api/account/v1/user/tags/transaction")
         |> json_response(200)
 
       assert Enum.all?(created, fn {_, _, map} -> map in response end)
@@ -434,24 +433,24 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       {_, _, %{"id" => id}} = Enum.at(created, 0)
 
       assert conn
-             |> delete("/api/account/v2/user/tags/transaction/#{id}")
+             |> delete("/api/account/v1/user/tags/transaction/#{id}")
              |> doc("Delete private transaction tag")
              |> json_response(200) == %{"message" => "OK"}
 
       assert Enum.all?(Enum.drop(created, 1), fn {_, _, %{"id" => id}} ->
                conn
-               |> delete("/api/account/v2/user/tags/transaction/#{id}")
+               |> delete("/api/account/v1/user/tags/transaction/#{id}")
                |> json_response(200) == %{"message" => "OK"}
              end)
 
       assert conn
-             |> get("/api/account/v2/user/tags/transaction")
-             |> json_response(200) == %{"items" => [], "next_page_params" => nil}
+             |> get("/api/account/v1/user/tags/transaction")
+             |> json_response(200) == []
 
       assert Enum.all?(created, fn {addr, _, _} ->
                response =
                  conn
-                 |> get("/api/account/v2/tags/transaction/#{addr}")
+                 |> get("/api/account/v1/tags/transaction/#{addr}")
                  |> json_response(200)
 
                response["personal_tx_tag"] == nil
@@ -464,7 +463,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map
         )
         |> doc(description: "Add address to watch list")
@@ -475,8 +474,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_watchlist_address_response["notification_methods"] == watchlist_address_map["notification_methods"]
       assert post_watchlist_address_response["address_hash"] == watchlist_address_map["address_hash"]
 
-      get_watchlist_address_response =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(0)
+      get_watchlist_address_response = conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(0)
 
       assert get_watchlist_address_response["notification_settings"] == watchlist_address_map["notification_settings"]
       assert get_watchlist_address_response["name"] == watchlist_address_map["name"]
@@ -489,21 +487,20 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response_1 =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map_1
         )
         |> json_response(200)
 
       get_watchlist_address_response_1_0 =
         conn
-        |> get("/api/account/v2/user/watchlist")
+        |> get("/api/account/v1/user/watchlist")
         |> doc(description: "Get addresses from watchlists")
         |> json_response(200)
-        |> Map.get("items")
         |> Enum.at(1)
 
       get_watchlist_address_response_1_1 =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(0)
+        conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(0)
 
       assert get_watchlist_address_response_1_0 == get_watchlist_address_response
 
@@ -534,11 +531,11 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       end
 
       assert conn
-             |> post("/api/account/v2/user/watchlist", build(:watchlist_address))
+             |> post("/api/account/v1/user/watchlist", build(:watchlist_address))
              |> json_response(200)
 
       assert conn
-             |> post("/api/account/v2/user/watchlist", build(:watchlist_address))
+             |> post("/api/account/v1/user/watchlist", build(:watchlist_address))
              |> json_response(422)
 
       Application.put_env(:explorer, Explorer.Account, old_env)
@@ -569,7 +566,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map
         )
         |> json_response(200)
@@ -579,8 +576,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_watchlist_address_response["notification_methods"] == watchlist_address_map["notification_methods"]
       assert post_watchlist_address_response["address_hash"] == watchlist_address_map["address_hash"]
 
-      get_watchlist_address_response =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(0)
+      get_watchlist_address_response = conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(0)
 
       assert get_watchlist_address_response["notification_settings"] == watchlist_address_map["notification_settings"]
       assert get_watchlist_address_response["name"] == watchlist_address_map["name"]
@@ -593,16 +589,16 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response_1 =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map_1
         )
         |> json_response(200)
 
       get_watchlist_address_response_1_0 =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(1)
+        conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(1)
 
       get_watchlist_address_response_1_1 =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(0)
+        conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(0)
 
       assert get_watchlist_address_response_1_0 == get_watchlist_address_response
 
@@ -618,15 +614,15 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert get_watchlist_address_response_1_1["id"] == post_watchlist_address_response_1["id"]
 
       assert conn
-             |> delete("/api/account/v2/user/watchlist/#{get_watchlist_address_response_1_1["id"]}")
+             |> delete("/api/account/v1/user/watchlist/#{get_watchlist_address_response_1_1["id"]}")
              |> doc(description: "Delete address from watchlist by id")
              |> json_response(200) == %{"message" => "OK"}
 
       assert conn
-             |> delete("/api/account/v2/user/watchlist/#{get_watchlist_address_response_1_0["id"]}")
+             |> delete("/api/account/v1/user/watchlist/#{get_watchlist_address_response_1_0["id"]}")
              |> json_response(200) == %{"message" => "OK"}
 
-      assert conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") == []
+      assert conn |> get("/api/account/v1/user/watchlist") |> json_response(200) == []
     end
 
     test "put watchlist address", %{conn: conn} do
@@ -635,7 +631,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map
         )
         |> json_response(200)
@@ -645,8 +641,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_watchlist_address_response["notification_methods"] == watchlist_address_map["notification_methods"]
       assert post_watchlist_address_response["address_hash"] == watchlist_address_map["address_hash"]
 
-      get_watchlist_address_response =
-        conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items") |> Enum.at(0)
+      get_watchlist_address_response = conn |> get("/api/account/v1/user/watchlist") |> json_response(200) |> Enum.at(0)
 
       assert get_watchlist_address_response["notification_settings"] == watchlist_address_map["notification_settings"]
       assert get_watchlist_address_response["name"] == watchlist_address_map["name"]
@@ -659,7 +654,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       put_watchlist_address_response =
         conn
         |> put(
-          "/api/account/v2/user/watchlist/#{post_watchlist_address_response["id"]}",
+          "/api/account/v1/user/watchlist/#{post_watchlist_address_response["id"]}",
           new_watchlist_address_map
         )
         |> doc(description: "Edit watchlist address")
@@ -680,7 +675,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           watchlist_address_map
         )
         |> json_response(200)
@@ -692,7 +687,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       assert conn
              |> post(
-               "/api/account/v2/user/watchlist",
+               "/api/account/v1/user/watchlist",
                watchlist_address_map
              )
              |> doc(description: "Example of error on creating watchlist address")
@@ -703,14 +698,14 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_watchlist_address_response_1 =
         conn
         |> post(
-          "/api/account/v2/user/watchlist",
+          "/api/account/v1/user/watchlist",
           new_watchlist_address_map
         )
         |> json_response(200)
 
       assert conn
              |> put(
-               "/api/account/v2/user/watchlist/#{post_watchlist_address_response_1["id"]}",
+               "/api/account/v1/user/watchlist/#{post_watchlist_address_response_1["id"]}",
                watchlist_address_map
              )
              |> doc(description: "Example of error on editing watchlist address")
@@ -722,7 +717,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/watchlist",
+        "/api/account/v1/user/watchlist",
         watchlist_address_map
       )
       |> json_response(200)
@@ -731,7 +726,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/watchlist",
+        "/api/account/v1/user/watchlist",
         watchlist_address_map_1
       )
       |> json_response(200)
@@ -766,7 +761,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         |> Enum.sort(fn x1, x2 -> Decimal.compare(x1, x2) in [:gt, :eq] end)
         |> Enum.take(150)
 
-      [wa2, wa1] = conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items")
+      [wa2, wa1] = conn |> get("/api/account/v1/user/watchlist") |> json_response(200)
 
       assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
                values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
@@ -786,7 +781,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/watchlist",
+        "/api/account/v1/user/watchlist",
         watchlist_address_map
       )
       |> json_response(200)
@@ -813,7 +808,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         token_contract_address_hash: token.contract_address_hash
       )
 
-      [wa1] = conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items")
+      [wa1] = conn |> get("/api/account/v1/user/watchlist") |> json_response(200)
 
       assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
                values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
@@ -826,7 +821,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_api_key_response =
         conn
         |> post(
-          "/api/account/v2/user/api_keys",
+          "/api/account/v1/user/api_keys",
           %{"name" => "test"}
         )
         |> doc(description: "Add api key")
@@ -840,7 +835,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       Enum.each(0..2, fn _x ->
         conn
         |> post(
-          "/api/account/v2/user/api_keys",
+          "/api/account/v1/user/api_keys",
           %{"name" => "test"}
         )
         |> json_response(200)
@@ -848,14 +843,14 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       assert conn
              |> post(
-               "/api/account/v2/user/api_keys",
+               "/api/account/v1/user/api_keys",
                %{"name" => "test"}
              )
              |> doc(description: "Example of error on creating api key")
              |> json_response(422) == %{"errors" => %{"name" => ["Max 3 keys per account"]}}
 
       assert conn
-             |> get("/api/account/v2/user/api_keys")
+             |> get("/api/account/v1/user/api_keys")
              |> doc(description: "Get api keys list")
              |> json_response(200)
              |> Enum.count() == 3
@@ -865,7 +860,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_api_key_response =
         conn
         |> post(
-          "/api/account/v2/user/api_keys",
+          "/api/account/v1/user/api_keys",
           %{"name" => "test"}
         )
         |> json_response(200)
@@ -876,7 +871,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       put_api_key_response =
         conn
         |> put(
-          "/api/account/v2/user/api_keys/#{post_api_key_response["api_key"]}",
+          "/api/account/v1/user/api_keys/#{post_api_key_response["api_key"]}",
           %{"name" => "test_1"}
         )
         |> doc(description: "Edit api key")
@@ -886,7 +881,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert put_api_key_response["name"] == "test_1"
 
       assert conn
-             |> get("/api/account/v2/user/api_keys")
+             |> get("/api/account/v1/user/api_keys")
              |> json_response(200) == [put_api_key_response]
     end
 
@@ -894,7 +889,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_api_key_response =
         conn
         |> post(
-          "/api/account/v2/user/api_keys",
+          "/api/account/v1/user/api_keys",
           %{"name" => "test"}
         )
         |> json_response(200)
@@ -903,17 +898,17 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_api_key_response["api_key"]
 
       assert conn
-             |> get("/api/account/v2/user/api_keys")
+             |> get("/api/account/v1/user/api_keys")
              |> json_response(200)
              |> Enum.count() == 1
 
       assert conn
-             |> delete("/api/account/v2/user/api_keys/#{post_api_key_response["api_key"]}")
+             |> delete("/api/account/v1/user/api_keys/#{post_api_key_response["api_key"]}")
              |> doc(description: "Delete api key")
              |> json_response(200) == %{"message" => "OK"}
 
       assert conn
-             |> get("/api/account/v2/user/api_keys")
+             |> get("/api/account/v1/user/api_keys")
              |> json_response(200) == []
     end
 
@@ -923,7 +918,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_custom_abi_response =
         conn
         |> post(
-          "/api/account/v2/user/custom_abis",
+          "/api/account/v1/user/custom_abis",
           custom_abi
         )
         |> doc(description: "Add custom abi")
@@ -939,7 +934,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       Enum.each(0..14, fn _x ->
         conn
         |> post(
-          "/api/account/v2/user/custom_abis",
+          "/api/account/v1/user/custom_abis",
           build(:custom_abi)
         )
         |> json_response(200)
@@ -947,14 +942,14 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       assert conn
              |> post(
-               "/api/account/v2/user/custom_abis",
+               "/api/account/v1/user/custom_abis",
                build(:custom_abi)
              )
              |> doc(description: "Example of error on creating custom abi")
              |> json_response(422) == %{"errors" => %{"name" => ["Max 15 ABIs per account"]}}
 
       assert conn
-             |> get("/api/account/v2/user/custom_abis")
+             |> get("/api/account/v1/user/custom_abis")
              |> doc(description: "Get custom abis list")
              |> json_response(200)
              |> Enum.count() == 15
@@ -966,7 +961,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_custom_abi_response =
         conn
         |> post(
-          "/api/account/v2/user/custom_abis",
+          "/api/account/v1/user/custom_abis",
           custom_abi
         )
         |> json_response(200)
@@ -981,7 +976,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       put_custom_abi_response =
         conn
         |> put(
-          "/api/account/v2/user/custom_abis/#{post_custom_abi_response["id"]}",
+          "/api/account/v1/user/custom_abis/#{post_custom_abi_response["id"]}",
           custom_abi_1
         )
         |> doc(description: "Edit custom abi")
@@ -993,7 +988,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert put_custom_abi_response["abi"] == custom_abi_1["abi"]
 
       assert conn
-             |> get("/api/account/v2/user/custom_abis")
+             |> get("/api/account/v1/user/custom_abis")
              |> json_response(200) == [put_custom_abi_response]
     end
 
@@ -1003,7 +998,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_custom_abi_response =
         conn
         |> post(
-          "/api/account/v2/user/custom_abis",
+          "/api/account/v1/user/custom_abis",
           custom_abi
         )
         |> json_response(200)
@@ -1012,17 +1007,17 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_custom_abi_response["id"]
 
       assert conn
-             |> get("/api/account/v2/user/custom_abis")
+             |> get("/api/account/v1/user/custom_abis")
              |> json_response(200)
              |> Enum.count() == 1
 
       assert conn
-             |> delete("/api/account/v2/user/custom_abis/#{post_custom_abi_response["id"]}")
+             |> delete("/api/account/v1/user/custom_abis/#{post_custom_abi_response["id"]}")
              |> doc(description: "Delete custom abi")
              |> json_response(200) == %{"message" => "OK"}
 
       assert conn
-             |> get("/api/account/v2/user/custom_abis")
+             |> get("/api/account/v1/user/custom_abis")
              |> json_response(200) == []
     end
   end
@@ -1034,7 +1029,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_public_tags_request_response =
         conn
         |> post(
-          "/api/account/v2/user/public_tags",
+          "/api/account/v1/user/public_tags",
           public_tags_request
         )
         |> doc(description: "Submit request to add a public tag")
@@ -1057,7 +1052,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_public_tags_request_response =
         conn
         |> post(
-          "/api/account/v2/user/public_tags",
+          "/api/account/v1/user/public_tags",
           public_tags_request
         )
         |> json_response(200)
@@ -1073,7 +1068,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_public_tags_request_response["id"]
 
       assert conn
-             |> get("/api/account/v2/user/public_tags")
+             |> get("/api/account/v1/user/public_tags")
              |> json_response(200)
              |> Enum.map(&convert_date/1) ==
                [post_public_tags_request_response]
@@ -1089,7 +1084,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
           response =
             conn
             |> post(
-              "/api/account/v2/user/public_tags",
+              "/api/account/v1/user/public_tags",
               request
             )
             |> json_response(200)
@@ -1109,7 +1104,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
         |> Enum.reverse()
 
       assert conn
-             |> get("/api/account/v2/user/public_tags")
+             |> get("/api/account/v1/user/public_tags")
              |> doc(description: "Get list of requests to add a public tag")
              |> json_response(200)
              |> Enum.map(&convert_date/1) == final_list
@@ -1117,18 +1112,18 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       %{"id" => id} = Enum.at(final_list, 0)
 
       assert conn
-             |> delete("/api/account/v2/user/public_tags/#{id}", %{"remove_reason" => "reason"})
+             |> delete("/api/account/v1/user/public_tags/#{id}", %{"remove_reason" => "reason"})
              |> doc(description: "Delete public tags request")
              |> json_response(200) == %{"message" => "OK"}
 
       Enum.each(Enum.drop(final_list, 1), fn request ->
         assert conn
-               |> delete("/api/account/v2/user/public_tags/#{request["id"]}", %{"remove_reason" => "reason"})
+               |> delete("/api/account/v1/user/public_tags/#{request["id"]}", %{"remove_reason" => "reason"})
                |> json_response(200) == %{"message" => "OK"}
       end)
 
       assert conn
-             |> get("/api/account/v2/user/public_tags")
+             |> get("/api/account/v1/user/public_tags")
              |> json_response(200) == []
     end
 
@@ -1138,7 +1133,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       post_public_tags_request_response =
         conn
         |> post(
-          "/api/account/v2/user/public_tags",
+          "/api/account/v1/user/public_tags",
           public_tags_request
         )
         |> json_response(200)
@@ -1154,7 +1149,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert post_public_tags_request_response["id"]
 
       assert conn
-             |> get("/api/account/v2/user/public_tags")
+             |> get("/api/account/v1/user/public_tags")
              |> json_response(200)
              |> Enum.map(&convert_date/1) ==
                [post_public_tags_request_response]
@@ -1165,7 +1160,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       put_public_tags_request_response =
         conn
         |> put(
-          "/api/account/v2/user/public_tags/#{post_public_tags_request_response["id"]}",
+          "/api/account/v1/user/public_tags/#{post_public_tags_request_response["id"]}",
           new_public_tags_request
         )
         |> doc(description: "Edit request to add a public tag")
@@ -1182,7 +1177,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       assert put_public_tags_request_response["id"] == post_public_tags_request_response["id"]
 
       assert conn
-             |> get("/api/account/v2/user/public_tags")
+             |> get("/api/account/v1/user/public_tags")
              |> json_response(200)
              |> Enum.map(&convert_date/1) ==
                [put_public_tags_request_response]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -1815,7 +1815,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/custom_abis",
+        "/api/account/v1/user/custom_abis",
         custom_abi
       )
 
@@ -1867,7 +1867,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/custom_abis",
+        "/api/account/v1/user/custom_abis",
         custom_abi
       )
 
@@ -1934,7 +1934,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       conn
       |> post(
-        "/api/account/v2/user/custom_abis",
+        "/api/account/v1/user/custom_abis",
         custom_abi
       )
 


### PR DESCRIPTION
Reverts blockscout/blockscout#8843

This change is incompatible with release 1.17.0, 1.17.1, 1.18.0-alpha. It should be done, after this issue release on frontend https://github.com/blockscout/frontend/issues/1367. @nikitosing please coordinate internally with frontend team.