### PR TITLE
fix: Update token's holder_count in the db from ETS module

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -105,7 +105,7 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :blocks, :realtime, blocks}) do
-    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
+    last_broadcasted_block_number = Helper.fetch_from_ets_cache(:number, :last_broadcasted_block)
 
     blocks
     |> Enum.sort_by(& &1.number, :asc)
@@ -327,7 +327,7 @@ defmodule BlockScoutWeb.Notifier do
 
   defp schedule_broadcasting(block) do
     :timer.sleep(@check_broadcast_sequence_period)
-    last_broadcasted_block_number = Helper.fetch_from_cache(:number, :last_broadcasted_block)
+    last_broadcasted_block_number = Helper.fetch_from_ets_cache(:number, :last_broadcasted_block)
 
     if last_broadcasted_block_number == BlockNumberHelper.previous_block_number(block.number) do
       broadcast_block(block)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -86,7 +86,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         )
 
       request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/counters")
+      assert response = json_response(request, 200)
 
+      Process.sleep(500)
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/counters")
       assert response = json_response(request, 200)
 
       assert response["transfers_count"] == "3"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4107,16 +4107,6 @@ defmodule Explorer.Chain do
     |> Repo.all()
   end
 
-  @spec count_token_holders_from_token_hash(Hash.Address.t()) :: non_neg_integer()
-  def count_token_holders_from_token_hash(contract_address_hash) do
-    query =
-      from(ctb in CurrentTokenBalance.token_holders_query_for_count(contract_address_hash),
-        select: fragment("COUNT(DISTINCT(?))", ctb.address_hash)
-      )
-
-    Repo.one!(query, timeout: :infinity)
-  end
-
   @spec address_to_unique_tokens(Hash.Address.t(), Token.t(), [paging_options | api?]) :: [Instance.t()]
   def address_to_unique_tokens(contract_address_hash, token, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -14,6 +14,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
 
   alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, Hash, Token}
+  alias Explorer.Repo
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -132,7 +133,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
 
   @doc """
   Builds an `Ecto.Query` to fetch all token holders, to count it
-  Used in `Explorer.Chain.count_token_holders_from_token_hash/1`
+  Used in `Explorer.Chain.Address.CurrentTokenBalance.count_token_holders_from_token_hash/1`
   """
   def token_holders_query_for_count(token_contract_address_hash) do
     from(
@@ -289,5 +290,15 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       where: tb.address_hash != ^@burn_address_hash,
       where: tb.value > 0
     )
+  end
+
+  @spec count_token_holders_from_token_hash(Hash.Address.t()) :: non_neg_integer()
+  def count_token_holders_from_token_hash(contract_address_hash) do
+    query =
+      from(ctb in __MODULE__.token_holders_query_for_count(contract_address_hash),
+        select: fragment("COUNT(DISTINCT(?))", ctb.address_hash)
+      )
+
+    Repo.one!(query, timeout: :infinity)
   end
 end

--- a/apps/explorer/lib/explorer/chain/cache/addresses_tabs_counters.ex
+++ b/apps/explorer/lib/explorer/chain/cache/addresses_tabs_counters.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Cache.AddressesTabsCounters do
 
   use GenServer
 
-  import Explorer.Counters.Helper, only: [fetch_from_cache: 3]
+  import Explorer.Counters.Helper, only: [fetch_from_ets_cache: 3]
 
   alias Explorer.Chain.Address.Counters
 
@@ -16,7 +16,7 @@ defmodule Explorer.Chain.Cache.AddressesTabsCounters do
 
   @spec get_counter(counter_type, String.t()) :: {DateTime.t(), non_neg_integer(), response_status} | nil
   def get_counter(counter_type, address_hash) do
-    address_hash |> cache_key(counter_type) |> fetch_from_cache(@cache_name, nil) |> check_staleness()
+    address_hash |> cache_key(counter_type) |> fetch_from_ets_cache(@cache_name, nil) |> check_staleness()
   end
 
   @spec set_counter(counter_type, String.t(), non_neg_integer()) :: :ok
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Cache.AddressesTabsCounters do
 
   @spec get_task(atom, String.t()) :: true | nil
   def get_task(counter_type, address_hash) do
