### PR TITLE
Compatibility with docker-compose 2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Chore
 
+- [#9196](https://github.com/blockscout/blockscout/pull/9196) - Compatibility with docker-compose 2.24
 - [#9193](https://github.com/blockscout/blockscout/pull/9193) - Equalize elixir stack versions
 
 <details>

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -26,7 +26,8 @@ services:
         POSTGRES_USER: 'blockscout'
         POSTGRES_PASSWORD: 'ceWb1MeLBEeOIfk65gU8EjF8'
     ports:
-      - 7432:5432
+      - target: 5432
+        published: 7432
     volumes:
       - ./blockscout-db-data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose/services/nginx.yml
+++ b/docker-compose/services/nginx.yml
@@ -12,6 +12,9 @@ services:
       BACK_PROXY_PASS: ${BACK_PROXY_PASS:-http://backend:4000}
       FRONT_PROXY_PASS: ${FRONT_PROXY_PASS:-http://frontend:3000}
     ports:
-      - 80:80
-      - 8080:8080
-      - 8081:8081
+      - target: 80
+        published: 80
+      - target: 8080
+        published: 8080
+      - target: 8081
+        published: 8081

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -26,7 +26,8 @@ services:
         POSTGRES_USER: 'stats'
         POSTGRES_PASSWORD: 'n0uejXPl61ci6ldCuE2gQU5Y'
     ports:
-      - 7433:5432
+      - target: 5432
+        published: 7433
     volumes:
       - ./stats-db-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Motivation

```
% docker-compose version
Docker Compose version 2.24.1

% docker-compose up -d
service ports services.stats-db.ports.[0] is missing a target port
```

## Changelog

Add compatibility with docker-compose v2.24

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
