### PR TITLE
chore: Increase MissingRangesCollector past check interval

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -13,6 +13,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   @default_missing_ranges_batch_size 100_000
   @future_check_interval Application.compile_env(:indexer, __MODULE__)[:future_check_interval]
   @past_check_interval 10
+  @increased_past_check_interval :timer.minutes(1)
 
   @spec start_link(term()) :: GenServer.on_start()
   def start_link(_) do
@@ -48,10 +49,10 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
 
     clear_to_bounds(min_number, max_number)
 
-    Process.send_after(self(), :update_future, @future_check_interval)
-    Process.send_after(self(), :update_past, @past_check_interval)
+    schedule_future_check()
+    schedule_past_check(false)
 
-    %{min_fetched_block_number: min_number, max_fetched_block_number: max_number}
+    %{min_fetched_block_number: min_number, max_fetched_block_number: max_number, first_check_completed?: false}
   end
 
   defp ranges_init(ranges, max_fetched_block_number \\ nil) do
@@ -63,10 +64,10 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
     |> MissingRangesManipulator.save_batch()
 
     if not is_nil(max_fetched_block_number) do
-      Process.send_after(self(), :update_future, @future_check_interval)
+      schedule_future_check()
     end
 
-    %{max_fetched_block_number: max_fetched_block_number}
+    %{max_fetched_block_number: max_fetched_block_number, first_check_completed?: false}
   end
 
   defp clear_to_bounds(min_number, max_number) do
@@ -130,7 +131,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
     if continue_future_updating?(max_number) do
       {new_max_number, batch} = fetch_missing_ranges_batch(max_number, true)
       MissingRangesManipulator.save_batch(batch)
-      Process.send_after(self(), :update_future, @future_check_interval)
+      schedule_future_check()
       {:noreply, %{state | max_fetched_block_number: new_max_number}}
     else
       {:noreply, state}
@@ -140,12 +141,12 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   def handle_info(:update_past, %{min_fetched_block_number: min_number} = state) do
     if min_number > first_block() do
       {new_min_number, batch} = fetch_missing_ranges_batch(min_number, false)
-      Process.send_after(self(), :update_past, @past_check_interval)
       MissingRangesManipulator.save_batch(batch)
+      schedule_past_check(state.first_check_completed?)
       {:noreply, %{state | min_fetched_block_number: new_min_number}}
     else
-      Process.send_after(self(), :update_past, @past_check_interval * 100)
-      {:noreply, %{state | min_fetched_block_number: state.max_fetched_block_number}}
+      schedule_past_check(true)
+      {:noreply, %{state | min_fetched_block_number: state.max_fetched_block_number, first_check_completed?: true}}
     end
   end
 
@@ -210,6 +211,16 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
     else
       true
     end
+  end
+
+  defp schedule_past_check(first_check_completed?) do
+    interval = if first_check_completed?, do: @increased_past_check_interval, else: @past_check_interval
+
+    Process.send_after(self(), :update_past, interval)
+  end
+
+  defp schedule_future_check do
+    Process.send_after(self(), :update_future, @future_check_interval)
   end
 
   defp missing_ranges_batch_size do


### PR DESCRIPTION
## Motivation

After the first chain inspection, `MissingRangesCollector` launches another inspection from the latest block. But all the checks after the first are not that important as first since they are done just as _sanitization_. However, all queries that `MissingRangesCollector` produce are complex and may use a lot of DB resources. It's useful to decrease count of such queries.

## Changelog

Increase `MissingRangesCollector` check interval after the first chain inspection is done.