### PR TITLE
fix: Fix BENS integration

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -289,12 +289,16 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     nil
   end
 
-  defp alter_address(%NotLoaded{}, address_hash, names, field) do
-    %{field => names[Address.checksum(address_hash)]}
+  defp alter_address(%NotLoaded{}, address_hash, names, :ens_domain_name) do
+    %{ens_domain_name: names[to_string(address_hash)]}
+  end
+
+  defp alter_address(%NotLoaded{}, address_hash, names, :metadata) do
+    %{metadata: names[Address.checksum(address_hash)]}
   end
 
   defp alter_address(%Address{} = address, address_hash, names, :ens_domain_name) do
-    %Address{address | ens_domain_name: names[Address.checksum(address_hash)]}
+    %Address{address | ens_domain_name: names[to_string(address_hash)]}
   end
 
   defp alter_address(%Address{} = address, address_hash, names, :metadata) do


### PR DESCRIPTION
## Motivation

missed end_domain_name in api responses example:
https://eth.blockscout.com/api/v2/addresses/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045

## Changelog

### Bug Fixes
- extract addresses using proper address case
## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
