### PR TITLE
chore: Temporarily ignore OP batches written to Celestia

### DIFF
--- a/apps/indexer/lib/indexer/transform/optimism/withdrawals.ex
+++ b/apps/indexer/lib/indexer/transform/optimism/withdrawals.ex
@@ -19,8 +19,8 @@ defmodule Indexer.Transform.Optimism.Withdrawals do
     Logger.metadata(fetcher: :optimism_withdrawals_realtime)
 
     items =
-      with false <- is_nil(Application.get_env(:indexer, Indexer.Fetcher.OptimismWithdrawal)[:start_block_l2]),
-           message_passer = Application.get_env(:indexer, Indexer.Fetcher.OptimismWithdrawal)[:message_passer],
+      with false <- is_nil(Application.get_env(:indexer, OptimismWithdrawal)[:start_block_l2]),
+           message_passer = Application.get_env(:indexer, OptimismWithdrawal)[:message_passer],
            true <- Helper.address_correct?(message_passer) do
         message_passer = String.downcase(message_passer)
 

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
         "Blockchair",
         "CALLCODE",
         "CBOR",
+        "Celestia",
         "Cldr",
         "Consolas",
         "Cyclomatic",


### PR DESCRIPTION
## Motivation

Some OP chains write batches to Celestia blobs instead of EIP-4844 ones. As we currently don't have a service which would give the data from Celestia blob, the `Indexer.Fetcher.Optimism.TxnBatch` will ignore transactions with "derivation version" greater than 0.

Also, this PR removes a small but important typo in `Indexer.Transform.Optimism.Withdrawals`.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
