### PR TITLE
perf: Enhance index for token holders list

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240404102510_enhance_index_for_token_holders_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240404102510_enhance_index_for_token_holders_list.exs
@@ -1,0 +1,21 @@
+defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenHoldersList do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    drop_if_exists(
+      index(:address_current_token_balances, [:token_contract_address_hash],
+        where: "address_hash != '\\x0000000000000000000000000000000000000000' AND value > 0",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:address_current_token_balances, ["token_contract_address_hash, value DESC, address_hash DESC"],
+        where: "address_hash != '\\x0000000000000000000000000000000000000000' AND value > 0",
+        concurrently: true
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240404102511_drop_outdated_index_for_token_holders_list.exs
+++ b/apps/explorer/priv/repo/migrations/20240404102511_drop_outdated_index_for_token_holders_list.exs
@@ -1,11 +1,11 @@
-defmodule Explorer.Repo.Migrations.EnhanceIndexForTokenHoldersList do
+defmodule Explorer.Repo.Migrations.DropOutdatedIndexForTokenHoldersList do
   use Ecto.Migration
   @disable_ddl_transaction true
   @disable_migration_lock true
 
   def change do
-    create_if_not_exists(
-      index(:address_current_token_balances, ["token_contract_address_hash, value DESC, address_hash DESC"],
+    drop_if_exists(
+      index(:address_current_token_balances, [:token_contract_address_hash],
         where: "address_hash != '\\x0000000000000000000000000000000000000000' AND value > 0",
         concurrently: true
       )


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9815


## Motivation

Slow execution of the query under the hood of `/api/v1?module=token&action=getTokenHolders&contractaddress=#{hash}&page=0&offset=0` endpoint.

## Changelog

Query in question:
```
SELECT a0.*
FROM address_current_token_balances AS a0
WHERE (a0.token_contract_address_hash = '\x...')
AND (a0.address_hash != '\x0000000000000000000000000000000000000000')
AND (a0.value > 0)
ORDER BY a0.value DESC, a0.address_hash DESC
LIMIT 10
OFFSET 0
```

Current execution plan:
```
eth_sepolia=> explain SELECT a0.* FROM address_current_token_balances AS a0 WHERE (a0.token_contract_address_hash = '\x54FA517F05e11Ffa87f4b22AE87d91Cec0C2D7E1') AND (a0.address_hash != '\x0000000000000000000000000000000000000000') AND (a0.value > 0) ORDER BY a0.value DESC, a0.address_hash DESC LIMIT 10 OFFSET 0;
                                                                                          QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=125990.55..126024.18 rows=10 width=108)
   ->  Incremental Sort  (cost=125990.55..123217344.94 rows=36596801 width=108)
         Sort Key: value DESC, address_hash DESC
         Presorted Key: value
         ->  Index Scan Backward using address_current_token_balances_token_contract_address_hash_valu on address_current_token_balances a0  (cost=0.70..121527853.88 rows=36596801 width=108)
               Index Cond: ((token_contract_address_hash = '\x54fa517f05e11ffa87f4b22ae87d91cec0c2d7e1'::bytea) AND (value > '0'::numeric))
               Filter: (address_hash <> '\x0000000000000000000000000000000000000000'::bytea)
 JIT:
   Functions: 6
   Options: Inlining false, Optimization false, Expressions true, Deforming true
(10 rows)
```

Execution plan after suggested index change:
```
eth_sepolia=> explain analyze SELECT a0.* FROM address_current_token_balances AS a0 WHERE (a0.token_contract_address_hash = '\x54FA517F05e11Ffa87f4b22AE87d91Cec0C2D7E1') AND (a0.address_hash != '\x0000000000000000000000000000000000000000') AND (a0.value > 0) ORDER BY a0.value DESC, a0.address_hash DESC LIMIT 10 OFFSET 0;
                                                                                                        QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.69..33.50 rows=10 width=108) (actual time=0.013..0.028 rows=10 loops=1)
   ->  Index Scan using address_current_token_balance_token_contract_address_hash_v_idx on address_current_token_balances a0  (cost=0.69..120387677.71 rows=36698411 width=108) (actual time=0.012..0.027 rows=10 loops=1)
         Index Cond: (token_contract_address_hash = '\x54fa517f05e11ffa87f4b22ae87d91cec0c2d7e1'::bytea)
 Planning Time: 0.214 ms
 Execution Time: 0.042 ms
(5 rows)
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
