### PR TITLE
fix: erc-404 token transfers null value

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/_total_transfers.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/_total_transfers.html.eex
@@ -1,7 +1,7 @@
 <%= case token_transfer_amount(@transfer) do %>
     <% {:ok, :erc721_instance} -> %>
         <%= render BlockScoutWeb.TransactionView, "_transfer_token_with_id.html", transfer: @transfer, token_id: List.first(@transfer.token_ids) %>
-    <% {:ok, :erc1155_instance, value} -> %>
+    <% {:ok, :erc1155_erc404_instance, value} -> %>
         <% transfer_type = Chain.get_token_transfer_type(@transfer) %>
         <%= if transfer_type == :token_spawning do %>
             <%= render BlockScoutWeb.TransactionView, "_transfer_token_with_id.html", transfer: @transfer, token_id: List.first(@transfer.token_ids) %>
@@ -9,7 +9,7 @@
             <%= "#{value} " %>
             <%= render BlockScoutWeb.TransactionView, "_transfer_token_with_id.html", transfer: @transfer, token_id: List.first(@transfer.token_ids) %>
         <% end %>
-    <% {:ok, :erc1155_instance, values, token_ids, _decimals} -> %>
+    <% {:ok, :erc1155_erc404_instance, values, token_ids, _decimals} -> %>
         <% values_ids = Enum.zip(values, token_ids) %>
         <%= for {value, token_id} <- values_ids do %>
             <div>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -266,14 +266,14 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       {:ok, :erc721_instance} ->
         %{"token_id" => token_transfer.token_ids && List.first(token_transfer.token_ids)}
 
-      {:ok, :erc1155_instance, value, decimals} ->
+      {:ok, :erc1155_erc404_instance, value, decimals} ->
         %{
           "token_id" => token_transfer.token_ids && List.first(token_transfer.token_ids),
           "value" => value,
           "decimals" => decimals
         }
 
-      {:ok, :erc1155_instance, values, token_ids, decimals} ->
+      {:ok, :erc1155_erc404_instance, values, token_ids, decimals} ->
         %{
           "token_id" => token_ids && List.first(token_ids),
           "value" => values && List.first(values),

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helper.ex
@@ -31,33 +31,33 @@ defmodule BlockScoutWeb.Tokens.Helper do
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount(%Token{type: type}, nil, nil, nil, _token_ids) when type in ["ERC-20", "ERC-404"] do
+  defp do_token_transfer_amount(%Token{type: type}, nil, nil, nil, _token_ids) when type == "ERC-20" do
     {:ok, "--"}
   end
 
-  defp do_token_transfer_amount(_token, type, nil, nil, _token_ids) when type in ["ERC-20", "ERC-404"] do
+  defp do_token_transfer_amount(_token, type, nil, nil, _token_ids) when type == "ERC-20" do
     {:ok, "--"}
   end
 
   # TODO: remove this clause along with token transfer denormalization
   defp do_token_transfer_amount(%Token{type: type, decimals: nil}, nil, amount, _amounts, _token_ids)
-       when type in ["ERC-20", "ERC-404"] do
+       when type == "ERC-20" do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, Decimal.new(0))}
   end
 
   defp do_token_transfer_amount(%Token{decimals: nil}, type, amount, _amounts, _token_ids)
-       when type in ["ERC-20", "ERC-404"] do
+       when type == "ERC-20" do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, Decimal.new(0))}
   end
 
   # TODO: remove this clause along with token transfer denormalization
   defp do_token_transfer_amount(%Token{type: type, decimals: decimals}, nil, amount, _amounts, _token_ids)
-       when type in ["ERC-20", "ERC-404"] do
+       when type in ["ERC-20"] do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, decimals)}
   end
 
   defp do_token_transfer_amount(%Token{decimals: decimals}, type, amount, _amounts, _token_ids)
