### PR TITLE
Refine token transfers token ids index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # ChangeLog
 
+## 6.0.0-dev
+
+### Features
+
+### Fixes
+
+### Chore
+
+- [#8996](https://github.com/blockscout/blockscout/pull/8996) - Refine token transfers token ids index
+
 ## Current
 
 ### Features

--- a/apps/explorer/priv/repo/migrations/20231213085254_add_btree_gin_extension.exs
+++ b/apps/explorer/priv/repo/migrations/20231213085254_add_btree_gin_extension.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.CreateBtreeGinExtension do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS btree_gin")
+  end
+
+  def down do
+    execute("DROP EXTENSION IF EXISTS btree_gin")
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20231213090140_add_token_transfers_token_contract_address_token_ids_index.exs
+++ b/apps/explorer/priv/repo/migrations/20231213090140_add_token_transfers_token_contract_address_token_ids_index.exs
@@ -1,0 +1,26 @@
+defmodule Explorer.Repo.Migrations.AddTokenTransfersTokenContractAddressTokenIdsIndex do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create(
+      index(
+        :token_transfers,
+        [:token_contract_address_hash, :token_ids],
+        name: "token_transfers_token_contract_address_hash_token_ids_index",
+        using: "GIN",
+        concurrently: true
+      )
+    )
+  end
+
+  def down do
+    drop_if_exists(
+      index(:token_transfers, [:token_contract_address_hash, :token_ids],
+        name: :token_transfers_token_contract_address_hash_token_ids_index
+      ),
+      concurrently: true
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20231213101235_drop_token_transfers_token_ids_index.exs
+++ b/apps/explorer/priv/repo/migrations/20231213101235_drop_token_transfers_token_ids_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.DropTokenTransfersTokenIdsIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(index(:token_transfers, [:token_ids], name: :token_transfers_token_ids_index))
+  end
+end


### PR DESCRIPTION
## Motivation

`token_ids` column is used in all queries only in the bundle with token_contract_address_hash. So, instead of gin index on token_ids column, it is a suggestion to create multicolumn index which will include token_contract_address_hash as well.

## Changelog

- add btree_gin extension
- create multicolumn gin index on [token_contract_address_hash, token_ids]
- remove index on token_ids

Queries lke this start to use new multicolumn index:
```
explain analyze select * from token_transfers tt where token_contract_address_hash='\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5' and token_ids @> ARRAY[809316282247589383998263052849978220592970297069::decimal] limit 1;
                                                                                             QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=28.00..32.02 rows=1 width=274) (actual time=0.084..0.086 rows=1 loops=1)
   ->  Bitmap Heap Scan on token_transfers tt  (cost=28.00..32.02 rows=1 width=274) (actual time=0.083..0.084 rows=1 loops=1)
         Recheck Cond: ((token_contract_address_hash = '\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5'::bytea) AND (token_ids @> '{809316282247589383998263052849978220592970297069}'::numeric[]))
         Heap Blocks: exact=1
         ->  Bitmap Index Scan on token_transfers_token_contract_address_hash_token_ids_index  (cost=0.00..28.00 rows=1 width=0) (actual time=0.077..0.077 rows=1 loops=1)
               Index Cond: ((token_contract_address_hash = '\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5'::bytea) AND (token_ids @> '{809316282247589383998263052849978220592970297069}'::numeric[]))
 Planning Time: 1.216 ms
 Execution Time: 0.247 ms
```

Before, query execution plan looked like:
```
mainnet_dev_denorm=# explain analyze select * from token_transfers tt where token_contract_address_hash='\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5' and token_ids @> ARRAY[809316282247589383998263052849978220592970297069::decimal] limit 1;
                                                                                  QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=5.07..332.98 rows=1 width=274) (actual time=0.078..0.079 rows=1 loops=1)
   ->  Bitmap Heap Scan on token_transfers tt  (cost=5.07..332.98 rows=1 width=274) (actual time=0.076..0.077 rows=1 loops=1)
         Recheck Cond: (token_contract_address_hash = '\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5'::bytea)
         Filter: (token_ids @> '{809316282247589383998263052849978220592970297069}'::numeric[])
         Heap Blocks: exact=1
         ->  Bitmap Index Scan on token_transfers_token_contract_address_hash_block_number_index  (cost=0.00..5.07 rows=85 width=0) (actual time=0.048..0.049 rows=85 loops=1)
               Index Cond: (token_contract_address_hash = '\x60eb332bd4a0e2a9eeb3212cfdd6ef03ce4cb3b5'::bytea)
 Planning Time: 0.354 ms
 Execution Time: 0.232 ms
(9 rows)
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
