### PR TITLE
fix: Add block range check into OP Withdrawals fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -132,7 +132,9 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
       ) do
     # find and fill all events between start_block and "safe" block
     # the "safe" block can be "latest" (when safe_block_is_latest == true)
-    fill_block_range(start_block, safe_block, message_passer, json_rpc_named_arguments)
+    if start_block <= safe_block do
+      fill_block_range(start_block, safe_block, message_passer, json_rpc_named_arguments)
+    end
 
     if not safe_block_is_latest do
       # find and fill all events between "safe" and "latest" block (excluding "safe")

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -132,9 +132,7 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
       ) do
     # find and fill all events between start_block and "safe" block
     # the "safe" block can be "latest" (when safe_block_is_latest == true)
-    if start_block <= safe_block do
-      fill_block_range(start_block, safe_block, message_passer, json_rpc_named_arguments)
-    end
+    fill_block_range(start_block, safe_block, message_passer, json_rpc_named_arguments)
 
     if not safe_block_is_latest do
       # find and fill all events between "safe" and "latest" block (excluding "safe")
@@ -299,10 +297,19 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
   end
 
   defp fill_block_range(start_block, end_block, message_passer, json_rpc_named_arguments) do
-    fill_block_range(start_block, end_block, message_passer, json_rpc_named_arguments, true)
-    fill_msg_nonce_gaps(start_block, message_passer, json_rpc_named_arguments, false)
-    {last_l2_block_number, _} = get_last_l2_item()
-    fill_block_range(max(start_block, last_l2_block_number), end_block, message_passer, json_rpc_named_arguments, false)
+    if start_block <= end_block do
+      fill_block_range(start_block, end_block, message_passer, json_rpc_named_arguments, true)
+      fill_msg_nonce_gaps(start_block, message_passer, json_rpc_named_arguments, false)
+      {last_l2_block_number, _} = get_last_l2_item()
+
+      fill_block_range(
+        max(start_block, last_l2_block_number),
+        end_block,
+        message_passer,
+        json_rpc_named_arguments,
+        false
+      )
+    end
   end
 
   defp fill_msg_nonce_gaps(start_block_l2, message_passer, json_rpc_named_arguments, scan_db \\ true) do

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -341,27 +341,29 @@ defmodule Indexer.Fetcher.PolygonEdge do
 
   @spec fill_block_range(integer(), integer(), {module(), module()}, binary(), list()) :: integer()
   def fill_block_range(start_block, end_block, {module, table}, contract_address, json_rpc_named_arguments) do
-    fill_block_range(start_block, end_block, module, contract_address, json_rpc_named_arguments, true)
+    if start_block <= end_block do
+      fill_block_range(start_block, end_block, module, contract_address, json_rpc_named_arguments, true)
 
-    fill_msg_id_gaps(
-      start_block,
-      table,
-      module,
-      contract_address,
-      json_rpc_named_arguments,
-      false
-    )
+      fill_msg_id_gaps(
+        start_block,
+        table,
+        module,
+        contract_address,
+        json_rpc_named_arguments,
+        false
+      )
 
-    {last_l2_block_number, _} = get_last_l2_item(table)
+      {last_l2_block_number, _} = get_last_l2_item(table)
 
-    fill_block_range(
-      max(start_block, last_l2_block_number),
-      end_block,
-      module,
-      contract_address,
-      json_rpc_named_arguments,
-      false
-    )
+      fill_block_range(
+        max(start_block, last_l2_block_number),
+        end_block,
+        module,
+        contract_address,
+        json_rpc_named_arguments,
+        false
+      )
+    end
   end
 
   @spec fill_msg_id_gaps(integer(), module(), module(), binary(), list(), boolean()) :: no_return()

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -339,7 +339,7 @@ defmodule Indexer.Fetcher.PolygonEdge do
     end)
   end
 
-  @spec fill_block_range(integer(), integer(), {module(), module()}, binary(), list()) :: integer()
+  @spec fill_block_range(integer(), integer(), {module(), module()}, binary(), list()) :: any()
   def fill_block_range(start_block, end_block, {module, table}, contract_address, json_rpc_named_arguments) do
     if start_block <= end_block do
       fill_block_range(start_block, end_block, module, contract_address, json_rpc_named_arguments, true)


### PR DESCRIPTION
## Motivation

The `Indexer.Fetcher.Optimism.Withdrawal` won't start because of invalid block range when using `safe` block as the end block of the range (this case is reproduced mainly on OP Mainnet). This PR adds a small but important fix so that the module wouldn't scan blocks excessively when the last known block from DB is behind the safe one.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
