### PR TITLE
Eliminate from_address_hash == #{address_hash} clause for transactions query in case of smart-contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Fixes
 
+- [#9467](https://github.com/blockscout/blockscout/pull/9467) - Eliminate from_address_hash == #{address_hash} clause for transactions query in case of smart-contracts
 - [#9444](https://github.com/blockscout/blockscout/pull/9444) - Fix quick search bug
 - [#9440](https://github.com/blockscout/blockscout/pull/9440) - Add `debug_traceBlockByNumber` to `method_to_url`
 - [#9387](https://github.com/blockscout/blockscout/pull/9387) - Filter out Vyper contracts in Solidityscan API endpoint

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -2,7 +2,7 @@ defmodule Explorer.Chain.Address.Counters do
   @moduledoc """
     Functions related to Explorer.Chain.Address counters
   """
-  import Ecto.Query, only: [from: 2, limit: 2, select: 3, union: 2, where: 3]
+  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, select: 3, union: 2, where: 3]
 
   import Explorer.Chain,
     only: [select_repo: 1, wrapped_union_subquery: 1]
@@ -128,10 +128,9 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def address_hash_to_transaction_count_query(address_hash) do
-    from(
-      transaction in Transaction,
-      where: transaction.to_address_hash == ^address_hash or transaction.from_address_hash == ^address_hash
-    )
+    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+    Transaction
+    |> where([transaction], ^dynamic)
   end
 
   @spec address_hash_to_transaction_count(Hash.Address.t()) :: non_neg_integer()

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1809,4 +1809,17 @@ defmodule Explorer.Chain.Transaction do
         |> Decimal.min(max_fee_per_gas |> Wei.sub(base_fee_per_gas) |> Wei.to(:wei))
         |> Wei.from(:wei)
   end
+
+  @doc """
+  Dynamically adds to/from for `transactions` query based on whether the target address EOA or smart-contract
+  """
+  @spec where_transactions_to_from(Hash.Address.t()) :: any()
+  def where_transactions_to_from(address_hash) do
+    {:ok, address} = Chain.hash_to_address(address_hash)
+
+    if Chain.contract?(address),
+      do: dynamic([transaction], transaction.to_address_hash == ^address_hash),
+      else:
+        dynamic([transaction], transaction.from_address_hash == ^address_hash or transaction.to_address_hash == ^address_hash)
+  end
 end

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -5,6 +5,7 @@ defmodule Explorer.GraphQL do
 
   import Ecto.Query,
     only: [
+      dynamic: 1,
       from: 2,
       order_by: 3,
       or_where: 3,
@@ -28,9 +29,10 @@ defmodule Explorer.GraphQL do
   """
   @spec address_to_transactions_query(Hash.Address.t(), :desc | :asc) :: Ecto.Query.t()
   def address_to_transactions_query(address_hash, order) do
+    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+
     Transaction
-    |> where([transaction], transaction.to_address_hash == ^address_hash)
-    |> or_where([transaction], transaction.from_address_hash == ^address_hash)
+    |> where([transaction], ^dynamic)
     |> or_where([transaction], transaction.created_contract_address_hash == ^address_hash)
     |> order_by([transaction], [{^order, transaction.block_number}, {^order, transaction.index}])
   end


### PR DESCRIPTION
## Motivation

Performance of the query "get count of transactions per address", when the address is smart-contract is slow: execution time is more than 60 secs leading to 500 internal server error when requesting the corresponding address transactions counter.

An example of target query (with smart-contract address on Goerli):
```
...
```

## Changelog

Before sending query to the DB we should properly propose where clauses: we should eliminate `from_address_hash == #{address_hash}` where clause for smart-contracts and leave it as is for EOAs. Since smart-contracts cannot be originators of transactions, there are no records satisfying this where clause in case of smart-contract address. Leaving this clause for smart-contracts leads to sequential scan of the whole token transfers table, which leads to long execution time of the original query.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
