### PR TITLE
Add `debug_traceBlockByNumber` to `method_to_url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+- [#9440](https://github.com/blockscout/blockscout/pull/9440) - Add `debug_traceBlockByNumber` to `method_to_url`
 - [#9387](https://github.com/blockscout/blockscout/pull/9387) - Filter out Vyper contracts in Solidityscan API endpoint
 - [#9377](https://github.com/blockscout/blockscout/pull/9377) - Speed up account abstraction proxy
 - [#9371](https://github.com/blockscout/blockscout/pull/9371) - Filter empty values before token update

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -17,7 +17,8 @@ config :explorer,
       fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
       method_to_url: [
         eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -17,7 +17,8 @@ config :explorer,
       fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
       method_to_url: [
         eth_call: ConfigHelper.eth_call_url(),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -22,7 +22,8 @@ config :indexer,
       fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
       method_to_url: [
         eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
+        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -22,7 +22,8 @@ config :indexer,
       fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
       method_to_url: [
         eth_call: ConfigHelper.eth_call_url(),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
+        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],


### PR DESCRIPTION
## Motivation

Now `debug_traceBlockByNumber` uses `ETHEREUM_JSONRPC_HTTP_URL`, however it should use `ETHEREUM_JSONRPC_TRACE_URL`

## Changelog

Added `debug_traceBlockByNumber` to `method_to_url` keyword list, so that `debug_traceBlockByNumber` uses `ETHEREUM_JSONRPC_TRACE_URL`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
