### PR TITLE
Process integer balance in genesis.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#9346](https://github.com/blockscout/blockscout/pull/9346) - Process integer balance in genesis.json
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations
 - [#9315](https://github.com/blockscout/blockscout/pull/9315) - Fix manual uncle reward calculation
 

--- a/apps/explorer/lib/explorer/chain_spec/geth/importer.ex
+++ b/apps/explorer/lib/explorer/chain_spec/geth/importer.ex
@@ -83,6 +83,10 @@ defmodule Explorer.ChainSpec.Geth.Importer do
     |> Enum.to_list()
   end
 
+  defp parse_number(number) when is_integer(number) do
+    number
+  end
+
   defp parse_number("0x" <> hex_number) do
     {number, ""} = Integer.parse(hex_number, 16)
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9345

## Motivation

Integer balances in genesis.json lead to crashing genesis data import.

When, say, balance is indicated like this:
```
"0x...": {
  "balance": 0,
  "code": 
  ...
}
```

## Changelog

Add parsing function clause to parse integer balances.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
