### PR TITLE
feat: Improve retry NFT fetcher

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3581,19 +3581,14 @@ defmodule Explorer.Chain do
         ) :: {:ok, accumulator}
         when accumulator: term()
   def stream_token_instances_with_error(initial, reducer, limited? \\ false) when is_function(reducer, 2) do
-    # likely to get valid metadata
-    high_priority = ["request error: 429", ":checkout_timeout", ":econnrefused", ":timeout"]
-    # almost impossible to get valid metadata
-    negative_priority = ["VM execution error", "no uri", "invalid json"]
-
     Instance
     |> where([instance], not is_nil(instance.error))
+    |> where([instance], is_nil(instance.refetch_after) or instance.refetch_after > ^DateTime.utc_now())
     |> select([instance], %{
       contract_address_hash: instance.token_contract_address_hash,
-      token_id: instance.token_id,
-      updated_at: instance.updated_at
+      token_id: instance.token_id
     })
-    |> order_by([instance], desc: instance.error in ^high_priority, asc: instance.error in ^negative_priority)
+    |> order_by([instance], asc: instance.refetch_after)
     |> add_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
   end
@@ -3789,6 +3784,12 @@ defmodule Explorer.Chain do
   end
 
   defp token_instance_metadata_on_conflict do
+    config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+    coef = config[:exp_timeout_coef]
+    base = config[:exp_timeout_base]
+    max_refetch_interval = config[:max_refetch_interval]
+
     from(
       token_instance in Instance,
       update: [
@@ -3799,7 +3800,22 @@ defmodule Explorer.Chain do
           owner_updated_at_log_index: token_instance.owner_updated_at_log_index,
           owner_address_hash: token_instance.owner_address_hash,
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", token_instance.inserted_at),
-          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", token_instance.updated_at)
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", token_instance.updated_at),
+          retries_count: token_instance.retries_count + 1,
+          refetch_after:
+            fragment(
+              """
+              CASE WHEN EXCLUDED.metadata IS NULL THEN
+                NOW() AT TIME ZONE 'UTC' + LEAST(interval '1 seconds' * (? * ? ^ (? + 1)), interval '1 milliseconds' * ?)
+              ELSE
+                NULL
+              END
+              """,
+              ^coef,
+              ^base,
+              token_instance.retries_count,
+              ^max_refetch_interval
+            )
         ]
       ],
       where: is_nil(token_instance.metadata)

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -16,6 +16,8 @@ defmodule Explorer.Chain.Token.Instance do
   * `token_contract_address_hash` - Address hash foreign key
   * `metadata` - Token instance metadata
   * `error` - error fetching token instance
