### PR TITLE
Handle input instead of init in create traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#9239](https://github.com/blockscout/blockscout/pull/9239) - Handle new case of `create` trace
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9139](https://github.com/blockscout/blockscout/pull/9139) - TokenBalanceOnDemand fixes
 - [#9125](https://github.com/blockscout/blockscout/pull/9125) - Fix Explorer.Chain.Cache.GasPriceOracle.merge_fees

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace.ex
@@ -237,13 +237,21 @@ defmodule EthereumJSONRPC.Nethermind.Trace do
 
   def elixir_to_params(%{"type" => "create" = type} = elixir) do
     %{
-      "action" => %{"from" => from_address_hash, "gas" => gas, "init" => init, "value" => value},
       "blockNumber" => block_number,
       "index" => index,
       "traceAddress" => trace_address,
       "transactionHash" => transaction_hash,
       "transactionIndex" => transaction_index
     } = elixir
+
+    {from_address_hash, gas, init, value} =
+      case elixir["action"] do
+        %{"from" => from_address_hash, "gas" => gas, "init" => init, "value" => value} ->
+          {from_address_hash, gas, init, value}
+
+        %{"from" => from_address_hash, "gas" => gas, "input" => init, "value" => value} ->
+          {from_address_hash, gas, init, value}
+      end
 
     %{
       block_number: block_number,


### PR DESCRIPTION
## Motivation

```
Task #PID<0.22514.311> started from Indexer.Fetcher.InternalTransaction terminating
** (MatchError) no match of right hand side value: %{"action" => %{"creationMethod" => "create", "from" => "0xb8824435a0355efcff385e194abd8f402477d13c", "gas" => 553865, "input" => "..." <> ..., "to" => "0x6cdac6fbf2dee54e7483d9a6836bf35dfedf8f58", "value" => 348720031979481989120}, "blockNumber" => 32076549, "index" => 0, "result" => %{"address" => "0x6cdac6fbf2dee54e7483d9a6836bf35dfedf8f58", "code" => "0x", "gasUsed" => 488148}, "subtraces" => 15, "traceAddress" => [], "transactionHash" => "0x430cc56b0648dde9605cf578ddd5b80abbc224141e84301f93d270d3eae1140e", "transactionIndex" => 20, "type" => "create"}
    (ethereum_jsonrpc 6.0.0) lib/ethereum_jsonrpc/nethermind/trace.ex:246: EthereumJSONRPC.Nethermind.Trace.elixir_to_params/1
    (elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.14.5) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
    (ethereum_jsonrpc 6.0.0) lib/ethereum_jsonrpc/trace_replay_block_transactions.ex:60: EthereumJSONRPC.TraceReplayBlockTransactions.trace_replay_block_transactions_responses_to_internal_transactions_params/3
    (indexer 6.0.0) lib/indexer/fetcher/internal_transaction.ex:117: Indexer.Fetcher.InternalTransaction.run/2
    (elixir 1.14.5) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (elixir 1.14.5) lib/task/supervised.ex:34: Task.Supervised.reply/4
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Function: &Indexer.BufferedTask.log_run/1
```
## Changelog
- Handle `input` and `init` in `create` traces

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
