### PR TITLE
feat: Add ENS category to search result; Add ENS to check-redirect

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -11,8 +11,7 @@ defmodule BlockScoutWeb.Chain do
       number_to_block: 1,
       string_to_address_hash: 1,
       string_to_block_hash: 1,
-      string_to_transaction_hash: 1,
-      token_contract_address_from_token_name: 1
+      string_to_transaction_hash: 1
     ]
 
   import Explorer.Helper, only: [parse_integer: 1]
@@ -33,6 +32,7 @@ defmodule BlockScoutWeb.Chain do
     Hash,
     InternalTransaction,
     Log,
+    Search,
     SmartContract,
     Token,
     Token.Instance,
@@ -106,7 +106,7 @@ defmodule BlockScoutWeb.Chain do
   def from_param(string) when is_binary(string) do
     case param_to_block_number(string) do
       {:ok, number} -> number_to_block(number)
-      _ -> token_address_from_name(string)
+      _ -> search_ens_domain(string)
     end
   end
 
@@ -571,10 +571,13 @@ defmodule BlockScoutWeb.Chain do
     end
   end
 
-  defp token_address_from_name(name) do
-    case token_contract_address_from_token_name(name) do
-      {:ok, hash} -> find_or_insert_address_from_hash(hash)
-      _ -> {:error, :not_found}
+  defp search_ens_domain(search_query) do
+    case Search.search_ens_name_in_bens(search_query) do
+      nil ->
+        {:error, :not_found}
+
+      result ->
+        {:ok, result}
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -37,7 +37,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "circulating_market_cap" =>
         search_result.circulating_market_cap && to_string(search_result.circulating_market_cap),
       "is_verified_via_admin_panel" => search_result.is_verified_via_admin_panel,
-      "certified" => if(search_result.certified, do: search_result.certified, else: false)
+      "certified" => if(search_result.certified, do: search_result.certified, else: false),
+      "priority" => search_result.priority
     }
   end
 
@@ -49,19 +50,21 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
-      "certified" => if(search_result.certified, do: search_result.certified, else: false)
+      "certified" => if(search_result.certified, do: search_result.certified, else: false),
+      "priority" => search_result.priority
     }
   end
 
   def prepare_search_result(%{type: address_or_contract_or_label} = search_result)
-      when address_or_contract_or_label in ["address", "label"] do
+      when address_or_contract_or_label in ["address", "label", "ens_domain"] do
     %{
       "type" => search_result.type,
       "name" => search_result.name,
       "address" => search_result.address_hash,
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
-      "ens_info" => search_result[:ens_info]
+      "ens_info" => search_result[:ens_info],
+      "priority" => search_result.priority
     }
   end
 
@@ -82,7 +85,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "block_hash" => block_hash,
       "url" => block_path(Endpoint, :show, block_hash),
       "timestamp" => search_result.timestamp,
-      "block_type" => block |> BlockView.block_type() |> String.downcase()
+      "block_type" => block |> BlockView.block_type() |> String.downcase(),
+      "priority" => search_result.priority
     }
   end
 
@@ -93,7 +97,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "type" => search_result.type,
       "tx_hash" => tx_hash,
       "url" => transaction_path(Endpoint, :show, tx_hash),
-      "timestamp" => search_result.timestamp
+      "timestamp" => search_result.timestamp,
+      "priority" => search_result.priority
     }
   end
 
@@ -103,7 +108,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{
       "type" => search_result.type,
       "user_operation_hash" => user_operation_hash,
-      "timestamp" => search_result.timestamp
+      "timestamp" => search_result.timestamp,
+      "priority" => search_result.priority
     }
   end
 
@@ -113,7 +119,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{
       "type" => search_result.type,
       "blob_hash" => blob_hash,
-      "timestamp" => search_result.timestamp
+      "timestamp" => search_result.timestamp,
+      "priority" => search_result.priority
     }
   end
 
@@ -130,6 +137,10 @@ defmodule BlockScoutWeb.API.V2.SearchView do
 
   defp redirect_search_results(%Address{} = item) do
     %{"type" => "address", "parameter" => Address.checksum(item.hash)}