+  * `refetch_after` - when to refetch the token instance
+  * `retries_count` - number of times the token instance has been retried
   """
   @primary_key false
   typed_schema "token_instances" do
@@ -26,6 +28,8 @@ defmodule Explorer.Chain.Token.Instance do
     field(:owner_updated_at_log_index, :integer)
     field(:current_token_balance, :any, virtual: true)
     field(:is_unique, :boolean, virtual: true)
+    field(:refetch_after, :utc_datetime_usec)
+    field(:retries_count, :integer)
 
     belongs_to(:owner, Address, foreign_key: :owner_address_hash, references: :hash, type: Hash.Address)
 
@@ -51,7 +55,9 @@ defmodule Explorer.Chain.Token.Instance do
       :error,
       :owner_address_hash,
       :owner_updated_at_block,
-      :owner_updated_at_log_index
+      :owner_updated_at_log_index,
+      :refetch_after,
+      :retries_count
     ])
     |> validate_required([:token_id, :token_contract_address_hash])
     |> foreign_key_constraint(:token_contract_address_hash)

--- a/apps/explorer/priv/repo/migrations/20240503091708_add_nft_instance_fetcher_aux_fields.exs
+++ b/apps/explorer/priv/repo/migrations/20240503091708_add_nft_instance_fetcher_aux_fields.exs
@@ -1,0 +1,10 @@
+defmodule Explorer.Repo.Migrations.AddNftInstanceFetcherAuxFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:token_instances) do
+      add(:refetch_after, :utc_datetime_usec, null: true)
+      add(:retries_count, :smallint, default: 0, null: false)
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -216,7 +216,6 @@ defmodule Indexer.BufferedTask do
   def start_link({module, base_init_opts}, genserver_opts \\ []) do
     default_opts = Application.get_all_env(:indexer)
     init_opts = Keyword.merge(default_opts, base_init_opts)
-
     GenServer.start_link(__MODULE__, {module, init_opts}, genserver_opts)
   end
 
@@ -295,6 +294,14 @@ defmodule Indexer.BufferedTask do
     count = length(current_buffer) + Enum.count(bound_queue) * max_batch_size
 
     {:reply, %{buffer: count, tasks: Enum.count(task_ref_to_batch)}, state}
+  end
+
+  def handle_call(
+        :state,
+        _from,
+        state
+      ) do
+    {:reply, state, state}
   end
 
   def handle_call({:push_back, entries}, _from, state) when is_list(entries) do

--- a/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
@@ -254,7 +254,8 @@ defmodule Indexer.Fetcher.TokenInstance.Helper do
       token_id: token_id,
       token_contract_address_hash: token_contract_address_hash,
       metadata: metadata,
-      error: nil
+      error: nil,
+      refetch_after: nil
     }
   end
 
@@ -265,10 +266,18 @@ defmodule Indexer.Fetcher.TokenInstance.Helper do
     do: token_instance_map_with_error(token_id, token_contract_address_hash, reason)
 
   defp token_instance_map_with_error(token_id, token_contract_address_hash, error) do
+    config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+    coef = config[:exp_timeout_coef]
+    max_refetch_interval = config[:max_refetch_interval]
+
+    timeout = min(coef * 1000, max_refetch_interval)
+
     %{
       token_id: token_id,
       token_contract_address_hash: token_contract_address_hash,
-      error: error
+      error: error,
+      refetch_after: DateTime.add(DateTime.utc_now(), timeout, :millisecond)
     }
   end
 

--- a/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/helper.ex
@@ -268,7 +268,7 @@ defmodule Indexer.Fetcher.TokenInstance.Helper do
   defp token_instance_map_with_error(token_id, token_contract_address_hash, error) do
     config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
 
-    coef = config[:exp_timeout_coef]
+    coef = config[:exp_timeout_coeff]
     max_refetch_interval = config[:max_refetch_interval]
 
     timeout = min(coef * 1000, max_refetch_interval)

--- a/apps/indexer/lib/indexer/fetcher/token_instance/retry.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/retry.ex
@@ -15,6 +15,8 @@ defmodule Indexer.Fetcher.TokenInstance.Retry do
 
   @default_max_batch_size 10
   @default_max_concurrency 10
+  @max_queue_size 5000
+  @busy_waiting_timeout 500
 
   @doc false
   def child_spec([init_options, gen_server_options]) do
@@ -32,31 +34,35 @@ defmodule Indexer.Fetcher.TokenInstance.Retry do
       Chain.stream_token_instances_with_error(
         initial_acc,
         fn data, acc ->
-          reducer.(data, acc)
+          reduce_if_que_is_not_full(data, acc, reducer)
         end
       )
 
     acc
   end
 
+  defp reduce_if_que_is_not_full(data, acc, reducer) do
+    bound_queue = GenServer.call(__MODULE__, :state).bound_queue
+
+    if bound_queue.size >= @max_queue_size or (bound_queue.maximum_size && bound_queue.size >= bound_queue.maximum_size) do
+      :timer.sleep(@busy_waiting_timeout)
+
+      reduce_if_que_is_not_full(data, acc, reducer)
+    else
+      reducer.(data, acc)
+    end
+  end
+
   @impl BufferedTask
   def run(token_instances, _json_rpc_named_arguments) when is_list(token_instances) do
-    refetch_interval = Application.get_env(:indexer, __MODULE__)[:refetch_interval]
-
-    token_instances
-    |> Enum.filter(fn %{contract_address_hash: _hash, token_id: _token_id, updated_at: updated_at} ->
-      updated_at
-      |> DateTime.add(refetch_interval, :millisecond)
-      |> DateTime.compare(DateTime.utc_now()) != :gt
-    end)
-    |> batch_fetch_instances()
+    batch_fetch_instances(token_instances)
 
     :ok
   end
 
   defp defaults do
     [
-      flush_interval: :timer.minutes(10),
+      flush_interval: :timer.seconds(10),
       max_concurrency: Application.get_env(:indexer, __MODULE__)[:concurrency] || @default_max_concurrency,
       max_batch_size: Application.get_env(:indexer, __MODULE__)[:batch_size] || @default_max_batch_size,
       task_supervisor: __MODULE__.TaskSupervisor

--- a/apps/indexer/lib/indexer/fetcher/token_instance/retry.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/retry.ex
@@ -34,20 +34,20 @@ defmodule Indexer.Fetcher.TokenInstance.Retry do
       Chain.stream_token_instances_with_error(
         initial_acc,
         fn data, acc ->
-          reduce_if_que_is_not_full(data, acc, reducer)
+          reduce_if_queue_is_not_full(data, acc, reducer)
         end
       )
 
     acc
   end
 
-  defp reduce_if_que_is_not_full(data, acc, reducer) do
+  defp reduce_if_queue_is_not_full(data, acc, reducer) do
     bound_queue = GenServer.call(__MODULE__, :state).bound_queue
 
     if bound_queue.size >= @max_queue_size or (bound_queue.maximum_size && bound_queue.size >= bound_queue.maximum_size) do
       :timer.sleep(@busy_waiting_timeout)
 
-      reduce_if_que_is_not_full(data, acc, reducer)
+      reduce_if_queue_is_not_full(data, acc, reducer)
     else
       reducer.(data, acc)
     end

--- a/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
@@ -385,7 +385,7 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
     test "retries count 0 for new instance" do
       config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
 
-      coef = config[:exp_timeout_coef]
+      coef = config[:exp_timeout_coeff]
       base = config[:exp_timeout_base]
       max_refetch_interval = config[:max_refetch_interval]
 
@@ -411,7 +411,7 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
     test "proper updates retries count and refetch after on retry" do
       config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
 
-      coef = config[:exp_timeout_coef]
+      coef = config[:exp_timeout_coeff]
       base = config[:exp_timeout_base]
       max_refetch_interval = config[:max_refetch_interval]
 
@@ -442,7 +442,7 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
     test "success insert after retry" do
       config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
 
-      coef = config[:exp_timeout_coef]
+      coef = config[:exp_timeout_coeff]
       base = config[:exp_timeout_base]
       max_refetch_interval = config[:max_refetch_interval]
 

--- a/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
@@ -4,7 +4,6 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
 
   alias Explorer.Chain.Token.Instance
   alias Explorer.Repo
-  alias EthereumJSONRPC.Encoder
   alias Indexer.Fetcher.TokenInstance.Helper
   alias Plug.Conn
 
@@ -379,6 +378,146 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
         metadata: nil,
         error: "wrong metadata type"
       } = 777 |> Instance.token_instance_query("0x5caebd3b32e210e85ce3e9d51638b9c445481567") |> Repo.one()
+    end
+  end
+
+  describe "check retries count and refetch after" do
+    test "retries count 0 for new instance" do
+      config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+      coef = config[:exp_timeout_coef]
+      base = config[:exp_timeout_base]
+      max_refetch_interval = config[:max_refetch_interval]
+
+      erc_721_token = insert(:token, type: "ERC-721")
+
+      token_instance = build(:token_instance, token_contract_address_hash: erc_721_token.contract_address_hash)
+
+      Helper.batch_fetch_instances([
+        %{contract_address_hash: token_instance.token_contract_address_hash, token_id: token_instance.token_id}
+      ])
+
+      now = DateTime.utc_now()
+      timeout = min(coef * base ** 0 * 1000, max_refetch_interval)
+      refetch_after = DateTime.add(now, timeout, :millisecond)
+
+      [instance] = Repo.all(Instance)
+
+      assert instance.retries_count == 0
+      assert DateTime.diff(refetch_after, instance.refetch_after) < 1
+      assert !is_nil(instance.error)
+    end
+
+    test "proper updates retries count and refetch after on retry" do
+      config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+      coef = config[:exp_timeout_coef]
+      base = config[:exp_timeout_base]
+      max_refetch_interval = config[:max_refetch_interval]
+
+      erc_721_token = insert(:token, type: "ERC-721")
+
+      token_instance =
+        insert(:token_instance,
+          token_contract_address_hash: erc_721_token.contract_address_hash,
+          error: "error",
+          metadata: nil
+        )
+
+      Helper.batch_fetch_instances([
+        %{contract_address_hash: token_instance.token_contract_address_hash, token_id: token_instance.token_id}
+      ])
+
+      now = DateTime.utc_now()
+      timeout = min(coef * base ** 1 * 1000, max_refetch_interval)
+      refetch_after = DateTime.add(now, timeout, :millisecond)
+
+      [instance] = Repo.all(Instance)
+
+      assert instance.retries_count == 1
+      assert DateTime.diff(refetch_after, instance.refetch_after) < 1
+      assert !is_nil(instance.error)
+    end
+
+    test "success insert after retry" do
+      config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+      coef = config[:exp_timeout_coef]
+      base = config[:exp_timeout_base]
+      max_refetch_interval = config[:max_refetch_interval]
+
+      erc_721_token = insert(:token, type: "ERC-721")
+
+      token_instance = build(:token_instance, token_contract_address_hash: erc_721_token.contract_address_hash)
+
+      Helper.batch_fetch_instances([
+        %{contract_address_hash: token_instance.token_contract_address_hash, token_id: token_instance.token_id}
+      ])
+
+      Helper.batch_fetch_instances([
+        %{contract_address_hash: token_instance.token_contract_address_hash, token_id: token_instance.token_id}
+      ])
+
+      now = DateTime.utc_now()
+      timeout = min(coef * base ** 1 * 1000, max_refetch_interval)
+      refetch_after = DateTime.add(now, timeout, :millisecond)
+
+      [instance] = Repo.all(Instance)
+
+      assert instance.retries_count == 1
+      assert DateTime.diff(refetch_after, instance.refetch_after) < 1
+      assert !is_nil(instance.error)
+
+      token_address = to_string(erc_721_token.contract_address_hash)
+
+      data =
+        "0xc87b56dd" <>
+          (ABI.TypeEncoder.encode([token_instance.token_id], [{:uint, 256}]) |> Base.encode16(case: :lower))
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn [
+                                %{
+                                  id: 0,
+                                  jsonrpc: "2.0",
+                                  method: "eth_call",
+                                  params: [
+                                    %{
+                                      data: ^data,
+                                      to: ^token_address
+                                    },
+                                    "latest"
+                                  ]
+                                }
+                              ],
+                              _options ->
+        {:ok,
+         [
+           %{
+             id: 0,
+             jsonrpc: "2.0",
+             result:
+               "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000115646174613a6170706c69636174696f6e2f6a736f6e3b757466382c7b226e616d65223a20224f4d4e493430342023333030303637303030303030303030303030222c226465736372697074696f6e223a225468652066726f6e74696572206f66207065726d697373696f6e6c657373206173736574732e222c2265787465726e616c5f75726c223a2268747470733a2f2f747769747465722e636f6d2f6f6d6e69636861696e343034222c22696d616765223a2268747470733a2f2f697066732e696f2f697066732f516d55364447586369535a5854483166554b6b45716a3734503846655850524b7853546a675273564b55516139352f626173652f3330303036373030303030303030303030302e4a5047227d0000000000000000000000"
+           }
+         ]}
+      end)
+
+      Helper.batch_fetch_instances([
+        %{contract_address_hash: token_instance.token_contract_address_hash, token_id: token_instance.token_id}
+      ])
+
+      [instance] = Repo.all(Instance)
+
+      assert instance.retries_count == 2
+      assert is_nil(instance.refetch_after)
+      assert is_nil(instance.error)
+
+      assert instance.metadata == %{
+               "name" => "OMNI404 #300067000000000000",
+               "description" => "The frontier of permissionless assets.",
+               "external_url" => "https://twitter.com/omnichain404",
+               "image" =>
+                 "https://ipfs.io/ipfs/QmU6DGXciSZXTH1fUKkEqj74P8FeXPRKxSTjgRsVKUQa95/base/300067000000000000.JPG"
+             }
     end
   end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -727,7 +727,9 @@ config :indexer, Indexer.Fetcher.TokenInstance.Helper,
 config :indexer, Indexer.Fetcher.TokenInstance.Retry,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_CONCURRENCY", 10),
   batch_size: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_BATCH_SIZE", 10),
-  refetch_interval: ConfigHelper.parse_time_env_var("INDEXER_TOKEN_INSTANCE_RETRY_REFETCH_INTERVAL", "24h")
+  max_refetch_interval: ConfigHelper.parse_time_env_var("INDEXER_TOKEN_INSTANCE_RETRY_MAX_REFETCH_INTERVAL", "168h"),
+  exp_timeout_base: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_BASE", 2),
+  exp_timeout_coef: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_COEF", 100)
 
 config :indexer, Indexer.Fetcher.TokenInstance.Realtime,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_REALTIME_CONCURRENCY", 10),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -729,7 +729,7 @@ config :indexer, Indexer.Fetcher.TokenInstance.Retry,
   batch_size: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_BATCH_SIZE", 10),
   max_refetch_interval: ConfigHelper.parse_time_env_var("INDEXER_TOKEN_INSTANCE_RETRY_MAX_REFETCH_INTERVAL", "168h"),
   exp_timeout_base: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_BASE", 2),
-  exp_timeout_coef: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_COEF", 100)
+  exp_timeout_coeff: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_COEFF", 100)
 
 config :indexer, Indexer.Fetcher.TokenInstance.Realtime,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_TOKEN_INSTANCE_REALTIME_CONCURRENCY", 10),

--- a/cspell.json
+++ b/cspell.json
@@ -172,6 +172,7 @@
         "clickover",
         "codeformat",
         "coef",
+        "coeff",
         "coinprice",
         "coinsupply",
         "coinzilla",


### PR DESCRIPTION
Closes #9575 

## Changelog
- Add new fields to `token_instances` table:
  - `retries_count`
  -  `refetch_after`
- Add exponentional timeout for retry of token instances:
formula (in seconds): `min(coef * base ^ retries_count, max_refetch_interval)`
Could be tuned by new ENVS:
`INDEXER_TOKEN_INSTANCE_RETRY_MAX_REFETCH_INTERVAL`, default: `168h`
`INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_BASE`, default: `2`
`INDEXER_TOKEN_INSTANCE_RETRY_EXPONENTIAL_TIMEOUT_COEF`, default: `100`
Values from retry count:
0: 1 min 40 s
1: 3 min 20 s
2: 6 min 40 s
3: 13 min 20 s
4: 26 min 40 s
5: 53 min 20 s
6: 1 h 46 min 40s
7: 3 h 33 min 20s
8: 7 h 6 min 40s
9: 14 h 13 min 20s
10: 1 d 4 h 26 min 40s
11: 2 d 8 h 53 min 20s
12: 4 d 17 h 46 min 40s
13: 9 d 11 h 33 min 20s (limited with default `INDEXER_TOKEN_INSTANCE_RETRY_MAX_REFETCH_INTERVAL`(168h = 1 week)

DEPRECATED `INDEXER_TOKEN_INSTANCE_RETRY_REFETCH_INTERVAL` ENV
https://github.com/blockscout/docs/pull/270
## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
