### PR TITLE
Hotfix for Optimism Ecotone batch blobs indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixes
 
+- [#9646](https://github.com/blockscout/blockscout/pull/9646) - Hotfix for Optimism Ecotone batch blobs indexing
 - [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`
 - [#9629](https://github.com/blockscout/blockscout/pull/9629) - Don't insert pbo for not inserted blocks
 - [#9601](https://github.com/blockscout/blockscout/pull/9601) - Fix token instance transform for some unconventional tokens

--- a/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
@@ -102,13 +102,13 @@ defmodule Explorer.Chain.Optimism.TxnBatch do
         end
       end)
 
-    Enum.each(Range.new(output_len, byte_size(output) - 1), fn i ->
+    Enum.each(Range.new(output_len, byte_size(output) - 1, 1), fn i ->
       <<0>> = binary_part(output, i, 1)
     end)
 
     output = binary_part(output, 0, output_len)
 
-    Enum.each(Range.new(ipos, @blob_size - 1), fn i ->
+    Enum.each(Range.new(ipos, @blob_size - 1, 1), fn i ->
       <<0>> = binary_part(b, i, 1)
     end)
 
@@ -118,10 +118,10 @@ defmodule Explorer.Chain.Optimism.TxnBatch do
   end
 
   defp decode_eip4844_field_element(b, opos, ipos, output) do
-    <<_::binary-size(ipos), ipos_byte::size(8), insert::binary-size(32), _::binary>> = b
+    <<_::binary-size(ipos), ipos_byte::size(8), insert::binary-size(31), _::binary>> = b
 
     if Bitwise.band(ipos_byte, 0b11000000) == 0 do
-      <<output_before_opos::binary-size(opos), _::binary-size(32), rest::binary>> = output
+      <<output_before_opos::binary-size(opos), _::binary-size(31), rest::binary>> = output
 
       {ipos_byte, opos + 32, ipos + 32, output_before_opos <> insert <> rest}
     end


### PR DESCRIPTION
## Motivation

The new implementation of `Indexer.Fetcher.Optimism.TxnBatch` module introduced in https://github.com/blockscout/blockscout/pull/9571  has incorrect blob decoding function for full blobs and doesn't take into account several blobs in one batch transaction.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
