### PR TITLE
API v1 allow multiple slashes in the path before "api"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
 - [#9234](https://github.com/blockscout/blockscout/pull/9234) - Add missing filters by non-pending transactions
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
+- [#9195](https://github.com/blockscout/blockscout/pull/9195) - API v1 allow multiple slashes in the path before "api"
 - [#9187](https://github.com/blockscout/blockscout/pull/9187) - Fix Internal Server Error on request for nonexistent token instance
 - [#9178](https://github.com/blockscout/blockscout/pull/9178) - Change internal txs tracer type to opcode for Hardhat node
 - [#9173](https://github.com/blockscout/blockscout/pull/9173) - Exclude genesis block from average block time calculation

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/rpc_translator.ex
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
   end
 
   def call(%Conn{params: %{"module" => module, "action" => action}} = conn, translations) do
-    with {:valid_api_request, true} <- {:valid_api_request, valid_api_request_path(conn)},
+    with {:valid_api_v1_request, true} <- {:valid_api_v1_request, valid_api_v1_request_path(conn)},
          {:ok, {controller, write_actions}} <- translate_module(translations, module),
          {:ok, action} <- translate_action(action),
          true <- action_accessed?(action, write_actions),
@@ -65,7 +65,7 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
       :rate_limit_reached ->
         AccessHelper.handle_rate_limit_deny(conn)
 
-      {:valid_api_request, false} ->
+      {:valid_api_v1_request, false} ->
         conn
         |> put_status(404)
         |> put_view(RPCView)
@@ -132,9 +132,10 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslator do
       {:error, Exception.format(:error, e, __STACKTRACE__)}
   end
 
-  defp valid_api_request_path(conn) do
-    if conn.request_path == "/api" || conn.request_path == "/api/" || conn.request_path == "/api/v1" ||
-         conn.request_path == "/api/v1/" do
+  defp valid_api_v1_request_path(conn) do
+    if String.ends_with?(conn.request_path, "/api") || String.ends_with?(conn.request_path, "/api/") ||
+         String.ends_with?(conn.request_path, "/api/v1") ||
+         String.ends_with?(conn.request_path, "/api/v1/") do
       true
     else
       false

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/rpc_translator_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/rpc_translator_test.exs
@@ -78,5 +78,12 @@ defmodule BlockScoutWeb.API.RPC.RPCTranslatorTest do
       result = RPCTranslator.call(conn, %{"test" => {TestController, []}})
       assert json_response(result, 200) == %{}
     end
+
+    test "allow multiple '/' before api", %{conn: conn} do
+      conn = %Conn{conn | params: %{"module" => "test", "action" => "test_action"}, request_path: "//api"}
+
+      result = RPCTranslator.call(conn, %{"test" => {TestController, []}})
+      assert json_response(result, 200) == %{}
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9194

## Motivation

//api/v1 path is prohibited.

## Changelog

Allow multiple slashes in the path before "api" for api v1 requests in order to make requests like this workable:
```
curl -s "http://localhost:4000//api/v1?module=contract&action=listcontracts&offset=1"
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
