### PR TITLE
fix: Correct processing of sized array to view in API v2

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -860,7 +860,15 @@ defmodule Explorer.SmartContract.Reader do
     value
   end
 
-  @spec zip_tuple_values_with_types(tuple, binary) :: [{binary, any}]
+  @spec zip_tuple_values_with_types(tuple, binary | tuple()) :: [{binary, any}]
+  def zip_tuple_values_with_types(value, {:tuple, tuple_types}) do
+    values_list =
+      value
+      |> Tuple.to_list()
+
+    Enum.zip(tuple_types, values_list)
+  end
+
   def zip_tuple_values_with_types(value, type) do
     types_string =
       type


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9853

## Motivation

Sized arrays are not properly processed before sending to the view.

## Changelog

Check the type of array item using `FunctionSelector.decode_type/1` instead of checking string ends with "[]".

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
