### PR TITLE
Exclude genesis block from average block time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#9158](https://github.com/blockscout/blockscout/pull/9158) - Increase shared memory for PostgreSQL containers
 - [#9155](https://github.com/blockscout/blockscout/pull/9155) - Allow bypassing avg block time in proxy implementation re-fetch ttl calculation
 - [#9148](https://github.com/blockscout/blockscout/pull/9148) - Add `/api/v2/utils/decode-calldata`
 - [#9145](https://github.com/blockscout/blockscout/pull/9145) - Proxy for Account abstraction microservice
@@ -12,7 +13,6 @@
 - [#9072](https://github.com/blockscout/blockscout/pull/9072) - Add tracing by block logic for geth
 - [#9068](https://github.com/blockscout/blockscout/pull/9068) - New RPC API v1 endpoints
 - [#9056](https://github.com/blockscout/blockscout/pull/9056) - Noves.fi API proxy
-- [#9158](https://github.com/blockscout/blockscout/pull/9158) - Increase shared memory for PostgreSQL containers
 
 ### Fixes
 
@@ -20,6 +20,7 @@
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9187](https://github.com/blockscout/blockscout/pull/9187) - Fix Internal Server Error on request for nonexistent token instance
 - [#9178](https://github.com/blockscout/blockscout/pull/9178) - Change internal txs tracer type to opcode for Hardhat node
+- [#9173](https://github.com/blockscout/blockscout/pull/9173) - Exclude genesis block from average block time calculation
 - [#9143](https://github.com/blockscout/blockscout/pull/9143) - Handle nil token_ids in token transfers on render
 - [#9139](https://github.com/blockscout/blockscout/pull/9139) - TokenBalanceOnDemand fixes
 - [#9125](https://github.com/blockscout/blockscout/pull/9125) - Fix Explorer.Chain.Cache.GasPriceOracle.merge_fees

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -131,24 +131,24 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       mining_address =
         insert(:address,
           fetched_coin_balance: 0,
-          fetched_coin_balance_block_number: 102,
+          fetched_coin_balance_block_number: 103,
           inserted_at: Timex.shift(now, minutes: -10)
         )
 
       mining_address_hash = to_string(mining_address.hash)
       # we space these very far apart so that we know it will consider the 0th block stale (it calculates how far
       # back we'd need to go to get 24 hours in the past)
-      Enum.each(0..100, fn i ->
-        insert(:block, number: i, timestamp: Timex.shift(now, hours: -(102 - i) * 25), miner: mining_address)
+      Enum.each(0..101, fn i ->
+        insert(:block, number: i, timestamp: Timex.shift(now, hours: -(103 - i) * 25), miner: mining_address)
       end)
 
-      insert(:block, number: 101, timestamp: Timex.shift(now, hours: -25), miner: mining_address)
+      insert(:block, number: 102, timestamp: Timex.shift(now, hours: -25), miner: mining_address)
       AverageBlockTime.refresh()
 
       address =
         insert(:address,
           fetched_coin_balance: 100,
-          fetched_coin_balance_block_number: 100,
+          fetched_coin_balance_block_number: 101,
           inserted_at: Timex.shift(now, minutes: -5)
         )
 
@@ -158,20 +158,20 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                                                      %{
                                                        id: id,
                                                        method: "eth_getBalance",
-                                                       params: [^mining_address_hash, "0x65"]
+                                                       params: [^mining_address_hash, "0x66"]
                                                      }
                                                    ],
                                                    _options ->
         {:ok, [%{id: id, jsonrpc: "2.0", result: "0x02"}]}
       end)
 
-      res = eth_block_number_fake_response("0x65")
+      res = eth_block_number_fake_response("0x66")
 
       expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn [
                                                      %{
                                                        id: 0,
                                                        method: "eth_getBlockByNumber",
-                                                       params: ["0x65", true]
+                                                       params: ["0x66", true]
                                                      }
                                                    ],
                                                    _ ->
@@ -182,7 +182,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                                                      %{
                                                        id: id,
                                                        method: "eth_getBalance",
-                                                       params: [^address_hash, "0x65"]
+                                                       params: [^address_hash, "0x66"]
                                                      }
                                                    ],
                                                    _options ->
@@ -193,7 +193,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                                                      %{
                                                        id: 0,
                                                        method: "eth_getBlockByNumber",
-                                                       params: ["0x65", true]
+                                                       params: ["0x66", true]
                                                      }
                                                    ],
                                                    _ ->
@@ -229,7 +229,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       assert received_address.hash == address.hash
       assert received_address.fetched_coin_balance == expected_wei
-      assert received_address.fetched_coin_balance_block_number == 101
+      assert received_address.fetched_coin_balance_block_number == 102
     end
   end
 

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -11,6 +11,9 @@ defmodule Explorer.Counters.AverageBlockTime do
   alias Explorer.Repo
   alias Timex.Duration
 
+  @num_of_blocks 100
+  @offset 100
+
   @doc """
   Starts a process to periodically update the counter of the token holders.
   """
@@ -62,10 +65,13 @@ defmodule Explorer.Counters.AverageBlockTime do
   end
 
   defp refresh_timestamps do
+    first_block_from_config = Application.get_env(:indexer, :first_block)
+
     base_query =
       from(block in Block,
-        limit: 100,
-        offset: 100,
+        where: block.number > ^first_block_from_config,
+        limit: ^@num_of_blocks,
+        offset: ^@offset,
         order_by: [desc: block.number],
         select: {block.number, block.timestamp}
       )
@@ -78,12 +84,12 @@ defmodule Explorer.Counters.AverageBlockTime do
         |> where(consensus: true)
       end
 
-    timestamps_row =
+    raw_timestamps =
       timestamps_query
       |> Repo.all()
 
     timestamps =
-      timestamps_row
+      raw_timestamps
       |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &Timex.after?/2)
       |> Enum.map(fn {number, timestamp} ->
         {number, DateTime.to_unix(timestamp, :millisecond)}


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9172

## Motivation

Exclude first block from average block time calculation.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
