### PR TITLE
Token type filling migrations

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -112,6 +112,8 @@ config :explorer, Explorer.Counters.BlockPriorityFeeCounter,
 config :explorer, Explorer.TokenInstanceOwnerAddressMigration.Supervisor, enabled: true
 
 config :explorer, Explorer.Migrator.TransactionsDenormalization, enabled: true
+config :explorer, Explorer.Migrator.AddressCurrentTokenBalanceTokenType, enabled: true
+config :explorer, Explorer.Migrator.AddressTokenBalanceTokenType, enabled: true
 
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: true
 

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -36,6 +36,8 @@ config :explorer, Explorer.Tracer, disabled?: false
 config :explorer, Explorer.TokenInstanceOwnerAddressMigration.Supervisor, enabled: false
 
 config :explorer, Explorer.Migrator.TransactionsDenormalization, enabled: false
+config :explorer, Explorer.Migrator.AddressCurrentTokenBalanceTokenType, enabled: false
+config :explorer, Explorer.Migrator.AddressTokenBalanceTokenType, enabled: false
 
 config :explorer,
   realtime_events_sender: Explorer.Chain.Events.SimpleSender

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -127,7 +127,9 @@ defmodule Explorer.Application do
         configure(Explorer.TokenInstanceOwnerAddressMigration.Supervisor),
         sc_microservice_configure(Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand),
         configure(Explorer.Chain.Cache.RootstockLockedBTC),
-        configure(Explorer.Migrator.TransactionsDenormalization)
+        configure(Explorer.Migrator.TransactionsDenormalization),
+        configure(Explorer.Migrator.AddressCurrentTokenBalanceTokenType),
+        configure(Explorer.Migrator.AddressTokenBalanceTokenType)
       ]
       |> List.flatten()
 

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -7,15 +7,37 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
 
   use Explorer.Chain.MapCache,
     name: :background_migrations_status,
-    key: :denormalization_finished
+    key: :denormalization_finished,
+    key: :tb_token_type_finished,
+    key: :ctb_token_type_finished
 
   @dialyzer :no_match
 
-  alias Explorer.Migrator.TransactionsDenormalization
+  alias Explorer.Migrator.{
+    AddressCurrentTokenBalanceTokenType,
+    AddressTokenBalanceTokenType,
+    TransactionsDenormalization
+  }
 
   defp handle_fallback(:denormalization_finished) do
     Task.start(fn ->
       set_denormalization_finished(TransactionsDenormalization.migration_finished?())
+    end)
+
+    {:return, false}
+  end
+
+  defp handle_fallback(:tb_token_type_finished) do
+    Task.start(fn ->
+      set_tb_token_type_finished(AddressTokenBalanceTokenType.migration_finished?())
+    end)
+
+    {:return, false}
+  end
+
+  defp handle_fallback(:ctb_token_type_finished) do
+    Task.start(fn ->
+      set_ctb_token_type_finished(AddressCurrentTokenBalanceTokenType.migration_finished?())
     end)
 
     {:return, false}

