### PR TITLE
Delete invalid current token balances in OnDemand fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current
 
+- [#8924](https://github.com/blockscout/blockscout/pull/8924) - Delete invalid current token balances in OnDemand fetcher
+
 ### Features
 
 ### Fixes


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8918

## Motivation

There was a bug that deriving new current token balances after deletion of old ones in blocks runner did not fill out field `token_type` and [therefore](https://github.com/blockscout/blockscout/blob/master/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex#L225) `token_id`. This bug was fixed [here](https://github.com/blockscout/blockscout/pull/8355).
But affected current token balances that has empty `token_type` and `token_id` still exists. Most of them were deleted by indexing new blocks, but those that were not deleted cause errors in `TokenBalanceOnDemand` fetcher.

## Changelog

Delete current token balances that has empty `token_type` in `TokenBalanceOnDemand` fetcher.