### PR TITLE
Enhance method decoding by candidates from DB

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -26,5 +26,5 @@ lib/indexer/fetcher/zkevm/transaction_batch.ex:252
 lib/block_scout_web/views/api/v2/transaction_view.ex:431
 lib/block_scout_web/views/api/v2/transaction_view.ex:472
 lib/explorer/chain/transaction.ex:167
-lib/explorer/chain/transaction.ex:1457
-lib/explorer/chain/transaction.ex:1458
+lib/explorer/chain/transaction.ex:1452
+lib/explorer/chain/transaction.ex:1453

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#8917](https://github.com/blockscout/blockscout/pull/8917) - Proxy detection hotfix in API v2
 - [#8915](https://github.com/blockscout/blockscout/pull/8915) - smart-contract: delete embeds_many relation on replace
 - [#8906](https://github.com/blockscout/blockscout/pull/8906) - Fix abi encoded string argument
+- [#8898](https://github.com/blockscout/blockscout/pull/8898) - Enhance method decoding by candidates from DB
 - [#8882](https://github.com/blockscout/blockscout/pull/8882) - Change order of proxy contracts patterns detection: existing popular EIPs to the top of the list
 - [#8707](https://github.com/blockscout/blockscout/pull/8707) - Fix native coin exchange rate with `EXCHANGE_RATES_COINGECKO_COIN_ID`
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_logs/_logs.html.eex
@@ -27,46 +27,43 @@
             ) %>
       </h3>
     </dd>
-      <%= case decoded_result do %>
-        <% {:error, :could_not_decode} -> %>
-          <dt class="col-md-2"><%= gettext "Decoded" %></dt>
-          <dd class="col-md-10">
-          <div class="alert alert-danger">
-            <%= gettext "Failed to decode log data." %>
-          </div>
-        <% {:ok, method_id, text, mapping} -> %>
-          <dt class="col-md-2"><%= gettext "Decoded" %></dt>
-          <dd class="col-md-10">
-          <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
-            <tr>
-              <td>Method Id</td>
-              <td colspan="3"><code>0x<%= method_id %></code></td>
-            </tr>
-            <tr>
-              <td>Call</td>
-              <td colspan="3"><code><%= text %></code></td>
-            </tr>
-          </table>
-          <%= render BlockScoutWeb.LogView, "_data_decoded_view.html", mapping: mapping %>
-        <% {:error, :contract_not_verified, results} -> %>
-           <%= for {:ok, method_id, text, mapping} <- results do %>
-             <dt class="col-md-2"><%= gettext "Decoded" %></dt>
-             <dd class="col-md-10">
-             <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
-               <tr>
-                 <td>Method Id</td>
-                 <td colspan="3"><code>0x<%= method_id %></code></td>
-               </tr>
-               <tr>
-                 <td>Call</td>
-                 <td colspan="3"><code><%= text %></code></td>
-               </tr>
-             </table>
-             <%= render BlockScoutWeb.LogView, "_data_decoded_view.html", mapping: mapping %>
-         </div>
+    <%= case decoded_result do %>
+      <% {:error, :could_not_decode} -> %>
+        <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+        <dd class="col-md-10">
+        <div class="alert alert-danger">
+          <%= gettext "Failed to decode log data." %>
+        </div>
+      <% {:ok, method_id, text, mapping} -> %>
+        <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+        <dd class="col-md-10">
+        <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
+          <tr>
+            <td>Method Id</td>
+            <td colspan="3"><code>0x<%= method_id %></code></td>
+          </tr>
+          <tr>
+            <td>Call</td>
+            <td colspan="3"><code><%= text %></code></td>
+          </tr>
+        </table>
+        <%= render BlockScoutWeb.LogView, "_data_decoded_view.html", mapping: mapping %>
+      <% {:error, :contract_not_verified, results} -> %>
+        <%= for {:ok, method_id, text, mapping} <- results do %>
+            <dt class="col-md-2"><%= gettext "Decoded" %></dt>
+            <dd class="col-md-10">
+            <table summary="Transaction Info" class="table thead-light table-bordered transaction-input-table">
+              <tr>
+                <td>Method Id</td>
+                <td colspan="3"><code>0x<%= method_id %></code></td>
+              </tr>
+              <tr>
+                <td>Call</td>
+                <td colspan="3"><code><%= text %></code></td>
+              </tr>
+            </table>
+            <%= render BlockScoutWeb.LogView, "_data_decoded_view.html", mapping: mapping %>
         <% end %>
-       <% _ -> %>
-          <%= nil %>
       <% end %>
     <dt class="col-md-2"><%= gettext "Topics" %></dt>
     <dd class="col-md-10">

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -498,7 +498,7 @@ defmodule BlockScoutWeb.AddressView do
   def contract_interaction_disabled?, do: Application.get_env(:block_scout_web, :contract)[:disable_interaction]
 
   def decode(log, transaction) do
-    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [], true)
+    {result, _events_acc} = Log.decode(log, transaction, [], true)
     result
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -497,8 +497,16 @@ defmodule BlockScoutWeb.AddressView do
 
   def contract_interaction_disabled?, do: Application.get_env(:block_scout_web, :contract)[:disable_interaction]
 
+  @doc """
+    Decodes given log
+  """
+  @spec decode(Log.t(), Transaction.t()) ::
+          {:ok, String.t(), String.t(), map()}
+          | {:error, atom()}
+          | {:error, atom(), list()}
+          | {{:error, :contract_not_verified, list()}, any()}
   def decode(log, transaction) do
-    {result, _events_acc} = Log.decode(log, transaction, [], true)
+    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [], true)
     result
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -184,10 +184,10 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     }
   end
 
-  def decode_logs(logs, skip_sig_provider?) do
+  defp decode_logs(logs, skip_sig_provider?) do
     {result, _, _} =
       Enum.reduce(logs, {[], %{}, %{}}, fn log, {results, contracts_acc, events_acc} ->
-        {result, events_acc} =
+        {result, contracts_acc, events_acc} =
           Log.decode(
             log,
             %Transaction{hash: log.transaction_hash},

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -648,7 +648,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   defp format_decoded_input(_), do: nil
 
   defp format_decoded_log_input({:error, :could_not_decode}), do: nil
-  defp format_decoded_log_input({:error, :no_matching_function}), do: nil
   defp format_decoded_log_input({:ok, _method_id, _text, _mapping} = decoded), do: decoded
   defp format_decoded_log_input({:error, _, candidates}), do: Enum.at(candidates, 0)
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -187,7 +187,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   def decode_logs(logs, skip_sig_provider?) do
     {result, _, _} =
       Enum.reduce(logs, {[], %{}, %{}}, fn log, {results, contracts_acc, events_acc} ->
-        {result, contracts_acc, events_acc} =
+        {result, events_acc} =
           Log.decode(
             log,
             %Transaction{hash: log.transaction_hash},

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Daily Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:101
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:98
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:23
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Topic"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:71
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:68
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 #, elixir-autogen, elixir-format
 msgid "Topics"

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Daily Transactions"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:101
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:98
 #: lib/block_scout_web/templates/log/_data_decoded_view.html.eex:7
 #: lib/block_scout_web/templates/transaction/_decoded_input_body.html.eex:23
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:121
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Topic"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_logs/_logs.html.eex:71
+#: lib/block_scout_web/templates/address_logs/_logs.html.eex:68
 #: lib/block_scout_web/templates/transaction_log/_logs.html.eex:91
 #, elixir-autogen, elixir-format
 msgid "Topics"

--- a/apps/explorer/lib/explorer/chain/contract_method.ex
+++ b/apps/explorer/lib/explorer/chain/contract_method.ex
@@ -5,6 +5,7 @@ defmodule Explorer.Chain.ContractMethod do
 
   require Logger
 
+  import Ecto.Query, only: [from: 2]
   use Explorer.Schema
 
   alias Explorer.Chain.{Hash, MethodIdentifier, SmartContract}
@@ -67,6 +68,18 @@ defmodule Explorer.Chain.ContractMethod do
       {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
+  end
+
+  @doc """
+  Finds limited number of contract methods by selector id
+  """
+  @spec find_contract_method_query(binary(), integer()) :: Ecto.Query.t()
+  def find_contract_method_query(method_id, limit) do
+    from(
+      contract_method in __MODULE__,
+      where: contract_method.identifier == ^method_id,
+      limit: ^limit
+    )
   end
 
   defp abi_element_to_contract_method(element) do

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -267,6 +267,10 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     end)
   end
 
+  @doc """
+  Returns combined ABI from proxy and implementation smart-contracts
+  """
+  @spec combine_proxy_implementation_abi(any(), any()) :: SmartContract.abi()
   def combine_proxy_implementation_abi(smart_contract, options \\ [])
 
   def combine_proxy_implementation_abi(%SmartContract{abi: abi} = smart_contract, options) when not is_nil(abi) do

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -774,12 +774,7 @@ defmodule Explorer.Chain.Transaction do
     if Map.has_key?(methods_acc, method_id) do
       {methods_acc[method_id], methods_acc}
     else
-      candidates_query =
-        from(
-          contract_method in ContractMethod,
-          where: contract_method.identifier == ^method_id,
-          limit: 1
-        )
+      candidates_query = ContractMethod.find_contract_method_query(method_id, 1)
 
       result =
         candidates_query
@@ -1181,7 +1176,7 @@ defmodule Explorer.Chain.Transaction do
       Enum.map_reduce(transactions, %{}, fn transaction, tokens_acc ->
         case Log.fetch_log_by_tx_hash_and_first_topic(transaction.hash, @transaction_fee_event_signature, @api_true) do
           fee_log when not is_nil(fee_log) ->
-            {:ok, _selector, mapping} = Log.find_and_decode(@transaction_fee_event_abi, fee_log, transaction)
+            {:ok, _selector, mapping} = Log.find_and_decode(@transaction_fee_event_abi, fee_log, transaction.hash)
 
             [{"token", "address", false, token_address_hash}, _, _, _, _, _] = mapping
 

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -60,7 +60,7 @@ defmodule Explorer.Chain.LogTest do
 
       log = insert(:log, transaction: transaction)
 
-      assert {{:error, :could_not_decode}, _, _} = Log.decode(log, transaction, [], false)
+      assert {{:error, :could_not_decode}, _} = Log.decode(log, transaction, [], false)
     end
 
     test "that a contract call transaction that has a verified contract returns the decoded input data" do
@@ -116,7 +116,7 @@ defmodule Explorer.Chain.LogTest do
                      152, 206, 227, 92, 181, 213, 23, 242, 210, 150, 162>>}},
                  {"_number", "uint256", false, 0},
                  {"_belly", "bool", true, true}
-               ]}, _, _} = Log.decode(log, transaction, [], false)
+               ]}, _} = Log.decode(log, transaction, [], false)
     end
 
     test "finds decoding candidates" do
