### PR TITLE
feat: Return number of days in address's coin-balance-history-by-day API v2 endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -34,7 +34,11 @@ defmodule BlockScoutWeb.API.V2.AddressView do
   end
 
   def render("coin_balances_by_day.json", %{coin_balances_by_day: coin_balances_by_day}) do
-    Enum.map(coin_balances_by_day, &prepare_coin_balance_history_by_day_entry/1)
+    %{
+      :items => Enum.map(coin_balances_by_day, &prepare_coin_balance_history_by_day_entry/1),
+      :days =>
+        Application.get_env(:block_scout_web, BlockScoutWeb.Chain.Address.CoinBalance)[:coin_balance_history_days]
+    }
   end
 
   def render("tokens.json", %{tokens: tokens, next_page_params: next_page_params}) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1683,11 +1683,14 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert [
-               %{"date" => _, "value" => "2000"},
-               %{"date" => _, "value" => "1000"},
-               %{"date" => _, "value" => "1000"}
-             ] = response
+      assert %{
+               "days" => 10,
+               "items" => [
+                 %{"date" => _, "value" => "2000"},
+                 %{"date" => _, "value" => "1000"},
+                 %{"date" => _, "value" => "1000"}
+               ]
+             } = response
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9805


## Motivation

Add COIN_BALANCE_HISTORY_DAYS value to the response of address's coin-balance-history-by-day API v2 endpoint

## Checklist for your Pull Request (PR)

  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
