### PR TITLE
Fix using of startblock/endblock in API v1 list endpoints: txlist, txlistinternal, tokentx

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1420,12 +1420,12 @@ defmodule BlockScoutWeb.Etherscan do
           "A string representing the order by block number direction. Defaults to descending order. Available values: asc, desc"
       },
       %{
-        key: "start_block",
+        key: "startblock",
         type: "integer",
         description: "A nonnegative integer that represents the starting block number."
       },
       %{
-        key: "end_block",
+        key: "endblock",
         type: "integer",
         description: "A nonnegative integer that represents the ending block number."
       },
@@ -1513,13 +1513,13 @@ defmodule BlockScoutWeb.Etherscan do
           "A string representing the order by block number direction. Defaults to ascending order. Available values: asc, desc. WARNING: Only available if 'address' is provided."
       },
       %{
-        key: "start_block",
+        key: "startblock",
         type: "integer",
         description:
           "A nonnegative integer that represents the starting block number. WARNING: Only available if 'address' is provided."
       },
       %{
-        key: "end_block",
+        key: "endblock",
         type: "integer",
         description:
           "A nonnegative integer that represents the ending block number. WARNING: Only available if 'address' is provided."
@@ -1588,12 +1588,12 @@ defmodule BlockScoutWeb.Etherscan do
           "A string representing the order by block number direction. Defaults to ascending order. Available values: asc, desc"
       },
       %{
-        key: "start_block",
+        key: "startblock",
         type: "integer",
         description: "A nonnegative integer that represents the starting block number."
       },
       %{
-        key: "end_block",
+        key: "endblock",
         type: "integer",
         description: "A nonnegative integer that represents the ending block number."
       },

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -18,8 +18,8 @@ defmodule Explorer.Etherscan do
     order_by_direction: :desc,
     page_number: 1,
     page_size: 10_000,
-    start_block: nil,
-    end_block: nil,
+    startblock: nil,
+    endblock: nil,
     start_timestamp: nil,
     end_timestamp: nil
   }
@@ -640,21 +640,21 @@ defmodule Explorer.Etherscan do
     |> Repo.replica().all()
   end
 
-  defp where_start_block_match(query, %{start_block: nil}), do: query
+  defp where_start_block_match(query, %{startblock: nil}), do: query
 
-  defp where_start_block_match(query, %{start_block: start_block}) do
+  defp where_start_block_match(query, %{startblock: start_block}) do
     where(query, [..., block], block.number >= ^start_block)
   end
 
-  defp where_end_block_match(query, %{end_block: nil}), do: query
+  defp where_end_block_match(query, %{endblock: nil}), do: query
 
-  defp where_end_block_match(query, %{end_block: end_block}) do
+  defp where_end_block_match(query, %{endblock: end_block}) do
     where(query, [..., block], block.number <= ^end_block)
   end
 
-  defp where_start_transaction_block_match(query, %{start_block: nil}), do: query
+  defp where_start_transaction_block_match(query, %{startblock: nil}), do: query
 
-  defp where_start_transaction_block_match(query, %{start_block: start_block} = params) do
+  defp where_start_transaction_block_match(query, %{startblock: start_block} = params) do
     if DenormalizationHelper.denormalization_finished?() do
       where(query, [transaction], transaction.block_number >= ^start_block)
     else
@@ -662,9 +662,9 @@ defmodule Explorer.Etherscan do
     end
   end
 
-  defp where_end_transaction_block_match(query, %{end_block: nil}), do: query
+  defp where_end_transaction_block_match(query, %{endblock: nil}), do: query
 
-  defp where_end_transaction_block_match(query, %{end_block: end_block} = params) do
+  defp where_end_transaction_block_match(query, %{endblock: end_block} = params) do
     if DenormalizationHelper.denormalization_finished?() do
       where(query, [transaction], transaction.block_number <= ^end_block)
     else
@@ -672,15 +672,15 @@ defmodule Explorer.Etherscan do
     end
   end
 
-  defp where_start_block_match_tt(query, %{start_block: nil}), do: query
+  defp where_start_block_match_tt(query, %{startblock: nil}), do: query
 
-  defp where_start_block_match_tt(query, %{start_block: start_block}) do
+  defp where_start_block_match_tt(query, %{startblock: start_block}) do
     where(query, [tt], tt.block_number >= ^start_block)
   end
 
-  defp where_end_block_match_tt(query, %{end_block: nil}), do: query
+  defp where_end_block_match_tt(query, %{endblock: nil}), do: query
 
-  defp where_end_block_match_tt(query, %{end_block: end_block}) do
+  defp where_end_block_match_tt(query, %{endblock: end_block}) do
     where(query, [tt], tt.block_number <= ^end_block)
   end
 

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -294,8 +294,8 @@ defmodule Explorer.EtherscanTest do
       end
 
       options = %{
-        start_block: second_block.number,
-        end_block: third_block.number
+        startblock: second_block.number,
+        endblock: third_block.number
       }
 
       found_transactions = Etherscan.list_transactions(address.hash, options)
@@ -309,7 +309,7 @@ defmodule Explorer.EtherscanTest do
       end
     end
 
-    test "with start_block but no end_block option" do
+    test "with startblock but no endblock option" do
       blocks = [_, _, third_block, fourth_block] = insert_list(4, :block)
       address = insert(:address)
 
@@ -320,7 +320,7 @@ defmodule Explorer.EtherscanTest do
       end
 
       options = %{
-        start_block: third_block.number
+        startblock: third_block.number
       }
 
       found_transactions = Etherscan.list_transactions(address.hash, options)
@@ -334,7 +334,7 @@ defmodule Explorer.EtherscanTest do
       end
     end
 
-    test "with end_block but no start_block option" do
+    test "with end_block but no startblock option" do
       blocks = [first_block, second_block, _, _] = insert_list(4, :block)
       address = insert(:address)
 
@@ -973,8 +973,8 @@ defmodule Explorer.EtherscanTest do
       end
 
       options = %{
-        start_block: second_block.number,
-        end_block: third_block.number
+        startblock: second_block.number,
+        endblock: third_block.number
       }
 
       found_internal_transactions = Etherscan.list_internal_transactions(address.hash, options)
@@ -1365,8 +1365,8 @@ defmodule Explorer.EtherscanTest do
       end
 
       options = %{
-        start_block: second_block.number,
-        end_block: third_block.number
+        startblock: second_block.number,
+        endblock: third_block.number
       }
 
       found_token_transfers = Etherscan.list_token_transfers(address.hash, nil, options)
@@ -1380,7 +1380,7 @@ defmodule Explorer.EtherscanTest do
       end
     end
 
-    test "with start_block but no end_block option" do
+    test "with startblock but no end_block option" do
       blocks = [_, _, third_block, fourth_block] = insert_list(4, :block)
       address = insert(:address)
 
@@ -1398,7 +1398,7 @@ defmodule Explorer.EtherscanTest do
         )
       end
 
-      options = %{start_block: third_block.number}
+      options = %{startblock: third_block.number}
 
       found_token_transfers = Etherscan.list_token_transfers(address.hash, nil, options)
 
@@ -1411,7 +1411,7 @@ defmodule Explorer.EtherscanTest do
       end
     end
 
-    test "with end_block but no start_block option" do
+    test "with end_block but no startblock option" do
       blocks = [first_block, second_block, _, _] = insert_list(4, :block)
       address = insert(:address)
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9321

## Motivation

`startblock`/`endblock` fillters don't work. 

## Changelog

Change logic to use `startblock`/`endblock` filters instead of `start_block`/`end_block`.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
