### PR TITLE
feat: Omit balanceOf requests for tokens that doesn't support it

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -9,11 +9,12 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   use Explorer.Schema
 
   import Ecto.Changeset
-  import Ecto.Query, only: [from: 2, where: 3, limit: 2, offset: 2, order_by: 3, preload: 2, dynamic: 2]
+  import Ecto.Query, only: [from: 2, limit: 2, offset: 2, order_by: 3, preload: 2, dynamic: 2]
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, CurrencyHelper, Hash, Token}
+  alias Explorer.Chain.Address.TokenBalance
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -326,12 +327,9 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   Deletes all CurrentTokenBalances with given `token_contract_address_hash` and below the given `block_number`.
   Used for cases when token doesn't implement balanceOf function
   """
+  @spec delete_placeholders_below(Hash.Address.t(), Block.block_number()) :: {non_neg_integer(), nil | [term()]}
   def delete_placeholders_below(token_contract_address_hash, block_number) do
-    __MODULE__
-    |> where([ctb], ctb.token_contract_address_hash == ^token_contract_address_hash)
-    |> where([ctb], ctb.block_number <= ^block_number)
-    |> where([ctb], is_nil(ctb.value_fetched_at) or is_nil(ctb.value))
-    |> Repo.delete_all()
+    TokenBalance.delete_token_balance_placeholders_below(__MODULE__, token_contract_address_hash, block_number)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -9,7 +9,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   use Explorer.Schema
 
   import Ecto.Changeset
-  import Ecto.Query, only: [from: 2, limit: 2, offset: 2, order_by: 3, preload: 2, dynamic: 2]
+  import Ecto.Query, only: [from: 2, where: 3, limit: 2, offset: 2, order_by: 3, preload: 2, dynamic: 2]
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias Explorer.{Chain, PagingOptions, Repo}
@@ -320,6 +320,18 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       )
 
     Repo.one!(query, timeout: :infinity)
+  end
+
+  @doc """
+  Deletes all CurrentTokenBalances with given `token_contract_address_hash` and below the given `block_number`.
+  Used for cases when token doesn't implement balanceOf function
+  """
+  def delete_placeholders_below(token_contract_address_hash, block_number) do
+    __MODULE__
+    |> where([ctb], ctb.token_contract_address_hash == ^token_contract_address_hash)
+    |> where([ctb], ctb.block_number <= ^block_number)
+    |> where([ctb], is_nil(ctb.value_fetched_at) or is_nil(ctb.value))
+    |> Repo.delete_all()
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Chain.Address.TokenBalance do
 
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.{Address, Block, Hash, Token}
@@ -118,5 +118,17 @@ defmodule Explorer.Chain.Address.TokenBalance do
       limit: ^1,
       order_by: [desc: :block_number]
     )
+  end
+
+  @doc """
+  Deletes all TokenBalances with given `token_contract_address_hash` and below the given `block_number`.
+  Used for cases when token doesn't implement balanceOf function
+  """
+  def delete_placeholders_below(token_contract_address_hash, block_number) do
+    TokenBalance
+    |> where([tb], tb.token_contract_address_hash == ^token_contract_address_hash)
+    |> where([tb], tb.block_number <= ^block_number)
+    |> where([tb], is_nil(tb.value_fetched_at) or is_nil(tb.value))
+    |> Repo.delete_all()
   end
 end

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -121,11 +121,22 @@ defmodule Explorer.Chain.Address.TokenBalance do
   end
 
   @doc """
