### PR TITLE
Change log topic type in the DB to bytea

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -14,10 +14,10 @@ lib/phoenix/router.ex:324
 lib/phoenix/router.ex:402
 lib/explorer/smart_contract/reader.ex:435
 lib/indexer/fetcher/polygon_edge.ex:737
-lib/indexer/fetcher/polygon_edge/deposit_execute.ex:140
-lib/indexer/fetcher/polygon_edge/deposit_execute.ex:184
-lib/indexer/fetcher/polygon_edge/withdrawal.ex:160
-lib/indexer/fetcher/polygon_edge/withdrawal.ex:204
+lib/indexer/fetcher/polygon_edge/deposit_execute.ex:146
+lib/indexer/fetcher/polygon_edge/deposit_execute.ex:190
+lib/indexer/fetcher/polygon_edge/withdrawal.ex:166
+lib/indexer/fetcher/polygon_edge/withdrawal.ex:210
 lib/indexer/fetcher/zkevm/transaction_batch.ex:116
 lib/indexer/fetcher/zkevm/transaction_batch.ex:156
 lib/indexer/fetcher/zkevm/transaction_batch.ex:252

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#9009](https://github.com/blockscout/blockscout/pull/9009) - Index for block refetch_needed
 - [#9006](https://github.com/blockscout/blockscout/pull/9006) - Drop unused indexes on address_current_token_balances table
+- [#9000](https://github.com/blockscout/blockscout/pull/9000) - Change log topic type in the DB to bytea
 - [#8996](https://github.com/blockscout/blockscout/pull/8996) - Refine token transfers token ids index
 - [#5322](https://github.com/blockscout/blockscout/pull/5322) - DB denormalization: block consensus and timestamp in transaction table
 
@@ -31,7 +32,6 @@
 ### Chore
 
 - [#9014](https://github.com/blockscout/blockscout/pull/9014) - Decrease amount of NFT in address collection: 15 -> 9
-- [#9000](https://github.com/blockscout/blockscout/pull/9000) - Change log topic type in the DB to bytea
 - [#8994](https://github.com/blockscout/blockscout/pull/8994) - Refactor transactions event preloads
 
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Chore
 
 - [#9014](https://github.com/blockscout/blockscout/pull/9014) - Decrease amount of NFT in address collection: 15 -> 9
+- [#9000](https://github.com/blockscout/blockscout/pull/9000) - Change log topic type in the DB to bytea
 - [#8994](https://github.com/blockscout/blockscout/pull/8994) - Refactor transactions event preloads
 
 <details>

--- a/apps/block_scout_web/test/block_scout_web/channels/websocket_v2_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/websocket_v2_test.exs
@@ -6,7 +6,15 @@ defmodule BlockScoutWeb.WebsocketV2Test do
   alias Explorer.Chain.{Address, Import, Token, TokenTransfer, Transaction}
   alias Explorer.Repo
 
+  @first_topic_hex_string "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  @second_topic_hex_string "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+  @third_topic_hex_string "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"
+
   describe "websocket v2" do
+    {:ok, first_topic} = Explorer.Chain.Hash.Full.cast(@first_topic_hex_string)
+    {:ok, second_topic} = Explorer.Chain.Hash.Full.cast(@second_topic_hex_string)
+    {:ok, third_topic} = Explorer.Chain.Hash.Full.cast(@third_topic_hex_string)
+
     @import_data %{
       blocks: %{
         params: [
@@ -34,9 +42,9 @@ defmodule BlockScoutWeb.WebsocketV2Test do
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
-            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            first_topic: first_topic,
+            second_topic: second_topic,
+            third_topic: third_topic,
             fourth_topic: nil,
             index: 0,
             transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
@@ -46,9 +54,9 @@ defmodule BlockScoutWeb.WebsocketV2Test do
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
-            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            first_topic: first_topic,
+            second_topic: second_topic,
+            third_topic: third_topic,
             fourth_topic: nil,
             index: 1,
             transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
@@ -58,9 +66,9 @@ defmodule BlockScoutWeb.WebsocketV2Test do
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
-            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            first_topic: first_topic,
+            second_topic: second_topic,
+            third_topic: third_topic,
             fourth_topic: nil,
             index: 2,
             transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
@@ -4,6 +4,22 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
   alias BlockScoutWeb.API.RPC.LogsController
   alias Explorer.Chain.{Log, Transaction}
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
+  @first_topic_hex_string_2 "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+  @second_topic_hex_string_1 "0x00000000000000000000000098a9dc37d3650b5b30d6c12789b3881ee0b70c16"
+  @second_topic_hex_string_2 "0x000000000000000000000000e2680fd7cdbb04e9087a647ad4d023ef6c8fb4e2"
+
+  @third_topic_hex_string_1 "0x0000000000000000000000005079fc00f00f30000e0c8c083801cfde000008b6"
+
+  @fourth_topic_hex_string_1 "0x8c9b7729443a4444242342b2ca385a239a5c1d76a88473e1cd2ab0c70dd1b9c7"
+  @fourth_topic_hex_string_2 "0x232b688786cc0d24a11e07563c1bfa129537cec9385dc5b1fb8f86462977239b"
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+
   describe "getLogs" do
     test "without fromBlock, toBlock, address, and topic{x}", %{conn: conn} do
       params = %{
@@ -434,13 +450,13 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic"
+        first_topic: topic(@first_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some other topic"
+        first_topic: topic(@first_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -492,15 +508,15 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some other topic",
-        second_topic: "some other second topic"
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -541,15 +557,15 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some other topic",
-        second_topic: "some other second topic"
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -589,19 +605,19 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
-        fourth_topic: "some fourth topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
+        fourth_topic: topic(@fourth_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
-        fourth_topic: "some other fourth topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
+        fourth_topic: topic(@fourth_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -791,7 +807,12 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
          third_topic: third_topic,
          fourth_topic: fourth_topic
        }) do
-    [first_topic, second_topic, third_topic, fourth_topic]
+    [
+      first_topic && Explorer.Chain.Hash.to_string(first_topic),
+      second_topic && Explorer.Chain.Hash.to_string(second_topic),
+      third_topic && Explorer.Chain.Hash.to_string(third_topic),
+      fourth_topic && Explorer.Chain.Hash.to_string(fourth_topic)
+    ]
   end
 
   defp integer_to_hex(integer), do: "0x" <> String.downcase(Integer.to_string(integer, 16))

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/transaction_controller_test.exs
@@ -5,7 +5,15 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
 
   @moduletag capture_log: true
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
+  @second_topic_hex_string_1 "0x00000000000000000000000098a9dc37d3650b5b30d6c12789b3881ee0b70c16"
+
   setup :verify_on_exit!
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
 
   describe "gettxreceiptstatus" do
     test "with missing txhash", %{conn: conn} do
@@ -414,8 +422,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
         insert(:log,
           address: address,
           transaction: transaction,
-          first_topic: "first topic",
-          second_topic: "second topic",
+          first_topic: topic(@first_topic_hex_string_1),
+          second_topic: topic(@second_topic_hex_string_1),
           block: block,
           block_number: block.number
         )
@@ -491,8 +499,8 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
         insert(:log,
           address: address,
           transaction: transaction,
-          first_topic: "first topic",
-          second_topic: "second topic",
+          first_topic: topic(@first_topic_hex_string_1),
+          second_topic: topic(@second_topic_hex_string_1),
           block: block,
           block_number: block.number
         )
@@ -520,7 +528,7 @@ defmodule BlockScoutWeb.API.RPC.TransactionControllerTest do
           %{
             "address" => "#{address.hash}",
             "data" => "#{log.data}",
-            "topics" => ["first topic", "second topic", nil, nil],
+            "topics" => [@first_topic_hex_string_1, @second_topic_hex_string_1, nil, nil],
             "index" => "#{log.index}"
           }
         ],

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -26,11 +26,17 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   import Explorer.Chain, only: [hash_to_lower_case_string: 1]
   import Mox
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
   @instances_amount_in_collection 9
 
   setup :set_mox_global
 
   setup :verify_on_exit!
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
 
   describe "/addresses/{address_hash}" do
     test "get 404 on non existing address", %{conn: conn} do
@@ -1761,10 +1767,10 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
           block: tx.block,
           block_number: tx.block_number,
           address: address,
-          first_topic: "0x123456789123456789"
+          first_topic: topic(@first_topic_hex_string_1)
         )
 
-      request = get(conn, "/api/v2/addresses/#{address.hash}/logs?topic=0x123456789123456789")
+      request = get(conn, "/api/v2/addresses/#{address.hash}/logs?topic=#{@first_topic_hex_string_1}")
       assert response = json_response(request, 200)
       assert Enum.count(response["items"]) == 1
       assert response["next_page_params"] == nil

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -8,6 +8,13 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
   alias Explorer.Chain.{Address, InternalTransaction, Log, Token, TokenTransfer, Transaction}
   alias Explorer.Repo
 
+  @first_topic_hex_string_1 "0x99e7b0ba56da2819c37c047f0511fd2bf6c9b4e27b4a979a19d6da0f74be8155"
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.TransactionsApiV2.child_id())
     Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.TransactionsApiV2.child_id())
@@ -976,7 +983,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
           index: 1,
           block: tx.block,
           block_number: tx.block_number,
-          first_topic: "0x99e7b0ba56da2819c37c047f0511fd2bf6c9b4e27b4a979a19d6da0f74be8155",
+          first_topic: topic(@first_topic_hex_string_1),
           data:
             "0x000000000000000000000000dc2b93f3291030f3f7a6d9363ac37757f7ad5c4300000000000000000000000000000000000000000000000000002824369a100000000000000000000000000046b555cb3962bf9533c437cbd04a2f702dfdb999000000000000000000000000000000000000000000000000000014121b4d0800000000000000000000000000faf7a981360c2fab3a5ab7b3d6d8d0cf97a91eb9000000000000000000000000000000000000000000000000000014121b4d0800"
         )
@@ -1039,7 +1046,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
           index: 1,
           block: tx.block,
           block_number: tx.block_number,
-          first_topic: "0x99e7b0ba56da2819c37c047f0511fd2bf6c9b4e27b4a979a19d6da0f74be8155",
+          first_topic: topic(@first_topic_hex_string_1),
           data:
             "0x000000000000000000000000dc2b93f3291030f3f7a6d9363ac37757f7ad5c4300000000000000000000000000000000000000000000000000002824369a100000000000000000000000000046b555cb3962bf9533c437cbd04a2f702dfdb999000000000000000000000000000000000000000000000000000014121b4d0800000000000000000000000000faf7a981360c2fab3a5ab7b3d6d8d0cf97a91eb9000000000000000000000000000000000000000000000000000014121b4d0800"
         )

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3589,32 +3589,6 @@ defmodule Explorer.Chain do
     |> Repo.stream_reduce(initial, reducer)
   end
 
-  @doc """
-  Returns a list of block numbers token transfer `t:Log.t/0`s that don't have an
-  associated `t:TokenTransfer.t/0` record.
-  """
-  def uncataloged_token_transfer_block_numbers do
-    query =
-      from(l in Log,
-        as: :log,
-        where:
-          l.first_topic == unquote(TokenTransfer.constant()) or
-            l.first_topic == unquote(TokenTransfer.erc1155_single_transfer_signature()) or
-            l.first_topic == unquote(TokenTransfer.erc1155_batch_transfer_signature()),
-        where:
-          not exists(
-            from(tf in TokenTransfer,
-              where: tf.transaction_hash == parent_as(:log).transaction_hash,
-              where: tf.log_index == parent_as(:log).index
-            )
-          ),
-        select: l.block_number,
-        distinct: l.block_number
-      )
-
-    Repo.stream_reduce(query, [], &[&1 | &2])
-  end
-
   def decode_contract_address_hash_response(resp) do
     case resp do
       "0x000000000000000000000000" <> address ->

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -35,10 +35,10 @@ defmodule Explorer.Chain.Log do
           block_hash: Hash.Full.t(),
           block_number: non_neg_integer() | nil,
           data: Data.t(),
-          first_topic: String.t(),
-          second_topic: String.t(),
-          third_topic: String.t(),
-          fourth_topic: String.t(),
+          first_topic: Hash.Full.t(),
+          second_topic: Hash.Full.t(),
+          third_topic: Hash.Full.t(),
+          fourth_topic: Hash.Full.t(),
           transaction: %Ecto.Association.NotLoaded{} | Transaction.t(),
           transaction_hash: Hash.Full.t(),
           index: non_neg_integer(),
@@ -48,10 +48,10 @@ defmodule Explorer.Chain.Log do
   @primary_key false
   schema "logs" do
     field(:data, Data)
-    field(:first_topic, :string)
-    field(:second_topic, :string)
-    field(:third_topic, :string)
-    field(:fourth_topic, :string)
+    field(:first_topic, Hash.Full)
+    field(:second_topic, Hash.Full)
+    field(:third_topic, Hash.Full)
+    field(:fourth_topic, Hash.Full)
     field(:index, :integer, primary_key: true)
     field(:type, :string)
     field(:block_number, :integer)
@@ -190,7 +190,8 @@ defmodule Explorer.Chain.Log do
   end
 
   defp find_method_candidates(log, transaction, options, events_acc, skip_sig_provider?) do
-    with "0x" <> hex_part <- log.first_topic,
+    with false <- is_nil(log.first_topic),
+         hex_part <- Base.encode16(log.first_topic.bytes, case: :lower),
          {number, ""} <- Integer.parse(hex_part, 16) do
       <<method_id::binary-size(4), _rest::binary>> = :binary.encode_unsigned(number)
 
@@ -201,7 +202,8 @@ defmodule Explorer.Chain.Log do
         {result, Map.put(events_acc, method_id, result)}
       end
     else
-      _ -> {{:error, :could_not_decode}, events_acc}
+      _ ->
+        {{:error, :could_not_decode}, events_acc}
     end
   end
 
@@ -243,10 +245,10 @@ defmodule Explorer.Chain.Log do
            abi
            |> ABI.parse_specification(include_events?: true)
            |> Event.find_and_decode(
-             decode16!(log.first_topic),
-             decode16!(log.second_topic),
-             decode16!(log.third_topic),
-             decode16!(log.fourth_topic),
+             log.first_topic && log.first_topic.bytes,
+             log.second_topic && log.second_topic.bytes,
+             log.third_topic && log.third_topic.bytes,
+             log.fourth_topic && log.fourth_topic.bytes,
              log.data.bytes
            ) do
       {:ok, selector, mapping}

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -190,10 +190,10 @@ defmodule Explorer.Chain.Log do
   end
 
   defp find_method_candidates(log, transaction, options, events_acc, skip_sig_provider?) do
-    with false <- is_nil(log.first_topic),
-         hex_part <- Base.encode16(log.first_topic.bytes, case: :lower),
-         {number, ""} <- Integer.parse(hex_part, 16) do
-      <<method_id::binary-size(4), _rest::binary>> = :binary.encode_unsigned(number)
+    if is_nil(log.first_topic) do
+      {{:error, :could_not_decode}, events_acc}
+    else
+      <<method_id::binary-size(4), _rest::binary>> = log.first_topic.bytes
 
       if Map.has_key?(events_acc, method_id) do
         {events_acc[method_id], events_acc}
@@ -201,9 +201,6 @@ defmodule Explorer.Chain.Log do
         result = find_method_candidates_from_db(method_id, log, transaction, options, skip_sig_provider?)
         {result, Map.put(events_acc, method_id, result)}
       end
-    else
-      _ ->
-        {{:error, :could_not_decode}, events_acc}
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -28,7 +28,7 @@ defmodule Explorer.Chain.TokenTransfer do
   import Ecto.Query, only: [from: 2, limit: 2, where: 3, join: 5, order_by: 3, preload: 3]
 
   alias Explorer.Chain
-  alias Explorer.Chain.{Address, Block, DenormalizationHelper, Hash, TokenTransfer, Transaction}
+  alias Explorer.Chain.{Address, Block, DenormalizationHelper, Hash, Log, TokenTransfer, Transaction}
   alias Explorer.Chain.Token.Instance
   alias Explorer.{PagingOptions, Repo}
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -375,6 +375,7 @@ defmodule Explorer.Chain.TokenTransfer do
   Returns a list of block numbers token transfer `t:Log.t/0`s that don't have an
   associated `t:TokenTransfer.t/0` record.
   """
+  @spec uncataloged_token_transfer_block_numbers :: {:ok, [non_neg_integer()]}
   def uncataloged_token_transfer_block_numbers do
     query =
       from(l in Log,

--- a/apps/explorer/priv/repo/migrations/20231213152332_alter_log_topic_columns_type.exs
+++ b/apps/explorer/priv/repo/migrations/20231213152332_alter_log_topic_columns_type.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.AlterLogTopicColumnsType do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    ALTER TABLE logs
+    ALTER COLUMN first_topic TYPE bytea
+    USING CAST(REPLACE(first_topic, '0x', '\\x') as bytea),
+    ALTER COLUMN second_topic TYPE bytea
+    USING CAST(REPLACE(second_topic, '0x', '\\x') as bytea),
+    ALTER COLUMN third_topic TYPE bytea
+    USING CAST(REPLACE(third_topic, '0x', '\\x') as bytea),
+    ALTER COLUMN fourth_topic TYPE bytea
+    USING CAST(REPLACE(fourth_topic, '0x', '\\x') as bytea)
+    ;
+    """)
+  end
+end

--- a/apps/explorer/test/explorer/chain/csv_export/address_log_csv_exporter_test.exs
+++ b/apps/explorer/test/explorer/chain/csv_export/address_log_csv_exporter_test.exs
@@ -4,6 +4,16 @@ defmodule Explorer.Chain.AddressLogCsvExporterTest do
   alias Explorer.Chain.Address
   alias Explorer.Chain.CSVExport.AddressLogCsvExporter
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
+  @second_topic_hex_string_1 "0x00000000000000000000000098a9dc37d3650b5b30d6c12789b3881ee0b70c16"
+  @third_topic_hex_string_1 "0x0000000000000000000000005079fc00f00f30000e0c8c083801cfde000008b6"
+  @fourth_topic_hex_string_1 "0x8c9b7729443a4444242342b2ca385a239a5c1d76a88473e1cd2ab0c70dd1b9c7"
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+
   describe "export/3" do
     test "exports address logs to csv" do
       address = insert(:address)
@@ -21,10 +31,10 @@ defmodule Explorer.Chain.AddressLogCsvExporterTest do
           block: transaction.block,
           block_number: transaction.block_number,
           data: "0x12",
-          first_topic: "0x13",
-          second_topic: "0x14",
-          third_topic: "0x15",
-          fourth_topic: "0x16"
+          first_topic: topic(@first_topic_hex_string_1),
+          second_topic: topic(@second_topic_hex_string_1),
+          third_topic: topic(@third_topic_hex_string_1),
+          fourth_topic: topic(@fourth_topic_hex_string_1)
         )
 
       from_period = Timex.format!(Timex.shift(Timex.now(), minutes: -1), "%Y-%m-%d", :strftime)

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -22,9 +22,16 @@ defmodule Explorer.Chain.ImportTest do
 
   @moduletag :capturelog
 
+  @first_topic_hex_string "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  @second_topic_hex_string "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+  @third_topic_hex_string "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d"
+
   doctest Import
 
   describe "all/1" do
+    {:ok, first_topic} = Explorer.Chain.Hash.Full.cast(@first_topic_hex_string)
+    {:ok, second_topic} = Explorer.Chain.Hash.Full.cast(@second_topic_hex_string)
+    {:ok, third_topic} = Explorer.Chain.Hash.Full.cast(@third_topic_hex_string)
     # set :timeout options to cover lines that use the timeout override when available
     @import_data %{
       blocks: %{
@@ -91,9 +98,9 @@ defmodule Explorer.Chain.ImportTest do
             block_hash: "0xf6b4b8c88df3ebd252ec476328334dc026cf66606a84fb769b3d3cbccc8471bd",
             address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             data: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
-            first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
-            third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+            first_topic: first_topic,
+            second_topic: second_topic,
+            third_topic: third_topic,
             fourth_topic: nil,
             index: 0,
             transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
@@ -165,6 +172,9 @@ defmodule Explorer.Chain.ImportTest do
     }
 
     test "with valid data" do
+      {:ok, first_topic} = Explorer.Chain.Hash.Full.cast(@first_topic_hex_string)
+      {:ok, second_topic} = Explorer.Chain.Hash.Full.cast(@second_topic_hex_string)
+      {:ok, third_topic} = Explorer.Chain.Hash.Full.cast(@third_topic_hex_string)
       difficulty = Decimal.new(340_282_366_920_938_463_463_374_607_431_768_211_454)
       total_difficulty = Decimal.new(12_590_447_576_074_723_148_144_860_474_975_121_280_509)
       token_transfer_amount = Decimal.new(1_000_000_000_000_000_000)
@@ -276,9 +286,9 @@ defmodule Explorer.Chain.ImportTest do
                           167, 100, 0, 0>>
                     },
                     index: 0,
-                    first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-                    second_topic: "0x000000000000000000000000e8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca",
-                    third_topic: "0x000000000000000000000000515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
+                    first_topic: ^first_topic,
+                    second_topic: ^second_topic,
+                    third_topic: ^third_topic,
                     fourth_topic: nil,
                     transaction_hash: %Hash{
                       byte_count: 32,

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -7,6 +7,13 @@ defmodule Explorer.Chain.LogTest do
   alias Explorer.Chain.{Log, SmartContract}
   alias Explorer.Repo
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+
   setup :set_mox_from_context
 
   doctest Log
@@ -36,18 +43,21 @@ defmodule Explorer.Chain.LogTest do
         params_for(
           :log,
           address_hash: build(:address).hash,
-          first_topic: "ham",
+          first_topic: @first_topic_hex_string_1,
           transaction_hash: build(:transaction).hash,
           block_hash: build(:block).hash
         )
 
-      assert %Changeset{changes: %{first_topic: "ham"}, valid?: true} = Log.changeset(%Log{}, params)
+      result = Log.changeset(%Log{}, params)
+
+      assert result.valid? == true
+      assert result.changes.first_topic == topic(@first_topic_hex_string_1)
     end
 
     test "assigns optional attributes" do
-      params = Map.put(params_for(:log), :first_topic, "ham")
+      params = Map.put(params_for(:log), :first_topic, topic(@first_topic_hex_string_1))
       changeset = Log.changeset(%Log{}, params)
-      assert changeset.changes.first_topic === "ham"
+      assert changeset.changes.first_topic === topic(@first_topic_hex_string_1)
     end
   end
 
@@ -99,9 +109,9 @@ defmodule Explorer.Chain.LogTest do
         insert(:log,
           address: to_address,
           transaction: transaction,
-          first_topic: topic1,
-          second_topic: topic2,
-          third_topic: topic3,
+          first_topic: topic(topic1),
+          second_topic: topic(topic2),
+          third_topic: topic(topic3),
           fourth_topic: nil,
           data: data
         )
@@ -153,9 +163,9 @@ defmodule Explorer.Chain.LogTest do
       log =
         insert(:log,
           transaction: transaction,
-          first_topic: topic1,
-          second_topic: topic2,
-          third_topic: topic3,
+          first_topic: topic(topic1),
+          second_topic: topic(topic2),
+          third_topic: topic(topic3),
           fourth_topic: nil,
           data: data
         )

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -2,9 +2,8 @@ defmodule Explorer.Chain.SmartContractTest do
   use Explorer.DataCase, async: false
 
   import Mox
-  alias Explorer.{Chain, PagingOptions}
+  alias Explorer.Chain
   alias Explorer.Chain.{Address, SmartContract}
-  alias Explorer.Chain.Hash
   alias Explorer.Chain.SmartContract.Proxy
 
   doctest Explorer.Chain.SmartContract

--- a/apps/explorer/test/explorer/chain/token_transfer_test.exs
+++ b/apps/explorer/test/explorer/chain/token_transfer_test.exs
@@ -325,4 +325,28 @@ defmodule Explorer.Chain.TokenTransferTest do
       assert Enum.member?(page_two, transaction_one_bytes) == true
     end
   end
+
+  describe "uncataloged_token_transfer_block_numbers/0" do
+    test "returns a list of block numbers" do
+      block = insert(:block)
+      address = insert(:address)
+
+      log =
+        insert(:token_transfer_log,
+          transaction:
+            insert(:transaction,
+              block_number: block.number,
+              block_hash: block.hash,
+              cumulative_gas_used: 0,
+              gas_used: 0,
+              index: 0
+            ),
+          block: block,
+          address_hash: address.hash
+        )
+
+      block_number = log.block_number
+      assert {:ok, [^block_number]} = TokenTransfer.uncataloged_token_transfer_block_numbers()
+    end
+  end
 end

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -6,6 +6,25 @@ defmodule Explorer.Etherscan.LogsTest do
   alias Explorer.Etherscan.Logs
   alias Explorer.Chain.Transaction
 
+  @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
+  @first_topic_hex_string_2 "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+  @first_topic_hex_string_3 "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c"
+
+  @second_topic_hex_string_1 "0x00000000000000000000000098a9dc37d3650b5b30d6c12789b3881ee0b70c16"
+  @second_topic_hex_string_2 "0x000000000000000000000000e2680fd7cdbb04e9087a647ad4d023ef6c8fb4e2"
+  @second_topic_hex_string_3 "0x0000000000000000000000005777d92f208679db4b9778590fa3cab3ac9e2168"
+
+  @third_topic_hex_string_1 "0x0000000000000000000000005079fc00f00f30000e0c8c083801cfde000008b6"
+  @third_topic_hex_string_2 "0x000000000000000000000000e2680fd7cdbb04e9087a647ad4d023ef6c8fb4e2"
+  @third_topic_hex_string_3 "0x0000000000000000000000000f6d9bd6fc315bbf95b5c44f4eba2b2762f8c372"
+
+  @fourth_topic_hex_string_1 "0x8c9b7729443a4444242342b2ca385a239a5c1d76a88473e1cd2ab0c70dd1b9c7"
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+
   describe "list_logs/1" do
     test "with empty db" do
       contract_address = build(:contract_address)
@@ -211,13 +230,13 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic"
+        first_topic: topic(@first_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some other topic"
+        first_topic: topic(@first_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -247,15 +266,15 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some second topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some OTHER second topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_2)
       ]
 
       _log1 = insert(:log, log1_details)
@@ -288,15 +307,15 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some second topic"
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic",
-        second_topic: "some OTHER second topic"
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2)
       ]
 
       log1 = insert(:log, log1_details)
@@ -327,14 +346,14 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
+        first_topic: topic(@first_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic",
+        first_topic: topic(@first_topic_hex_string_2),
         block_number: block.number
       ]
 
@@ -366,16 +385,16 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some second topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic",
-        second_topic: "some OTHER second topic",
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2),
         block_number: block.number
       ]
 
@@ -409,27 +428,27 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic",
-        second_topic: "some OTHER second topic",
-        third_topic: "some OTHER third topic",
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2),
+        third_topic: topic(@third_topic_hex_string_2),
         block_number: block.number
       ]
 
       log3_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some ALT first topic",
-        second_topic: "some ALT second topic",
-        third_topic: "some ALT third topic",
+        first_topic: topic(@first_topic_hex_string_3),
+        second_topic: topic(@second_topic_hex_string_3),
+        third_topic: topic(@third_topic_hex_string_3),
         block_number: block.number
       ]
 
@@ -469,27 +488,27 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some first topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER first topic",
-        second_topic: "some OTHER second topic",
-        third_topic: "some OTHER third topic",
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2),
+        third_topic: topic(@third_topic_hex_string_2),
         block_number: block.number
       ]
 
       log3_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some ALT first topic",
