### PR TITLE
Stream blocks without internal transactions in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- [#9461](https://github.com/blockscout/blockscout/pull/9461) - Fetch blocks without internal transactions backwards
+
 ### Fixes
 
 ### Chore

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1829,7 +1829,8 @@ defmodule Explorer.Chain do
       from(
         po in PendingBlockOperation,
         where: not is_nil(po.block_number),
-        select: po.block_number
+        select: po.block_number,
+        order_by: [desc: po.block_number]
       )
 
     query

--- a/apps/explorer/priv/repo/migrations/20240224112210_create_index_pending_block_operations_block_number.exs
+++ b/apps/explorer/priv/repo/migrations/20240224112210_create_index_pending_block_operations_block_number.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.CreateIndexPendingBlockOperationsBlockNumber do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    create_if_not_exists(index(:pending_block_operations, :block_number, concurrently: true))
+  end
+end


### PR DESCRIPTION
## Motivation

Whenever there is a long backlog of blocks without fetched internal transactions, it makes sense to fetch them in `block_number desc` order instead of random as-is order, as more recent blocks likely contain more relevant information for the end user.
It may also lead to faster loading overall, as nearby blocks share most of the state Merkle Patricia tree, thus querying them sequentially from the same node may improve node's internal cache hit ratio.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
