### PR TITLE
perf: Add EIP4844 blob transactions index

### DIFF
--- a/apps/explorer/priv/beacon/migrations/20240318154323_create_blob_transactions_index.exs
+++ b/apps/explorer/priv/beacon/migrations/20240318154323_create_blob_transactions_index.exs
@@ -1,5 +1,7 @@
 defmodule Explorer.Repo.Beacon.Migrations.AddTransactionsRecentBlobTransactionsIndex do
   use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
 
   def change do
     create_if_not_exists(

--- a/apps/explorer/priv/beacon/migrations/20240318154323_create_blob_transactions_index.exs
+++ b/apps/explorer/priv/beacon/migrations/20240318154323_create_blob_transactions_index.exs
@@ -1,0 +1,13 @@
+defmodule Explorer.Repo.Beacon.Migrations.AddTransactionsRecentBlobTransactionsIndex do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(
+      index(:transactions, ["block_number DESC, index DESC"],
+        name: :transactions_recent_blob_transactions_index,
+        where: "type = 3",
+        concurrently: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
## Changelog

### Enhancements
* Add index on recent blob transactions to avoid query performance issues. 

Affected API:

`/api/v2/transactions?type=[blob_transaction]`

Affected query SQL (simplified):

```sql
EXPLAIN
SELECT *
FROM transactions
         JOIN blocks ON transactions.block_hash = blocks.hash
WHERE block_number IS NOT NULL
  AND index IS NOT NULL
  AND type = 3
ORDER BY block_number DESC, index DESC
LIMIT 50;
```

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
