### PR TITLE
Fix abi encoded string argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#8917](https://github.com/blockscout/blockscout/pull/8917) - Proxy detection hotfix in API v2
 - [#8915](https://github.com/blockscout/blockscout/pull/8915) - smart-contract: delete embeds_many relation on replace
+- [#8906](https://github.com/blockscout/blockscout/pull/8906) - Fix abi encoded string argument
 - [#8882](https://github.com/blockscout/blockscout/pull/8882) - Change order of proxy contracts patterns detection: existing popular EIPs to the top of the list
 
 ### Chore

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -33,10 +33,10 @@ defmodule EthereumJSONRPC.Encoder do
     end)
   end
 
-  defp parse_args(<<"0x", hexadecimal_digits::binary>>, _type), do: Base.decode16!(hexadecimal_digits, case: :mixed)
-
   defp parse_args(<<hexadecimal_digits::binary>>, type) when type in [:string, "string"],
     do: hexadecimal_digits |> Base.encode16() |> try_to_decode()
+
+  defp parse_args(<<"0x", hexadecimal_digits::binary>>, _type), do: Base.decode16!(hexadecimal_digits, case: :mixed)
 
   defp parse_args(<<hexadecimal_digits::binary>>, _type), do: try_to_decode(hexadecimal_digits)
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -13,7 +13,7 @@ defmodule EthereumJSONRPC.Encoder do
   """
   @spec encode_function_call(ABI.FunctionSelector.t(), [term()]) :: String.t()
   def encode_function_call(function_selector, args) when is_list(args) do
-    parsed_args = parse_args(args)
+    parsed_args = parse_args(args, function_selector.types)
 
     encoded_args =
       function_selector
@@ -25,16 +25,22 @@ defmodule EthereumJSONRPC.Encoder do
 
   def encode_function_call(function_selector, args), do: encode_function_call(function_selector, [args])
 
-  defp parse_args(args) when is_list(args) do
+  defp parse_args(args, types) when is_list(args) do
     args
-    |> Enum.map(&parse_args/1)
+    |> Enum.zip(types)
+    |> Enum.map(fn {arg, type} ->
+      parse_args(arg, type)
+    end)
   end
 
-  defp parse_args(<<"0x", hexadecimal_digits::binary>>), do: Base.decode16!(hexadecimal_digits, case: :mixed)
+  defp parse_args(<<"0x", hexadecimal_digits::binary>>, _type), do: Base.decode16!(hexadecimal_digits, case: :mixed)
 
-  defp parse_args(<<hexadecimal_digits::binary>>), do: try_to_decode(hexadecimal_digits)
+  defp parse_args(<<hexadecimal_digits::binary>>, type) when type in [:string, "string"],
+    do: hexadecimal_digits |> Base.encode16() |> try_to_decode()
 
-  defp parse_args(arg), do: arg
+  defp parse_args(<<hexadecimal_digits::binary>>, _type), do: try_to_decode(hexadecimal_digits)
+
+  defp parse_args(arg, _type), do: arg
 
   defp try_to_decode(hexadecimal_digits) do
     case Base.decode16(hexadecimal_digits, case: :mixed) do

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
@@ -43,6 +43,22 @@ defmodule EthereumJSONRPC.EncoderTest do
                "0xa07a712d000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000183635363466353632336532613966303030316362376665650000000000000000"
     end
 
+    test "generates the correct encoding with string started with 0x" do
+      function_selector = %ABI.FunctionSelector{
+        function: "isNewsletterCoverFullyClaimed",
+        input_names: ["newsletterId"],
+        inputs_indexed: nil,
+        return_names: [""],
+        returns: [:bool],
+        state_mutability: :view,
+        type: :function,
+        types: [:string]
+      }
+
+      assert Encoder.encode_function_call(function_selector, ["0x123"]) ==
+               "0xa07a712d000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000053078313233000000000000000000000000000000000000000000000000000000"
+    end
+
     test "generates the correct encoding with addresses arguments" do
       function_selector = %ABI.FunctionSelector{
         function: "tokens",

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/encoder_test.exs
@@ -27,6 +27,22 @@ defmodule EthereumJSONRPC.EncoderTest do
                "0x9507d39a000000000000000000000000000000000000000000000000000000000000000a"
     end
 
+    test "generates the correct encoding with string argument" do
+      function_selector = %ABI.FunctionSelector{
+        function: "isNewsletterCoverFullyClaimed",
+        input_names: ["newsletterId"],
+        inputs_indexed: nil,
+        return_names: [""],
+        returns: [:bool],
+        state_mutability: :view,
+        type: :function,
+        types: [:string]
+      }
+
+      assert Encoder.encode_function_call(function_selector, ["6564f5623e2a9f0001cb7fee"]) ==
+               "0xa07a712d000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000183635363466353632336532613966303030316362376665650000000000000000"
+    end
+
     test "generates the correct encoding with addresses arguments" do
       function_selector = %ABI.FunctionSelector{
         function: "tokens",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8904

## Motivation

The string argument of contract method is incorrectly ABI-encoded before request.

## Changelog

If argument of :string or "string" type convert it to hex first.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
