### PR TITLE
fix: Fix Geth block tracing errors handling

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -93,8 +93,14 @@ defmodule EthereumJSONRPC.Geth do
     blocks_responses
     |> EthereumJSONRPC.sanitize_responses(id_to_params)
     |> Enum.reduce([], fn
-      %{result: _result}, acc -> acc
-      %{error: error}, acc -> [error | acc]
+      %{result: result}, acc ->
+        Enum.reduce(result, acc, fn
+          %{"result" => _calls_result}, inner_acc -> inner_acc
+          %{"error" => error}, inner_acc -> [error | inner_acc]
+        end)
+
+      %{error: error}, acc ->
+        [error | acc]
     end)
     |> case do
       [] -> :ok


### PR DESCRIPTION
## Motivation

If there was an error in inner transaction tracing result, function `check_errors_exist/2` will miss it so the further step will fail since it expects successful results in transaction traces.

## Changelog

Update `check_errors_exist/2` so it checks inner transaction trace result as well.