### PR TITLE
Enhanced unfetched token balances index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#9197](https://github.com/blockscout/blockscout/pull/9197) - Add `MARKET_HISTORY_FETCH_INTERVAL` env
 - [#9196](https://github.com/blockscout/blockscout/pull/9196) - Compatibility with docker-compose 2.24
 - [#9193](https://github.com/blockscout/blockscout/pull/9193) - Equalize elixir stack versions
+- [#9153](https://github.com/blockscout/blockscout/pull/9153) - Enhanced unfetched token balances index
 
 <details>
   <summary>Dependencies version bumps</summary>

--- a/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Repo.Migrations.EnhancedUnfetchedTokenBalancesIndex do
 
   def up do
     execute("""
-      CREATE INDEX unfetched_address_token_balances_index on address_token_balances(token_type)
+      CREATE INDEX unfetched_address_token_balances_index on address_token_balances(id)
       WHERE (
           ((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)
       );

--- a/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
@@ -1,0 +1,18 @@
+defmodule Explorer.Repo.Migrations.EnhancedUnfetchedTokenBalancesIndex do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+      CREATE INDEX unfetched_address_token_balances_index on address_token_balances(token_type)
+      WHERE (
+          ((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)
+      );
+    """)
+  end
+
+  def down do
+    execute("""
+      DROP INDEX unfetched_address_token_balances_index;
+    """)
+  end
+end


### PR DESCRIPTION
## Motivation

Long execution of query for method https://github.com/blockscout/blockscout/blob/502dec051c88e98a3a5beffb5e93be43a2957418/apps/explorer/lib/explorer/chain/address/token_balance.ex#L85

## Changelog

Add parital index with `where` clause exactly as in `unfetched_token_balances/0` function

Execution plan before index installed:
```
eth_goerli_dev=# explain analyze SELECT a0.*
  FROM "address_token_balances" AS a0
 WHERE (((((a0."address_hash" != '\x0000000000000000000000000000000000000000') AND (a0."token_type" = 'ERC-721')) OR (a0."token_type" = 'ERC-20')) OR (a0."token_type" = 'ERC-1155')) AND ((a0."value_fetched_at" IS NULL) OR (a0."value" IS NULL))) LIMIT 100000;
                                                                                                                                      QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1000.00..5839.06 rows=62 width=109) (actual time=0.321..23.322 rows=45 loops=1)
   ->  Gather  (cost=1000.00..5839.06 rows=62 width=109) (actual time=0.320..23.307 rows=45 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Seq Scan on address_token_balances a0  (cost=0.00..4832.86 rows=26 width=109) (actual time=2.138..13.724 rows=15 loops=3)
               Filter: (((value_fetched_at IS NULL) OR (value IS NULL)) AND (((address_hash <> '\x0000000000000000000000000000000000000000'::bytea) AND ((token_type)::text = 'ERC-721'::text)) OR ((token_type)::text = 'ERC-20'::text) OR ((token_type)::text = 'ERC-1155'::text)))
               Rows Removed by Filter: 58099
 Planning Time: 0.303 ms
 Execution Time: 23.357 ms
```

Execution plan after index installed:
```
eth_goerli_dev=# explain analyze SELECT a0.*
  FROM "address_token_balances" AS a0
 WHERE (((((a0."address_hash" != '\x0000000000000000000000000000000000000000') AND (a0."token_type" = 'ERC-721')) OR (a0."token_type" = 'ERC-20')) OR (a0."token_type" = 'ERC-1155')) AND ((a0."value_fetched_at" IS NULL) OR (a0."value" IS NULL))) LIMIT 100000;
                                                                                  QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.14..107.66 rows=62 width=109) (actual time=0.032..0.084 rows=45 loops=1)
   ->  Index Scan using unfetched_address_token_balances_index on address_token_balances a0  (cost=0.14..107.66 rows=62 width=109) (actual time=0.031..0.073 rows=45 loops=1)
 Planning Time: 0.713 ms
 Execution Time: 0.107 ms
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
