### PR TITLE
fix: Broadcast realtime coin balances

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/coin_balance/catchup.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance/catchup.ex
@@ -62,7 +62,7 @@ defmodule Indexer.Fetcher.CoinBalance.Catchup do
               tracer: Tracer
             )
   def run(entries, json_rpc_named_arguments) do
-    Helper.run(entries, json_rpc_named_arguments, true)
+    Helper.run(entries, json_rpc_named_arguments, :catchup)
   end
 
   defp defaults do

--- a/apps/indexer/lib/indexer/fetcher/coin_balance/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance/helper.ex
@@ -32,16 +32,20 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     Supervisor.child_spec({BufferedTask, [{module, merged_init_options}, gen_server_options]}, id: module)
   end
 
-  def run(entries, json_rpc_named_arguments, filter_non_traceable_blocks? \\ true) do
+  def run(entries, json_rpc_named_arguments, fetcher_type) do
     # the same address may be used more than once in the same block, but we only want one `Balance` for a given
     # `{address, block}`, so take unique params only
     unique_entries = Enum.uniq(entries)
 
     unique_filtered_entries =
-      if filter_non_traceable_blocks? do
-        Enum.filter(unique_entries, fn {_hash, block_number} -> RangesHelper.traceable_block_number?(block_number) end)
-      else
-        unique_entries
+      case fetcher_type do
+        :realtime ->
+          unique_entries
+
+        _ ->
+          Enum.filter(unique_entries, fn {_hash, block_number} ->
+            RangesHelper.traceable_block_number?(block_number)
+          end)
       end
 
     unique_entry_count = Enum.count(unique_filtered_entries)
@@ -54,7 +58,7 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     |> EthereumJSONRPC.fetch_balances(json_rpc_named_arguments)
     |> case do
       {:ok, fetched_balances} ->
-        run_fetched_balances(fetched_balances, unique_filtered_entries)
+        run_fetched_balances(fetched_balances, fetcher_type)
 
       {:error, reason} ->
         Logger.error(
@@ -126,8 +130,8 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     })
   end
 
-  defp run_fetched_balances(%FetchedBalances{errors: errors} = fetched_balances, _) do
-    with {:ok, imported} <- import_fetched_balances(fetched_balances) do
+  defp run_fetched_balances(%FetchedBalances{errors: errors} = fetched_balances, fetcher_type) do
+    with {:ok, imported} <- import_fetched_balances(fetched_balances, fetcher_type) do
       Accounts.drop(imported[:addresses])
     end
 

--- a/apps/indexer/lib/indexer/fetcher/coin_balance/realtime.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance/realtime.ex
@@ -44,7 +44,7 @@ defmodule Indexer.Fetcher.CoinBalance.Realtime do
               tracer: Tracer
             )
   def run(entries, json_rpc_named_arguments) do
-    Helper.run(entries, json_rpc_named_arguments, false)
+    Helper.run(entries, json_rpc_named_arguments, :realtime)
   end
 
   defp defaults do


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/9182

## Motivation

Realtime coin balance fetcher doesn't broadcast them after import.

## Changelog

Added `fetcher_type` param to `Indexer.Fetcher.CoinBalance.Helper.run` which is used as `:broadcast` option for import.