### PR TITLE
IPFS gateway URL extra params

### DIFF
--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -131,6 +131,135 @@ defmodule Explorer.SmartContract.ReaderTest do
 
       assert response == %{"e72878b4" => {:ok, []}}
     end
+
+    @abi [
+      %{
+        "type" => "function",
+        "stateMutability" => "view",
+        "payable" => false,
+        "outputs" => [
+          %{"type" => "string", "name" => ""}
+        ],
+        "name" => "tokenURI",
+        "inputs" => [
+          %{
+            "type" => "uint256",
+            "name" => "_tokenId"
+          }
+        ],
+        "constant" => true
+      }
+    ]
+
+    @abi_uri [
+      %{
+        "type" => "function",
+        "stateMutability" => "view",
+        "payable" => false,
+        "outputs" => [
+          %{
+            "type" => "string",
+            "name" => "",
+            "internalType" => "string"
+          }
+        ],
+        "name" => "uri",
+        "inputs" => [
+          %{
+            "type" => "uint256",
+            "name" => "_id",
+            "internalType" => "uint256"
+          }
+        ],
+        "constant" => true
+      }
+    ]
+
+    test "fetches json metadata", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn [
+                                  %{
+                                    id: 0,
+                                    jsonrpc: "2.0",
+                                    method: "eth_call",
+                                    params: [
+                                      %{
+                                        data:
+                                          "0xc87b56dd000000000000000000000000000000000000000000000000fdd5b9fa9d4bfb20",
+                                        to: "0x5caebd3b32e210e85ce3e9d51638b9c445481567"
+                                      },
+                                      "latest"
+                                    ]
+                                  }
+                                ],
+                                _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result:
+                 "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003568747470733a2f2f7661756c742e7761727269646572732e636f6d2f31383239303732393934373636373130323439362e6a736f6e0000000000000000000000"
+             }
+           ]}
+        end)
+      end
+
+      assert %{
+               "c87b56dd" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
+             } ==
+               Reader.query_contract(
+                 "0x5caebd3b32e210e85ce3e9d51638b9c445481567",
+                 @abi,
+                 %{
+                   "c87b56dd" => [18_290_729_947_667_102_496]
+                 }
+               )
+    end
+
+    test "fetches json metadata for ERC-1155 token", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn [
+                                  %{
+                                    id: 0,
+                                    jsonrpc: "2.0",
+                                    method: "eth_call",
+                                    params: [
+                                      %{
+                                        data:
+                                          "0x0e89341c000000000000000000000000000000000000000000000000fdd5b9fa9d4bfb20",
+                                        to: "0x5caebd3b32e210e85ce3e9d51638b9c445481567"
+                                      },
+                                      "latest"
+                                    ]
+                                  }
+                                ],
+                                _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result:
+                 "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003568747470733a2f2f7661756c742e7761727269646572732e636f6d2f31383239303732393934373636373130323439362e6a736f6e0000000000000000000000"
+             }
+           ]}
+        end)
+      end
+
+      assert %{
+               "0e89341c" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
+             } ==
+               Reader.query_contract(
+                 "0x5caebd3b32e210e85ce3e9d51638b9c445481567",
+                 @abi_uri,
+                 %{
+                   "0e89341c" => [18_290_729_947_667_102_496]
+                 }
+               )
+    end
   end
 
   describe "query_verified_contract/3" do

--- a/apps/explorer/test/explorer/smart_contract/reader_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/reader_test.exs
@@ -214,7 +214,8 @@ defmodule Explorer.SmartContract.ReaderTest do
                  @abi,
                  %{
                    "c87b56dd" => [18_290_729_947_667_102_496]
-                 }
+                 },
+                 false
                )
     end
 
@@ -257,7 +258,8 @@ defmodule Explorer.SmartContract.ReaderTest do
                  @abi_uri,
                  %{
                    "0e89341c" => [18_290_729_947_667_102_496]
-                 }
+                 },
+                 false
                )
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -38,6 +38,8 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
 
       if gateway_url_param_key && gateway_url_param_value do
         url <> "?#{gateway_url_param_key}=#{gateway_url_param_value}"
+      else
+        url
       end
     else
       url

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -69,7 +69,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
           {:error, binary} | {:error_code, any} | {:ok, %{metadata: any}}
   def fetch_json(uri, token_id \\ nil, hex_token_id \\ nil, from_base_uri? \\ false)
 