@@ -171,7 +171,7 @@ defmodule Explorer.Chain.LogTest do
                     {"_number", "uint256", false, 0},
                     {"_belly", "bool", true, true}
                   ]}
-               ]}, _, _} = Log.decode(log, transaction, [], false)
+               ]}, _} = Log.decode(log, transaction, [], false)
     end
   end
 

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -60,7 +60,7 @@ defmodule Explorer.Chain.LogTest do
 
       log = insert(:log, transaction: transaction)
 
-      assert {{:error, :could_not_decode}, _} = Log.decode(log, transaction, [], false)
+      assert {{:error, :could_not_decode}, _, _} = Log.decode(log, transaction, [], false)
     end
 
     test "that a contract call transaction that has a verified contract returns the decoded input data" do
@@ -116,7 +116,7 @@ defmodule Explorer.Chain.LogTest do
                      152, 206, 227, 92, 181, 213, 23, 242, 210, 150, 162>>}},
                  {"_number", "uint256", false, 0},
                  {"_belly", "bool", true, true}
-               ]}, _} = Log.decode(log, transaction, [], false)
+               ]}, _, _} = Log.decode(log, transaction, [], false)
     end
 
     test "finds decoding candidates" do
@@ -171,7 +171,7 @@ defmodule Explorer.Chain.LogTest do
                     {"_number", "uint256", false, 0},
                     {"_belly", "bool", true, true}
                   ]}
-               ]}, _} = Log.decode(log, transaction, [], false)
+               ]}, _, _} = Log.decode(log, transaction, [], false)
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8892

## Motivation

Methods decoding doesn't work properly, if 3 conditions are satisfied:
- contract emitted event is a proxy contract
- Blockscout didn't recognize it as a proxy
- Implementation is verified

## Changelog

Find method candidates from the DB, if no ABI for such selector in the contract or/and sig-provider microservice is disabled.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
