### PR TITLE
Make Postgres@15 default option

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -410,7 +410,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -470,7 +470,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -541,7 +541,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -609,7 +609,7 @@ jobs:
           - 6379:6379
 
       postgres:
-        image: postgres
+        image: postgres:15
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Chore
 
+- [#9198](https://github.com/blockscout/blockscout/pull/9198) - Make Postgres@15 default option
 - [#9196](https://github.com/blockscout/blockscout/pull/9196) - Compatibility with docker-compose 2.24
 - [#9193](https://github.com/blockscout/blockscout/pull/9193) - Equalize elixir stack versions
 

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db-init:
-    image: postgres:14
+    image: postgres:15
     volumes:
       - ./blockscout-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -15,7 +15,7 @@ services:
     depends_on:
       db-init:
         condition: service_completed_successfully
-    image: postgres:14
+    image: postgres:15
     user: 2000:2000
     shm_size: 256m
     restart: always

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   stats-db-init:
-    image: postgres:14
+    image: postgres:15
     volumes:
       - ./stats-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -15,7 +15,7 @@ services:
     depends_on:
       stats-db-init:
         condition: service_completed_successfully
-    image: postgres:14
+    image: postgres:15
     user: 2000:2000
     shm_size: 256m
     restart: always


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8044

## Motivation

Migrate to Postgres 15.

## Changelog

Make Postgres 15 default option in the CI and docker-compose.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
