### PR TITLE
fix: handle transactions with `gas_price` set to `nil` in `transaction_revert_reason/2`

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2867,19 +2867,6 @@ defmodule Explorer.Chain do
       ) do
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
-    gas_hex =
-      if gas do
-        gas_hex_without_prefix =
-          gas
-          |> Decimal.to_integer()
-          |> Integer.to_string(16)
-          |> String.downcase()
-
-        "0x" <> gas_hex_without_prefix
-      else
-        "0x0"
-      end
-
     req =
       EthereumJSONRPCTransaction.eth_call_request(
         0,
@@ -2887,7 +2874,7 @@ defmodule Explorer.Chain do
         data,
         to_address_hash,
         from_address_hash,
-        gas_hex,
+        Wei.hex_format(gas),
         Wei.hex_format(gas_price),
         Wei.hex_format(value)
       )

--- a/apps/explorer/lib/explorer/chain/wei.ex
+++ b/apps/explorer/lib/explorer/chain/wei.ex
@@ -133,6 +133,10 @@ defmodule Explorer.Chain.Wei do
     "0x" <> hex
   end
 
+  def hex_format(nil) do
+    "0x0"
+  end
+
   @doc """
   Sums two Wei values.
 

--- a/apps/explorer/lib/explorer/chain/wei.ex
+++ b/apps/explorer/lib/explorer/chain/wei.ex
@@ -118,7 +118,7 @@ defmodule Explorer.Chain.Wei do
   @wei_per_ether Decimal.new(1_000_000_000_000_000_000)
   @wei_per_gwei Decimal.new(1_000_000_000)
 
-  @spec hex_format(Wei.t() | Decimal.t()) :: String.t()
+  @spec hex_format(Wei.t() | Decimal.t() | nil) :: String.t()
   def hex_format(%Wei{value: decimal}) do
     hex_format(decimal)
   end


### PR DESCRIPTION
Closes #9137
Resolves https://github.com/blockscout/blockscout/issues/9878

## Changelog

### Enhancements

A regression test for Bug Fix.

### Bug Fixes

Add a case for handling `nil` values in `Wei.hex_format`.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