-       when type in ["ERC-20", "ERC-404"] do
+       when type in ["ERC-20"] do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, decimals)}
   end
 
@@ -71,19 +71,21 @@ defmodule BlockScoutWeb.Tokens.Helper do
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount(%Token{type: "ERC-1155", decimals: decimals}, nil, amount, amounts, token_ids) do
+  defp do_token_transfer_amount(%Token{type: type, decimals: decimals}, nil, amount, amounts, token_ids)
+       when type in ["ERC-1155", "ERC-404"] do
     if amount do
-      {:ok, :erc1155_instance, CurrencyHelper.format_according_to_decimals(amount, decimals)}
+      {:ok, :erc1155_erc404_instance, CurrencyHelper.format_according_to_decimals(amount, decimals)}
     else
-      {:ok, :erc1155_instance, amounts, token_ids, decimals}
+      {:ok, :erc1155_erc404_instance, amounts, token_ids, decimals}
     end
   end
 
-  defp do_token_transfer_amount(%Token{decimals: decimals}, "ERC-1155", amount, amounts, token_ids) do
+  defp do_token_transfer_amount(%Token{decimals: decimals}, type, amount, amounts, token_ids)
+       when type in ["ERC-1155", "ERC-404"] do
     if amount do
-      {:ok, :erc1155_instance, CurrencyHelper.format_according_to_decimals(amount, decimals)}
+      {:ok, :erc1155_erc404_instance, CurrencyHelper.format_according_to_decimals(amount, decimals)}
     else
-      {:ok, :erc1155_instance, amounts, token_ids, decimals}
+      {:ok, :erc1155_erc404_instance, amounts, token_ids, decimals}
     end
   end
 
@@ -107,11 +109,11 @@ defmodule BlockScoutWeb.Tokens.Helper do
 
   # TODO: remove this clause along with token transfer denormalization
   defp do_token_transfer_amount_for_api(%Token{type: type}, nil, nil, nil, _token_ids)
-       when type in ["ERC-20", "ERC-404"] do
+       when type == "ERC-20" do
     {:ok, nil}
   end
 
-  defp do_token_transfer_amount_for_api(_token, type, nil, nil, _token_ids) when type in ["ERC-20", "ERC-404"] do
+  defp do_token_transfer_amount_for_api(_token, type, nil, nil, _token_ids) when type == "ERC-20" do
     {:ok, nil}
   end
 
@@ -123,7 +125,7 @@ defmodule BlockScoutWeb.Tokens.Helper do
          _amounts,
          _token_ids
        )
-       when type in ["ERC-20", "ERC-404"] do
+       when type == "ERC-20" do
     {:ok, amount, decimals}
   end
 
@@ -134,7 +136,7 @@ defmodule BlockScoutWeb.Tokens.Helper do
          _amounts,
          _token_ids
        )
-       when type in ["ERC-20", "ERC-404"] do
+       when type == "ERC-20" do
     {:ok, amount, decimals}
   end
 
@@ -149,30 +151,32 @@ defmodule BlockScoutWeb.Tokens.Helper do
 
   # TODO: remove this clause along with token transfer denormalization
   defp do_token_transfer_amount_for_api(
-         %Token{type: "ERC-1155", decimals: decimals},
+         %Token{type: type, decimals: decimals},
          nil,
          amount,
          amounts,
          token_ids
-       ) do
+       )
+       when type in ["ERC-1155", "ERC-404"] do
     if amount do
-      {:ok, :erc1155_instance, amount, decimals}
+      {:ok, :erc1155_erc404_instance, amount, decimals}
     else
-      {:ok, :erc1155_instance, amounts, token_ids, decimals}
+      {:ok, :erc1155_erc404_instance, amounts, token_ids, decimals}
     end
   end
 
   defp do_token_transfer_amount_for_api(
          %Token{decimals: decimals},
-         "ERC-1155",
+         type,
          amount,
          amounts,
          token_ids
-       ) do
+       )
+       when type in ["ERC-1155", "ERC-404"] do
     if amount do