-  Deletes all TokenBalances with given `token_contract_address_hash` and below the given `block_number`.
-  Used for cases when token doesn't implement balanceOf function
+  Deletes all token balances with given `token_contract_address_hash` and below the given `block_number`.
+  Used for cases when token doesn't implement `balanceOf` function
   """
+  @spec delete_placeholders_below(Hash.Address.t(), Block.block_number()) :: {non_neg_integer(), nil | [term()]}
   def delete_placeholders_below(token_contract_address_hash, block_number) do
-    TokenBalance
+    delete_token_balance_placeholders_below(__MODULE__, token_contract_address_hash, block_number)
+  end
+
+  @doc """
+  Deletes all token balances or current token balances with given `token_contract_address_hash` and below the given `block_number`.
+  Used for cases when token doesn't implement `balanceOf` function
+  """
+  @spec delete_token_balance_placeholders_below(atom(), Hash.Address.t(), Block.block_number()) ::
+          {non_neg_integer(), nil | [term()]}
+  def delete_token_balance_placeholders_below(module, token_contract_address_hash, block_number) do
+    module
     |> where([tb], tb.token_contract_address_hash == ^token_contract_address_hash)
     |> where([tb], tb.block_number <= ^block_number)
     |> where([tb], is_nil(tb.value_fetched_at) or is_nil(tb.value))

--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
   alias Ecto.{Changeset, Multi, Repo}
   alias Explorer.Chain.Address.CurrentTokenBalance
   alias Explorer.Chain.{Hash, Import}
-  alias Explorer.Chain.Import.Runner.Tokens
+  alias Explorer.Chain.Import.Runner.{Address.TokenBalances, Tokens}
   alias Explorer.Prometheus.Instrumenter
 
   @behaviour Import.Runner
@@ -108,6 +108,14 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
       |> Map.put(:timestamps, timestamps)
 
     multi
+    |> Multi.run(:filter_placeholders, fn _, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> TokenBalances.filter_placeholders(changes_list) end,
+        :block_following,
+        :current_token_balances,
+        :filter_placeholders
+      )
+    end)
     |> Multi.run(:address_current_token_balances, fn repo, _ ->
       Instrumenter.block_import_stage_runner(
         fn -> insert(repo, changes_list, insert_options) end,

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -65,6 +65,9 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
   @impl Import.Runner
   def timeout, do: @timeout
 
+  @doc """
+  Filters out changes with empty `value` or `value_fetched_at` for tokens that doesn't implement `balanceOf` function.
+  """
   @spec filter_placeholders([map()]) :: {:ok, [map()]}
   def filter_placeholders(changes_list) do
     {placeholders, filled_balances} =

--- a/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/token_balances.ex
@@ -11,6 +11,7 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.Import
   alias Explorer.Prometheus.Instrumenter
+  alias Explorer.Utility.MissingBalanceOfToken
 
   @behaviour Import.Runner
 
@@ -42,9 +43,18 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
       |> Map.put_new(:timeout, @timeout)
       |> Map.put(:timestamps, timestamps)
 
-    Multi.run(multi, :address_token_balances, fn repo, _ ->
+    multi
+    |> Multi.run(:filter_placeholders, fn _, _ ->
       Instrumenter.block_import_stage_runner(
-        fn -> insert(repo, changes_list, insert_options) end,
+        fn -> filter_placeholders(changes_list) end,
+        :block_referencing,
+        :token_balances,
+        :filter_placeholders
+      )
+    end)
+    |> Multi.run(:address_token_balances, fn repo, %{filter_placeholders: filtered_changes_list} ->
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, filtered_changes_list, insert_options) end,
         :block_referencing,
         :token_balances,
         :address_token_balances
@@ -54,6 +64,16 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalances do
 
   @impl Import.Runner
   def timeout, do: @timeout
+
+  @spec filter_placeholders([map()]) :: {:ok, [map()]}
+  def filter_placeholders(changes_list) do
+    {placeholders, filled_balances} =
+      Enum.split_with(changes_list, fn balance_params ->
+        is_nil(Map.get(balance_params, :value_fetched_at)) or is_nil(Map.get(balance_params, :value))
+      end)
+
+    {:ok, filled_balances ++ MissingBalanceOfToken.filter_token_balances_params(placeholders)}
+  end
 
   @spec insert(Repo.t(), [map()], %{
           optional(:on_conflict) => Import.Runner.on_conflict(),

--- a/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
+++ b/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
@@ -22,6 +22,8 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
       type: Hash.Address,
       null: false
     )
+
+    timestamps()
   end
 
   @doc false
@@ -29,12 +31,21 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
     cast(missing_balance_of_token, params, [:token_contract_address_hash, :block_number])
   end
 
+  @doc """
+  Returns all records by provided token contract address hashes
+  """
+  @spec get_by_hashes([Hash.Address.t()]) :: [%__MODULE__{}]
   def get_by_hashes(token_contract_address_hashes) do
     __MODULE__
     |> where([mbot], mbot.token_contract_address_hash in ^token_contract_address_hashes)
     |> Repo.all()
   end
 
+  @doc """
+  Filters provided token balances params by presence of record with the same `token_contract_address_hash`
+  and above or equal `block_number` in `missing_balance_of_tokens`.
+  """
+  @spec filter_token_balances_params([map()]) :: [map()]
   def filter_token_balances_params(params) do
     missing_balance_of_tokens_map =
       params
@@ -51,14 +62,26 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
     end)
   end
 
+  @doc """
+  Inserts new `missing_balance_of_tokens` records by provided params (except for `ERC-404` token type)
+  """
+  @spec insert_from_params([map()]) :: {non_neg_integer(), nil | [term()]}
   def insert_from_params(token_balance_params) do
+    now = DateTime.utc_now()
+
     params =
       token_balance_params
       |> Enum.reject(&(&1.token_type == "ERC-404"))
       |> Enum.group_by(& &1.token_contract_address_hash, & &1.block_number)
       |> Enum.map(fn {token_contract_address_hash, block_numbers} ->
         {:ok, token_contract_address_hash_casted} = Hash.Address.cast(token_contract_address_hash)
-        %{token_contract_address_hash: token_contract_address_hash_casted, block_number: Enum.max(block_numbers)}
+
+        %{
+          token_contract_address_hash: token_contract_address_hash_casted,
+          block_number: Enum.max(block_numbers),
+          inserted_at: now,
+          updated_at: now
+        }
       end)
 
     Repo.insert_all(__MODULE__, params, on_conflict: on_conflict(), conflict_target: :token_contract_address_hash)
@@ -69,7 +92,8 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
       mbot in __MODULE__,
       update: [
         set: [
-          block_number: fragment("GREATEST(EXCLUDED.block_number, ?)", mbot.block_number)
+          block_number: fragment("GREATEST(EXCLUDED.block_number, ?)", mbot.block_number),
+          updated_at: fragment("EXCLUDED.updated_at")
         ]
       ]
     )

--- a/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
+++ b/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
@@ -1,0 +1,77 @@
+defmodule Explorer.Utility.MissingBalanceOfToken do
+  @moduledoc """
+  Module is responsible for keeping address hashes of tokens that does not support the balanceOf function
+  and the maximum block number for which this function call returned an error.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, Token}
+  alias Explorer.Repo
+
+  @primary_key false
+  typed_schema "missing_balance_of_tokens" do
+    field(:block_number, :integer)
+
+    belongs_to(
+      :token,
+      Token,
+      foreign_key: :token_contract_address_hash,
+      references: :contract_address_hash,
+      primary_key: true,
+      type: Hash.Address,
+      null: false
+    )
+  end
+
+  @doc false
+  def changeset(missing_balance_of_token \\ %__MODULE__{}, params) do
+    cast(missing_balance_of_token, params, [:token_contract_address_hash, :block_number])
+  end
+
+  def get_by_hashes(token_contract_address_hashes) do
+    __MODULE__
+    |> where([mbot], mbot.token_contract_address_hash in ^token_contract_address_hashes)
+    |> Repo.all()
+  end
+
+  def filter_token_balances_params(params) do
+    missing_balance_of_tokens_map =
+      params
+      |> Enum.map(& &1.token_contract_address_hash)
+      |> get_by_hashes()
+      |> Enum.map(&{to_string(&1.token_contract_address_hash), &1.block_number})
+      |> Map.new()
+
+    Enum.filter(params, fn %{token_contract_address_hash: token_contract_address_hash, block_number: block_number} ->
+      case missing_balance_of_tokens_map[to_string(token_contract_address_hash)] do
+        nil -> true
+        missing_balance_of_block_number -> block_number > missing_balance_of_block_number
+      end
+    end)
+  end
+
+  def insert_from_params(token_balance_params) do
+    params =
+      token_balance_params
+      |> Enum.reject(&(&1.token_type == "ERC-404"))
+      |> Enum.group_by(& &1.token_contract_address_hash, & &1.block_number)
+      |> Enum.map(fn {token_contract_address_hash, block_numbers} ->
+        {:ok, token_contract_address_hash_casted} = Hash.Address.cast(token_contract_address_hash)
+        %{token_contract_address_hash: token_contract_address_hash_casted, block_number: Enum.max(block_numbers)}
+      end)
+
+    Repo.insert_all(__MODULE__, params, on_conflict: on_conflict(), conflict_target: :token_contract_address_hash)
+  end
+
+  defp on_conflict do
+    from(
+      mbot in __MODULE__,
+      update: [
+        set: [
+          block_number: fragment("GREATEST(EXCLUDED.block_number, ?)", mbot.block_number)
+        ]
+      ]
+    )
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240502064431_create_missing_balance_of_tokens.exs
+++ b/apps/explorer/priv/repo/migrations/20240502064431_create_missing_balance_of_tokens.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.CreateMissingBalanceOfTokens do
+  use Ecto.Migration
+
+  def change do
+    create table(:missing_balance_of_tokens, primary_key: false) do
+      add(:token_contract_address_hash, :bytea, primary_key: true)
+      add(:block_number, :bigint)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240502064431_create_missing_balance_of_tokens.exs
+++ b/apps/explorer/priv/repo/migrations/20240502064431_create_missing_balance_of_tokens.exs
@@ -5,6 +5,8 @@ defmodule Explorer.Repo.Migrations.CreateMissingBalanceOfTokens do
     create table(:missing_balance_of_tokens, primary_key: false) do
       add(:token_contract_address_hash, :bytea, primary_key: true)
       add(:block_number, :bigint)
