### PR TITLE
Allow payable function with output appear in the Read tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#9075](https://github.com/blockscout/blockscout/pull/9075) - Fix fetching contract codes
+- [#9073](https://github.com/blockscout/blockscout/pull/9073) - Allow payable function with output appear in the Read tab
 
 ### Chore
 

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -23,7 +23,7 @@ defmodule Explorer.SmartContract.Helper do
   @spec read_with_wallet_method?(%{}) :: true | false
   def read_with_wallet_method?(function),
     do:
-      !error?(function) && !event?(function) && !constructor?(function) && nonpayable?(function) &&
+      !error?(function) && !event?(function) && !constructor?(function) &&
         !empty_outputs?(function)
 
   def empty_outputs?(function), do: is_nil(function["outputs"]) || function["outputs"] == []

--- a/apps/explorer/test/explorer/smart_contract/helper_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/helper_test.exs
@@ -124,4 +124,30 @@ defmodule Explorer.SmartContract.HelperTest do
       refute Helper.nonpayable?(function)
     end
   end
+
+  describe "read_with_wallet_method?" do
+    test "returns payable method with output in the read tab" do
+      function = %{
+        "type" => "function",
+        "stateMutability" => "payable",
+        "outputs" => [%{"type" => "address", "name" => "", "internalType" => "address"}],
+        "name" => "returnaddress",
+        "inputs" => []
+      }
+
+      assert Helper.read_with_wallet_method?(function)
+    end
+
+    test "doesn't return payable method with no output in the read tab" do
+      function = %{
+        "type" => "function",
+        "stateMutability" => "payable",
+        "outputs" => [],
+        "name" => "returnaddress",
+        "inputs" => []
+      }
+
+      refute Helper.read_with_wallet_method?(function)
+    end
+  end
 end

--- a/cspell.json
+++ b/cspell.json
@@ -389,6 +389,7 @@
         "rerequest",
         "reshows",
         "retryable",
+        "returnaddress",
         "reuseaddr",
         "RPC's",
         "RPCs",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9066

## Motivation

Allow payable functions with output to appear in the Read tab of smart-contract.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