+  end
+
+  defp redirect_search_results(%{address_hash: address_hash}) do
+    %{"type" => "address", "parameter" => address_hash}
   end
 
   defp redirect_search_results(%Block{} = item) do

--- a/apps/block_scout_web/test/block_scout_web/chain_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/chain_test.exs
@@ -44,20 +44,6 @@ defmodule BlockScoutWeb.ChainTest do
       assert {:ok, %Address{hash: ^hash}} = address |> Phoenix.Param.to_param() |> Chain.from_param()
     end
 
-    test "finds a token by its name" do
-      name = "AYR"
-      insert(:token, symbol: name)
-
-      assert {:ok, %Address{}} = name |> Chain.from_param()
-    end
-
-    test "finds a token by its name even if lowercase name was passed" do
-      name = "ayr"
-      insert(:token, symbol: String.upcase(name))
-
-      assert {:ok, %Address{}} = name |> Chain.from_param()
-    end
-
     test "returns {:error, :not_found} when garbage is passed in" do
       assert {:error, :not_found} = Chain.from_param("any ol' thing")
     end

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -606,6 +606,11 @@ defmodule Explorer.Chain.Search do
     end
   end
 
+  @doc """
+  Try to resolve ENS domain via BENS
+  """
+  @spec search_ens_name_in_bens(binary()) ::
+          nil | %{address_hash: binary(), expiry_date: any(), name: any(), names_count: non_neg_integer()}
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -630,6 +630,7 @@ defmodule Explorer.Chain.Search do
   defp merge_address_search_result_with_ens_info([address], ens_info) do
     address
     |> compose_result_checksummed_address_hash()
+    |> Map.put(:type, "ens_domain")
     |> Map.put(:ens_info, ens_info)
     |> Map.put(:priority, 2)
   end

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -78,7 +78,7 @@ defmodule Explorer.Chain.Search do
 
     ens_result = (ens_task && await_ens_task(ens_task)) || []
 
-    result ++ ens_result
+    ens_result ++ result
   end
 
   def base_joint_query(string, term) do
@@ -258,6 +258,7 @@ defmodule Explorer.Chain.Search do
           |> compose_result_checksummed_address_hash()
           |> format_timestamp()
         end)
+        |> Enum.sort_by(fn item -> item.priority end, :desc)
 
       _ ->
         []
@@ -593,10 +594,7 @@ defmodule Explorer.Chain.Search do
   end
 
   defp search_ens_name(search_query, options) do
-    trimmed_query = String.trim(search_query)
-
-    with true <- Regex.match?(~r/\w+\.\w+/, trimmed_query),
-         result when is_map(result) <- ens_domain_name_lookup(search_query) do
+    if result = search_ens_name_in_bens(search_query) do
       [
         result[:address_hash]
         |> search_address_query()
@@ -604,21 +602,36 @@ defmodule Explorer.Chain.Search do
         |> merge_address_search_result_with_ens_info(result)
       ]
     else
+      []
+    end
+  end
+
+  def search_ens_name_in_bens(search_query) do
+    trimmed_query = String.trim(search_query)
+
+    with true <- Regex.match?(~r/\w+\.\w+/, trimmed_query),
+         %{address_hash: _address_hash} = result <- ens_domain_name_lookup(search_query) do
+      result
+    else
       _ ->
-        []
+        nil
     end
   end
 
   defp merge_address_search_result_with_ens_info([], ens_info) do
     search_fields()
     |> Map.put(:address_hash, ens_info[:address_hash])
-    |> Map.put(:type, "address")
+    |> Map.put(:type, "ens_domain")
     |> Map.put(:ens_info, ens_info)
     |> Map.put(:timestamp, nil)
+    |> Map.put(:priority, 2)
   end
 
   defp merge_address_search_result_with_ens_info([address], ens_info) do
-    Map.put(address |> compose_result_checksummed_address_hash(), :ens_info, ens_info)
+    address
+    |> compose_result_checksummed_address_hash()
+    |> Map.put(:ens_info, ens_info)
+    |> Map.put(:priority, 2)
   end
 
   defp search_fields do


### PR DESCRIPTION
Closes #9504
Closes #9114
## Changelog
- add new type to search results: `ens_domain`
- add ens domain resolution on check-redirect
- remove outdated token resolution from check-redirect
## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
