### PR TITLE
Return current exchange rate in api/v2/stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- [#9109](https://github.com/blockscout/blockscout/pull/9109) - Return current exchange rate in api/v2/stats
 - [#9102](https://github.com/blockscout/blockscout/pull/9102) - Fix some log topics for Suave and Polygon Edge
 - [#9075](https://github.com/blockscout/blockscout/pull/9075) - Fix fetching contract codes
 - [#9073](https://github.com/blockscout/blockscout/pull/9073) - Allow payable function with output appear in the Read tab

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -27,7 +27,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
           :standard
       end
 
-    exchange_rate_from_db = Market.get_native_coin_exchange_rate_from_db()
+    exchange_rate_from_db = Market.get_coin_exchange_rate()
 
     transaction_stats = Helper.get_transaction_stats()
 

--- a/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/exchange_rates.ex
@@ -10,6 +10,7 @@ defmodule Explorer.ExchangeRates do
   require Logger
 
   alias Explorer.Chain.Events.Publisher
+  alias Explorer.Market
   alias Explorer.ExchangeRates.{Source, Token}
 
   @interval Application.compile_env(:explorer, __MODULE__)[:cache_period]
@@ -123,8 +124,27 @@ defmodule Explorer.ExchangeRates do
   @spec fetch_rates :: Task.t()
   defp fetch_rates do
     Task.Supervisor.async_nolink(Explorer.MarketTaskSupervisor, fn ->
-      Source.fetch_exchange_rates()
+      case Source.fetch_exchange_rates() do
+        {:ok, tokens} -> {:ok, add_coin_info_from_db(tokens)}
+        err -> err
+      end
     end)
+  end
+
+  defp add_coin_info_from_db(tokens) do
+    case Market.fetch_recent_history() do
+      [today | _the_rest] ->
+        tvl_from_history = Map.get(today, :tvl)
+
+        tokens
+        |> Enum.map(fn
+          %Token{tvl_usd: nil} = token -> %{token | tvl_usd: tvl_from_history}
+          token -> token
+        end)
+
+      _ ->
+        tokens
+    end
   end
 
   defp list_from_store(:ets) do

--- a/apps/explorer/lib/explorer/market/market_history.ex
+++ b/apps/explorer/lib/explorer/market/market_history.ex
@@ -20,7 +20,7 @@ defmodule Explorer.Market.MarketHistory do
    * `:date` - The date in UTC.
    * `:opening_price` - Opening price in USD.
    * `:market_cap` - Market cap in USD.
-   * `:market_cap` - TVL in USD.
+   * `:tvl` - TVL in USD.
   """
   @type t :: %__MODULE__{
           closing_price: Decimal.t() | nil,

--- a/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/exchange_rates_test.exs
@@ -1,5 +1,5 @@
 defmodule Explorer.ExchangeRatesTest do
-  use ExUnit.Case, async: false
+  use Explorer.DataCase
 
   import Mox
 
@@ -7,12 +7,16 @@ defmodule Explorer.ExchangeRatesTest do
   alias Explorer.ExchangeRates
   alias Explorer.ExchangeRates.Token
   alias Explorer.ExchangeRates.Source.TestSource
+  alias Explorer.Market.MarketHistoryCache
 
   @moduletag :capture_log
 
   setup :verify_on_exit!
 
   setup do
+    Supervisor.terminate_child(Explorer.Supervisor, {ConCache, MarketHistoryCache.cache_name()})
+    Supervisor.restart_child(Explorer.Supervisor, {ConCache, MarketHistoryCache.cache_name()})
+
     # Use TestSource mock and ets table for this test set
     source_configuration = Application.get_env(:explorer, Explorer.ExchangeRates.Source)
     rates_configuration = Application.get_env(:explorer, Explorer.ExchangeRates)
@@ -24,6 +28,8 @@ defmodule Explorer.ExchangeRatesTest do
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.ExchangeRates.Source, source_configuration)
       Application.put_env(:explorer, Explorer.ExchangeRates, rates_configuration)
+      Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
     end)
   end
 


### PR DESCRIPTION
## Motivation

![image](https://github.com/blockscout/blockscout/assets/53992153/7f4ee923-29d6-4aba-9cc6-f4144dbfae37)


## Changelog

- In `BlockScoutWeb.API.V2.StatsController` try to use data from `Explorer.ExchangeRates` firstly and only then use `Explorer.Market.get_native_coin_exchange_rate_from_db/0`
- Use tvl data from `MarketHistory` when fetching coin exchange rate, so they are available in `Explorer.ExchangeRates`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
