### PR TITLE
fix: vyper contracts re-verificaiton

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/vyper/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper/publisher.ex
@@ -126,7 +126,6 @@ defmodule Explorer.SmartContract.Vyper.Publisher do
     attrs = address_hash |> attributes(params, abi)
 
     create_or_update_smart_contract(address_hash, attrs)
-    # SmartContract.create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
   end
 
   @doc """

--- a/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
@@ -1,0 +1,80 @@
+defmodule Explorer.SmartContract.Vyper.PublisherTest do
+  use ExUnit.Case, async: true
+
+  use Explorer.DataCase
+
+  doctest Explorer.SmartContract.Vyper.Publisher
+
+  @moduletag timeout: :infinity
+
+  alias Explorer.Chain.{ContractMethod, SmartContract}
+  alias Explorer.{Factory, Repo}
+  alias Explorer.SmartContract.Vyper.Publisher
+
+  setup do
+    configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+    Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+    end)
+  end
+
+  describe "publish/2" do
+    test "with valid data creates a smart_contract" do
+      contract_code_info = Factory.contract_code_info_vyper()
+
+      contract_address = insert(:contract_address, contract_code: contract_code_info.bytecode)
+
+      :transaction
+      |> insert(created_contract_address_hash: contract_address.hash, input: contract_code_info.tx_input)
+      |> with_block(status: :ok)
+
+      valid_attrs = %{
+        "contract_source_code" => contract_code_info.source_code,
+        "compiler_version" => contract_code_info.version,
+        "name" => contract_code_info.name
+      }
+
+      response = Publisher.publish(contract_address.hash, valid_attrs)
+      assert {:ok, %SmartContract{} = smart_contract} = response
+
+      assert smart_contract.address_hash == contract_address.hash
+      assert smart_contract.name == valid_attrs["name"]
+      assert smart_contract.compiler_version == valid_attrs["compiler_version"]
+      assert smart_contract.contract_source_code == valid_attrs["contract_source_code"]
+      assert is_nil(smart_contract.constructor_arguments)
+      assert smart_contract.abi == contract_code_info.abi
+    end
+
+    test "allows to re-verify vyper contracts" do
+      contract_code_info = Factory.contract_code_info_vyper()
+
+      contract_address = insert(:contract_address, contract_code: contract_code_info.bytecode)
+
+      :transaction
+      |> insert(created_contract_address_hash: contract_address.hash, input: contract_code_info.tx_input)
+      |> with_block(status: :ok)
+
+      valid_attrs = %{
+        "contract_source_code" => contract_code_info.source_code,
+        "compiler_version" => contract_code_info.version,
+        "name" => contract_code_info.name
+      }
+
+      response = Publisher.publish(contract_address.hash, valid_attrs)
+      assert {:ok, %SmartContract{}} = response
+
+      updated_name = "AnotherContractName"
+
+      valid_attrs =
+        valid_attrs
+        |> Map.put("name", updated_name)
+
+      response = Publisher.publish(contract_address.hash, valid_attrs)
+      assert {:ok, %SmartContract{} = smart_contract} = response
+
+      assert smart_contract.name == valid_attrs["name"]
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -451,6 +451,48 @@ defmodule Explorer.Factory do
     }
   end
 
+  def contract_code_info_vyper do
+    %{
+      bytecode:
+        "0x5f3560e01c60026001821660011b61005b01601e395f51565b63158ef93e81186100535734610057575f5460405260206040f3610053565b633fa4f245811861005357346100575760015460405260206040f35b5f5ffd5b5f80fd00180037",
+      tx_input:
+        "0x3461001c57607b6001555f5f5561005f61002060003961005f6000f35b5f80fd5f3560e01c60026001821660011b61005b01601e395f51565b63158ef93e81186100535734610057575f5460405260206040f3610053565b633fa4f245811861005357346100575760015460405260206040f35b5f5ffd5b5f80fd0018003784185f810400a16576797065728300030a0013",
+      name: "SimpleContract",
+      source_code: """
+      initialized: public(bool)
+      value: public(uint256)
+
+      @external
+      def __init__():
+          self.value = 123
+          self.initialized = False
+      """,
+      abi: [
+        %{
+          "inputs" => [],
+          "outputs" => [],
+          "stateMutability" => "nonpayable",
+          "type" => "constructor"
+        },
+        %{
+          "inputs" => [],
+          "name" => "initialized",
+          "outputs" => [%{"name" => "", "type" => "bool"}],
+          "stateMutability" => "view",
+          "type" => "function"
+        },
+        %{
+          "inputs" => [],
+          "name" => "value",
+          "outputs" => [%{"name" => "", "type" => "uint256"}],
+          "stateMutability" => "view",
+          "type" => "function"
+        }
+      ],
+      version: "v0.3.10"
+    }
+  end
+
   def address_hash do
     {:ok, address_hash} =
       "address_hash"


### PR DESCRIPTION
## Motivation

When trying to re-verify Vyper contracts an error with unique constraint violation occurs. Blockscout prints the error, but the verification hangs out indefinitely. 

For Solidity contracts re-verification works.

## Changelog

### Enhancements
Added test cases for publishing the Solidity and Vyper contracts when there is already a verified one.

### Bug Fixes
Defined a `create_or_update_smart_contract` function similar to the one defined for Solidity.Publisher module. Internally, it works the same way: checks if the contract is already verified and based on that calls either the update or create smart-contract method

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
