### PR TITLE
Add base and priority fee to gas oracle response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#9202](https://github.com/blockscout/blockscout/pull/9202) - Add base and priority fee to gas oracle response
+
 ### Fixes
 
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -53,8 +53,8 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "uncles_hashes" => prepare_uncles(block.uncle_relations),
       # "state_root" => "TODO",
       "rewards" => prepare_rewards(block.rewards, block, single_block?),
-      "gas_target_percentage" => gas_target(block),
-      "gas_used_percentage" => gas_used_percentage(block),
+      "gas_target_percentage" => Block.gas_target(block),
+      "gas_used_percentage" => Block.gas_used_percentage(block),
       "burnt_fees_percentage" => burnt_fees_percentage(burnt_fees, transaction_fees),
       "type" => block |> BlockView.block_type() |> String.downcase(),
       "tx_fees" => transaction_fees,
@@ -84,24 +84,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
     %{"hash" => uncle_relation.uncle_hash}
   end
 
-  def gas_target(block) do
-    if Decimal.compare(block.gas_limit, 0) == :gt do
-      elasticity_multiplier = Application.get_env(:explorer, :elasticity_multiplier)
-      ratio = Decimal.div(block.gas_used, Decimal.div(block.gas_limit, elasticity_multiplier))
-      ratio |> Decimal.sub(1) |> Decimal.mult(100) |> Decimal.to_float()
-    else
-      Decimal.new(0)
-    end
-  end
-
-  def gas_used_percentage(block) do
-    if Decimal.compare(block.gas_limit, 0) == :gt do
-      block.gas_used |> Decimal.div(block.gas_limit) |> Decimal.mult(100) |> Decimal.to_float()
-    else
-      Decimal.new(0)
-    end
-  end
-
   def burnt_fees_percentage(_, %Decimal{coef: 0}), do: nil
 
   def burnt_fees_percentage(burnt_fees, transaction_fees)
@@ -117,18 +99,24 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   def count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
   def count_withdrawals(_), do: nil
 
-  defp chain_type_fields(result, block, single_block?) do
-    case single_block? && Application.get_env(:explorer, :chain_type) do
-      "rsk" ->
-        result
-        |> Map.put("minimum_gas_price", block.minimum_gas_price)
-        |> Map.put("bitcoin_merged_mining_header", block.bitcoin_merged_mining_header)
-        |> Map.put("bitcoin_merged_mining_coinbase_transaction", block.bitcoin_merged_mining_coinbase_transaction)
-        |> Map.put("bitcoin_merged_mining_merkle_proof", block.bitcoin_merged_mining_merkle_proof)
-        |> Map.put("hash_for_merged_mining", block.hash_for_merged_mining)
+  case Application.compile_env(:explorer, :chain_type) do
+    "rsk" ->
+      defp chain_type_fields(result, block, single_block?) do
+        if single_block? do
+          result
+          |> Map.put("minimum_gas_price", block.minimum_gas_price)
+          |> Map.put("bitcoin_merged_mining_header", block.bitcoin_merged_mining_header)
+          |> Map.put("bitcoin_merged_mining_coinbase_transaction", block.bitcoin_merged_mining_coinbase_transaction)
+          |> Map.put("bitcoin_merged_mining_merkle_proof", block.bitcoin_merged_mining_merkle_proof)
+          |> Map.put("hash_for_merged_mining", block.hash_for_merged_mining)
+        else
+          result
+        end
+      end
 
-      _ ->
+    _ ->
+      defp chain_type_fields(result, _block, _single_block?) do
         result
