### PR TITLE
Increase shared memory for PostgreSQL containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#9155](https://github.com/blockscout/blockscout/pull/9155) - Allow bypassing avg block time in proxy implementation re-fetch ttl calculation
 - [#9072](https://github.com/blockscout/blockscout/pull/9072) - Add tracing by block logic for geth
 - [#9056](https://github.com/blockscout/blockscout/pull/9056) - Noves.fi API proxy
+- [#9158](https://github.com/blockscout/blockscout/pull/9158) - Increase shared memory for PostgreSQL containers
 
 ### Fixes
 

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -17,6 +17,7 @@ services:
         condition: service_completed_successfully
     image: postgres:14
     user: 2000:2000
+    shm_size: 256m
     restart: always
     container_name: 'db'
     command: postgres -c 'max_connections=200' -c 'client_connection_check_interval=60000'

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -17,6 +17,7 @@ services:
         condition: service_completed_successfully
     image: postgres:14
     user: 2000:2000
+    shm_size: 256m
     restart: always
     container_name: 'stats-postgres'
     command: postgres -c 'max_connections=200'


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

I stumbled upon an issue where the stats data are not stored in the database due to the issue with the shared memory of the PostgreSQL database containers. Database containers report the error similar to the following:
```
FATAL:  could not resize shared memory segment "/PostgreSQL.809456988" to 1048576 bytes: No space left on device
```

This issue was even acknowledged in the official docs of PostgreSQL, [check it out here](https://www.instaclustr.com/blog/postgresql-docker-and-shared-memory/).

The fix for the issue is to specify the size of the shared memory for the database containers, by default the docker assigns 64MB but this is enough in most cases, but it seems that with Blockscout, 64MB is not enough. I propose we set it to 256MB by default which seems to solve the issues on my side.

## Changelog

### Enhancements
Set the shared memory size of the PostgreSQL containers by specifying the `shm_size` property in the docker-compose configs.

### Bug Fixes
Solves the issue where the stats data are not stored in the database. Found this issue from the past https://github.com/blockscout/blockscout/issues/8648, closed by doesn't seem to be fully resolved.

### Incompatible Changes
No incompatible changes

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
