### PR TITLE
fix: Fix UTF-8 json handling in NFT metadata fetching

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
@@ -221,7 +221,8 @@ defmodule Indexer.Fetcher.TokenInstance.Helper do
   defp prepare_token_id(%Decimal{} = token_id), do: Decimal.to_integer(token_id)
   defp prepare_token_id(token_id), do: token_id
 
-  defp prepare_request("ERC-721", contract_address_hash_string, token_id, from_base_uri?) do
+  defp prepare_request(erc_721_404, contract_address_hash_string, token_id, from_base_uri?)
+       when erc_721_404 in ["ERC-404", "ERC-721"] do
     request = %{
       contract_address: contract_address_hash_string,
       block_number: nil

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -85,30 +85,17 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
     fetch_metadata_inner(token_uri, token_id, hex_token_id, from_base_uri?)
   end
 
-  defp fetch_json_from_uri({:ok, ["data:application/json;utf8," <> json]}, token_id, hex_token_id, from_base_uri?) do
-    decoded_json = URI.decode(json)
-
-    fetch_json_from_uri({:ok, [decoded_json]}, token_id, hex_token_id, from_base_uri?)
-  rescue
-    e ->
-      Logger.warn(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
-        fetcher: :token_instances
-      )
-
-      {:error, "invalid data:application/json;utf8,"}
+  defp fetch_json_from_uri(
+         {:ok, ["data:application/json;utf8," = type <> json]},
+         token_id,
+         hex_token_id,
+         from_base_uri?
+       ) do
+    fetch_json_from_json_string(json, token_id, hex_token_id, from_base_uri?, type)
   end
 
-  defp fetch_json_from_uri({:ok, ["data:application/json," <> json]}, token_id, hex_token_id, from_base_uri?) do
-    decoded_json = URI.decode(json)
-
-    fetch_json_from_uri({:ok, [decoded_json]}, token_id, hex_token_id, from_base_uri?)
-  rescue
-    e ->
-      Logger.warn(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
-        fetcher: :token_instances
-      )
-
-      {:error, "invalid data:application/json"}
+  defp fetch_json_from_uri({:ok, ["data:application/json," = type <> json]}, token_id, hex_token_id, from_base_uri?) do
+    fetch_json_from_json_string(json, token_id, hex_token_id, from_base_uri?, type)
   end
 
   defp fetch_json_from_uri(
@@ -166,6 +153,19 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
     Logger.warn(["Unknown metadata uri format #{inspect(uri)}."], fetcher: :token_instances)
 
     {:error, "unknown metadata uri format"}
+  end
+
+  defp fetch_json_from_json_string(json, token_id, hex_token_id, from_base_uri?, type) do
+    decoded_json = URI.decode(json)
+
+    fetch_json_from_uri({:ok, [decoded_json]}, token_id, hex_token_id, from_base_uri?)
+  rescue
+    e ->
+      Logger.warn(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
+        fetcher: :token_instances
+      )
+
+      {:error, "invalid #{type}"}
   end
 
   defp fetch_from_ipfs(ipfs_uid, hex_token_id) do

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -86,7 +86,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
   end
 
   defp fetch_json_from_uri(
-         {:ok, ["data:application/json;utf8," = type <> json]},
+         {:ok, [type = "data:application/json;utf8," <> json]},
          token_id,
          hex_token_id,
          from_base_uri?
@@ -94,7 +94,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
     fetch_json_from_json_string(json, token_id, hex_token_id, from_base_uri?, type)
   end
 
-  defp fetch_json_from_uri({:ok, ["data:application/json," = type <> json]}, token_id, hex_token_id, from_base_uri?) do
+  defp fetch_json_from_uri({:ok, [type = "data:application/json," <> json]}, token_id, hex_token_id, from_base_uri?) do
     fetch_json_from_json_string(json, token_id, hex_token_id, from_base_uri?, type)
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -85,6 +85,19 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
     fetch_metadata_inner(token_uri, token_id, hex_token_id, from_base_uri?)
   end
 
+  defp fetch_json_from_uri({:ok, ["data:application/json;utf8," <> json]}, token_id, hex_token_id, from_base_uri?) do
+    decoded_json = URI.decode(json)
+
+    fetch_json_from_uri({:ok, [decoded_json]}, token_id, hex_token_id, from_base_uri?)
+  rescue
+    e ->
+      Logger.warn(["Unknown metadata format #{inspect(json)}.", Exception.format(:error, e, __STACKTRACE__)],
+        fetcher: :token_instances
+      )
+
+      {:error, "invalid data:application/json;utf8,"}
+  end
+
   defp fetch_json_from_uri({:ok, ["data:application/json," <> json]}, token_id, hex_token_id, from_base_uri?) do
     decoded_json = URI.decode(json)
 

--- a/cspell.json
+++ b/cspell.json
@@ -627,7 +627,8 @@
         "zetachain",
         "zksync",
         "filecoin",
-        "Filecoin"
+        "Filecoin",
+        "permissionless"
     ],
     "enableFiletypes": [
         "dotenv",


### PR DESCRIPTION
Closes #9696 

## Changelog
- Fix UTF-8 json handling in NFT metadata fetching
- Add clause for ERC-404 in `Indexer.Fetcher.TokenInstance.Helper.prepare_request/4`
## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
