### PR TITLE
Filter out Vyper contracts in Solidityscan API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixes
 
+- [#9387](https://github.com/blockscout/blockscout/pull/9387) - Filter out Vyper contracts in Solidityscan API endpoint
 - [#9377](https://github.com/blockscout/blockscout/pull/9377) - Speed up account abstraction proxy
 - [#9371](https://github.com/blockscout/blockscout/pull/9371) - Filter empty values before token update
 - [#9356](https://github.com/blockscout/blockscout/pull/9356) - Remove ERC-1155 logs params from coin balances params

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -27,6 +27,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   @wrong_api_key "Wrong API key"
   @address_not_found "Address not found"
   @address_is_not_smart_contract "Address is not smart-contract"
+  @vyper_smart_contract_is_not_supported "Vyper smart-contracts are not supported by SolidityScan"
   @empty_response "Empty response"
   @tx_interpreter_service_disabled "Transaction Interpretation Service is not enabled"
   @disabled "API endpoint is disabled"
@@ -259,6 +260,13 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> put_status(:not_found)
     |> put_view(ApiView)
     |> render(:message, %{message: @address_is_not_smart_contract})
+  end
+
+  def call(conn, {:is_vyper_contract, result}) when result == true do
+    conn
+    |> put_status(:not_found)
+    |> put_view(ApiView)
+    |> render(:message, %{message: @vyper_smart_contract_is_not_supported})
   end
 
   def call(conn, {:is_empty_response, true}) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9380

## Motivation

Filter out Vyper contracts in Solidityscan API endpoint.


## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
