### PR TITLE
fix: Add non-unique log_index support in update_token_instances_owner

### DIFF
--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -550,7 +550,7 @@ defmodule Explorer.Factory do
         collated_params
       )
       when is_list(collated_params) do
-    next_transaction_index = block_hash_to_next_transaction_index(block_hash)
+    next_transaction_index = collated_params[:index] || block_hash_to_next_transaction_index(block_hash)
 
     cumulative_gas_used = collated_params[:cumulative_gas_used] || Enum.random(21_000..100_000)
     gas_used = collated_params[:gas_used] || Enum.random(21_000..100_000)


### PR DESCRIPTION
## Motivation

In cases when `log_index` is not unique within block, function `Explorer.Chain.Import.Runner.Blocks.update_token_instances_owner/3` may encounter an error due to excess token transfers in query result.

## Changelog

Modified `update_token_instances_owner` queries for `polygon_zkevm` chain type so they use `transaction_hash` as an additional token transfer identifier.