### PR TITLE
Drop unused indexes on address_current_token_balances table

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -28,6 +28,7 @@ on:
   pull_request:
     branches:
       - master
+      - v6.0.0-dev
       - production-optimism
 
 env:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v6.0.0-dev
       - production-core
       - production-eth-experimental
       - production-eth-goerli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Chore
 
+- [#9006](https://github.com/blockscout/blockscout/pull/9006) - Drop unused indexes on address_current_token_balances table
 - [#8996](https://github.com/blockscout/blockscout/pull/8996) - Refine token transfers token ids index
 
 ## Current
@@ -27,7 +28,6 @@
 
 - [#9014](https://github.com/blockscout/blockscout/pull/9014) - Decrease amount of NFT in address collection: 15 -> 9
 - [#8994](https://github.com/blockscout/blockscout/pull/8994) - Refactor transactions event preloads
-- [#8991](https://github.com/blockscout/blockscout/pull/8991) - Manage DB queue target via runtime env var
 
 <details>
   <summary>Dependencies version bumps</summary>

--- a/apps/explorer/priv/repo/migrations/20231215104320_drop_unused_actb_indexes.exs
+++ b/apps/explorer/priv/repo/migrations/20231215104320_drop_unused_actb_indexes.exs
@@ -1,0 +1,21 @@
+defmodule Explorer.Repo.Migrations.DropUnusedActbIndexes do
+  use Ecto.Migration
+
+  def change do
+    drop(
+      index(
+        :address_current_token_balances,
+        [:value],
+        name: :address_current_token_balances_value,
+        where: "value IS NOT NULL"
+      )
+    )
+
+    drop(
+      index(
+        :address_current_token_balances,
+        [:address_hash, :block_number, :token_contract_address_hash]
+      )
+    )
+  end
+end


### PR DESCRIPTION
## Motivation

Unused indexes are detected in `address_current_token_balances` table:

![Screenshot 2023-12-15 at 13 51 51](https://github.com/blockscout/blockscout/assets/4341812/a490cfcb-89c0-4013-878a-8e0a50d5286a)

## Changelog

- Remove partial index on `value` column where value is not null in `address_current_token_balances` table.
- Remove multi-column index on `[:address_hash, :block_number, :token_contract_address_hash]` columns in `address_current_token_balances` table.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
