### PR TITLE
chore: Enable Rust sc-verifier microservice by default

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
@@ -7,6 +7,15 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
 
   @moduletag timeout: :infinity
 
+  setup do
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
+  end
+
   describe "/api/v2/smart-contracts/verification/config" do
     test "get cfg", %{conn: conn} do
       request = get(conn, "/api/v2/smart-contracts/verification/config")

--- a/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
@@ -8,7 +8,14 @@ defmodule BlockScoutWeb.AddressContractVerificationTest do
   setup do
     bypass = Bypass.open()
 
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
     Application.put_env(:explorer, :solc_bin_api_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
 
     {:ok, bypass: bypass}
   end

--- a/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
@@ -6,6 +6,16 @@ defmodule Explorer.SmartContract.CompilerVersionTest do
   alias Explorer.SmartContract.CompilerVersion
   alias Plug.Conn
 
+  setup do
+    # Use TestSource mock and ets table for this test set
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
+  end
+
   describe "fetch_versions/1" do
     setup do
       bypass = Bypass.open()

--- a/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
@@ -7,7 +7,6 @@ defmodule Explorer.SmartContract.CompilerVersionTest do
   alias Plug.Conn
 
   setup do
-    # Use TestSource mock and ets table for this test set
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -12,7 +12,6 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
   alias Explorer.SmartContract.Solidity.Publisher
 
   setup do
-    # Use TestSource mock and ets table for this test set
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -11,6 +11,16 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
   alias Explorer.{Factory, Repo}
   alias Explorer.SmartContract.Solidity.Publisher
 
+  setup do
+    # Use TestSource mock and ets table for this test set
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
+  end
+
   describe "publish/2" do
     test "with valid data creates a smart_contract" do
       contract_code_info = Factory.contract_code_info_modern_compiler()

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -62,7 +62,6 @@ defmodule Explorer.SmartContract.Solidity.VerifierTest do
   """
 
   setup do
-    # Use TestSource mock and ets table for this test set
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -61,6 +61,16 @@ defmodule Explorer.SmartContract.Solidity.VerifierTest do
   }
   """
 
+  setup do
+    # Use TestSource mock and ets table for this test set
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
+  end
+
   describe "evaluate_authenticity/2" do
     setup do
       {:ok, contract_code_info: Factory.contract_code_info()}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -422,7 +422,7 @@ config :explorer, Explorer.ThirdPartyIntegrations.NovesFi,
   chain_name: System.get_env("NOVES_FI_CHAIN_NAME"),
   api_key: System.get_env("NOVES_FI_API_TOKEN")
 
-enabled? = ConfigHelper.parse_bool_env_var("MICROSERVICE_SC_VERIFIER_ENABLED")
+enabled? = ConfigHelper.parse_bool_env_var("MICROSERVICE_SC_VERIFIER_ENABLED", "true")
 # or "eth_bytecode_db"
 type = System.get_env("MICROSERVICE_SC_VERIFIER_TYPE", "sc_verifier")
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9745

## Motivation

We provide a fallback to our sc-verifier microservice endpoint. However, integration with it is disabled by default.

## Changelog

Enable Rust sc-verifier microservice by default

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
