### PR TITLE
fix: Separate ZkSync and ZkEvm readers in API controller

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -31,8 +31,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias Explorer.Chain
   alias Explorer.Chain.Beacon.Reader, as: BeaconReader
   alias Explorer.Chain.{Hash, Transaction}
-  alias Explorer.Chain.PolygonZkevm.Reader
-  alias Explorer.Chain.ZkSync.Reader
+  alias Explorer.Chain.PolygonZkevm.Reader, as: PolygonZkevmReader
+  alias Explorer.Chain.ZkSync.Reader, as: ZkSyncReader
   alias Explorer.Counters.{FreshPendingTransactionsCounter, Transactions24hStats}
   alias Indexer.Fetcher.FirstTraceOnDemand
 
@@ -169,7 +169,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def polygon_zkevm_batch(conn, %{"batch_number" => batch_number} = _params) do
     transactions =
       batch_number
-      |> Reader.batch_transactions(api?: true)
+      |> PolygonZkevmReader.batch_transactions(api?: true)
       |> Enum.map(fn tx -> tx.hash end)
       |> Chain.hashes_to_transactions(api?: true, necessity_by_association: @transaction_necessity_by_association)
 
@@ -186,7 +186,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def zksync_batch(conn, %{"batch_number" => batch_number} = _params) do
     transactions =
       batch_number
-      |> Reader.batch_transactions(api?: true)
+      |> ZkSyncReader.batch_transactions(api?: true)
       |> Enum.map(fn tx -> tx.hash end)
       |> Chain.hashes_to_transactions(api?: true, necessity_by_association: @transaction_necessity_by_association)
 


### PR DESCRIPTION
## Motivation

Solves an issue for `/api/v2/transactions/zkevm-batch/:batch_number` API endpoint.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
