### PR TITLE
Docker-compose 2.24.6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#9512](https://github.com/blockscout/blockscout/pull/9512) - Docker-compose 2.24.6 compatibility
+
 ### Chore
 
 ## 6.2.2

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -67,7 +70,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -75,6 +79,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/erigon.yml
+++ b/docker-compose/erigon.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -52,7 +55,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -60,6 +64,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/external-backend.yml
+++ b/docker-compose/external-backend.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -37,6 +40,9 @@ services:
       service: stats-db-init
 
   stats-db:
+    depends_on:
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -44,6 +50,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/external-db.yml
+++ b/docker-compose/external-db.yml
@@ -39,7 +39,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -47,6 +48,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/external-frontend.yml
+++ b/docker-compose/external-frontend.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -49,7 +52,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -57,6 +61,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/ganache.yml
+++ b/docker-compose/ganache.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -59,7 +62,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -67,6 +71,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/geth-clique-consensus.yml
+++ b/docker-compose/geth-clique-consensus.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -53,7 +56,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -61,6 +65,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/geth.yml
+++ b/docker-compose/geth.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -52,7 +55,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -60,6 +64,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/hardhat-network.yml
+++ b/docker-compose/hardhat-network.yml
@@ -12,6 +12,9 @@ services:
       service: db-init
 
   db:
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/db.yml
       service: db
@@ -59,7 +62,8 @@ services:
 
   stats-db:
     depends_on:
-      - backend
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -67,6 +71,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/microservices.yml
+++ b/docker-compose/microservices.yml
@@ -27,6 +27,9 @@ services:
       service: stats-db-init
 
   stats-db:
+    depends_on:
+      stats-db-init:
+        condition: service_completed_successfully
     extends:
       file: ./services/stats.yml
       service: stats-db
@@ -34,6 +37,7 @@ services:
   stats:
     depends_on:
       - stats-db
+      - backend
     extends:
       file: ./services/stats.yml
       service: stats

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -12,9 +12,6 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   db:
-    depends_on:
-      db-init:
-        condition: service_completed_successfully
     image: postgres:15
     user: 2000:2000
     shm_size: 256m

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -12,9 +12,6 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   stats-db:
-    depends_on:
-      stats-db-init:
-        condition: service_completed_successfully
     image: postgres:15
     user: 2000:2000
     shm_size: 256m
@@ -43,8 +40,6 @@ services:
     platform: linux/amd64
     restart: always
     container_name: 'stats'
-    depends_on:
-      - "stats-db"
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     env_file:


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9496
Resolves https://github.com/blockscout/blockscout/issues/9411

## Motivation

Docker-compose setup doesn't work with Docker compose v2.24.6 because of error:
```
service "db" can't be used with `extends` as it declare `depends_on`
```

## Changelog

Add compatibility with Docker-compose version 2.24.6 by moving `depends_on` from the base to extended service.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
