### PR TITLE
Fix missing `0x` prefix in `eth_getLogs` response 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- [#9514](https://github.com/blockscout/blockscout/pull/9514) Fix missing `0x` prefix for `blockNumber`, `logIndex`, `transactionIndex` and remove `transactionLogIndex` in `eth_getLogs` response. 
 - [#9512](https://github.com/blockscout/blockscout/pull/9512) - Docker-compose 2.24.6 compatibility
 
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- [#9514](https://github.com/blockscout/blockscout/pull/9514) Fix missing `0x` prefix for `blockNumber`, `logIndex`, `transactionIndex` and remove `transactionLogIndex` in `eth_getLogs` response. 
+- [#9514](https://github.com/blockscout/blockscout/pull/9514) - Fix missing `0x` prefix for `blockNumber`, `logIndex`, `transactionIndex` and remove `transactionLogIndex` in `eth_getLogs` response.
 - [#9512](https://github.com/blockscout/blockscout/pull/9512) - Docker-compose 2.24.6 compatibility
 
 ### Chore

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -198,7 +198,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
       assert Enum.count(response["result"]) == 1000
 
-      {last_log_index, ""} = Integer.parse(List.last(response["result"])["logIndex"], 16)
+      "0x" <> hexadecimal_digits = List.last(response["result"])["logIndex"]
+      {last_log_index, ""} = Integer.parse(hexadecimal_digits, 16)
 
       next_page_params = %{
         "blockNumber" => Integer.to_string(transaction.block_number, 16),
@@ -225,7 +226,8 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
       assert Enum.all?(inserted_records, fn record ->
                Enum.any?(all_found_logs, fn found_log ->
-                 {index, ""} = Integer.parse(found_log["logIndex"], 16)
+                 "0x" <> hexadecimal_digits = found_log["logIndex"]
+                 {index, ""} = Integer.parse(hexadecimal_digits, 16)
 
                  record.index == index
                end)

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -26,7 +26,7 @@ defmodule Explorer.Chain.Log do
    * `fourth_topic` - `topics[3]`
    * `transaction` - transaction for which `log` is
    * `transaction_hash` - foreign key for `transaction`.
-   * `index` - index of the log entry in all logs for the `transaction`
+   * `index` - index of the log entry within the block
   """
   @primary_key false
   typed_schema "logs" do

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -180,7 +180,6 @@ defmodule Explorer.EthRPC do
       "topics" => topics,
       "transactionHash" => to_string(log.transaction_hash),
       "transactionIndex" => log.transaction_index,
-      "transactionLogIndex" => log.index
     }
   end
 

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -173,13 +173,19 @@ defmodule Explorer.EthRPC do
     %{
       "address" => to_string(log.address_hash),
       "blockHash" => to_string(log.block_hash),
-      "blockNumber" => Integer.to_string(log.block_number, 16),
+      "blockNumber" =>
+        log.block_number
+        |> encode_quantity(),
       "data" => to_string(log.data),
-      "logIndex" => Integer.to_string(log.index, 16),
+      "logIndex" =>
+        log.index
+        |> encode_quantity(),
       "removed" => log.block_consensus == false,
       "topics" => topics,
       "transactionHash" => to_string(log.transaction_hash),
-      "transactionIndex" => log.transaction_index,
+      "transactionIndex" =>
+        log.transaction_index
+        |> encode_quantity()
     }
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -3,7 +3,7 @@ defmodule Explorer.SmartContract.Reader do
   Reads Smart Contract functions from the blockchain.
 
   For information on smart contract's Application Binary Interface (ABI), visit the
-  [wiki](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI).
+  [wiki](https://docs.soliditylang.org/en/develop/abi-spec.html).
   """
 
   alias EthereumJSONRPC.{Contract, Encoder}


### PR DESCRIPTION

Closes #9419.

## Motivation

Improve compliance with the [Ethereum JSON-RPC Specification](https://ethereum.github.io/execution-apis/api-documentation/).

## Changelog

### Bug Fixes

Fix missing `0x` prefix for `blockNumber`, `logIndex`, and `transactionIndex` in `eth_getLogs` response.

### Incompatible Changes

Remove `transactionLogIndex` in `eth_getLogs` response.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
