### PR TITLE
Fix log decoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9139](https://github.com/blockscout/blockscout/pull/9139) - TokenBalanceOnDemand fixes
 - [#9125](https://github.com/blockscout/blockscout/pull/9125) - Fix Explorer.Chain.Cache.GasPriceOracle.merge_fees

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
@@ -1,0 +1,91 @@
+defmodule BlockScoutWeb.API.V2.TransactionViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  import Mox
+
+  alias BlockScoutWeb.API.V2.TransactionView
+  alias Explorer.Repo
+
+  describe "decode_logs/2" do
+    test "doesn't use decoding candidate event with different 2nd, 3d or 4th topic" do
+      insert(:contract_method,
+        identifier: Base.decode16!("d20a68b2", case: :lower),
+        abi: %{
+          "name" => "OptionSettled",
+          "type" => "event",
+          "inputs" => [
+            %{"name" => "accountId", "type" => "uint256", "indexed" => true, "internalType" => "uint256"},
+            %{"name" => "option", "type" => "address", "indexed" => false, "internalType" => "address"},
+            %{"name" => "subId", "type" => "uint256", "indexed" => false, "internalType" => "uint256"},
+            %{"name" => "amount", "type" => "int256", "indexed" => false, "internalType" => "int256"},
+            %{"name" => "value", "type" => "int256", "indexed" => false, "internalType" => "int256"}
+          ],
+          "anonymous" => false
+        }
+      )
+
+      topic1_bytes = ExKeccak.hash_256("OptionSettled(uint256,address,uint256,int256,int256)")
+      topic1 = "0x" <> Base.encode16(topic1_bytes, case: :lower)
+      log1_topic2 = "0x0000000000000000000000000000000000000000000000000000000000005d19"
+      log2_topic2 = "0x000000000000000000000000000000000000000000000000000000000000634a"
+
+      log1_data =
+        "0x000000000000000000000000aeb81cbe6b19ceeb0dbe0d230cffe35bb40a13a700000000000000000000000000000000000000000000045d964b80006597b700fffffffffffffffffffffffffffffffffffffffffffffffffe55aca2c2f40000ffffffffffffffffffffffffffffffffffffffffffffffe3a8289da3d7a13ef2"
+
+      log2_data =
+        "0x000000000000000000000000aeb81cbe6b19ceeb0dbe0d230cffe35bb40a13a700000000000000000000000000000000000000000000045d964b80006597b700000000000000000000000000000000000000000000000000011227ebced227ae00000000000000000000000000000000000000000000001239fdf180a3d6bd85"
+
+      transaction = insert(:transaction)
+
+      log1 =
+        insert(:log,
+          transaction: transaction,
+          first_topic: topic(topic1),
+          second_topic: topic(log1_topic2),
+          third_topic: nil,
+          fourth_topic: nil,
+          data: log1_data
+        )
+
+      log2 =
+        insert(:log,
+          transaction: transaction,
+          first_topic: topic(topic1),
+          second_topic: topic(log2_topic2),
+          third_topic: nil,
+          fourth_topic: nil,
+          data: log2_data
+        )
+
+      logs = [log1, log2]
+
+      assert [
+               {:ok, "d20a68b2",
+                "OptionSettled(uint256 indexed accountId, address option, uint256 subId, int256 amount, int256 value)",
+                [
+                  {"accountId", "uint256", true, 23833},
+                  {"option", "address", false,
+                   <<174, 184, 28, 190, 107, 25, 206, 235, 13, 190, 13, 35, 12, 255, 227, 91, 180, 10, 19, 167>>},
+                  {"subId", "uint256", false, 20_615_843_020_801_704_441_600},
+                  {"amount", "int256", false, -120_000_000_000_000_000},
+                  {"value", "int256", false, -522_838_470_013_113_778_446}
+                ]},
+               {:ok, "d20a68b2",
+                "OptionSettled(uint256 indexed accountId, address option, uint256 subId, int256 amount, int256 value)",
+                [
+                  {"accountId", "uint256", true, 25418},
+                  {"option", "address", false,
+                   <<174, 184, 28, 190, 107, 25, 206, 235, 13, 190, 13, 35, 12, 255, 227, 91, 180, 10, 19, 167>>},
+                  {"subId", "uint256", false, 20_615_843_020_801_704_441_600},
+                  {"amount", "int256", false, 77_168_037_359_396_782},
+                  {"value", "int256", false, 336_220_154_890_848_484_741}
+                ]}
+             ] = TransactionView.decode_logs(logs, false)
+    end
+  end
+
+  defp topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
+end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -188,11 +188,11 @@ defmodule Explorer.Chain.Log do
     else
       <<method_id::binary-size(4), _rest::binary>> = log.first_topic.bytes
 
-      if Map.has_key?(events_acc, method_id) do
-        {events_acc[method_id], events_acc}
+      if Map.has_key?(events_acc, {method_id, log.second_topic, log.third_topic, log.fourth_topic}) do
+        {events_acc[{method_id, log.second_topic, log.third_topic, log.fourth_topic}], events_acc}
       else
         result = find_method_candidates_from_db(method_id, log, transaction, options, skip_sig_provider?)
-        {result, Map.put(events_acc, method_id, result)}
+        {result, Map.put(events_acc, {method_id, log.second_topic, log.third_topic, log.fourth_topic}, result)}
       end
     end
   end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -187,12 +187,13 @@ defmodule Explorer.Chain.Log do
       {{:error, :could_not_decode}, events_acc}
     else
       <<method_id::binary-size(4), _rest::binary>> = log.first_topic.bytes
+      key = {method_id, log.second_topic, log.third_topic, log.fourth_topic}
 
-      if Map.has_key?(events_acc, {method_id, log.second_topic, log.third_topic, log.fourth_topic}) do
-        {events_acc[{method_id, log.second_topic, log.third_topic, log.fourth_topic}], events_acc}
+      if Map.has_key?(events_acc, key) do
+        {events_acc[key], events_acc}
       else
         result = find_method_candidates_from_db(method_id, log, transaction, options, skip_sig_provider?)
-        {result, Map.put(events_acc, {method_id, log.second_topic, log.third_topic, log.fourth_topic}, result)}
+        {result, Map.put(events_acc, key, result)}
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9247

## Motivation

Wrong decoding of the logs in some circumstances described in the issue above ☝️ .

## Changelog

Change the key of `events_acc` mapping in the `find_method_candidates` function to store also topics. Otherwise, it applies the response from the 1st found event to other events.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