-      {:ok, :erc1155_instance, amount, decimals}
+      {:ok, :erc1155_erc404_instance, amount, decimals}
     else
-      {:ok, :erc1155_instance, amounts, token_ids, decimals}
+      {:ok, :erc1155_erc404_instance, amounts, token_ids, decimals}
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/tokens/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/tokens/helper.ex
@@ -31,33 +31,29 @@ defmodule BlockScoutWeb.Tokens.Helper do
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount(%Token{type: type}, nil, nil, nil, _token_ids) when type == "ERC-20" do
+  defp do_token_transfer_amount(%Token{type: "ERC-20"}, nil, nil, nil, _token_ids) do
     {:ok, "--"}
   end
 
-  defp do_token_transfer_amount(_token, type, nil, nil, _token_ids) when type == "ERC-20" do
+  defp do_token_transfer_amount(_token, "ERC-20", nil, nil, _token_ids) do
     {:ok, "--"}
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount(%Token{type: type, decimals: nil}, nil, amount, _amounts, _token_ids)
-       when type == "ERC-20" do
+  defp do_token_transfer_amount(%Token{type: "ERC-20", decimals: nil}, nil, amount, _amounts, _token_ids) do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, Decimal.new(0))}
   end
 
-  defp do_token_transfer_amount(%Token{decimals: nil}, type, amount, _amounts, _token_ids)
-       when type == "ERC-20" do
+  defp do_token_transfer_amount(%Token{decimals: nil}, "ERC-20", amount, _amounts, _token_ids) do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, Decimal.new(0))}
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount(%Token{type: type, decimals: decimals}, nil, amount, _amounts, _token_ids)
-       when type in ["ERC-20"] do
+  defp do_token_transfer_amount(%Token{type: "ERC-20", decimals: decimals}, nil, amount, _amounts, _token_ids) do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, decimals)}
   end
 
-  defp do_token_transfer_amount(%Token{decimals: decimals}, type, amount, _amounts, _token_ids)
-       when type in ["ERC-20"] do
+  defp do_token_transfer_amount(%Token{decimals: decimals}, "ERC-20", amount, _amounts, _token_ids) do
     {:ok, CurrencyHelper.format_according_to_decimals(amount, decimals)}
   end
 
@@ -108,35 +104,32 @@ defmodule BlockScoutWeb.Tokens.Helper do
   end
 
   # TODO: remove this clause along with token transfer denormalization
-  defp do_token_transfer_amount_for_api(%Token{type: type}, nil, nil, nil, _token_ids)
-       when type == "ERC-20" do
+  defp do_token_transfer_amount_for_api(%Token{type: "ERC-20"}, nil, nil, nil, _token_ids) do
     {:ok, nil}
   end
 
-  defp do_token_transfer_amount_for_api(_token, type, nil, nil, _token_ids) when type == "ERC-20" do
+  defp do_token_transfer_amount_for_api(_token, "ERC-20", nil, nil, _token_ids) do
     {:ok, nil}
   end
 
   # TODO: remove this clause along with token transfer denormalization
   defp do_token_transfer_amount_for_api(
-         %Token{type: type, decimals: decimals},
+         %Token{type: "ERC-20", decimals: decimals},
          nil,
          amount,
          _amounts,
          _token_ids
-       )
-       when type == "ERC-20" do
+       ) do
     {:ok, amount, decimals}
   end
 
   defp do_token_transfer_amount_for_api(
          %Token{decimals: decimals},
-         type,
+         "ERC-20",
          amount,
          _amounts,
          _token_ids
-       )
-       when type == "ERC-20" do
+       ) do
     {:ok, amount, decimals}
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9697

## Motivation

Transferred token value is null in the response of `/api/v2/tokens/#{hash}/transfers` API endpoint for ERC-404 token type even when it is not null in the DB.


## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
