### PR TITLE
Exclude preloads of smart-contracts in the lists for user operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#9355](https://github.com/blockscout/blockscout/pull/9355) - Exclude preloads of smart-contracts in the lists for user operations
+
 ### Chore
 
 <details>

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
@@ -152,24 +152,23 @@ defmodule BlockScoutWeb.API.V2.Proxy.AccountAbstractionController do
   end
 
   defp address_info_from_hash_string(address_hash_string, list?) do
-    necessity_by_association_base = %{
-      :names => :optional
-    }
-
     necessity_by_association =
       if list? do
-        necessity_by_association_base
+        []
       else
-        Map.put(necessity_by_association_base, :smart_contract, :optional)
+        [
+          necessity_by_association: %{
+            :names => :optional,
+            :smart_contract => :optional
+          }
+        ]
       end
 
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, address} <-
            Chain.hash_to_address(
              address_hash,
-             [
-               necessity_by_association: necessity_by_association
-             ],
+             necessity_by_association,
              false
            ) do
       Helper.address_with_info(address, address_hash_string)


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/9354

## Motivation

Preloads for the user operations-related lists are heavy and increase the response time of corresponding API endpoints.

## Changelog

Remove preloads for the list endpoints for user operations.
⚠️ this is a temporary solution to speed up user operation lists API endpoints. The drawback is that `is_verified` flag won't be returned.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
