### PR TITLE
feat: Support verifier alliance and eth-bytecode-db v1.7.0 changes

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
@@ -66,7 +66,7 @@ defmodule BlockScoutWeb.API.V2.ImportController do
           | {:not_found, {:error, :not_found}}
           | {:sensitive_endpoints_api_key, any()}
           | Plug.Conn.t()
-  def try_to_search_contract(conn, %{"address_hash_param" => address_hash_string}) do
+  def try_to_search_contract(conn, %{"address_hash_param" => address_hash_string} = params) do
     with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
            {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
          {:api_key, ^api_key} <- {:api_key, get_api_key_header(conn)},
@@ -79,7 +79,9 @@ defmodule BlockScoutWeb.API.V2.ImportController do
       with {:ok, %{"sourceType" => type} = source} <-
              %{}
              |> prepare_bytecode_for_microservice(creation_tx_input, Data.to_string(address.contract_code))
-             |> EthBytecodeDBInterface.search_contract_in_eth_bytecode_internal_db(),
+             |> EthBytecodeDBInterface.search_contract_in_eth_bytecode_internal_db(
+               params_to_contract_search_options(params)
+             ),
            {:ok, _} <- LookUpSmartContractSourcesOnDemand.process_contract_source(type, source, address.hash) do
         conn
         |> put_view(ApiView)
@@ -92,6 +94,16 @@ defmodule BlockScoutWeb.API.V2.ImportController do
       end
     end
   end
+
+  defp params_to_contract_search_options(%{"import_from" => "verifier_alliance"}) do
+    [only_verifier_alliance?: true]
+  end
+
+  defp params_to_contract_search_options(%{"import_from" => "eth_bytecode_db"}) do
+    [only_eth_bytecode_db?: true]
+  end
+
+  defp params_to_contract_search_options(_), do: []
 
   defp valid_url?(url) when is_binary(url) do
     uri = URI.parse(url)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -168,6 +168,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
       "is_fully_verified" => fully_verified,
       "is_verified_via_sourcify" => address.smart_contract.verified_via_sourcify && smart_contract_verified,
       "is_verified_via_eth_bytecode_db" => address.smart_contract.verified_via_eth_bytecode_db,
+      "is_verified_via_verifier_alliance" => address.smart_contract.verified_via_verifier_alliance,
       "is_vyper_contract" => target_contract.is_vyper_contract,
       "minimal_proxy_address_hash" =>
         minimal_proxy_template && Address.checksum(metadata_for_verification.address_hash),

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -276,6 +276,7 @@ defmodule Explorer.Chain.SmartContract do
   * `autodetect_constructor_args` - field was added for storing user's choice
   * `is_yul` - field was added for storing user's choice
   * `verified_via_eth_bytecode_db` - whether contract automatically verified via eth-bytecode-db or not.
+  * `verified_via_verifier_alliance` - whether contract automatically verified via Verifier Alliance or not.
   """
   typed_schema "smart_contracts" do
     field(:name, :string, null: false)
@@ -303,6 +304,7 @@ defmodule Explorer.Chain.SmartContract do
     field(:metadata_from_verified_twin, :boolean, virtual: true)
     field(:verified_via_eth_bytecode_db, :boolean)
     field(:license_type, Ecto.Enum, values: @license_enum, default: :none)
+    field(:verified_via_verifier_alliance, :boolean)
 
     has_many(
       :decompiled_smart_contracts,
@@ -355,7 +357,8 @@ defmodule Explorer.Chain.SmartContract do
       :implementation_address_hash,
       :implementation_fetched_at,
       :verified_via_eth_bytecode_db,
-      :license_type
+      :license_type,
+      :verified_via_verifier_alliance
     ])
     |> validate_required([
       :name,
@@ -397,7 +400,8 @@ defmodule Explorer.Chain.SmartContract do
         :implementation_name,
         :autodetect_constructor_args,
         :verified_via_eth_bytecode_db,
-        :license_type
+        :license_type,
+        :verified_via_verifier_alliance
       ])
       |> (&if(verification_with_files?,
             do: &1,

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -179,6 +179,7 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
       |> Map.put("verified_via_eth_bytecode_db", automatically_verified?)
       |> Map.put("verified_via_sourcify", source["sourcify?"])
       |> Map.put("license_type", initial_params["license_type"])
+      |> Map.put("verified_via_verifier_alliance", source["verifier_alliance?"])
 
     publish_smart_contract(address_hash, prepared_params, Jason.decode!(abi_string || "null"))
   end
@@ -274,7 +275,8 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
       is_yul: params["is_yul"] || false,
       compiler_settings: clean_compiler_settings,
       verified_via_eth_bytecode_db: params["verified_via_eth_bytecode_db"] || false,
-      license_type: prepare_license_type(params["license_type"]) || :none
+      license_type: prepare_license_type(params["license_type"]) || :none,
+      verified_via_verifier_alliance: params["verified_via_verifier_alliance"] || false
     }
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/vyper/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/publisher.ex
@@ -83,7 +83,7 @@ defmodule Explorer.SmartContract.Vyper.Publisher do
           "sourceFiles" => sources,
           "compilerSettings" => compiler_settings_string,
           "matchType" => match_type
-        },
+        } = source,
         address_hash,
         initial_params,
         save_file_path?,
@@ -117,6 +117,7 @@ defmodule Explorer.SmartContract.Vyper.Publisher do
       )
       |> Map.put("compiler_settings", if(standard_json?, do: compiler_settings))
       |> Map.put("license_type", initial_params["license_type"])
+      |> Map.put("verified_via_verifier_alliance", source["verifier_alliance?"])
 
     publish_smart_contract(address_hash, prepared_params, Jason.decode!(abi_string))
   end
@@ -185,7 +186,8 @@ defmodule Explorer.SmartContract.Vyper.Publisher do
       file_path: params["file_path"],
       verified_via_eth_bytecode_db: params["verified_via_eth_bytecode_db"] || false,
       compiler_settings: clean_compiler_settings,
-      license_type: prepare_license_type(params["license_type"]) || :none
+      license_type: prepare_license_type(params["license_type"]) || :none,
+      verified_via_verifier_alliance: params["verified_via_verifier_alliance"] || false
     }
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240325195446_add_verified_via_verifier_alliance.exs
+++ b/apps/explorer/priv/repo/migrations/20240325195446_add_verified_via_verifier_alliance.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddVerifiedViaVerifierAlliance do
+  use Ecto.Migration
+
+  def change do
+    alter table(:smart_contracts) do
+      add(:verified_via_verifier_alliance, :boolean, null: true)
+    end
+  end
+end


### PR DESCRIPTION
Closes #9415 

## Changelog
- Add new field `verified_via_verifier_alliance` to `smart_contracts` table

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
