### PR TITLE
Reset missing ranges collector to max number after the cycle is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`
 - [#9638](https://github.com/blockscout/blockscout/pull/9638) - Do not broadcast coin balance changes with empty value/delta
+- [#9635](https://github.com/blockscout/blockscout/pull/9635) - Reset missing ranges collector to max number after the cycle is done
 - [#9629](https://github.com/blockscout/blockscout/pull/9629) - Don't insert pbo for not inserted blocks
 - [#9601](https://github.com/blockscout/blockscout/pull/9601) - Fix token instance transform for some unconventional tokens
 - [#9597](https://github.com/blockscout/blockscout/pull/9597) - Update token transfers block_consensus by block_number

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -145,14 +145,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
       {:noreply, %{state | min_fetched_block_number: new_min_number}}
     else
       Process.send_after(self(), :update_past, @past_check_interval * 100)
-      {:noreply, %{state | min_fetched_block_number: reset_min_fetched_block_number(state.max_fetched_block_number)}}
-    end
-  end
-
-  defp reset_min_fetched_block_number(max_fetched_block_number) do
-    case MissingBlockRange.fetch_min_max() do
-      %{min: nil} -> max_fetched_block_number
-      %{min: min} -> min
+      {:noreply, %{state | min_fetched_block_number: state.max_fetched_block_number}}
     end
   end
 


### PR DESCRIPTION
## Motivation

`MissingRangesCollector` won't start another chain crawling until `missing_block_ranges` is empty so if there are missing blocks above the point where collector started, they will be refetched only after all other missing blocks are processed. We should give higher priority to latest blocks.

## Changelog

Reset `MissingRangesCollector` `min_fetched_block_number` to `max_fetched_block_number` after the cycle is done