### PR TITLE
feat: Exit on provided invalid CHAIN_TYPE

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/api_router.ex
@@ -144,15 +144,15 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/watchlist", V2.TransactionController, :watchlist_transactions)
       get("/stats", V2.TransactionController, :stats)
 
-      if Application.compile_env(:explorer, :chain_type) == "polygon_zkevm" do
+      if Application.compile_env(:explorer, :chain_type) == :polygon_zkevm do
         get("/zkevm-batch/:batch_number", V2.TransactionController, :polygon_zkevm_batch)
       end
 
-      if Application.compile_env(:explorer, :chain_type) == "zksync" do
+      if Application.compile_env(:explorer, :chain_type) == :zksync do
         get("/zksync-batch/:batch_number", V2.TransactionController, :zksync_batch)
       end
 
-      if Application.compile_env(:explorer, :chain_type) == "suave" do
+      if Application.compile_env(:explorer, :chain_type) == :suave do
         get("/execution-node/:execution_node_hash_param", V2.TransactionController, :execution_node)
       end
 
@@ -164,7 +164,7 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/:transaction_hash_param/state-changes", V2.TransactionController, :state_changes)
       get("/:transaction_hash_param/summary", V2.TransactionController, :summary)
 
-      if Application.compile_env(:explorer, :chain_type) == "ethereum" do
+      if Application.compile_env(:explorer, :chain_type) == :ethereum do
         get("/:transaction_hash_param/blobs", V2.TransactionController, :blobs)
       end
     end
@@ -220,16 +220,16 @@ defmodule BlockScoutWeb.ApiRouter do
       get("/transactions/watchlist", V2.MainPageController, :watchlist_transactions)
       get("/indexing-status", V2.MainPageController, :indexing_status)
 
-      if Application.compile_env(:explorer, :chain_type) == "optimism" do
+      if Application.compile_env(:explorer, :chain_type) == :optimism do
         get("/optimism-deposits", V2.MainPageController, :optimism_deposits)
       end
 
-      if Application.compile_env(:explorer, :chain_type) == "polygon_zkevm" do
+      if Application.compile_env(:explorer, :chain_type) == :polygon_zkevm do
         get("/zkevm/batches/confirmed", V2.PolygonZkevmController, :batches_confirmed)
         get("/zkevm/batches/latest-number", V2.PolygonZkevmController, :batch_latest_number)
       end
 
-      if Application.compile_env(:explorer, :chain_type) == "zksync" do
+      if Application.compile_env(:explorer, :chain_type) == :zksync do
         get("/zksync/batches/confirmed", V2.ZkSyncController, :batches_confirmed)
         get("/zksync/batches/latest-number", V2.ZkSyncController, :batch_latest_number)
       end
@@ -246,7 +246,7 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/optimism" do
-      if Application.compile_env(:explorer, :chain_type) == "optimism" do
+      if Application.compile_env(:explorer, :chain_type) == :optimism do
         get("/txn-batches", V2.OptimismController, :txn_batches)
         get("/txn-batches/count", V2.OptimismController, :txn_batches_count)
         get("/output-roots", V2.OptimismController, :output_roots)
@@ -261,7 +261,7 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/polygon-edge" do
-      if Application.compile_env(:explorer, :chain_type) == "polygon_edge" do
+      if Application.compile_env(:explorer, :chain_type) == :polygon_edge do
         get("/deposits", V2.PolygonEdgeController, :deposits)
         get("/deposits/count", V2.PolygonEdgeController, :deposits_count)
         get("/withdrawals", V2.PolygonEdgeController, :withdrawals)
@@ -270,7 +270,7 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/shibarium" do
-      if Application.compile_env(:explorer, :chain_type) == "shibarium" do
+      if Application.compile_env(:explorer, :chain_type) == :shibarium do
         get("/deposits", V2.ShibariumController, :deposits)
         get("/deposits/count", V2.ShibariumController, :deposits_count)
         get("/withdrawals", V2.ShibariumController, :withdrawals)
@@ -284,7 +284,7 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/zkevm" do
-      if Application.compile_env(:explorer, :chain_type) == "polygon_zkevm" do
+      if Application.compile_env(:explorer, :chain_type) == :polygon_zkevm do
         get("/batches", V2.PolygonZkevmController, :batches)
         get("/batches/count", V2.PolygonZkevmController, :batches_count)
         get("/batches/:batch_number", V2.PolygonZkevmController, :batch)
@@ -325,13 +325,13 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/blobs" do
-      if Application.compile_env(:explorer, :chain_type) == "ethereum" do
+      if Application.compile_env(:explorer, :chain_type) == :ethereum do
         get("/:blob_hash_param", V2.BlobController, :blob)
       end
     end
 
     scope "/validators" do
-      if Application.compile_env(:explorer, :chain_type) == "stability" do
+      if Application.compile_env(:explorer, :chain_type) == :stability do
         scope "/stability" do
           get("/", V2.ValidatorController, :stability_validators_list)
           get("/counters", V2.ValidatorController, :stability_validators_counters)
@@ -340,7 +340,7 @@ defmodule BlockScoutWeb.ApiRouter do
     end
 
     scope "/zksync" do
-      if Application.compile_env(:explorer, :chain_type) == "zksync" do
+      if Application.compile_env(:explorer, :chain_type) == :zksync do
         get("/batches", V2.ZkSyncController, :batches)
         get("/batches/count", V2.ZkSyncController, :batches_count)
         get("/batches/:batch_number", V2.ZkSyncController, :batch)

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -782,7 +782,7 @@ defmodule BlockScoutWeb.Chain do
   end
 
   defp hash_to_blob(hash) do
-    if Application.get_env(:explorer, :chain_type) == "ethereum" do
+    if Application.get_env(:explorer, :chain_type) == :ethereum do
       BeaconReader.blob(hash, false)
     else
       {:error, :not_found}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias Explorer.Chain.InternalTransaction
 
   case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" ->
+    :ethereum ->
       @chain_type_transaction_necessity_by_association %{
         :beacon_blob_transaction => :optional
       }
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         [transactions: :beacon_blob_transaction] => :optional
       }
 
