### PR TITLE
Remove duplicated tx hashes while indexing OP batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- [#9652](https://github.com/blockscout/blockscout/pull/9652) - Remove duplicated tx hashes while indexing OP batches
+
 ### Chore
 
 <details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### Fixes
 
-- [#9652](https://github.com/blockscout/blockscout/pull/9652) - Remove duplicated tx hashes while indexing OP batches
-
 ### Chore
 
 <details>
@@ -36,6 +34,7 @@
 
 ### Fixes
 
+- [#9652](https://github.com/blockscout/blockscout/pull/9652) - Remove duplicated tx hashes while indexing OP batches
 - [#9646](https://github.com/blockscout/blockscout/pull/9646) - Hotfix for Optimism Ecotone batch blobs indexing
 - [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`
 - [#9638](https://github.com/blockscout/blockscout/pull/9638) - Do not broadcast coin balance changes with empty value/delta

--- a/apps/indexer/lib/indexer/fetcher/optimism/txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/txn_batch.ex
@@ -615,7 +615,7 @@ defmodule Indexer.Fetcher.Optimism.TxnBatch do
 
     seq = %{
       id: frame_sequence_id,
-      l1_transaction_hashes: Enum.reverse(l1_transaction_hashes),
+      l1_transaction_hashes: Enum.uniq(Enum.reverse(l1_transaction_hashes)),
       l1_timestamp: channel.l1_timestamp
     }
 


### PR DESCRIPTION
## Motivation

`Indexer.Fetcher.Optimism.TxnBatch` module duplicates L1 tx hashes due to different frames containing in one transaction (when using EIP-4844 blobs). This PR fixes it.

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
