### PR TITLE
Remove daily balances updating from BlockReward fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#8955](https://github.com/blockscout/blockscout/pull/8955) - Remove daily balances updating from BlockReward fetcher
+
 ### Chore
 
 <details>

--- a/apps/indexer/lib/indexer/fetcher/block_reward.ex
+++ b/apps/indexer/lib/indexer/fetcher/block_reward.ex
@@ -20,7 +20,7 @@ defmodule Indexer.Fetcher.BlockReward do
   alias Explorer.Chain.Cache.Accounts
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.BlockReward.Supervisor, as: BlockRewardSupervisor
-  alias Indexer.Fetcher.{CoinBalance, CoinBalanceDailyUpdater}
+  alias Indexer.Fetcher.CoinBalance
   alias Indexer.Transform.{AddressCoinBalances, AddressCoinBalancesDaily, Addresses}
 
   @behaviour BufferedTask
@@ -273,26 +273,6 @@ defmodule Indexer.Fetcher.BlockReward do
   defp import_block_reward_params(block_rewards_params) when is_list(block_rewards_params) do
     addresses_params = Addresses.extract_addresses(%{block_reward_contract_beneficiaries: block_rewards_params})
     address_coin_balances_params_set = AddressCoinBalances.params_set(%{beneficiary_params: block_rewards_params})
-
-    address_coin_balances_params_with_block_timestamp =
-      block_rewards_params
-      |> Enum.map(fn block_rewards_param ->
-        %{
-          address_hash: block_rewards_param.address_hash,
-          block_number: block_rewards_param.block_number,
-          block_timestamp: block_rewards_param.block_timestamp
-        }
-      end)
-      |> Enum.into(MapSet.new())
-
-    address_coin_balances_params_with_block_timestamp_set = %{
-      address_coin_balances_params_with_block_timestamp: address_coin_balances_params_with_block_timestamp
-    }
-
-    address_coin_balances_daily_params_set =
-      AddressCoinBalancesDaily.params_set(address_coin_balances_params_with_block_timestamp_set)
-
-    CoinBalanceDailyUpdater.add_daily_balances_params(address_coin_balances_daily_params_set)
 
     Chain.import(%{
       addresses: %{params: addresses_params},


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8954

## Motivation

Daily coin balances updating with placeholders in BlockReward fetcher is not needed since there is call of `CoinBalance.async_fetch_balances/1` after rewards import and daily balances are updated along with coin balances asynchronously.

## Changelog

Remove daily balances updating from BlockReward fetcher.