### PR TITLE
Change bens address search  to get_address func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#9441](https://github.com/blockscout/blockscout/pull/9441) - Update BENS integration: change endpoint for resolving address in search
 - [#9437](https://github.com/blockscout/blockscout/pull/9437) - Add Enum.uniq before sanitizing token transfers
 - [#9403](https://github.com/blockscout/blockscout/pull/9403) - Null round handling
 - [#9401](https://github.com/blockscout/blockscout/pull/9401) - Eliminate incorrect token transfers with empty token_ids

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -66,6 +66,13 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
     end
   end
 
+  @spec get_address(binary()) :: {:error, :disabled | binary() | Jason.DecodeError.t()} | {:ok, any}
+  def get_address(address) do
+    with :ok <- Microservice.check_enabled(__MODULE__) do
+      http_get_request(get_address_url(address), nil)
+    end
+  end
+
   @doc """
     Lookup for ENS domain name via GET {{baseUrl}}/api/v1/:chainId/domains:lookup
   """
@@ -136,6 +143,10 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
 
   defp address_lookup_url do
     "#{addresses_url()}:lookup"
+  end
+
+  defp get_address_url(address) do
+    "#{addresses_url()}/#{address}"
   end
 
   defp domain_lookup_url do
@@ -214,7 +225,7 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   end
 
   @doc """
-    Preload ENS info to search result, using address_lookup/1
+    Preload ENS info to search result, using get_address/1
   """
   @spec preload_ens_info_to_search_results(list) :: list
   def preload_ens_info_to_search_results(list) do
@@ -223,7 +234,7 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
         search_result
 
       %{type: "address"} = search_result ->
-        ens_info = search_result[:address_hash] |> address_lookup() |> parse_lookup_response()
+        ens_info = search_result[:address_hash] |> get_address() |> parse_get_address_response()
         Map.put(search_result, :ens_info, ens_info)
 
       search_result ->
@@ -258,6 +269,29 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   end
 
   defp parse_lookup_response(_), do: nil
+
+  defp parse_get_address_response(
+         {:ok,
+          %{
+            "domain" => %{
+              "name" => name,
+              "expiry_date" => expiry_date,
+              "resolved_address" => %{"hash" => address_hash_string}
+            },
+            "resolved_domains_count" => resolved_domains_count
+          }}
+       ) do
+    {:ok, hash} = Chain.string_to_address_hash(address_hash_string)
+
+    %{
+      name: name,
+      expiry_date: expiry_date,
+      names_count: resolved_domains_count,
+      address_hash: Address.checksum(hash)
+    }
+  end
+
+  defp parse_get_address_response(_), do: nil
 
   defp item_to_address_hash_strings(%Transaction{
          to_address_hash: nil,


### PR DESCRIPTION
Change bens integration for search: 
change endpoint from `GET /addresses:lookup` to `GET /addresses/{address}`

blocking on https://github.com/blockscout/blockscout-rs/pull/784

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