-    address_hash |> task_cache_key(counter_type) |> fetch_from_cache(@cache_name, nil)
+    address_hash |> task_cache_key(counter_type) |> fetch_from_ets_cache(@cache_name, nil)
   end
 
   def save_txs_counter_progress(address_hash, results) do

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -258,7 +258,7 @@ defmodule Explorer.Chain.Token do
     Updates token_holder_count for a given contract_address_hash.
     It used by Explorer.Counters.TokenHoldersCounter module.
   """
-  @spec update_token_holder_count(Hash.Address.t(), integer()) :: :ok
+  @spec update_token_holder_count(Hash.Address.t(), integer()) :: {non_neg_integer(), nil}
   def update_token_holder_count(contract_address_hash, holder_count) when not is_nil(holder_count) do
     now = DateTime.utc_now()
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -81,7 +81,11 @@ defmodule Explorer.Chain.Token do
   alias Ecto.Changeset
   alias Explorer.{Chain, SortingHelper}
   alias Explorer.Chain.{BridgedToken, Hash, Search, Token}
+  alias Explorer.Repo
   alias Explorer.SmartContract.Helper
+
+  # milliseconds
+  @timeout 60_000
 
   @default_sorting [
     desc_nulls_last: :circulating_market_cap,
@@ -248,5 +252,23 @@ defmodule Explorer.Chain.Token do
       |> select([token], token.contract_address_hash)
 
     (last_address_hash && where(query, [token], token.contract_address_hash > ^last_address_hash)) || query
+  end
+
+  @doc """
+    Updates token_holder_count for a given contract_address_hash.
+    It used by Explorer.Counters.TokenHoldersCounter module.
+  """
+  @spec update_token_holder_count(Hash.Address.t(), integer()) :: :ok
+  def update_token_holder_count(contract_address_hash, holder_count) when not is_nil(holder_count) do
+    now = DateTime.utc_now()
+
+    Repo.update_all(
+      from(t in __MODULE__,
+        where: t.contract_address_hash == ^contract_address_hash,
+        update: [set: [holder_count: ^holder_count, updated_at: ^now]]
+      ),
+      [],
+      timeout: @timeout
+    )
   end
 end

--- a/apps/explorer/lib/explorer/counters/address_token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_token_transfers_counter.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Counters.AddressTokenTransfersCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -67,28 +67,20 @@ defmodule Explorer.Counters.AddressTokenTransfersCounter do
 
   defp update_cache(address) do
     address_hash_string = to_string(address.hash)
-    put_into_cache("hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
     new_data = Counters.address_to_token_transfer_count(address)
-    put_into_cache("hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
     put_into_db(address, new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp put_into_db(address, value) do
     address
     |> Changeset.change(%{token_transfers_count: value})
     |> Repo.update()
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
+++ b/apps/explorer/lib/explorer/counters/address_tokens_usd_sum.ex
@@ -20,7 +20,7 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -76,21 +76,13 @@ defmodule Explorer.Counters.AddressTokenUsdSum do
   end
 
   defp update_cache(address_hash_string, token_balances) do
-    put_into_cache("hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
     new_data = address_tokens_fiat_sum(token_balances)
-    put_into_cache("hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
+++ b/apps/explorer/lib/explorer/counters/address_transactions_counter.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -67,28 +67,20 @@ defmodule Explorer.Counters.AddressTransactionsCounter do
 
   defp update_cache(address) do
     address_hash_string = to_string(address.hash)
-    put_into_cache("hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
     new_data = Counters.address_to_transaction_count(address)
-    put_into_cache("hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
     put_into_db(address, new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp put_into_db(address, value) do
     address
     |> Changeset.change(%{transactions_count: value})
     |> Repo.update()
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/block_burnt_fee_counter.ex
+++ b/apps/explorer/lib/explorer/counters/block_burnt_fee_counter.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Counters.BlockBurntFeeCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -58,23 +58,15 @@ defmodule Explorer.Counters.BlockBurntFeeCounter do
   defp update_cache(block_hash) do
     block_hash_string = get_block_hash_string(block_hash)
     new_data = Chain.block_to_gas_used_by_1559_txs(block_hash)
-    put_into_cache("#{block_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "#{block_hash_string}", new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp get_block_hash_string(block_hash) do
     Base.encode16(block_hash.bytes, case: :lower)
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/block_priority_fee_counter.ex
+++ b/apps/explorer/lib/explorer/counters/block_priority_fee_counter.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Counters.BlockPriorityFeeCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -58,23 +58,15 @@ defmodule Explorer.Counters.BlockPriorityFeeCounter do
   defp update_cache(block_hash) do
     block_hash_string = get_block_hash_string(block_hash)
     new_data = Chain.block_to_priority_fee_of_1559_txs(block_hash)
-    put_into_cache("#{block_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "#{block_hash_string}", new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp get_block_hash_string(block_hash) do
     Base.encode16(block_hash.bytes, case: :lower)
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/helper.ex
+++ b/apps/explorer/lib/explorer/counters/helper.ex
@@ -16,7 +16,7 @@ defmodule Explorer.Counters.Helper do
     DateTime.to_unix(utc_now, :millisecond)
   end
 
-  def fetch_from_cache(key, cache_name, default \\ 0) do
+  def fetch_from_ets_cache(key, cache_name, default \\ nil) do
     case :ets.lookup(cache_name, key) do
       [{_, value}] ->
         value
@@ -24,6 +24,10 @@ defmodule Explorer.Counters.Helper do
       [] ->
         default
     end
+  end
+
+  def put_into_ets_cache(cache_name, key, value) do
+    :ets.insert(cache_name, {key, value})
   end
 
   def create_cache_table(cache_name) do

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -4,11 +4,13 @@ defmodule Explorer.Counters.TokenHoldersCounter do
   """
   use GenServer
 