-  def fetch_json(uri, _token_id, _hex_token_id, _from_base_uri?) when uri == {:ok, [""]} do
+  def fetch_json({:ok, [""]}, _token_id, _hex_token_id, _from_base_uri?) do
     {:error, @no_uri_error}
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -32,7 +32,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
 
     ipfs_params = Application.get_env(:indexer, :ipfs)
 
-    if ipfs_params[:gateway_url_param_location] == "query" do
+    if ipfs_params[:gateway_url_param_location] == :query do
       gateway_url_param_key = ipfs_params[:gateway_url_param_key]
       gateway_url_param_value = ipfs_params[:gateway_url_param_value]
 
@@ -48,7 +48,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
   defp ipfs_headers do
     ipfs_params = Application.get_env(:indexer, :ipfs)
 
-    if ipfs_params[:gateway_url_param_location] == "header" do
+    if ipfs_params[:gateway_url_param_location] == :header do
       gateway_url_param_key = ipfs_params[:gateway_url_param_key]
       gateway_url_param_value = ipfs_params[:gateway_url_param_value]
 

--- a/apps/indexer/test/indexer/fetcher/token_instance/metadata_retriever_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/metadata_retriever_test.exs
@@ -84,7 +84,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetrieverTest do
 
       Application.put_env(:indexer, :ipfs,
         gateway_url: Keyword.get(configuration, :gateway_url),
-        gateway_url_param_location: "query",
+        gateway_url_param_location: :query,
         gateway_url_param_key: "x-apikey",
         gateway_url_param_value: "mykey"
       )
@@ -128,7 +128,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetrieverTest do
 
       Application.put_env(:indexer, :ipfs,
         gateway_url: Keyword.get(configuration, :gateway_url),
-        gateway_url_param_location: "query2",
+        gateway_url_param_location: :query2,
         gateway_url_param_key: "x-apikey",
         gateway_url_param_value: "mykey"
       )
@@ -170,7 +170,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetrieverTest do
 
       Application.put_env(:indexer, :ipfs,
         gateway_url: Keyword.get(configuration, :gateway_url),
-        gateway_url_param_location: "header",
+        gateway_url_param_location: :header,
         gateway_url_param_key: "x-apikey",
         gateway_url_param_value: "mykey"
       )

--- a/apps/indexer/test/indexer/fetcher/token_instance/metadata_retriever_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/metadata_retriever_test.exs
@@ -1,4 +1,4 @@
-defmodule Explorer.Token.InstanceMetadataRetrieverTest do
+defmodule Indexer.Fetcher.TokenInstance.MetadataRetrieverTest do
   use EthereumJSONRPC.Case
 
   alias Indexer.Fetcher.TokenInstance.MetadataRetriever
@@ -9,144 +9,160 @@ defmodule Explorer.Token.InstanceMetadataRetrieverTest do
   setup :verify_on_exit!
   setup :set_mox_global
 
