### PR TITLE
Add missing filters by non-pending transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#9261](https://github.com/blockscout/blockscout/pull/9261) - Fix pending transactions sanitizer
 - [#9253](https://github.com/blockscout/blockscout/pull/9253) - Don't fetch first trace for pending transactions
 - [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
+- [#9234](https://github.com/blockscout/blockscout/pull/9234) - Add missing filters by non-pending transactions
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9187](https://github.com/blockscout/blockscout/pull/9187) - Fix Internal Server Error on request for nonexistent token instance
 - [#9178](https://github.com/blockscout/blockscout/pull/9178) - Change internal txs tracer type to opcode for Hardhat node

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -107,6 +107,7 @@ defmodule Explorer.Etherscan do
         from(
           it in InternalTransaction,
           inner_join: transaction in assoc(it, :transaction),
+          where: not is_nil(transaction.block_hash),
           where: it.transaction_hash == ^transaction_hash,
           limit: 10_000,
           select:
@@ -232,6 +233,7 @@ defmodule Explorer.Etherscan do
           from(
             it in InternalTransaction,
             inner_join: transaction in assoc(it, :transaction),
+            where: not is_nil(transaction.block_hash),
             order_by: [{^options.order_by_direction, transaction.block_number}],
             limit: ^options.page_size,
             offset: ^offset(options),


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/9229

## Motivation

After the liquidation of block joins in transaction denormalization PR, there are places left where inner join with blocks was needed not only for select fields from it but for filtering non-pending transactions as well.

## Changelog
Added filters by `block_hash is not null` to places described above