### PR TITLE
chore: Add queue expanding logic to memory monitor

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/sequence.ex
+++ b/apps/indexer/lib/indexer/block/catchup/sequence.ex
@@ -229,6 +229,10 @@ defmodule Indexer.Block.Catchup.Sequence do
     {:reply, BoundQueue.shrunk?(bound_queue), state}
   end
 
+  def handle_call(:expand, _from, %__MODULE__{bound_queue: bound_queue} = state) do
+    {:reply, :ok, %{state | bound_queue: BoundQueue.expand(bound_queue)}}
+  end
+
   @spec push_chunked_range(BoundQueue.t(Range.t()), step, Range.t(), edge()) ::
           {:ok, BoundQueue.t(Range.t())} | {:error, reason :: String.t()}
   defp push_chunked_range(bound_queue, step, _.._ = range, edge \\ :back)

--- a/apps/indexer/lib/indexer/bound_queue.ex
+++ b/apps/indexer/lib/indexer/bound_queue.ex
@@ -113,6 +113,13 @@ defmodule Indexer.BoundQueue do
   end
 
   @doc """
+  Set queue maximum_size to nil
+  """
+  def expand(bound_queue) do
+    %{bound_queue | maximum_size: nil}
+  end
+
+  @doc """
   Whether the queue was shrunk.
   """
   def shrunk?(%__MODULE__{maximum_size: nil}), do: false

--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -323,6 +323,10 @@ defmodule Indexer.BufferedTask do
     {:reply, BoundQueue.shrunk?(bound_queue), state}
   end
 
+  def handle_call(:expand, _from, %__MODULE__{bound_queue: bound_queue} = state) do
+    {:reply, :ok, %{state | bound_queue: BoundQueue.expand(bound_queue)}}
+  end
+
   defp drop_task(state, ref) do
     spawn_next_batch(%BufferedTask{state | task_ref_to_batch: Map.delete(state.task_ref_to_batch, ref)})
   end

--- a/apps/indexer/lib/indexer/memory/shrinkable.ex
+++ b/apps/indexer/lib/indexer/memory/shrinkable.ex
@@ -22,4 +22,12 @@ defmodule Indexer.Memory.Shrinkable do
   def shrunk?(pid) when is_pid(pid) do
     GenServer.call(pid, :shrunk?)
   end
+
+  @doc """
+  Asks `pid` to expand its size
+  """
+  @spec expand(pid()) :: :ok
+  def expand(pid) when is_pid(pid) do
+    GenServer.call(pid, :expand)
+  end
 end


### PR DESCRIPTION
## Motivation

In cases, when application exceeds memory limit, `Indexer.Memory.Monitor` is trying to shrink the queues. But after that, queues will be shrunk until the next application restart. If there is enough free memory, we should expand the queues back to speed up indexing. 

## Changelog

Added expand logic to `Indexer.Memory.Monitor`.