### PR TITLE
fix: Set refetch_needed: false on block import

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -339,6 +339,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           size: fragment("EXCLUDED.size"),
           timestamp: fragment("EXCLUDED.timestamp"),
           total_difficulty: fragment("EXCLUDED.total_difficulty"),
+          refetch_needed: fragment("EXCLUDED.refetch_needed"),
           # Don't update `hash` as it is used for the conflict target
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", block.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", block.updated_at)
@@ -350,7 +351,8 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
           fragment("EXCLUDED.miner_hash <> ?", block.miner_hash) or fragment("EXCLUDED.nonce <> ?", block.nonce) or
           fragment("EXCLUDED.number <> ?", block.number) or fragment("EXCLUDED.parent_hash <> ?", block.parent_hash) or
           fragment("EXCLUDED.size <> ?", block.size) or fragment("EXCLUDED.timestamp <> ?", block.timestamp) or
-          fragment("EXCLUDED.total_difficulty <> ?", block.total_difficulty)
+          fragment("EXCLUDED.total_difficulty <> ?", block.total_difficulty) or
+          fragment("EXCLUDED.refetch_needed <> ?", block.refetch_needed)
     )
   end
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -109,7 +109,9 @@ defmodule Indexer.Block.Catchup.Fetcher do
       pop_in(options_with_block_rewards_errors[:block_rewards][:errors])
 
     full_chain_import_options =
-      put_in(options_without_block_rewards_errors, [:blocks, :params, Access.all(), :consensus], true)
+      options_without_block_rewards_errors
+      |> put_in([:blocks, :params, Access.all(), :consensus], true)
+      |> put_in([:blocks, :params, Access.all(), :refetch_needed], false)
 
     with {:import, {:ok, imported} = ok} <- {:import, Chain.import(full_chain_import_options)} do
       async_import_remaining_block_data(

--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -222,6 +222,7 @@ defmodule Indexer.Block.Realtime.Fetcher do
       options
       |> Map.drop(@import_options)
       |> put_in([:blocks, :params, Access.all(), :consensus], true)
+      |> put_in([:blocks, :params, Access.all(), :refetch_needed], false)
       |> put_in([:block_rewards], chain_import_block_rewards)
 
     with {:import, {:ok, imported} = ok} <- {:import, Chain.import(chain_import_options)} do


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/9674

## Motivation

There is missing `refetch_needed: false` setting in block import process which causes blocks to infinitely refetch.

## Changelog

Add `refetch_needed: false` for all blocks imported by block fetchers