### PR TITLE
fix: Replace tx gas_price with effectiveGasPrice from receipt

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -138,6 +138,7 @@ defmodule EthereumJSONRPC.Receipt do
 
   """
   @spec elixir_to_params(elixir) :: %{
+          optional(:gas_price) => non_neg_integer(),
           cumulative_gas_used: non_neg_integer,
           gas_used: non_neg_integer,
           created_contract_address_hash: String.t() | nil,
@@ -169,8 +170,14 @@ defmodule EthereumJSONRPC.Receipt do
       status: status,
       transaction_hash: transaction_hash,
       transaction_index: transaction_index
-    }
+    } |> maybe_append_gas_price(elixir)
   end
+
+  defp maybe_append_gas_price(params, %{"effectiveGasPrice" => effective_gas_price}) do
+    Map.put(params, :gas_price, effective_gas_price)
+  end
+
+  defp maybe_append_gas_price(params, _), do: params
 
   defp chain_type_fields(params, elixir) do
     case Application.get_env(:explorer, :chain_type) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -170,7 +170,8 @@ defmodule EthereumJSONRPC.Receipt do
       status: status,
       transaction_hash: transaction_hash,
       transaction_index: transaction_index
-    } |> maybe_append_gas_price(elixir)
+    }
+    |> maybe_append_gas_price(elixir)
   end
 
   defp maybe_append_gas_price(params, %{"effectiveGasPrice" => effective_gas_price}) do


### PR DESCRIPTION
Closes #9730 

## Changelog
- Replace tx gas_price with effectiveGasPrice from receipt

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
