### PR TITLE
fix: Change CoinGecko token image attribute priority

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/coin_gecko.ex
@@ -257,7 +257,7 @@ defmodule Explorer.ExchangeRates.Source.CoinGecko do
   defp get_coin_image(image_data) do
     image_url_raw =
       if image_data do
-        image_data["thumb"] || image_data["small"]
+        image_data["small"] || image_data["thumb"]
       else
         nil
       end

--- a/apps/explorer/test/explorer/exchange_rates/source/coin_gecko_test.exs
+++ b/apps/explorer/test/explorer/exchange_rates/source/coin_gecko_test.exs
@@ -121,7 +121,7 @@ defmodule Explorer.ExchangeRates.Source.CoinGeckoTest do
           symbol: "POA",
           usd_value: Decimal.new("0.01345698"),
           volume_24h_usd: Decimal.new("119946"),
-          image_url: "https://assets.coingecko.com/coins/images/3157/thumb/poa-network.png?1548331565"
+          image_url: "https://assets.coingecko.com/coins/images/3157/small/poa-network.png?1548331565"
         }
       ]
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9658

## Motivation

Currently, we get token image from CoinGecko API from `thumb` atribute -> and `small` as a fallback.

## Changelog

Change priority to s`mall` -> `thumb` as a fallback.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
