### PR TITLE
Fix fetch_coin_balance query to compare between balances with values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixes
 
 - [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`
+- [#9638](https://github.com/blockscout/blockscout/pull/9638) - Fix fetch_coin_balance query to compare between balances with values
 - [#9629](https://github.com/blockscout/blockscout/pull/9629) - Don't insert pbo for not inserted blocks
 - [#9601](https://github.com/blockscout/blockscout/pull/9601) - Fix token instance transform for some unconventional tokens
 - [#9597](https://github.com/blockscout/blockscout/pull/9597) - Update token transfers block_consensus by block_number

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -193,11 +193,13 @@ defmodule BlockScoutWeb.AddressChannel do
       ) do
     coin_balance = Chain.get_coin_balance(socket.assigns.address_hash, block_number)
 
-    rendered_coin_balance = AddressViewAPI.render("coin_balance.json", %{coin_balance: coin_balance})
+    if coin_balance.value && coin_balance.delta do
+      rendered_coin_balance = AddressViewAPI.render("coin_balance.json", %{coin_balance: coin_balance})
 
-    push(socket, "coin_balance", %{coin_balance: rendered_coin_balance})
+      push(socket, "coin_balance", %{coin_balance: rendered_coin_balance})
 
-    push_current_coin_balance(socket, block_number, coin_balance)
+      push_current_coin_balance(socket, block_number, coin_balance)
+    end
 
     {:noreply, socket}
   end
@@ -207,19 +209,21 @@ defmodule BlockScoutWeb.AddressChannel do
 
     Gettext.put_locale(BlockScoutWeb.Gettext, socket.assigns.locale)
 
-    rendered_coin_balance =
-      View.render_to_string(
-        AddressCoinBalanceView,
-        "_coin_balances.html",
-        conn: socket,
-        coin_balance: coin_balance
-      )
+    if coin_balance.value && coin_balance.delta do
+      rendered_coin_balance =
+        View.render_to_string(
+          AddressCoinBalanceView,
+          "_coin_balances.html",
+          conn: socket,
+          coin_balance: coin_balance
+        )
 
-    push(socket, "coin_balance", %{
-      coin_balance_html: rendered_coin_balance
-    })
+      push(socket, "coin_balance", %{
+        coin_balance_html: rendered_coin_balance
+      })
 
-    push_current_coin_balance(socket, block_number, coin_balance)
+      push_current_coin_balance(socket, block_number, coin_balance)
+    end
 
     {:noreply, socket}
   end

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -50,7 +50,6 @@ defmodule Explorer.Chain.Address.CoinBalance do
         cb in CoinBalance,
         where: cb.address_hash == ^address_hash,
         where: cb.block_number <= ^block_number,
-        where: not is_nil(cb.value),
         inner_join: b in Block,
         on: cb.block_number == b.number,
         limit: ^2,

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -50,6 +50,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
         cb in CoinBalance,
         where: cb.address_hash == ^address_hash,
         where: cb.block_number <= ^block_number,
+        where: not is_nil(cb.value),
         inner_join: b in Block,
         on: cb.block_number == b.number,
         limit: ^2,


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9567

## Motivation

Since we calculate delta in the response it would make sense to return only last values of balances with non-null values.

## Changelog

Return latest balances with non-null "value" in `fetch_coin_balance/2`

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
