### PR TITLE
Remove ERC-1155 logs params from coin balances params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- [#9356](https://github.com/blockscout/blockscout/pull/9356) - Remove ERC-1155 logs params from coin balances params
 - [#9346](https://github.com/blockscout/blockscout/pull/9346) - Process integer balance in genesis.json
 - [#9317](https://github.com/blockscout/blockscout/pull/9317) - Include null gas price txs in fee calculations
 - [#9315](https://github.com/blockscout/blockscout/pull/9315) - Fix manual uncle reward calculation

--- a/apps/indexer/lib/indexer/transform/address_coin_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances.ex
@@ -32,7 +32,11 @@ defmodule Indexer.Transform.AddressCoinBalances do
   defp reducer({:logs_params, logs_params}, acc) when is_list(logs_params) do
     # a log MUST have address_hash and block_number
     logs_params
-    |> Enum.reject(&(&1.first_topic == TokenTransfer.constant()))
+    |> Enum.reject(
+      &(&1.first_topic == TokenTransfer.constant() or
+          &1.first_topic == TokenTransfer.erc1155_single_transfer_signature() or
+          &1.first_topic == TokenTransfer.erc1155_batch_transfer_signature())
+    )
     |> Enum.into(acc, fn
       %{address_hash: address_hash, block_number: block_number}
       when is_binary(address_hash) and is_integer(block_number) ->


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/8575

## Motivation

We should filter out ERC-1155 token transfers from address coin balances params as well since they also cannot change the balance of native coin.