### PR TITLE
ci: remove polygon edge and suave from CI runs

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT
         env:
-          matrixStringifiedObject: '{"chain-type": ["ethereum", "polygon_edge", "polygon_zkevm", "rsk", "suave", "stability", "filecoin", "optimism"]}'
+          matrixStringifiedObject: '{"chain-type": ["ethereum", "polygon_zkevm", "rsk", "stability", "filecoin", "optimism"]}'
 
   build-and-cache:
     name: Build and Cache deps


### PR DESCRIPTION
## Changelog

### Enhancements
* Reduce the number of CI jobs by removing tests for non-essential chain types from the CI pipeline

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
