### PR TITLE
feat: Clone with immutable arguments proxy pattern

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -231,7 +231,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   end
 
   @doc """
-  Returns additional sources of the smart-contract or from bytecode twin or from implementation, if it fits minimal proxy pattern (EIP-1167)
+  Returns additional sources of the smart-contract or from bytecode twin or from implementation, if it fits minimal proxy pattern (EIP-1167, Clone with immutable arguments)
   """
   @spec get_additional_sources(SmartContract.t(), boolean, SmartContract.t() | nil, %{
           :verified_contract => any(),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1186,7 +1186,7 @@ defmodule Explorer.Chain do
                   implementation_address_fetched?: false,
                   refetch_necessity_checked?: false
                 },
-                Keyword.put(options, :unverified_proxy_only?, true)
+                Keyword.put(options, :proxy_without_abi?, true)
               )
 
             add_implementation_and_bytecode_twin_to_result(address_result, implementation_address_hashes, hash, options)

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -584,7 +584,7 @@ defmodule Explorer.Chain.SmartContract do
     {implementation_address_hash, _} =
       Implementation.get_implementation(
         smart_contract,
-        Keyword.put(options, :unverified_proxy_only?, true)
+        Keyword.put(options, :proxy_without_abi?, true)
       )
 
     implementation_smart_contract =
@@ -959,7 +959,7 @@ defmodule Explorer.Chain.SmartContract do
                 implementation_address_fetched?: false,
                 refetch_necessity_checked?: false
               },
-              Keyword.put(options, :unverified_proxy_only?, true)
+              Keyword.put(options, :proxy_without_abi?, true)
             )
 
           {implementation_smart_contract, true}

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -45,7 +45,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   # aaf10f42 = keccak256(getAddress(bytes32))
   @get_address_signature "21f8a721"
 
-  @typep options :: [{:api?, true | false}, {:unverified_proxy_only?, true | false}]
+  @typep options :: [{:api?, true | false}, {:proxy_without_abi?, true | false}]
 
   @doc """
   Fetches into DB proxy contract implementation's address and name from different proxy patterns
@@ -55,7 +55,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   def fetch_implementation_address_hash(proxy_address_hash, proxy_abi, options)
       when not is_nil(proxy_address_hash) do
     %{implementation_address_hash_strings: implementation_address_hash_strings, proxy_type: proxy_type} =
-      if options[:unverified_proxy_only?] do
+      if options[:proxy_without_abi?] do
         get_implementation_address_hash_string_for_non_verified_proxy(proxy_address_hash)
       else
         get_implementation_address_hash_string(proxy_address_hash, proxy_abi)

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -6,7 +6,17 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   alias EthereumJSONRPC.Contract
   alias Explorer.Chain.{Hash, SmartContract}
   alias Explorer.Chain.SmartContract.Proxy
-  alias Explorer.Chain.SmartContract.Proxy.{Basic, EIP1167, EIP1822, EIP1967, EIP2535, EIP930, MasterCopy}
+
+  alias Explorer.Chain.SmartContract.Proxy.{
+    Basic,
+    CloneWithImmutableArguments,
+    EIP1167,
+    EIP1822,
+    EIP1967,
+    EIP2535,
+    EIP930,
+    MasterCopy
+  }
 
   import Explorer.Chain,
     only: [
@@ -217,6 +227,28 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     get_implementation_address_hash_string_by_module(
       EIP1167,
       :eip1167,
+      [
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?
+      ],
+      :get_implementation_address_hash_string_clones_with_immutable_arguments
+    )
+  end
+
+  @doc """
+  Returns implementation address by following "Clone with immutable arguments" pattern or tries next proxy pattern
+  """
+  @spec get_implementation_address_hash_string_clones_with_immutable_arguments(Hash.Address.t(), any(), bool()) ::
+          %{implementation_address_hash_strings: [String.t()] | :error | nil, proxy_type: atom() | :unknown}
+  def get_implementation_address_hash_string_clones_with_immutable_arguments(
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback? \\ true
+      ) do
+    get_implementation_address_hash_string_by_module(
+      CloneWithImmutableArguments,
+      :clone_with_immutable_arguments,
       [
         proxy_address_hash,
         proxy_abi,

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
@@ -1,0 +1,55 @@
+defmodule Explorer.Chain.SmartContract.Proxy.CloneWithImmutableArguments do
+  @moduledoc """
+  Module for fetching proxy implementation from https://github.com/wighawag/clones-with-immutable-args
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Address, Hash, SmartContract}
+  alias Explorer.Chain.SmartContract.Proxy
+
+  @doc """
+  Get implementation address following "Clone with immutable arguments" pattern
+  """
+  @spec get_implementation_smart_contract(Hash.Address.t(), Keyword.t()) :: SmartContract.t() | nil
+  def get_implementation_smart_contract(address_hash, options \\ []) do
+    address_hash
+    |> get_implementation_address_hash_string(options)
+    |> Proxy.implementation_to_smart_contract(options)
+  end
+
+  @doc """
+  Get implementation address hash string following "Clone with immutable arguments" pattern
+  """
+  @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: String.t() | nil
+  def get_implementation_address_hash_string(address_hash, options \\ []) do
+    case Chain.select_repo(options).get(Address, address_hash) do
+      nil ->
+        nil
+
+      target_address ->
+        contract_code = target_address.contract_code
+
+        case contract_code do
+          %Chain.Data{bytes: contract_code_bytes} ->
+            contract_bytecode = Base.encode16(contract_code_bytes, case: :lower)
+
+            contract_bytecode |> get_proxy_clone_with_immutable_arguments() |> Proxy.abi_decode_address_output()
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  defp get_proxy_clone_with_immutable_arguments(contract_bytecode) do
+    case contract_bytecode do
+      "3d3d3d3d363d3d3761" <>
+          <<_::binary-size(4)>> <>
+          "603736393661" <> <<_::binary-size(4)>> <> "013d73" <> <<template_address::binary-size(40)>> <> _ ->
+        "0x" <> template_address
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -42,6 +42,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
         :basic_get_implementation,
         :comptroller,
         :eip2535,
+        :clone_with_immutable_arguments,
         :unknown
       ],
       null: true

--- a/apps/explorer/lib/explorer/etherscan/contracts.ex
+++ b/apps/explorer/lib/explorer/etherscan/contracts.ex
@@ -53,7 +53,7 @@ defmodule Explorer.Etherscan.Contracts do
                   refetch_necessity_checked?: false
                 },
                 [
-                  {:unverified_proxy_only?, true}
+                  {:proxy_without_abi?, true}
                 ]
               )
 

--- a/apps/explorer/priv/repo/migrations/20240501131140_new_proxy_type_clones_with_immutable_arguments.exs
+++ b/apps/explorer/priv/repo/migrations/20240501131140_new_proxy_type_clones_with_immutable_arguments.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.NewProxyTypeClonesWithImmutableArguments do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TYPE proxy_type ADD VALUE 'clone_with_immutable_arguments' BEFORE 'unknown'")
+  end
+end


### PR DESCRIPTION
Superseed of https://github.com/blockscout/blockscout/pull/9993

Resolves https://github.com/blockscout/blockscout/issues/9739

## Motivation

Adding new proxy pattern "Clone with immutable arguments".

## Changelog

A new proxy type is added :clone_with_immutable_arguments

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
