### PR TITLE
Fix stats service dependency in external-backend.yml

### DIFF
--- a/docker-compose/external-backend.yml
+++ b/docker-compose/external-backend.yml
@@ -50,7 +50,6 @@ services:
   stats:
     depends_on:
       - stats-db
-      - backend
     extends:
       file: ./services/stats.yml
       service: stats


### PR DESCRIPTION
## Motivation

The stats service in external-backend.yml has a dependency on backend, resulting in the error `Service 'stats' depends on service 'backend' which is undefined.`

## Changelog

### Bug Fixes
Removed `depends_on: backend` in external-backend.yml to fix the error.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
