### PR TITLE
Don't insert pbo for not inserted blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- [#9629](https://github.com/blockscout/blockscout/pull/9629) - Don't insert pbo for not inserted blocks
 - [#9601](https://github.com/blockscout/blockscout/pull/9601) - Fix token instance transform for some unconventional tokens
 - [#9597](https://github.com/blockscout/blockscout/pull/9597) - Update token transfers block_consensus by block_number
 - [#9596](https://github.com/blockscout/blockscout/pull/9596) - Fix logging

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -64,12 +64,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
     hashes = Enum.map(changes_list, & &1.hash)
 
-    items_for_pending_ops =
-      changes_list
-      |> filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
-      |> Enum.filter(& &1.consensus)
-      |> Enum.map(&{&1.number, &1.hash})
-
     consensus_block_numbers = consensus_block_numbers(changes_list)
 
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
@@ -100,10 +94,10 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :blocks
       )
     end)
-    |> Multi.run(:new_pending_operations, fn repo, %{lose_consensus: nonconsensus_items} ->
+    |> Multi.run(:new_pending_operations, fn repo, %{blocks: blocks} ->
       Instrumenter.block_import_stage_runner(
         fn ->
-          new_pending_operations(repo, nonconsensus_items, items_for_pending_ops, insert_options)
+          new_pending_operations(repo, blocks, insert_options)
         end,
         :address_referencing,
         :blocks,
@@ -441,18 +435,13 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     lose_consensus(ExplorerRepo, [], block_numbers, [], opts)
   end
 
-  defp new_pending_operations(repo, nonconsensus_items, items, %{
-         timeout: timeout,
-         timestamps: timestamps
-       }) do
+  defp new_pending_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
     sorted_pending_ops =
-      items
-      |> MapSet.new()
-      |> MapSet.difference(MapSet.new(nonconsensus_items))
+      inserted_blocks
+      |> filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
+      |> Enum.filter(& &1.consensus)
+      |> Enum.map(&%{block_hash: &1.hash, block_number: &1.number})
       |> Enum.sort()
-      |> Enum.map(fn {number, hash} ->
-        %{block_hash: hash, block_number: number}
-      end)
 
     Import.insert_changes_list(
       repo,


### PR DESCRIPTION
## Motivation

In cases when block was unchanged during block import, function `Import.insert_changes_list` won't return this block, but we still would insert new `PendingBlockOperation` for it. And since `async_import_internal_transactions/1` operates with blocks, it means that the task for this block won't appear in `Indexer.Fetcher.InternalTransaction` queue and therefore the corresponding record in `pending_block_operations` will remain there until the next application restart.

## Changelog

Insert in `pending_block_operations` only actually updated blocks.