### PR TITLE
Add Port 4000 For external frontend docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#8634](https://github.com/blockscout/blockscout/pull/8634) - API v2: NFT for address
 - [#8609](https://github.com/blockscout/blockscout/pull/8609) - Change logs format to JSON; Add endpoint url to the block_scout_web logging
 - [#8558](https://github.com/blockscout/blockscout/pull/8558) - Add CoinBalanceDailyUpdater
+- [#8925](https://github.com/blockscout/blockscout/pull/8925) - Add Port 4000 For external frontend docker-compose
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current
 
 ### Features
+- [#8925](https://github.com/blockscout/blockscout/pull/8925) - Add Port 4000 For external frontend docker-compose
 
 ### Fixes
 
@@ -20,7 +21,6 @@
 - [#8634](https://github.com/blockscout/blockscout/pull/8634) - API v2: NFT for address
 - [#8609](https://github.com/blockscout/blockscout/pull/8609) - Change logs format to JSON; Add endpoint url to the block_scout_web logging
 - [#8558](https://github.com/blockscout/blockscout/pull/8558) - Add CoinBalanceDailyUpdater
-- [#8925](https://github.com/blockscout/blockscout/pull/8925) - Add Port 4000 For external frontend docker-compose
 
 ### Fixes
 

--- a/docker-compose/docker-compose-no-build-external-frontend.yml
+++ b/docker-compose/docker-compose-no-build-external-frontend.yml
@@ -31,6 +31,8 @@ services:
         INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: 'true'
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'
         CHAIN_ID: '1337'
+    ports:
+    - 4000:4000
 
   visualizer:
     extends:


### PR DESCRIPTION
Hello I am making a pull request for the file docker-compose-no-build-external-frontend.yml

## Motivation

- I added port 4000 to the docker-compose-no-build-external-frontend.yml file.
- My reason for adding port 4000 to the docker-compose-no-build-external-frontend.yml file is so that people who want to use the old ui can access it again. because I see in the docker-compose-backend.yml file there is no port 4000 because blockscout has focused on the latest ui.

## Changelog

### Enhancements
-

### Bug Fixes
-

### Incompatible Changes
-

## Upgrading

-

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
