### PR TITLE
feat: Support Optimism Fault Proofs

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -313,6 +313,8 @@ defmodule BlockScoutWeb.ApiRouter do
         get("/deposits/count", V2.OptimismController, :deposits_count)
         get("/withdrawals", V2.OptimismController, :withdrawals)
         get("/withdrawals/count", V2.OptimismController, :withdrawals_count)
+        get("/games", V2.OptimismController, :games)
+        get("/games/count", V2.OptimismController, :games_count)
       end
     end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     ]
 
   alias Explorer.Chain
-  alias Explorer.Chain.Optimism.{Deposit, OutputRoot, TxnBatch, Withdrawal}
+  alias Explorer.Chain.Optimism.{Deposit, DisputeGame, OutputRoot, TxnBatch, Withdrawal}
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -55,6 +55,28 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
 
   def output_roots_count(conn, _params) do
     items_count(conn, OutputRoot)
+  end
+
+  def games(conn, params) do
+    {games, next_page} =
+      params
+      |> paging_options()
+      |> Keyword.put(:api?, true)
+      |> DisputeGame.list()
+      |> split_list_by_page()
+
+    next_page_params = next_page_params(next_page, games, params)
+
+    conn
+    |> put_status(200)
+    |> render(:optimism_games, %{
+      games: games,
+      next_page_params: next_page_params
+    })
+  end
+
+  def games_count(conn, _params) do
+    items_count(conn, DisputeGame)
   end
 
   def deposits(conn, params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -13,6 +13,10 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/txn-batches` endpoint.
+  """
+  @spec txn_batches(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def txn_batches(conn, params) do
     {batches, next_page} =
       params
@@ -31,10 +35,18 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     })
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/txn-batches/count` endpoint.
+  """
+  @spec txn_batches_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def txn_batches_count(conn, _params) do
     items_count(conn, TxnBatch)
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/output-roots` endpoint.
+  """
+  @spec output_roots(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def output_roots(conn, params) do
     {roots, next_page} =
       params
@@ -53,10 +65,18 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     })
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/output-roots/count` endpoint.
+  """
+  @spec output_roots_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def output_roots_count(conn, _params) do
     items_count(conn, OutputRoot)
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/games` endpoint.
+  """
+  @spec games(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def games(conn, params) do
     {games, next_page} =
       params
@@ -75,10 +95,18 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     })
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/games/count` endpoint.
+  """
+  @spec games_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def games_count(conn, _params) do
     items_count(conn, DisputeGame)
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/deposits` endpoint.
+  """
+  @spec deposits(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def deposits(conn, params) do
     {deposits, next_page} =
       params
@@ -97,10 +125,18 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     })
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/deposits/count` endpoint.
+  """
+  @spec deposits_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def deposits_count(conn, _params) do
     items_count(conn, Deposit)
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/withdrawals` endpoint.
+  """
+  @spec withdrawals(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals(conn, params) do
     {withdrawals, next_page} =
       params
@@ -119,6 +155,10 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
     })
   end
 
