### PR TITLE
Don't fetch first trace for pending transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixes
 
 - [#9261](https://github.com/blockscout/blockscout/pull/9261) - Fix pending transactions sanitizer
+- [#9253](https://github.com/blockscout/blockscout/pull/9253) - Don't fetch first trace for pending transactions
 - [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9187](https://github.com/blockscout/blockscout/pull/9187) - Fix Internal Server Error on request for nonexistent token instance

--- a/apps/indexer/lib/indexer/fetcher/first_trace_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/first_trace_on_demand.ex
@@ -60,6 +60,9 @@ defmodule Indexer.Fetcher.FirstTraceOnDemand do
   end
 
   @impl true
+  # Don't fetch first trace for pending transactions
+  def handle_cast({:fetch, %{block_hash: nil}}, state), do: {:noreply, state}
+
   def handle_cast({:fetch, transaction}, state) do
     fetch_first_trace(transaction, state)
 


### PR DESCRIPTION
## Motivation

Fetching first trace for pending transaction is meaningless and causes minor bugs.

## Changelog

Check if transaction is pending before fetching its first trace