### PR TITLE
chore: Remove /config/json-rpc-url API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -130,7 +130,6 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/config" do
-      get("/json-rpc-url", V2.ConfigController, :json_rpc_url)
       get("/backend-version", V2.ConfigController, :backend_version)
     end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -1,14 +1,6 @@
 defmodule BlockScoutWeb.API.V2.ConfigController do
   use BlockScoutWeb, :controller
 
-  def json_rpc_url(conn, _params) do
-    json_rpc_url = Application.get_env(:block_scout_web, :json_rpc)
-
-    conn
-    |> put_status(200)
-    |> render(:json_rpc_url, %{url: json_rpc_url})
-  end
-
   def backend_version(conn, _params) do
     backend_version = Application.get_env(:block_scout_web, :version)
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/config_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/config_view.ex
@@ -1,10 +1,4 @@
 defmodule BlockScoutWeb.API.V2.ConfigView do
-  def render("json_rpc_url.json", %{url: url}) do
-    %{
-      "json_rpc_url" => url
-    }
-  end
-
   def render("backend_version.json", %{version: version}) do
     %{
       "backend_version" => version

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
@@ -1,22 +1,22 @@
 defmodule BlockScoutWeb.API.V2.ConfigControllerTest do
   use BlockScoutWeb.ConnCase
 
-  describe "/config/json-rpc-url" do
+  describe "/config/backend-version" do
     test "get json rps url if set", %{conn: conn} do
-      url = "http://rps.url:1234/v1"
-      Application.put_env(:block_scout_web, :json_rpc, url)
+      version = "v6.3.0-beta"
+      Application.put_env(:block_scout_web, :version, version)
 
-      request = get(conn, "/api/v2/config/json-rpc-url")
+      request = get(conn, "/api/v2/config/backend-version")
 
-      assert %{"json_rpc_url" => ^url} = json_response(request, 200)
+      assert %{"backend_version" => ^version} = json_response(request, 200)
     end
 
-    test "get empty json rps url if not set", %{conn: conn} do
-      Application.put_env(:block_scout_web, :json_rpc, nil)
+    test "get nil backend version if not set", %{conn: conn} do
+      Application.put_env(:block_scout_web, :version, nil)
 
-      request = get(conn, "/api/v2/config/json-rpc-url")
+      request = get(conn, "/api/v2/config/backend-version")
 
-      assert %{"json_rpc_url" => nil} = json_response(request, 200)
+      assert %{"backend_version" => nil} = json_response(request, 200)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9728

## Motivation

/config/json-rpc-url API endpoint is unused by frontend.

## Changelog

Remove /config/json-rpc-url API endpoint.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
