### PR TITLE
Fix no function clause matching in BENS.item_to_address_hash_strings/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixes
 
+- [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`
 - [#9629](https://github.com/blockscout/blockscout/pull/9629) - Don't insert pbo for not inserted blocks
 - [#9601](https://github.com/blockscout/blockscout/pull/9601) - Fix token instance transform for some unconventional tokens
 - [#9597](https://github.com/blockscout/blockscout/pull/9597) - Update token transfers block_consensus by block_number

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -294,16 +294,8 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   defp parse_get_address_response(_), do: nil
 
   defp item_to_address_hash_strings(%Transaction{
-         to_address_hash: nil,
-         created_contract_address_hash: created_contract_address_hash,
-         from_address_hash: from_address_hash
-       }) do
-    [to_string(created_contract_address_hash), to_string(from_address_hash)]
-  end
-
-  defp item_to_address_hash_strings(%Transaction{
          to_address_hash: to_address_hash,
-         created_contract_address_hash: nil,
+         created_contract_address_hash: created_contract_address_hash,
          from_address_hash: from_address_hash,
          token_transfers: token_transfers
        }) do
@@ -316,7 +308,9 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
           []
       end
 
-    [to_string(to_address_hash), to_string(from_address_hash)] ++ token_transfers_addresses
+    ([to_address_hash, created_contract_address_hash, from_address_hash]
+     |> Enum.reject(&is_nil/1)
+     |> Enum.map(&to_string/1)) ++ token_transfers_addresses
   end
 
   defp item_to_address_hash_strings(%TokenTransfer{


### PR DESCRIPTION
Closes #9625 

## Changelog
- Fix no function clause matching in BENS.item_to_address_hash_strings/1

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
