### PR TITLE
chore: Show blocks range in internal transactions fetching error

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -118,7 +118,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
       {:error, reason} ->
         Logger.error(
           fn ->
-            ["failed to fetch internal transactions for blocks: ", Exception.format(:error, reason)]
+            [
+              "failed to fetch internal transactions for blocks #{inspect(filtered_unique_numbers)}: ",
+              Exception.format(:error, reason)
+            ]
           end,
           error_count: filtered_unique_numbers_count
         )
@@ -131,7 +134,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
       {:error, reason, stacktrace} ->
         Logger.error(
           fn ->
-            ["failed to fetch internal transactions for blocks: ", Exception.format(:error, reason, stacktrace)]
+            [
+              "failed to fetch internal transactions for blocks #{inspect(filtered_unique_numbers)}: ",
+              Exception.format(:error, reason, stacktrace)
+            ]
           end,
           error_count: filtered_unique_numbers_count
         )


### PR DESCRIPTION
## Motivation

In some cases internal transactions fetching error doesn't contain info about for which transaction or block this error arose.

## Changelog

Show blocks range in internal transactions fetching error.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
