### PR TITLE
Proper handling of empty transactions list in etc_getBlockByNumber

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/zksync/discovery/batches_data.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/discovery/batches_data.ex
@@ -393,7 +393,7 @@ defmodule Indexer.Fetcher.ZkSync.Discovery.BatchesData do
       l2_txs =
         case Map.get(resp.result, "transactions") do
           nil ->
-            []
+            l2_txs
 
           new_txs ->
             Enum.reduce(new_txs, l2_txs, fn l2_tx_hash, l2_txs ->


### PR DESCRIPTION
## Motivation

I have discovered a logic issue of collecting rollup transactions from the response of `eth_getBlockByNumber` if the transactions list is empty.

## Changelog

The code without fix returns `[]` if the transactions list in the current response of `eth_getBlockByNumber` is empty. But it is not correct since if any transactions have been already collected by handling the previous responses they will be cleared.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
