### PR TITLE
Fix read contract bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations
 - [#9315](https://github.com/blockscout/blockscout/pull/9315) - Fix manual uncle reward calculation
+- [#9300](https://github.com/blockscout/blockscout/pull/9300) - Fix read contract bug
 
 ### Chore
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -2084,6 +2084,88 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                "result" => %{"names" => ["bool"], "output" => [%{"type" => "bool", "value" => true}]}
              } == response
     end
+
+    test "query read method 1", %{conn: conn} do
+      abi = [
+        %{
+          "inputs" => [
+            %{
+              "internalType" => "uint256",
+              "name" => "amountIn",
+              "type" => "uint256"
+            },
+            %{
+              "internalType" => "address[]",
+              "name" => "path",
+              "type" => "address[]"
+            }
+          ],
+          "name" => "getAmountsOut",
+          "outputs" => [
+            %{
+              "internalType" => "uint256[]",
+              "name" => "amounts",
+              "type" => "uint256[]"
+            }
+          ],
+          "stateMutability" => "view",
+          "type" => "function"
+        }
+      ]
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [
+             %{
+               id: id,
+               method: "eth_call",
+               params: [
+                 %{
+                   data:
+                     "0xd06ca61f00000000000000000000000000000000000000000000003635c9adc5dea0000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000909fd75ce23a7e61787fe2763652935f921164610000000000000000000000009801eeb848987c0a8d6443912827bd36c288f8fb"
+                 },
+                 _
+               ]
+             }
+           ],
+           _opts ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result:
+                 "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000003635c9adc5dea000000000000000000000000000000000000000000000000000000037240fc3496a65"
+             }
+           ]}
+        end
+      )
+
+      target_contract = insert(:smart_contract, abi: abi)
+
+      request =
+        post(conn, "/api/v2/smart-contracts/#{target_contract.address_hash}/query-read-method", %{
+          "contract_type" => "regular",
+          "args" => [
+            "1000000000000000000000",
+            ["0x909Fd75Ce23a7e61787FE2763652935F92116461", "0x9801eeb848987c0a8d6443912827bd36c288f8fb"]
+          ],
+          "method_id" => "d06ca61f"
+        })
+
+      assert response = json_response(request, 200)
+
+      assert %{
+               "is_error" => false,
+               "result" => %{
+                 "names" => ["amounts"],
+                 "output" => [
+                   %{"type" => "uint256[]", "value" => [1_000_000_000_000_000_000_000, 15_520_773_838_563_941]}
+                 ]
+               }
+             } == response
+    end
   end
 
   describe "/smart-contracts/{address_hash}/methods-read-proxy" do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/encoder.ex
@@ -25,6 +25,10 @@ defmodule EthereumJSONRPC.Encoder do
 
   def encode_function_call(function_selector, args), do: encode_function_call(function_selector, [args])
 
+  defp parse_args(args, {:array, type}) when is_list(args) do
+    Enum.map(args, fn arg -> parse_args(arg, type) end)
+  end
+
   defp parse_args(args, types) when is_list(args) do
     args
     |> Enum.zip(types)


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/9341

## Motivation
```
>>>  curl --request POST \
  --url https://unreal.blockscout.com/api/v2/smart-contracts/0xc4330B6fb035F75107F29bf741B945167f2f5330/query-read-method \
  --header 'accept: application/json' \
  --header 'content-type: application/json' \
  --data '{"args": ["1000000000000000000000",["0x909Fd75Ce23a7e61787FE2763652935F92116461","0x9801eeb848987c0a8d6443912827bd36c288f8fb"]],"method_id": "d06ca61f","contract_type": "regular","from": "0xa8FCe579a11E551635b9c9CB915BEcd873C51254"}' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   703  100   471  100   232   1759    866 --:--:-- --:--:-- --:--:--  2623

{
  "is_error": true,
  "result": {
    "error": "protocol Enumerable not implemented for {:array, :address} of type Tuple. This protocol is implemented for the following type(s): Cldr.Unit.Range, DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Floki.HTMLTree, Flow, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Indexer.BoundQueue, Jason.OrderedObject, List, Map, MapSet, Postgrex.Stream, Range, Stream, Timex.Interval"
  }
} 
```

## Changelog
- Add clause for list arguments in querying contracts

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
