### PR TITLE
Fetch realtime coin balances only for addresses for which it has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#9102](https://github.com/blockscout/blockscout/pull/9102) - Fix some log topics for Suave and Polygon Edge
 - [#9075](https://github.com/blockscout/blockscout/pull/9075) - Fix fetching contract codes
 - [#9073](https://github.com/blockscout/blockscout/pull/9073) - Allow payable function with output appear in the Read tab
+- [#9069](https://github.com/blockscout/blockscout/pull/9069) - Fetch realtime coin balances only for addresses for which it has changed
 
 ### Chore
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -195,7 +195,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
         block_fetcher,
         %{
           address_coin_balances: %{params: address_coin_balances_params},
-          address_hash_to_fetched_balance_block_number: address_hash_to_block_number,
           addresses: %{params: addresses_params},
           block_rewards: block_rewards
         } = options
@@ -209,7 +208,6 @@ defmodule Indexer.Block.Realtime.Fetcher do
            }}} <-
            {:balances,
             balances(block_fetcher, %{
-              address_hash_to_block_number: address_hash_to_block_number,
               addresses_params: addresses_params,
               balances_params: address_coin_balances_params
             })},
@@ -474,33 +472,11 @@ defmodule Indexer.Block.Realtime.Fetcher do
     end
   end
 
-  defp fetch_balances_params_list(%{
-         addresses_params: addresses_params,
-         address_hash_to_block_number: address_hash_to_block_number,
-         balances_params: balances_params
-       }) do
-    addresses_params
-    |> addresses_params_to_fetched_balances_params_set(%{address_hash_to_block_number: address_hash_to_block_number})
-    |> MapSet.union(balances_params_to_fetch_balances_params_set(balances_params))
+  defp fetch_balances_params_list(%{balances_params: balances_params}) do
+    balances_params
+    |> balances_params_to_fetch_balances_params_set()
     # stable order for easier moxing
     |> Enum.sort_by(fn %{hash_data: hash_data, block_quantity: block_quantity} -> {hash_data, block_quantity} end)
-  end
-
-  defp addresses_params_to_fetched_balances_params_set(addresses_params, %{
-         address_hash_to_block_number: address_hash_to_block_number
-       }) do
-    Enum.into(addresses_params, MapSet.new(), fn %{hash: address_hash} = address_params when is_binary(address_hash) ->
-      block_number =
-        case address_params do
-          %{fetched_coin_balance_block_number: block_number} when is_integer(block_number) ->
-            block_number
-
-          _ ->
-            Map.fetch!(address_hash_to_block_number, String.downcase(address_hash))
-        end
-
-      %{hash_data: address_hash, block_quantity: integer_to_quantity(block_number)}
-    end)
   end
 
   defp balances_params_to_fetch_balances_params_set(balances_params) do


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/8575

## Motivation

Currently, in realtime fetcher we fetch coin balances from node for every address we extracted from block data (transactions, token transfers, logs, etc.). But all addresses whose balance could change are already presented in `address_coin_balances` import option. So it's not needed to fetch balances for all of the extracted addresses since their balances couldn't change. This way we can get rid of a large number of unnecessary requests to node.

## Changelog

Removed unnecessary addresses from balance fetching params list.