### PR TITLE
Output user address as an object in API v2 for Shibarium

### DIFF
--- a/.github/workflows/publish-docker-image-for-shibarium.yml
+++ b/.github/workflows/publish-docker-image-for-shibarium.yml
@@ -1,0 +1,43 @@
+name: Stability Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - production-shibarium
+env:
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      DOCKER_CHAIN_NAME: shibarium
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo-and-short-sha
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-${{ env.DOCKER_CHAIN_NAME }}:${{ env.RELEASE_VERSION }}-postrelease-${{ env.SHORT_SHA }}
+          build-args: |
+            CACHE_EXCHANGE_RATES_PERIOD=
+            API_V1_READ_METHODS_DISABLED=false
+            DISABLE_WEBAPP=false
+            API_V1_WRITE_METHODS_DISABLED=false
+            CACHE_TOTAL_GAS_USAGE_COUNTER_ENABLED=
+            ADMIN_PANEL_ENABLED=false
+            CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=shibarium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Chore
 
 - [#9393](https://github.com/blockscout/blockscout/pull/9393) - Bump actions/cache to v4
+- [#9389](https://github.com/blockscout/blockscout/pull/9389) - Output user address as an object in API v2 for Shibarium
 - [#9361](https://github.com/blockscout/blockscout/pull/9361) - Define BRIDGED_TOKENS_ENABLED env in Dockerfile
 - [#8851](https://github.com/blockscout/blockscout/pull/8851) - Fix dialyzer and add TypedEctoSchema
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
@@ -57,6 +57,7 @@ defmodule BlockScoutWeb.API.V2.ShibariumView do
     items
     |> Enum.map(& &1.user)
     |> Enum.reject(&is_nil(&1))
+    |> Enum.uniq()
     |> Chain.hashes_to_addresses(
       necessity_by_association: %{:names => :optional, :smart_contract => :optional},
       api?: true

--- a/apps/indexer/lib/indexer/fetcher/shibarium/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/helper.ex
@@ -96,7 +96,7 @@ defmodule Indexer.Fetcher.Shibarium.Helper do
         updated_count
       rescue
         error in Postgrex.Error ->
-          # if this is unique violation, we just ignode such an operation as it was inserted before
+          # if this is unique violation, we just ignore such an operation as it was inserted before
           if error.postgres.code != :unique_violation do
             reraise error, __STACKTRACE__
           end

--- a/apps/indexer/lib/indexer/fetcher/shibarium/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/helper.ex
@@ -76,22 +76,34 @@ defmodule Indexer.Fetcher.Shibarium.Helper do
     ShibariumCounter.withdrawals_count_save(Reader.withdrawals_count())
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp bind_existing_operation_in_db(op, calling_module) do
     {query, set} = make_query_for_bind(op, calling_module)
 
-    {updated_count, _} =
-      Repo.update_all(
-        from(b in Bridge,
-          join: s in subquery(query),
-          on:
-            b.operation_hash == s.operation_hash and b.l1_transaction_hash == s.l1_transaction_hash and
-              b.l2_transaction_hash == s.l2_transaction_hash
-        ),
-        set: set
-      )
+    updated_count =
+      try do
+        {updated_count, _} =
+          Repo.update_all(
+            from(b in Bridge,
+              join: s in subquery(query),
+              on:
+                b.operation_hash == s.operation_hash and b.l1_transaction_hash == s.l1_transaction_hash and
+                  b.l2_transaction_hash == s.l2_transaction_hash
+            ),
+            set: set
+          )
+
+        updated_count
+      rescue
+        error in Postgrex.Error ->
+          # if this is unique violation, we just ignode such an operation as it was inserted before
+          if error.postgres.code != :unique_violation do
+            reraise error, __STACKTRACE__
+          end
+      end
 
     # increment the cached count of complete rows
-    case updated_count > 0 && op.operation_type do
+    case !is_nil(updated_count) && updated_count > 0 && op.operation_type do
       :deposit -> ShibariumCounter.deposits_count_save(updated_count, true)
       :withdrawal -> ShibariumCounter.withdrawals_count_save(updated_count, true)
       false -> nil

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
@@ -27,6 +27,7 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
   alias Explorer.{Chain, Repo}
   alias Indexer.Fetcher.RollupL1ReorgMonitor
   alias Indexer.Helper
+  alias Indexer.Transform.Addresses
 
   @block_check_interval_range_size 100
   @eth_get_logs_range_size 1000
@@ -257,9 +258,17 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
             )
             |> prepare_operations(json_rpc_named_arguments)
 
+          insert_items = prepare_insert_items(operations, __MODULE__)
+
+          addresses =
+            Addresses.extract_addresses(%{
+              shibarium_bridge_operations: insert_items
+            })
+
           {:ok, _} =
             Chain.import(%{
-              shibarium_bridge_operations: %{params: prepare_insert_items(operations, __MODULE__)},
+              addresses: %{params: addresses, on_conflict: :nothing},
+              shibarium_bridge_operations: %{params: insert_items},
               timeout: :infinity
             })
 

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l2.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l2.ex
@@ -29,6 +29,7 @@ defmodule Indexer.Fetcher.Shibarium.L2 do
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Shibarium.Bridge
   alias Indexer.Helper
+  alias Indexer.Transform.Addresses
 
   @eth_get_logs_range_size 100
   @fetcher_name :shibarium_bridge_l2
@@ -180,9 +181,17 @@ defmodule Indexer.Fetcher.Shibarium.L2 do
         |> get_logs_all(child_chain, bone_withdraw, json_rpc_named_arguments)
         |> prepare_operations(weth)
 
+      insert_items = prepare_insert_items(operations, __MODULE__)
+
+      addresses =
+        Addresses.extract_addresses(%{
+          shibarium_bridge_operations: insert_items
+        })
+
       {:ok, _} =
         Chain.import(%{
-          shibarium_bridge_operations: %{params: prepare_insert_items(operations, __MODULE__)},
+          addresses: %{params: addresses, on_conflict: :nothing},
+          shibarium_bridge_operations: %{params: insert_items},
           timeout: :infinity
         })
 


### PR DESCRIPTION
## Motivation

Current implementation of API v2 JSON output for Shibarium returns the `user` address field as a raw byte sequence. This PR extends this field to JSON object with extra data about the user address as it's implemented for other API v2 entities.

This change assumes that the `User` link on Deposits and Withdrawals UI pages must refer to L2 address page.

If the JSON object cannot be constructed on backend side, the `user` field will be a byte sequence (as a fallback solution).

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
