### PR TITLE
Massive blocks fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - [#9490](https://github.com/blockscout/blockscout/pull/9490) - Add blob transaction counter and filter in block view
+- [#9486](https://github.com/blockscout/blockscout/pull/9486) - Massive blocks fetcher
 - [#9473](https://github.com/blockscout/blockscout/pull/9473) - Add user_op interpretation
 - [#9461](https://github.com/blockscout/blockscout/pull/9461) - Fetch blocks without internal transactions backwards
 - [#9460](https://github.com/blockscout/blockscout/pull/9460) - Optimism chain type

--- a/apps/explorer/lib/explorer/utility/massive_block.ex
+++ b/apps/explorer/lib/explorer/utility/massive_block.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Utility.MassiveBlock do
 
   alias Explorer.Repo
 
-  schema "massive_blocks" do
+  typed_schema "massive_blocks" do
     field(:number, :integer)
 
     timestamps()

--- a/apps/explorer/lib/explorer/utility/massive_block.ex
+++ b/apps/explorer/lib/explorer/utility/massive_block.ex
@@ -1,0 +1,38 @@
+defmodule Explorer.Utility.MassiveBlock do
+  @moduledoc """
+  Module is responsible for keeping the block numbers that are too large for regular import
+  and need more time to complete.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Repo
+
+  schema "massive_blocks" do
+    field(:number, :integer)
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(massive_block \\ %__MODULE__{}, params) do
+    cast(massive_block, params, [:number])
+  end
+
+  def get_last_block_number do
+    Repo.aggregate(__MODULE__, :max, :number)
+  end
+
+  def insert_block_numbers(numbers) do
+    now = DateTime.utc_now()
+    params = Enum.map(numbers, &%{number: &1, inserted_at: now, updated_at: now})
+
+    Repo.insert_all(__MODULE__, params, on_conflict: {:replace, [:updated_at]}, conflict_target: :number)
+  end
+
+  def delete_block_number(number) do
+    __MODULE__
+    |> where([mb], mb.number == ^number)
+    |> Repo.delete_all()
+  end
+end

--- a/apps/explorer/lib/explorer/utility/massive_block.ex
+++ b/apps/explorer/lib/explorer/utility/massive_block.ex
@@ -8,8 +8,9 @@ defmodule Explorer.Utility.MassiveBlock do
 
   alias Explorer.Repo
 
+  @primary_key false
   typed_schema "massive_blocks" do
-    field(:number, :integer)
+    field(:number, :integer, primary_key: true)
 
     timestamps()
   end
@@ -19,8 +20,11 @@ defmodule Explorer.Utility.MassiveBlock do
     cast(massive_block, params, [:number])
   end
 
-  def get_last_block_number do
-    Repo.aggregate(__MODULE__, :max, :number)
+  def get_last_block_number(except_numbers) do
+    __MODULE__
+    |> where([mb], mb.number not in ^except_numbers)
+    |> select([mb], max(mb.number))
+    |> Repo.one()
   end
 
   def insert_block_numbers(numbers) do

--- a/apps/explorer/priv/repo/migrations/20240226074456_create_massive_blocks.exs
+++ b/apps/explorer/priv/repo/migrations/20240226074456_create_massive_blocks.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.CreateMassiveBlocks do
+  use Ecto.Migration
+
+  def change do
+    create table(:massive_blocks, primary_key: false) do
+      add(:number, :bigint, primary_key: true)
+
+      timestamps()
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
@@ -38,9 +38,14 @@ defmodule Indexer.Block.Catchup.MassiveBlocksFetcher do
     {:noreply, state}
   end
 
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
   defp process_block(block_fetcher, number) do
     case Fetcher.fetch_and_import_range(block_fetcher, number..number, %{timeout: :infinity}) do
       {:ok, _result} ->
+        Logger.info("MassiveBlockFetcher successfully proceed block #{inspect(number)}")
         MassiveBlock.delete_block_number(number)
 
       {:error, error} ->

--- a/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
@@ -1,0 +1,68 @@
+defmodule Indexer.Block.Catchup.MassiveBlocksFetcher do
+  @moduledoc """
+  Fetches and indexes blocks by numbers from massive_blocks table.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Explorer.Utility.MassiveBlock
+  alias Indexer.Block.Fetcher
+
+  @increased_interval 10000
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    send_new_task()
+
+    {:ok, %{block_fetcher: generate_block_fetcher()}}
+  end
+
+  @impl true
+  def handle_info(:task, state) do
+    case MassiveBlock.get_last_block_number() do
+      nil ->
+        send_new_task(@increased_interval)
+
+      number ->
+        process_block(state.block_fetcher, number)
+        send_new_task()
+    end
+
+    {:noreply, state}
+  end
+
+  defp process_block(block_fetcher, number) do
+    case Fetcher.fetch_and_import_range(block_fetcher, number..number, %{timeout: :infinity}) do
+      {:ok, _result} ->
+        MassiveBlock.delete_block_number(number)
+
+      {:error, error} ->
+        Logger.error("MassiveBlockFetcher failed: #{inspect(error)}")
+    end
+  end
+
+  defp generate_block_fetcher do
+    receipts_batch_size = Application.get_env(:indexer, :receipts_batch_size)
+    receipts_concurrency = Application.get_env(:indexer, :receipts_concurrency)
+    json_rpc_named_arguments = Application.get_env(:indexer, :json_rpc_named_arguments)
+
+    %Fetcher{
+      broadcast: :catchup,
+      callback_module: Indexer.Block.Catchup.Fetcher,
+      json_rpc_named_arguments: json_rpc_named_arguments,
+      receipts_batch_size: receipts_batch_size,
+      receipts_concurrency: receipts_concurrency
+    }
+  end
+
+  defp send_new_task(interval \\ 0) do
+    Process.send_after(self(), :task, interval)
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Indexer.Block.Catchup.Supervisor do
 
   use Supervisor
 
-  alias Indexer.Block.Catchup.{BoundIntervalSupervisor, MissingRangesCollector}
+  alias Indexer.Block.Catchup.{BoundIntervalSupervisor, MassiveBlocksFetcher, MissingRangesCollector}
 
   def child_spec([init_arguments]) do
     child_spec([init_arguments, []])
@@ -31,6 +31,7 @@ defmodule Indexer.Block.Catchup.Supervisor do
       [
         {MissingRangesCollector, []},
         {Task.Supervisor, name: Indexer.Block.Catchup.TaskSupervisor},
+        {MassiveBlocksFetcher, []},
         {BoundIntervalSupervisor, [bound_interval_supervisor_arguments, [name: BoundIntervalSupervisor]]}
       ],
       strategy: :one_for_one

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -118,7 +118,7 @@ defmodule Indexer.Block.Fetcher do
   end
 
   @decorate span(tracer: Tracer)
-  @spec fetch_and_import_range(t, Range.t()) ::
+  @spec fetch_and_import_range(t, Range.t(), map) ::
           {:ok, %{inserted: %{}, errors: [EthereumJSONRPC.Transport.error()]}}
           | {:error,
              {step :: atom(), reason :: [Ecto.Changeset.t()] | term()}
@@ -129,7 +129,8 @@ defmodule Indexer.Block.Fetcher do
           callback_module: callback_module,
           json_rpc_named_arguments: json_rpc_named_arguments
         } = state,
-        _.._ = range
+        _.._ = range,
+        additional_options \\ %{}
       )
       when callback_module != nil do
     {fetch_time, fetched_blocks} =
@@ -228,7 +229,7 @@ defmodule Indexer.Block.Fetcher do
          {:ok, inserted} <-
            __MODULE__.import(
              state,
-             import_options(basic_import_options, chain_type_import_options)
+             basic_import_options |> Map.merge(additional_options) |> import_options(chain_type_import_options)
            ),
          {:tx_actions, {:ok, inserted_tx_actions}} <-
            {:tx_actions,


### PR DESCRIPTION
## Motivation

There are cases when reorg (or regular block) contains a lot of data and can't be imported in the regular amount of time. For such cases, we can add a separate fetcher that sets `timeout: :infinity` for such blocks so catchup fetcher won't get stuck.

## Changelog

- Added `MassiveBlocksFetcher` to handle blocks mentioned above
- Added new schema `massive_blocks` to store these blocks
- Store blocks as _massive_ if there was a timeout error in catchup fetcher