### PR TITLE
chore: Add metrics for realtime event handlers queue length

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -72,7 +72,7 @@ config :logger, :api_v2,
        block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :api_v2]
 
-config :prometheus, BlockScoutWeb.Prometheus.Instrumenter,
+config :prometheus, BlockScoutWeb.Prometheus.PhoenixInstrumenter,
   # override default for Phoenix 1.4 compatibility
   # * `:transport_name` to `:transport`
   # * remove `:vsn`

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -7,14 +7,15 @@ defmodule BlockScoutWeb.Application do
 
   alias BlockScoutWeb.API.APILogger
   alias BlockScoutWeb.Counters.{BlocksIndexedCounter, InternalTransactionsIndexedCounter}
-  alias BlockScoutWeb.{Endpoint, Prometheus}
-  alias BlockScoutWeb.{MainPageRealtimeEventHandler, RealtimeEventHandler, SmartContractRealtimeEventHandler}
+  alias BlockScoutWeb.Prometheus.{Exporter, PhoenixInstrumenter}
+  alias BlockScoutWeb.{Endpoint, MainPageRealtimeEventHandler, RealtimeEventHandler, SmartContractRealtimeEventHandler}
+  alias BlockScoutWeb.Utility.EventHandlersMetrics
 
   def start(_type, _args) do
     import Supervisor
 
-    Prometheus.Instrumenter.setup()
-    Prometheus.Exporter.setup()
+    PhoenixInstrumenter.setup()
+    Exporter.setup()
 
     APILogger.message(
       "Current global API rate limit #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:global_limit])} reqs/sec"
@@ -38,7 +39,8 @@ defmodule BlockScoutWeb.Application do
       {RealtimeEventHandler, name: RealtimeEventHandler},
       {SmartContractRealtimeEventHandler, name: SmartContractRealtimeEventHandler},
       {BlocksIndexedCounter, name: BlocksIndexedCounter},
-      {InternalTransactionsIndexedCounter, name: InternalTransactionsIndexedCounter}
+      {InternalTransactionsIndexedCounter, name: InternalTransactionsIndexedCounter},
+      {EventHandlersMetrics, []}
     ]
 
     opts = [strategy: :one_for_one, name: BlockScoutWeb.Supervisor, max_restarts: 1_000]

--- a/apps/block_scout_web/lib/block_scout_web/prometheus/instrumenter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/prometheus/instrumenter.ex
@@ -1,16 +1,17 @@
 defmodule BlockScoutWeb.Prometheus.Instrumenter do
   @moduledoc """
-  Phoenix request metrics for `Prometheus`.
+  BlockScoutWeb metrics for `Prometheus`.
   """
 
-  @dialyzer {:no_match,
-             [
-               phoenix_channel_join: 3,
-               phoenix_channel_receive: 3,
-               phoenix_controller_call: 3,
-               phoenix_controller_render: 3,
-               setup: 0
-             ]}
+  use Prometheus.Metric
 
-  use Prometheus.PhoenixInstrumenter
+  @gauge [
+    name: :event_handler_queue_length,
+    labels: [:handler],
+    help: "Number of events in event handlers queue"
+  ]
+
+  def event_handler_queue_length(handler, length) do
+    Gauge.set([name: :event_handler_queue_length, labels: [handler]], length)
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/prometheus/phoenix_instrumenter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/prometheus/phoenix_instrumenter.ex
@@ -1,0 +1,16 @@
+defmodule BlockScoutWeb.Prometheus.PhoenixInstrumenter do
+  @moduledoc """
+  Phoenix request metrics for `Prometheus`.
+  """
+
+  @dialyzer {:no_match,
+             [
+               phoenix_channel_join: 3,
+               phoenix_channel_receive: 3,
+               phoenix_controller_call: 3,
+               phoenix_controller_render: 3,
+               setup: 0
+             ]}
+
+  use Prometheus.PhoenixInstrumenter
+end

--- a/apps/block_scout_web/lib/block_scout_web/utility/event_handlers_metrics.ex
+++ b/apps/block_scout_web/lib/block_scout_web/utility/event_handlers_metrics.ex
@@ -1,0 +1,45 @@
+defmodule BlockScoutWeb.Utility.EventHandlersMetrics do
+  @moduledoc """
+  Module responsible for periodically setting current event handlers queue length metrics.
+  """
+
+  use GenServer
+
+  alias BlockScoutWeb.{MainPageRealtimeEventHandler, RealtimeEventHandler, SmartContractRealtimeEventHandler}
+  alias BlockScoutWeb.Prometheus.Instrumenter
+
+  @interval :timer.minutes(1)
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    schedule_next_run()
+
+    {:ok, %{}}
+  end
+
+  def handle_info(:set_metrics, state) do
+    set_metrics()
+    schedule_next_run()
+
+    {:noreply, state}
+  end
+
+  defp set_metrics do
+    set_handler_metric(MainPageRealtimeEventHandler, :main_page)
+    set_handler_metric(RealtimeEventHandler, :common)
+    set_handler_metric(SmartContractRealtimeEventHandler, :smart_contract)
+  end
+
+  defp set_handler_metric(handler, label) do
+    {_, queue_length} = Process.info(Process.whereis(handler), :message_queue_len)
+    Instrumenter.event_handler_queue_length(label, queue_length)
+  end
+
+  defp schedule_next_run do
+    Process.send_after(self(), :set_metrics, @interval)
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8912

## Changelog

- Renamed `BlockScoutWeb.Prometheus.Instrumenter` to `BlockScoutWeb.Prometheus.PhoenixInstrumenter`
- Added `BlockScoutWeb.Prometheus.Instrumenter` for purposes other than phoenix stats
- Added event handlers queue length metrics