### PR TITLE
fix: Handle DB unavailability by PolygonZkevm.TransactionBatch fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_zkevm/transaction_batch.ex
@@ -40,7 +40,8 @@ defmodule Indexer.Fetcher.PolygonZkevm.TransactionBatch do
     chunk_size = config[:chunk_size]
     recheck_interval = config[:recheck_interval]
 
-    Process.send(self(), :continue, [])
+    # two seconds pause needed to avoid exceeding Supervisor restart intensity when DB issues
+    Process.send_after(self(), :continue, 2000)
 
     {:ok,
      %{


### PR DESCRIPTION
## Motivation

The `Indexer.Fetcher.PolygonZkevm.TransactionBatch` module doesn't have 2-second initialization pause (like other indexing modules) to reduce restart intensity when DB issues. Due to that, the module stops restarting after 3 attempts until the whole Blockscout instance is reloaded (because Supervisor has a limitation of 3 restarts max within 5 seconds).

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
