### PR TITLE
Add EIP-4844 compatibility (not full support yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#8997](https://github.com/blockscout/blockscout/pull/8997) - Isolate throttable error count by request method
+- [#8975](https://github.com/blockscout/blockscout/pull/8975) - Add EIP-4844 compatibility (not full support yet)
 - [#8972](https://github.com/blockscout/blockscout/pull/8972) - BENS integration
 - [#8957](https://github.com/blockscout/blockscout/pull/8957) - Add Tx Interpreter Service integration
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -766,6 +766,11 @@ defmodule EthereumJSONRPC.Block do
     {key, quantity_to_integer(quantity)}
   end
 
+  # to be merged with clause above ^
+  defp entry_to_elixir({key, _quantity}, _block) when key in ~w(blobGasUsed excessBlobGas) do
+    {:ignore, :ignore}
+  end
+
   # Size and totalDifficulty may be `nil` for uncle blocks
   defp entry_to_elixir({key, nil}, _block) when key in ~w(size totalDifficulty) do
     {key, nil}

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -319,6 +319,11 @@ defmodule EthereumJSONRPC.Receipt do
     :ignore
   end
 
+  # EIP-4844 transaction receipt fields
+  defp entry_to_elixir({key, _}) when key in ~w(blobGasUsed blobGasPrice) do
+    :ignore
+  end
+
   defp entry_to_elixir({key, value}) do
     {:error, {:unknown_key, %{key: key, value: value}}}
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -621,6 +621,16 @@ defmodule EthereumJSONRPC.Transaction do
     {key, quantity_to_integer(quantity)}
   end
 
+  # to be merged with the clause above ^
+  defp entry_to_elixir({"maxFeePerBlobGas", _value}) do
+    {nil, nil}
+  end
+
+  # EIP-4844 specific field with value of type of list of hashes
+  defp entry_to_elixir({"blobVersionedHashes", _value}) do
+    {nil, nil}
+  end
+
   # as always ganache has it's own vision on JSON RPC standard
   defp entry_to_elixir({key, nil}) when key in ~w(r s v) do
     {key, 0}


### PR DESCRIPTION
## Motivation

Blockscout now fails to fetch receipts for EIP-4844 transactions that causes poor experience on EIP-4844 chains.
Do we need such restrictions on receipts or maybe we can simply ignore all unknown fields like we do with blocks and transactions?

## Changelog

Add EIP-4844 fields to known fields, but ignore them.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
