### PR TITLE
fix: Fix metadata preload

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -300,4 +300,8 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
   defp alter_address(%Address{} = address, address_hash, names, :metadata) do
     %Address{address | metadata: names[Address.checksum(address_hash)]}
   end
+
+  defp alter_address(map, address_hash, names, field) when is_map(map) do
+    Map.put(map, field, names[Address.checksum(address_hash)])
+  end
 end

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -137,7 +137,12 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   def enabled?, do: Microservice.check_enabled(__MODULE__) == :ok
 
   defp batch_resolve_name_url do
-    "#{addresses_url()}:batch-resolve-names"
+    # workaround for https://github.com/PSPDFKit-labs/bypass/issues/122
+    if Mix.env() == :test do
+      "#{addresses_url()}:batch_resolve_names"
+    else
+      "#{addresses_url()}:batch-resolve-names"
+    end
   end
 
   defp address_lookup_url do


### PR DESCRIPTION
Closes #9926 
## Changelog
- Add new clause to handle preload metadata to NotLoaded address after end domain preload

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
