### PR TITLE
perf: Improve performance of token page transfers tab

### DIFF
--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -93,7 +93,7 @@ defmodule Explorer.GraphQL do
       tt in TokenTransfer,
       inner_join: t in assoc(tt, :transaction),
       where: tt.token_contract_address_hash == ^token_contract_address_hash,
-      order_by: [desc: tt.block_number],
+      order_by: [desc: tt.block_number, desc: tt.log_index],
       select: tt
     )
   end

--- a/apps/explorer/priv/repo/migrations/20240403151125_enhance_index_for_token_transfers_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240403151125_enhance_index_for_token_transfers_list.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenTransfersList do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    drop_if_exists(index(:token_transfers, [:token_contract_address_hash, :block_number], concurrently: true))
+    create_if_not_exists(index(:token_transfers, ["token_contract_address_hash, block_number DESC, log_index DESC"], concurrently: true))
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240403151125_enhance_index_for_token_transfers_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240403151125_enhance_index_for_token_transfers_list.exs
@@ -5,6 +5,9 @@ defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenTransfersList do
 
   def change do
     drop_if_exists(index(:token_transfers, [:token_contract_address_hash, :block_number], concurrently: true))
-    create_if_not_exists(index(:token_transfers, ["token_contract_address_hash, block_number DESC, log_index DESC"], concurrently: true))
+
+    create_if_not_exists(
+      index(:token_transfers, ["token_contract_address_hash, block_number DESC, log_index DESC"], concurrently: true)
+    )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240403151126_drop_index_for_token_transfers_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240403151126_drop_index_for_token_transfers_list.exs
@@ -4,8 +4,6 @@ defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenTransfersList do
   @disable_migration_lock true
 
   def change do
-    create_if_not_exists(
-      index(:token_transfers, ["token_contract_address_hash, block_number DESC, log_index DESC"], concurrently: true)
-    )
+    drop_if_exists(index(:token_transfers, [:token_contract_address_hash, :block_number], concurrently: true))
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240403151126_drop_outdated_index_for_token_transfers_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240403151126_drop_outdated_index_for_token_transfers_list.exs
@@ -1,4 +1,4 @@
-defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenTransfersList do
+defmodule Explorer.Repo.Migrations.DropOutdatedIndexForTokenTransfersList do
   use Ecto.Migration
   @disable_ddl_transaction true
   @disable_migration_lock true


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9808

## Motivation

503 response of the api/v2/tokens/#{hash}/transfers API v2 endpoint for seom tokens.

## Changelog

The simplified query looks like this:
```
SELECT t0.*
FROM token_transfers AS t0
WHERE (t0.block_consensus = TRUE)
AND ((t0.token_contract_address_hash = '\x...')
AND NOT (t0.block_number IS NULL))
ORDER BY t0.block_number DESC, t0.log_index DESC LIMIT 50;
```

And execution plan before the changes:
```
eth_sepolia=> explain SELECT t0.* FROM token_transfers AS t0 WHERE (t0.block_consensus = TRUE) AND ((t0.token_contract_address_hash = '\xdcF5D3E08c5007deCECDb34808C49331bD82a247') AND NOT (t0.block_number IS NULL)) ORDER BY t0.block_number DESC, t0.log_index DESC LIMIT 50;
                                                                            QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..2678.18 rows=50 width=229)
   ->  Index Scan Backward using "token_transfers_block_number_ASC_log_index_ASC_index" on token_transfers t0  (cost=0.57..1587043329.05 rows=29635488 width=229)
         Index Cond: (block_number IS NOT NULL)
         Filter: (block_consensus AND (token_contract_address_hash = '\xdcf5d3e08c5007dececdb34808c49331bd82a247'::bytea))
```

The execution of the query didn't finish in 60 secs.

Instead of using `btree (token_contract_address_hash, block_number)`, which is unused by the execution plan, it is suggested to use more specific `btree (token_contract_address_hash, block_number DESC, log_index DESC)`.

Execution plan after the suggested index is implemented:
```
eth_sepolia=> explain analyze SELECT t0.* FROM token_transfers AS t0 WHERE (t0.block_consensus = TRUE) AND ((t0.token_contract_address_hash = '\xdcF5D3E08c5007deCECDb34808C49331bD82a247') AND NOT (t0.block_number IS NULL)) ORDER BY t0.block_number DESC, t0.log_index DESC LIMIT 50;
                                                                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.70..193.92 rows=50 width=229) (actual time=0.022..0.039 rows=50 loops=1)
   ->  Index Scan using token_transfers_token_contract_address_hash_block_number_lo_idx on token_transfers t0  (cost=0.70..109922431.27 rows=28444375 width=229) (actual time=0.022..0.035 rows=50 loops=1)
         Index Cond: ((token_contract_address_hash = '\xdcf5d3e08c5007dececdb34808c49331bd82a247'::bytea) AND (block_number IS NOT NULL))
         Filter: block_consensus
 Planning Time: 0.127 ms
 Execution Time: 0.056 ms
```

In addition, log_index sorting in a descending direction is added to a similar GraphQL query.

After that, seems, all queries from `token_transfers` table, which use filter by token_contract_address_hash, and sorting should use this index in their execution plans.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