+
+      timestamps()
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/token_balances_test.exs
@@ -219,6 +219,47 @@ defmodule Explorer.Chain.Import.Runner.Address.TokenBalancesTest do
             }} = run_changes(second_changes, options)
   end
 
+  test "filters out changes with tokens that doesn't implement balanceOf function" do
+    address = insert(:address)
+    token = insert(:token)
+
+    options = %{
+      timeout: :infinity,
+      timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+    }
+
+    block_number = 1
+    next_block_number = block_number + 1
+    token_contract_address_hash = token.contract_address_hash
+
+    insert(:missing_balance_of_token,
+      token_contract_address_hash: token_contract_address_hash,
+      block_number: block_number
+    )
+
+    address_hash = address.hash
+
+    changes_list = [
+      %{
+        address_hash: address_hash,
+        block_number: block_number,
+        token_contract_address_hash: token_contract_address_hash,
+        token_id: 11,
+        token_type: "ERC-721"
+      },
+      %{
+        address_hash: address_hash,
+        block_number: next_block_number,
+        token_contract_address_hash: token_contract_address_hash,
+        token_id: 12,
+        token_type: "ERC-721"
+      }
+    ]
+
+    assert {:ok, %{address_token_balances: [%{block_number: ^next_block_number}]}} =
+             run_changes_list(changes_list, options)
+  end
+
   defp run_changes(changes, options) when is_map(changes) do
     run_changes_list([changes], options)
   end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -55,7 +55,7 @@ defmodule Explorer.Factory do
   alias Explorer.Market.MarketHistory
   alias Explorer.Repo
 
