### PR TITLE
Move missing ranges sanitize to a separate background migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#9396](https://github.com/blockscout/blockscout/pull/9396) - More-Minimal Proxy support
 - [#9379](https://github.com/blockscout/blockscout/pull/9379) - Filter non-traceable transactions for zetachain
 - [#9364](https://github.com/blockscout/blockscout/pull/9364) - Fix using of startblock/endblock in API v1 list endpoints: txlist, txlistinternal, tokentx
+- [#9360](https://github.com/blockscout/blockscout/pull/9360) - Move missing ranges sanitize to a separate background migration
 - [#9351](https://github.com/blockscout/blockscout/pull/9351) - Noves.fi: add proxy endpoint for describeTxs endpoint
 - [#9282](https://github.com/blockscout/blockscout/pull/9282) - Add `license_type` to smart contracts
 - [#9202](https://github.com/blockscout/blockscout/pull/9202) - Add base and priority fee to gas oracle response

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -114,6 +114,7 @@ config :explorer, Explorer.TokenInstanceOwnerAddressMigration.Supervisor, enable
 config :explorer, Explorer.Migrator.TransactionsDenormalization, enabled: true
 config :explorer, Explorer.Migrator.AddressCurrentTokenBalanceTokenType, enabled: true
 config :explorer, Explorer.Migrator.AddressTokenBalanceTokenType, enabled: true
+config :explorer, Explorer.Migrator.SanitizeMissingBlockRanges, enabled: true
 
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: true
 

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -38,6 +38,7 @@ config :explorer, Explorer.TokenInstanceOwnerAddressMigration.Supervisor, enable
 config :explorer, Explorer.Migrator.TransactionsDenormalization, enabled: false
 config :explorer, Explorer.Migrator.AddressCurrentTokenBalanceTokenType, enabled: false
 config :explorer, Explorer.Migrator.AddressTokenBalanceTokenType, enabled: false
+config :explorer, Explorer.Migrator.SanitizeMissingBlockRanges, enabled: false
 
 config :explorer,
   realtime_events_sender: Explorer.Chain.Events.SimpleSender

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -128,7 +128,8 @@ defmodule Explorer.Application do
         configure(Explorer.Chain.Cache.RootstockLockedBTC),
         configure(Explorer.Migrator.TransactionsDenormalization),
         configure(Explorer.Migrator.AddressCurrentTokenBalanceTokenType),
-        configure(Explorer.Migrator.AddressTokenBalanceTokenType)
+        configure(Explorer.Migrator.AddressTokenBalanceTokenType),
+        configure(Explorer.Migrator.SanitizeMissingBlockRanges)
       ]
       |> List.flatten()
 

--- a/apps/explorer/lib/explorer/migrator/sanitize_missing_block_ranges.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_missing_block_ranges.ex
@@ -1,0 +1,34 @@
+defmodule Explorer.Migrator.SanitizeMissingBlockRanges do
+  @moduledoc """
+  Remove invalid missing block ranges (from_number < to_number and intersecting ones)
+  """
+
+  use GenServer, restart: :transient
+
+  alias Explorer.Migrator.MigrationStatus
+  alias Explorer.Utility.MissingBlockRange
+
+  @migration_name "sanitize_missing_ranges"
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    case MigrationStatus.get_status(@migration_name) do
+      "completed" ->
+        :ignore
+
+      _ ->
+        MigrationStatus.set_status(@migration_name, "started")
+        {:ok, %{}, {:continue, :ok}}
+    end
+  end
+
+  def handle_continue(:ok, state) do
+    MissingBlockRange.sanitize_missing_block_ranges()
+    MigrationStatus.set_status(@migration_name, "completed")
+
+    {:stop, :normal, state}
+  end
+end

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -145,7 +145,7 @@ defmodule Explorer.Utility.MissingBlockRange do
     __MODULE__
     |> where([r], r.from_number < r.to_number)
     |> update([r], set: [from_number: r.to_number, to_number: r.from_number])
-    |> Repo.update_all([])
+    |> Repo.update_all([], timeout: :infinity)
 
     {last_range, merged_ranges} = delete_and_merge_ranges()
 
@@ -175,7 +175,7 @@ defmodule Explorer.Utility.MissingBlockRange do
              (r.to_number <= r1.from_number and r.to_number >= r1.to_number)) and r1.id != r.id
       )
       |> select([r, r1], r)
-      |> Repo.delete_all()
+      |> Repo.delete_all(timeout: :infinity)
 
     intersecting_ranges
   end

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -44,8 +44,6 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   end
 
   defp default_init do
-    MissingBlockRange.sanitize_missing_block_ranges()
-
     {min_number, max_number} = get_initial_min_max()
 
     clear_to_bounds(min_number, max_number)


### PR DESCRIPTION
## Motivation

Since missing ranges sanitize should run only once (because it fixes data affected by already fixed bug), it makes sense to move it to a separate process and update its status once it's completed.