### PR TITLE
Add Compound proxy contract pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Features
 
+- [#8900](https://github.com/blockscout/blockscout/pull/8900) - Add Compound proxy contract pattern
+
 ### Fixes
 
 - [#8917](https://github.com/blockscout/blockscout/pull/8917) - Proxy detection hotfix in API v2

--- a/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.AddressContractView do
   use BlockScoutWeb, :view
 
+  require Logger
+
   import Explorer.Helper, only: [decode_data: 2]
 
   alias ABI.FunctionSelector
@@ -132,6 +134,12 @@ defmodule BlockScoutWeb.AddressContractView do
     chain_id = Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:chain_id]
     repo_url = Application.get_env(:explorer, Explorer.ThirdPartyIntegrations.Sourcify)[:repo_url]
     match = if partial_match, do: "/partial_match/", else: "/full_match/"
-    repo_url <> match <> chain_id <> "/" <> checksummed_hash <> "/"
+
+    if chain_id do
+      repo_url <> match <> chain_id <> "/" <> checksummed_hash <> "/"
+    else
+      Logger.warning("chain_id is nil. Please set CHAIN_ID env variable.")
+      nil
+    end
   end
 end

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -3581,7 +3581,7 @@ msgstr ""
 msgid "fallback"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:28
+#: lib/block_scout_web/views/address_contract_view.ex:30
 #, elixir-autogen, elixir-format
 msgid "false"
 msgstr ""
@@ -3637,7 +3637,7 @@ msgstr ""
 msgid "string"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:27
+#: lib/block_scout_web/views/address_contract_view.ex:29
 #, elixir-autogen, elixir-format
 msgid "true"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -3581,7 +3581,7 @@ msgstr ""
 msgid "fallback"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:28
+#: lib/block_scout_web/views/address_contract_view.ex:30
 #, elixir-autogen, elixir-format
 msgid "false"
 msgstr ""
@@ -3637,7 +3637,7 @@ msgstr ""
 msgid "string"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:27
+#: lib/block_scout_web/views/address_contract_view.ex:29
 #, elixir-autogen, elixir-format
 msgid "true"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -20,6 +20,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @implementation_signature "5c60da1b"
   # aaf10f42 = keccak256(getImplementation())
   @get_implementation_signature "aaf10f42"
+  # bb82aa5e = keccak256(comptrollerImplementation()) Compound protocol proxy pattern
+  @comptroller_implementation_signature "bb82aa5e"
   # aaf10f42 = keccak256(getAddress(bytes32))
   @get_address_signature "21f8a721"
 
@@ -220,6 +222,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
     get_implementation_method_abi = get_naive_implementation_abi(proxy_abi, "getImplementation")
 
+    comptroller_implementation_method_abi = get_naive_implementation_abi(proxy_abi, "comptrollerImplementation")
+
     master_copy_method_abi = get_master_copy_pattern(proxy_abi)
 
     get_address_method_abi = get_naive_implementation_abi(proxy_abi, "getAddress")
@@ -233,6 +237,13 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
       master_copy_method_abi ->
         MasterCopy.get_implementation_address_hash_string(proxy_address_hash)
+
+      comptroller_implementation_method_abi ->
+        Basic.get_implementation_address_hash_string(
+          @comptroller_implementation_signature,
+          proxy_address_hash,
+          proxy_abi
+        )
 
       get_address_method_abi ->
         EIP930.get_implementation_address_hash_string(@get_address_signature, proxy_address_hash, proxy_abi)

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -439,7 +439,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       :json_rpc,
       fn [
            %{
-             id: id,
+             id: _id,
              method: "eth_call",
              params: [
                %{data: "0x5c60da1b", to: "0x000000000000000000000000" <> ^beacon_contract_address_hash_string},
@@ -452,7 +452,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
           :ok,
           [
             %{
-              id: id,
+              id: _id,
               jsonrpc: "2.0",
               result: "0x000000000000000000000000" <> implementation_contract_address_hash_string
             }


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8899

Based on https://github.com/blockscout/blockscout/pull/8882 (current PR should be reviewed after #8882)

## Motivation

Compound proxy pattern is not supported.

## Changelog

Try to fetch implementation from `comptrollerImplementation()`

https://blog.openzeppelin.com/compound-comprehensive-protocol-audit#implementation-used-as-interface

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
