### PR TITLE
Tokens import improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Fixes
 
 - [#9654](https://github.com/blockscout/blockscout/pull/9654) - Send timeout param in debug_traceBlockByNumber request
+- [#9653](https://github.com/blockscout/blockscout/pull/9653) - Tokens import improvements
 - [#9652](https://github.com/blockscout/blockscout/pull/9652) - Remove duplicated tx hashes while indexing OP batches
 - [#9646](https://github.com/blockscout/blockscout/pull/9646) - Hotfix for Optimism Ecotone batch blobs indexing
 - [#9640](https://github.com/blockscout/blockscout/pull/9640) - Fix no function clause matching in `BENS.item_to_address_hash_strings/1`

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
@@ -2,8 +2,8 @@ defmodule BlockScoutWeb.API.V2.ImportController do
   use BlockScoutWeb, :controller
 
   alias BlockScoutWeb.API.V2.ApiView
-  alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.{Data, SmartContract, Token}
+  alias Explorer.Chain
+  alias Explorer.Chain.{Data, SmartContract}
   alias Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand
   alias Explorer.SmartContract.EthBytecodeDBInterface
 
@@ -35,7 +35,7 @@ defmodule BlockScoutWeb.API.V2.ImportController do
         |> put_token_string_field(token_symbol, :symbol)
         |> put_token_string_field(token_name, :name)
 
-      case token |> Token.changeset(changeset) |> Repo.update() do
+      case Chain.update_token(token, changeset, true) do
         {:ok, _} ->
           conn
           |> put_view(ApiView)

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -119,7 +119,10 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
     ordered_changes_list =
       changes_list
       # brand new tokens start with no holders
-      |> Stream.map(&Map.put_new(&1, :holder_count, 0))
+      # set cataloged: nil, if not set before, to get proper COALESCE result
+      # if don't set it, cataloged will default to false (as in DB schema)
+      # and COALESCE in on_conflict will return false
+      |> Stream.map(fn token -> token |> Map.put_new(:holder_count, 0) |> Map.put_new(:cataloged, nil) end)
       # Enforce Token ShareLocks order (see docs: sharelocks.md)
       |> Enum.sort_by(& &1.contract_address_hash)
 

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -178,7 +178,6 @@ defmodule Explorer.Token.MetadataRetriever do
       token_to_update =
         Token
         |> Repo.get_by(contract_address_hash: contract_address_hash)
-        |> Repo.preload([:contract_address])
 
       set_skip_metadata(token_to_update)
     end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -707,7 +707,7 @@ defmodule Explorer.Factory do
       cataloged: true,
       icon_url: sequence("https://example.com/icon"),
       fiat_value: 10.1,
-      is_verified_via_admin_panel: Enum.random([true, false])
+      is_verified_via_admin_panel: false
     }
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token.ex
+++ b/apps/indexer/lib/indexer/fetcher/token.ex
@@ -51,7 +51,7 @@ defmodule Indexer.Fetcher.Token do
   @impl BufferedTask
   @decorate trace(name: "fetch", resource: "Indexer.Fetcher.Token.run/2", service: :indexer, tracer: Tracer)
   def run([token_contract_address], _json_rpc_named_arguments) do
-    options = [necessity_by_association: %{[contract_address: :smart_contract] => :optional}]
+    options = [necessity_by_association: %{}]
 
     case Chain.token_from_address_hash(token_contract_address, options) do
       {:ok, %Token{} = token} ->

--- a/apps/indexer/lib/indexer/fetcher/token.ex
+++ b/apps/indexer/lib/indexer/fetcher/token.ex
@@ -51,9 +51,7 @@ defmodule Indexer.Fetcher.Token do
   @impl BufferedTask
   @decorate trace(name: "fetch", resource: "Indexer.Fetcher.Token.run/2", service: :indexer, tracer: Tracer)
   def run([token_contract_address], _json_rpc_named_arguments) do
-    options = [necessity_by_association: %{}]
-
-    case Chain.token_from_address_hash(token_contract_address, options) do
+    case Chain.token_from_address_hash(token_contract_address) do
       {:ok, %Token{} = token} ->
         catalog_token(token)
     end

--- a/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_total_supply_on_demand.ex
@@ -45,7 +45,6 @@ defmodule Indexer.Fetcher.TokenTotalSupplyOnDemand do
     token =
       Token
       |> Repo.get_by(contract_address_hash: address)
-      |> Repo.preload([:contract_address])
 
     if is_nil(token.total_supply_updated_at_block) or
          BlockNumber.get_max() - token.total_supply_updated_at_block > @ttl_in_blocks do
@@ -55,8 +54,7 @@ defmodule Indexer.Fetcher.TokenTotalSupplyOnDemand do
         token_address_hash
         |> MetadataRetriever.get_total_supply_of()
 
-      {:ok, token} =
-        Chain.update_token(token, Map.put(token_params, :total_supply_updated_at_block, BlockNumber.get_max()))
+      {:ok, token} = Chain.update_token(token, token_params)
 
       Publisher.broadcast(%{token_total_supply: [token]}, :on_demand)
       :ok

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -79,7 +79,7 @@ defmodule Indexer.Fetcher.TokenUpdater do
 
   @doc false
   def update_metadata(metadata_list) when is_list(metadata_list) do
-    options = [necessity_by_association: %{[contract_address: :smart_contract] => :optional}]
+    options = [necessity_by_association: %{}]
 
     Enum.each(metadata_list, fn %{contract_address_hash: contract_address_hash} = metadata ->
       {:ok, hash} = Hash.Address.cast(contract_address_hash)

--- a/apps/indexer/lib/indexer/fetcher/token_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_updater.ex
@@ -79,12 +79,10 @@ defmodule Indexer.Fetcher.TokenUpdater do
 
   @doc false
   def update_metadata(metadata_list) when is_list(metadata_list) do
-    options = [necessity_by_association: %{}]
-
     Enum.each(metadata_list, fn %{contract_address_hash: contract_address_hash} = metadata ->
       {:ok, hash} = Hash.Address.cast(contract_address_hash)
 
-      with {:ok, %Token{cataloged: true} = token} <- Chain.token_from_address_hash(hash, options) do
+      with {:ok, %Token{cataloged: true} = token} <- Chain.token_from_address_hash(hash) do
         update_metadata(token, metadata)
       end
     end)


### PR DESCRIPTION
Closes #9655 

## Motivation
- Metadata for tokens imported via admin-rs overwrited

## Changelog

### Enhancements
- Removed unnecessary preloads on tokens update
- Spread `total_supply_updated_at_block` field filling

### Bug Fixes
- Add check on `is_verified_via_admin_panel` field in `Explorer.Chain.update_token/3`
- Add `Map.put_new(:cataloged, nil)` to make on_conflict work as expected

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
