### PR TITLE
Fix timestamp handler for unfinalized zkEVM batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - [#9572](https://github.com/blockscout/blockscout/pull/9572) - Fix Shibarium L1 fetcher
+- [#9563](https://github.com/blockscout/blockscout/pull/9563) - Fix timestamp handler for unfinalized zkEVM batches
 - [#9514](https://github.com/blockscout/blockscout/pull/9514) - Fix missing `0x` prefix for `blockNumber`, `logIndex`, `transactionIndex` and remove `transactionLogIndex` in `eth_getLogs` response.
 - [#9512](https://github.com/blockscout/blockscout/pull/9512) - Docker-compose 2.24.6 compatibility
 - [#9262](https://github.com/blockscout/blockscout/pull/9262) - Fix withdrawal status

--- a/apps/explorer/lib/explorer/chain/polygon_zkevm/transaction_batch.ex
+++ b/apps/explorer/lib/explorer/chain/polygon_zkevm/transaction_batch.ex
@@ -6,9 +6,9 @@ defmodule Explorer.Chain.PolygonZkevm.TransactionBatch do
   alias Explorer.Chain.Hash
   alias Explorer.Chain.PolygonZkevm.{BatchTransaction, LifecycleTransaction}
 
-  @optional_attrs ~w(sequence_id verify_id)a
+  @optional_attrs ~w(timestamp sequence_id verify_id)a
 
-  @required_attrs ~w(number timestamp l2_transactions_count global_exit_root acc_input_hash state_root)a
+  @required_attrs ~w(number l2_transactions_count global_exit_root acc_input_hash state_root)a
 
   @primary_key false
   typed_schema "polygon_zkevm_transaction_batches" do

--- a/apps/explorer/priv/polygon_zkevm/migrations/20240306080627_make_timestamp_optional.exs
+++ b/apps/explorer/priv/polygon_zkevm/migrations/20240306080627_make_timestamp_optional.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.PolygonZkevm.Migrations.MakeTimestampOptional do
+  use Ecto.Migration
+
+  def change do
+    alter table("polygon_zkevm_transaction_batches") do
+      modify(:timestamp, :"timestamp without time zone", null: true)
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
@@ -209,7 +209,14 @@ defmodule Indexer.Fetcher.PolygonZkevm.TransactionBatch do
                                                                     {batches, l2_txs, l1_txs, next_id, hash_to_id} =
                                                                       _acc ->
         number = quantity_to_integer(Map.get(res.result, "number"))
-        {:ok, timestamp} = DateTime.from_unix(quantity_to_integer(Map.get(res.result, "timestamp")))
+
+        # the timestamp is undefined for unfinalized batches
+        timestamp =
+          case DateTime.from_unix(quantity_to_integer(Map.get(res.result, "timestamp"))) do
+            {:ok, ts} -> ts
+            _ -> nil
+          end
+
         l2_transaction_hashes = Map.get(res.result, "transactions")
         global_exit_root = Map.get(res.result, "globalExitRoot")
         acc_input_hash = Map.get(res.result, "accInputHash")

--- a/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
@@ -212,7 +212,7 @@ defmodule Indexer.Fetcher.PolygonZkevm.TransactionBatch do
 
         # the timestamp is undefined for unfinalized batches
         timestamp =
-          case DateTime.from_unix(quantity_to_integer(Map.get(res.result, "timestamp"))) do
+          case DateTime.from_unix(quantity_to_integer(Map.get(res.result, "timestamp", 0xFFFFFFFFFFFFFFFF))) do
             {:ok, ts} -> ts
             _ -> nil
           end


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/9564.

## Motivation

`Indexer.Fetcher.PolygonZkevm.TransactionBatch` module stopped working at the end of historical sync of the batches because of undefined timestamp for the latest unfinalized batches. This PR fixes it allowing to store `nil` in the `timestamp` column.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
