### PR TITLE
Improve marking of failed internal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#9346](https://github.com/blockscout/blockscout/pull/9346) - Process integer balance in genesis.json
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations
 - [#9315](https://github.com/blockscout/blockscout/pull/9315) - Fix manual uncle reward calculation
+- [#9306](https://github.com/blockscout/blockscout/pull/9306) - Improve marking of failed internal transactions
 - [#9305](https://github.com/blockscout/blockscout/pull/9305) - Add effective gas price calculation as fallback
 - [#9300](https://github.com/blockscout/blockscout/pull/9300) - Fix read contract bug
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -342,9 +342,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
       has_failed_parent?(failed_parent_paths, tail, [head | reverse_path_acc])
   end
 
-  defp has_failed_parent?(failed_parent_paths, [], reverse_path_acc) do
-    MapSet.member?(failed_parent_paths, reverse_path_acc)
-  end
+  # don't count itself as a parent
+  defp has_failed_parent?(_failed_parent_paths, [], _reverse_path_acc), do: false
 
   defp handle_unique_key_violation(%{exception: %{postgres: %{code: :unique_violation}}}, block_numbers) do
     BlocksRunner.invalidate_consensus_blocks(block_numbers)

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -254,11 +254,11 @@ defmodule Indexer.Fetcher.InternalTransaction do
   end
 
   defp import_internal_transaction(internal_transactions_params, unique_numbers) do
-    internal_transactions_params_without_failed_creations = remove_failed_creations(internal_transactions_params)
+    internal_transactions_params_marked = mark_failed_transactions(internal_transactions_params)
 
     addresses_params =
       Addresses.extract_addresses(%{
-        internal_transactions: internal_transactions_params_without_failed_creations
+        internal_transactions: internal_transactions_params_marked
       })
 
     address_hash_to_block_number =
@@ -269,11 +269,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
     empty_block_numbers =
       unique_numbers
       |> MapSet.new()
-      |> MapSet.difference(MapSet.new(internal_transactions_params_without_failed_creations, & &1.block_number))
+      |> MapSet.difference(MapSet.new(internal_transactions_params_marked, & &1.block_number))
       |> Enum.map(&%{block_number: &1})
 
-    internal_transactions_and_empty_block_numbers =
-      internal_transactions_params_without_failed_creations ++ empty_block_numbers
+    internal_transactions_and_empty_block_numbers = internal_transactions_params_marked ++ empty_block_numbers
 
     imports =
       Chain.import(%{
@@ -310,32 +309,41 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end
   end
 
-  defp remove_failed_creations(internal_transactions_params) do
+  defp mark_failed_transactions(internal_transactions_params) do
+    # we store reversed trace addresses for more efficient list head-tail decomposition in has_failed_parent?
+    failed_parent_paths =
+      internal_transactions_params
+      |> Enum.filter(& &1[:error])
+      |> Enum.map(&Enum.reverse([&1.transaction_hash | &1.trace_address]))
+      |> MapSet.new()
+
     internal_transactions_params
     |> Enum.map(fn internal_transaction_param ->
-      transaction_index = internal_transaction_param[:transaction_index]
-      block_number = internal_transaction_param[:block_number]
-
-      failed_parent =
-        internal_transactions_params
-        |> Enum.filter(fn internal_transactions_param ->
-          internal_transactions_param[:block_number] == block_number &&
-            internal_transactions_param[:transaction_index] == transaction_index &&
-            internal_transactions_param[:trace_address] == [] && !is_nil(internal_transactions_param[:error])
-        end)
-        |> Enum.at(0)
-
-      if failed_parent do
+      if has_failed_parent?(
+           failed_parent_paths,
+           internal_transaction_param.trace_address,
+           [internal_transaction_param.transaction_hash]
+         ) do
+        # TODO: consider keeping these deleted fields in the reverted transactions
         internal_transaction_param
         |> Map.delete(:created_contract_address_hash)
         |> Map.delete(:created_contract_code)
         |> Map.delete(:gas_used)
         |> Map.delete(:output)
-        |> Map.put(:error, internal_transaction_param[:error] || failed_parent[:error])
+        |> Map.put(:error, internal_transaction_param[:error] || "Parent reverted")
       else
         internal_transaction_param
       end
     end)
+  end
+
+  defp has_failed_parent?(failed_parent_paths, [head | tail], reverse_path_acc) do
+    MapSet.member?(failed_parent_paths, reverse_path_acc) or
+      has_failed_parent?(failed_parent_paths, tail, [head | reverse_path_acc])
+  end
+
+  defp has_failed_parent?(failed_parent_paths, [], reverse_path_acc) do
+    MapSet.member?(failed_parent_paths, reverse_path_acc)
   end
 
   defp handle_unique_key_violation(%{exception: %{postgres: %{code: :unique_violation}}}, block_numbers) do


### PR DESCRIPTION
## Motivation

Current internal transactions fetcher does not correctly handle parent trace failures in some cases.

Consider the following call order: `A => B => C => D`, where call `B => C` reverts. Correct implementation should also mark call `C => D` as failed. Current implementation, however, considered only the status of the top-level call `A => B`, which is not correct. 

Current implementation also has a sub-optimal performance, as `remove_failed_creations` was at least `O(n^2)`, considering single internal transaction batch can contain thousands of transactions from multiple blocks, this can easily start to consume multiple seconds of CPU time.

Simple local benchmark of 1000 transactions containing 20 recursive traces each took current implementation 15 seconds to finish, while the new implementation managed to complete in 0.03 seconds.

Example of incorrectly processed transaction - https://gnosis.blockscout.com/tx/0xc19b5624523023190697b73059e05f61ce4627dc756b4ab74deccd5ec6a4d815?tab=internal (note that incorrect status of create trace lead to the contract_code update, which is also invalid)

## Changelog

### Enhancements
* Optimize `mark_failed_transactions` implementation to `O(n*log(n))` (isn't the most optimal way, but should be already good enough)

### Bug Fixes
* Fix propagation of errors from parent internal transactions

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
