### PR TITLE
Index for block refetch_needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Chore
 
+- [#9009](https://github.com/blockscout/blockscout/pull/9009) - Index for block refetch_needed
 - [#9006](https://github.com/blockscout/blockscout/pull/9006) - Drop unused indexes on address_current_token_balances table
 - [#8996](https://github.com/blockscout/blockscout/pull/8996) - Refine token transfers token ids index
 
@@ -27,7 +28,6 @@
 ### Chore
 
 - [#9014](https://github.com/blockscout/blockscout/pull/9014) - Decrease amount of NFT in address collection: 15 -> 9
-- [#9009](https://github.com/blockscout/blockscout/pull/9009) - Index for block refetch_needed
 - [#8994](https://github.com/blockscout/blockscout/pull/8994) - Refactor transactions event preloads
 
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Chore
 
 - [#9014](https://github.com/blockscout/blockscout/pull/9014) - Decrease amount of NFT in address collection: 15 -> 9
+- [#9009](https://github.com/blockscout/blockscout/pull/9009) - Index for block refetch_needed
 - [#8994](https://github.com/blockscout/blockscout/pull/8994) - Refactor transactions event preloads
 
 <details>

--- a/apps/explorer/priv/repo/migrations/20231215132609_add_index_blocks_refetch_needed.exs
+++ b/apps/explorer/priv/repo/migrations/20231215132609_add_index_blocks_refetch_needed.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.AddIndexBlocksRefetchNeeded do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE INDEX consensus_block_hashes_refetch_needed ON blocks((1)) WHERE consensus and refetch_needed;
+    """)
+  end
+
+  def down do
+    execute("""
+    DROP INDEX consensus_block_hashes_refetch_needed;
+    """)
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20231215132609_add_index_blocks_refetch_needed.exs
+++ b/apps/explorer/priv/repo/migrations/20231215132609_add_index_blocks_refetch_needed.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Repo.Migrations.AddIndexBlocksRefetchNeeded do
 
   def up do
     execute("""
-    CREATE INDEX consensus_block_hashes_refetch_needed ON blocks((1)) WHERE consensus and refetch_needed;
+    CREATE INDEX consensus_block_hashes_refetch_needed ON blocks(hash) WHERE consensus and refetch_needed;
     """)
   end
 


### PR DESCRIPTION
## Motivation

[Query](https://github.com/blockscout/blockscout/blob/0673e7fd07ae9829bf4d07e0dcf7be85945ba49f/apps/indexer/lib/indexer/temporary/blocks_transactions_mismatch.ex#L53-L59):
```
SELECT b0."hash", count(t1."hash") 
  FROM "blocks" AS b0 LEFT OUTER JOIN "transactions" AS t1 ON t1."block_hash" = b0."hash" 
 WHERE ((b0."consensus" = true) AND b0."refetch_needed") 
 GROUP BY b0."hash" LIMIT 100000;
```
is slow on some instances because of no index which covers `refetch_needed=true` condition.

![Screenshot 2023-12-15 at 18 02 58](https://github.com/blockscout/blockscout/assets/4341812/d88ef239-ba1f-46d7-8ab5-988c7bae6747)

![Screenshot 2023-12-15 at 17 57 39](https://github.com/blockscout/blockscout/assets/4341812/a289a09f-bd5f-4ec1-8e16-6a6f83679160)


## Changelog

The suggestion is to add index:
```
CREATE INDEX consensus_block_hashes_refetch_needed ON blocks((1)) WHERE consensus and refetch_needed;
```

Query execution plan without index:
```
 QUERY PLAN
 ----------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=1039.91..1041.03 rows=1 width=41) (actual time=2.347..2.349 rows=0 loops=1)
    ->  GroupAggregate  (cost=1039.91..1041.03 rows=1 width=41) (actual time=2.345..2.347 rows=0 loops=1)
          Group Key: b0.hash
          ->  Sort  (cost=1039.91..1040.28 rows=147 width=66) (actual time=2.344..2.346 rows=0 loops=1)
                Sort Key: b0.hash
                Sort Method: quicksort  Memory: 25kB
                ->  Nested Loop Left Join  (cost=13.83..1034.62 rows=147 width=66) (actual time=2.331..2.333 rows=0 loops=1)
                      ->  Seq Scan on blocks b0  (cost=0.00..317.88 rows=1 width=33) (actual time=2.330..2.331 rows=0 loops=1)
                            Filter: (consensus AND refetch_needed)
                            Rows Removed by Filter: 7788
                      ->  Bitmap Heap Scan on transactions t1  (cost=13.83..714.93 rows=181 width=66) (never executed)
                            Recheck Cond: (block_hash = b0.hash)
                            ->  Bitmap Index Scan on transactions_block_hash_index_index  (cost=0.00..13.79 rows=181 width=0) (never executed)
                                  Index Cond: (block_hash = b0.hash)
  Planning Time: 0.627 ms
  Execution Time: 2.435 ms
```

Query execution plan after index implemented:
```
                                                                                QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=730.17..731.29 rows=1 width=41) (actual time=0.028..0.029 rows=0 loops=1)
   ->  GroupAggregate  (cost=730.17..731.29 rows=1 width=41) (actual time=0.027..0.028 rows=0 loops=1)
         Group Key: b0.hash
         ->  Sort  (cost=730.17..730.54 rows=147 width=66) (actual time=0.026..0.027 rows=0 loops=1)
               Sort Key: b0.hash
               Sort Method: quicksort  Memory: 25kB
               ->  Nested Loop Left Join  (cost=13.96..724.88 rows=147 width=66) (actual time=0.004..0.005 rows=0 loops=1)
                     ->  Index Scan using consensus_block_hashes_refetch_needed on blocks b0  (cost=0.12..8.14 rows=1 width=33) (actual time=0.004..0.004 rows=0 loops=1)
                     ->  Bitmap Heap Scan on transactions t1  (cost=13.83..714.93 rows=181 width=66) (never executed)
                           Recheck Cond: (block_hash = b0.hash)
                           ->  Bitmap Index Scan on transactions_block_hash_index_index  (cost=0.00..13.79 rows=181 width=0) (never executed)
                                 Index Cond: (block_hash = b0.hash)
 Planning Time: 0.547 ms
 Execution Time: 0.079 ms
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
