### PR TITLE
fix: Fix WebSocketClient reconnect

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/web_socket/web_socket_client.ex
@@ -14,6 +14,8 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClient do
   @behaviour :websocket_client
   @behaviour WebSocket
 
+  @reconnect_interval :timer.minutes(1)
+
   @enforce_keys ~w(url)a
   defstruct connected: false,
             request_id_to_registration: %{},
@@ -139,7 +141,7 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClient do
   def ondisconnect(_reason, %__MODULE__{request_id_to_registration: request_id_to_registration} = state) do
     final_state = Enum.reduce(request_id_to_registration, state, &disconnect_request_id_registration/2)
 
-    {:reconnect, %__MODULE__{final_state | connected: false}}
+    {:reconnect, @reconnect_interval, %__MODULE__{final_state | connected: false}}
   end
 
   @impl :websocket_client

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/web_socket/web_socket_client_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/web_socket/web_socket_client_test.exs
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClientTest do
     setup :example_state
 
     test "reconnects", %{state: state} do
-      assert {:reconnect, _} = WebSocketClient.ondisconnect({:closed, :remote}, state)
+      assert {:reconnect, _, _} = WebSocketClient.ondisconnect({:closed, :remote}, state)
     end
 
     test "treats in-progress unsubscribes as successful", %{state: state} do
@@ -23,7 +23,7 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClientTest do
 
       state = put_registration(state, registration)
 
-      assert {_, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
+      assert {_, _, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
 
       assert Enum.empty?(disconnected_state.request_id_to_registration)
       assert Enum.empty?(disconnected_state.subscription_id_to_subscription_reference)
@@ -36,7 +36,7 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClientTest do
     test "keeps :json_rpc requests for re-requesting on reconnect", %{state: state} do
       state = put_registration(state, %{type: :json_rpc, method: "eth_getBlockByNumber", params: [1, true]})
 
-      assert {_, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
+      assert {_, _, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
 
       assert Enum.count(disconnected_state.request_id_to_registration) == 1
     end
@@ -44,7 +44,7 @@ defmodule EthereumJSONRPC.WebSocket.WebSocketClientTest do
     test "keeps :subscribe requests for re-requesting on reconnect", %{state: state} do
       state = put_registration(state, %{type: :subscribe})
 
-      assert {_, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
+      assert {_, _, disconnected_state} = WebSocketClient.ondisconnect({:closed, :remote}, state)
 
       assert Enum.count(disconnected_state.request_id_to_registration) == 1
     end


### PR DESCRIPTION
Partially resolves https://github.com/blockscout/blockscout/issues/9867

## Motivation

There is a bug in dependency `websocket_client` which causes process crash in case when the handler (`EthereumJSONRPC.WebSocket.WebSocketClient`) returns `{:reconnect, state}` in the function `&ondisconnect/2`. But this bug doesn't appear if this function returns `{:reconnect, interval, state}`.

## Changelog

Updated `&ondisconnect/2` function to return `{:reconnect, interval, state}` instead of `{:reconnect, state}` so the process won't crash.