### PR TITLE
Add ASC indices for logs, token transfers, transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Chore
 
+- [#9055](https://github.com/blockscout/blockscout/pull/9055) - Add ASC indices for logs, token transfers, transactions
 - [#9038](https://github.com/blockscout/blockscout/pull/9038) - Token type filling migrations
 - [#9009](https://github.com/blockscout/blockscout/pull/9009) - Index for block refetch_needed
 - [#9007](https://github.com/blockscout/blockscout/pull/9007) - Drop logs type index

--- a/apps/explorer/priv/repo/migrations/20231225113850_transactions_asc_indices.exs
+++ b/apps/explorer/priv/repo/migrations/20231225113850_transactions_asc_indices.exs
@@ -1,0 +1,47 @@
+defmodule Explorer.Repo.Migrations.TransactionsAscIndices do
+  use Ecto.Migration
+
+  def change do
+    create(
+      index(
+        :transactions,
+        [
+          :from_address_hash,
+          "block_number ASC NULLS LAST",
+          "index ASC NULLS LAST",
+          "inserted_at ASC",
+          "hash DESC"
+        ],
+        name: "transactions_from_address_hash_with_pending_index_asc"
+      )
+    )
+
+    create(
+      index(
+        :transactions,
+        [
+          :to_address_hash,
+          "block_number ASC NULLS LAST",
+          "index ASC NULLS LAST",
+          "inserted_at ASC",
+          "hash DESC"
+        ],
+        name: "transactions_to_address_hash_with_pending_index_asc"
+      )
+    )
+
+    create(
+      index(
+        :transactions,
+        [
+          :created_contract_address_hash,
+          "block_number ASC NULLS LAST",
+          "index ASC NULLS LAST",
+          "inserted_at ASC",
+          "hash DESC"
+        ],
+        name: "transactions_created_contract_address_hash_with_pending_index_a"
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20231225115026_logs_asc_index.exs
+++ b/apps/explorer/priv/repo/migrations/20231225115026_logs_asc_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.LogsAscIndex do
+  use Ecto.Migration
+
+  def change do
+    create(index(:logs, ["block_number ASC, index ASC"]))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20231225115100_token_transfers_asc_index.exs
+++ b/apps/explorer/priv/repo/migrations/20231225115100_token_transfers_asc_index.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.TokenTransfersAscIndex do
+  use Ecto.Migration
+
+  def change do
+    create(index(:token_transfers, ["block_number ASC", "log_index ASC"]))
+  end
+end


### PR DESCRIPTION
## Motivation

Slow execution of queries in ASC direction from the API requests like this:
```
api?module=account&action=tokentx&startblock=0&endblock=670727&offset=7000&page=1&sort=desc&address=0x03709784c96aeaaa9dd38df14a23e996681b2c66
```

## Changelog

Add indices in ascending order similar to existing on the tables `transactions`, `logs`, `token_transfers`.
`internal_transactions` is skipped intentionally, because requests in different diresctions is out of practical usage on this table.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
