### PR TITLE
Change to use L2 blocknumber instead of timestamp in withdrawal status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- [#9258](https://github.com/blockscout/blockscout/pull/92492581) - Fix withdrawal status
 - [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
 >>>>>>> d06d4f3cab (Fix log decoding bug (#9241))
 - [#9109](https://github.com/blockscout/blockscout/pull/9109) - Return current exchange rate in api/v2/stats

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1860,7 +1860,7 @@ defmodule Explorer.Chain do
         on: we.withdrawal_hash == w.hash and we.l1_event_type == :WithdrawalFinalized,
         select: %{
           hash: w.hash,
-          l2_timestamp: l2_block.timestamp,
+          l2_block_number: l2_block.number,
           l1_transaction_hash: we.l1_transaction_hash,
           msg_nonce: w.msg_nonce
         }
@@ -1895,16 +1895,16 @@ defmodule Explorer.Chain do
       )
 
     if is_nil(l1_timestamp) do
-      last_root_timestamp =
+      last_root_l2_block_number =
         Repo.replica().one(
           from(root in OptimismOutputRoot,
-            select: root.l1_timestamp,
+            select: root.l2_block_number,
             order_by: [desc: root.l2_output_index],
             limit: 1
           )
         ) || 0
 
-      if w.l2_timestamp > last_root_timestamp do
+      if w.l2_block_number > last_root_l2_block_number do
         {"Waiting for state root", nil}
       else
         {"Ready to prove", nil}


### PR DESCRIPTION
## Motivation
The `l1Timestamp` of `L2OutputOracle`'s `OutputProposed` Event indicates the time when the output was submitted in L1. Comparing this with the timestamp of the L2 block may result in an incorrect comparison.

For example,
when a withdrawal tx occurred 3 minutes ago in block 14 in L2, the most recent output submitted to the L2OutputOracle Contract is 1 minute ago, and the latest block number in L2 is 10, timestamp comparison is meaningless. (This may occur due to gas price, etc.)

before PR, https://github.com/blockscout/blockscout/pull/8702

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
