### PR TITLE
Fix manual uncle reward calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations
+- [#9315](https://github.com/blockscout/blockscout/pull/9315) - Fix manual uncle reward calculation
 
 ### Chore
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/block_view.ex
@@ -41,8 +41,7 @@ defmodule BlockScoutWeb.API.RPC.BlockView do
       "uncleInclusionReward" =>
         static_reward
         |> Decimal.mult(Enum.count(uncles))
-        |> Decimal.mult(Decimal.from_float(Block.uncle_reward_coef()))
-        |> Decimal.normalize()
+        |> Decimal.div(Block.uncle_reward_coef())
         |> Decimal.to_string(:normal)
     }
 

--- a/apps/explorer/lib/explorer/chain/wei.ex
+++ b/apps/explorer/lib/explorer/chain/wei.ex
@@ -20,6 +20,7 @@ defmodule Explorer.Chain.Wei do
 
   """
 
+  require Decimal
   alias Explorer.Chain.Wei
 
   defstruct ~w(value)a
@@ -193,6 +194,29 @@ defmodule Explorer.Chain.Wei do
   def mult(%Wei{value: value}, %Decimal{} = multiplier) do
     value
     |> Decimal.mult(multiplier)
+    |> from(:wei)
+  end
+
+  @doc """
+  Divides Wei values by an `t:integer/0` or `t:Decimal.t/0`.
+
+  ## Example
+
+      iex> wei = %Explorer.Chain.Wei{value: Decimal.new(10)}
+      iex> divisor = 5
+      iex> Explorer.Chain.Wei.div(wei, divisor)
+      %Explorer.Chain.Wei{value: Decimal.new(2)}
+  """
+  @spec div(t(), pos_integer() | Decimal.t()) :: t()
+  def div(%Wei{value: value}, divisor) when is_integer(divisor) and divisor > 0 do
+    value
+    |> Decimal.div(divisor)
+    |> from(:wei)
+  end
+
+  def div(%Wei{value: value}, %Decimal{sign: 1} = divisor) do
+    value
+    |> Decimal.div(divisor)
     |> from(:wei)
   end
 

--- a/apps/explorer/test/explorer/chain/block_test.exs
+++ b/apps/explorer/test/explorer/chain/block_test.exs
@@ -95,7 +95,7 @@ defmodule Explorer.Chain.BlockTest do
       block =
         build(:block, number: range.from, uncles: ["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273311"])
 
-      expected_uncle_reward = Wei.mult(reward, Decimal.from_float(1 / 32))
+      expected_uncle_reward = Wei.div(reward, 32)
 
       assert %{uncle_reward: ^expected_uncle_reward} = Block.block_reward_by_parts(block, [])
     end


### PR DESCRIPTION

## Changelog

Take into account the case when there are two uncles in a single block

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