-    end
+      end
   end
 end

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -345,8 +345,8 @@ defmodule Explorer.Chain.Block do
 
 
   """
-  @spec next_block_base_fee :: Decimal.t() | nil
-  def next_block_base_fee do
+  @spec next_block_base_fee_per_gas :: Decimal.t() | nil
+  def next_block_base_fee_per_gas do
     query =
       from(block in Block,
         where: block.consensus == true,
@@ -356,12 +356,12 @@ defmodule Explorer.Chain.Block do
 
     case Repo.one(query) do
       nil -> nil
-      block -> next_block_base_fee(block)
+      block -> next_block_base_fee_per_gas(block)
     end
   end
 
-  @spec next_block_base_fee(t()) :: Decimal.t() | nil
-  def next_block_base_fee(block) do
+  @spec next_block_base_fee_per_gas(t()) :: Decimal.t() | nil
+  def next_block_base_fee_per_gas(block) do
     elasticity_multiplier = Application.get_env(:explorer, :elasticity_multiplier)
     base_fee_max_change_denominator = Application.get_env(:explorer, :base_fee_max_change_denominator)
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -280,7 +280,7 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
 
     {slow_fee, average_fee, fast_fee, base_fee_wei} =
       case nil not in [slow_priority_fee_per_gas, average_priority_fee_per_gas, fast_priority_fee_per_gas] &&
-             Block.next_block_base_fee() do
+             Block.next_block_base_fee_per_gas() do
         %Decimal{} = base_fee ->
           base_fee_wei = base_fee |> Wei.from(:wei)
 

--- a/apps/explorer/test/explorer/chain/block_test.exs
+++ b/apps/explorer/test/explorer/chain/block_test.exs
@@ -101,14 +101,14 @@ defmodule Explorer.Chain.BlockTest do
     end
   end
 
-  describe "next_block_base_fee" do
+  describe "next_block_base_fee_per_gas" do
     test "with no blocks in the database returns nil" do
-      assert Block.next_block_base_fee() == nil
+      assert Block.next_block_base_fee_per_gas() == nil
     end
 
     test "ignores non consensus blocks" do
       insert(:block, consensus: false, base_fee_per_gas: Wei.from(Decimal.new(1), :wei))
-      assert Block.next_block_base_fee() == nil
+      assert Block.next_block_base_fee_per_gas() == nil
     end
 
     test "returns the next block base fee" do
@@ -119,7 +119,7 @@ defmodule Explorer.Chain.BlockTest do
         gas_used: Decimal.new(15_000_000)
       )
 
-      assert Block.next_block_base_fee() == Decimal.new(1000)
+      assert Block.next_block_base_fee_per_gas() == Decimal.new(1000)
 
       insert(:block,
         consensus: true,
@@ -128,7 +128,7 @@ defmodule Explorer.Chain.BlockTest do
         gas_used: Decimal.new(3_000_000)
       )
 
-      assert Block.next_block_base_fee() == Decimal.new(900)
+      assert Block.next_block_base_fee_per_gas() == Decimal.new(900)
 
       insert(:block,
         consensus: true,
@@ -137,7 +137,7 @@ defmodule Explorer.Chain.BlockTest do
         gas_used: Decimal.new(27_000_000)
       )
 
-      assert Block.next_block_base_fee() == Decimal.new(1100)
+      assert Block.next_block_base_fee_per_gas() == Decimal.new(1100)
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/cache/gas_price_oracle_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/gas_price_oracle_test.exs
@@ -1,54 +1,12 @@
 defmodule Explorer.Chain.Cache.GasPriceOracleTest do
   use Explorer.DataCase
 
-  import Mox
-
   alias Explorer.Chain.Cache.GasPriceOracle
+  alias Explorer.Chain.Wei
   alias Explorer.Counters.AverageBlockTime
-
-  @block %{
-    "difficulty" => "0x0",
-    "gasLimit" => "0x0",
-    "gasUsed" => "0x0",
-    "hash" => "0x29c850324e357f3c0c836d79860c5af55f7b651e5d7ee253c1af1b14908af49c",
-    "extraData" => "0x0",
-    "logsBloom" => "0x0",
-    "miner" => "0x0",
-    "number" => "0x1",
-    "parentHash" => "0x0",
-    "receiptsRoot" => "0x0",
-    "size" => "0x0",
-    "sha3Uncles" => "0x0",
-    "stateRoot" => "0x0",
-    "timestamp" => "0x0",
-    "baseFeePerGas" => "0x1DCD6500",
-    "totalDifficulty" => "0x0",
-    "transactions" => [
-      %{
-        "blockHash" => "0x29c850324e357f3c0c836d79860c5af55f7b651e5d7ee253c1af1b14908af49c",
-        "blockNumber" => "0x1",
-        "from" => "0x0",
-        "gas" => "0x0",
-        "gasPrice" => "0x0",
-        "hash" => "0xa2e81bb56b55ba3dab2daf76501b50dfaad240cccb905dbf89d65c7a84a4a48e",
-        "input" => "0x",
-        "nonce" => "0x0",
-        "r" => "0x0",
-        "s" => "0x0",
-        "to" => "0x0",
-        "transactionIndex" => "0x0",
-        "v" => "0x0",
-        "value" => "0x0"
-      }
-    ],
-    "transactionsRoot" => "0x0",
-    "uncles" => []
-  }
 
   describe "get_average_gas_price/4" do
     test "returns nil percentile values if no blocks in the DB" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       assert {{:ok,
                %{
                  slow: nil,
@@ -58,8 +16,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns nil percentile values if blocks are empty in the DB" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       insert(:block)
       insert(:block)
       insert(:block)
@@ -73,8 +29,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns nil percentile values for blocks with failed txs in the DB" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
 
       :transaction
@@ -99,8 +53,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns nil percentile values for transactions with 0 gas price aka 'whitelisted transactions' in the DB" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
       block2 = insert(:block, number: 101, hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729")
 
@@ -137,8 +89,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns the same percentile values if gas price is the same over transactions" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
       block2 = insert(:block, number: 101, hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729")
 
@@ -175,8 +125,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns correct min gas price from the block" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
       block2 = insert(:block, number: 101, hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729")
 
@@ -225,8 +173,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns correct average percentile" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
       block2 = insert(:block, number: 101, hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729")
       block3 = insert(:block, number: 102, hash: "0x659b2a1cc4dd1a5729900cf0c81c471d1c7891b2517bf9466f7fba56ead2fca0")
@@ -274,10 +220,16 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "returns correct gas price for EIP-1559 transactions" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 = insert(:block, number: 100, hash: "0x3e51328bccedee581e8ba35190216a61a5d67fd91ca528f3553142c0c7d18391")
-      block2 = insert(:block, number: 101, hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729")
+
+      block2 =
+        insert(:block,
+          number: 101,
+          hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729",
+          gas_limit: Decimal.new(10_000_000),
+          gas_used: Decimal.new(5_000_000),
+          base_fee_per_gas: Wei.from(Decimal.new(500_000_000), :wei)
+        )
 
       :transaction
       |> insert(
@@ -330,8 +282,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "return gas prices with time if available" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
-
       block1 =
         insert(:block,
           number: 100,
@@ -343,7 +293,10 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
         insert(:block,
           number: 101,
           hash: "0x76c3da57334fffdc66c0d954dce1a910fcff13ec889a13b2d8b0b6e9440ce729",
-          timestamp: ~U[2023-12-12 12:13:00.000000Z]
+          timestamp: ~U[2023-12-12 12:13:00.000000Z],
+          gas_limit: Decimal.new(10_000_000),
+          gas_used: Decimal.new(5_000_000),
+          base_fee_per_gas: Wei.from(Decimal.new(500_000_000), :wei)
         )
 
       :transaction
@@ -405,7 +358,6 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
     end
 
     test "return gas prices with average block time if earliest_processing_start is not available" do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options -> {:ok, [%{id: id, result: @block}]} end)
       old_env = Application.get_env(:explorer, AverageBlockTime)
       Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
       start_supervised!(AverageBlockTime)
@@ -432,7 +384,10 @@ defmodule Explorer.Chain.Cache.GasPriceOracleTest do
         insert(:block,
           number: block_number + 103,
           consensus: true,
-          timestamp: Timex.shift(first_timestamp, seconds: -7)
+          timestamp: Timex.shift(first_timestamp, seconds: -7),
+          gas_limit: Decimal.new(10_000_000),
+          gas_used: Decimal.new(5_000_000),
+          base_fee_per_gas: Wei.from(Decimal.new(500_000_000), :wei)
         )
 
       AverageBlockTime.refresh()

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -206,7 +206,8 @@ config :explorer,
   restricted_list: System.get_env("RESTRICTED_LIST"),
   restricted_list_key: System.get_env("RESTRICTED_LIST_KEY"),
   checksum_function: checksum_function && String.to_atom(checksum_function),
-  elasticity_multiplier: ConfigHelper.parse_integer_env_var("EIP_1559_ELASTICITY_MULTIPLIER", 2)
+  elasticity_multiplier: ConfigHelper.parse_integer_env_var("EIP_1559_ELASTICITY_MULTIPLIER", 2),
+  base_fee_max_change_denominator: ConfigHelper.parse_integer_env_var("EIP_1559_BASE_FEE_MAX_CHANGE_DENOMINATOR", 8)
 
 config :explorer, :proxy,
   caching_implementation_data_enabled: true,


### PR DESCRIPTION
Closes #9201

## Changelog

- Calculate the base fee of the next block by ourselves instead of query the node

- Added `EIP_1559_BASE_FEE_MAX_CHANGE_DENOMINATOR` env variable with default value of 8 to accomplish the task above (https://github.com/blockscout/docs/pull/235)

- Added base and proirity fee 

Response example:
<pre>
{
    "average_block_time": 15030.0,
    "coin_price": null,
    "coin_price_change_percentage": null,
    "gas_price_updated_at": "2024-01-19T21:06:35.462186Z",
    "gas_prices": {
        "average": {
            <b>"base_fee": 23.6,</b>
            "fiat_price": null,
            "price": 23.85,
            <b>"priority_fee": 0.26,</b>
            "time": 15030.0
        },
        "fast": {
            <b>"base_fee": 23.6,</b>
            "fiat_price": null,
            "price": 25.18,
            <b>"priority_fee": 1.59,</b>
            "time": 15030.0
        },
        "slow": {
            <b>"base_fee": 23.6,</b>
            "fiat_price": null,
            "price": 23.64,
            <b>"priority_fee": 0.05,</b>
            "time": 15030.0
        }
    },
    "gas_prices_update_in": 32000,
    "gas_used_today": "0",
    "market_cap": "0",
    "network_utilization_percentage": 33.13972293333333,
    "static_gas_price": null,
    "total_addresses": "177985",
    "total_blocks": "4405",
    "total_gas_used": "0",
    "total_transactions": "300805",
    "transactions_today": "0",
    "tvl": null
}
</pre>

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
