### PR TITLE
Fix token instance transform panic

### DIFF
--- a/apps/indexer/lib/indexer/transform/token_instances.ex
+++ b/apps/indexer/lib/indexer/transform/token_instances.ex
@@ -51,21 +51,18 @@ defmodule Indexer.Transform.TokenInstances do
 
     current_key = {token_contract_address_hash, token_id}
 
-    Map.put(
+    Map.update(
       acc,
       current_key,
-      Enum.max_by(
-        [
-          params,
-          acc[current_key] || params
-        ],
-        fn %{
-             owner_updated_at_block: owner_updated_at_block,
-             owner_updated_at_log_index: owner_updated_at_log_index
-           } ->
-          {owner_updated_at_block, owner_updated_at_log_index}
-        end
-      )
+      params,
+      fn current ->
+        Enum.max_by([params, current], fn ti ->
+          {
+            Map.get(ti, :owner_updated_at_block, 0),
+            Map.get(ti, :owner_updated_at_log_index, 0)
+          }
+        end)
+      end
     )
   end
 
@@ -78,7 +75,7 @@ defmodule Indexer.Transform.TokenInstances do
          acc
        ) do
     Enum.reduce(token_ids, acc, fn id, sub_acc ->
-      Map.put(sub_acc, {token_contract_address_hash, id}, %{
+      Map.put_new(sub_acc, {token_contract_address_hash, id}, %{
         token_contract_address_hash: token_contract_address_hash,
         token_id: id,
         token_type: "ERC-1155"


### PR DESCRIPTION
## Changelog

The following token on eth-sepolia causes a panic in block catchup indexer - `0xda843dcec4b156590aef070ca4e3ef2cc6f7fd84`:
```
{"time":"2024-03-11T10:06:25.308Z","severity":"error","message":"** (FunctionClauseError) no function clause matching in anonymous fn/1 in Indexer.Transform.TokenInstances.transfer_to_instances/2\n    (indexer 6.2.2) lib/indexer/transform/token_instances.ex:62: anonymous fn(%{token_contract_address_hash: \"0xda843dcec4b156590aef070ca4e3ef2cc6f7fd84\", token_id: 47, token_type: \"ERC-1155\"}) in Indexer.Transform.TokenInstances.transfer_to_instances/2\n    (elixir 1.14.5) lib/enum.ex:4052: anonymous fn/4 in Enum.aggregate_by/4\n    (elixir 1.14.5) lib/enum.ex:4067: Enum.\"-aggregate_by/4-lists^foldl/2-0-\"/3\n    (elixir 1.14.5) lib/enum.ex:4067: Enum.aggregate_by/4\n    (indexer 6.2.2) lib/indexer/transform/token_instances.ex:57: Indexer.Transform.TokenInstances.transfer_to_instances/2\n    (elixir 1.14.5) lib/enum.ex:2468: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (indexer 6.2.2) lib/indexer/transform/token_instances.ex:12: Indexer.Transform.TokenInstances.reducer/2\n    (stdlib 3.17) maps.erl:410: :maps.fold_1/3\n\n\nRetrying.","metadata":{"fetcher":"block_catchup","first_block_number":5442572,"last_block_number":5442572}}
```

### Bug Fixes
* Fix token instance transform to handle unconventional tokens without panic

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
