### PR TITLE
Remove redundant subquery in internal transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2820,7 +2820,6 @@ defmodule Explorer.Chain do
     InternalTransaction
     |> for_parent_transaction(hash)
     |> join_associations(necessity_by_association)
-    |> where_transaction_has_multiple_internal_transactions()
     |> InternalTransaction.where_is_different_from_parent_transaction()
     |> InternalTransaction.where_nonpending_block()
     |> page_internal_transaction(paging_options)
@@ -3460,34 +3459,6 @@ defmodule Explorer.Chain do
       query,
       [ctb, t],
       ^condition
-    )
-  end
-
-  @doc """
-  Ensures the following conditions are true:
-
-    * excludes internal transactions of type call with no siblings in the
-      transaction
-    * includes internal transactions of type create, reward, or selfdestruct
-      even when they are alone in the parent transaction
-
-  """
-  @spec where_transaction_has_multiple_internal_transactions(Ecto.Query.t()) :: Ecto.Query.t()
-  def where_transaction_has_multiple_internal_transactions(query) do
-    where(
-      query,
-      [internal_transaction, transaction],
-      internal_transaction.type != ^:call or
-        fragment(
-          """
-          EXISTS (SELECT sibling.*
-          FROM internal_transactions AS sibling
-          WHERE sibling.transaction_hash = ? AND sibling.index != ?
-          )
-          """,
-          transaction.hash,
-          internal_transaction.index
-        )
     )
   end
 

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -132,7 +132,6 @@ defmodule Explorer.Etherscan do
       end
 
     query
-    |> Chain.where_transaction_has_multiple_internal_transactions()
     |> InternalTransaction.where_is_different_from_parent_transaction()
     |> InternalTransaction.where_nonpending_block()
     |> Repo.replica().all()
@@ -260,7 +259,6 @@ defmodule Explorer.Etherscan do
         end
 
       query
-      |> Chain.where_transaction_has_multiple_internal_transactions()
       |> InternalTransaction.where_address_fields_match(address_hash, direction)
       |> InternalTransaction.where_is_different_from_parent_transaction()
       |> where_start_block_match(options)

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -18,7 +18,7 @@ defmodule Explorer.GraphQL do
     Transaction
   }
 
-  alias Explorer.{Chain, Repo}
+  alias Explorer.Repo
 
   @doc """
   Returns a query to fetch transactions with a matching `to_address_hash`,
@@ -67,7 +67,7 @@ defmodule Explorer.GraphQL do
 
     query
     |> InternalTransaction.where_nonpending_block()
-    |> Chain.where_transaction_has_multiple_internal_transactions()
+    |> InternalTransaction.where_is_different_from_parent_transaction()
   end
 
   @doc """

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -745,18 +745,6 @@ defmodule Explorer.EtherscanTest do
 
       assert length(internal_transactions2) == 1
     end
-
-    # Note that `list_internal_transactions/1` relies on
-    # `Chain.where_transaction_has_multiple_transactions/1` to ensure the
-    # following behavior:
-    #
-    # * exclude internal transactions of type call with no siblings in the
-    #   transaction
-    #
-    # * include internal transactions of type create, reward, or suicide
-    #   even when they are alone in the parent transaction
-    #
-    # These two requirements are tested in `Explorer.ChainTest`.
   end
 
   describe "list_internal_transactions/2 with address hash" do
@@ -988,18 +976,6 @@ defmodule Explorer.EtherscanTest do
         assert internal_transaction.block_number in expected_block_numbers
       end
     end
-
-    # Note that `list_internal_transactions/2` relies on
-    # `Chain.where_transaction_has_multiple_transactions/1` to ensure the
-    # following behavior:
-    #
-    # * exclude internal transactions of type call with no siblings in the
-    #   transaction
-    #
-    # * include internal transactions of type create, reward, or suicide
-    #   even when they are alone in the parent transaction
-    #
-    # These two requirements are tested in `Explorer.ChainTest`.
   end
 
   describe "list_token_transfers/2" do

--- a/apps/explorer/test/explorer/graphql_test.exs
+++ b/apps/explorer/test/explorer/graphql_test.exs
@@ -215,18 +215,6 @@ defmodule Explorer.GraphQLTest do
 
       assert index_order == Enum.sort(index_order)
     end
-
-    # Note that `transaction_to_internal_transactions_query/1` relies on
-    # `Explorer.Chain.where_transaction_has_multiple_transactions/1` to ensure the
-    # following behavior:
-    #
-    # * exclude internal transactions of type call with no siblings in the
-    #   transaction
-    #
-    # * include internal transactions of type create, reward, or suicide
-    #   even when they are alone in the parent transaction
-    #
-    # These two requirements are tested in `Explorer.ChainTest`.
   end
 
   describe "get_token_transfer/1" do


### PR DESCRIPTION
## Changelog

### Enhancements
* It seems that functionally, `Chain.where_transaction_has_multiple_internal_transactions/1` has the same purpose as `InternalTransaction.where_is_different_from_parent_transaction/1` and therefore can be removed.


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
