### PR TITLE
fix: erc-404 type stored in token balances tables

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -353,7 +353,7 @@ defmodule Explorer.Chain.Token.Instance do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
     CurrentTokenBalance
-    |> where([ctb], ctb.address_hash == ^address_hash and ctb.value > 0 and ctb.token_type == "ERC-404")
+    |> where([ctb], ctb.address_hash == ^address_hash and not is_nil(ctb.token_id) and ctb.token_type == "ERC-404")
     |> group_by([ctb], ctb.token_contract_address_hash)
     |> order_by([ctb], asc: ctb.token_contract_address_hash)
     |> select([ctb], %{

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -165,6 +165,7 @@ defmodule Explorer.Chain.ImportTest do
             to_address_hash: "0x515c09c5bba1ed566b02a5b0599ec5d5d0aee73d",
             token_contract_address_hash: "0x8bf38d4764929064f2d4d3a56520a76ab3df415b",
             token_type: "ERC-20",
+            token: %{type: "ERC-20"},
             transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5"
           }
         ],

--- a/apps/indexer/lib/indexer/transform/address_token_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_token_balances.ex
@@ -17,7 +17,7 @@ defmodule Indexer.Transform.AddressTokenBalances do
                                  to_address_hash: to_address_hash,
                                  token_contract_address_hash: token_contract_address_hash,
                                  token_ids: token_ids,
-                                 token_type: token_type
+                                 token: %{type: token_type}
                                },
                                acc
                                when is_integer(block_number) and is_binary(from_address_hash) and

--- a/apps/indexer/test/indexer/transform/address_token_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_token_balances_test.exs
@@ -26,7 +26,8 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
         to_address_hash: to_address_hash,
         token_contract_address_hash: token_contract_address_hash,
         token_ids: nil,
-        token_type: "ERC-20"
+        token_type: "ERC-20",
+        token: %{type: "ERC-20"}
       }
 
       params_set = AddressTokenBalances.params_set(%{token_transfers_params: [token_transfer_params]})
@@ -49,6 +50,7 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
         to_address_hash: to_address_hash,
         token_contract_address_hash: token_contract_address_hash,
         token_type: "ERC-721",
+        token: %{type: "ERC-721"},
         token_ids: nil
       }
 
@@ -78,6 +80,7 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
         to_address_hash: to_address_hash,
         token_contract_address_hash: token_contract_address_hash,
         token_type: "ERC-721",
+        token: %{type: "ERC-1155"},
         token_ids: [1]
       }
 
@@ -90,7 +93,7 @@ defmodule Indexer.Transform.AddressTokenBalancesTest do
                    block_number: 1,
                    token_contract_address_hash: "0xe18035bf8712672935fdb4e5e431b1a0183d2dfc",
                    token_id: 1,
-                   token_type: "ERC-721"
+                   token_type: "ERC-1155"
                  }
                ])
     end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9699

## Motivation

A wrong amount for ERC-404 token in `https://base.blockscout.com/api/v2/addresses/#{hash}/nft/collections` API endpoint.

## Changelog

Despite we [started to keep different token types in token transfers](https://github.com/blockscout/blockscout/pull/6893) of the same token based on the event signature (to what standard this event actually belongs) we shouldn't extrapolate this logic to token balances. However, token balances are derived from the token transfers params set. Thus, we override a token type in the balances as well. This leads to troubles in UI like incorrect filtering and wrong amount display.

This PR adds the actual token type to token transfers params set which is used by `AddressTokenBalances` transformer.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
