### PR TITLE
Re-add missing blob transactions count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#9631](https://github.com/blockscout/blockscout/pull/9631) - Initial support of zksync chain type
 - [#9532](https://github.com/blockscout/blockscout/pull/9532) - Add last output root size counter
-- [#9490](https://github.com/blockscout/blockscout/pull/9490) - Add blob transaction counter and filter in block view
+- [#9490](https://github.com/blockscout/blockscout/pull/9490), [#9644](https://github.com/blockscout/blockscout/pull/9644) - Add blob transaction counter and filter in block view
 - [#9486](https://github.com/blockscout/blockscout/pull/9486) - Massive blocks fetcher
 - [#9473](https://github.com/blockscout/blockscout/pull/9473) - Add user_op interpretation
 - [#9461](https://github.com/blockscout/blockscout/pull/9461) - Fetch blocks without internal transactions backwards

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -96,12 +96,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   def count_transactions(%Block{transactions: txs}) when is_list(txs), do: Enum.count(txs)
   def count_transactions(_), do: nil
 
-  def count_blob_transactions(%Block{transactions: txs}) when is_list(txs),
-    # EIP-2718 blob transaction type
-    do: Enum.count(txs, &(&1.type == 3))
-
-  def count_blob_transactions(_), do: nil
-
   def count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
   def count_withdrawals(_), do: nil
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
@@ -29,21 +29,21 @@ defmodule BlockScoutWeb.API.V2.EthereumView do
     blob_gas_used = Map.get(block, :blob_gas_used)
     excess_blob_gas = Map.get(block, :excess_blob_gas)
 
+    extended_out_json =
+      out_json
+      |> Map.put("blob_tx_count", count_blob_transactions(block))
+      |> Map.put("blob_gas_used", blob_gas_used)
+      |> Map.put("excess_blob_gas", excess_blob_gas)
+
     if single_block? do
       blob_gas_price = Block.transaction_blob_gas_price(block.transactions)
       burnt_blob_transaction_fees = Decimal.mult(blob_gas_used || 0, blob_gas_price || 0)
 
-      out_json
-      |> Map.put("blob_tx_count", count_blob_transactions(block))
-      |> Map.put("blob_gas_used", blob_gas_used)
-      |> Map.put("excess_blob_gas", excess_blob_gas)
+      extended_out_json
       |> Map.put("blob_gas_price", blob_gas_price)
       |> Map.put("burnt_blob_fees", burnt_blob_transaction_fees)
     else
-      out_json
-      |> Map.put("blob_tx_count", count_blob_transactions(block))
-      |> Map.put("blob_gas_used", blob_gas_used)
-      |> Map.put("excess_blob_gas", excess_blob_gas)
+      extended_out_json
     end
   end
 end


### PR DESCRIPTION
Re-add `blob_tx_count` from https://github.com/blockscout/blockscout/pull/9490 missed during https://github.com/blockscout/blockscout/pull/9631 refactoring