### PR TITLE
fix: Don't put error to NFT metadata

### DIFF
--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -90,22 +90,24 @@ defmodule Explorer.Helper do
   Decode json
   """
   @spec decode_json(any()) :: map() | list() | nil
-  def decode_json(nil), do: nil
+  def decode_json(data, nft? \\ false)
 
-  def decode_json(data) do
+  def decode_json(nil, _), do: nil
+
+  def decode_json(data, nft?) do
     if String.valid?(data) do
-      safe_decode_json(data)
+      safe_decode_json(data, nft?)
     else
       data
       |> :unicode.characters_to_binary(:latin1)
-      |> safe_decode_json()
+      |> safe_decode_json(nft?)
     end
   end
 
-  defp safe_decode_json(data) do
+  defp safe_decode_json(data, nft?) do
     case Jason.decode(data) do
       {:ok, decoded} -> decoded
-      _ -> %{error: data}
+      _ -> if nft?, do: {:error, data}, else: %{error: data}
     end
   end
 
@@ -114,7 +116,7 @@ defmodule Explorer.Helper do
   """
   @spec maybe_decode(binary) :: any
   def maybe_decode(data) do
-    case safe_decode_json(data) do
+    case safe_decode_json(data, false) do
       %{error: _} -> data
       decoded -> decoded
     end

--- a/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/metadata_retriever.ex
@@ -179,7 +179,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
   end
 
   defp fetch_json_from_uri({:ok, [json]}, _ipfs?, _token_id, hex_token_id, _from_base_uri?) do
-    json = ExplorerHelper.decode_json(json)
+    json = ExplorerHelper.decode_json(json, true)
 
     check_type(json, hex_token_id)
   rescue
@@ -289,7 +289,7 @@ defmodule Indexer.Fetcher.TokenInstance.MetadataRetriever do
 
       check_type(json, nil)
     else
-      json = ExplorerHelper.decode_json(body)
+      json = ExplorerHelper.decode_json(body, true)
 
       check_type(json, hex_token_id)
     end


### PR DESCRIPTION
Closes #9860

## Changelog
- Alter behavior of `Explorer.Helper.{safe_decode_json, decode_json}` functions

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
