### PR TITLE
Fix migrators cache updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes
 
+- [#9113](https://github.com/blockscout/blockscout/pull/9113) - Fix migrators cache updating
 - [#9101](https://github.com/blockscout/blockscout/pull/9101) - Fix migration_finished? logic
 - [#9062](https://github.com/blockscout/blockscout/pull/9062) - Fix blockscout-ens integration
 - [#9061](https://github.com/blockscout/blockscout/pull/9061) - Arbitrum allow tx receipt gasUsedForL1 field

--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Migrator.FillingMigration do
       def init(_) do
         case MigrationStatus.get_status(migration_name()) do
           "completed" ->
+            update_cache()
             :ignore
 
           _ ->


### PR DESCRIPTION
## Motivation

First call of migrator's cache would result in `false` even if migration is already finished.

## Changelog

Update cache on migrator init if migration is already finished.