### PR TITLE
perf: Paging function edge cases fix

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_internal_transaction_controller_test.exs
@@ -403,6 +403,19 @@ defmodule BlockScoutWeb.AddressInternalTransactionControllerTest do
 
       path = address_internal_transaction_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address.hash))
 
+      empty_page_response =
+        conn
+        |> get(path, %{
+          "block_number" => Integer.to_string(0),
+          "transaction_index" => Integer.to_string(0),
+          "index" => "0",
+          "type" => "JSON"
+        })
+        |> json_response(200)
+        |> Map.get("items")
+
+      assert Enum.count(empty_page_response) == 0
+
       first_page_response =
         conn
         |> get(path, %{"type" => "JSON"})

--- a/apps/explorer/lib/explorer/account/tag_address.ex
+++ b/apps/explorer/lib/explorer/account/tag_address.ex
@@ -99,12 +99,18 @@ defmodule Explorer.Account.TagAddress do
   def get_tags_address_by_identity_id(id, options) when not is_nil(id) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    id
-    |> tags_address_by_identity_id_query()
-    |> order_by([tag], desc: tag.id)
-    |> page_address_tags(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Repo.account_repo().all()
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
+
+      _ ->
+        id
+        |> tags_address_by_identity_id_query()
+        |> order_by([tag], desc: tag.id)
+        |> page_address_tags(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Repo.account_repo().all()
+    end
   end
 
   def get_tags_address_by_identity_id(_, _), do: []

--- a/apps/explorer/lib/explorer/account/tag_transaction.ex
+++ b/apps/explorer/lib/explorer/account/tag_transaction.ex
@@ -98,12 +98,18 @@ defmodule Explorer.Account.TagTransaction do
   def get_tags_transaction_by_identity_id(id, options) when not is_nil(id) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    id
-    |> tags_transaction_by_identity_id_query()
-    |> order_by([tag], desc: tag.id)
-    |> page_transaction_tags(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Repo.account_repo().all()
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
+
+      _ ->
+        id
+        |> tags_transaction_by_identity_id_query()
+        |> order_by([tag], desc: tag.id)
+        |> page_transaction_tags(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Repo.account_repo().all()
+    end
   end
 
   def get_tags_transaction_by_identity_id(_, _), do: []

--- a/apps/explorer/lib/explorer/account/watchlist_address.ex
+++ b/apps/explorer/lib/explorer/account/watchlist_address.ex
@@ -133,12 +133,18 @@ defmodule Explorer.Account.WatchlistAddress do
   def get_watchlist_addresses_by_watchlist_id(watchlist_id, options) when not is_nil(watchlist_id) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    watchlist_id
-    |> watchlist_addresses_by_watchlist_id_query()
-    |> order_by([wla], desc: wla.id)
-    |> page_watchlist_address(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Repo.account_repo().all()
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
+
+      _ ->
+        watchlist_id
+        |> watchlist_addresses_by_watchlist_id_query()
+        |> order_by([wla], desc: wla.id)
+        |> page_watchlist_address(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Repo.account_repo().all()
+    end
   end
 
   def get_watchlist_addresses_by_watchlist_id(_, _), do: []

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3302,8 +3302,7 @@ defmodule Explorer.Chain do
     hardcoded_where_for_page_int_tx(query, block_number, transaction_index, index, desc)
   end
 
-  def page_internal_transaction(query, %PagingOptions{key: {index}}, %{index_int_tx_desc_order: desc})
-      when index == 0 do
+  def page_internal_transaction(query, %PagingOptions{key: {0}}, %{index_int_tx_desc_order: desc}) do
     if desc do
       query
     else

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3306,7 +3306,7 @@ defmodule Explorer.Chain do
     if desc do
       query
     else
-      where(query, [internal_transaction], internal_transaction.index > ^index)
+      where(query, [internal_transaction], internal_transaction.index > 0)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3323,7 +3323,8 @@ defmodule Explorer.Chain do
       where(
         query,
         [internal_transaction],
-        internal_transaction.block_number == 0 and internal_transaction.index > ^index
+        internal_transaction.block_number == 0 and
+        internal_transaction.transaction_index == 0 and internal_transaction.index > ^index
       )
 
   defp hardcoded_where_for_page_int_tx(query, block_number, 0, index, false),
@@ -3332,7 +3333,8 @@ defmodule Explorer.Chain do
         query,
         [internal_transaction],
         internal_transaction.block_number < ^block_number or
-          (internal_transaction.block_number == ^block_number and internal_transaction.index > ^index)
+          (internal_transaction.block_number == ^block_number and
+          internal_transaction.transaction_index == 0 and internal_transaction.index > ^index)
       )
 
   defp hardcoded_where_for_page_int_tx(query, block_number, transaction_index, index, false),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3184,7 +3184,7 @@ defmodule Explorer.Chain do
 
   defp handle_block_paging_options(query, paging_options) do
     case paging_options do
-      %PagingOptions{key: {_block_number, 0}} ->
+      %PagingOptions{key: {_block_number, 0}, is_index_in_asc_order: false} ->
         []
 
       _ ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3324,7 +3324,7 @@ defmodule Explorer.Chain do
         query,
         [internal_transaction],
         internal_transaction.block_number == 0 and
-        internal_transaction.transaction_index == 0 and internal_transaction.index > ^index
+          internal_transaction.transaction_index == 0 and internal_transaction.index > ^index
       )
 
   defp hardcoded_where_for_page_int_tx(query, block_number, 0, index, false),
@@ -3334,7 +3334,7 @@ defmodule Explorer.Chain do
         [internal_transaction],
         internal_transaction.block_number < ^block_number or
           (internal_transaction.block_number == ^block_number and
-          internal_transaction.transaction_index == 0 and internal_transaction.index > ^index)
+             internal_transaction.transaction_index == 0 and internal_transaction.index > ^index)
       )
 
   defp hardcoded_where_for_page_int_tx(query, block_number, transaction_index, index, false),

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -349,18 +349,24 @@ defmodule Explorer.Chain.Address do
   defp fetch_top_addresses(options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    base_query =
-      from(a in Address,
-        where: a.fetched_coin_balance > ^0,
-        order_by: [desc: a.fetched_coin_balance, asc: a.hash],
-        preload: [:names, :smart_contract],
-        select: {a, a.transactions_count}
-      )
+    case paging_options do
+      %PagingOptions{key: {0, _hash}} ->
+        []
 
-    base_query
-    |> page_addresses(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Chain.select_repo(options).all()
+      _ ->
+        base_query =
+          from(a in Address,
+            where: a.fetched_coin_balance > ^0,
+            order_by: [desc: a.fetched_coin_balance, asc: a.hash],
+            preload: [:names, :smart_contract],
+            select: {a, a.transactions_count}
+          )
+
+        base_query
+        |> page_addresses(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   defp page_addresses(query, %PagingOptions{key: nil}), do: query

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -92,14 +92,21 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   """
   def token_holders_ordered_by_value_query_without_address_preload(token_contract_address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    offset = (max(paging_options.page_number, 1) - 1) * paging_options.page_size
 
-    token_contract_address_hash
-    |> token_holders_query
-    |> order_by([tb], desc: :value, desc: :address_hash)
-    |> Chain.page_token_balances(paging_options)
-    |> limit(^paging_options.page_size)
-    |> offset(^offset)
+    case paging_options do
+      %PagingOptions{key: {0, _}} ->
+        []
+
+      _ ->
+        offset = (max(paging_options.page_number, 1) - 1) * paging_options.page_size
+
+        token_contract_address_hash
+        |> token_holders_query
+        |> order_by([tb], desc: :value, desc: :address_hash)
+        |> Chain.page_token_balances(paging_options)
+        |> limit(^paging_options.page_size)
+        |> offset(^offset)
+    end
   end
 
   @doc """
@@ -116,12 +123,18 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   def token_holders_1155_by_token_id(token_contract_address_hash, token_id, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    token_contract_address_hash
-    |> token_holders_by_token_id_query(token_id)
-    |> preload(:address)
-    |> order_by([tb], desc: :value, desc: :address_hash)
-    |> Chain.page_token_balances(paging_options)
-    |> limit(^paging_options.page_size)
+    case paging_options do
+      %PagingOptions{key: {0, _}} ->
+        []
+
+      _ ->
+        token_contract_address_hash
+        |> token_holders_by_token_id_query(token_id)
+        |> preload(:address)
+        |> order_by([tb], desc: :value, desc: :address_hash)
+        |> Chain.page_token_balances(paging_options)
+        |> limit(^paging_options.page_size)
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/optimism/deposit.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/deposit.ex
@@ -63,16 +63,22 @@ defmodule Explorer.Chain.Optimism.Deposit do
   def list(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    base_query =
-      from(d in __MODULE__,
-        order_by: [desc: d.l1_block_number, desc: d.l2_transaction_hash]
-      )
+    case paging_options do
+      %PagingOptions{key: {0, _l2_tx_hash}} ->
+        []
 
-    base_query
-    |> join_association(:l2_transaction, :required)
-    |> page_deposits(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(d in __MODULE__,
+            order_by: [desc: d.l1_block_number, desc: d.l2_transaction_hash]
+          )
+
+        base_query
+        |> join_association(:l2_transaction, :required)
+        |> page_deposits(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   defp page_deposits(query, %PagingOptions{key: nil}), do: query

--- a/apps/explorer/lib/explorer/chain/optimism/output_root.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/output_root.ex
@@ -61,6 +61,10 @@ defmodule Explorer.Chain.Optimism.OutputRoot do
 
   defp page_output_roots(query, %PagingOptions{key: nil}), do: query
 
+  defp page_output_roots(query, %PagingOptions{key: {0}}) do
+    query
+  end
+
   defp page_output_roots(query, %PagingOptions{key: {index}}) do
     from(r in query, where: r.l2_output_index < ^index)
   end

--- a/apps/explorer/lib/explorer/chain/optimism/output_root.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/output_root.ex
@@ -47,23 +47,25 @@ defmodule Explorer.Chain.Optimism.OutputRoot do
   def list(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    base_query =
-      from(r in __MODULE__,
-        order_by: [desc: r.l2_output_index],
-        select: r
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> page_output_roots(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(r in __MODULE__,
+            order_by: [desc: r.l2_output_index],
+            select: r
+          )
+
+        base_query
+        |> page_output_roots(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   defp page_output_roots(query, %PagingOptions{key: nil}), do: query
-
-  defp page_output_roots(query, %PagingOptions{key: {0}}) do
-    query
-  end
 
   defp page_output_roots(query, %PagingOptions{key: {index}}) do
     from(r in query, where: r.l2_output_index < ^index)

--- a/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
@@ -46,16 +46,22 @@ defmodule Explorer.Chain.Optimism.TxnBatch do
   def list(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    base_query =
-      from(tb in __MODULE__,
-        order_by: [desc: tb.l2_block_number]
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> join_association(:frame_sequence, :required)
-    |> page_txn_batches(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(tb in __MODULE__,
+            order_by: [desc: tb.l2_block_number]
+          )
+
+        base_query
+        |> join_association(:frame_sequence, :required)
+        |> page_txn_batches(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/polygon_edge/reader.ex
+++ b/apps/explorer/lib/explorer/chain/polygon_edge/reader.ex
@@ -17,27 +17,33 @@ defmodule Explorer.Chain.PolygonEdge.Reader do
   def deposits(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, default_paging_options())
 
-    base_query =
-      from(
-        de in DepositExecute,
-        inner_join: d in Deposit,
-        on: d.msg_id == de.msg_id and not is_nil(d.l1_timestamp),
-        select: %{
-          msg_id: de.msg_id,
-          from: d.from,
-          to: d.to,
-          l1_transaction_hash: d.l1_transaction_hash,
-          l1_timestamp: d.l1_timestamp,
-          success: de.success,
-          l2_transaction_hash: de.l2_transaction_hash
-        },
-        order_by: [desc: de.msg_id]
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> page_deposits_or_withdrawals(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            de in DepositExecute,
+            inner_join: d in Deposit,
+            on: d.msg_id == de.msg_id and not is_nil(d.l1_timestamp),
+            select: %{
+              msg_id: de.msg_id,
+              from: d.from,
+              to: d.to,
+              l1_transaction_hash: d.l1_transaction_hash,
+              l1_timestamp: d.l1_timestamp,
+              success: de.success,
+              l2_transaction_hash: de.l2_transaction_hash
+            },
+            order_by: [desc: de.msg_id]
+          )
+
+        base_query
+        |> page_deposits_or_withdrawals(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @spec deposits_count(list()) :: term() | nil
@@ -56,30 +62,36 @@ defmodule Explorer.Chain.PolygonEdge.Reader do
   def withdrawals(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, default_paging_options())
 
-    base_query =
-      from(
-        w in Withdrawal,
-        left_join: we in WithdrawalExit,
-        on: we.msg_id == w.msg_id,
-        left_join: b in Block,
-        on: b.number == w.l2_block_number and b.consensus == true,
-        select: %{
-          msg_id: w.msg_id,
-          from: w.from,
-          to: w.to,
-          l2_transaction_hash: w.l2_transaction_hash,
-          l2_timestamp: b.timestamp,
-          success: we.success,
-          l1_transaction_hash: we.l1_transaction_hash
-        },
-        where: not is_nil(w.from),
-        order_by: [desc: w.msg_id]
-      )
+    case paging_options do
+      %PagingOptions{key: 0} ->
+        []
 
-    base_query
-    |> page_deposits_or_withdrawals(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            w in Withdrawal,
+            left_join: we in WithdrawalExit,
+            on: we.msg_id == w.msg_id,
+            left_join: b in Block,
+            on: b.number == w.l2_block_number and b.consensus == true,
+            select: %{
+              msg_id: w.msg_id,
+              from: w.from,
+              to: w.to,
+              l2_transaction_hash: w.l2_transaction_hash,
+              l2_timestamp: b.timestamp,
+              success: we.success,
+              l1_transaction_hash: we.l1_transaction_hash
+            },
+            where: not is_nil(w.from),
+            order_by: [desc: w.msg_id]
+          )
+
+        base_query
+        |> page_deposits_or_withdrawals(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @spec withdrawals_count(list()) :: term() | nil

--- a/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
+++ b/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
@@ -327,6 +327,10 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
 
   defp page_deposits_or_withdrawals(query, %PagingOptions{key: nil}), do: query
 
+  defp page_deposits_or_withdrawals(query, %PagingOptions{key: {0}}) do
+    query
+  end
+
   defp page_deposits_or_withdrawals(query, %PagingOptions{key: {index}}) do
     from(b in query, where: b.index < ^index)
   end

--- a/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
+++ b/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
@@ -69,10 +69,16 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
       else
         paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-        base_query
-        |> Chain.join_associations(necessity_by_association)
-        |> page_batches(paging_options)
-        |> limit(^paging_options.page_size)
+        case paging_options do
+          %PagingOptions{key: {0}} ->
+            []
+
+          _ ->
+            base_query
+            |> Chain.join_associations(necessity_by_association)
+            |> page_batches(paging_options)
+            |> limit(^paging_options.page_size)
+        end
       end
 
     select_repo(options).all(query)
@@ -239,20 +245,26 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
   def deposits(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    base_query =
-      from(
-        b in Bridge,
-        left_join: t1 in assoc(b, :l1_token),
-        left_join: t2 in assoc(b, :l2_token),
-        where: b.type == :deposit and not is_nil(b.l1_transaction_hash),
-        preload: [l1_token: t1, l2_token: t2],
-        order_by: [desc: b.index]
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> page_deposits_or_withdrawals(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            b in Bridge,
+            left_join: t1 in assoc(b, :l1_token),
+            left_join: t2 in assoc(b, :l2_token),
+            where: b.type == :deposit and not is_nil(b.l1_transaction_hash),
+            preload: [l1_token: t1, l2_token: t2],
+            order_by: [desc: b.index]
+          )
+
+        base_query
+        |> page_deposits_or_withdrawals(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @doc """
@@ -277,20 +289,26 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
   def withdrawals(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    base_query =
-      from(
-        b in Bridge,
-        left_join: t1 in assoc(b, :l1_token),
-        left_join: t2 in assoc(b, :l2_token),
-        where: b.type == :withdrawal and not is_nil(b.l2_transaction_hash),
-        preload: [l1_token: t1, l2_token: t2],
-        order_by: [desc: b.index]
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> page_deposits_or_withdrawals(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            b in Bridge,
+            left_join: t1 in assoc(b, :l1_token),
+            left_join: t2 in assoc(b, :l2_token),
+            where: b.type == :withdrawal and not is_nil(b.l2_transaction_hash),
+            preload: [l1_token: t1, l2_token: t2],
+            order_by: [desc: b.index]
+          )
+
+        base_query
+        |> page_deposits_or_withdrawals(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @doc """
@@ -326,10 +344,6 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
   end
 
   defp page_deposits_or_withdrawals(query, %PagingOptions{key: nil}), do: query
-
-  defp page_deposits_or_withdrawals(query, %PagingOptions{key: {0}}) do
-    query
-  end
 
   defp page_deposits_or_withdrawals(query, %PagingOptions{key: {index}}) do
     from(b in query, where: b.index < ^index)

--- a/apps/explorer/lib/explorer/chain/shibarium/reader.ex
+++ b/apps/explorer/lib/explorer/chain/shibarium/reader.ex
@@ -19,24 +19,30 @@ defmodule Explorer.Chain.Shibarium.Reader do
   def deposits(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, default_paging_options())
 
-    base_query =
-      from(
-        sb in Bridge,
-        where: sb.operation_type == :deposit and not is_nil(sb.l1_block_number) and not is_nil(sb.l2_block_number),
-        select: %{
-          l1_block_number: sb.l1_block_number,
-          l1_transaction_hash: sb.l1_transaction_hash,
-          l2_transaction_hash: sb.l2_transaction_hash,
-          user: sb.user,
-          timestamp: sb.timestamp
-        },
-        order_by: [desc: sb.l1_block_number]
-      )
+    case paging_options do
+      %PagingOptions{key: {0}} ->
+        []
 
-    base_query
-    |> page_deposits(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            sb in Bridge,
+            where: sb.operation_type == :deposit and not is_nil(sb.l1_block_number) and not is_nil(sb.l2_block_number),
+            select: %{
+              l1_block_number: sb.l1_block_number,
+              l1_transaction_hash: sb.l1_transaction_hash,
+              l2_transaction_hash: sb.l2_transaction_hash,
+              user: sb.user,
+              timestamp: sb.timestamp
+            },
+            order_by: [desc: sb.l1_block_number]
+          )
+
+        base_query
+        |> page_deposits(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @doc """
@@ -60,24 +66,31 @@ defmodule Explorer.Chain.Shibarium.Reader do
   def withdrawals(options \\ []) do
     paging_options = Keyword.get(options, :paging_options, default_paging_options())
 
-    base_query =
-      from(
-        sb in Bridge,
-        where: sb.operation_type == :withdrawal and not is_nil(sb.l1_block_number) and not is_nil(sb.l2_block_number),
-        select: %{
-          l2_block_number: sb.l2_block_number,
-          l2_transaction_hash: sb.l2_transaction_hash,
-          l1_transaction_hash: sb.l1_transaction_hash,
-          user: sb.user,
-          timestamp: sb.timestamp
-        },
-        order_by: [desc: sb.l2_block_number]
-      )
+    case paging_options do
+      %PagingOptions{key: 0} ->
+        []
 
-    base_query
-    |> page_withdrawals(paging_options)
-    |> limit(^paging_options.page_size)
-    |> select_repo(options).all()
+      _ ->
+        base_query =
+          from(
+            sb in Bridge,
+            where:
+              sb.operation_type == :withdrawal and not is_nil(sb.l1_block_number) and not is_nil(sb.l2_block_number),
+            select: %{
+              l2_block_number: sb.l2_block_number,
+              l2_transaction_hash: sb.l2_transaction_hash,
+              l1_transaction_hash: sb.l1_transaction_hash,
+              user: sb.user,
+              timestamp: sb.timestamp
+            },
+            order_by: [desc: sb.l2_block_number]
+          )
+
+        base_query
+        |> page_withdrawals(paging_options)
+        |> limit(^paging_options.page_size)
+        |> select_repo(options).all()
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -147,15 +147,22 @@ defmodule Explorer.Chain.Token.Instance do
   @spec erc_721_token_instances_by_owner_address_hash(binary() | Hash.Address.t(), keyword) :: [Instance.t()]
   def erc_721_token_instances_by_owner_address_hash(address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
-    __MODULE__
-    |> where([ti], ti.owner_address_hash == ^address_hash)
-    |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
-    |> limit(^paging_options.page_size)
-    |> page_erc_721_token_instances(paging_options)
-    |> Chain.join_associations(necessity_by_association)
-    |> Chain.select_repo(options).all()
+    case paging_options do
+      %PagingOptions{key: {0}, asc_order: false} ->
+        []
+
+      _ ->
+        necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+        __MODULE__
+        |> where([ti], ti.owner_address_hash == ^address_hash)
+        |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
+        |> limit(^paging_options.page_size)
+        |> page_erc_721_token_instances(paging_options)
+        |> Chain.join_associations(necessity_by_association)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   defp page_erc_721_token_instances(query, %PagingOptions{key: {contract_address_hash, token_id, "ERC-721"}}) do
@@ -167,22 +174,29 @@ defmodule Explorer.Chain.Token.Instance do
   @spec erc_1155_token_instances_by_address_hash(binary() | Hash.Address.t(), keyword) :: [Instance.t()]
   def erc_1155_token_instances_by_address_hash(address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
-    __MODULE__
-    |> join(:inner, [ti], ctb in CurrentTokenBalance,
-      as: :ctb,
-      on:
-        ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
-          ctb.address_hash == ^address_hash
-    )
-    |> where([ctb: ctb], ctb.value > 0 and ctb.token_type == "ERC-1155")
-    |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
-    |> limit(^paging_options.page_size)
-    |> page_erc_1155_token_instances(paging_options)
-    |> select_merge([ctb: ctb], %{current_token_balance: ctb})
-    |> Chain.join_associations(necessity_by_association)
-    |> Chain.select_repo(options).all()
+    case paging_options do
+      %PagingOptions{key: {0}, asc_order: false} ->
+        []
+
+      _ ->
+        necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+        __MODULE__
+        |> join(:inner, [ti], ctb in CurrentTokenBalance,
+          as: :ctb,
+          on:
+            ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
+              ctb.address_hash == ^address_hash
+        )
+        |> where([ctb: ctb], ctb.value > 0 and ctb.token_type == "ERC-1155")
+        |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
+        |> limit(^paging_options.page_size)
+        |> page_erc_1155_token_instances(paging_options)
+        |> select_merge([ctb: ctb], %{current_token_balance: ctb})
+        |> Chain.join_associations(necessity_by_association)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   defp page_erc_1155_token_instances(query, %PagingOptions{key: {contract_address_hash, token_id, "ERC-1155"}}) do
@@ -194,22 +208,29 @@ defmodule Explorer.Chain.Token.Instance do
   @spec erc_404_token_instances_by_address_hash(binary() | Hash.Address.t(), keyword) :: [Instance.t()]
   def erc_404_token_instances_by_address_hash(address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
-    __MODULE__
-    |> join(:inner, [ti], ctb in CurrentTokenBalance,
-      as: :ctb,
-      on:
-        ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
-          ctb.address_hash == ^address_hash
-    )
-    |> where([ctb: ctb], ctb.value > 0 and ctb.token_type == "ERC-404")
-    |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
-    |> limit(^paging_options.page_size)
-    |> page_erc_404_token_instances(paging_options)
-    |> select_merge([ctb: ctb], %{current_token_balance: ctb})
-    |> Chain.join_associations(necessity_by_association)
-    |> Chain.select_repo(options).all()
+    case paging_options do
+      %PagingOptions{key: {0}, asc_order: false} ->
+        []
+
+      _ ->
+        necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+        __MODULE__
+        |> join(:inner, [ti], ctb in CurrentTokenBalance,
+          as: :ctb,
+          on:
+            ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
+              ctb.address_hash == ^address_hash
+        )
+        |> where([ctb: ctb], ctb.value > 0 and ctb.token_type == "ERC-404")
+        |> order_by([ti], asc: ti.token_contract_address_hash, desc: ti.token_id)
+        |> limit(^paging_options.page_size)
+        |> page_erc_404_token_instances(paging_options)
+        |> select_merge([ctb: ctb], %{current_token_balance: ctb})
+        |> Chain.join_associations(necessity_by_association)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   defp page_erc_404_token_instances(query, %PagingOptions{key: {contract_address_hash, token_id, "ERC-404"}}) do
@@ -447,33 +468,45 @@ defmodule Explorer.Chain.Token.Instance do
   def token_instances_by_holder_address_hash(%Token{type: "ERC-721"} = token, holder_address_hash, options) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    token.contract_address_hash
-    |> address_to_unique_token_instances()
-    |> where([ti], ti.owner_address_hash == ^holder_address_hash)
-    |> limit(^paging_options.page_size)
-    |> page_token_instance(paging_options)
-    |> Chain.select_repo(options).all()
-    |> Enum.map(&put_is_unique(&1, token, options))
+    case paging_options do
+      %PagingOptions{key: {0}, asc_order: false} ->
+        []
+
+      _ ->
+        token.contract_address_hash
+        |> address_to_unique_token_instances()
+        |> where([ti], ti.owner_address_hash == ^holder_address_hash)
+        |> limit(^paging_options.page_size)
+        |> page_token_instance(paging_options)
+        |> Chain.select_repo(options).all()
+        |> Enum.map(&put_is_unique(&1, token, options))
+    end
   end
 
   def token_instances_by_holder_address_hash(%Token{} = token, holder_address_hash, options) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-    __MODULE__
-    |> where([ti], ti.token_contract_address_hash == ^token.contract_address_hash)
-    |> join(:inner, [ti], ctb in CurrentTokenBalance,
-      as: :ctb,
-      on:
-        ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
-          ctb.address_hash == ^holder_address_hash
-    )
-    |> where([ctb: ctb], ctb.value > 0)
-    |> order_by([ti], desc: ti.token_id)
-    |> limit(^paging_options.page_size)
-    |> page_token_instance(paging_options)
-    |> select_merge([ctb: ctb], %{current_token_balance: ctb})
-    |> Chain.select_repo(options).all()
-    |> Enum.map(&put_is_unique(&1, token, options))
+    case paging_options do
+      %PagingOptions{key: {0}, asc_order: false} ->
+        []
+
+      _ ->
+        __MODULE__
+        |> where([ti], ti.token_contract_address_hash == ^token.contract_address_hash)
+        |> join(:inner, [ti], ctb in CurrentTokenBalance,
+          as: :ctb,
+          on:
+            ctb.token_contract_address_hash == ti.token_contract_address_hash and ctb.token_id == ti.token_id and
+              ctb.address_hash == ^holder_address_hash
+        )
+        |> where([ctb: ctb], ctb.value > 0)
+        |> order_by([ti], desc: ti.token_id)
+        |> limit(^paging_options.page_size)
+        |> page_token_instance(paging_options)
+        |> select_merge([ctb: ctb], %{current_token_balance: ctb})
+        |> Chain.select_repo(options).all()
+        |> Enum.map(&put_is_unique(&1, token, options))
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -228,6 +228,18 @@ defmodule Explorer.Chain.TokenTransfer do
     )
   end
 
+  def page_token_transfer(query, %PagingOptions{key: {0, 0}}) do
+    query
+  end
+
+  def page_token_transfer(query, %PagingOptions{key: {block_number, 0}}) do
+    where(
+      query,
+      [tt],
+      tt.block_number < ^block_number
+    )
+  end
+
   def page_token_transfer(query, %PagingOptions{key: {block_number, log_index}}) do
     where(
       query,
@@ -301,6 +313,10 @@ defmodule Explorer.Chain.TokenTransfer do
   end
 
   defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: nil}), do: query
+
+  defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: {0, _index}}) do
+    query
+  end
 
   defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: {block_number, _index}}) do
     where(

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -157,31 +157,45 @@ defmodule Explorer.Chain.TokenTransfer do
   @spec fetch_token_transfers_from_token_hash(Hash.t(), [paging_options | api?]) :: []
   def fetch_token_transfers_from_token_hash(token_address_hash, options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    preloads = DenormalizationHelper.extend_transaction_preload([:transaction, :token, :from_address, :to_address])
 
-    only_consensus_transfers_query()
-    |> where([tt], tt.token_contract_address_hash == ^token_address_hash and not is_nil(tt.block_number))
-    |> preload(^preloads)
-    |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-    |> page_token_transfer(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Chain.select_repo(options).all()
+    case paging_options do
+      %PagingOptions{key: {0, 0}} ->
+        []
+
+      _ ->
+        preloads = DenormalizationHelper.extend_transaction_preload([:transaction, :token, :from_address, :to_address])
+
+        only_consensus_transfers_query()
+        |> where([tt], tt.token_contract_address_hash == ^token_address_hash and not is_nil(tt.block_number))
+        |> preload(^preloads)
+        |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
+        |> page_token_transfer(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   @spec fetch_token_transfers_from_token_hash_and_token_id(Hash.t(), non_neg_integer(), [paging_options | api?]) :: []
   def fetch_token_transfers_from_token_hash_and_token_id(token_address_hash, token_id, options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    preloads = DenormalizationHelper.extend_transaction_preload([:transaction, :token, :from_address, :to_address])
 
-    only_consensus_transfers_query()
-    |> where([tt], tt.token_contract_address_hash == ^token_address_hash)
-    |> where([tt], fragment("? @> ARRAY[?::decimal]", tt.token_ids, ^Decimal.new(token_id)))
-    |> where([tt], not is_nil(tt.block_number))
-    |> preload(^preloads)
-    |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-    |> page_token_transfer(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Chain.select_repo(options).all()
+    case paging_options do
+      %PagingOptions{key: {0, 0}} ->
+        []
+
+      _ ->
+        preloads = DenormalizationHelper.extend_transaction_preload([:transaction, :token, :from_address, :to_address])
+
+        only_consensus_transfers_query()
+        |> where([tt], tt.token_contract_address_hash == ^token_address_hash)
+        |> where([tt], fragment("? @> ARRAY[?::decimal]", tt.token_ids, ^Decimal.new(token_id)))
+        |> where([tt], not is_nil(tt.block_number))
+        |> preload(^preloads)
+        |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
+        |> page_token_transfer(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Chain.select_repo(options).all()
+    end
   end
 
   @spec count_token_transfers_from_token_hash(Hash.t()) :: non_neg_integer()
@@ -228,10 +242,6 @@ defmodule Explorer.Chain.TokenTransfer do
     )
   end
 
-  def page_token_transfer(query, %PagingOptions{key: {0, 0}}) do
-    query
-  end
-
   def page_token_transfer(query, %PagingOptions{key: {block_number, 0}}) do
     where(
       query,
@@ -263,33 +273,45 @@ defmodule Explorer.Chain.TokenTransfer do
   to the address hash.
   """
   def where_any_address_fields_match(:to, address_hash, paging_options) do
-    query =
-      from(
-        tt in TokenTransfer,
-        where: tt.to_address_hash == ^address_hash,
-        select: type(tt.transaction_hash, :binary),
-        distinct: tt.transaction_hash
-      )
+    case paging_options do
+      %PagingOptions{key: {0, _index}} ->
+        []
 
-    query
-    |> page_transaction_hashes_from_token_transfers(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Repo.all()
+      _ ->
+        query =
+          from(
+            tt in TokenTransfer,
+            where: tt.to_address_hash == ^address_hash,
+            select: type(tt.transaction_hash, :binary),
+            distinct: tt.transaction_hash
+          )
+
+        query
+        |> page_transaction_hashes_from_token_transfers(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Repo.all()
+    end
   end
 
   def where_any_address_fields_match(:from, address_hash, paging_options) do
-    query =
-      from(
-        tt in TokenTransfer,
-        where: tt.from_address_hash == ^address_hash,
-        select: type(tt.transaction_hash, :binary),
-        distinct: tt.transaction_hash
-      )
+    case paging_options do
+      %PagingOptions{key: {0, _index}} ->
+        []
 
-    query
-    |> page_transaction_hashes_from_token_transfers(paging_options)
-    |> limit(^paging_options.page_size)
-    |> Repo.all()
+      _ ->
+        query =
+          from(
+            tt in TokenTransfer,
+            where: tt.from_address_hash == ^address_hash,
+            select: type(tt.transaction_hash, :binary),
+            distinct: tt.transaction_hash
+          )
+
+        query
+        |> page_transaction_hashes_from_token_transfers(paging_options)
+        |> limit(^paging_options.page_size)
+        |> Repo.all()
+    end
   end
 
   def where_any_address_fields_match(_, address_hash, paging_options) do
@@ -299,24 +321,27 @@ defmodule Explorer.Chain.TokenTransfer do
   end
 
   defp transaction_hashes_from_token_transfers_sql(address_bytes, %PagingOptions{page_size: page_size} = paging_options) do
-    query =
-      from(token_transfer in TokenTransfer,
-        where: token_transfer.to_address_hash == ^address_bytes or token_transfer.from_address_hash == ^address_bytes,
-        select: type(token_transfer.transaction_hash, :binary),
-        distinct: token_transfer.transaction_hash,
-        limit: ^page_size
-      )
+    case paging_options do
+      %PagingOptions{key: {0, _index}} ->
+        []
 
-    query
-    |> page_transaction_hashes_from_token_transfers(paging_options)
-    |> Repo.all()
+      _ ->
+        query =
+          from(token_transfer in TokenTransfer,
+            where:
+              token_transfer.to_address_hash == ^address_bytes or token_transfer.from_address_hash == ^address_bytes,
+            select: type(token_transfer.transaction_hash, :binary),
+            distinct: token_transfer.transaction_hash,
+            limit: ^page_size
+          )
+
+        query
+        |> page_transaction_hashes_from_token_transfers(paging_options)
+        |> Repo.all()
+    end
   end
 
   defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: nil}), do: query
-
-  defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: {0, _index}}) do
-    query
-  end
 
   defp page_transaction_hashes_from_token_transfers(query, %PagingOptions{key: {block_number, _index}}) do
     where(

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1531,12 +1531,32 @@ defmodule Explorer.Chain.Transaction do
   def page_transaction(query, %PagingOptions{is_pending_tx: true} = options),
     do: page_pending_transaction(query, options)
 
+  def page_transaction(query, %PagingOptions{key: {0, index}, is_index_in_asc_order: true}) do
+    where(
+      query,
+      [transaction],
+      transaction.block_number == 0 and transaction.index > ^index
+    )
+  end
+
   def page_transaction(query, %PagingOptions{key: {block_number, index}, is_index_in_asc_order: true}) do
     where(
       query,
       [transaction],
       transaction.block_number < ^block_number or
         (transaction.block_number == ^block_number and transaction.index > ^index)
+    )
+  end
+
+  def page_transaction(query, %PagingOptions{key: {0, 0}}) do
+    query
+  end
+
+  def page_transaction(query, %PagingOptions{key: {block_number, 0}}) do
+    where(
+      query,
+      [transaction],
+      transaction.block_number < ^block_number
     )
   end
 
@@ -1547,6 +1567,10 @@ defmodule Explorer.Chain.Transaction do
       transaction.block_number < ^block_number or
         (transaction.block_number == ^block_number and transaction.index < ^index)
     )
+  end
+
+  def page_transaction(query, %PagingOptions{key: {0}}) do
+    query
   end
 
   def page_transaction(query, %PagingOptions{key: {index}}) do

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1363,9 +1363,14 @@ defmodule Explorer.Chain.Transaction do
     from_block = Chain.from_block(options)
     to_block = Chain.to_block(options)
 
-    options
-    |> Keyword.get(:paging_options, Chain.default_paging_options())
-    |> fetch_transactions(from_block, to_block, !only_mined?)
+    paging_options =
+      options
+      |> Keyword.get(:paging_options, Chain.default_paging_options())
+
+    case paging_options do
+      %PagingOptions{key: {0, 0}, is_index_in_asc_order: false} -> []
+      _ -> fetch_transactions(paging_options, from_block, to_block, !only_mined?)
+    end
   end
 
   def address_to_transactions_tasks_query(options, _only_mined?, false) do

--- a/apps/explorer/lib/explorer/chain/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/withdrawal.ex
@@ -47,6 +47,10 @@ defmodule Explorer.Chain.Withdrawal do
   @spec page_withdrawals(Ecto.Query.t(), PagingOptions.t()) :: Ecto.Query.t()
   def page_withdrawals(query, %PagingOptions{key: nil}), do: query
 
+  def page_withdrawals(query, %PagingOptions{key: {0}}) do
+    query
+  end
+
   def page_withdrawals(query, %PagingOptions{key: {index}}) do
     where(query, [withdrawal], withdrawal.index < ^index)
   end

--- a/apps/explorer/lib/explorer/chain/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/withdrawal.ex
@@ -47,10 +47,6 @@ defmodule Explorer.Chain.Withdrawal do
   @spec page_withdrawals(Ecto.Query.t(), PagingOptions.t()) :: Ecto.Query.t()
   def page_withdrawals(query, %PagingOptions{key: nil}), do: query
 
-  def page_withdrawals(query, %PagingOptions{key: {0}}) do
-    query
-  end
-
   def page_withdrawals(query, %PagingOptions{key: {index}}) do
     where(query, [withdrawal], withdrawal.index < ^index)
   end

--- a/apps/explorer/lib/explorer/chain/zksync/reader.ex
+++ b/apps/explorer/lib/explorer/chain/zksync/reader.ex
@@ -157,10 +157,16 @@ defmodule Explorer.Chain.ZkSync.Reader do
       else
         paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
-        base_query
-        |> Chain.join_associations(necessity_by_association)
-        |> page_batches(paging_options)
-        |> limit(^paging_options.page_size)
+        case paging_options do
+          %PagingOptions{key: {0}} ->
+            []
+
+          _ ->
+            base_query
+            |> Chain.join_associations(necessity_by_association)
+            |> page_batches(paging_options)
+            |> limit(^paging_options.page_size)
+        end
       end
 
     select_repo(options).all(query)

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -864,11 +864,11 @@ defmodule Explorer.Chain.TransactionTest do
       }
 
       if Application.get_env(:explorer, :chain_type) == :optimism do
-        {:actual, nil} ==
-          Transaction.fee(
-            transaction,
-            :wei
-          )
+        assert {:actual, nil} ==
+                 Transaction.fee(
+                   transaction,
+                   :wei
+                 )
       else
         assert {:actual, Decimal.new("5200000000000")} ==
                  Transaction.fee(


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9819

## Motivation

Skipping of edge cases in pagination leads to heavy meaningless queries being sent to the DB.

## Changelog

If 0 is sent for some of pagination key, we should avoid constructing query where `key < 0` since the DB doesn't store negative values for indexes, values or block numbers.

For instance, execution plan of some of the queries with not sanitized query:

```
eth_sepolia=> explain analyze SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL FROM transactions AS t0 WHERE ((t0.block_number < 5613705) OR ((t0.block_number = 5613705) AND (t0.index < 0))) AND (NOT (t0.block_number IS NULL) AND NOT (t0.index IS NULL)) ORDER BY t0.block_number DESC, t0.index DESC LIMIT 51;
                                                                                             QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..232.54 rows=51 width=601) (actual time=83365.545..83375.112 rows=51 loops=1)
   ->  Index Scan using transactions_recent_collated_index on transactions t0  (cost=0.57..846752412.92 rows=186163165 width=601) (actual time=83365.545..83375.108 rows=51 loops=1)
         Index Cond: ((block_number IS NOT NULL) AND (index IS NOT NULL))
         Filter: ((block_number < 5613705) OR ((block_number = 5613705) AND (index < 0)))
         Rows Removed by Filter: 8215939
         SubPlan 1
           ->  Limit  (cost=0.70..0.97 rows=1 width=33) (actual time=0.190..0.190 rows=0 loops=51)
                 ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.70..2900.16 rows=10730 width=33) (actual time=0.190..0.190 rows=0 loops=51)
                       Index Cond: (transaction_hash = t0.hash)
                       Heap Fetches: 9
 Planning Time: 0.239 ms
 Execution Time: 83375.138 ms
```

After sanitization:

```
eth_sepolia=> explain analyze SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL FROM transactions AS t0 WHERE ((t0.block_number < 5613705)) AND (NOT (t0.block_number IS NULL) AND NOT (t0.index IS NULL)) ORDER BY t0.block_number DESC, t0.index DESC LIMIT 51;
                                                                                             QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..224.77 rows=51 width=601) (actual time=0.982..21.060 rows=51 loops=1)
   ->  Index Scan using transactions_recent_collated_index on transactions t0  (cost=0.57..818372415.96 rows=186163165 width=601) (actual time=0.981..21.056 rows=51 loops=1)
         Index Cond: ((block_number < 5613705) AND (block_number IS NOT NULL) AND (index IS NOT NULL))
         SubPlan 1
           ->  Limit  (cost=0.70..0.97 rows=1 width=33) (actual time=0.361..0.361 rows=0 loops=51)
                 ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.70..2900.16 rows=10730 width=33) (actual time=0.361..0.361 rows=0 loops=51)
                       Index Cond: (transaction_hash = t0.hash)
                       Heap Fetches: 9
 Planning Time: 0.249 ms
 Execution Time: 21.105 ms
(10 rows)
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
