### PR TITLE
Noves.fi: add proxy endpoint for describeTxs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Features
 
-- [#9168](https://github.com/blockscout/blockscout/pull/9168) - Support EIP4844 blobs indexing & API
+- [#9351](https://github.com/blockscout/blockscout/pull/9351) - Noves.fi: add proxy endpoint for describeTxs endpoint
 - [#9202](https://github.com/blockscout/blockscout/pull/9202) - Add base and priority fee to gas oracle response
+- [#9168](https://github.com/blockscout/blockscout/pull/9168) - Support EIP4844 blobs indexing & API
 
 ### Fixes
 

--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -324,6 +324,7 @@ defmodule BlockScoutWeb.ApiRouter do
         get("/transactions/:transaction_hash_param", V2.Proxy.NovesFiController, :transaction)
         get("/transactions/:transaction_hash_param/describe", V2.Proxy.NovesFiController, :describe_transaction)
         get("/addresses/:address_hash_param/transactions", V2.Proxy.NovesFiController, :address_transactions)
+        get("/transactions", V2.Proxy.NovesFiController, :describe_transactions)
       end
 
       scope "/account-abstraction" do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/noves_fi_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/noves_fi_controller.ex
@@ -45,13 +45,28 @@ defmodule BlockScoutWeb.API.V2.Proxy.NovesFiController do
   end
 
   @doc """
-    Function to handle GET requests to `/api/v2/proxy/noves-fi/transactions/:transaction_hash_param/describe` endpoint.
+    Function to handle GET requests to `/api/v2/proxy/noves-fi/transactions/:transaction_hash_param/transactions` endpoint.
   """
   @spec address_transactions(Plug.Conn.t(), map()) :: Plug.Conn.t() | {atom(), any()}
   def address_transactions(conn, %{"address_hash_param" => address_hash_string} = params) do
     with {:ok, _address_hash, _address} <- AddressController.validate_address(address_hash_string, params),
          url = NovesFi.address_txs_url(address_hash_string),
          {response, status} <- NovesFi.noves_fi_api_request(url, conn),
+         {:is_empty_response, false} <- {:is_empty_response, is_nil(response)} do
+      conn
+      |> put_status(status)
+      |> json(response)
+    end
+  end
+
+  @doc """
+    Function to handle GET requests to `/api/v2/proxy/noves-fi/transactions` endpoint.
+  """
+  @spec describe_transactions(Plug.Conn.t(), map()) :: Plug.Conn.t() | {atom(), any()}
+  def describe_transactions(conn, _) do
+    url = NovesFi.describe_txs_url()
+
+    with {response, status} <- NovesFi.noves_fi_api_request(url, conn, :post_transactions),
          {:is_empty_response, false} <- {:is_empty_response, is_nil(response)} do
       conn
       |> put_status(status)

--- a/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
@@ -12,41 +12,43 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
   Proxy request to noves.fi API endpoints
   """
   @spec noves_fi_api_request(String.t(), Plug.Conn.t(), :get | :post_transactions) :: {any(), integer()}
-  def noves_fi_api_request(url, conn, method \\ :get) do
+  def noves_fi_api_request(url, conn, method \\ :get)
+
+  def noves_fi_api_request(url, conn, :post_transactions) do
+    headers = [{"apiKey", api_key()}, {"Content-Type", "application/json"}, {"accept", "text/plain"}]
+
+    hashes =
+      conn.query_params
+      |> Map.get("hashes")
+      |> (&if(is_map(&1),
+            do: Map.values(&1),
+            else: String.split(&1, ",")
+          )).()
+
+    prepared_params =
+      conn.query_params
+      |> Map.drop(["hashes"])
+
+    case HTTPoison.post(url, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout, params: prepared_params) do
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+        {Helper.decode_json(body), status}
+
+      _ ->
+        {nil, 500}
+    end
+  end
+
+  def noves_fi_api_request(url, conn, :get) do
     headers = [{"apiKey", api_key()}]
 
-    if method == :post_transactions do
-      headers = headers ++ [{"Content-Type", "application/json"}, {"accept", "text/plain"}]
+    url_with_params = url <> "?" <> conn.query_string
 
-      hashes =
-        conn.query_params
-        |> Map.get("hashes")
-        |> (&if(is_map(&1),
-              do: Map.values(&1),
-              else: String.split(&1, ",")
-            )).()
+    case HTTPoison.get(url_with_params, headers, recv_timeout: @recv_timeout) do
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+        {Helper.decode_json(body), status}
 
-      prepared_params =
-        conn.query_params
-        |> Map.drop(["hashes"])
-
-      case HTTPoison.post(url, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout, params: prepared_params) do
-        {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
-          {Helper.decode_json(body), status}
-
-        _ ->
-          {nil, 500}
-      end
-    else
-      url_with_params = url <> "?" <> conn.query_string
-
-      case HTTPoison.get(url_with_params, headers, recv_timeout: @recv_timeout) do
-        {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
-          {Helper.decode_json(body), status}
-
-        _ ->
-          {nil, 500}
-      end
+      _ ->
+        {nil, 500}
     end
   end
 

--- a/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
@@ -26,17 +26,11 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
               else: String.split(&1, ",")
             )).()
 
-      prepared_query_string =
+      prepared_params =
         conn.query_params
         |> Map.drop(["hashes"])
-        |> Map.to_list()
-        |> Enum.reduce("", fn {key, value}, query_string ->
-          query_string <> "#{key}=#{value}"
-        end)
 
-      url_with_params = url <> "?" <> prepared_query_string
-
-      case HTTPoison.post(url_with_params, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout) do
+      case HTTPoison.post(url, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout, params: prepared_params) do
         {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
           {Helper.decode_json(body), status}
 

--- a/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
@@ -21,7 +21,10 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
       hashes =
         conn.query_params
         |> Map.get("hashes")
-        |> Map.values()
+        |> (&if(is_map(&1),
+              do: Map.values(&1),
+              else: String.split(&1, ",")
+            )).()
 
       prepared_query_string =
         conn.query_params


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9350

## Motivation

add proxy endpoint for Noves.fi `describeTxs` API endpoint.

## Changelog

Input array of hashes is supported through comma-separated `hashes` list or via `hashes[0]`, ... , `hashes[i]`, ..., `hashes[n]`

Proxy endpoint on Blockscout side:
```
curl -X 'GET' --globoff 'http://localhost:4000/api/v2/proxy/noves-fi/transactions?viewAsAccountAddress=0x2e68e2d2bf87cbc636278bfe30a93a63a4a778b0&hashes[0]=0x0db65a24aaa672821f2737341f93df6a9786f6128c5e57db4bbfd307f64b1848&hashes[1]=0x2fd1facf2d631122befcaa5fe2ef7bfc471cf0fa84d5f17a7111961b9a775b9a'
```

or

```
curl -X 'GET' --globoff 'http://localhost:4000/api/v2/proxy/noves-fi/transactions?viewAsAccountAddress=0x2e68e2d2bf87cbc636278bfe30a93a63a4a778b0&hashes=0x0db65a24aaa672821f2737341f93df6a9786f6128c5e57db4bbfd307f64b1848&,0x2fd1facf2d631122befcaa5fe2ef7bfc471cf0fa84d5f17a7111961b9a775b9a'
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
