### PR TITLE
Fix pending transactions sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixes
 
+- [#9261](https://github.com/blockscout/blockscout/pull/9261) - Fix pending transactions sanitizer
 - [#9241](https://github.com/blockscout/blockscout/pull/9241) - Fix log decoding bug
 - [#9229](https://github.com/blockscout/blockscout/pull/9229) - Add missing filter to txlist query
 - [#9187](https://github.com/blockscout/blockscout/pull/9187) - Fix Internal Server Error on request for nonexistent token instance

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -13,7 +13,6 @@ defmodule Indexer.PendingTransactionsSanitizer do
 
   alias Ecto.Changeset
   alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.Hash.Full, as: Hash
   alias Explorer.Chain.Import.Runner.Blocks
   alias Explorer.Chain.Transaction
 
@@ -158,7 +157,6 @@ defmodule Indexer.PendingTransactionsSanitizer do
     if block.consensus do
       Blocks.invalidate_consensus_blocks([block.number])
     else
-      {:ok, hash} = Hash.cast(block.hash)
       tx_info = to_elixir(tx)
 
       changeset =
@@ -168,8 +166,9 @@ defmodule Indexer.PendingTransactionsSanitizer do
         |> Changeset.put_change(:gas_used, tx_info["gasUsed"])
         |> Changeset.put_change(:index, tx_info["transactionIndex"])
         |> Changeset.put_change(:block_number, block.number)
-        |> Changeset.put_change(:block_hash, hash)
+        |> Changeset.put_change(:block_hash, block.hash)
         |> Changeset.put_change(:block_timestamp, block.timestamp)
+        |> Changeset.put_change(:block_consensus, false)
 
       Repo.update(changeset)
 


### PR DESCRIPTION
## Motivation

After transactions denormalization, in case when we fill transaction in `PendingTransactionsSanitizer`, we should also fill `block_timestamp` field.

## Changelog

- Fill `block_timestamp` field in `PendingTransactionsSanitizer` as well
- Filter rpc transactions and token transfers by block consensus