### PR TITLE
Set client_connection_check_interval for main Postgres DB in docker-compose setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chore
 
+- [#8911](https://github.com/blockscout/blockscout/pull/8911) - Set client_connection_check_interval for main Postgres DB in docker-compose setup
+
 ## 5.3.2-beta
 
 ### Features

--- a/docker-compose/services/docker-compose-db.yml
+++ b/docker-compose/services/docker-compose-db.yml
@@ -19,7 +19,7 @@ services:
     user: 2000:2000
     restart: always
     container_name: 'db'
-    command: postgres -c 'max_connections=200'
+    command: postgres -c 'max_connections=200' -c 'client_connection_check_interval=60000'
     environment:
         POSTGRES_DB: 'blockscout'
         POSTGRES_USER: 'blockscout'


### PR DESCRIPTION
## Motivation

Constant growth of DB connections from the main application because application doesn't kill the process on the DB, even when application already doesn't wait result from the process. We tried to apply updating [ecto-sql -> 3.11.0](https://github.com/blockscout/blockscout/pull/8860), which contains db_connection@2.6.0, which seems [contains the fix for the problem](https://github.com/elixir-ecto/postgrex/issues/661) on the application side (killing unused DB connections). Unfortunately, this fix didn't help.

## Changelog

Set 1 min `client_connection_check_interval` for Postgres DB in docker-compose setup.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
