### PR TITLE
Fix Shibarium L1 fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#9572](https://github.com/blockscout/blockscout/pull/9572) - Fix Shibarium L1 fetcher
 - [#9514](https://github.com/blockscout/blockscout/pull/9514) - Fix missing `0x` prefix for `blockNumber`, `logIndex`, `transactionIndex` and remove `transactionLogIndex` in `eth_getLogs` response.
 - [#9512](https://github.com/blockscout/blockscout/pull/9512) - Docker-compose 2.24.6 compatibility
 - [#9262](https://github.com/blockscout/blockscout/pull/9262) - Fix withdrawal status

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -240,13 +240,7 @@ defmodule Indexer.Helper do
   def get_blocks_by_events(events, json_rpc_named_arguments, retries) do
     events
     |> Enum.reduce(%{}, fn event, acc ->
-      block_number =
-        if is_map(event) do
-          event.block_number
-        else
-          event["blockNumber"]
-        end
-
+      block_number = Map.get(event, :block_number, event["blockNumber"])
       Map.put(acc, block_number, 0)
     end)
     |> Stream.map(fn {block_number, _} -> %{number: block_number} end)


### PR DESCRIPTION
## Motivation

Shibarium instance started to display an error `key :block_number not found` in its logs. Because of that, `Indexer.Fetcher.Shibarium.L1` stopped working correctly. The error appeared due to the previous incorrect refactoring.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