-  @abi [
-    %{
-      "type" => "function",
-      "stateMutability" => "view",
-      "payable" => false,
-      "outputs" => [
-        %{"type" => "string", "name" => ""}
-      ],
-      "name" => "tokenURI",
-      "inputs" => [
-        %{
-          "type" => "uint256",
-          "name" => "_tokenId"
-        }
-      ],
-      "constant" => true
-    }
-  ]
-
-  @abi_uri [
-    %{
-      "type" => "function",
-      "stateMutability" => "view",
-      "payable" => false,
-      "outputs" => [
-        %{
-          "type" => "string",
-          "name" => "",
-          "internalType" => "string"
-        }
-      ],
-      "name" => "uri",
-      "inputs" => [
-        %{
-          "type" => "uint256",
-          "name" => "_id",
-          "internalType" => "uint256"
-        }
-      ],
-      "constant" => true
-    }
-  ]
-
-  describe "fetch_metadata/2" do
-    @tag :no_nethermind
-    @tag :no_geth
-    test "fetches json metadata", %{json_rpc_named_arguments: json_rpc_named_arguments} do
-      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
-        EthereumJSONRPC.Mox
-        |> expect(:json_rpc, fn [
-                                  %{
-                                    id: 0,
-                                    jsonrpc: "2.0",
-                                    method: "eth_call",
-                                    params: [
-                                      %{
-                                        data:
-                                          "0xc87b56dd000000000000000000000000000000000000000000000000fdd5b9fa9d4bfb20",
-                                        to: "0x5caebd3b32e210e85ce3e9d51638b9c445481567"
-                                      },
-                                      "latest"
-                                    ]
-                                  }
-                                ],
-                                _options ->
-          {:ok,
-           [
-             %{
-               id: 0,
-               jsonrpc: "2.0",
-               result:
-                 "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003568747470733a2f2f7661756c742e7761727269646572732e636f6d2f31383239303732393934373636373130323439362e6a736f6e0000000000000000000000"
-             }
-           ]}
-        end)
-      end
-
-      assert %{
-               "c87b56dd" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
-             } ==
-               MetadataRetriever.query_contract(
-                 "0x5caebd3b32e210e85ce3e9d51638b9c445481567",
-                 %{
-                   "c87b56dd" => [18_290_729_947_667_102_496]
-                 },
-                 @abi
-               )
-    end
-
-    test "fetches json metadata for ERC-1155 token", %{json_rpc_named_arguments: json_rpc_named_arguments} do
-      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
-        EthereumJSONRPC.Mox
-        |> expect(:json_rpc, fn [
-                                  %{
-                                    id: 0,
-                                    jsonrpc: "2.0",
-                                    method: "eth_call",
-                                    params: [
-                                      %{
-                                        data:
-                                          "0x0e89341c000000000000000000000000000000000000000000000000fdd5b9fa9d4bfb20",
-                                        to: "0x5caebd3b32e210e85ce3e9d51638b9c445481567"
-                                      },
-                                      "latest"
-                                    ]
-                                  }
-                                ],
-                                _options ->
-          {:ok,
-           [
-             %{
-               id: 0,
-               jsonrpc: "2.0",
-               result:
-                 "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003568747470733a2f2f7661756c742e7761727269646572732e636f6d2f31383239303732393934373636373130323439362e6a736f6e0000000000000000000000"
-             }
-           ]}
-        end)
-      end
-
-      assert %{
-               "0e89341c" => {:ok, ["https://vault.warriders.com/18290729947667102496.json"]}
-             } ==
-               MetadataRetriever.query_contract(
-                 "0x5caebd3b32e210e85ce3e9d51638b9c445481567",
-                 %{
-                   "0e89341c" => [18_290_729_947_667_102_496]
-                 },
-                 @abi_uri
-               )
-    end
-  end
-
-  describe "fetch_json/1" do
+  describe "fetch_json/4" do
     setup do
       bypass = Bypass.open()
 
       {:ok, bypass: bypass}
