### PR TITLE
feat: save smart-contract proxy type in the DB

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
@@ -14,12 +14,15 @@ defmodule BlockScoutWeb.API.V2.AddressViewTest do
         contract_code_md5: "123"
       )
 
-    insert(:proxy_implementation,
-      proxy_address_hash: proxy_address.hash,
-      proxy_type: "eip1967",
-      address_hashes: [implementation_address.hash],
-      names: []
-    )
+    implementation =
+      insert(:proxy_implementation,
+        proxy_address_hash: proxy_address.hash,
+        proxy_type: "eip1967",
+        address_hashes: [implementation_address.hash],
+        names: []
+      )
+
+    assert implementation.proxy_type == :eip1967
 
     TestHelper.get_eip1967_implementation_zero_addresses()
 

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.API.V2.AddressViewTest do
 
     insert(:proxy_implementation,
       proxy_address_hash: proxy_address.hash,
+      proxy_type: "eip1967",
       address_hashes: [implementation_address.hash],
       names: []
     )

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -205,7 +205,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   Returns EIP-1167 implementation address or tries next proxy pattern
   """
   @spec get_implementation_address_hash_string_eip1167(Hash.Address.t(), any(), bool()) ::
-          %{implementation_address_hash_string: String.t() | :error | nil, proxy_type: atom() | :unknown}
+          %{implementation_address_hash_string: String.t() | :error | nil, proxy_type: atom()}
   def get_implementation_address_hash_string_eip1167(proxy_address_hash, proxy_abi, go_to_fallback? \\ true) do
     get_implementation_address_hash_string_by_module(
       EIP1167,
@@ -222,7 +222,10 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Returns EIP-1967 implementation address or tries next proxy pattern
   """