-  alias Explorer.Utility.MissingBlockRange
+  alias Explorer.Utility.{MissingBalanceOfToken, MissingBlockRange}
 
   alias Ueberauth.Strategy.Auth0
   alias Ueberauth.Auth.Info
@@ -1087,6 +1087,13 @@ defmodule Explorer.Factory do
     %MissingBlockRange{
       from_number: 1,
       to_number: 0
+    }
+  end
+
+  def missing_balance_of_token_factory do
+    %MissingBalanceOfToken{
+      token_contract_address_hash: insert(:token).contract_address_hash,
+      block_number: block_number()
     }
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -151,8 +151,9 @@ defmodule Indexer.Fetcher.TokenBalance do
 
   defp handle_failed_balances(failed_token_balances) do
     {missing_balance_of_balances, other_failed_balances} =
-      Enum.split_with(failed_token_balances, fn failed_token_balance ->
-        failed_token_balance.error =~ "execution reverted"
+      Enum.split_with(failed_token_balances, fn
+        %{error: error} when is_binary(error) -> error =~ "execution reverted"
+        _ -> false
       end)
 
     MissingBalanceOfToken.insert_from_params(missing_balance_of_balances)

--- a/apps/indexer/lib/indexer/token_balances.ex
+++ b/apps/indexer/lib/indexer/token_balances.ex
@@ -41,7 +41,7 @@ defmodule Indexer.TokenBalances do
   * `token_type` - type of the token that balance belongs to
   * `token_id` - token id for ERC-1155/ERC-404 tokens
   """
-  def fetch_token_balances_from_blockchain([]), do: {:ok, []}
+  def fetch_token_balances_from_blockchain([]), do: {:ok, %{fetched_token_balances: [], failed_token_balances: []}}
 
   @decorate span(tracer: Tracer)
   def fetch_token_balances_from_blockchain(token_balances) do

--- a/cspell.json
+++ b/cspell.json
@@ -337,6 +337,7 @@
         "malihu",
         "mallowance",
         "maxlength",
+        "mbot",
         "mcap",
         "mconst",
         "mdef",


### PR DESCRIPTION
## Motivation
There are tokens that doesn't support `balanceOf` function but we still keep and try to fetch balances for them which means that there would be endless errors on their fetching.

## Changelog
- Added table `missing_balance_of_token` that keeps information about such tokens and the max block number where `balanceOf` wasn't presented
- Filter token balances by this table before fetching
- Insert tokens for which `balanceOf` function returned `execution reverted`
- Filter token balances placeholders before insert