### PR TITLE
fix: Eliminate from_address_hash == #{address_hash} clause for transactions query in case of smart-contracts

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -671,7 +671,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       "is_verified_via_verifier_alliance" => implementation_contract.verified_via_verifier_alliance,
       "language" => smart_contract_language(implementation_contract),
       "license_type" => "bsd_3_clause",
-      "certified" => false
+      "certified" => false,
+      "is_blueprint" => false
     }
 
     request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(proxy_address.hash)}")

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -2,7 +2,7 @@ defmodule Explorer.Chain.Address.Counters do
   @moduledoc """
     Functions related to Explorer.Chain.Address counters
   """
-  import Ecto.Query, only: [from: 2, limit: 2, select: 3, union: 2, where: 3]
+  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, select: 3, union: 2, where: 3]
 
   import Explorer.Chain,
     only: [select_repo: 1, wrapped_union_subquery: 1]
@@ -128,10 +128,10 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def address_hash_to_transaction_count_query(address_hash) do
-    from(
-      transaction in Transaction,
-      where: transaction.to_address_hash == ^address_hash or transaction.from_address_hash == ^address_hash
-    )
+    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+
+    Transaction
+    |> where([transaction], ^dynamic)
   end
 
   @spec address_hash_to_transaction_count(Hash.Address.t()) :: non_neg_integer()

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -2,7 +2,7 @@ defmodule Explorer.Chain.Address.Counters do
   @moduledoc """
     Functions related to Explorer.Chain.Address counters
   """
-  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, select: 3, union: 2, where: 3]
+  import Ecto.Query, only: [from: 2, limit: 2, select: 3, union: 2, where: 3]
 
   import Explorer.Chain,
     only: [select_repo: 1, wrapped_union_subquery: 1]
