### PR TITLE
fix: Disable BlockReward fetcher for unsupported variants

### DIFF
--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -241,11 +241,10 @@ defmodule Indexer.Supervisor do
     end
   end
 
-  @variants_with_unimplemented_fetch_beneficiaries [
-    EthereumJSONRPC.Filecoin,
-    EthereumJSONRPC.Ganache,
-    EthereumJSONRPC.Geth,
-    EthereumJSONRPC.RSK
+  @variants_with_implemented_fetch_beneficiaries [
+    EthereumJSONRPC.Besu,
+    EthereumJSONRPC.Erigon,
+    EthereumJSONRPC.Nethermind
   ]
 
   defp maybe_add_block_reward_fetcher(
@@ -253,7 +252,7 @@ defmodule Indexer.Supervisor do
          {_, [[json_rpc_named_arguments: json_rpc_named_arguments, memory_monitor: _memory_monitor]]} = params
        ) do
     case Keyword.fetch(json_rpc_named_arguments, :variant) do
-      {:ok, ignored_variant} when ignored_variant in @variants_with_unimplemented_fetch_beneficiaries ->
+      {:ok, ignored_variant} when ignored_variant not in @variants_with_implemented_fetch_beneficiaries ->
         Application.put_env(:indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true)
         fetchers
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -254,6 +254,7 @@ defmodule Indexer.Supervisor do
        ) do
     case Keyword.fetch(json_rpc_named_arguments, :variant) do
       {:ok, ignored_variant} when ignored_variant in @variants_with_unimplemented_fetch_beneficiaries ->
+        Application.put_env(:indexer, Indexer.Fetcher.BlockReward.Supervisor, disabled?: true)
         fetchers
 
       _ ->


### PR DESCRIPTION
## Motivation
A huge amount of `SELECT b0."number", b0."hash" FROM "blocks" AS b0 WHERE ((b0."consensus" = ?) AND b0."number" = ANY($1))` requests
<img width="1095" alt="image" src="https://github.com/blockscout/blockscout/assets/32202610/0f74da05-fc45-40eb-b10c-b49911f4fd7d">

## Changelog
- Disable BlockReward fetcher for unsupported variants: 
    EthereumJSONRPC.Filecoin,
    EthereumJSONRPC.Ganache,
    EthereumJSONRPC.Geth,
    EthereumJSONRPC.RSK

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
