### PR TITLE
Fix: (token_balances) handle missing mode match in fetch_from_blockchain

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -119,24 +119,30 @@ defmodule Indexer.Fetcher.TokenBalance do
     %{fetched_token_balances: fetched_token_balances, failed_token_balances: _failed_token_balances} =
       1..@max_retries
       |> Enum.reduce_while(%{fetched_token_balances: [], failed_token_balances: retryable_params_list}, fn _x, acc ->
-        {:ok, %{fetched_token_balances: fetched_token_balances, failed_token_balances: failed_token_balances}} =
-          TokenBalances.fetch_token_balances_from_blockchain(acc.failed_token_balances)
+        case TokenBalances.fetch_token_balances_from_blockchain(acc.failed_token_balances) do
+          {:ok, %{fetched_token_balances: fetched_token_balances, failed_token_balances: failed_token_balances}} ->
+            all_token_balances = %{
+              fetched_token_balances: acc.fetched_token_balances ++ fetched_token_balances,
+              failed_token_balances: failed_token_balances
+            }
 
-        all_token_balances = %{
-          fetched_token_balances: acc.fetched_token_balances ++ fetched_token_balances,
-          failed_token_balances: failed_token_balances
-        }
+            if Enum.empty?(failed_token_balances) do
+              {:halt, all_token_balances}
+            else
+              failed_token_balances = increase_retries_count(failed_token_balances)
 
-        if Enum.empty?(failed_token_balances) do
-          {:halt, all_token_balances}
-        else
-          failed_token_balances = increase_retries_count(failed_token_balances)
+              token_balances_updated_retries_count =
+                all_token_balances
+                |> Map.put(:failed_token_balances, failed_token_balances)
 
-          token_balances_updated_retries_count =
-            all_token_balances
-            |> Map.put(:failed_token_balances, failed_token_balances)
+              {:cont, token_balances_updated_retries_count}
+            end
 
-          {:cont, token_balances_updated_retries_count}
+          {:ok, []} ->
+            {:halt, acc}
+
+          _error ->
+            {:halt, acc}
         end
       end)
 


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

I encountered an indexer error log like this:

```
 {"time":"2024-03-28T07:32:12.339Z","severity":"error","message":"Task #PID<0.19063.0> started from Indexer.Fetcher.TokenBalance terminating\n** (MatchError) no match of right hand side value: {:ok, []}\n    (indexer 6.3.0) lib/indexer/fetcher/token_balance.ex:122: anonymous fn/2 in Indexer.Fetcher.TokenBalance.fetch_from_blockchain/1\n    (elixir 1.14.5) lib/range.ex:392: Enumerable.Range.reduce/5\n    (elixir 1.14.5) lib/enum.ex:2514: Enum.reduce_while/3\n    (indexer 6.3.0) lib/indexer/fetcher/token_balance.ex:121: Indexer.Fetcher.TokenBalance.fetch_from_blockchain/1\n    (indexer 6.3.0) lib/indexer/fetcher/token_balance.ex:101: Indexer.Fetcher.TokenBalance.run/2\n    (elixir 1.14.5) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2\n    (elixir 1.14.5) lib/task/supervised.ex:34: Task.Supervised.reply/4\n    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{batch: [{<<158, 224, 35, 230, 97, 215, 168, 80, 110, 40, 12, 86, 86, 69, 158, 8, 31, 217, 142, 3>>, <<98, 236, 62, 120, 66, 133, 248, 54, 41, 154, 167, 116, 23, 189, 189, 201, 166, 94, 220, 241>>, 163089, \"ERC-20\", nil, 3}, {<<241, 231, 72, 168, 242, 72, 91, 77, 245, 74, 189, 1, 83, 109, 48, 187, 200, 228, 225, 55>>, <<98, 236, 62, 120, 66, 133, 248, 54, 41, 154, 167, 116, 23, 189, 189, 201, 166, 94, 220, 241>>, 164072, \"ERC-20\", nil, 3}, {<<9, 110, 29, 200, 57, 192, 160, 33, 154, 115, 210, 235, 197, 215, 240, 129, 10, 204, 

```

## Changelog

### Bug Fixes

Correct the issue where the `fetch_token_balances_from_blockchain` function's response was not fully pattern matched, leading to potential unhandled outcomes.
Now includes handling for empty list and error scenarios, ensuring the function behaves predictably across all possible return values.

This fix improves the reliability of the token balance retrieval process by ensuring that all cases are handled gracefully.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
