### PR TITLE
Add status in stream_transactions_with_unfetched_created_contract_codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#9075](https://github.com/blockscout/blockscout/pull/9075) - Fix fetching contract codes
+
 ### Chore
 
 <details>

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1988,7 +1988,7 @@ defmodule Explorer.Chain do
       from(t in Transaction,
         where:
           not is_nil(t.block_hash) and not is_nil(t.created_contract_address_hash) and
-            is_nil(t.created_contract_code_indexed_at),
+            is_nil(t.created_contract_code_indexed_at) and t.status == ^1,
         select: ^fields
       )
 

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -98,6 +98,7 @@ defmodule Indexer.Fetcher.ContractCode do
     Logger.debug("fetching created_contract_code for transactions")
 
     entries
+    |> Enum.uniq()
     |> Enum.map(&params/1)
     |> EthereumJSONRPC.fetch_codes(json_rpc_named_arguments)
     |> case do


### PR DESCRIPTION
closes: #8800 

## Changelog

### Bug Fixes
I fixed the bug with `status` in `stream_transactions_with_unfetched_created_contract_codes`.
https://etherscan.io/tx/0x5b60f03db1dde242de1f01a6763ee11addc1a8411e4f4feda99ffc6b862c1149

Contracts that failed to be created should be filtered out.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