--- a/apps/explorer/lib/explorer/migrator/address_current_token_balance_token_type.ex
+++ b/apps/explorer/lib/explorer/migrator/address_current_token_balance_token_type.ex
@@ -1,0 +1,51 @@
+defmodule Explorer.Migrator.AddressCurrentTokenBalanceTokenType do
+  @moduledoc """
+  Fill empty token_type's for address_current_token_balances
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "ctb_token_type"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers do
+    limit = batch_size() * concurrency()
+
+    unprocessed_data_query()
+    |> select([ctb], ctb.id)
+    |> limit(^limit)
+    |> Repo.all(timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    from(ctb in CurrentTokenBalance, where: is_nil(ctb.token_type))
+  end
+
+  @impl FillingMigration
+  def update_batch(token_balance_ids) do
+    query =
+      from(current_token_balance in CurrentTokenBalance,
+        join: token in assoc(current_token_balance, :token),
+        where: current_token_balance.id in ^token_balance_ids,
+        update: [set: [token_type: token.type]]
+      )
+
+    Repo.update_all(query, [], timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def update_cache do
+    BackgroundMigrations.set_ctb_token_type_finished(true)
+  end
+end

--- a/apps/explorer/lib/explorer/migrator/address_token_balance_token_type.ex
+++ b/apps/explorer/lib/explorer/migrator/address_token_balance_token_type.ex
@@ -1,0 +1,51 @@
+defmodule Explorer.Migrator.AddressTokenBalanceTokenType do
+  @moduledoc """
+  Fill empty token_type's for address_token_balances
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "tb_token_type"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers do
+    limit = batch_size() * concurrency()
+
+    unprocessed_data_query()
+    |> select([tb], tb.id)
+    |> limit(^limit)
+    |> Repo.all(timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    from(tb in TokenBalance, where: is_nil(tb.token_type))
+  end
+
+  @impl FillingMigration
+  def update_batch(token_balance_ids) do
+    query =
+      from(token_balance in TokenBalance,
+        join: token in assoc(token_balance, :token),
+        where: token_balance.id in ^token_balance_ids,
+        update: [set: [token_type: token.type]]
+      )
+
+    Repo.update_all(query, [], timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def update_cache do
+    BackgroundMigrations.set_tb_token_type_finished(true)
+  end
+end

--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -1,0 +1,83 @@
+defmodule Explorer.Migrator.FillingMigration do
+  @moduledoc """
+  Template for creating migrations that fills some fields in existing entities
+  """
+
+  @callback migration_name :: String.t()
+  @callback unprocessed_data_query :: Ecto.Query.t()
+  @callback last_unprocessed_identifiers :: [any()]
+  @callback update_batch([any()]) :: any()
+  @callback update_cache :: any()
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Explorer.Migrator.FillingMigration
+
+      use GenServer, restart: :transient
+
+      import Ecto.Query
+
+      alias Explorer.Migrator.MigrationStatus
+      alias Explorer.Repo
+
+      @default_batch_size 500
+
+      def start_link(_) do
+        GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+      end
+
+      def migration_finished? do
+        not Repo.exists?(unprocessed_data_query())
+      end
+
+      @impl true
+      def init(_) do
+        case MigrationStatus.get_status(migration_name()) do
+          "completed" ->
+            :ignore
+
+          _ ->
+            MigrationStatus.set_status(migration_name(), "started")
+            schedule_batch_migration()
+            {:ok, %{}}
+        end
+      end
+
+      @impl true
+      def handle_info(:migrate_batch, state) do
+        case last_unprocessed_identifiers() do
+          [] ->
+            update_cache()
+            MigrationStatus.set_status(migration_name(), "completed")
+            {:stop, :normal, state}
+
+          hashes ->
+            hashes
+            |> Enum.chunk_every(batch_size())
+            |> Enum.map(&run_task/1)
+            |> Task.await_many(:infinity)
+
+            schedule_batch_migration()
+
+            {:noreply, state}
+        end
+      end
+
+      defp run_task(batch), do: Task.async(fn -> update_batch(batch) end)
+
+      defp schedule_batch_migration do
+        Process.send(self(), :migrate_batch, [])
+      end
+
+      defp batch_size do
+        Application.get_env(:explorer, __MODULE__)[:batch_size] || @default_batch_size
+      end
+
+      defp concurrency do
+        default = 4 * System.schedulers_online()
+
+        Application.get_env(:explorer, __MODULE__)[:concurrency] || default
+      end
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/migrator/transactions_denormalization.ex
+++ b/apps/explorer/lib/explorer/migrator/transactions_denormalization.ex
@@ -3,78 +3,39 @@ defmodule Explorer.Migrator.TransactionsDenormalization do
   Migrates all transactions to have set block_consensus and block_timestamp
   """
 
-  use GenServer, restart: :transient
+  use Explorer.Migrator.FillingMigration
 
   import Ecto.Query
 
   alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.Transaction
-  alias Explorer.Migrator.MigrationStatus
+  alias Explorer.Migrator.FillingMigration
   alias Explorer.Repo
 
-  @default_batch_size 500
   @migration_name "denormalization"
 
-  @spec start_link(term()) :: GenServer.on_start()
-  def start_link(_) do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
-  end
+  @impl FillingMigration
+  def migration_name, do: @migration_name
 
-  def migration_finished? do
-    not Repo.exists?(unprocessed_transactions_query())
-  end
-
-  @impl true
-  def init(_) do
-    case MigrationStatus.get_status(@migration_name) do
-      "completed" ->
-        :ignore
-
-      _ ->
-        MigrationStatus.set_status(@migration_name, "started")
-        schedule_batch_migration()
-        {:ok, %{}}
-    end
-  end
-
-  @impl true
-  def handle_info(:migrate_batch, state) do
-    case last_unprocessed_transaction_hashes() do
-      [] ->
-        BackgroundMigrations.set_denormalization_finished(true)
-        MigrationStatus.set_status(@migration_name, "completed")
-        {:stop, :normal, state}
-
-      hashes ->
-        hashes
-        |> Enum.chunk_every(batch_size())
-        |> Enum.map(&run_task/1)
-        |> Task.await_many(:infinity)
-
-        schedule_batch_migration()
-
-        {:noreply, state}
-    end
-  end
-
-  defp run_task(batch), do: Task.async(fn -> update_batch(batch) end)
-
-  defp last_unprocessed_transaction_hashes do
+  @impl FillingMigration
+  def last_unprocessed_identifiers do
     limit = batch_size() * concurrency()
 
-    unprocessed_transactions_query()
+    unprocessed_data_query()
     |> select([t], t.hash)
     |> limit(^limit)
     |> Repo.all(timeout: :infinity)
   end
 
-  defp unprocessed_transactions_query do
+  @impl FillingMigration
+  def unprocessed_data_query do
     from(t in Transaction,
       where: not is_nil(t.block_hash) and (is_nil(t.block_consensus) or is_nil(t.block_timestamp))
     )
   end
 
-  defp update_batch(transaction_hashes) do
+  @impl FillingMigration
+  def update_batch(transaction_hashes) do
     query =
       from(transaction in Transaction,
         join: block in assoc(transaction, :block),
@@ -85,17 +46,8 @@ defmodule Explorer.Migrator.TransactionsDenormalization do
     Repo.update_all(query, [], timeout: :infinity)
   end
 
-  defp schedule_batch_migration do
-    Process.send(self(), :migrate_batch, [])
-  end
-
-  defp batch_size do
-    Application.get_env(:explorer, __MODULE__)[:batch_size] || @default_batch_size
-  end
-
-  defp concurrency do
-    default = 4 * System.schedulers_online()
-
-    Application.get_env(:explorer, __MODULE__)[:concurrency] || default
+  @impl FillingMigration
+  def update_cache do
+    BackgroundMigrations.set_denormalization_finished(true)
   end
 end

--- a/apps/explorer/test/explorer/chain/address/token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/token_balance_test.exs
@@ -46,6 +46,7 @@ defmodule Explorer.Chain.Address.TokenBalanceTest do
         :token_balance,
         address: burn_address,
         token_contract_address_hash: token.contract_address_hash,
+        token_type: "ERC-721",
         value_fetched_at: nil
       )
 

--- a/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Migrator.AddressCurrentTokenBalanceTokenTypeTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Migrator.{AddressCurrentTokenBalanceTokenType, MigrationStatus}
+  alias Explorer.Repo
+
+  describe "Migrate current token balances" do
+    test "Set token_type for not processed current token balances" do
+      Enum.each(0..10, fn _x ->
+        current_token_balance = insert(:address_current_token_balance, token_type: nil)
+        assert %{token_type: nil} = current_token_balance
+      end)
+
+      assert MigrationStatus.get_status("ctb_token_type") == nil
+
+      AddressCurrentTokenBalanceTokenType.start_link([])
+      Process.sleep(100)
+
+      CurrentTokenBalance
+      |> Repo.all()
+      |> Repo.preload(:token)
+      |> Enum.each(fn ctb ->
+        assert %{token_type: token_type, token: %{type: token_type}} = ctb
+        assert not is_nil(token_type)
+      end)
+
+      assert MigrationStatus.get_status("ctb_token_type") == "completed"
+    end
+  end
+end

--- a/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
@@ -27,6 +27,7 @@ defmodule Explorer.Migrator.AddressCurrentTokenBalanceTokenTypeTest do
       end)
 
       assert MigrationStatus.get_status("ctb_token_type") == "completed"
+      assert BackgroundMigrations.get_ctb_token_type_finished() == true
     end
   end
 end

--- a/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
@@ -1,0 +1,32 @@
+defmodule Explorer.Migrator.AddressTokenBalanceTokenTypeTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Migrator.{AddressTokenBalanceTokenType, MigrationStatus}
+  alias Explorer.Repo
+
+  describe "Migrate token balances" do
+    test "Set token_type for not processed token balances" do
+      Enum.each(0..10, fn _x ->
+        token_balance = insert(:token_balance, token_type: nil)
+        assert %{token_type: nil} = token_balance
+      end)
+
+      assert MigrationStatus.get_status("tb_token_type") == nil
+
+      AddressTokenBalanceTokenType.start_link([])
+      Process.sleep(100)
+
+      TokenBalance
+      |> Repo.all()
+      |> Repo.preload(:token)
+      |> Enum.each(fn tb ->
+        assert %{token_type: token_type, token: %{type: token_type}} = tb
+        assert not is_nil(token_type)
+      end)
+
+      assert MigrationStatus.get_status("tb_token_type") == "completed"
+    end
+  end
+end

--- a/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
@@ -27,6 +27,7 @@ defmodule Explorer.Migrator.AddressTokenBalanceTokenTypeTest do
       end)
 
       assert MigrationStatus.get_status("tb_token_type") == "completed"
+      assert BackgroundMigrations.get_tb_token_type_finished() == true
     end
   end
 end

--- a/apps/explorer/test/explorer/migrator/transactions_denormalization_migrator_test.exs
+++ b/apps/explorer/test/explorer/migrator/transactions_denormalization_migrator_test.exs
@@ -1,8 +1,9 @@
 defmodule Explorer.Migrator.TransactionsDenormalizationTest do
   use Explorer.DataCase, async: false
 
+  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.Transaction
-  alias Explorer.Migrator.TransactionsDenormalization
+  alias Explorer.Migrator.{MigrationStatus, TransactionsDenormalization}
   alias Explorer.Repo
 
   describe "Migrate transactions" do
@@ -20,6 +21,8 @@ defmodule Explorer.Migrator.TransactionsDenormalizationTest do
         assert not is_nil(timestamp)
       end)
 
+      assert MigrationStatus.get_status("denormalization") == nil
+
       TransactionsDenormalization.start_link([])
       Process.sleep(100)
 
@@ -33,6 +36,8 @@ defmodule Explorer.Migrator.TransactionsDenormalizationTest do
                  block: %{consensus: consensus, timestamp: timestamp}
                } = t
       end)
+
+      assert MigrationStatus.get_status("denormalization") == "completed"
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9023

## Changelog

Moved root logic of denormalization migration to the separate `use`able module, added migrations based on this "interface"