### PR TITLE
chore: Migrate to GET variant of {{metadata_url}}/api/v1/metadata

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1814,7 +1814,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         )
       end)
 
-      Bypass.expect_once(bypass, "POST", "api/v1/metadata", fn conn ->
+      Bypass.expect_once(bypass, "GET", "api/v1/metadata", fn conn ->
         Conn.resp(
           conn,
           200,


### PR DESCRIPTION
## Motivation
Metadata microservice migrated to GET methods in endpoints

## Changelog
- Support GET endpoints
- Add chain id parameter to metadata request

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
