### PR TITLE
fix: fetching GraphQL schema by GraphiQL IDE

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -97,8 +97,8 @@ config :block_scout_web, BlockScoutWeb.CSPHeader,
 config :block_scout_web, Api.GraphQL,
   enabled: ConfigHelper.parse_bool_env_var("API_GRAPHQL_ENABLED", "true"),
   token_limit: ConfigHelper.parse_integer_env_var("API_GRAPHQL_TOKEN_LIMIT", 1000),
-  # Needs to be 200 to support the schema introspection for graphiql
-  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 200)
+  # Needs to be 215 to support the schema introspection for graphiql
+  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 215)
 
 # Configures Ueberauth local settings
 config :ueberauth, Ueberauth,

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/address_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/address_test.exs
@@ -407,7 +407,9 @@ defmodule BlockScoutWeb.GraphQL.Schema.Query.AddressTest do
 
       variables = %{
         "hash" => to_string(address.hash),
-        "first" => 67
+        # Add +5 because of the increase in complexity limit. For more info, see
+        # https://github.com/blockscout/blockscout/pull/9630
+        "first" => 67 + 5
       }
 
       conn = post(conn, "/api/v1/graphql", query: query, variables: variables)

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/addresses_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/addresses_test.exs
@@ -157,10 +157,10 @@ defmodule BlockScoutWeb.GraphQL.Schema.Query.AddressesTest do
     end
 
     test "correlates complexity to size of 'hashes' argument", %{conn: conn} do
-      # max of 50 addresses with four fields of complexity 1 can be fetched
-      # per query:
-      # 50 * 4 = 200, which is equal to a max complexity of 200
-      hashes = 51 |> build_list(:address) |> Enum.map(&to_string(&1.hash))
+      # max of 53 addresses with four fields of complexity 1 can be fetched per
+      # query: 53 * 4 = 212, which is the upper bound before reaching the max
+      # complexity limit of 215
+      hashes = 54 |> build_list(:address) |> Enum.map(&to_string(&1.hash))
 
       query = """
       query ($hashes: [AddressHash!]!) {

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/introspection_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/introspection_test.exs
@@ -1,0 +1,120 @@
+defmodule BlockScoutWeb.Schema.Query.IntrospectionTest do
+  use BlockScoutWeb.ConnCase
+
+  test "fetches schema", %{conn: conn} do
+    introspection_query = ~S"""
+    query IntrospectionQuery {
+      __schema {
+        queryType {
+          name
+        }
+        mutationType {
+          name
+        }
+
+        types {
+          ...FullType
+        }
+        directives {
+          name
+          description
+
+          locations
+          args {
+            ...InputValue
+          }
+        }
+      }
+    }
+
+    fragment FullType on __Type {
+      kind
+      name
+      description
+
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+
+    fragment InputValue on __InputValue {
+      name
+      description
+      type {
+        ...TypeRef
+      }
+      defaultValue
+    }
+
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                      ofType {
+                        kind
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    conn = get(conn, "/api/v1/graphql", query: introspection_query)
+    response = json_response(conn, 200)
+
+    assert %{"data" => %{"__schema" => %{"directives" => _}}} = response
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -114,8 +114,8 @@ config :block_scout_web, Api.GraphQL,
     ),
   enabled: ConfigHelper.parse_bool_env_var("API_GRAPHQL_ENABLED", "true"),
   token_limit: ConfigHelper.parse_integer_env_var("API_GRAPHQL_TOKEN_LIMIT", 1000),
-  # Needs to be 200 to support the schema introspection for graphiql
-  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 200)
+  # Needs to be 215 to support the schema introspection for graphiql
+  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 215)
 
 # Configures History
 price_chart_config =


### PR DESCRIPTION
Closes #9135.

## Changelog

### Enhancements

A regression test for Bug Fix.

### Bug Fixes

Slightly increase `max_complexity` limit for executing GraphQL queries. Fix tests that were dependent on the previously set limit.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