-        second_topic: "some ALT second topic",
-        third_topic: "some ALT third topic",
+        first_topic: topic(@first_topic_hex_string_3),
+        second_topic: topic(@second_topic_hex_string_3),
+        third_topic: topic(@third_topic_hex_string_3),
         block_number: block.number
       ]
 
@@ -529,27 +548,27 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some OTHER second topic",
-        third_topic: "some third topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_2),
+        third_topic: topic(@third_topic_hex_string_1),
         block_number: block.number
       ]
 
       log3_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
         block_number: block.number
       ]
 
@@ -589,28 +608,28 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
         block_number: block.number
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some OTHER topic",
-        second_topic: "some OTHER second topic",
-        third_topic: "some OTHER third topic",
-        fourth_topic: "some fourth topic",
+        first_topic: topic(@first_topic_hex_string_2),
+        second_topic: topic(@second_topic_hex_string_2),
+        third_topic: topic(@third_topic_hex_string_2),
+        fourth_topic: topic(@fourth_topic_hex_string_1),
         block_number: block.number
       ]
 
       log3_details = [
         address: contract_address,
         transaction: transaction,
-        first_topic: "some topic",
-        second_topic: "some second topic",
-        third_topic: "some third topic",
-        fourth_topic: "some fourth topic",
+        first_topic: topic(@first_topic_hex_string_1),
+        second_topic: topic(@second_topic_hex_string_1),
+        third_topic: topic(@third_topic_hex_string_1),
+        fourth_topic: topic(@fourth_topic_hex_string_1),
         block_number: block.number
       ]
 

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge/deposit_execute.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge/deposit_execute.ex
@@ -12,6 +12,7 @@ defmodule Indexer.Fetcher.PolygonEdge.DepositExecute do
 
   import EthereumJSONRPC, only: [quantity_to_integer: 1]
   import Indexer.Fetcher.PolygonEdge, only: [fill_block_range: 5, get_block_number_by_tag: 3]