+  @doc """
+    Function to handle GET requests to `/api/v2/optimism/withdrawals/count` endpoint.
+  """
+  @spec withdrawals_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals_count(conn, _params) do
     items_count(conn, Withdrawal)
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -9,6 +9,10 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
   alias Explorer.Chain.{Block, Transaction}
   alias Explorer.Chain.Optimism.Withdrawal
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/txn-batches` endpoint.
+  """
+  @spec render(binary(), map()) :: map() | list() | non_neg_integer()
   def render("optimism_txn_batches.json", %{
         batches: batches,
         next_page_params: next_page_params
@@ -46,6 +50,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/output-roots` endpoint.
+  """
   def render("optimism_output_roots.json", %{
         roots: roots,
         next_page_params: next_page_params
@@ -66,6 +73,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/games` endpoint.
+  """
   def render("optimism_games.json", %{
         games: games,
         next_page_params: next_page_params
@@ -96,6 +106,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/deposits` endpoint.
+  """
   def render("optimism_deposits.json", %{
         deposits: deposits,
         next_page_params: next_page_params
@@ -116,6 +129,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/main-page/optimism-deposits` endpoint.
+  """
   def render("optimism_deposits.json", %{deposits: deposits}) do
     Enum.map(deposits, fn deposit ->
       %{
@@ -127,6 +143,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     end)
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/withdrawals` endpoint.
+  """
   def render("optimism_withdrawals.json", %{
         withdrawals: withdrawals,
         next_page_params: next_page_params,
@@ -176,10 +195,18 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     }
   end
 
+  @doc """
+    Function to render GET requests to `/api/v2/optimism/:entity/count` endpoints.
+  """
   def render("optimism_items_count.json", %{count: count}) do
     count
   end
 
+  @doc """
+    Extends the json output with a sub-map containing information related
+    zksync: batch number and associated L1 transactions and their timestmaps.
+  """
+  @spec extend_transaction_json_response(map(), map()) :: map()
   def extend_transaction_json_response(out_json, %Transaction{} = transaction) do
     out_json
     |> add_optional_transaction_field(transaction, :l1_fee)

--- a/apps/explorer/lib/explorer/application/constants.ex
+++ b/apps/explorer/lib/explorer/application/constants.ex
@@ -30,12 +30,20 @@ defmodule Explorer.Application.Constants do
     |> validate_required(@required_attrs)
   end
 
+  @doc """
+    Reads constant row from the database by constant's key.
+  """
+  @spec get_constant_by_key(binary(), list()) :: Ecto.Schema.t() | term() | nil
   def get_constant_by_key(key, options \\ []) do
     __MODULE__
     |> where([constant], constant.key == ^key)
     |> Chain.select_repo(options).one()
   end
 
+  @doc """
+    Reads constant value from the database by constant's key.
+  """
+  @spec get_constant_value(binary(), list()) :: binary() | nil
   def get_constant_value(key, options \\ []) do
     __MODULE__
     |> where([constant], constant.key == ^key)
@@ -43,6 +51,10 @@ defmodule Explorer.Application.Constants do
     |> Chain.select_repo(options).one()
   end
 
+  @doc """
+    Sets or updates a value of the specified constant by its key.
+  """
+  @spec set_constant_value(binary(), binary()) :: Ecto.Schema.t()
   def set_constant_value(key, value) do
     existing_value = Repo.get(__MODULE__, key)
 
@@ -57,12 +69,20 @@ defmodule Explorer.Application.Constants do
     end
   end
 
+  @doc """
+    For usage in Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand
+  """
+  @spec insert_keys_manager_contract_address(binary()) :: Ecto.Schema.t()
   def insert_keys_manager_contract_address(value) do
     %{key: @keys_manager_contract_address_key, value: value}
     |> changeset()
     |> Repo.insert!()
   end
 
+  @doc """
+    For usage in Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand and Explorer.Chain.Block.Reward
+  """
+  @spec get_keys_manager_contract_address(list()) :: %__MODULE__{} | nil
   def get_keys_manager_contract_address(options \\ []) do
     get_constant_by_key(@keys_manager_contract_address_key, options)
   end

--- a/apps/explorer/lib/explorer/application/constants.ex
+++ b/apps/explorer/lib/explorer/application/constants.ex
@@ -30,10 +30,31 @@ defmodule Explorer.Application.Constants do
     |> validate_required(@required_attrs)
   end
 
-  def get_constant_by_key(key, options) do
+  def get_constant_by_key(key, options \\ []) do
     __MODULE__
     |> where([constant], constant.key == ^key)
     |> Chain.select_repo(options).one()
+  end
+
+  def get_constant_value(key, options \\ []) do
+    __MODULE__
+    |> where([constant], constant.key == ^key)
+    |> select([constant], constant.value)
+    |> Chain.select_repo(options).one()
+  end
+
+  def set_constant_value(key, value) do
+    existing_value = Repo.get(__MODULE__, key)
+
+    if existing_value do
+      existing_value
+      |> changeset(%{value: value})
+      |> Repo.update!()
+    else
+      %{key: key, value: value}
+      |> changeset()
+      |> Repo.insert!()
+    end
   end
 
   def insert_keys_manager_contract_address(value) do
@@ -51,17 +72,7 @@ defmodule Explorer.Application.Constants do
   """
   @spec insert_last_processed_token_address_hash(Hash.Address.t()) :: Ecto.Schema.t()
   def insert_last_processed_token_address_hash(address_hash) do
-    existing_value = Repo.get(__MODULE__, @last_processed_erc_721_token)
-
-    if existing_value do
-      existing_value
-      |> changeset(%{value: to_string(address_hash)})
-      |> Repo.update!()
-    else
-      %{key: @last_processed_erc_721_token, value: to_string(address_hash)}
-      |> changeset()
-      |> Repo.insert!()
-    end
+    set_constant_value(@last_processed_erc_721_token, to_string(address_hash))
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/dispute_games.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/dispute_games.ex
@@ -1,0 +1,110 @@
+defmodule Explorer.Chain.Import.Runner.Optimism.DisputeGames do
+  @moduledoc """
+  Bulk imports `t:Explorer.Chain.Optimism.DisputeGame.t/0`.
+  """
+
+  require Ecto.Query
+
+  alias Ecto.{Changeset, Multi, Repo}
+  alias Explorer.Chain.Import
+  alias Explorer.Chain.Optimism.DisputeGame
+  alias Explorer.Prometheus.Instrumenter
+
+  import Ecto.Query, only: [from: 2]
+
+  @behaviour Import.Runner
+
+  # milliseconds
+  @timeout 60_000
+
+  @type imported :: [DisputeGame.t()]
+
+  @impl Import.Runner
+  def ecto_schema_module, do: DisputeGame
+
+  @impl Import.Runner
+  def option_key, do: :optimism_dispute_games
+
+  @impl Import.Runner
+  def imported_table_row do
+    %{
+      value_type: "[#{ecto_schema_module()}.t()]",
+      value_description: "List of `t:#{ecto_schema_module()}.t/0`s"
+    }
+  end
+
+  @impl Import.Runner
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
+
+    Multi.run(multi, :insert_dispute_games, fn repo, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :optimism_dispute_games,
+        :optimism_dispute_games
+      )
+    end)
+  end
+
+  @impl Import.Runner
+  def timeout, do: @timeout
+
+  @spec insert(Repo.t(), [map()], %{required(:timeout) => timeout(), required(:timestamps) => Import.timestamps()}) ::
+          {:ok, [DisputeGame.t()]}
+          | {:error, [Changeset.t()]}
+  def insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
+    on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
+
+    # Enforce DisputeGame ShareLocks order (see docs: sharelock.md)
+    ordered_changes_list = Enum.sort_by(changes_list, & &1.index)
+
+    {:ok, inserted} =
+      Import.insert_changes_list(
+        repo,
+        ordered_changes_list,
+        for: DisputeGame,
+        returning: true,
+        timeout: timeout,
+        timestamps: timestamps,
+        conflict_target: :index,
+        on_conflict: on_conflict
+      )
+
+    {:ok, inserted}
+  end
+
+  defp default_on_conflict do
+    from(
+      game in DisputeGame,
+      update: [
+        set: [
+          # don't update `index` as it is a primary key and used for the conflict target
+          game_type: fragment("EXCLUDED.game_type"),
+          address: fragment("EXCLUDED.address"),
+          extra_data: fragment("EXCLUDED.extra_data"),
+          created_at: fragment("EXCLUDED.created_at"),
+          resolved_at: fragment("EXCLUDED.resolved_at"),
+          status: fragment("EXCLUDED.status"),
+          inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", game.inserted_at),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", game.updated_at)
+        ]
+      ],
+      where:
+        fragment(
+          "(EXCLUDED.game_type, EXCLUDED.address, EXCLUDED.extra_data, EXCLUDED.created_at, EXCLUDED.resolved_at, EXCLUDED.status) IS DISTINCT FROM (?, ?, ?, ?, ?, ?)",
+          game.game_type,
+          game.address,
+          game.extra_data,
+          game.created_at,
+          game.resolved_at,
+          game.status
+        )
+    )
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
@@ -89,16 +89,18 @@ defmodule Explorer.Chain.Import.Runner.Optimism.WithdrawalEvents do
           l1_timestamp: fragment("EXCLUDED.l1_timestamp"),
           l1_transaction_hash: fragment("EXCLUDED.l1_transaction_hash"),
           l1_block_number: fragment("EXCLUDED.l1_block_number"),
+          game_index: fragment("EXCLUDED.game_index"),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", we.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", we.updated_at)
         ]
       ],
       where:
         fragment(
-          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_transaction_hash, EXCLUDED.l1_block_number) IS DISTINCT FROM (?, ?, ?)",
+          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_transaction_hash, EXCLUDED.l1_block_number, EXCLUDED.game_index) IS DISTINCT FROM (?, ?, ?, ?)",
           we.l1_timestamp,
           we.l1_transaction_hash,
-          we.l1_block_number
+          we.l1_block_number,
+          we.game_index
         )
     )
   end

--- a/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
@@ -23,6 +23,7 @@ defmodule Explorer.Chain.Import.Stage.BlockReferencing do
     Runner.Optimism.FrameSequences,
     Runner.Optimism.TxnBatches,
     Runner.Optimism.OutputRoots,
+    Runner.Optimism.DisputeGames,
     Runner.Optimism.Deposits,
     Runner.Optimism.Withdrawals,
     Runner.Optimism.WithdrawalEvents

--- a/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
 
   use Explorer.Schema
 
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Data, Hash}
 
   @required_attrs ~w(index game_type address created_at)a
   @optional_attrs ~w(extra_data resolved_at status)a
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
           index: non_neg_integer(),
           game_type: non_neg_integer(),
           address: Hash.t(),
-          extra_data: Hash.t() | nil,
+          extra_data: Data.t() | nil,
           created_at: DateTime.t(),
           resolved_at: DateTime.t() | nil,
           status: non_neg_integer() | nil
@@ -23,7 +23,7 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
     field(:index, :integer, primary_key: true)
     field(:game_type, :integer)
     field(:address, Hash.Address)
-    field(:extra_data, Hash.Full)
+    field(:extra_data, Data)
     field(:created_at, :utc_datetime_usec)
     field(:resolved_at, :utc_datetime_usec)
     field(:status, :integer)

--- a/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
@@ -3,7 +3,10 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
 
   use Explorer.Schema
 
+  import Ecto.Query
+
   alias Explorer.Chain.{Data, Hash}
+  alias Explorer.Repo
 
   @required_attrs ~w(index game_type address created_at)a
   @optional_attrs ~w(extra_data resolved_at status)a
@@ -36,5 +39,22 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
     |> cast(attrs, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
     |> unique_constraint(:index)
+  end
+
+  @doc """
+    Returns the last index written to op_dispute_games table. If there is no one, returns -1.
+  """
+  @spec get_last_known_index() :: integer()
+  def get_last_known_index do
+    query =
+      from(game in __MODULE__,
+        select: game.index,
+        order_by: [desc: game.index],
+        limit: 1
+      )
+
+    query
+    |> Repo.one()
+    |> Kernel.||(-1)
   end
 end

--- a/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
@@ -1,0 +1,40 @@
+defmodule Explorer.Chain.Optimism.DisputeGame do
+  @moduledoc "Models a dispute game for Optimism."
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.Hash
+
+  @required_attrs ~w(index game_type address created_at)a
+  @optional_attrs ~w(extra_data resolved_at status)a
+
+  @type t :: %__MODULE__{
+          index: non_neg_integer(),
+          game_type: non_neg_integer(),
+          address: Hash.t(),
+          extra_data: Hash.t() | nil,
+          created_at: DateTime.t(),
+          resolved_at: DateTime.t() | nil,
+          status: non_neg_integer() | nil
+        }
+
+  @primary_key false
+  schema "op_dispute_games" do
+    field(:index, :integer, primary_key: true)
+    field(:game_type, :integer)
+    field(:address, Hash.Address)
+    field(:extra_data, Hash.Full)
+    field(:created_at, :utc_datetime_usec)
+    field(:resolved_at, :utc_datetime_usec)
+    field(:status, :integer)
+
+    timestamps()
+  end
+
+  def changeset(%__MODULE__{} = games, attrs \\ %{}) do
+    games
+    |> cast(attrs, @required_attrs ++ @optional_attrs)
+    |> validate_required(@required_attrs)
+    |> unique_constraint(:index)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -23,6 +23,9 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
   @withdrawal_status_proven "Proven"
   @withdrawal_status_relayed "Relayed"
 
+  @dispute_game_finality_delay_seconds "optimism_dispute_game_finality_delay_seconds"
+  @proof_maturity_delay_seconds "optimism_proof_maturity_delay_seconds"
+
   @required_attrs ~w(msg_nonce hash l2_transaction_hash l2_block_number)a
 
   @type t :: %__MODULE__{
@@ -182,6 +185,22 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     end
   end
 
+  @doc """
+    Returns a name of the dispute_game_finality_delay_seconds constant.
+  """
+  @spec dispute_game_finality_delay_seconds_constant() :: binary()
+  def dispute_game_finality_delay_seconds_constant do
+    @dispute_game_finality_delay_seconds
+  end
+
+  @doc """
+    Returns a name of the proof_maturity_delay_seconds constant.
+  """
+  @spec proof_maturity_delay_seconds_constant() :: binary()
+  def proof_maturity_delay_seconds_constant do
+    @proof_maturity_delay_seconds
+  end
+
   defp appropriate_games_found(withdrawal_l2_block_number, respected_games) do
     respected_games
     |> Enum.any?(fn game ->
@@ -265,10 +284,9 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
       {@withdrawal_status_waiting_to_resolve, nil}
     else
       dispute_game_finality_delay_seconds =
-        Helper.parse_integer(Constants.get_constant_value("optimism_dispute_game_finality_delay_seconds"))
+        Helper.parse_integer(Constants.get_constant_value(@dispute_game_finality_delay_seconds))
 
-      proof_maturity_delay_seconds =
-        Helper.parse_integer(Constants.get_constant_value("optimism_proof_maturity_delay_seconds"))
+      proof_maturity_delay_seconds = Helper.parse_integer(Constants.get_constant_value(@proof_maturity_delay_seconds))
 
       false = is_nil(dispute_game_finality_delay_seconds)
       false = is_nil(proof_maturity_delay_seconds)

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
@@ -6,13 +6,15 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
   alias Explorer.Chain.Hash
 
   @required_attrs ~w(withdrawal_hash l1_event_type l1_timestamp l1_transaction_hash l1_block_number)a
+  @optional_attrs ~w(game_index)a
 
   @type t :: %__MODULE__{
           withdrawal_hash: Hash.t(),
           l1_event_type: String.t(),
           l1_timestamp: DateTime.t(),
           l1_transaction_hash: Hash.t(),
-          l1_block_number: non_neg_integer()
+          l1_block_number: non_neg_integer(),
+          game_index: non_neg_integer() | nil
         }
 
   @primary_key false
@@ -22,13 +24,14 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     field(:l1_timestamp, :utc_datetime_usec)
     field(:l1_transaction_hash, Hash.Full)
     field(:l1_block_number, :integer)
+    field(:game_index, :integer)
 
     timestamps()
   end
 
   def changeset(%__MODULE__{} = withdrawal_events, attrs \\ %{}) do
     withdrawal_events
-    |> cast(attrs, @required_attrs)
+    |> cast(attrs, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
   end
 end

--- a/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
+++ b/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
@@ -5,5 +5,17 @@ defmodule Explorer.Repo.Optimism.Migrations.FaultProofsSupport do
     alter table(:op_withdrawal_events) do
       add(:game_index, :integer, null: true)
     end
+
+    create table(:op_dispute_games, primary_key: false) do
+      add(:index, :integer, null: false, primary_key: true)
+      add(:game_type, :smallint, null: false)
+      add(:address, :bytea, null: false)
+      add(:extra_data, :bytea, null: true, default: nil)
+      add(:created_at, :"timestamp without time zone", null: false)
+      add(:resolved_at, :"timestamp without time zone", null: true, default: nil)
+      add(:status, :smallint, null: true, default: nil)
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
   end
 end

--- a/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
+++ b/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
@@ -17,5 +17,7 @@ defmodule Explorer.Repo.Optimism.Migrations.FaultProofsSupport do
 
       timestamps(null: false, type: :utc_datetime_usec)
     end
+
+    create(index(:op_dispute_games, :game_type))
   end
 end

--- a/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
+++ b/apps/explorer/priv/optimism/migrations/20240328125102_fault_proofs_support.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Optimism.Migrations.FaultProofsSupport do
+  use Ecto.Migration
+
+  def change do
+    alter table(:op_withdrawal_events) do
+      add(:game_index, :integer, null: true)
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -261,7 +261,8 @@ defmodule Indexer.Fetcher.Optimism do
          block_check_interval: block_check_interval,
          start_block: start_block,
          end_block: last_safe_block,
-         json_rpc_named_arguments: json_rpc_named_arguments
+         json_rpc_named_arguments: json_rpc_named_arguments,
+         stop: false
        }}
     else
       {:start_block_l1_undefined, true} ->

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -24,7 +24,7 @@ defmodule Indexer.Fetcher.Optimism do
 
   @fetcher_name :optimism
   @block_check_interval_range_size 100
-  @eth_get_logs_range_size 1000
+  @eth_get_logs_range_size 250
   @finite_retries_number 3
 
   def child_spec(start_link_arguments) do

--- a/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
@@ -241,11 +241,18 @@ defmodule Indexer.Fetcher.Optimism.DisputeGame do
     end
   end
 
-  defp get_dispute_game_factory_address(optimism_portal, json_rpc_named_arguments, retries \\ 3) do
+  defp get_dispute_game_factory_address(optimism_portal, json_rpc_named_arguments) do
     req = Contract.eth_call_request("0xf2b4e617", optimism_portal, 0, nil, nil)
-    error_message = &"Cannot fetch DisputeGameFactory contract address. Error: #{inspect(&1)}"
 
-    case IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, retries) do
+    error_message =
+      &"Cannot fetch DisputeGameFactory contract address. Probably, this is the first implementation of OptimismPortal. Error: #{inspect(&1)}"
+
+    case IndexerHelper.repeated_call(
+           &json_rpc/2,
+           [req, json_rpc_named_arguments],
+           error_message,
+           IndexerHelper.infinite_retries_number()
+         ) do
       {:ok, "0x000000000000000000000000" <> address} -> "0x" <> address
       _ -> nil
     end

--- a/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
@@ -270,7 +270,7 @@ defmodule Indexer.Fetcher.Optimism.DisputeGame do
 
   defp get_start_index(end_index, new_end_index) do
     if new_end_index < end_index do
-      # reorg occured
+      # reorg occurred
       remove_games_after_reorg(new_end_index)
       max(new_end_index, 0)
     else

--- a/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
@@ -1,0 +1,274 @@
+defmodule Indexer.Fetcher.Optimism.DisputeGame do
+  @moduledoc """
+  Fills op_dispute_games DB table.
+  """
+
+  use GenServer
+  use Indexer.Fetcher
+
+  require Logger
+
+  import Ecto.Query
+
+  import EthereumJSONRPC, only: [json_rpc: 2, quantity_to_integer: 1]
+
+  alias EthereumJSONRPC.Contract
+  alias Explorer.{Chain, Helper, Repo}
+  alias Explorer.Chain.Optimism.DisputeGame
+  alias Indexer.Helper, as: IndexerHelper
+
+  @fetcher_name :optimism_dispute_games
+  @game_check_interval 15_000
+  @games_range_size 50
+
+  def child_spec(start_link_arguments) do
+    spec = %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, start_link_arguments},
+      restart: :transient,
+      type: :worker
+    }
+
+    Supervisor.child_spec(spec, [])
+  end
+
+  def start_link(args, gen_server_options \\ []) do
+    GenServer.start_link(__MODULE__, args, Keyword.put_new(gen_server_options, :name, __MODULE__))
+  end
+
+  @impl GenServer
+  def init(_args) do
+    {:ok, %{}, {:continue, :ok}}
+  end
+
+  @impl GenServer
+  def handle_continue(:ok, _state) do
+    Logger.metadata(fetcher: @fetcher_name)
+
+    env = Application.get_all_env(:indexer)[Indexer.Fetcher.Optimism]
+    rpc = env[:optimism_l1_rpc]
+    optimism_portal = env[:optimism_l1_portal]
+
+    with {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(rpc)},
+         {:optimism_portal_valid, true} <- {:optimism_portal_valid, IndexerHelper.address_correct?(optimism_portal)},
+         json_rpc_named_arguments = IndexerHelper.json_rpc_named_arguments(rpc),
+         dispute_game_factory = get_dispute_game_factory_address(optimism_portal, json_rpc_named_arguments),
+         {:dispute_game_factory_available, true} <- {:dispute_game_factory_available, !is_nil(dispute_game_factory)},
+         game_count = get_game_count(dispute_game_factory, json_rpc_named_arguments),
+         {:game_count_available, true} <- {:game_count_available, !is_nil(game_count)} do
+
+      Process.send(self(), :continue, [])
+
+      last_known_index = get_last_known_index()
+      end_index = game_count - 1
+
+      {:noreply,
+       %{
+         dispute_game_factory: dispute_game_factory,
+         start_index: get_start_index(last_known_index, end_index),
+         end_index: end_index,
+         json_rpc_named_arguments: json_rpc_named_arguments
+       }}
+    else
+      {:rpc_l1_undefined, true} ->
+        Logger.error("L1 RPC URL is not defined.")
+        {:stop, :normal, %{}}
+
+      {:optimism_portal_valid, false} ->
+        Logger.error("OptimismPortal contract address is invalid or undefined.")
+        {:stop, :normal, %{}}
+
+      {:dispute_game_factory_available, false} ->
+        Logger.error("Cannot get DisputeGameFactory contract address from the OptimismPortal contract.")
+        {:stop, :normal, %{}}
+
+      {:game_count_available, false} ->
+        Logger.error("Cannot read gameCount() public getter from the DisputeGameFactory contract.")
+        {:stop, :normal, %{}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(
+        :continue,
+        %{
+          dispute_game_factory: dispute_game_factory,
+          start_index: start_index,
+          end_index: end_index,
+          json_rpc_named_arguments: json_rpc_named_arguments
+        } = state
+      ) do
+    time_before = Timex.now()
+
+    chunks_number = ceil((end_index - start_index + 1) / @games_range_size)
+    chunk_range = Range.new(0, max(chunks_number - 1, 0), 1)
+
+    chunk_range
+    |> Enum.each(fn current_chunk ->
+      chunk_start = start_index + @games_range_size * current_chunk
+      chunk_end = min(chunk_start + @games_range_size - 1, end_index)
+
+      if chunk_end >= chunk_start do
+        log_games_chunk_handling(chunk_start, chunk_end, start_index, end_index, nil)
+
+        games = read_game_list(chunk_start, chunk_end, dispute_game_factory, json_rpc_named_arguments)
+
+        {:ok, _} =
+          Chain.import(%{
+            optimism_dispute_games: %{params: games},
+            timeout: :infinity
+          })
+
+        log_games_chunk_handling(chunk_start, chunk_end, start_index, end_index, "#{Enum.count(games)} dispute game(s)")
+      end
+    end)
+
+    game_count = get_game_count(dispute_game_factory, json_rpc_named_arguments, IndexerHelper.infinite_retries_number())
+
+    false = is_nil(game_count)
+
+    new_end_index = game_count - 1
+
+    delay =
+      if new_end_index == end_index do
+        # there are no new games, so wait for some time to let the new game appear
+        max(@game_check_interval - Timex.diff(Timex.now(), time_before, :milliseconds), 0)
+      else
+        0
+      end
+
+    Process.send_after(self(), :continue, delay)
+
+    {:noreply, %{state | start_index: get_start_index(end_index, new_end_index), end_index: new_end_index}}
+  end
+
+  @impl GenServer
+  def handle_info({ref, _result}, state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, state}
+  end
+
+  defp get_dispute_game_factory_address(optimism_portal, json_rpc_named_arguments, retries \\ 3) do
+    req = Contract.eth_call_request("0xf2b4e617", optimism_portal, 0, nil, nil)
+    error_message = &"Cannot fetch DisputeGameFactory contract address. Error: #{inspect(&1)}"
+    case IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, retries) do
+      {:ok, "0x000000000000000000000000" <> address} -> "0x" <> address
+      _ -> nil
+    end
+  end
+
+  defp get_game_count(dispute_game_factory, json_rpc_named_arguments, retries \\ 3) do
+    req = Contract.eth_call_request("0x4d1975b4", dispute_game_factory, 0, nil, nil)
+    error_message = &"Cannot fetch game count from the DisputeGameFactory contract. Error: #{inspect(&1)}"
+    case IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, retries) do
+      {:ok, count} -> quantity_to_integer(count)
+      _ -> nil
+    end
+  end
+
+  defp get_last_known_index do
+    query =
+      from(game in DisputeGame,
+        select: game.index,
+        order_by: [desc: game.index],
+        limit: 1
+      )
+
+    query
+    |> Repo.one()
+    |> Kernel.||(-1)
+  end
+
+  defp get_start_index(end_index, new_end_index) do
+    if new_end_index < end_index do
+      # reorg occured
+      remove_games_after_reorg(new_end_index)
+      max(new_end_index, 0)
+    else
+      end_index + 1
+    end
+  end
+
+  defp log_games_chunk_handling(chunk_start, chunk_end, start_index, end_index, items_count) do
+    is_start = is_nil(items_count)
+
+    {type, found} =
+      if is_start do
+        {"Start", ""}
+      else
+        {"Finish", " Handled #{items_count}."}
+      end
+
+    target_range =
+      if chunk_start != start_index or chunk_end != end_index do
+        progress =
+          if is_start do
+            ""
+          else
+            percentage =
+              (chunk_end - start_index + 1)
+              |> Decimal.div(end_index - start_index + 1)
+              |> Decimal.mult(100)
+              |> Decimal.round(2)
+              |> Decimal.to_string()
+
+            " Progress: #{percentage}%"
+          end
+
+        " Target range: #{start_index}..#{end_index}.#{progress}"
+      else
+        ""
+      end
+
+    if chunk_start == chunk_end do
+      Logger.info("#{type} handling a game ##{chunk_start}.#{found}#{target_range}")
+    else
+      Logger.info("#{type} handling games #{chunk_start}..#{chunk_end}.#{found}#{target_range}")
+    end
+  end
+
+  defp read_game_list(start_index, end_index, dispute_game_factory, json_rpc_named_arguments, retries \\ 10) do
+    requests =
+      start_index..end_index
+      |> Enum.map(fn index ->
+        calldata = "0x" <>
+          (ABI.TypeEncoder.encode([index], %ABI.FunctionSelector{
+             function: "gameAtIndex",
+             types: [
+               {:uint,256}
+             ]
+           })
+           |> Base.encode16(case: :lower))
+
+        Contract.eth_call_request(calldata, dispute_game_factory, index, nil, nil)
+      end)
+
+    error_message = &"Cannot call gameAtIndex() public getter of DisputeGameFactory. Error: #{inspect(&1)}"
+    case IndexerHelper.repeated_call(&json_rpc/2, [requests, json_rpc_named_arguments], error_message, retries) do
+      {:ok, results} ->
+        Enum.map(results, fn result ->
+          [game_type, created_at, address] = Helper.decode_data(result.result, [{:uint,32}, {:uint,64}, :address])
+
+          %{
+            index: result.id,
+            game_type: game_type,
+            address: address,
+            created_at: Timex.from_unix(created_at)
+          }
+        end)
+      
+      _ ->
+        []
+    end
+  end
+
+  defp remove_games_after_reorg(starting_index) do
+    {deleted_count, _} = Repo.delete_all(from(g in DisputeGame, where: g.index >= ^starting_index))
+
+    if deleted_count > 0 do
+      Logger.warning(
+        "As L1 reorg was detected, all rows with index >= #{starting_index} were removed from the op_dispute_games table. Number of removed rows: #{deleted_count}."
+      )
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -261,9 +261,18 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
 
     if method_signature == "0x4870496f" do
       # the signature of `proveWithdrawalTransaction(tuple _tx, uint256 _disputeGameIndex, tuple _outputRootProof, bytes[] _withdrawalProof)` method
+
+      # to get (slice) `_disputeGameIndex` from the tx input, we need to know its offset in the input string (represented as 0x...):
+      # offset = 10 symbols of signature (incl. `0x` prefix) + 64 symbols (representing 32 bytes) of the `_tx` tuple offset, totally is 74
+      game_index_offset = String.length(method_signature) + 32 * 2
+      game_index_length = 32 * 2
+
+      game_index_range_start = game_index_offset
+      game_index_range_end = game_index_range_start + game_index_length - 1
+
       {game_index, ""} =
         input
-        |> String.slice(74..137)
+        |> String.slice(game_index_range_start..game_index_range_end)
         |> Integer.parse(16)
 
       game_index

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -156,10 +156,40 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
     end
   end
 
+  defp get_transaction_input_by_hash(blocks, tx_hashes) do
+    Enum.reduce(blocks, %{}, fn block, acc ->
+      block
+      |> Map.get("transactions", [])
+      |> Enum.filter(fn tx ->
+        Enum.member?(tx_hashes, tx["hash"])
+      end)
+      |> Enum.map(fn tx ->
+        {tx["hash"], tx["input"]}
+      end)
+      |> Enum.into(%{})
+      |> Map.merge(acc)
+    end)
+  end
+
   defp prepare_events(events, json_rpc_named_arguments) do
-    timestamps =
+    blocks =
       events
       |> get_blocks_by_events(json_rpc_named_arguments, Helper.infinite_retries_number())
+
+    tx_hashes =
+      events
+      |> Enum.reduce([], fn event, acc ->
+        if Enum.at(event["topics"], 0) == @withdrawal_proven_event do
+          [event["transactionHash"] | acc]
+        else
+          acc
+        end
+      end)
+
+    input_by_hash = get_transaction_input_by_hash(blocks, tx_hashes)
+
+    timestamps =
+      blocks
       |> Enum.reduce(%{}, fn block, acc ->
         block_number = quantity_to_integer(Map.get(block, "number"))
         {:ok, timestamp} = DateTime.from_unix(quantity_to_integer(Map.get(block, "timestamp")))
@@ -167,11 +197,19 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
       end)
 
     Enum.map(events, fn event ->
-      l1_event_type =
+      tx_hash = event["transactionHash"]
+
+      {l1_event_type, game_index} =
         if Enum.at(event["topics"], 0) == @withdrawal_proven_event do
-          "WithdrawalProven"
+          {game_index, ""} =
+            input_by_hash
+            |> Map.get(tx_hash)
+            |> String.slice(74..137)
+            |> Integer.parse(16)
+
+          {"WithdrawalProven", game_index}
         else
-          "WithdrawalFinalized"
+          {"WithdrawalFinalized", nil}
         end
 
       l1_block_number = quantity_to_integer(event["blockNumber"])
@@ -180,8 +218,9 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
         withdrawal_hash: Enum.at(event["topics"], 1),
         l1_event_type: l1_event_type,
         l1_timestamp: Map.get(timestamps, l1_block_number),
-        l1_transaction_hash: event["transactionHash"],
-        l1_block_number: l1_block_number
+        l1_transaction_hash: tx_hash,
+        l1_block_number: l1_block_number,
+        game_index: game_index
       }
     end)
   end
@@ -208,7 +247,7 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
       |> Stream.map(fn {block_number, _} -> %{number: block_number} end)
       |> Stream.with_index()
       |> Enum.into(%{}, fn {params, id} -> {id, params} end)
-      |> Blocks.requests(&ByNumber.request(&1, false, false))
+      |> Blocks.requests(&ByNumber.request(&1, true, false))
 
     error_message = &"Cannot fetch blocks with batch request. Error: #{inspect(&1)}. Request: #{inspect(request)}"
 

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -147,6 +147,7 @@ defmodule Indexer.Supervisor do
           [[memory_monitor: memory_monitor, json_rpc_named_arguments: json_rpc_named_arguments]]
         ),
         configure(Indexer.Fetcher.Optimism.OutputRoot.Supervisor, [[memory_monitor: memory_monitor]]),
+        configure(Indexer.Fetcher.Optimism.DisputeGame.Supervisor, [[memory_monitor: memory_monitor]]),
         configure(Indexer.Fetcher.Optimism.Deposit.Supervisor, [[memory_monitor: memory_monitor]]),
         configure(
           Indexer.Fetcher.Optimism.Withdrawal.Supervisor,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -714,6 +714,7 @@ config :indexer, Indexer.Fetcher.CoinBalance.Realtime,
 
 config :indexer, Indexer.Fetcher.Optimism.TxnBatch.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
 config :indexer, Indexer.Fetcher.Optimism.OutputRoot.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
+config :indexer, Indexer.Fetcher.Optimism.DisputeGame.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
 config :indexer, Indexer.Fetcher.Optimism.Deposit.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
 config :indexer, Indexer.Fetcher.Optimism.Withdrawal.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
 config :indexer, Indexer.Fetcher.Optimism.WithdrawalEvent.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/9893.

## Motivation

This PR adds support of Optimism Fault Proofs to correctly determine statuses of withdrawals indexed by `Indexer.Fetcher.Optimism.Withdrawal` module.

Also, the new `Indexer.Fetcher.Optimism.DisputeGame` module is introduced that indexes dispute games used by the Withdrawal module to get withdrawal status.

The changes are backward compatible with pre-Fault Proofs implementation and activated seamlessly after `OptimismPortal` contract upgrades.

Now, the withdrawal status can be one of:
- `Waiting for state root` (when waiting for appropriate dispute games to appear in `DisputeGameFactory` contract)
- `Ready to prove` (when appropriate dispute games found in `DisputeGameFactory` contract)
- `Waiting a game to resolve` (when `WithdrawalProven` is emitted on L1 by `OptimismPortal` contract but the dispute game bound to the withdrawal is not resolved to `Defender wins` status yet)
- `In challenge period` (when the withdrawal must wait until it's allowed to be finalized)
- `Ready for relay` (when the withdrawal is ready to be finalized)
- `Proven` (replaces the above three statuses in case of the module cannot determine a game bound to the withdrawal)
- `Relayed` (when `WithdrawalFinalized` event is emitted on L1 by `OptimismPortal` contract and the withdrawal is finalized)

To see the games indexed, a new API endpoint was added: `/api/v2/optimism/games` (and `/api/v2/optimism/games/count`) with the following fields for each JSON item:
- `index` (numeric)
- `game_type` (numeric)
- `contract_address` (string in the form of `0x...`)
- `l2_block_number` (numeric)
- `created_at` (datetime, e.g. `2024-04-16T09:56:48.000000Z`)
- `status` (string, can be one of: `In progress`, `Challenger wins`, `Defender wins`)
- `resolved_at` (null or datetime)

Example of the API output (truncated):

```
{"items":[{"contract_address":"0xa1f95f4387bb74050df37ef0a5672bdc7ef9ffd1","created_at":"2024-04-16T09:56:48.000000Z","game_type":0,"index":2647,"l2_block_number":10729366,"resolved_at":null,"status":"In progress"},...,{"contract_address":"0xb128c980db9d8f9838d0c639e8b5e094cf112fbd","created_at":"2024-04-15T21:41:48.000000Z","game_type":0,"index":2598,"l2_block_number":10707321,"resolved_at":null,"status":"In progress"}],"next_page_params":{"index":2598,"items_count":50}}
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