-    "zksync" ->
+    :zksync ->
       @chain_type_transaction_necessity_by_association %{}
       @chain_type_block_necessity_by_association %{
         :zksync_batch => :optional,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -176,7 +176,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
   end
 
   case Application.compile_env(:explorer, :chain_type) do
-    "rsk" ->
+    :rsk ->
       defp add_chain_type_fields(response) do
         alias Explorer.Chain.Cache.RootstockLockedBTC
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -42,7 +42,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
   case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" ->
+    :ethereum ->
       @chain_type_transaction_necessity_by_association %{
         :beacon_blob_transaction => :optional
       }
@@ -101,20 +101,20 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
     necessity_by_association =
       case Application.get_env(:explorer, :chain_type) do
-        "polygon_zkevm" ->
+        :polygon_zkevm ->
           necessity_by_association_with_actions
           |> Map.put(:zkevm_batch, :optional)
           |> Map.put(:zkevm_sequence_transaction, :optional)
           |> Map.put(:zkevm_verify_transaction, :optional)
 
-        "zksync" ->
+        :zksync ->
           necessity_by_association_with_actions
           |> Map.put(:zksync_batch, :optional)
           |> Map.put(:zksync_commit_transaction, :optional)
           |> Map.put(:zksync_prove_transaction, :optional)
           |> Map.put(:zksync_execute_transaction, :optional)
 
-        "suave" ->
+        :suave ->
           necessity_by_association_with_actions
           |> Map.put(:logs, :optional)
           |> Map.put([execution_node: :names], :optional)

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -12,7 +12,7 @@ defmodule BlockScoutWeb.PagingHelper do
   @allowed_filter_labels ["validated", "pending"]
 
   case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" ->
+    :ethereum ->
       @allowed_type_labels [
         "coin_transfer",
         "contract_call",

--- a/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/chain/show.html.eex
@@ -92,7 +92,7 @@
       <!-- Stats -->
       <div class="dashboard-banner-network-plain-container">
         <div class="dashboard-banner-network-stats">
-          <%= unless Application.get_env(:explorer, :chain_type) == "optimism" do %>
+          <%= unless Application.get_env(:explorer, :chain_type) == :optimism do %>
             <%= case @average_block_time do %>
               <% {:error, :disabled} -> %>
                 <%= nil %>

--- a/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/transaction/overview.html.eex
@@ -195,7 +195,7 @@
               </dd>
             </dl>
           <% end %>
-          <%= if Application.get_env(:explorer, :chain_type) == "optimism" && @transaction.l1_block_number do %>
+          <%= if Application.get_env(:explorer, :chain_type) == :optimism && @transaction.l1_block_number do %>
             <!-- L1 Block -->
             <dl class="row">
               <dt class="col-sm-3 col-lg-2 text-muted">
@@ -394,7 +394,7 @@
           <!-- L1/L2 Gas Price -->
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted">
-              <%= if Application.get_env(:explorer, :chain_type) == "optimism" do %>
+              <%= if Application.get_env(:explorer, :chain_type) == :optimism do %>
                 <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
                   text: gettext("Price per unit of gas specified by the sender on L2. Higher gas prices can prioritize transaction inclusion during times of high usage.") %>
                 <%= gettext "L2 Gas Price" %>
@@ -420,7 +420,7 @@
           <!-- Gas Limit -->
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted">
-              <%= if Application.get_env(:explorer, :chain_type) == "optimism" do %>
+              <%= if Application.get_env(:explorer, :chain_type) == :optimism do %>
                 <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
                   text: gettext("Maximum gas amount approved for the transaction on L2.") %>
                 <%= gettext "L2 Gas Limit" %>
@@ -479,7 +479,7 @@
           <!-- L1/L2 Gas Used by Transaction -->
           <dl class="row">
             <dt class="col-sm-3 col-lg-2 text-muted transaction-gas-used">
-              <%= if Application.get_env(:explorer, :chain_type) == "optimism" do %>
+              <%= if Application.get_env(:explorer, :chain_type) == :optimism do %>
                 <%= render BlockScoutWeb.CommonComponentsView, "_i_tooltip_2.html",
                   text: gettext("Actual gas amount used by the transaction on L2.") %>
                 <%= gettext "L2 Gas Used by Transaction" %>
@@ -492,7 +492,7 @@
             <% gas_used_perc = gas_used_perc(@transaction) %>
             <dd class="col-sm-9 col-lg-10"> <%= gas_used(@transaction) %> <%= if gas_used_perc, do: "| #{gas_used_perc}%" %></dd>
           </dl>
-          <%= if Application.get_env(:explorer, :chain_type) == "optimism" do %>
+          <%= if Application.get_env(:explorer, :chain_type) == :optimism do %>
             <%= if @transaction.l1_gas_used do %>
               <!-- L1 Gas Used by Transaction -->
               <dl class="row">

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -100,7 +100,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   def count_withdrawals(_), do: nil
 
   case Application.compile_env(:explorer, :chain_type) do
-    "rsk" ->
+    :rsk ->
       defp chain_type_fields(result, block, single_block?) do
         if single_block? do
           # credo:disable-for-next-line Credo.Check.Design.AliasUsage
@@ -110,7 +110,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
         end
       end
 
-    "zksync" ->
+    :zksync ->
       defp chain_type_fields(result, block, single_block?) do
         if single_block? do
           # credo:disable-for-next-line Credo.Check.Design.AliasUsage
@@ -120,7 +120,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
         end
       end
 
-    "ethereum" ->
+    :ethereum ->
       defp chain_type_fields(result, block, single_block?) do
         # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         BlockScoutWeb.API.V2.EthereumView.extend_block_json_response(result, block, single_block?)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -795,7 +795,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   case Application.compile_env(:explorer, :chain_type) do
-    "polygon_edge" ->
+    :polygon_edge ->
       defp chain_type_transformations(transactions) do
         transactions
       end
@@ -809,7 +809,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         end
       end
 
-    "polygon_zkevm" ->
+    :polygon_zkevm ->
       defp chain_type_transformations(transactions) do
         transactions
       end
@@ -823,7 +823,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         end
       end
 
-    "zksync" ->
+    :zksync ->
       defp chain_type_transformations(transactions) do
         transactions
       end
@@ -837,7 +837,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         end
       end
 
-    "optimism" ->
+    :optimism ->
       defp chain_type_transformations(transactions) do
         transactions
       end
@@ -851,7 +851,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         end
       end
 
-    "suave" ->
+    :suave ->
       defp chain_type_transformations(transactions) do
         transactions
       end
@@ -871,7 +871,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         end
       end
 
-    "stability" ->
+    :stability ->
       defp chain_type_transformations(transactions) do
         # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         BlockScoutWeb.API.V2.StabilityView.transform_transactions(transactions)
@@ -882,7 +882,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         BlockScoutWeb.API.V2.StabilityView.extend_transaction_json_response(result, transaction)
       end
 
-    "ethereum" ->
+    :ethereum ->
       defp chain_type_transformations(transactions) do
         transactions
       end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -967,7 +967,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     end
   end
 
-  if Application.compile_env(:explorer, :chain_type) == "stability" do
+  if Application.compile_env(:explorer, :chain_type) == :stability do
     @first_topic_hex_string_1 "0x99e7b0ba56da2819c37c047f0511fd2bf6c9b4e27b4a979a19d6da0f74be8155"
 
     defp topic(topic_hex_string) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
   use BlockScoutWeb.ConnCase
 
-  if Application.compile_env(:explorer, :chain_type) == "stability" do
+  if Application.compile_env(:explorer, :chain_type) == :stability do
     alias Explorer.Chain.Address
     alias Explorer.Chain.Cache.StabilityValidatorsCounters
     alias Explorer.Chain.Stability.Validator, as: ValidatorStability

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/block.ex
@@ -9,7 +9,7 @@ defmodule EthereumJSONRPC.Block do
   alias EthereumJSONRPC.{Transactions, Uncles, Withdrawals}
 
   case Application.compile_env(:explorer, :chain_type) do
-    "rsk" ->
+    :rsk ->
       @chain_type_fields quote(
                            do: [
                              bitcoin_merged_mining_header: EthereumJSONRPC.data(),
@@ -20,7 +20,7 @@ defmodule EthereumJSONRPC.Block do
                            ]
                          )
 
-    "ethereum" ->
+    :ethereum ->
       @chain_type_fields quote(
                            do: [
                              withdrawals_root: EthereumJSONRPC.hash(),
@@ -94,14 +94,14 @@ defmodule EthereumJSONRPC.Block do
      `t:EthereumJSONRPC.hash/0`.
    * `"baseFeePerGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote amount of fee burnt per unit gas used. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
    #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
        * `"minimumGasPrice"` - `t:EthereumJSONRPC.quantity/0` of the minimum gas price for this block.
        * `"bitcoinMergedMiningHeader"` - `t:EthereumJSONRPC.data/0` of the Bitcoin merged mining header.
        * `"bitcoinMergedMiningCoinbaseTransaction"` - `t:EthereumJSONRPC.data/0` of the Bitcoin merged mining coinbase transaction.
        * `"bitcoinMergedMiningMerkleProof"` - `t:EthereumJSONRPC.data/0` of the Bitcoin merged mining merkle proof.
        * `"hashForMergedMining"` - `t:EthereumJSONRPC.data/0` of the hash for merged mining.
       """
-    "ethereum" -> """
+    :ethereum -> """
        * `"withdrawalsRoot"` - `t:EthereumJSONRPC.hash/0` of the root of the withdrawals.
        * `"blobGasUsed"` - `t:EthereumJSONRPC.quantity/0` of the total amount of blob gas consumed by the transactions within the block.
        * `"excessBlobGas"` - `t:EthereumJSONRPC.quantity/0` of the running total of blob gas consumed in excess of the target, prior to the block.
@@ -160,14 +160,14 @@ defmodule EthereumJSONRPC.Block do
       ...>     "transactions" => [],
       ...>     "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
           "minimumGasPrice" => 345786,\
           "bitcoinMergedMiningHeader" => "0x00006d20ffd048280094a6ea0851d854036aacaa25ee0f23f0040200000000000000000078d2638fe0b4477c54601e6449051afba8228e0a88ff06b0c91f091fd34d5da57487c76402610517372c2fe9",\
           "bitcoinMergedMiningCoinbaseTransaction" => "0x00000000000000805bf0dc9203da49a3b4e3ec913806e43102cc07db991272dc8b7018da57eb5abe59a32d070000ffffffff03449a4d26000000001976a914536ffa992491508dca0354e52f32a3a7a679a53a88ac00000000000000002b6a2952534b424c4f434b3ad2508d21d28c8f89d495923c0758ec3f64bd6755b4ec416f5601312600542a400000000000000000266a24aa21a9ed4ae42ea6dca2687aaed665714bf58b055c4e11f2fb038605930d630b49ad7b9d00000000",\
           "bitcoinMergedMiningMerkleProof" => "0x8e5a4ba74eb4eb2f9ad4cabc2913aeed380a5becf7cd4d513341617efb798002bd83a783c31c66a8a8f6cc56c071c2d471cb610e3dc13054b9d216021d8c7e9112f622564449ebedcedf7d4ccb6fe0ffac861b7ed1446c310813cdf712e1e6add28b1fe1c0ae5e916194ba4f285a9340aba41e91bf847bf31acf37a9623a04a2348a37ab9faa5908122db45596bbc03e9c3644b0d4589471c4ff30fc139f3ba50506e9136fa0df799b487494de3e2b3dec937338f1a2e18da057c1f60590a9723672a4355b9914b1d01af9f582d9e856f6e1744be00f268b0b01d559329f7e0685aa63ffeb7c28486d7462292021d1345cddbf7c920ca34bb7aa4c6cdbe068806e35d0db662e7fcda03cb4d779594638c62a1fdd7ec98d1fb6d240d853958abe57561d9b9d0465cf8b9d6ee3c58b0d8b07d6c4c5d8f348e43fe3c06011b6a0008db4e0b16c77ececc3981f9008201cea5939869d648e59a09bd2094b1196ff61126bffb626153deed2563e1745436247c94a85d2947756b606d67633781c99d7",\
           "hashForMergedMining" => "0xd2508d21d28c8f89d495923c0758ec3f64bd6755b4ec416f5601312600542a40",\
       """
-    "ethereum" -> """
+    :ethereum -> """
           "withdrawalsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
           "blobGasUsed" => 262144,\
           "excessBlobGas" => 79429632,\
@@ -197,7 +197,7 @@ defmodule EthereumJSONRPC.Block do
         total_difficulty: 340282366920938463463374607431465668165,
         transactions_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
 
             bitcoin_merged_mining_coinbase_transaction: "0x00000000000000805bf0dc9203da49a3b4e3ec913806e43102cc07db991272dc8b7018da57eb5abe59a32d070000ffffffff03449a4d26000000001976a914536ffa992491508dca0354e52f32a3a7a679a53a88ac00000000000000002b6a2952534b424c4f434b3ad2508d21d28c8f89d495923c0758ec3f64bd6755b4ec416f5601312600542a400000000000000000266a24aa21a9ed4ae42ea6dca2687aaed665714bf58b055c4e11f2fb038605930d630b49ad7b9d00000000",\
             bitcoin_merged_mining_header: "0x00006d20ffd048280094a6ea0851d854036aacaa25ee0f23f0040200000000000000000078d2638fe0b4477c54601e6449051afba8228e0a88ff06b0c91f091fd34d5da57487c76402610517372c2fe9",\
@@ -205,7 +205,7 @@ defmodule EthereumJSONRPC.Block do
             hash_for_merged_mining: "0xd2508d21d28c8f89d495923c0758ec3f64bd6755b4ec416f5601312600542a40",\
             minimum_gas_price: 345786,\
       """
-    "ethereum" -> """
+    :ethereum -> """
             withdrawals_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
             blob_gas_used: 262144,\
             excess_blob_gas: 79429632,\
@@ -261,14 +261,14 @@ defmodule EthereumJSONRPC.Block do
         total_difficulty: 1039309006117,
         transactions_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
             bitcoin_merged_mining_coinbase_transaction: nil,\
             bitcoin_merged_mining_header: nil,\
             bitcoin_merged_mining_merkle_proof: nil,\
             hash_for_merged_mining: nil,\
             minimum_gas_price: nil,\
       """
-    "ethereum" -> """
+    :ethereum -> """
             withdrawals_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
             blob_gas_used: 0,\
             excess_blob_gas: 0,\
@@ -464,7 +464,7 @@ defmodule EthereumJSONRPC.Block do
 
   defp chain_type_fields(params, elixir) do
     case Application.get_env(:explorer, :chain_type) do
-      "rsk" ->
+      :rsk ->
         params
         |> Map.merge(%{
           minimum_gas_price: Map.get(elixir, "minimumGasPrice"),
@@ -474,7 +474,7 @@ defmodule EthereumJSONRPC.Block do
           hash_for_merged_mining: Map.get(elixir, "hashForMergedMining")
         })
 
-      "ethereum" ->
+      :ethereum ->
         params
         |> Map.merge(%{
           withdrawals_root:

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/blocks.ex
@@ -117,14 +117,14 @@ defmodule EthereumJSONRPC.Blocks do
           total_difficulty: 131072,
           transactions_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
               bitcoin_merged_mining_coinbase_transaction: nil,\
               bitcoin_merged_mining_header: nil,\
               bitcoin_merged_mining_merkle_proof: nil,\
               hash_for_merged_mining: nil,\
               minimum_gas_price: nil,\
       """
-    "ethereum" -> """
+    :ethereum -> """
               withdrawals_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",\
               blob_gas_used: 0,\
               excess_blob_gas: 0,\

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -76,11 +76,11 @@ defmodule EthereumJSONRPC.Receipt do
         transaction_hash: "0x3a3eb134e6792ce9403ea4188e5e79693de9e4c94e499db132be086400da79e6",
         transaction_index: 0,\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" -> """
+    :ethereum -> """
             blob_gas_price: 0,\
             blob_gas_used: 0\
       """
-    "optimism" -> """
+    :optimism -> """
           l1_fee: 0,\
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
@@ -122,11 +122,11 @@ defmodule EthereumJSONRPC.Receipt do
         transaction_hash: "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
         transaction_index: 0,\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" -> """
+    :ethereum -> """
             blob_gas_price: 0,\
             blob_gas_used: 0\
       """
-    "optimism" -> """
+    :optimism -> """
           l1_fee: 0,\
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
@@ -186,14 +186,14 @@ defmodule EthereumJSONRPC.Receipt do
 
   defp chain_type_fields(params, elixir) do
     case Application.get_env(:explorer, :chain_type) do
-      "ethereum" ->
+      :ethereum ->
         params
         |> Map.merge(%{
           blob_gas_price: Map.get(elixir, "blobGasPrice", 0),
           blob_gas_used: Map.get(elixir, "blobGasUsed", 0)
         })
 
-      "optimism" ->
+      :optimism ->
         params
         |> Map.merge(%{
           l1_fee: Map.get(elixir, "l1Fee", 0),

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
@@ -101,11 +101,11 @@ defmodule EthereumJSONRPC.Receipts do
           transaction_hash: "0x53bd884872de3e488692881baeec262e7b95234d3965248c39fe992fffd433e5",
           transaction_index: 0,\
   #{case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" -> """
+    :ethereum -> """
             blob_gas_price: 0,\
             blob_gas_used: 0\
       """
-    "optimism" -> """
+    :optimism -> """
         l1_fee: 0,\
         l1_fee_scalar: 0,\
         l1_gas_price: 0,\

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -12,7 +12,7 @@ defmodule EthereumJSONRPC.Transaction do
   alias EthereumJSONRPC
 
   case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" ->
+    :ethereum ->
       @chain_type_fields quote(
                            do: [
                              max_fee_per_blob_gas: non_neg_integer(),
@@ -20,7 +20,7 @@ defmodule EthereumJSONRPC.Transaction do
                            ]
                          )
 
-    "optimism" ->
+    :optimism ->
       @chain_type_fields quote(
                            do: [
                              l1_tx_origin: EthereumJSONRPC.hash(),
@@ -28,7 +28,7 @@ defmodule EthereumJSONRPC.Transaction do
                            ]
                          )
 
-    "suave" ->
+    :suave ->
       @chain_type_fields quote(
                            do: [
                              execution_node_hash: EthereumJSONRPC.address(),
@@ -84,15 +84,15 @@ defmodule EthereumJSONRPC.Transaction do
    * `"maxFeePerGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote max fee per unit of gas used. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
    * `"type"` - `t:EthereumJSONRPC.quantity/0` denotes transaction type. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
    #{case Application.compile_env(:explorer, :chain_type) do
-    "ethereum" -> """
+    :ethereum -> """
        * `"maxFeePerBlobGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote max fee per unit of blob gas used. Introduced in [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md)
        * `"blobVersionedHashes"` - `t:list/0` of `t:EthereumJSONRPC.hash/0` of included data blobs hashes. Introduced in [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md)
       """
-    "optimism" -> """
+    :optimism -> """
        * `"l1TxOrigin"` - .
        * `"l1BlockNumber"` - .
       """
-    "suave" -> """
+    :suave -> """
        * `"executionNode"` - `t:EthereumJSONRPC.address/0` of execution node (used by Suave).
        * `"requestRecord"` - map of wrapped transaction data (used by Suave).
       """
@@ -470,13 +470,13 @@ defmodule EthereumJSONRPC.Transaction do
 
   defp chain_type_fields(params, elixir) do
     case Application.get_env(:explorer, :chain_type) do
-      "ethereum" ->
+      :ethereum ->
         put_if_present(elixir, params, [
           {"blobVersionedHashes", :blob_versioned_hashes},
           {"maxFeePerBlobGas", :max_fee_per_blob_gas}
         ])
 
-      "optimism" ->
+      :optimism ->
         # we need to put blobVersionedHashes for Indexer.Fetcher.Optimism.TxnBatch module
         put_if_present(elixir, params, [
           {"l1TxOrigin", :l1_tx_origin},
@@ -484,7 +484,7 @@ defmodule EthereumJSONRPC.Transaction do
           {"blobVersionedHashes", :blob_versioned_hashes}
         ])
 
-      "suave" ->
+      :suave ->
         wrapped = Map.get(elixir, "requestRecord")
 
         if is_nil(wrapped) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
@@ -118,15 +118,15 @@ defmodule EthereumJSONRPC.Variant do
   # credo:disable-for-next-line
   defp get_default_variant do
     case Application.get_env(:explorer, :chain_type) do
-      "optimism" -> "geth"
-      "polygon_zkevm" -> "geth"
-      "zetachain" -> "geth"
-      "shibarium" -> "geth"
-      "stability" -> "geth"
-      "zksync" -> "geth"
-      "arbitrum" -> "geth"
-      "rsk" -> "rsk"
-      "filecoin" -> "filecoin"
+      :optimism -> "geth"
+      :polygon_zkevm -> "geth"
+      :zetachain -> "geth"
+      :shibarium -> "geth"
+      :stability -> "geth"
+      :zksync -> "geth"
+      :arbitrum -> "geth"
+      :rsk -> "rsk"
+      :filecoin -> "filecoin"
       _ -> "nethermind"
     end
   end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/block_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/block_test.exs
@@ -55,7 +55,7 @@ defmodule EthereumJSONRPC.BlockTest do
                  transactions_root: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
                  uncles: []
                }
-               |> (&if(Application.get_env(:explorer, :chain_type) == "rsk",
+               |> (&if(Application.get_env(:explorer, :chain_type) == :rsk,
                      do:
                        Map.merge(
                          &1,
@@ -69,7 +69,7 @@ defmodule EthereumJSONRPC.BlockTest do
                        ),
                      else: &1
                    )).()
-               |> (&if(Application.get_env(:explorer, :chain_type) == "ethereum",
+               |> (&if(Application.get_env(:explorer, :chain_type) == :ethereum,
                      do:
                        Map.merge(
                          &1,

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/filecoin_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/filecoin_test.exs
@@ -12,7 +12,7 @@ defmodule EthereumJSONRPC.FilecoinTest do
       initial_env = Application.get_all_env(:ethereum_jsonrpc)
       old_env = Application.get_env(:explorer, :chain_type)
 
-      Application.put_env(:explorer, :chain_type, "filecoin")
+      Application.put_env(:explorer, :chain_type, :filecoin)
 
       on_exit(fn ->
         Application.put_all_env([{:ethereum_jsonrpc, initial_env}])

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -136,7 +136,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.SanitizeMissingBlockRanges),
         configure(Explorer.Migrator.SanitizeIncorrectNFTTokenTransfers),
         configure(Explorer.Migrator.TokenTransferTokenType),
-        configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, "stability")
+        configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, :stability)
       ]
       |> List.flatten()
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2248,7 +2248,7 @@ defmodule Explorer.Chain do
     range_max = max(range_start, range_end)
 
     ordered_missing_query =
-      if Application.get_env(:explorer, :chain_type) == "filecoin" do
+      if Application.get_env(:explorer, :chain_type) == :filecoin do
         from(b in Block,
           right_join:
             missing_range in fragment(

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Block.Schema do
   alias Explorer.Chain.ZkSync.BatchBlock, as: ZkSyncBatchBlock
 
   @chain_type_fields (case Application.compile_env(:explorer, :chain_type) do
-                        "ethereum" ->
+                        :ethereum ->
                           elem(
                             quote do
                               field(:blob_gas_used, :decimal)
@@ -15,7 +15,7 @@ defmodule Explorer.Chain.Block.Schema do
                             2
                           )
 
-                        "rsk" ->
+                        :rsk ->
                           elem(
                             quote do
                               field(:bitcoin_merged_mining_header, :binary)
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.Block.Schema do
                             2
                           )
 
-                        "zksync" ->
+                        :zksync ->
                           elem(
                             quote do
                               has_one(:zksync_batch_block, ZkSyncBatchBlock, foreign_key: :hash, references: :hash)
@@ -106,11 +106,11 @@ defmodule Explorer.Chain.Block do
 
   @optional_attrs ~w(size refetch_needed total_difficulty difficulty base_fee_per_gas)a
                   |> (&(case Application.compile_env(:explorer, :chain_type) do
-                          "rsk" ->
+                          :rsk ->
                             &1 ++
                               ~w(minimum_gas_price bitcoin_merged_mining_header bitcoin_merged_mining_coinbase_transaction bitcoin_merged_mining_merkle_proof hash_for_merged_mining)a
 
-                          "ethereum" ->
+                          :ethereum ->
                             &1 ++
                               ~w(blob_gas_used excess_blob_gas)a
 
@@ -155,14 +155,14 @@ defmodule Explorer.Chain.Block do
    * `transactions` - the `t:Explorer.Chain.Transaction.t/0` in this block.
    * `base_fee_per_gas` - Minimum fee required per unit of gas. Fee adjusts based on network congestion.
   #{case Application.compile_env(:explorer, :chain_type) do
-    "rsk" -> """
+    :rsk -> """
        * `bitcoin_merged_mining_header` - Bitcoin merged mining header on Rootstock chains.
        * `bitcoin_merged_mining_coinbase_transaction` - Bitcoin merged mining coinbase transaction on Rootstock chains.
        * `bitcoin_merged_mining_merkle_proof` - Bitcoin merged mining merkle proof on Rootstock chains.
        * `hash_for_merged_mining` - Hash for merged mining on Rootstock chains.
        * `minimum_gas_price` - Minimum block gas price on Rootstock chains.
       """
-    "ethereum" -> """
+    :ethereum -> """
        * `blob_gas_used` - The total amount of blob gas consumed by the transactions within the block.
        * `excess_blob_gas` - The running total of blob gas consumed in excess of the target, prior to the block.
       """

--- a/apps/explorer/lib/explorer/chain/block_number_helper.ex
+++ b/apps/explorer/lib/explorer/chain/block_number_helper.ex
@@ -9,7 +9,7 @@ defmodule Explorer.Chain.BlockNumberHelper do
   def next_block_number(number), do: neighbor_block_number(number, :next)
 
   case Application.compile_env(:explorer, :chain_type) do
-    "filecoin" ->
+    :filecoin ->
       def null_rounds_count, do: Explorer.Chain.NullRoundHeight.total()
 
       defp neighbor_block_number(number, direction),

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -719,7 +719,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   end
 
   defp refs_to_token_transfers_query(historical_token_transfers_query, filtered_query) do
-    if Application.get_env(:explorer, :chain_type) == "polygon_zkevm" do
+    if Application.get_env(:explorer, :chain_type) == :polygon_zkevm do
       from(historical_tt in subquery(historical_token_transfers_query),
         inner_join: tt in subquery(filtered_query),
         on:
@@ -760,7 +760,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   end
 
   defp derived_token_transfers_query(refs_to_token_transfers, filtered_query) do
-    if Application.get_env(:explorer, :chain_type) == "polygon_zkevm" do
+    if Application.get_env(:explorer, :chain_type) == :polygon_zkevm do
       from(tt in filtered_query,
         inner_join: tt_1 in subquery(refs_to_token_transfers),
         on:

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -343,7 +343,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     all_tuples = MapSet.union(transactions_tuples, internal_transactions_tuples)
 
     invalid_block_numbers =
-      if Application.get_env(:explorer, :chain_type) == "zetachain" do
+      if Application.get_env(:explorer, :chain_type) == :zetachain do
         Enum.reduce(internal_transactions_tuples, [], fn {transaction_hash, block_number}, acc ->
           # credo:disable-for-next-line
           case Enum.find(transactions_tuples, fn {t_hash, _block_number} -> t_hash == transaction_hash end) do

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -109,7 +109,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
 
   defp default_on_conflict do
     case Application.get_env(:explorer, :chain_type) do
-      "suave" ->
+      :suave ->
         from(
           transaction in Transaction,
           update: [
@@ -205,7 +205,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
             )
         )
 
-      "optimism" ->
+      :optimism ->
         from(
           transaction in Transaction,
           update: [

--- a/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
@@ -62,22 +62,22 @@ defmodule Explorer.Chain.Import.Stage.BlockReferencing do
   @impl Stage
   def runners do
     case Application.get_env(:explorer, :chain_type) do
-      "optimism" ->
+      :optimism ->
         @default_runners ++ @optimism_runners
 
-      "polygon_edge" ->
+      :polygon_edge ->
         @default_runners ++ @polygon_edge_runners
 
-      "polygon_zkevm" ->
+      :polygon_zkevm ->
         @default_runners ++ @polygon_zkevm_runners
 
-      "shibarium" ->
+      :shibarium ->
         @default_runners ++ @shibarium_runners
 
-      "ethereum" ->
+      :ethereum ->
         @default_runners ++ @ethereum_runners
 
-      "zksync" ->
+      :zksync ->
         @default_runners ++ @zksync_runners
 
       _ ->

--- a/apps/explorer/lib/explorer/chain/internal_transaction/call_type.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction/call_type.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.InternalTransaction.CallType do
   use Ecto.Type
 
   @base_call_types ~w(call callcode delegatecall staticcall)a
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     @call_types @base_call_types ++ ~w(invalid)a
   else
     @call_types @base_call_types
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.InternalTransaction.CallType do
      the current contract's context with the delegated contract's code.  There's some good chances for finding bugs
      when fuzzing these if the memory layout differs between the current contract and the delegated contract.
    * `:staticcall`
-   #{if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+   #{if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     """
       * `:invalid`
     """
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.InternalTransaction.CallType do
     ""
   end}
   """
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     @type t :: :call | :callcode | :delegatecall | :staticcall | :invalid
   else
     @type t :: :call | :callcode | :delegatecall | :staticcall
@@ -71,7 +71,7 @@ defmodule Explorer.Chain.InternalTransaction.CallType do
   def cast(call_type) when call_type in ["call", "callcode", "delegatecall", "staticcall"],
     do: {:ok, String.to_existing_atom(call_type)}
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     def cast("invalid"), do: {:ok, :invalid}
   end
 
@@ -123,7 +123,7 @@ defmodule Explorer.Chain.InternalTransaction.CallType do
   def load(call_type) when call_type in ["call", "callcode", "delegatecall", "staticcall"],
     do: {:ok, String.to_existing_atom(call_type)}
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     def load("invalid"), do: {:ok, :invalid}
   end
 

--- a/apps/explorer/lib/explorer/chain/internal_transaction/type.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction/type.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.InternalTransaction.Type do
    * `:reward`
    * `:selfdestruct`
    * `:stop`
-   #{if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+   #{if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     """
       * `:invalid`
     """
@@ -20,7 +20,7 @@ defmodule Explorer.Chain.InternalTransaction.Type do
     ""
   end}
   """
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     @type t :: :call | :create | :create2 | :reward | :selfdestruct | :stop | :invalid
   else
     @type t :: :call | :create | :create2 | :reward | :selfdestruct | :stop
@@ -75,7 +75,7 @@ defmodule Explorer.Chain.InternalTransaction.Type do
   def cast(type) when type in ["call", "create", "create2", "reward", "selfdestruct", "stop"],
     do: {:ok, String.to_existing_atom(type)}
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     def cast("invalid"), do: {:ok, :invalid}
   end
 
@@ -110,7 +110,7 @@ defmodule Explorer.Chain.InternalTransaction.Type do
   @spec dump(term()) :: {:ok, String.t()} | :error
   def dump(type) when type in [:call, :create, :create2, :reward, :selfdestruct, :stop], do: {:ok, Atom.to_string(type)}
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     def dump(:invalid), do: {:ok, "invalid"}
   end
 
@@ -146,7 +146,7 @@ defmodule Explorer.Chain.InternalTransaction.Type do
   def load(type) when type in ["call", "create", "create2", "reward", "selfdestruct", "stop"],
     do: {:ok, String.to_existing_atom(type)}
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     def load("invalid"), do: {:ok, :invalid}
   end
 

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -117,7 +117,7 @@ defmodule Explorer.Chain.Search do
             tx_block_query
           end
 
-        if Application.get_env(:explorer, :chain_type) == "ethereum" do
+        if Application.get_env(:explorer, :chain_type) == :ethereum do
           blob_query = search_blob_query(string)
 
           tx_block_op_query
@@ -203,7 +203,7 @@ defmodule Explorer.Chain.Search do
           end
 
         blob_result =
-          if valid_full_hash?(search_query) && Application.get_env(:explorer, :chain_type) == "ethereum" do
+          if valid_full_hash?(search_query) && Application.get_env(:explorer, :chain_type) == :ethereum do
             search_query
             |> search_blob_query()
             |> select_repo(options).all()

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.Transaction.Schema do
   alias Explorer.Chain.ZkSync.BatchTransaction, as: ZkSyncBatchTransaction
 
   @chain_type_fields (case Application.compile_env(:explorer, :chain_type) do
-                        "ethereum" ->
+                        :ethereum ->
                           # elem(quote do ... end, 2) doesn't work with a single has_one instruction
                           quote do
                             [
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.Transaction.Schema do
                             ]
                           end
 
-                        "optimism" ->
+                        :optimism ->
                           elem(
                             quote do
                               field(:l1_fee, Wei)
@@ -40,7 +40,7 @@ defmodule Explorer.Chain.Transaction.Schema do
                             2
                           )
 
-                        "suave" ->
+                        :suave ->
                           elem(
                             quote do
                               belongs_to(
@@ -75,7 +75,7 @@ defmodule Explorer.Chain.Transaction.Schema do
                             2
                           )
 
-                        "polygon_zkevm" ->
+                        :polygon_zkevm ->
                           elem(
                             quote do
                               has_one(:zkevm_batch_transaction, ZkevmBatchTransaction,
@@ -98,7 +98,7 @@ defmodule Explorer.Chain.Transaction.Schema do
                             2
                           )
 
-                        "zksync" ->
+                        :zksync ->
                           elem(
                             quote do
                               has_one(:zksync_batch_transaction, ZkSyncBatchTransaction,
@@ -578,8 +578,8 @@ defmodule Explorer.Chain.Transaction do
 
   defp custom_optional_attrs do
     case Application.get_env(:explorer, :chain_type) do
-      "suave" -> @suave_optional_attrs
-      "optimism" -> @optimism_optional_attrs
+      :suave -> @suave_optional_attrs
+      :optimism -> @optimism_optional_attrs
       _ -> @empty_attrs
     end
   end
@@ -1653,7 +1653,7 @@ defmodule Explorer.Chain.Transaction do
   end
 
   def fee(%Transaction{gas_price: nil, gas_used: gas_used} = transaction, unit) do
-    if Application.get_env(:explorer, :chain_type) == "optimism" do
+    if Application.get_env(:explorer, :chain_type) == :optimism do
       {:actual, nil}
     else
       gas_price = effective_gas_price(transaction)

--- a/apps/explorer/test/explorer/chain/beacon/reader_test.exs
+++ b/apps/explorer/test/explorer/chain/beacon/reader_test.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.Beacon.ReaderTest do
 
   alias Explorer.Chain.Beacon.Reader
 
-  if Application.compile_env(:explorer, :chain_type) == "ethereum" do
+  if Application.compile_env(:explorer, :chain_type) == :ethereum do
     doctest Reader
   end
 end

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -90,7 +90,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
          } do
       old_env = Application.get_env(:explorer, :chain_type)
 
-      Application.put_env(:explorer, :chain_type, "polygon_zkevm")
+      Application.put_env(:explorer, :chain_type, :polygon_zkevm)
 
       previous_consensus_block = insert(:block, hash: previous_block_hash, number: previous_block_number)
       %{hash: block_hash, number: block_number} = consensus_block = insert(:block)

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -863,7 +863,7 @@ defmodule Explorer.Chain.TransactionTest do
         block: %{base_fee_per_gas: %Explorer.Chain.Wei{value: 42_000_000_000}}
       }
 
-      if Application.get_env(:explorer, :chain_type) == "optimism" do
+      if Application.get_env(:explorer, :chain_type) == :optimism do
         {:actual, nil} ==
           Transaction.fee(
             transaction,

--- a/apps/explorer/test/explorer/counters/last_output_root_size_counter_test.exs
+++ b/apps/explorer/test/explorer/counters/last_output_root_size_counter_test.exs
@@ -3,7 +3,7 @@ defmodule Explorer.Counters.LastOutputRootSizeCounterTest do
 
   alias Explorer.Counters.LastOutputRootSizeCounter
 
-  if Application.compile_env(:explorer, :chain_type) == "optimism" do
+  if Application.compile_env(:explorer, :chain_type) == :optimism do
     test "populates the cache with the number of transactions in last output root" do
       first_block = insert(:block)
 

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -263,26 +263,26 @@ defmodule Indexer.Block.Fetcher do
          shibarium_bridge_operations: shibarium_bridge_operations
        }) do
     case Application.get_env(:explorer, :chain_type) do
-      "ethereum" ->
+      :ethereum ->
         basic_import_options
         |> Map.put_new(:beacon_blob_transactions, %{
           params: transactions_with_receipts |> Enum.filter(&Map.has_key?(&1, :max_fee_per_blob_gas))
         })
 
-      "optimism" ->
+      :optimism ->
         basic_import_options
         |> Map.put_new(:optimism_withdrawals, %{params: optimism_withdrawals})
 
-      "polygon_edge" ->
+      :polygon_edge ->
         basic_import_options
         |> Map.put_new(:polygon_edge_withdrawals, %{params: polygon_edge_withdrawals})
         |> Map.put_new(:polygon_edge_deposit_executes, %{params: polygon_edge_deposit_executes})
 
-      "polygon_zkevm" ->
+      :polygon_zkevm ->
         basic_import_options
         |> Map.put_new(:polygon_zkevm_bridge_operations, %{params: polygon_zkevm_bridge_operations})
 
-      "shibarium" ->
+      :shibarium ->
         basic_import_options
         |> Map.put_new(:shibarium_bridge_operations, %{params: shibarium_bridge_operations})
 

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -168,7 +168,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
     Process.cancel_timer(timer)
   end
 
-  if Application.compile_env(:explorer, :chain_type) == "stability" do
+  if Application.compile_env(:explorer, :chain_type) == :stability do
     defp fetch_validators_async do
       GenServer.cast(Indexer.Fetcher.Stability.Validator, :update_validators_list)
     end
@@ -311,27 +311,27 @@ defmodule Indexer.Block.Realtime.Fetcher do
   end
 
   defp remove_optimism_assets_by_number(block_number_to_fetch) do
-    if Application.get_env(:explorer, :chain_type) == "optimism" do
+    if Application.get_env(:explorer, :chain_type) == :optimism do
       OptimismTxnBatch.handle_l2_reorg(block_number_to_fetch)
       OptimismWithdrawal.remove(block_number_to_fetch)
     end
   end
 
   defp remove_polygon_edge_assets_by_number(block_number_to_fetch) do
-    if Application.get_env(:explorer, :chain_type) == "polygon_edge" do
+    if Application.get_env(:explorer, :chain_type) == :polygon_edge do
       Withdrawal.remove(block_number_to_fetch)
       DepositExecute.remove(block_number_to_fetch)
     end
   end
 
   defp remove_polygon_zkevm_assets_by_number(block_number_to_fetch) do
-    if Application.get_env(:explorer, :chain_type) == "polygon_zkevm" do
+    if Application.get_env(:explorer, :chain_type) == :polygon_zkevm do
       PolygonZkevmBridgeL2.reorg_handle(block_number_to_fetch)
     end
   end
 
   defp remove_shibarium_assets_by_number(block_number_to_fetch) do
-    if Application.get_env(:explorer, :chain_type) == "shibarium" do
+    if Application.get_env(:explorer, :chain_type) == :shibarium do
       ShibariumBridgeL2.reorg_handle(block_number_to_fetch)
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -240,7 +240,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   @zetachain_non_traceable_type 88
   defp filter_non_traceable_transactions(transactions) do
     case Application.get_env(:explorer, :chain_type) do
-      "zetachain" -> Enum.reject(transactions, &(&1.type == @zetachain_non_traceable_type))
+      :zetachain -> Enum.reject(transactions, &(&1.type == @zetachain_non_traceable_type))
       _ -> transactions
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -587,7 +587,7 @@ defmodule Indexer.Fetcher.PolygonEdge do
   defp import_events(events, calling_module) do
     # here we explicitly check CHAIN_TYPE as Dialyzer throws an error otherwise
     {import_data, event_name} =
-      case Application.get_env(:explorer, :chain_type) == "polygon_edge" && calling_module do
+      case Application.get_env(:explorer, :chain_type) == :polygon_edge && calling_module do
         Deposit ->
           {%{polygon_edge_deposits: %{params: events}, timeout: :infinity}, "StateSynced"}
 

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge/deposit_execute.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge/deposit_execute.ex
@@ -197,7 +197,7 @@ defmodule Indexer.Fetcher.PolygonEdge.DepositExecute do
 
     # here we explicitly check CHAIN_TYPE as Dialyzer throws an error otherwise
     import_options =
-      if Application.get_env(:explorer, :chain_type) == "polygon_edge" do
+      if Application.get_env(:explorer, :chain_type) == :polygon_edge do
         %{
           polygon_edge_deposit_executes: %{params: executes},
           timeout: :infinity

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge/withdrawal.ex
@@ -212,7 +212,7 @@ defmodule Indexer.Fetcher.PolygonEdge.Withdrawal do
 
     # here we explicitly check CHAIN_TYPE as Dialyzer throws an error otherwise
     import_options =
-      if Application.get_env(:explorer, :chain_type) == "polygon_edge" do
+      if Application.get_env(:explorer, :chain_type) == :polygon_edge do
         %{
           polygon_edge_withdrawals: %{params: withdrawals},
           timeout: :infinity

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -261,7 +261,7 @@ defmodule Indexer.Supervisor do
 
   defp add_chain_type_dependent_fetchers(fetchers) do
     case Application.get_env(:explorer, :chain_type) do
-      "stability" ->
+      :stability ->
         [{ValidatorStability, []} | fetchers]
 
       _ ->

--- a/apps/indexer/lib/indexer/transform/polygon_zkevm/bridge.ex
+++ b/apps/indexer/lib/indexer/transform/polygon_zkevm/bridge.ex
@@ -21,7 +21,7 @@ defmodule Indexer.Transform.PolygonZkevm.Bridge do
 
     items =
       with false <- is_nil(Application.get_env(:indexer, BridgeL2)[:start_block]),
-           false <- Application.get_env(:explorer, :chain_type) != "polygon_zkevm",
+           false <- Application.get_env(:explorer, :chain_type) != :polygon_zkevm,
            rpc_l1 = Application.get_all_env(:indexer)[BridgeL1][:rpc],
            {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(rpc_l1)},
            rollup_network_id_l1 = Application.get_all_env(:indexer)[BridgeL1][:rollup_network_id_l1],

--- a/apps/indexer/lib/indexer/transform/shibarium/bridge.ex
+++ b/apps/indexer/lib/indexer/transform/shibarium/bridge.ex
@@ -24,7 +24,7 @@ defmodule Indexer.Transform.Shibarium.Bridge do
 
     items =
       with false <- is_nil(Application.get_env(:indexer, Indexer.Fetcher.Shibarium.L2)[:start_block]),
-           false <- Application.get_env(:explorer, :chain_type) != "shibarium",
+           false <- Application.get_env(:explorer, :chain_type) != :shibarium,
            child_chain = Application.get_env(:indexer, Indexer.Fetcher.Shibarium.L2)[:child_chain],
            weth = Application.get_env(:indexer, Indexer.Fetcher.Shibarium.L2)[:weth],
            bone_withdraw = Application.get_env(:indexer, Indexer.Fetcher.Shibarium.L2)[:bone_withdraw],

--- a/apps/indexer/test/indexer/fetcher/beacon/blob_test.exs
+++ b/apps/indexer/test/indexer/fetcher/beacon/blob_test.exs
@@ -10,7 +10,7 @@ defmodule Indexer.Fetcher.Beacon.BlobTest do
   setup :verify_on_exit!
   setup :set_mox_global
 
-  if Application.compile_env(:explorer, :chain_type) == "ethereum" do
+  if Application.compile_env(:explorer, :chain_type) == :ethereum do
     describe "init/1" do
       setup do
         initial_env = Application.get_env(:indexer, BlobSupervisor)

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -505,7 +505,7 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
     assert %{block_number: ^block_number, block_hash: ^block_hash} = Repo.one(PendingBlockOperation)
   end
 
-  if Application.compile_env(:explorer, :chain_type) == "arbitrum" do
+  if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     test "fetches internal transactions from Arbitrum", %{
       json_rpc_named_arguments: json_rpc_named_arguments
     } do

--- a/apps/indexer/test/indexer/fetcher/rootstock_data_test.exs
+++ b/apps/indexer/test/indexer/fetcher/rootstock_data_test.exs
@@ -10,7 +10,7 @@ defmodule Indexer.Fetcher.RootstockDataTest do
   setup :verify_on_exit!
   setup :set_mox_global
 
-  if Application.compile_env(:explorer, :chain_type) == "rsk" do
+  if Application.compile_env(:explorer, :chain_type) == :rsk do
     test "do not start when all old blocks are fetched", %{json_rpc_named_arguments: json_rpc_named_arguments} do
       RootstockData.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
 

--- a/apps/indexer/test/indexer/fetcher/stability/validator_test.exs
+++ b/apps/indexer/test/indexer/fetcher/stability/validator_test.exs
@@ -40,7 +40,7 @@ defmodule Indexer.Fetcher.Stability.ValidatorTest do
     ]
   }
 
-  if Application.compile_env(:explorer, :chain_type) == "stability" do
+  if Application.compile_env(:explorer, :chain_type) == :stability do
     describe "check update_validators_list" do
       test "deletes absent validators" do
         _validator = insert(:validator_stability)

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -10,17 +10,17 @@ defmodule ConfigHelper do
     base_repos = [Explorer.Repo, Explorer.Repo.Account]
 
     repos =
-      case System.get_env("CHAIN_TYPE") do
-        "ethereum" -> base_repos ++ [Explorer.Repo.Beacon]
-        "optimism" -> base_repos ++ [Explorer.Repo.Optimism]
-        "polygon_edge" -> base_repos ++ [Explorer.Repo.PolygonEdge]
-        "polygon_zkevm" -> base_repos ++ [Explorer.Repo.PolygonZkevm]
-        "rsk" -> base_repos ++ [Explorer.Repo.RSK]
-        "shibarium" -> base_repos ++ [Explorer.Repo.Shibarium]
-        "suave" -> base_repos ++ [Explorer.Repo.Suave]
-        "filecoin" -> base_repos ++ [Explorer.Repo.Filecoin]
-        "stability" -> base_repos ++ [Explorer.Repo.Stability]
-        "zksync" -> base_repos ++ [Explorer.Repo.ZkSync]
+      case chain_type() do
+        :ethereum -> base_repos ++ [Explorer.Repo.Beacon]
+        :optimism -> base_repos ++ [Explorer.Repo.Optimism]
+        :polygon_edge -> base_repos ++ [Explorer.Repo.PolygonEdge]
+        :polygon_zkevm -> base_repos ++ [Explorer.Repo.PolygonZkevm]
+        :rsk -> base_repos ++ [Explorer.Repo.RSK]
+        :shibarium -> base_repos ++ [Explorer.Repo.Shibarium]
+        :suave -> base_repos ++ [Explorer.Repo.Suave]
+        :filecoin -> base_repos ++ [Explorer.Repo.Filecoin]
+        :stability -> base_repos ++ [Explorer.Repo.Stability]
+        :zksync -> base_repos ++ [Explorer.Repo.ZkSync]
         _ -> base_repos
       end
 
@@ -123,7 +123,7 @@ defmodule ConfigHelper do
   end
 
   defp wrong_value_error(value, env_var, catalog) do
-    "Wrong value #{value} of #{env_var} environment variable. Supported values are #{inspect(catalog)}"
+    "Invalid value \"#{value}\" of #{env_var} environment variable is provided. Supported values are #{inspect(catalog)}"
   end
 
   def safe_get_env(env_var, default_value) do
@@ -249,8 +249,23 @@ defmodule ConfigHelper do
     err -> raise "Invalid JSON in environment variable #{env_var}: #{inspect(err)}"
   end
 
-  @spec chain_type() :: String.t()
-  def chain_type, do: System.get_env("CHAIN_TYPE") || "default"
+  @supported_chain_types [
+    "default",
+    "arbitrum",
+    "ethereum",
+    "filecoin",
+    "optimism",
+    "polygon_edge",
+    "polygon_zkevm",
+    "rsk",
+    "shibarium",
+    "stability",
+    "suave",
+    "zetachain"
+  ]
+
+  @spec chain_type() :: atom() | nil
+  def chain_type, do: parse_catalog_value("CHAIN_TYPE", @supported_chain_types, true, "default")
 
   @spec eth_call_url(String.t() | nil) :: String.t() | nil
   def eth_call_url(default \\ nil) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -187,7 +187,7 @@ config :ethereum_jsonrpc, EthereumJSONRPC.Geth,
   block_traceable?: ConfigHelper.parse_bool_env_var("ETHEREUM_JSONRPC_GETH_TRACE_BY_BLOCK"),
   debug_trace_timeout: System.get_env("ETHEREUM_JSONRPC_DEBUG_TRACE_TRANSACTION_TIMEOUT", "5s"),
   tracer:
-    if(ConfigHelper.chain_type() == "polygon_edge",
+    if(ConfigHelper.chain_type() == :polygon_edge,
       do: "polygon_edge",
       else: System.get_env("INDEXER_INTERNAL_TRANSACTIONS_TRACER_TYPE", "call_tracer")
     )
@@ -284,7 +284,7 @@ config :explorer, Explorer.Chain.Cache.RootstockLockedBTC,
   global_ttl: ConfigHelper.parse_time_env_var("ROOTSTOCK_LOCKED_BTC_CACHE_PERIOD", "10m"),
   locking_cap: ConfigHelper.parse_integer_env_var("ROOTSTOCK_LOCKING_CAP", 21_000_000)
 
-config :explorer, Explorer.Chain.Cache.OptimismFinalizationPeriod, enabled: ConfigHelper.chain_type() == "optimism"
+config :explorer, Explorer.Chain.Cache.OptimismFinalizationPeriod, enabled: ConfigHelper.chain_type() == :optimism
 
 config :explorer, Explorer.Counters.AddressTransactionsGasUsageCounter,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_ADDRESS_TRANSACTIONS_GAS_USAGE_COUNTER_PERIOD", "30m")
@@ -313,8 +313,8 @@ config :explorer, Explorer.Counters.AddressTokenTransfersCounter,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_ADDRESS_TOKEN_TRANSFERS_COUNTER_PERIOD", "1h")
 
 config :explorer, Explorer.Counters.LastOutputRootSizeCounter,
-  enabled: ConfigHelper.chain_type() == "optimism",
-  enable_consolidation: ConfigHelper.chain_type() == "optimism",
+  enabled: ConfigHelper.chain_type() == :optimism,
+  enable_consolidation: ConfigHelper.chain_type() == :optimism,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_OPTIMISM_LAST_OUTPUT_ROOT_SIZE_COUNTER_PERIOD", "5m")
 
 config :explorer, Explorer.Counters.Transactions24hStats,
@@ -754,12 +754,12 @@ config :indexer, Indexer.Fetcher.CoinBalance.Realtime,
   batch_size: coin_balances_batch_size,
   concurrency: coin_balances_concurrency
 
-config :indexer, Indexer.Fetcher.Optimism.TxnBatch.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
-config :indexer, Indexer.Fetcher.Optimism.OutputRoot.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
-config :indexer, Indexer.Fetcher.Optimism.DisputeGame.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
-config :indexer, Indexer.Fetcher.Optimism.Deposit.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
-config :indexer, Indexer.Fetcher.Optimism.Withdrawal.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
-config :indexer, Indexer.Fetcher.Optimism.WithdrawalEvent.Supervisor, enabled: ConfigHelper.chain_type() == "optimism"
+config :indexer, Indexer.Fetcher.Optimism.TxnBatch.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
+config :indexer, Indexer.Fetcher.Optimism.OutputRoot.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
+config :indexer, Indexer.Fetcher.Optimism.DisputeGame.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
+config :indexer, Indexer.Fetcher.Optimism.Deposit.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
+config :indexer, Indexer.Fetcher.Optimism.Withdrawal.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
+config :indexer, Indexer.Fetcher.Optimism.WithdrawalEvent.Supervisor, enabled: ConfigHelper.chain_type() == :optimism
 
 config :indexer, Indexer.Fetcher.Optimism,
   optimism_l1_rpc: System.get_env("INDEXER_OPTIMISM_L1_RPC"),
@@ -793,15 +793,15 @@ config :indexer, Indexer.Fetcher.Withdrawal.Supervisor,
 
 config :indexer, Indexer.Fetcher.Withdrawal, first_block: System.get_env("WITHDRAWALS_FIRST_BLOCK")
 
-config :indexer, Indexer.Fetcher.PolygonEdge.Deposit.Supervisor, enabled: ConfigHelper.chain_type() == "polygon_edge"
+config :indexer, Indexer.Fetcher.PolygonEdge.Deposit.Supervisor, enabled: ConfigHelper.chain_type() == :polygon_edge
 
 config :indexer, Indexer.Fetcher.PolygonEdge.DepositExecute.Supervisor,
-  enabled: ConfigHelper.chain_type() == "polygon_edge"
+  enabled: ConfigHelper.chain_type() == :polygon_edge
 
-config :indexer, Indexer.Fetcher.PolygonEdge.Withdrawal.Supervisor, enabled: ConfigHelper.chain_type() == "polygon_edge"
+config :indexer, Indexer.Fetcher.PolygonEdge.Withdrawal.Supervisor, enabled: ConfigHelper.chain_type() == :polygon_edge
 
 config :indexer, Indexer.Fetcher.PolygonEdge.WithdrawalExit.Supervisor,
-  enabled: ConfigHelper.chain_type() == "polygon_edge"
+  enabled: ConfigHelper.chain_type() == :polygon_edge
 
 config :indexer, Indexer.Fetcher.PolygonEdge,
   polygon_edge_l1_rpc: System.get_env("INDEXER_POLYGON_EDGE_L1_RPC"),
@@ -841,7 +841,7 @@ config :indexer, Indexer.Fetcher.ZkSync.BatchesStatusTracker.Supervisor,
 
 config :indexer, Indexer.Fetcher.RootstockData.Supervisor,
   disabled?:
-    ConfigHelper.chain_type() != "rsk" || ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ROOTSTOCK_DATA_FETCHER")
+    ConfigHelper.chain_type() != :rsk || ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ROOTSTOCK_DATA_FETCHER")
 
 config :indexer, Indexer.Fetcher.RootstockData,
   interval: ConfigHelper.parse_time_env_var("INDEXER_ROOTSTOCK_DATA_FETCHER_INTERVAL", "3s"),
@@ -853,7 +853,7 @@ config :indexer, Indexer.Fetcher.Beacon, beacon_rpc: System.get_env("INDEXER_BEA
 
 config :indexer, Indexer.Fetcher.Beacon.Blob.Supervisor,
   disabled?:
-    ConfigHelper.chain_type() != "ethereum" ||
+    ConfigHelper.chain_type() != :ethereum ||
       ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_BEACON_BLOB_FETCHER")
 
 config :indexer, Indexer.Fetcher.Beacon.Blob,
@@ -880,9 +880,9 @@ config :indexer, Indexer.Fetcher.Shibarium.L2,
   weth: System.get_env("INDEXER_SHIBARIUM_L2_WETH_CONTRACT"),
   bone_withdraw: System.get_env("INDEXER_SHIBARIUM_L2_BONE_WITHDRAW_CONTRACT")
 
-config :indexer, Indexer.Fetcher.Shibarium.L1.Supervisor, enabled: ConfigHelper.chain_type() == "shibarium"
+config :indexer, Indexer.Fetcher.Shibarium.L1.Supervisor, enabled: ConfigHelper.chain_type() == :shibarium
 
-config :indexer, Indexer.Fetcher.Shibarium.L2.Supervisor, enabled: ConfigHelper.chain_type() == "shibarium"
+config :indexer, Indexer.Fetcher.Shibarium.L2.Supervisor, enabled: ConfigHelper.chain_type() == :shibarium
 
 config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL1,
   rpc: System.get_env("INDEXER_POLYGON_ZKEVM_L1_RPC"),
@@ -893,10 +893,10 @@ config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL1,
   rollup_network_id_l1: ConfigHelper.parse_integer_or_nil_env_var("INDEXER_POLYGON_ZKEVM_L1_BRIDGE_NETWORK_ID"),
   rollup_index_l1: ConfigHelper.parse_integer_or_nil_env_var("INDEXER_POLYGON_ZKEVM_L1_BRIDGE_ROLLUP_INDEX")
 
-config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL1.Supervisor, enabled: ConfigHelper.chain_type() == "polygon_zkevm"
+config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL1.Supervisor, enabled: ConfigHelper.chain_type() == :polygon_zkevm
 
 config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL1Tokens.Supervisor,
-  enabled: ConfigHelper.chain_type() == "polygon_zkevm"
+  enabled: ConfigHelper.chain_type() == :polygon_zkevm
 
 config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL2,
   start_block: System.get_env("INDEXER_POLYGON_ZKEVM_L2_BRIDGE_START_BLOCK"),
@@ -904,7 +904,7 @@ config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL2,
   rollup_network_id_l2: ConfigHelper.parse_integer_or_nil_env_var("INDEXER_POLYGON_ZKEVM_L2_BRIDGE_NETWORK_ID"),
   rollup_index_l2: ConfigHelper.parse_integer_or_nil_env_var("INDEXER_POLYGON_ZKEVM_L2_BRIDGE_ROLLUP_INDEX")
 
-config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL2.Supervisor, enabled: ConfigHelper.chain_type() == "polygon_zkevm"
+config :indexer, Indexer.Fetcher.PolygonZkevm.BridgeL2.Supervisor, enabled: ConfigHelper.chain_type() == :polygon_zkevm
 
 config :indexer, Indexer.Fetcher.PolygonZkevm.TransactionBatch,
   chunk_size: ConfigHelper.parse_integer_env_var("INDEXER_POLYGON_ZKEVM_BATCHES_CHUNK_SIZE", 20),
@@ -912,7 +912,7 @@ config :indexer, Indexer.Fetcher.PolygonZkevm.TransactionBatch,
 
 config :indexer, Indexer.Fetcher.PolygonZkevm.TransactionBatch.Supervisor,
   enabled:
-    ConfigHelper.chain_type() == "polygon_zkevm" &&
+    ConfigHelper.chain_type() == :polygon_zkevm &&
       ConfigHelper.parse_bool_env_var("INDEXER_POLYGON_ZKEVM_BATCHES_ENABLED")
 
 Code.require_file("#{config_env()}.exs", "config/runtime")


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/9865

## Motivation

Validate value in `CHAIN_TYPE` env variable. It should be one of the:
```
  @supported_chain_types [
    "default",
    "arbitrum",
    "ethereum",
    "filecoin",
    "optimism",
    "polygon_edge",
    "polygon_zkevm",
    "rsk",
    "shibarium",
    "stability",
    "suave",
    "zetachain"
  ]
```

## Changelog

If invalid chain type provided, application will exit with success code and error message like this:
```
17:03:57.392 [error] Invalid value "etherium" of CHAIN_TYPE environment variable is provided. Supported values are ["default", "arbitrum", "ethereum", "filecoin", "optimism", "polygon_edge", "polygon_zkevm", "rsk", "shibarium", "stability", "suave", "zetachain"]
```

Output interface of `chain_type/1` is changed: it returns `atom` instead of `string` currently. It uses `parse_catalog_value/4` function, which is supposed to be used in case of dictionary values.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