@@ -128,7 +128,7 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def address_hash_to_transaction_count_query(address_hash) do
-    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+    dynamic = Transaction.where_transactions_to_from(address_hash)
 
     Transaction
     |> where([transaction], ^dynamic)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1752,6 +1752,7 @@ defmodule Explorer.Chain.Transaction do
 
   @doc """
   Dynamically adds to/from for `transactions` query based on whether the target address EOA or smart-contract
+  todo: pay attention to [EIP-5003](https://eips.ethereum.org/EIPS/eip-5003): if it will be included, this logic should be rolled back.
   """
   @spec where_transactions_to_from(Hash.Address.t()) :: any()
   def where_transactions_to_from(address_hash) do

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1755,14 +1755,15 @@ defmodule Explorer.Chain.Transaction do
   """
   @spec where_transactions_to_from(Hash.Address.t()) :: any()
   def where_transactions_to_from(address_hash) do
-    {:ok, address} = Chain.hash_to_address(address_hash)
-
-    if Chain.contract?(address),
-      do: dynamic([transaction], transaction.to_address_hash == ^address_hash),
-      else:
+    with {:ok, address} <- Chain.hash_to_address(address_hash),
+         true <- Chain.contract?(address) do
+      dynamic([transaction], transaction.to_address_hash == ^address_hash)
+    else
+      _ ->
         dynamic(
           [transaction],
           transaction.from_address_hash == ^address_hash or transaction.to_address_hash == ^address_hash
         )
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1749,4 +1749,20 @@ defmodule Explorer.Chain.Transaction do
         |> Decimal.min(max_fee_per_gas |> Wei.sub(base_fee_per_gas) |> Wei.to(:wei))
         |> Wei.from(:wei)
   end
+
+  @doc """
+  Dynamically adds to/from for `transactions` query based on whether the target address EOA or smart-contract
+  """
+  @spec where_transactions_to_from(Hash.Address.t()) :: any()
+  def where_transactions_to_from(address_hash) do
+    {:ok, address} = Chain.hash_to_address(address_hash)
+
+    if Chain.contract?(address),
+      do: dynamic([transaction], transaction.to_address_hash == ^address_hash),
+      else:
+        dynamic(
+          [transaction],
+          transaction.from_address_hash == ^address_hash or transaction.to_address_hash == ^address_hash
+        )
+  end
 end

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -164,16 +164,13 @@ defmodule Explorer.Etherscan.Logs do
       dynamic =
         dynamic(
           [transaction],
-          ^Transaction.where_transactions_to_from(address_hash) and
-            transaction.block_number >= ^prepared_filter.from_block and
-            transaction.block_number <= ^prepared_filter.to_block
+          ^Transaction.where_transactions_to_from(address_hash) or
+            transaction.created_contract_address_hash == ^address_hash
         )
 
       all_transaction_logs_query =
         all_transaction_logs_query_base
-        |> where([transaction], transaction.created_contract_address_hash == ^address_hash)
-        |> or_where([transaction], ^dynamic)
-
+        |> where([transaction], ^dynamic)
       query_with_blocks =
         from(log_transaction_data in subquery(all_transaction_logs_query),
           join: block in Block,

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [dynamic: 2, from: 2, limit: 2, where: 3, or_where: 3, subquery: 1, order_by: 3, union: 2]
+  import Ecto.Query, only: [dynamic: 2, from: 2, limit: 2, where: 3, subquery: 1, order_by: 3, union: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Block, DenormalizationHelper, InternalTransaction, Log, Transaction}

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, where: 3, subquery: 1, order_by: 3, union: 2]
+  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, where: 3, or_where: 3, subquery: 1, order_by: 3, union: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Block, DenormalizationHelper, InternalTransaction, Log, Transaction}

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [from: 2, limit: 2, where: 3, subquery: 1, order_by: 3, union: 2]
+  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, where: 3, subquery: 1, order_by: 3, union: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Block, DenormalizationHelper, InternalTransaction, Log, Transaction}
@@ -145,7 +145,9 @@ defmodule Explorer.Etherscan.Logs do
         |> union(^query_from_address_hash_wrapped)
         |> union(^query_created_contract_address_hash_wrapped)
 
-      all_transaction_logs_query =
+      dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+
+      all_transaction_logs_query_base =
         from(transaction in Transaction,
           join: log in ^logs_query,
           on: log.transaction_hash == transaction.hash,
@@ -164,6 +166,11 @@ defmodule Explorer.Etherscan.Logs do
           },
           union: ^internal_transaction_log_query
         )
+
+      all_transaction_logs_query =
+        all_transaction_logs_query_base
+        |> or_where([transaction], transaction.created_contract_address_hash == ^address_hash)
+        |> or_where([transaction], ^dynamic)
 
       query_with_blocks =
         from(log_transaction_data in subquery(all_transaction_logs_query),

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -171,6 +171,7 @@ defmodule Explorer.Etherscan.Logs do
       all_transaction_logs_query =
         all_transaction_logs_query_base
         |> where([transaction], ^dynamic)
+
       query_with_blocks =
         from(log_transaction_data in subquery(all_transaction_logs_query),
           join: block in Block,

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [dynamic: 1, from: 2, limit: 2, where: 3, or_where: 3, subquery: 1, order_by: 3, union: 2]
+  import Ecto.Query, only: [dynamic: 2, from: 2, limit: 2, where: 3, or_where: 3, subquery: 1, order_by: 3, union: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Block, DenormalizationHelper, InternalTransaction, Log, Transaction}
@@ -145,18 +145,12 @@ defmodule Explorer.Etherscan.Logs do
         |> union(^query_from_address_hash_wrapped)
         |> union(^query_created_contract_address_hash_wrapped)
 
-      dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
-
       all_transaction_logs_query_base =
         from(transaction in Transaction,
           join: log in ^logs_query,
           on: log.transaction_hash == transaction.hash,
           where: transaction.block_number >= ^prepared_filter.from_block,
           where: transaction.block_number <= ^prepared_filter.to_block,
-          where:
-            transaction.to_address_hash == ^address_hash or
-              transaction.from_address_hash == ^address_hash or
-              transaction.created_contract_address_hash == ^address_hash,
           select: map(log, ^@log_fields),
           select_merge: %{
             gas_price: transaction.gas_price,
@@ -167,9 +161,17 @@ defmodule Explorer.Etherscan.Logs do
           union: ^internal_transaction_log_query
         )
 
+      dynamic =
+        dynamic(
+          [transaction],
+          ^Transaction.where_transactions_to_from(address_hash) and
+            transaction.block_number >= ^prepared_filter.from_block and
+            transaction.block_number <= ^prepared_filter.to_block
+        )
+
       all_transaction_logs_query =
         all_transaction_logs_query_base
-        |> or_where([transaction], transaction.created_contract_address_hash == ^address_hash)
+        |> where([transaction], transaction.created_contract_address_hash == ^address_hash)
         |> or_where([transaction], ^dynamic)
 
       query_with_blocks =

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -5,7 +5,6 @@ defmodule Explorer.GraphQL do
 
   import Ecto.Query,
     only: [
-      dynamic: 1,
       from: 2,
       order_by: 3,
       or_where: 3,
@@ -29,7 +28,7 @@ defmodule Explorer.GraphQL do
   """
   @spec address_to_transactions_query(Hash.Address.t(), :desc | :asc) :: Ecto.Query.t()
   def address_to_transactions_query(address_hash, order) do
-    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+    dynamic = Transaction.where_transactions_to_from(address_hash)
 
     Transaction
     |> where([transaction], ^dynamic)

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -5,6 +5,7 @@ defmodule Explorer.GraphQL do
 
   import Ecto.Query,
     only: [
+      dynamic: 1,
       from: 2,
       order_by: 3,
       or_where: 3,
@@ -28,9 +29,10 @@ defmodule Explorer.GraphQL do
   """
   @spec address_to_transactions_query(Hash.Address.t(), :desc | :asc) :: Ecto.Query.t()
   def address_to_transactions_query(address_hash, order) do
+    dynamic = dynamic(^Transaction.where_transactions_to_from(address_hash))
+
     Transaction
-    |> where([transaction], transaction.to_address_hash == ^address_hash)
-    |> or_where([transaction], transaction.from_address_hash == ^address_hash)
+    |> where([transaction], ^dynamic)
     |> or_where([transaction], transaction.created_contract_address_hash == ^address_hash)
     |> order_by([transaction], [{^order, transaction.block_number}, {^order, transaction.index}])
   end


### PR DESCRIPTION
## Motivation

Adding `from_address_hash == #{address_hash}` on `transactions` table is redundant in case of smart-contracts. In some cases it can lead to long query execution.

## Changelog

Before sending query to the DB we should properly propose where clauses: we should eliminate `from_address_hash == #{address_hash}` where clause for smart-contracts and leave it as is for EOAs. Since smart-contracts cannot be originators of transactions, there are no records satisfying this where clause in case of smart-contract address. Leaving this clause for smart-contracts leads to sequential scan of the whole token transfers table, which leads to long execution time of the original query.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