+  import Indexer.Helper, only: [log_topic_to_string: 1]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Log
@@ -128,8 +129,13 @@ defmodule Indexer.Fetcher.PolygonEdge.DepositExecute do
 
   @spec event_to_deposit_execute(binary(), binary(), binary(), binary()) :: map()
   def event_to_deposit_execute(second_topic, third_topic, l2_transaction_hash, l2_block_number) do
+    msg_id =
+      second_topic
+      |> log_topic_to_string()
+      |> quantity_to_integer()
+
     %{
-      msg_id: quantity_to_integer(second_topic),
+      msg_id: msg_id,
       l2_transaction_hash: l2_transaction_hash,
       l2_block_number: quantity_to_integer(l2_block_number),
       success: quantity_to_integer(third_topic) != 0

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge/withdrawal.ex
@@ -13,6 +13,7 @@ defmodule Indexer.Fetcher.PolygonEdge.Withdrawal do
   import EthereumJSONRPC, only: [quantity_to_integer: 1]
   import Explorer.Helper, only: [decode_data: 2]
   import Indexer.Fetcher.PolygonEdge, only: [fill_block_range: 5, get_block_number_by_tag: 3]
+  import Indexer.Helper, only: [log_topic_to_string: 1]
 
   alias ABI.TypeDecoder
   alias Explorer.{Chain, Repo}
@@ -133,6 +134,11 @@ defmodule Indexer.Fetcher.PolygonEdge.Withdrawal do
 
   @spec event_to_withdrawal(binary(), map(), binary(), binary()) :: map()
   def event_to_withdrawal(second_topic, data, l2_transaction_hash, l2_block_number) do
+    msg_id =
+      second_topic
+      |> log_topic_to_string()
+      |> quantity_to_integer()
+
     [data_bytes] = decode_data(data, [:bytes])
 
     sig = binary_part(data_bytes, 0, 32)
@@ -148,7 +154,7 @@ defmodule Indexer.Fetcher.PolygonEdge.Withdrawal do
       end
 
     %{
-      msg_id: quantity_to_integer(second_topic),
+      msg_id: msg_id,
       from: from,
       to: to,
       l2_transaction_hash: l2_transaction_hash,

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -32,4 +32,13 @@ defmodule Indexer.Helper do
   def is_address_correct?(_address) do
     false
   end
+
+  @spec log_topic_to_string(any()) :: binary() | nil
+  def log_topic_to_string(topic) do
+    if is_binary(topic) or is_nil(topic) do
+      topic
+    else
+      Hash.to_string(topic)
+    end
+  end
 end

--- a/apps/indexer/lib/indexer/temporary/uncataloged_token_transfers.ex
+++ b/apps/indexer/lib/indexer/temporary/uncataloged_token_transfers.ex
@@ -12,7 +12,7 @@ defmodule Indexer.Temporary.UncatalogedTokenTransfers do
 
   require Logger
 
-  alias Explorer.Chain
+  alias Explorer.Chain.TokenTransfer
   alias Indexer.Block.Catchup.Fetcher
   alias Indexer.Temporary.UncatalogedTokenTransfers
 
@@ -52,7 +52,7 @@ defmodule Indexer.Temporary.UncatalogedTokenTransfers do
   end
 
   def handle_info(:scan, state) do
-    {:ok, block_numbers} = Chain.uncataloged_token_transfer_block_numbers()
+    {:ok, block_numbers} = TokenTransfer.uncataloged_token_transfer_block_numbers()
 
     case block_numbers do
       [] ->

--- a/apps/indexer/lib/indexer/transform/transaction_actions.ex
+++ b/apps/indexer/lib/indexer/transform/transaction_actions.ex
@@ -285,8 +285,15 @@ defmodule Indexer.Transform.TransactionActions do
     [debt_amount, collateral_amount, _liquidator, _receive_a_token] =
       decode_data(log.data, [{:uint, 256}, {:uint, 256}, :address, :bool])
 
-    debt_address = truncate_address_hash(log.third_topic)
-    collateral_address = truncate_address_hash(log.second_topic)
+    debt_address =
+      log.third_topic
+      |> Helper.log_topic_to_string()
+      |> truncate_address_hash()
+    
+    collateral_address =
+      log.second_topic
+      |> Helper.log_topic_to_string()
+      |> truncate_address_hash()
 
     case get_token_data([debt_address, collateral_address]) do
       false ->
@@ -318,7 +325,10 @@ defmodule Indexer.Transform.TransactionActions do
 
   defp aave_handle_event(type, amount, log, address_topic, chain_id)
        when type in ["borrow", "supply", "withdraw", "repay", "flash_loan"] do
-    address = truncate_address_hash(address_topic)
+    address =
+      address_topic
+      |> Helper.log_topic_to_string()
+      |> truncate_address_hash()
 
     case get_token_data([address]) do
       false ->
@@ -345,7 +355,10 @@ defmodule Indexer.Transform.TransactionActions do
   end
 
   defp aave_handle_event(type, log, address_topic, chain_id) when type in ["enable_collateral", "disable_collateral"] do
-    address = truncate_address_hash(address_topic)
+    address =
+      address_topic
+      |> Helper.log_topic_to_string()
+      |> truncate_address_hash()
 
     case get_token_data([address]) do
       false ->
@@ -448,12 +461,23 @@ defmodule Indexer.Transform.TransactionActions do
       |> Enum.reduce(%{}, fn log, acc ->
         if sanitize_first_topic(log.first_topic) == @uniswap_v3_transfer_nft_event do
           # This is Transfer event for NFT
-          from = truncate_address_hash(log.second_topic)
+          from =
+            log.second_topic
+            |> Helper.log_topic_to_string()
+            |> truncate_address_hash()
 
           # credo:disable-for-next-line
           if from == burn_address_hash_string() do
-            to = truncate_address_hash(log.third_topic)
-            [token_id] = decode_data(log.fourth_topic, [{:uint, 256}])
+            to =
+              log.third_topic
+              |> Helper.log_topic_to_string()
+              |> truncate_address_hash()
+            
+            [token_id] =
+              log.fourth_topic
+              |> Helper.log_topic_to_string()
+              |> decode_data([{:uint, 256}])
+            
             mint_nft_ids = Map.put_new(acc, to, %{ids: [], log_index: log.index})
 
             Map.put(mint_nft_ids, to, %{
@@ -970,7 +994,7 @@ defmodule Indexer.Transform.TransactionActions do
   end
 
   defp sanitize_first_topic(first_topic) do
-    if is_nil(first_topic), do: "", else: String.downcase(first_topic)
+    if is_nil(first_topic), do: "", else: String.downcase(Helper.log_topic_to_string(first_topic))
   end
 
   defp truncate_address_hash(nil), do: burn_address_hash_string()

--- a/apps/indexer/lib/indexer/transform/transaction_actions.ex
+++ b/apps/indexer/lib/indexer/transform/transaction_actions.ex
@@ -289,7 +289,7 @@ defmodule Indexer.Transform.TransactionActions do
       log.third_topic
       |> Helper.log_topic_to_string()
       |> truncate_address_hash()
-    
+
     collateral_address =
       log.second_topic
       |> Helper.log_topic_to_string()
@@ -472,12 +472,12 @@ defmodule Indexer.Transform.TransactionActions do
               log.third_topic
               |> Helper.log_topic_to_string()
               |> truncate_address_hash()
-            
+
             [token_id] =
               log.fourth_topic
               |> Helper.log_topic_to_string()
               |> decode_data([{:uint, 256}])
-            
+
             mint_nft_ids = Map.put_new(acc, to, %{ids: [], log_index: log.index})
 
             Map.put(mint_nft_ids, to, %{


### PR DESCRIPTION
## Motivation

To save storage space for `logs` table (which is in top 3 by storage occupied) we can migrate log topics from `character varying(255)` to `bytea`.

## Changelog

Change type `character varying(255)` to `bytea` for the  next columns in `logs` table:
- `first_topic`
- `second_topic`
- `third_topic`
- `fourth_topic`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