-  alias Explorer.Chain
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Chain.Token
   alias Explorer.Counters.Helper
 
-  @cache_name :token_holders_counter
-  @last_update_key "last_update"
+  @api_true [api?: true]
+  @cache_name :token_holders_count
+  @ets_last_update_key "last_update"
 
   config = Application.compile_env(:explorer, Explorer.Counters.TokenHoldersCounter)
   @enable_consolidation Keyword.get(config, :enable_consolidation)
@@ -20,7 +22,7 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -45,16 +47,14 @@ defmodule Explorer.Counters.TokenHoldersCounter do
       update_cache(address_hash)
     end
 
-    address_hash_string = to_string(address_hash)
-    fetch_from_cache("hash_#{address_hash_string}")
+    fetch_count_from_cache(address_hash)
   end
 
   def cache_name, do: @cache_name
 
   defp cache_expired?(address_hash) do
     cache_period = Application.get_env(:explorer, __MODULE__)[:cache_period]
-    address_hash_string = to_string(address_hash)
-    updated_at = fetch_from_cache("hash_#{address_hash_string}_#{@last_update_key}")
+    updated_at = fetch_updated_at_from_cache(address_hash, @cache_name)
 
     cond do
       is_nil(updated_at) -> true
@@ -65,21 +65,33 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   defp update_cache(address_hash) do
     address_hash_string = to_string(address_hash)
-    put_into_cache("hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
-    new_data = Chain.count_token_holders_from_token_hash(address_hash)
-    put_into_cache("hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@ets_last_update_key}", Helper.current_time())
+    new_data = CurrentTokenBalance.count_token_holders_from_token_hash(address_hash)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
+    put_into_db_cache(address_hash, new_data)
   end
 
-  defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
+  def fetch_count_from_cache(address_hash) do
+    address_hash_string = to_string(address_hash)
+    key = "hash_#{address_hash_string}"
+
+    Helper.fetch_from_ets_cache(key, @cache_name) || fetch_from_db_cache(address_hash)
   end
 
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
+  def fetch_updated_at_from_cache(address_hash, cache_name) do
+    address_hash_string = to_string(address_hash)
+    key = "hash_#{address_hash_string}_#{@ets_last_update_key}"
+
+    Helper.fetch_from_ets_cache(key, cache_name)
   end
 
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
+  def fetch_from_db_cache(address_hash) do
+    token = Token.get_by_contract_address_hash(address_hash, @api_true)
+    token.holder_count
+  end
+
+  def put_into_db_cache(address_hash, count) do
+    Token.update_token_holder_count(address_hash, count)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -44,7 +44,9 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   def fetch(address_hash) do
     if cache_expired?(address_hash) do
-      update_cache(address_hash)
+      Task.start_link(fn ->
+        update_cache(address_hash)
+      end)
     end
 
     fetch_count_from_cache(address_hash)

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   def fetch_from_db_cache(address_hash) do
     token = Token.get_by_contract_address_hash(address_hash, @api_true)
-    token.holder_count
+    token.holder_count || 0
   end
 
   def put_into_db_cache(address_hash, count) do

--- a/apps/explorer/lib/explorer/counters/token_holders_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_holders_counter.ex
@@ -65,9 +65,9 @@ defmodule Explorer.Counters.TokenHoldersCounter do
 
   defp update_cache(address_hash) do
     address_hash_string = to_string(address_hash)
-    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@ets_last_update_key}", Helper.current_time())
     new_data = CurrentTokenBalance.count_token_holders_from_token_hash(address_hash)
     Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@ets_last_update_key}", Helper.current_time())
     put_into_db_cache(address_hash, new_data)
   end
 

