### PR TITLE
Allow bypassing avg block time in proxy implementation re-fetch ttl calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#9155](https://github.com/blockscout/blockscout/pull/9155) - Allow bypassing avg block time in proxy implementation re-fetch ttl calculation
 - [#9072](https://github.com/blockscout/blockscout/pull/9072) - Add tracing by block logic for geth
 - [#9056](https://github.com/blockscout/blockscout/pull/9056) - Noves.fi API proxy
 

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -24,11 +24,13 @@ config :explorer, Explorer.Repo.Replica1,
   ownership_timeout: :timer.minutes(1),
   timeout: :timer.seconds(60),
   queue_target: 1000,
-  enable_caching_implementation_data_of_proxy: true,
-  avg_block_time_as_ttl_cached_implementation_data_of_proxy: false,
-  fallback_ttl_cached_implementation_data_of_proxy: :timer.seconds(20),
-  implementation_data_fetching_timeout: :timer.seconds(20),
   log: false
+
+config :explorer, :proxy,
+  caching_implementation_data_enabled: true,
+  implementation_data_ttl_via_avg_block_time: false,
+  fallback_cached_implementation_data_ttl: :timer.seconds(20),
+  implementation_data_fetching_timeout: :timer.seconds(20)
 
 # Configure API database
 config :explorer, Explorer.Repo.Account,

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -15,8 +15,13 @@ defmodule Explorer.Chain.SmartContractTest do
     test "check proxy_contract/1 function" do
       smart_contract = insert(:smart_contract)
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
-      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+        |> Keyword.replace(:implementation_data_fetching_timeout, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       refute smart_contract.implementation_fetched_at
 
@@ -26,7 +31,12 @@ defmodule Explorer.Chain.SmartContractTest do
       verify!(EthereumJSONRPC.Mox)
       assert_implementation_never_fetched(smart_contract.address_hash)
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, 0)
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, 0)
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       get_eip1967_implementation_error_response()
       refute Proxy.proxy_contract?(smart_contract)
@@ -42,10 +52,22 @@ defmodule Explorer.Chain.SmartContractTest do
       verify!(EthereumJSONRPC.Mox)
       assert_implementation_address(smart_contract.address_hash)
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
+
       assert Proxy.proxy_contract?(smart_contract)
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, 0)
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, 0)
+
+      Application.put_env(:explorer, :proxy, proxy)
+
       get_eip1967_implementation_non_zero_address()
       assert Proxy.proxy_contract?(smart_contract)
       verify!(EthereumJSONRPC.Mox)
@@ -59,8 +81,13 @@ defmodule Explorer.Chain.SmartContractTest do
       smart_contract = insert(:smart_contract)
       implementation_smart_contract = insert(:smart_contract, name: "proxy")
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
-      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+        |> Keyword.replace(:implementation_data_fetching_timeout, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       refute smart_contract.implementation_fetched_at
 
@@ -71,7 +98,12 @@ defmodule Explorer.Chain.SmartContractTest do
       assert_implementation_never_fetched(smart_contract.address_hash)
 
       # extract proxy info from db
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, 0)
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, 0)
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       string_implementation_address_hash = to_string(implementation_smart_contract.address_hash)
 
@@ -116,7 +148,12 @@ defmodule Explorer.Chain.SmartContractTest do
 
       contract_1 = SmartContract.address_hash_to_smart_contract(smart_contract.address_hash)
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       assert {^string_implementation_address_hash, "proxy"} =
                SmartContract.get_implementation_address_hash(smart_contract)
@@ -126,7 +163,12 @@ defmodule Explorer.Chain.SmartContractTest do
       assert contract_1.implementation_fetched_at == contract_2.implementation_fetched_at &&
                contract_1.updated_at == contract_2.updated_at
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, 0)
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, 0)
+
+      Application.put_env(:explorer, :proxy, proxy)
       get_eip1967_implementation_zero_addresses()
 
       assert {^string_implementation_address_hash, "proxy"} =
@@ -147,8 +189,13 @@ defmodule Explorer.Chain.SmartContractTest do
       twin = SmartContract.address_hash_to_smart_contract(another_address.hash)
       implementation_smart_contract = insert(:smart_contract, name: "proxy")
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
-      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+        |> Keyword.replace(:implementation_data_fetching_timeout, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       # fetch nil implementation
       get_eip1967_implementation_zero_addresses()
@@ -184,8 +231,13 @@ defmodule Explorer.Chain.SmartContractTest do
 
       implementation_smart_contract = insert(:smart_contract, name: "proxy")
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
-      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+        |> Keyword.replace(:implementation_data_fetching_timeout, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       # fetch nil implementation
       get_eip1967_implementation_zero_addresses()
@@ -231,8 +283,13 @@ defmodule Explorer.Chain.SmartContractTest do
 
       implementation_smart_contract = insert(:smart_contract, name: "proxy")
 
-      Application.put_env(:explorer, :fallback_ttl_cached_implementation_data_of_proxy, :timer.seconds(20))
-      Application.put_env(:explorer, :implementation_data_fetching_timeout, :timer.seconds(20))
+      proxy =
+        :explorer
+        |> Application.get_env(:proxy)
+        |> Keyword.replace(:fallback_cached_implementation_data_ttl, :timer.seconds(20))
+        |> Keyword.replace(:implementation_data_fetching_timeout, :timer.seconds(20))
+
+      Application.put_env(:explorer, :proxy, proxy)
 
       # fetch nil implementation
       get_eip1967_implementation_zero_addresses()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -203,14 +203,17 @@ config :explorer,
       do: Explorer.Chain.Events.DBSender,
       else: Explorer.Chain.Events.SimpleSender
     ),
-  enable_caching_implementation_data_of_proxy: true,
-  avg_block_time_as_ttl_cached_implementation_data_of_proxy: true,
-  fallback_ttl_cached_implementation_data_of_proxy: :timer.seconds(4),
-  implementation_data_fetching_timeout: :timer.seconds(2),
   restricted_list: System.get_env("RESTRICTED_LIST"),
   restricted_list_key: System.get_env("RESTRICTED_LIST_KEY"),
   checksum_function: checksum_function && String.to_atom(checksum_function),
   elasticity_multiplier: ConfigHelper.parse_integer_env_var("EIP_1559_ELASTICITY_MULTIPLIER", 2)
+
+config :explorer, :proxy,
+  caching_implementation_data_enabled: true,
+  implementation_data_ttl_via_avg_block_time:
+    ConfigHelper.parse_bool_env_var("CONTRACT_PROXY_IMPLEMENTATION_TTL_VIA_AVG_BLOCK_TIME", "true"),
+  fallback_cached_implementation_data_ttl: :timer.seconds(4),
+  implementation_data_fetching_timeout: :timer.seconds(2)
 
 config :explorer, Explorer.Chain.Events.Listener,
   enabled:


### PR DESCRIPTION
## Motivation

Allow us to manage whether should we use average block time for implementation re-fetch or not.

## Changelog

A new runtime env variable is introduced:
`CONTRACT_PROXY_IMPLEMENTATION_TTL_VIA_AVG_BLOCK_TIME` - default is true. If false, implementation re-fetch ttl will be set to 0 meaning it will be refetched every time someone opens the contract page.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. https://github.com/blockscout/docs/pull/224
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
