### PR TITLE
Fix tx input decoding in tx summary microservice request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- [#9039](https://github.com/blockscout/blockscout/pull/9039) - Fix tx input decoding in tx summary microservice request
 - [#9013](https://github.com/blockscout/blockscout/pull/9013) - Speed up `Indexer.Fetcher.TokenInstance.LegacySanitize`
 - [#8955](https://github.com/blockscout/blockscout/pull/8955) - Remove daily balances updating from BlockReward fetcher
 - [#8846](https://github.com/blockscout/blockscout/pull/8846) - Handle nil gas_price at address view

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -39,7 +39,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
 
     case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
       {:ok, %Response{body: body, status_code: 200}} ->
-        body |> Jason.decode() |> preload_tokens()
+        body |> Jason.decode() |> preload_template_variables()
 
       error ->
         old_truncate = Application.get_env(:logger, :truncate)
@@ -148,12 +148,12 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     |> Enum.map(fn {log, decoded_log} -> TransactionView.prepare_log(log, transaction.hash, decoded_log, true) end)
   end
 
-  defp preload_tokens({:ok, %{"success" => true, "data" => %{"summaries" => summaries} = data}}) do
+  defp preload_template_variables({:ok, %{"success" => true, "data" => %{"summaries" => summaries} = data}}) do
     summaries_updated =
       Enum.map(summaries, fn %{"summary_template_variables" => summary_template_variables} = summary ->
         summary_template_variables_preloaded =
           Enum.reduce(summary_template_variables, %{}, fn {key, value}, acc ->
-            Map.put(acc, key, preload_token(value))
+            Map.put(acc, key, preload_template_variable(value))
           end)
 
         Map.put(summary, "summary_template_variables", summary_template_variables_preloaded)
@@ -162,17 +162,46 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     {:ok, %{"success" => true, "data" => Map.put(data, "summaries", summaries_updated)}}
   end
 
-  defp preload_tokens(error), do: error
+  defp preload_template_variables(error), do: error
 
-  defp preload_token(%{"type" => "token", "value" => %{"address" => address_hash_string} = value}),
+  defp preload_template_variable(%{"type" => "token", "value" => %{"address" => address_hash_string} = value}),
     do: %{
       "type" => "token",
       "value" => address_hash_string |> Chain.token_from_address_hash(@api_true) |> token_from_db() |> Map.merge(value)
     }
 
-  defp preload_token(other), do: other
+  defp preload_template_variable(%{"type" => "address", "value" => %{"hash" => address_hash_string} = value}),
+    do: %{
+      "type" => "address",
+      "value" =>
+        address_hash_string
+        |> Chain.hash_to_address(
+          [
+            necessity_by_association: %{
+              :names => :optional,
+              :smart_contract => :optional
+            },
+            api?: true
+          ],
+          false
+        )
+        |> address_from_db()
+        |> Map.merge(value)
+    }
+
+  defp preload_template_variable(other), do: other
 
   defp token_from_db({:error, _}), do: %{}
-
   defp token_from_db({:ok, token}), do: TokenView.render("token.json", %{token: token})
+
+  defp address_from_db({:error, _}), do: %{}
+
+  defp address_from_db({:ok, address}),
+    do:
+      Helper.address_with_info(
+        nil,
+        address,
+        address.hash,
+        true
+      )
 end

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -76,7 +76,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
         created_contract_address: [:names, :token, :smart_contract]
       ])
 
-    skip_sig_provider? = true
+    skip_sig_provider? = false
     {decoded_input, _abi_acc, _methods_acc} = Transaction.decoded_input_data(transaction, skip_sig_provider?, @api_true)
 
     decoded_input_data = decoded_input |> TransactionView.format_decoded_input() |> TransactionView.decoded_input()

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -79,7 +79,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     skip_sig_provider? = true
     {decoded_input, _abi_acc, _methods_acc} = Transaction.decoded_input_data(transaction, skip_sig_provider?, @api_true)
 
-    decoded_input_data = TransactionView.decoded_input(decoded_input)
+    decoded_input_data = decoded_input |> TransactionView.format_decoded_input() |> TransactionView.decoded_input()
 
     %{
       data: %{

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1017,10 +1017,10 @@ defmodule Explorer.Chain do
   Optionally it also accepts a boolean to fetch the `has_decompiled_code?` virtual field or not
 
   """
-  @spec hash_to_address(Hash.Address.t(), [necessity_by_association_option | api?], boolean()) ::
+  @spec hash_to_address(Hash.Address.t() | binary(), [necessity_by_association_option | api?], boolean()) ::
           {:ok, Address.t()} | {:error, :not_found}
   def hash_to_address(
-        %Hash{byte_count: unquote(Hash.Address.byte_count())} = hash,
+        hash,
         options \\ [
           necessity_by_association: %{
             :contracts_creation_internal_transaction => :optional,

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -595,15 +595,17 @@ defmodule Explorer.Chain.Transaction do
 
   # Because there is no contract association, we know the contract was not verified
   @spec decoded_input_data(
-          %{:__struct__ => Ecto.Association.NotLoaded | Explorer.Chain.Transaction, optional(any()) => any()},
-          any(),
-          any(),
-          any(),
-          any()
+          NotLoaded.t() | Transaction.t(),
+          boolean(),
+          [Chain.api?()],
+          full_abi_acc,
+          methods_acc
         ) ::
-          {{:error | :ok | binary(), any()}
-           | {:error, :contract_not_verified | :contract_verified, list()}
-           | {:ok, binary(), binary(), list()}, any(), any()}
+          {error_type | success_type, full_abi_acc, methods_acc}
+        when full_abi_acc: map(),
+             methods_acc: map(),
+             error_type: {:error, any()} | {:error, :contract_not_verified | :contract_verified, list()},
+             success_type: {:ok | binary(), any()} | {:ok, binary(), binary(), list()}
   def decoded_input_data(tx, skip_sig_provider? \\ false, options, full_abi_acc \\ %{}, methods_acc \\ %{})
 
   def decoded_input_data(%__MODULE__{to_address: nil}, _, _, full_abi_acc, methods_acc),

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -594,6 +594,16 @@ defmodule Explorer.Chain.Transaction do
   end
 
   # Because there is no contract association, we know the contract was not verified
+  @spec decoded_input_data(
+          %{:__struct__ => Ecto.Association.NotLoaded | Explorer.Chain.Transaction, optional(any()) => any()},
+          any(),
+          any(),
+          any(),
+          any()
+        ) ::
+          {{:error | :ok | binary(), any()}
+           | {:error, :contract_not_verified | :contract_verified, list()}
+           | {:ok, binary(), binary(), list()}, any(), any()}
   def decoded_input_data(tx, skip_sig_provider? \\ false, options, full_abi_acc \\ %{}, methods_acc \\ %{})
 
   def decoded_input_data(%__MODULE__{to_address: nil}, _, _, full_abi_acc, methods_acc),


### PR DESCRIPTION
## Motivation

- `decoded_input` was missed in tx summary request for unverified contracts 

## Changelog

- Add address info preload to summary template variable with `type=address`
- Fix tx input decoding in tx summary microservice request
- Light refactoring:
  - Add spec for `decoded_input_data`
  - Get rid of doubled Enum.reverse in `decode_transactions` (TransactionView API v2)
## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
