### PR TITLE
Add blob transaction count and transaction type filter to block view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [#9490](https://github.com/blockscout/blockscout/pull/9490) - Add blob transaction counter and filter in block view
 - [#9461](https://github.com/blockscout/blockscout/pull/9461) - Fetch blocks without internal transactions backwards
 - [#9460](https://github.com/blockscout/blockscout/pull/9460) - Optimism chain type
 - [#8702](https://github.com/blockscout/blockscout/pull/8702) - Add OP withdrawal status to transaction page in API

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -10,7 +10,9 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       parse_block_hash_or_number_param: 1
     ]
 
-  import BlockScoutWeb.PagingHelper, only: [delete_parameters_from_next_page_params: 1, select_block_type: 1]
+  import BlockScoutWeb.PagingHelper,
+    only: [delete_parameters_from_next_page_params: 1, select_block_type: 1, type_filter_options: 1]
+
   import Explorer.MicroserviceInterfaces.BENS, only: [maybe_preload_ens: 1]
 
   alias BlockScoutWeb.API.V2.{TransactionView, WithdrawalView}
@@ -109,6 +111,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       full_options =
         @transaction_necessity_by_association
         |> Keyword.merge(put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true))
+        |> Keyword.merge(type_filter_options(params))
         |> Keyword.merge(@api_true)
 
       transactions_plus_one = Chain.block_to_transactions(block.hash, full_options, false)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -96,6 +96,12 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   def count_transactions(%Block{transactions: txs}) when is_list(txs), do: Enum.count(txs)
   def count_transactions(_), do: nil
 
+  def count_blob_transactions(%Block{transactions: txs}) when is_list(txs),
+    # EIP-2718 blob transaction type
+    do: Enum.count(txs, &(&1.type == 3))
+
+  def count_blob_transactions(_), do: nil
+
   def count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
   def count_withdrawals(_), do: nil
 
@@ -121,12 +127,14 @@ defmodule BlockScoutWeb.API.V2.BlockView do
           burnt_blob_transaction_fees = Decimal.mult(block.blob_gas_used || 0, blob_gas_price || 0)
 
           result
+          |> Map.put("blob_tx_count", count_blob_transactions(block))
           |> Map.put("blob_gas_used", block.blob_gas_used)
           |> Map.put("excess_blob_gas", block.excess_blob_gas)
           |> Map.put("blob_gas_price", blob_gas_price)
           |> Map.put("burnt_blob_fees", burnt_blob_transaction_fees)
         else
           result
+          |> Map.put("blob_tx_count", count_blob_transactions(block))
           |> Map.put("blob_gas_used", block.blob_gas_used)
           |> Map.put("excess_blob_gas", block.excess_blob_gas)
         end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -545,12 +545,14 @@ defmodule Explorer.Chain do
           ]
   def block_to_transactions(block_hash, options \\ [], old_ui? \\ true) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+    type_filter = Keyword.get(options, :type)
 
     options
     |> Keyword.get(:paging_options, @default_paging_options)
     |> fetch_transactions_in_ascending_order_by_index()
     |> join(:inner, [transaction], block in assoc(transaction, :block))
     |> where([_, block], block.hash == ^block_hash)
+    |> apply_filter_by_tx_type_to_transactions(type_filter)
     |> join_associations(necessity_by_association)
     |> Transaction.put_has_token_transfers_to_tx(old_ui?)
     |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()


### PR DESCRIPTION
## Changelog

### Enhancements
* Add block transaction filter for queries like: `api/v2/blocks/<block_id>/transactions?type=[blob_transaction]`
* Add blob transaction counter in block view

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