-  @spec get_implementation_address_hash_string_eip1967(Hash.Address.t(), any(), bool()) :: String.t() | :error | nil
+  @spec get_implementation_address_hash_string_eip1967(Hash.Address.t(), any(), bool()) :: %{
+          implementation_address_hash_string: String.t() | :error | nil,
+          proxy_type: atom()
+        }
   def get_implementation_address_hash_string_eip1967(proxy_address_hash, proxy_abi, go_to_fallback?) do
     get_implementation_address_hash_string_by_module(
       EIP1967,
@@ -239,7 +242,10 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Returns EIP-1822 implementation address or tries next proxy pattern
   """
-  @spec get_implementation_address_hash_string_eip1822(Hash.Address.t(), any(), bool()) :: String.t() | :error | nil
+  @spec get_implementation_address_hash_string_eip1822(Hash.Address.t(), any(), bool()) :: %{
+          implementation_address_hash_string: String.t() | :error | nil,
+          proxy_type: atom()
+        }
   def get_implementation_address_hash_string_eip1822(proxy_address_hash, proxy_abi, go_to_fallback?) do
     get_implementation_address_hash_string_by_module(EIP1822, :eip1822, [proxy_address_hash, proxy_abi, go_to_fallback?])
   end
@@ -277,7 +283,10 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     %{implementation_address_hash_string: value, proxy_type: :unknown}
   end
 
-  @spec fallback_proxy_detection(Hash.Address.t(), any(), :error | nil) :: String.t() | :error | nil
+  @spec fallback_proxy_detection(Hash.Address.t(), any(), :error | nil) :: %{
+          implementation_address_hash_string: String.t() | :error | nil,
+          proxy_type: atom()
+        }
   def fallback_proxy_detection(proxy_address_hash, proxy_abi, fallback_value \\ nil) do
     implementation_method_abi = get_naive_implementation_abi(proxy_abi, "implementation")
 

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
       is_burn_signature: 1,
       get_implementation: 2,
       get_proxy_implementations: 1,
-      save_implementation_data: 3
+      save_implementation_data: 4
     ]
 
   # supported signatures:
@@ -44,7 +44,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
           {String.t() | nil | :empty, String.t() | nil | :empty}
   def fetch_implementation_address_hash(proxy_address_hash, proxy_abi, options)
       when not is_nil(proxy_address_hash) do
-    implementation_address_hash_string =
+    %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: proxy_type} =
       if options[:unverified_proxy_only?] do
         get_implementation_address_hash_string_for_non_verified_proxy(proxy_address_hash)
       else
@@ -55,6 +55,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
       save_implementation_data(
         implementation_address_hash_string,
         proxy_address_hash,
+        proxy_type,
         options
       )
     else
@@ -203,10 +204,12 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Returns EIP-1167 implementation address or tries next proxy pattern
   """
-  @spec get_implementation_address_hash_string_eip1167(Hash.Address.t(), any(), bool()) :: String.t() | :error | nil
+  @spec get_implementation_address_hash_string_eip1167(Hash.Address.t(), any(), bool()) ::
+          %{implementation_address_hash_string: String.t() | :error | nil, proxy_type: atom() | :unknown}
   def get_implementation_address_hash_string_eip1167(proxy_address_hash, proxy_abi, go_to_fallback? \\ true) do
     get_implementation_address_hash_string_by_module(
       EIP1167,
+      :eip1167,
       [
         proxy_address_hash,
         proxy_abi,
@@ -223,6 +226,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   def get_implementation_address_hash_string_eip1967(proxy_address_hash, proxy_abi, go_to_fallback?) do
     get_implementation_address_hash_string_by_module(
       EIP1967,
+      :eip1967,
       [
         proxy_address_hash,
         proxy_abi,
@@ -237,11 +241,12 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   """
   @spec get_implementation_address_hash_string_eip1822(Hash.Address.t(), any(), bool()) :: String.t() | :error | nil
   def get_implementation_address_hash_string_eip1822(proxy_address_hash, proxy_abi, go_to_fallback?) do
-    get_implementation_address_hash_string_by_module(EIP1822, [proxy_address_hash, proxy_abi, go_to_fallback?])
+    get_implementation_address_hash_string_by_module(EIP1822, :eip1822, [proxy_address_hash, proxy_abi, go_to_fallback?])
   end
 
   defp get_implementation_address_hash_string_by_module(
          module,
+         proxy_type,
          [proxy_address_hash, proxy_abi, go_to_fallback?] = args,
          next_func \\ :fallback_proxy_detection
        ) do
@@ -249,7 +254,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
     if !is_nil(implementation_address_hash_string) && implementation_address_hash_string !== burn_address_hash_string() &&
          implementation_address_hash_string !== :error do
-      implementation_address_hash_string
+      %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: proxy_type}
     else
       cond do
         next_func !== :fallback_proxy_detection ->
@@ -267,7 +272,9 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   end
 
   defp implementation_fallback_value(implementation_address_hash_string) do
-    if implementation_address_hash_string == :error, do: :error, else: nil
+    value = if implementation_address_hash_string == :error, do: :error, else: nil
+
+    %{implementation_address_hash_string: value, proxy_type: :unknown}
   end
 
   @spec fallback_proxy_detection(Hash.Address.t(), any(), :error | nil) :: String.t() | :error | nil
@@ -284,23 +291,36 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
     cond do
       implementation_method_abi ->
-        Basic.get_implementation_address_hash_string(@implementation_signature, proxy_address_hash, proxy_abi)
+        implementation_address_hash_string =
+          Basic.get_implementation_address_hash_string(@implementation_signature, proxy_address_hash, proxy_abi)
+
+        %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: :basic_implementation}
 
       get_implementation_method_abi ->
-        Basic.get_implementation_address_hash_string(@get_implementation_signature, proxy_address_hash, proxy_abi)
+        implementation_address_hash_string =
+          Basic.get_implementation_address_hash_string(@get_implementation_signature, proxy_address_hash, proxy_abi)
+
+        %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: :basic_get_implementation}
 
       master_copy_method_abi ->
-        MasterCopy.get_implementation_address_hash_string(proxy_address_hash)
+        implementation_address_hash_string = MasterCopy.get_implementation_address_hash_string(proxy_address_hash)
+        %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: :master_copy}
 
       comptroller_implementation_method_abi ->
-        Basic.get_implementation_address_hash_string(
-          @comptroller_implementation_signature,
-          proxy_address_hash,
-          proxy_abi
-        )
+        implementation_address_hash_string =
+          Basic.get_implementation_address_hash_string(
+            @comptroller_implementation_signature,
+            proxy_address_hash,
+            proxy_abi
+          )
+
+        %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: :comptroller}
 
       get_address_method_abi ->
-        EIP930.get_implementation_address_hash_string(@get_address_signature, proxy_address_hash, proxy_abi)
+        implementation_address_hash_string =
+          EIP930.get_implementation_address_hash_string(@get_address_signature, proxy_address_hash, proxy_abi)
+
+        %{implementation_address_hash_string: implementation_address_hash_string, proxy_type: :eip_930}
 
       true ->
         fallback_value

--- a/apps/explorer/priv/repo/migrations/20240419101821_migrate_proxy_implementations.exs
+++ b/apps/explorer/priv/repo/migrations/20240419101821_migrate_proxy_implementations.exs
@@ -4,7 +4,7 @@ defmodule Explorer.Repo.Migrations.MigrateProxyImplementations do
   def change do
     execute("""
     INSERT INTO proxy_implementations(proxy_address_hash, address_hashes, names, inserted_at, updated_at)
-    SELECT address_hash, ARRAY [implementation_address_hash], CASE WHEN implementation_name IS NULL THEN '{}' ELSE ARRAY [implementation_name] END, inserted_at, implementation_fetched_at
+    SELECT address_hash, ARRAY [implementation_address_hash], CASE WHEN implementation_name IS NULL THEN '{}' ELSE ARRAY [implementation_name] END, implementation_fetched_at, implementation_fetched_at
     FROM smart_contracts
     WHERE implementation_fetched_at IS NOT NULL
     AND implementation_address_hash IS NOT NULL

--- a/apps/explorer/priv/repo/migrations/20240419101821_migrate_proxy_implementations.exs
+++ b/apps/explorer/priv/repo/migrations/20240419101821_migrate_proxy_implementations.exs
@@ -3,8 +3,8 @@ defmodule Explorer.Repo.Migrations.MigrateProxyImplementations do
 
   def change do
     execute("""
-    INSERT INTO proxy_implementations(proxy_address_hash, address_hashes, names, updated_at)
-    SELECT address_hash, ARRAY [implementation_address_hash], CASE WHEN implementation_name IS NULL THEN '{}' ELSE ARRAY [implementation_name] END, implementation_fetched_at
+    INSERT INTO proxy_implementations(proxy_address_hash, address_hashes, names, inserted_at, updated_at)
+    SELECT address_hash, ARRAY [implementation_address_hash], CASE WHEN implementation_name IS NULL THEN '{}' ELSE ARRAY [implementation_name] END, inserted_at, implementation_fetched_at
     FROM smart_contracts
     WHERE implementation_fetched_at IS NOT NULL
     AND implementation_address_hash IS NOT NULL

--- a/apps/explorer/priv/repo/migrations/20240425091614_add_proxy_type_column.exs
+++ b/apps/explorer/priv/repo/migrations/20240425091614_add_proxy_type_column.exs
@@ -8,7 +8,7 @@ defmodule Explorer.Repo.Migrations.AddProxyTypeColumn do
     )
 
     alter table(:proxy_implementations) do
-      add(:proxy_type, :proxy_type, null: false)
+      add(:proxy_type, :proxy_type, null: true)
     end
 
     create(index(:proxy_implementations, [:proxy_type]))

--- a/apps/explorer/priv/repo/migrations/20240425091614_add_proxy_type_column.exs
+++ b/apps/explorer/priv/repo/migrations/20240425091614_add_proxy_type_column.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.AddProxyTypeColumn do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE TYPE proxy_type AS ENUM ('eip1167', 'eip1967', 'eip1822', 'eip930', 'master_copy', 'basic_implementation', 'basic_get_implementation', 'comptroller', 'unknown')",
+      "DROP TYPE proxy_type"
+    )
+
+    alter table(:proxy_implementations) do
+      add(:proxy_type, :proxy_type, null: false)
+    end
+
+    create(index(:proxy_implementations, [:proxy_type]))
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy/models/implementation_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy/models/implementation_test.exs
@@ -259,6 +259,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation.Test do
 
   def assert_exact_name_and_address(address_hash, implementation_address_hash, implementation_name) do
     implementation = Implementation.get_proxy_implementations(address_hash)
+    assert implementation.proxy_type
     assert implementation.updated_at
     assert implementation.names == [implementation_name]
 
@@ -268,6 +269,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation.Test do
 
   def assert_implementation_name(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
+    assert implementation.proxy_type
     assert implementation.updated_at
     assert implementation.names
   end
@@ -286,6 +288,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation.Test do
 
   def assert_empty_implementation(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
+    assert implementation.proxy_type == :unknown
     assert implementation.updated_at
     assert implementation.names == []
     assert implementation.address_hashes == []

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy/models/implementation_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy/models/implementation_test.exs
@@ -163,7 +163,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation.Test do
       {:ok, addr} = Chain.hash_to_address(twin_address.hash)
       bytecode_twin = addr.smart_contract
 
-      implementation_smart_contract = insert(:smart_contract, name: "implementation")
+      _implementation_smart_contract = insert(:smart_contract, name: "implementation")
 
       # fetch nil implementation
       assert {nil, nil} = Implementation.get_implementation(bytecode_twin)

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -535,7 +535,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
 
   def assert_implementation_address(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
-    assert proxy_type
+    assert implementation.proxy_type
     assert implementation.updated_at
     assert implementation.address_hashes
   end
@@ -547,7 +547,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
 
   def assert_empty_implementation(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
-    assert proxy_type == :unknown
+    assert implementation.proxy_type == :unknown
     assert implementation.updated_at
     assert implementation.names == []
     assert implementation.address_hashes == []

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -535,6 +535,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
 
   def assert_implementation_address(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
+    assert proxy_type
     assert implementation.updated_at
     assert implementation.address_hashes
   end
@@ -546,6 +547,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
 
   def assert_empty_implementation(address_hash) do
     implementation = Implementation.get_proxy_implementations(address_hash)
+    assert proxy_type == :unknown
     assert implementation.updated_at
     assert implementation.names == []
     assert implementation.address_hashes == []


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9952


## Motivation

Save smart-contract proxy type in the DB

## Changelog

`proxy_type` column is added to `proxy_implementations` table with this supported number of proxy types:
https://github.com/blockscout/blockscout/blob/1dff35f02594bbf7f6f9b29210b0f8b643c4e59a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex#L33-L44

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
