### PR TITLE
fix: Remove backend dependency in microservices.yml

### DIFF
--- a/docker-compose/microservices.yml
+++ b/docker-compose/microservices.yml
@@ -37,7 +37,6 @@ services:
   stats:
     depends_on:
       - stats-db
-      - backend
     extends:
       file: ./services/stats.yml
       service: stats


### PR DESCRIPTION
## Motivation

The stats service in microservices.yml has a dependency on backend, resulting in the error `service "stats" depends on undefined service backend`

## Changelog

### Bug Fixes
Removed `depends_on: backend` in microservices.yml to fix the error.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
