### PR TITLE
perf: Adjust unfetched_address_token_balances_index to fit all bound query conditions

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
@@ -7,7 +7,8 @@ defmodule Explorer.Repo.Migrations.FixIndexForUnfetchedTokenBalances do
     create_if_not_exists(
       index(:address_token_balances, ["id"],
         name: "unfetched_address_token_balances_v2_index",
-        where: "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155' OR token_type = 'ERC-404') AND (value_fetched_at IS NULL OR value IS NULL)",
+        where:
+          "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155' OR token_type = 'ERC-404') AND (value_fetched_at IS NULL OR value IS NULL)",
         concurrently: true
       )
     )

--- a/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
@@ -1,0 +1,14 @@
+defmodule Explorer.Repo.Migrations.FixIndexForUnfetchedTokenBalances do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute("""
+      CREATE INDEX CONCURRENTLY unfetched_address_token_balances_v2_index on address_token_balances(id)
+      WHERE (
+          ((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155' OR token_type = 'ERC-404') AND (value_fetched_at IS NULL OR value IS NULL)
+      );
+    """)
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418135458_fix_index_for_unfetched_token_balances.exs
@@ -4,11 +4,12 @@ defmodule Explorer.Repo.Migrations.FixIndexForUnfetchedTokenBalances do
   @disable_migration_lock true
 
   def change do
-    execute("""
-      CREATE INDEX CONCURRENTLY unfetched_address_token_balances_v2_index on address_token_balances(id)
-      WHERE (
-          ((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155' OR token_type = 'ERC-404') AND (value_fetched_at IS NULL OR value IS NULL)
-      );
-    """)
+    create_if_not_exists(
+      index(:address_token_balances, ["id"],
+        name: "unfetched_address_token_balances_v2_index",
+        where: "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155' OR token_type = 'ERC-404') AND (value_fetched_at IS NULL OR value IS NULL)",
+        concurrently: true
+      )
+    )
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.DropOutdatedIndexForUnfetchedTokenBalances do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    execute("""
+      DROP INDEX CONCURRENTLY IF EXISTS unfetched_address_token_balances_index;
+    """)
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
@@ -9,7 +9,8 @@ defmodule Explorer.Repo.Migrations.DropOutdatedIndexForUnfetchedTokenBalances do
         :address_token_balances,
         ~w(id)a,
         name: :unfetched_address_token_balances_index,
-        where: "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)",
+        where:
+          "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)",
         concurrently: true
       )
     )

--- a/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
+++ b/apps/explorer/priv/repo/migrations/20240418140425_drop_outdated_index_for_unfetched_token_balances.exs
@@ -4,8 +4,14 @@ defmodule Explorer.Repo.Migrations.DropOutdatedIndexForUnfetchedTokenBalances do
   @disable_migration_lock true
 
   def change do
-    execute("""
-      DROP INDEX CONCURRENTLY IF EXISTS unfetched_address_token_balances_index;
-    """)
+    drop_if_exists(
+      index(
+        :address_token_balances,
+        ~w(id)a,
+        name: :unfetched_address_token_balances_index,
+        where: "((address_hash != '\\x0000000000000000000000000000000000000000' AND token_type = 'ERC-721') OR token_type = 'ERC-20' OR token_type = 'ERC-1155') AND (value_fetched_at IS NULL OR value IS NULL)",
+        concurrently: true
+      )
+    )
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9911

## Motivation

After adding support of ERC-404 tokens underlined in `unfetched_token_balances/0` query was changed: new condition added: ` or tb.token_type == "ERC-404"`. We should reflect this in the corresponding index.

## Changelog

- Drop `unfetched_address_token_balances_index` index
- Create `unfetched_address_token_balances_index_v2` with all needed conditions.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
