### PR TITLE
Fix average block time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#8891](https://github.com/blockscout/blockscout/pull/8891) - Fix average block time
+
 ### Chore
 
 ## 5.3.2-beta

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -84,7 +84,7 @@ defmodule Explorer.Counters.AverageBlockTime do
 
     timestamps =
       timestamps_row
-      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &>=/2)
+      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &Timex.after?/2)
       |> Enum.map(fn {number, timestamp} ->
         {number, DateTime.to_unix(timestamp, :millisecond)}
       end)
@@ -125,7 +125,7 @@ defmodule Explorer.Counters.AverageBlockTime do
   defp compose_durations(durations, block_number, last_block_number, last_timestamp, timestamp) do
     block_numbers_range = last_block_number - block_number
 
-    if block_numbers_range == 0 do
+    if block_numbers_range <= 0 do
       {durations, block_number, timestamp}
     else
       duration = (last_timestamp - timestamp) / block_numbers_range


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8870

## Changelog

- Replaced `DateTime` structs comparison from `&>=/2` to `&Timex.after?/2` since primitive operators aren't accurate for structs
- Removed negative durations from total durations so non-chronological order of blocks won't result in negative avg time