--- a/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
+++ b/apps/explorer/lib/explorer/counters/token_transfers_counter.ex
@@ -20,7 +20,7 @@ defmodule Explorer.Counters.TokenTransfersCounter do
 
   @impl true
   def init(_args) do
-    create_cache_table()
+    Helper.create_cache_table(@cache_name)
 
     {:ok, %{consolidate?: enable_consolidation?()}, {:continue, :ok}}
   end
@@ -65,21 +65,13 @@ defmodule Explorer.Counters.TokenTransfersCounter do
 
   defp update_cache(address_hash) do
     address_hash_string = to_string(address_hash)
-    put_into_cache("hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}_#{@last_update_key}", Helper.current_time())
     new_data = Chain.count_token_transfers_from_token_hash(address_hash)
-    put_into_cache("hash_#{address_hash_string}", new_data)
+    Helper.put_into_ets_cache(@cache_name, "hash_#{address_hash_string}", new_data)
   end
 
   defp fetch_from_cache(key) do
-    Helper.fetch_from_cache(key, @cache_name)
-  end
-
-  defp put_into_cache(key, value) do
-    :ets.insert(@cache_name, {key, value})
-  end
-
-  defp create_cache_table do
-    Helper.create_cache_table(@cache_name)
+    Helper.fetch_from_ets_cache(key, @cache_name)
   end
 
   defp enable_consolidation?, do: @enable_consolidation

--- a/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/current_token_balance_test.exs
@@ -200,4 +200,31 @@ defmodule Explorer.Chain.Address.CurrentTokenBalanceTest do
       assert token_balances == [current_token_balance_a.address_hash]
     end
   end
+
+  describe "count_token_holders_from_token_hash" do
+    test "returns the most current count about token holders" do
+      address_a = insert(:address, hash: "0xe49fedd93960a0267b3c3b2c1e2d66028e013fee")
+      address_b = insert(:address, hash: "0x5f26097334b6a32b7951df61fd0c5803ec5d8354")
+
+      %Token{contract_address_hash: contract_address_hash} = insert(:token)
+
+      insert(
+        :address_current_token_balance,
+        address: address_a,
+        block_number: 1000,
+        token_contract_address_hash: contract_address_hash,
+        value: 5000
+      )
+
+      insert(
+        :address_current_token_balance,
+        address: address_b,
+        block_number: 1002,
+        token_contract_address_hash: contract_address_hash,
+        value: 1000
+      )
+
+      assert CurrentTokenBalance.count_token_holders_from_token_hash(contract_address_hash) == 2
+    end
+  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4194,33 +4194,6 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "count_token_holders_from_token_hash" do
-    test "returns the most current count about token holders" do
-      address_a = insert(:address, hash: "0xe49fedd93960a0267b3c3b2c1e2d66028e013fee")
-      address_b = insert(:address, hash: "0x5f26097334b6a32b7951df61fd0c5803ec5d8354")
-
-      %Token{contract_address_hash: contract_address_hash} = insert(:token)
-
-      insert(
-        :address_current_token_balance,
-        address: address_a,
-        block_number: 1000,
-        token_contract_address_hash: contract_address_hash,
-        value: 5000
-      )
-
-      insert(
-        :address_current_token_balance,
-        address: address_b,
-        block_number: 1002,
-        token_contract_address_hash: contract_address_hash,
-        value: 1000
-      )
-
-      assert Chain.count_token_holders_from_token_hash(contract_address_hash) == 2
-    end
-  end
-
   describe "address_to_transactions_with_token_transfers/2" do
     test "paginates transactions by the block number" do
       address = insert(:address)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9352
Resolves https://github.com/blockscout/blockscout/issues/8902

## Motivation

`holder_count` in `tokens` table is not updated at ETS cache update.

## Changelog

Update `holder_count` in `tokens` table at the time of updating the same value in the ETS cache.

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
