### PR TITLE
Change index creation to concurrent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ### Chore
 
+- [#9323](https://github.com/blockscout/blockscout/pull/9323) - Change index creation to concurrent
 - [#9322](https://github.com/blockscout/blockscout/pull/9322) - Create repo setup actions
 - [#9303](https://github.com/blockscout/blockscout/pull/9303) - Add workflow for Shibarium
 - [#9233](https://github.com/blockscout/blockscout/pull/9233) - "cataloged" index on tokens table

--- a/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240114181404_enhanced_unfetched_token_balances_index.exs
@@ -1,9 +1,11 @@
 defmodule Explorer.Repo.Migrations.EnhancedUnfetchedTokenBalancesIndex do
   use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def up do
     execute("""
-      CREATE INDEX unfetched_address_token_balances_index on address_token_balances(id)
+      CREATE INDEX CONCURRENTLY unfetched_address_token_balances_index on address_token_balances(id)
       WHERE (
           ((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)
       );

--- a/apps/explorer/priv/repo/migrations/20240123102336_add_tokens_cataloged_index.exs
+++ b/apps/explorer/priv/repo/migrations/20240123102336_add_tokens_cataloged_index.exs
@@ -1,5 +1,7 @@
 defmodule Explorer.Repo.Migrations.AddTokensCatalogedIndex do
   use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def change do
     create(
@@ -7,7 +9,8 @@ defmodule Explorer.Repo.Migrations.AddTokensCatalogedIndex do
         :tokens,
         ~w(cataloged)a,
         name: :uncataloged_tokens,
-        where: ~s|"cataloged" = false|
+        where: ~s|"cataloged" = false|,
+        concurrently: true
       )
     )
   end


### PR DESCRIPTION
## Motivation

Change 2 DB indexes creation introduced in 6.1.0 release to `concurrent` creation.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
