### PR TITLE
feat(ci): try running json rpc unit tests without matrix

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -425,9 +425,6 @@ jobs:
         working-directory: apps/block_scout_web/assets
 
   test_nethermind_mox_ethereum_jsonrpc:
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}
     name: EthereumJSONRPC Tests
     runs-on: ubuntu-latest
     needs:
@@ -477,8 +474,12 @@ jobs:
       - name: mix test --exclude no_nethermind
         run: |
           cd apps/ethereum_jsonrpc
-          mix compile
-          mix test --no-start --exclude no_nethermind
+          for chain_type in $(echo '${{ needs.matrix-builder.outputs.matrix }}' | jq -r '."chain-type"[]'); do
+            export CHAIN_TYPE=$chain_type
+            echo "Testing for $chain_type"
+            mix compile
+            mix test --no-start --exclude no_nethermind
+          done
         env:
           # match POSTGRES_PASSWORD for postgres image below
           PGPASSWORD: postgres
@@ -486,7 +487,6 @@ jobs:
           PGUSER: postgres
           ETHEREUM_JSONRPC_CASE: "EthereumJSONRPC.Case.Nethermind.Mox"
           ETHEREUM_JSONRPC_WEB_SOCKET_CASE: "EthereumJSONRPC.WebSocket.Case.Mox"
-          CHAIN_TYPE: "${{ matrix.chain-type }}"
   test_nethermind_mox_explorer:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Motivation

Try to improve overall throughput of concurrent CI jobs by reducing the number of short-time jobs

## Changelog

### Enhancements
* Run JSON RPC chain typed unit tests in a single job

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