+    end
+
+    test "returns {:error, @no_uri_error} when empty uri is passed" do
+      error = {:error, "no uri"}
+      token_id = "TOKEN_ID"
+      hex_token_id = "HEX_TOKEN_ID"
+      from_base_uri = true
+
+      result = MetadataRetriever.fetch_json({:ok, [""]}, token_id, hex_token_id, from_base_uri)
+
+      assert result == error
+    end
+
+    test "returns {:error, @vm_execution_error} when 'execution reverted' error passed in uri" do
+      uri_error = {:error, "something happened: execution reverted"}
+      token_id = "TOKEN_ID"
+      hex_token_id = "HEX_TOKEN_ID"
+      from_base_uri = true
+      result_error = {:error, "VM execution error"}
+
+      result = MetadataRetriever.fetch_json(uri_error, token_id, hex_token_id, from_base_uri)
+
+      assert result == result_error
+    end
+
+    test "returns {:error, @vm_execution_error} when 'VM execution error' error passed in uri" do
+      error = {:error, "VM execution error"}
+      token_id = "TOKEN_ID"
+      hex_token_id = "HEX_TOKEN_ID"
+      from_base_uri = true
+
+      result = MetadataRetriever.fetch_json(error, token_id, hex_token_id, from_base_uri)
+
+      assert result == error
+    end
+
+    test "returns {:error, error} when all other errors passed in uri" do
+      error = {:error, "Some error"}
+      token_id = "TOKEN_ID"
+      hex_token_id = "HEX_TOKEN_ID"
+      from_base_uri = true
+
+      result = MetadataRetriever.fetch_json(error, token_id, hex_token_id, from_base_uri)
+
+      assert result == error
+    end
+
+    test "returns {:error, truncated_error} when long error passed in uri" do
+      error =
+        {:error,
+         "ERROR: Unable to establish a connection to the database server. The database server may be offline, or there could be a network issue preventing access. Please ensure that the database server is running and that the network configuration is correct. Additionally, check the database credentials and permissions to ensure they are valid. If the issue persists, contact your system administrator for further assistance. Error code: DB_CONN_FAILED_101234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"}
+
+      token_id = "TOKEN_ID"
+      hex_token_id = "HEX_TOKEN_ID"
+      from_base_uri = true
+
+      truncated_error =
+        {:error,
+         "ERROR: Unable to establish a connection to the database server. The database server may be offline, or there could be a network issue preventing access. Please ensure that the database server is running and that the network configuration is correct. Ad..."}
+
+      result = MetadataRetriever.fetch_json(error, token_id, hex_token_id, from_base_uri)
+
+      assert result == truncated_error
+    end
+
+    test "Constructs IPFS link with query param" do
+      configuration = Application.get_env(:indexer, :ipfs)
+
+      Application.put_env(:indexer, :ipfs,
+        gateway_url: Keyword.get(configuration, :gateway_url),
+        gateway_url_param_location: "query",
+        gateway_url_param_key: "x-apikey",
+        gateway_url_param_value: "mykey"
+      )
+
+      data = "QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+
+      result = %{
+        "name" => "asda",
+        "description" => "asda",
+        "salePrice" => 34,
+        "img_hash" => "QmUfW3PVnh9GGuHcQgc3ZeNEbhwp5HE8rS5ac9MDWWQebz",
+        "collectionId" => "1871_1665123820823"
+      }
+
+      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
+
+      Explorer.Mox.HTTPoison
+      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP?x-apikey=mykey",
+                         _headers,
+                         _options ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
+      end)
+
+      assert {:ok,
+              %{
+                metadata: %{
+                  "collectionId" => "1871_1665123820823",
+                  "description" => "asda",
+                  "img_hash" => "QmUfW3PVnh9GGuHcQgc3ZeNEbhwp5HE8rS5ac9MDWWQebz",
+                  "name" => "asda",
+                  "salePrice" => 34
+                }
+              }} == MetadataRetriever.fetch_json({:ok, [data]})
+
+      Application.put_env(:explorer, :http_adapter, HTTPoison)
+      Application.put_env(:indexer, :ipfs, configuration)
+    end
+
+    test "Constructs IPFS link with no query param, if gateway_url_param_location is invalid" do
+      configuration = Application.get_env(:indexer, :ipfs)
+
+      Application.put_env(:indexer, :ipfs,
+        gateway_url: Keyword.get(configuration, :gateway_url),
+        gateway_url_param_location: "query2",
+        gateway_url_param_key: "x-apikey",
+        gateway_url_param_value: "mykey"
+      )
+
+      data = "QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+
+      result = %{
+        "name" => "asda",
+        "description" => "asda",
+        "salePrice" => 34,
+        "img_hash" => "QmUfW3PVnh9GGuHcQgc3ZeNEbhwp5HE8rS5ac9MDWWQebz",
+        "collectionId" => "1871_1665123820823"
+      }
+
+      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
+
+      Explorer.Mox.HTTPoison
+      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP", _headers, _options ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
+      end)
+
+      assert {:ok,
+              %{
+                metadata: %{
+                  "collectionId" => "1871_1665123820823",
+                  "description" => "asda",
+                  "img_hash" => "QmUfW3PVnh9GGuHcQgc3ZeNEbhwp5HE8rS5ac9MDWWQebz",
+                  "name" => "asda",
+                  "salePrice" => 34
+                }
+              }} == MetadataRetriever.fetch_json({:ok, [data]})
+
+      Application.put_env(:explorer, :http_adapter, HTTPoison)
+      Application.put_env(:indexer, :ipfs, configuration)
     end
 
     test "fetches json with latin1 encoding", %{bypass: bypass} do

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -111,9 +111,10 @@ defmodule ConfigHelper do
       else
         if shutdown_on_wrong_value? do
           Logger.error(wrong_value_error(value, env_var, catalog))
-          exit(:shutdown)
+          exit(:wrong_value)
         else
           Logger.warning(wrong_value_error(value, env_var, catalog))
+          nil
         end
       end
     else

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -111,7 +111,7 @@ defmodule ConfigHelper do
       else
         if shutdown_on_wrong_value? do
           Logger.error(wrong_value_error(value, env_var, catalog))
-          exit(:wrong_value)
+          exit(:shutdown)
         else
           Logger.warning(wrong_value_error(value, env_var, catalog))
           nil

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -1,4 +1,6 @@
 defmodule ConfigHelper do
