### PR TITLE
EIP-1167 display multiple sources of implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#9125](https://github.com/blockscout/blockscout/pull/9125) - Fix Explorer.Chain.Cache.GasPriceOracle.merge_fees
+- [#9124](https://github.com/blockscout/blockscout/pull/9124) - EIP-1167 display multiple sources of bytecode twin
 - [#9110](https://github.com/blockscout/blockscout/pull/9110) - Improve update_in in gas tracker
 - [#9109](https://github.com/blockscout/blockscout/pull/9109) - Return current exchange rate in api/v2/stats
 - [#9102](https://github.com/blockscout/blockscout/pull/9102) - Fix some log topics for Suave and Polygon Edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - [#9125](https://github.com/blockscout/blockscout/pull/9125) - Fix Explorer.Chain.Cache.GasPriceOracle.merge_fees
-- [#9124](https://github.com/blockscout/blockscout/pull/9124) - EIP-1167 display multiple sources of bytecode twin
+- [#9124](https://github.com/blockscout/blockscout/pull/9124) - EIP-1167 display multiple sources of implementation
 - [#9110](https://github.com/blockscout/blockscout/pull/9110) - Improve update_in in gas tracker
 - [#9109](https://github.com/blockscout/blockscout/pull/9109) - Return current exchange rate in api/v2/stats
 - [#9102](https://github.com/blockscout/blockscout/pull/9102) - Fix some log topics for Suave and Polygon Edge

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_contract_controller.ex
@@ -15,7 +15,7 @@ defmodule BlockScoutWeb.AddressContractController do
       necessity_by_association: %{
         :contracts_creation_internal_transaction => :optional,
         :names => :optional,
-        :smart_contract => :optional,
+        [smart_contract: :smart_contract_additional_sources] => :optional,
         :token => :optional,
         :contracts_creation_transaction => :optional
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -20,7 +20,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   @smart_contract_address_options [
     necessity_by_association: %{
       :contracts_creation_internal_transaction => :optional,
-      :smart_contract => :optional,
+      [smart_contract: :smart_contract_additional_sources] => :optional,
       :contracts_creation_transaction => :optional
     },
     api?: true

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.SmartContractController do
   def index(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action} = params) do
     address_options = [
       necessity_by_association: %{
-        [smart_contract: :smart_contract_additional_sources] => :optional
+        :smart_contract => :optional
       }
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.SmartContractController do
   def index(conn, %{"hash" => address_hash_string, "type" => contract_type, "action" => action} = params) do
     address_options = [
       necessity_by_association: %{
-        :smart_contract => :optional
+        [smart_contract: :smart_contract_additional_sources] => :optional
       }
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/visualize_sol2uml_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/visualize_sol2uml_controller.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.VisualizeSol2umlController do
            # check that contract is verified. partial and twin verification is ok for this case
            false <- is_nil(address.smart_contract) do
         sources =
-          address.smart_contract_additional_sources
+          address.smart_contract.smart_contract_additional_sources
           |> Enum.map(fn additional_source -> {additional_source.file_name, additional_source.contract_source_code} end)
           |> Enum.into(%{})
           |> Map.merge(%{

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_contract/index.html.eex
@@ -2,9 +2,8 @@
 <% minimal_proxy_template = EIP1167.get_implementation_address(@address.hash) %>
 <% metadata_for_verification = minimal_proxy_template || SmartContract.get_address_verified_twin_contract(@address.hash).verified_contract %>
 <% smart_contract_verified = BlockScoutWeb.AddressView.smart_contract_verified?(@address) %>
-<% additional_sources_from_twin = SmartContract.get_address_verified_twin_contract(@address.hash).additional_sources %>
 <% fully_verified = SmartContract.verified_with_full_match?(@address.hash)%>
-<% additional_sources = if smart_contract_verified, do: @address.smart_contract_additional_sources, else: additional_sources_from_twin %>
+<% additional_sources = BlockScoutWeb.API.V2.SmartContractView.additional_sources(@address.smart_contract, smart_contract_verified, minimal_proxy_template, SmartContract.get_address_verified_twin_contract(@address.hash)) %>
 <% visualize_sol2uml_enabled = Explorer.Visualize.Sol2uml.enabled?() %>
 <section class="container">
   <% is_proxy = BlockScoutWeb.AddressView.smart_contract_is_proxy?(@address) %>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/contract_view.ex
@@ -171,7 +171,7 @@ defmodule BlockScoutWeb.API.RPC.ContractView do
 
     additional_sources =
       if AddressView.smart_contract_verified?(address),
-        do: address.smart_contract_additional_sources,
+        do: address.smart_contract.smart_contract_additional_sources,
         else: additional_sources_from_twin
 
     additional_sources_array =

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   alias BlockScoutWeb.{ABIEncodedValueView, AddressContractView, AddressView}
   alias Ecto.Changeset
   alias Explorer.Chain
-  alias Explorer.Chain.{Address, SmartContract}
+  alias Explorer.Chain.{Address, SmartContract, SmartContractAdditionalSource}
   alias Explorer.Chain.SmartContract.Proxy.EIP1167
   alias Explorer.Visualize.Sol2uml
 
@@ -136,14 +136,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   # credo:disable-for-next-line
   def prepare_smart_contract(%Address{smart_contract: %SmartContract{} = smart_contract} = address) do
     minimal_proxy_template = EIP1167.get_implementation_address(address.hash, @api_true)
-    twin = SmartContract.get_address_verified_twin_contract(address.hash, @api_true)
-    metadata_for_verification = minimal_proxy_template || twin.verified_contract
+    bytecode_twin = SmartContract.get_address_verified_twin_contract(address.hash, @api_true)
+    metadata_for_verification = minimal_proxy_template || bytecode_twin.verified_contract
     smart_contract_verified = AddressView.smart_contract_verified?(address)
-    additional_sources_from_twin = twin.additional_sources
     fully_verified = SmartContract.verified_with_full_match?(address.hash, @api_true)
 
     additional_sources =
-      if smart_contract_verified, do: address.smart_contract_additional_sources, else: additional_sources_from_twin
+      additional_sources(smart_contract, smart_contract_verified, minimal_proxy_template, bytecode_twin)
 
     visualize_sol2uml_enabled = Sol2uml.enabled?()
     target_contract = if smart_contract_verified, do: address.smart_contract, else: metadata_for_verification
@@ -190,6 +189,26 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
 
   def prepare_smart_contract(address) do
     bytecode_info(address)
+  end
+
+  @doc """
+  Returns additional sources of the smart-contract or from bytecode twin or from implementation, if it fits minimal proxy pattern (EIP-1167)
+  """
+  @spec additional_sources(SmartContract.t(), boolean, SmartContract.t() | nil, %{
+          :verified_contract => any(),
+          :additional_sources => SmartContractAdditionalSource.t() | nil
+        }) :: [SmartContractAdditionalSource.t()]
+  def additional_sources(smart_contract, smart_contract_verified, minimal_proxy_template, bytecode_twin) do
+    cond do
+      !is_nil(minimal_proxy_template) ->
+        minimal_proxy_template.smart_contract_additional_sources
+
+      smart_contract_verified ->
+        smart_contract.smart_contract_additional_sources
+
+      true ->
+        bytecode_twin.additional_sources
+    end
   end
 
   defp bytecode_info(address) do

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -336,7 +336,7 @@ msgstr ""
 msgid "All functions displayed below are from ABI of that contract. In order to verify current contract, proceed with"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
@@ -688,12 +688,12 @@ msgstr ""
 msgid "Compiler"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:143
+#: lib/block_scout_web/templates/address_contract/index.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Compiler Settings"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:72
+#: lib/block_scout_web/templates/address_contract/index.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Compiler version"
 msgstr ""
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:97
+#: lib/block_scout_web/templates/address_contract/index.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Constructor Arguments"
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:158
+#: lib/block_scout_web/templates/address_contract/index.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Contract ABI"
 msgstr ""
@@ -793,8 +793,8 @@ msgstr ""
 msgid "Contract Creation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:175
-#: lib/block_scout_web/templates/address_contract/index.html.eex:190
+#: lib/block_scout_web/templates/address_contract/index.html.eex:174
+#: lib/block_scout_web/templates/address_contract/index.html.eex:189
 #, elixir-autogen, elixir-format
 msgid "Contract Creation Code"
 msgstr ""
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Contract Name"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:26
+#: lib/block_scout_web/templates/address_contract/index.html.eex:25
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:11
 #, elixir-autogen, elixir-format
 msgid "Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB"
@@ -822,12 +822,12 @@ msgstr ""
 msgid "Contract name or address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:64
+#: lib/block_scout_web/templates/address_contract/index.html.eex:63
 #, elixir-autogen, elixir-format
 msgid "Contract name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:107
+#: lib/block_scout_web/templates/address_contract/index.html.eex:106
 #, elixir-autogen, elixir-format
 msgid "Contract source code"
 msgstr ""
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Contracts"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:181
+#: lib/block_scout_web/templates/address_contract/index.html.eex:180
 #, elixir-autogen, elixir-format
 msgid "Contracts that self destruct in their constructors have no contract code published and cannot be verified."
 msgstr ""
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Contribute"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:160
+#: lib/block_scout_web/templates/address_contract/index.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Copy ABI"
 msgstr ""
@@ -878,7 +878,7 @@ msgstr ""
 msgid "Copy Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:145
+#: lib/block_scout_web/templates/address_contract/index.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Copy Compiler Settings"
 msgstr ""
@@ -889,8 +889,8 @@ msgstr ""
 msgid "Copy Contract Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:177
-#: lib/block_scout_web/templates/address_contract/index.html.eex:193
+#: lib/block_scout_web/templates/address_contract/index.html.eex:176
+#: lib/block_scout_web/templates/address_contract/index.html.eex:192
 #, elixir-autogen, elixir-format
 msgid "Copy Contract Creation Code"
 msgstr ""
@@ -900,8 +900,8 @@ msgstr ""
 msgid "Copy Decompiled Contract Code"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:214
-#: lib/block_scout_web/templates/address_contract/index.html.eex:224
+#: lib/block_scout_web/templates/address_contract/index.html.eex:213
+#: lib/block_scout_web/templates/address_contract/index.html.eex:223
 #, elixir-autogen, elixir-format
 msgid "Copy Deployed ByteCode"
 msgstr ""
@@ -937,8 +937,8 @@ msgstr ""
 msgid "Copy Raw Trace"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:121
-#: lib/block_scout_web/templates/address_contract/index.html.eex:133
+#: lib/block_scout_web/templates/address_contract/index.html.eex:120
+#: lib/block_scout_web/templates/address_contract/index.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Copy Source Code"
 msgstr ""
@@ -1109,8 +1109,8 @@ msgstr ""
 msgid "Delegate Call"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:212
-#: lib/block_scout_web/templates/address_contract/index.html.eex:220
+#: lib/block_scout_web/templates/address_contract/index.html.eex:211
+#: lib/block_scout_web/templates/address_contract/index.html.eex:219
 #, elixir-autogen, elixir-format
 msgid "Deployed ByteCode"
 msgstr ""
@@ -1140,7 +1140,7 @@ msgstr ""
 msgid "Difficulty"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:182
+#: lib/block_scout_web/templates/address_contract/index.html.eex:181
 #, elixir-autogen, elixir-format
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 msgid "ETH RPC API Documentation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:83
+#: lib/block_scout_web/templates/address_contract/index.html.eex:82
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:30
 #: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:22
 #, elixir-autogen, elixir-format
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Export Data"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:249
+#: lib/block_scout_web/templates/address_contract/index.html.eex:248
 #, elixir-autogen, elixir-format
 msgid "External libraries"
 msgstr ""
@@ -2002,12 +2002,12 @@ msgstr ""
 msgid "Optimization"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:68
+#: lib/block_scout_web/templates/address_contract/index.html.eex:67
 #, elixir-autogen, elixir-format
 msgid "Optimization enabled"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:77
+#: lib/block_scout_web/templates/address_contract/index.html.eex:76
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:62
 #: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:54
 #, elixir-autogen, elixir-format
@@ -2776,12 +2776,12 @@ msgstr ""
 msgid "This block has not been processed yet."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:48
+#: lib/block_scout_web/templates/address_contract/index.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "This contract has been partially verified via Sourcify."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:52
+#: lib/block_scout_web/templates/address_contract/index.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "This contract has been verified via Sourcify."
 msgstr ""
@@ -3268,7 +3268,7 @@ msgstr ""
 msgid "Verified Contracts"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:89
+#: lib/block_scout_web/templates/address_contract/index.html.eex:88
 #, elixir-autogen, elixir-format
 msgid "Verified at"
 msgstr ""
@@ -3288,10 +3288,10 @@ msgstr ""
 msgid "Verified contracts, %{subnetwork}, %{coin}"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
-#: lib/block_scout_web/templates/address_contract/index.html.eex:30
-#: lib/block_scout_web/templates/address_contract/index.html.eex:198
-#: lib/block_scout_web/templates/address_contract/index.html.eex:229
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
+#: lib/block_scout_web/templates/address_contract/index.html.eex:29
+#: lib/block_scout_web/templates/address_contract/index.html.eex:197
+#: lib/block_scout_web/templates/address_contract/index.html.eex:228
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Verify & Publish"
@@ -3541,7 +3541,7 @@ msgstr ""
 msgid "balance of the address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "button"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -336,7 +336,7 @@ msgstr ""
 msgid "All functions displayed below are from ABI of that contract. In order to verify current contract, proceed with"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "All metadata displayed below is from that contract. In order to verify current contract, click"
 msgstr ""
@@ -688,12 +688,12 @@ msgstr ""
 msgid "Compiler"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:143
+#: lib/block_scout_web/templates/address_contract/index.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Compiler Settings"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:72
+#: lib/block_scout_web/templates/address_contract/index.html.eex:71
 #, elixir-autogen, elixir-format
 msgid "Compiler version"
 msgstr ""
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Connection Lost, click to load newer validations"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:97
+#: lib/block_scout_web/templates/address_contract/index.html.eex:96
 #, elixir-autogen, elixir-format
 msgid "Constructor Arguments"
 msgstr ""
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Contract"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:158
+#: lib/block_scout_web/templates/address_contract/index.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Contract ABI"
 msgstr ""
@@ -793,8 +793,8 @@ msgstr ""
 msgid "Contract Creation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:175
-#: lib/block_scout_web/templates/address_contract/index.html.eex:190
+#: lib/block_scout_web/templates/address_contract/index.html.eex:174
+#: lib/block_scout_web/templates/address_contract/index.html.eex:189
 #, elixir-autogen, elixir-format
 msgid "Contract Creation Code"
 msgstr ""
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Contract Name"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:26
+#: lib/block_scout_web/templates/address_contract/index.html.eex:25
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:11
 #, elixir-autogen, elixir-format
 msgid "Contract is not verified. However, we found a verified contract with the same bytecode in Blockscout DB"
@@ -822,12 +822,12 @@ msgstr ""
 msgid "Contract name or address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:64
+#: lib/block_scout_web/templates/address_contract/index.html.eex:63
 #, elixir-autogen, elixir-format
 msgid "Contract name:"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:107
+#: lib/block_scout_web/templates/address_contract/index.html.eex:106
 #, elixir-autogen, elixir-format
 msgid "Contract source code"
 msgstr ""
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Contracts"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:181
+#: lib/block_scout_web/templates/address_contract/index.html.eex:180
 #, elixir-autogen, elixir-format
 msgid "Contracts that self destruct in their constructors have no contract code published and cannot be verified."
 msgstr ""
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Contribute"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:160
+#: lib/block_scout_web/templates/address_contract/index.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Copy ABI"
 msgstr ""
@@ -878,7 +878,7 @@ msgstr ""
 msgid "Copy Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:145
+#: lib/block_scout_web/templates/address_contract/index.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Copy Compiler Settings"
 msgstr ""
@@ -889,8 +889,8 @@ msgstr ""
 msgid "Copy Contract Address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:177
-#: lib/block_scout_web/templates/address_contract/index.html.eex:193
+#: lib/block_scout_web/templates/address_contract/index.html.eex:176
+#: lib/block_scout_web/templates/address_contract/index.html.eex:192
 #, elixir-autogen, elixir-format
 msgid "Copy Contract Creation Code"
 msgstr ""
@@ -900,8 +900,8 @@ msgstr ""
 msgid "Copy Decompiled Contract Code"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:214
-#: lib/block_scout_web/templates/address_contract/index.html.eex:224
+#: lib/block_scout_web/templates/address_contract/index.html.eex:213
+#: lib/block_scout_web/templates/address_contract/index.html.eex:223
 #, elixir-autogen, elixir-format
 msgid "Copy Deployed ByteCode"
 msgstr ""
@@ -937,8 +937,8 @@ msgstr ""
 msgid "Copy Raw Trace"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:121
-#: lib/block_scout_web/templates/address_contract/index.html.eex:133
+#: lib/block_scout_web/templates/address_contract/index.html.eex:120
+#: lib/block_scout_web/templates/address_contract/index.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Copy Source Code"
 msgstr ""
@@ -1109,8 +1109,8 @@ msgstr ""
 msgid "Delegate Call"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:212
-#: lib/block_scout_web/templates/address_contract/index.html.eex:220
+#: lib/block_scout_web/templates/address_contract/index.html.eex:211
+#: lib/block_scout_web/templates/address_contract/index.html.eex:219
 #, elixir-autogen, elixir-format
 msgid "Deployed ByteCode"
 msgstr ""
@@ -1140,7 +1140,7 @@ msgstr ""
 msgid "Difficulty"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:182
+#: lib/block_scout_web/templates/address_contract/index.html.eex:181
 #, elixir-autogen, elixir-format
 msgid "Displaying the init data provided of the creating transaction."
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 msgid "ETH RPC API Documentation"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:83
+#: lib/block_scout_web/templates/address_contract/index.html.eex:82
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:30
 #: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:22
 #, elixir-autogen, elixir-format
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Export Data"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:249
+#: lib/block_scout_web/templates/address_contract/index.html.eex:248
 #, elixir-autogen, elixir-format
 msgid "External libraries"
 msgstr ""
@@ -2002,12 +2002,12 @@ msgstr ""
 msgid "Optimization"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:68
+#: lib/block_scout_web/templates/address_contract/index.html.eex:67
 #, elixir-autogen, elixir-format
 msgid "Optimization enabled"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:77
+#: lib/block_scout_web/templates/address_contract/index.html.eex:76
 #: lib/block_scout_web/templates/address_contract_verification_via_flattened_code/new.html.eex:62
 #: lib/block_scout_web/templates/address_contract_verification_via_multi_part_files/new.html.eex:54
 #, elixir-autogen, elixir-format
@@ -2776,12 +2776,12 @@ msgstr ""
 msgid "This block has not been processed yet."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:48
+#: lib/block_scout_web/templates/address_contract/index.html.eex:47
 #, elixir-autogen, elixir-format
 msgid "This contract has been partially verified via Sourcify."
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:52
+#: lib/block_scout_web/templates/address_contract/index.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "This contract has been verified via Sourcify."
 msgstr ""
@@ -3268,7 +3268,7 @@ msgstr ""
 msgid "Verified Contracts"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:89
+#: lib/block_scout_web/templates/address_contract/index.html.eex:88
 #, elixir-autogen, elixir-format
 msgid "Verified at"
 msgstr ""
@@ -3288,10 +3288,10 @@ msgstr ""
 msgid "Verified contracts, %{subnetwork}, %{coin}"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
-#: lib/block_scout_web/templates/address_contract/index.html.eex:30
-#: lib/block_scout_web/templates/address_contract/index.html.eex:198
-#: lib/block_scout_web/templates/address_contract/index.html.eex:229
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
+#: lib/block_scout_web/templates/address_contract/index.html.eex:29
+#: lib/block_scout_web/templates/address_contract/index.html.eex:197
+#: lib/block_scout_web/templates/address_contract/index.html.eex:228
 #: lib/block_scout_web/templates/smart_contract/_functions.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Verify & Publish"
@@ -3541,7 +3541,7 @@ msgstr ""
 msgid "balance of the address"
 msgstr ""
 
-#: lib/block_scout_web/templates/address_contract/index.html.eex:28
+#: lib/block_scout_web/templates/address_contract/index.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "button"
 msgstr ""

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -305,6 +305,115 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
       assert correct_response == response
     end
+
+    test "get smart-contract multiple additional sources from EIP-1167 implementation", %{conn: conn} do
+      implementation_contract =
+        insert(:smart_contract,
+          external_libraries: [],
+          constructor_arguments: "",
+          abi: [
+            %{
+              "type" => "constructor",
+              "inputs" => [
+                %{"type" => "address", "name" => "_proxyStorage"},
+                %{"type" => "address", "name" => "_implementationAddress"}
+              ]
+            },
+            %{
+              "constant" => false,
+              "inputs" => [%{"name" => "x", "type" => "uint256"}],
+              "name" => "set",
+              "outputs" => [],
+              "payable" => false,
+              "stateMutability" => "nonpayable",
+              "type" => "function"
+            },
+            %{
+              "constant" => true,
+              "inputs" => [],
+              "name" => "get",
+              "outputs" => [%{"name" => "", "type" => "uint256"}],
+              "payable" => false,
+              "stateMutability" => "view",
+              "type" => "function"
+            }
+          ]
+        )
+
+      insert(:smart_contract_additional_source,
+        file_name: "test1",
+        contract_source_code: "test2",
+        address_hash: implementation_contract.address_hash
+      )
+
+      insert(:smart_contract_additional_source,
+        file_name: "test3",
+        contract_source_code: "test4",
+        address_hash: implementation_contract.address_hash
+      )
+
+      implementation_contract_address_hash_string =
+        Base.encode16(implementation_contract.address_hash.bytes, case: :lower)
+
+      proxy_tx_input =
+        "0x11b804ab000000000000000000000000" <>
+          implementation_contract_address_hash_string <>
+          "000000000000000000000000000000000000000000000000000000000000006035323031313537360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000284e159163400000000000000000000000034420c13696f4ac650b9fafe915553a1abcd7dd30000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000000000220000000000000000000000000ff5ae9b0a7522736299d797d80b8fc6f31d61100000000000000000000000000ff5ae9b0a7522736299d797d80b8fc6f31d6110000000000000000000000000000000000000000000000000000000000000003e8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034420c13696f4ac650b9fafe915553a1abcd7dd300000000000000000000000000000000000000000000000000000000000000184f7074696d69736d2053756273637269626572204e465473000000000000000000000000000000000000000000000000000000000000000000000000000000054f504e46540000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037697066733a2f2f516d66544e504839765651334b5952346d6b52325a6b757756424266456f5a5554545064395538666931503332752f300000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000c82bbe41f2cf04e3a8efa18f7032bdd7f6d98a81000000000000000000000000efba8a2a82ec1fb1273806174f5e28fbb917cf9500000000000000000000000000000000000000000000000000000000"
+
+      proxy_deployed_bytecode =
+        "0x363d3d373d3d3d363d73" <> implementation_contract_address_hash_string <> "5af43d82803e903d91602b57fd5bf3"
+
+      proxy_address =
+        insert(:contract_address,
+          contract_code: proxy_deployed_bytecode
+        )
+
+      insert(:transaction,
+        created_contract_address_hash: proxy_address.hash,
+        input: proxy_tx_input
+      )
+      |> with_block(status: :ok)
+
+      correct_response = %{
+        "verified_twin_address_hash" => Address.checksum(implementation_contract.address_hash),
+        "is_verified" => false,
+        "is_changed_bytecode" => false,
+        "is_partially_verified" => implementation_contract.partially_verified,
+        "is_fully_verified" => false,
+        "is_verified_via_sourcify" => false,
+        "is_vyper_contract" => implementation_contract.is_vyper_contract,
+        "minimal_proxy_address_hash" => "0x" <> implementation_contract_address_hash_string,
+        "sourcify_repo_url" => nil,
+        "can_be_visualized_via_sol2uml" => false,
+        "name" => implementation_contract && implementation_contract.name,
+        "compiler_version" => implementation_contract.compiler_version,
+        "optimization_enabled" => implementation_contract.optimization,
+        "optimization_runs" => implementation_contract.optimization_runs,
+        "evm_version" => implementation_contract.evm_version,
+        "verified_at" => implementation_contract.inserted_at |> to_string() |> String.replace(" ", "T"),
+        "source_code" => implementation_contract.contract_source_code,
+        "file_path" => implementation_contract.file_path,
+        "additional_sources" => [
+          %{"file_path" => "test1", "source_code" => "test2"},
+          %{"file_path" => "test3", "source_code" => "test4"}
+        ],
+        "compiler_settings" => implementation_contract.compiler_settings,
+        "external_libraries" => [],
+        "constructor_args" => nil,
+        "decoded_constructor_args" => nil,
+        "is_self_destructed" => false,
+        "deployed_bytecode" => proxy_deployed_bytecode,
+        "creation_bytecode" => proxy_tx_input,
+        "abi" => implementation_contract.abi,
+        "is_verified_via_eth_bytecode_db" => implementation_contract.verified_via_eth_bytecode_db,
+        "language" => smart_contract_language(implementation_contract)
+      }
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(proxy_address.hash)}")
+      response = json_response(request, 200)
+
+      assert correct_response == response
+    end
   end
 
   describe "/smart-contracts/{address_hash} <> eth_bytecode_db" do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1232,7 +1232,7 @@ defmodule Explorer.Chain do
       options
       |> Keyword.get(:necessity_by_association, %{})
       |> Map.merge(%{
-        smart_contract_additional_sources: :optional
+        [smart_contract: :smart_contract_additional_sources] => :optional
       })
 
     query =
@@ -1246,6 +1246,7 @@ defmodule Explorer.Chain do
       |> join_associations(necessity_by_association)
       |> with_decompiled_code_flag(hash, query_decompiled_code_flag)
       |> select_repo(options).one()
+      |> Repo.preload(smart_contract: :smart_contract_additional_sources)
 
     address_updated_result =
       case address_result do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1246,7 +1246,6 @@ defmodule Explorer.Chain do
       |> join_associations(necessity_by_association)
       |> with_decompiled_code_flag(hash, query_decompiled_code_flag)
       |> select_repo(options).one()
-      |> Repo.preload(smart_contract: :smart_contract_additional_sources)
 
     address_updated_result =
       case address_result do

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -19,7 +19,6 @@ defmodule Explorer.Chain.Address do
     Hash,
     InternalTransaction,
     SmartContract,
-    SmartContractAdditionalSource,
     Token,
     Transaction,
     Wei,
@@ -77,8 +76,7 @@ defmodule Explorer.Chain.Address do
              :token,
              :contracts_creation_internal_transaction,
              :contracts_creation_transaction,
-             :names,
-             :smart_contract_additional_sources
+             :names
            ]}
 
   @derive {Jason.Encoder,
@@ -89,8 +87,7 @@ defmodule Explorer.Chain.Address do
              :token,
              :contracts_creation_internal_transaction,
              :contracts_creation_transaction,
-             :names,
-             :smart_contract_additional_sources
+             :names
            ]}
 
   @primary_key {:hash, Hash.Address, autogenerate: false}
@@ -125,7 +122,6 @@ defmodule Explorer.Chain.Address do
 
     has_many(:names, Address.Name, foreign_key: :address_hash)
     has_many(:decompiled_smart_contracts, DecompiledSmartContract, foreign_key: :address_hash)
-    has_many(:smart_contract_additional_sources, SmartContractAdditionalSource, foreign_key: :address_hash)
     has_many(:withdrawals, Withdrawal, foreign_key: :address_hash)
 
     timestamps()

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -312,6 +312,11 @@ defmodule Explorer.Chain.SmartContract do
       type: Hash.Address
     )
 
+    has_many(:smart_contract_additional_sources, SmartContractAdditionalSource,
+      references: :address_hash,
+      foreign_key: :address_hash
+    )
+
     timestamps()
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1167 do
   Module for fetching proxy implementation from https://eips.ethereum.org/EIPS/eip-1167 (Minimal Proxy Contract)
   """
 
-  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain
   alias Explorer.Chain.{Address, Hash, SmartContract}
   alias Explorer.Chain.SmartContract.Proxy
 
@@ -62,6 +62,5 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1167 do
     |> SmartContract.get_smart_contract_query()
     |> Chain.join_associations(necessity_by_association)
     |> Chain.select_repo(options).one(timeout: 10_000)
-    |> Repo.preload([:smart_contract_additional_sources])
   end
 end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1167 do
   Module for fetching proxy implementation from https://eips.ethereum.org/EIPS/eip-1167 (Minimal Proxy Contract)
   """
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Address, Hash, SmartContract}
   alias Explorer.Chain.SmartContract.Proxy
 
@@ -54,8 +54,14 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1167 do
   defp implementation_to_smart_contract(nil, _options), do: nil
 
   defp implementation_to_smart_contract(address_hash, options) do
+    necessity_by_association = %{
+      :smart_contract_additional_sources => :optional
+    }
+
     address_hash
     |> SmartContract.get_smart_contract_query()
+    |> Chain.join_associations(necessity_by_association)
     |> Chain.select_repo(options).one(timeout: 10_000)
+    |> Repo.preload([:smart_contract_additional_sources])
   end
 end

--- a/apps/explorer/lib/explorer/chain/smart_contract_additional_sources.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract_additional_sources.ex
@@ -15,11 +15,13 @@ defmodule Explorer.Chain.SmartContractAdditionalSource do
   @typedoc """
   * `file_name` - the name of the Solidity file with contract code (with extension).
   * `contract_source_code` - the Solidity source code from the file with `file_name`.
+  * `address_hash` - foreign key for `smart_contract`.
   """
 
   @type t :: %Explorer.Chain.SmartContractAdditionalSource{
           file_name: String.t(),
-          contract_source_code: String.t()
+          contract_source_code: String.t(),
+          address_hash: Hash.Address.t()
         }
 
   schema "smart_contracts_additional_sources" do

--- a/apps/explorer/lib/explorer/etherscan/contracts.ex
+++ b/apps/explorer/lib/explorer/etherscan/contracts.ex
@@ -26,9 +26,8 @@ defmodule Explorer.Etherscan.Contracts do
         address ->
           address_with_smart_contract =
             Repo.replica().preload(address, [
-              :smart_contract,
-              :decompiled_smart_contracts,
-              :smart_contract_additional_sources
+              [smart_contract: :smart_contract_additional_sources],
+              :decompiled_smart_contracts
             ])
 
           if address_with_smart_contract.smart_contract do

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -581,9 +581,10 @@ defmodule Explorer.Chain.SmartContractTest do
       secondary_sources: secondary_sources,
       changed_sources: changed_sources
     } do
-      sc_before_call = Repo.get_by(Address, hash: address.hash) |> Repo.preload(:smart_contract_additional_sources)
+      sc_before_call =
+        Repo.get_by(Address, hash: address.hash) |> Repo.preload(smart_contract: :smart_contract_additional_sources)
 
-      assert sc_before_call.smart_contract_additional_sources
+      assert sc_before_call.smart_contract.smart_contract_additional_sources
              |> Enum.with_index()
              |> Enum.all?(fn {el, ind} ->
                {:ok, src} = Enum.fetch(secondary_sources, ind)
@@ -595,9 +596,10 @@ defmodule Explorer.Chain.SmartContractTest do
       assert {:ok, %SmartContract{}} =
                SmartContract.update_smart_contract(%{address_hash: address.hash}, [], changed_sources)
 
-      sc_after_call = Repo.get_by(Address, hash: address.hash) |> Repo.preload(:smart_contract_additional_sources)
+      sc_after_call =
+        Repo.get_by(Address, hash: address.hash) |> Repo.preload(smart_contract: :smart_contract_additional_sources)
 
-      assert sc_after_call.smart_contract_additional_sources
+      assert sc_after_call.smart_contract.smart_contract_additional_sources
              |> Enum.with_index()
              |> Enum.all?(fn {el, ind} ->
                {:ok, src} = Enum.fetch(changed_sources, ind)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -3083,7 +3083,7 @@ defmodule Explorer.ChainTest do
           :contracts_creation_internal_transaction,
           :contracts_creation_transaction,
           :token,
-          :smart_contract_additional_sources
+          [smart_contract: :smart_contract_additional_sources]
         ])
 
       options = [

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -38,6 +38,7 @@ defmodule Explorer.Factory do
     Log,
     PendingBlockOperation,
     SmartContract,
+    SmartContractAdditionalSource,
     Token,
     TokenTransfer,
     Token.Instance,
@@ -872,6 +873,10 @@ defmodule Explorer.Factory do
       is_vyper_contract: Enum.random([true, false]),
       verified_via_eth_bytecode_db: Enum.random([true, false])
     }
+  end
+
+  def smart_contract_additional_source_factory do
+    %SmartContractAdditionalSource{}
   end
 
   def unique_smart_contract_factory do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9045

## Motivation

Smart-contract page and API don't return additional source codes of verified bytecode twin.

## Changelog

Return all additional sources of bytecode twin implementation in case of smart-contract follows EIP-1167 pattern.
Chore: bind `smart_contract_additional_sources` to `smart_contracts`. Before the changes it was bound to `address`, which is logically incorrect since `smart_contract_additional_sources` may exist only for verified smart contract - all of verified smart_contracts are in `smart_contracts` table.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
