### PR TITLE
Equalize elixir stack versions

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -35,7 +35,7 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: "25.2.1"
+  OTP_VERSION: "25.3.2.8"
   ELIXIR_VERSION: "1.14.5"
   ACCOUNT_AUTH0_DOMAIN: "blockscoutcom.us.auth0.com"
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,7 +8,7 @@ on:
         required: true
 
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
 
 jobs:

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -9,7 +9,7 @@ on:
       - '**/README.md'
       - 'docker-compose/*'
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
   RELEASE_VERSION: 6.0.0
 

--- a/.github/workflows/publish-docker-image-for-stability.yml
+++ b/.github/workflows/publish-docker-image-for-stability.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - production-stability
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-docker-image-for-suave.yml
+++ b/.github/workflows/publish-docker-image-for-suave.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - production-suave
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-docker-image-staging-on-demand.yml
+++ b/.github/workflows/publish-docker-image-staging-on-demand.yml
@@ -10,7 +10,7 @@ on:
       - '**/README.md'
       - 'docker-compose/*'
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
   RELEASE_VERSION: 6.0.0
 

--- a/.github/workflows/release-additional.yml
+++ b/.github/workflows/release-additional.yml
@@ -10,7 +10,7 @@ on:
     types: [published]
 
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
     types: [published]
 
 env:
-  OTP_VERSION: '25.2.1'
+  OTP_VERSION: '25.3.2.8'
   ELIXIR_VERSION: '1.14.5'
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.14.5-otp-25
-erlang 25.3.2.6
+erlang 25.3.2.8
 nodejs 18.17.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.14.5-erlang-24.2.2-alpine-3.18.2 AS builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.8-alpine-3.18.4 AS builder
 
 WORKDIR /app
 
@@ -64,7 +64,7 @@ RUN mkdir -p /opt/release \
   && mv _build/${MIX_ENV}/rel/blockscout /opt/release
 
 ##############################################################
-FROM hexpm/elixir:1.14.5-erlang-24.2.2-alpine-3.18.2
+FROM hexpm/elixir:1.14.5-erlang-25.3.2.8-alpine-3.18.4
 
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,3 @@
 # BlockScout Docker Integration
 
-This integration is not production ready, and should be used for local BlockScout deployment only.
-
-For usage instructions and ENV variables, see the [docker integration documentation](https://docs.blockscout.com/for-developers/information-and-settings/docker-integration-local-use-only).
+For usage instructions and ENV variables, see the [docker integration documentation](https://docs.blockscout.com/for-developers/deployment/docker-compose-deployment).


### PR DESCRIPTION
## Changelog

* Equalize elixir stack version across the local builds, ci and docker images. Use Erlang OTP 25.3.2.8 and Elixir 1.14.5 everywhere.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