+  require Logger
+
   import Bitwise
   alias Explorer.ExchangeRates.Source
   alias Explorer.Market.History.Source.{MarketCap, Price, TVL}
@@ -93,6 +95,34 @@ defmodule ConfigHelper do
       {seconds, s} when s in ["s", ""] -> :timer.seconds(seconds)
       _ -> 0
     end
+  end
+
+  @doc """
+  Parses value of env var through catalogued values list. If a value is not in the list, nil is returned.
+  Also, the application shutdown option is supported, if a value is wrong.
+  """
+  @spec parse_catalog_value(String.t(), List.t(), bool(), String.t() | nil) :: atom() | nil
+  def parse_catalog_value(env_var, catalog, shutdown_on_wrong_value?, default_value \\ nil) do
+    value = env_var |> safe_get_env(default_value)
+
+    if value !== "" do
+      if value in catalog do
+        String.to_atom(value)
+      else
+        if shutdown_on_wrong_value? do
+          Logger.error(wrong_value_error(value, env_var, catalog))
+          exit(:shutdown)
+        else
+          Logger.warning(wrong_value_error(value, env_var, catalog))
+        end
+      end
+    else
+      nil
+    end
+  end
+
+  defp wrong_value_error(value, env_var, catalog) do
+    "Wrong value #{value} of #{env_var} environment variable. Supported values are #{inspect(catalog)}"
   end
 
   def safe_get_env(env_var, default_value) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -594,8 +594,13 @@ config :indexer,
     ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_BALANCES_FETCHER_INIT_QUERY_LIMIT", 100_000),
   coin_balances_fetcher_init_limit:
     ConfigHelper.parse_integer_env_var("INDEXER_COIN_BALANCES_FETCHER_INIT_QUERY_LIMIT", 2000),
-  ipfs_gateway_url: System.get_env("IPFS_GATEWAY_URL", "https://ipfs.io/ipfs"),
   graceful_shutdown_period: ConfigHelper.parse_time_env_var("INDEXER_GRACEFUL_SHUTDOWN_PERIOD", "5m")
+
+config :indexer, :ipfs,
+  gateway_url: System.get_env("IPFS_GATEWAY_URL", "https://ipfs.io/ipfs"),
+  gateway_url_param_key: System.get_env("IPFS_GATEWAY_URL_PARAM_KEY"),
+  gateway_url_param_value: System.get_env("IPFS_GATEWAY_URL_PARAM_VALUE"),
+  gateway_url_param_location: System.get_env("IPFS_GATEWAY_URL_PARAM_LOCATION")
 
 config :indexer, Indexer.Supervisor, enabled: !ConfigHelper.parse_bool_env_var("DISABLE_INDEXER")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -600,7 +600,8 @@ config :indexer, :ipfs,
   gateway_url: System.get_env("IPFS_GATEWAY_URL", "https://ipfs.io/ipfs"),
   gateway_url_param_key: System.get_env("IPFS_GATEWAY_URL_PARAM_KEY"),
   gateway_url_param_value: System.get_env("IPFS_GATEWAY_URL_PARAM_VALUE"),
-  gateway_url_param_location: System.get_env("IPFS_GATEWAY_URL_PARAM_LOCATION")
+  gateway_url_param_location:
+    ConfigHelper.parse_catalog_value("IPFS_GATEWAY_URL_PARAM_LOCATION", ["query", "header"], true)
 
 config :indexer, Indexer.Supervisor, enabled: !ConfigHelper.parse_bool_env_var("DISABLE_INDEXER")
 

--- a/cspell.json
+++ b/cspell.json
@@ -368,6 +368,7 @@
         "munknownc",
         "munknowne",
         "mydep",
+        "mykey",
         "nanomorph",
         "nbsp",
         "newkey",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9897

## Motivation

Allow to provide authentication parameters for IPFS gateway URL endpoint.

## Changelog

New runtime env variables are added for management of authentication to IPFS gateway URL:
- `IPFS_GATEWAY_URL_PARAM_LOCATION` - whether to add auth params: to query string or to the headers. Available values: `"query"/"header"`.
- `IPFS_GATEWAY_URL_PARAM_KEY` - the key of the parameter.
- `IPFS_GATEWAY_URL_PARAM_VALUE` - the value of the parameter.

If the value of `IPFS_GATEWAY_URL_PARAM_LOCATION` is invalid, the application will stop and throw an explicit error.


## Checklist for your Pull Request (PR)

  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. https://github.com/blockscout/docs/pull/264
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
