### PR TITLE
Make Dockerfile use specified user with uid/gid

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ ARG BLOCKSCOUT_GID=10001
 
 RUN apk --no-cache --update add jq curl && \
     addgroup --system --gid ${BLOCKSCOUT_GID} ${BLOCKSCOUT_GROUP} && \
-    adduser --system --uid ${BLOCKSCOUT_UID} --ingroup ${BLOCKSCOUT_GROUP} ${BLOCKSCOUT_USER}
+    adduser --system --uid ${BLOCKSCOUT_UID} --ingroup ${BLOCKSCOUT_GROUP} --disabled-password ${BLOCKSCOUT_USER}
 
 WORKDIR /app
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,12 +93,10 @@ RUN apk --no-cache --update add jq curl && \
 
 WORKDIR /app
 
-COPY --from=builder /opt/release/blockscout .
-COPY --from=builder /app/apps/explorer/node_modules ./node_modules
-COPY --from=builder /app/config/config_helper.exs ./config/config_helper.exs
-COPY --from=builder /app/config/config_helper.exs /app/releases/${RELEASE_VERSION}/config_helper.exs
-COPY --from=builder /app/config/assets/precompiles-arbitrum.json ./config/assets/precompiles-arbitrum.json
-
-RUN chown --recursive ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app
+COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /opt/release/blockscout .
+COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app/apps/explorer/node_modules ./node_modules
+COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app/config/config_helper.exs ./config/config_helper.exs
+COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app/config/config_helper.exs /app/releases/${RELEASE_VERSION}/config_helper.exs
+COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app/config/assets/precompiles-arbitrum.json ./config/assets/precompiles-arbitrum.json
 
 USER ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,8 +82,14 @@ ARG SHRINK_INTERNAL_TRANSACTIONS_ENABLED
 ENV SHRINK_INTERNAL_TRANSACTIONS_ENABLED=${SHRINK_INTERNAL_TRANSACTIONS_ENABLED}
 ARG BLOCKSCOUT_VERSION
 ENV BLOCKSCOUT_VERSION=${BLOCKSCOUT_VERSION}
+ARG BLOCKSCOUT_USER=blockscout
+ARG BLOCKSCOUT_GROUP=blockscout
+ARG BLOCKSCOUT_UID=10001
+ARG BLOCKSCOUT_GID=10001
 
-RUN apk --no-cache --update add jq curl
+RUN apk --no-cache --update add jq curl && \
+    addgroup --system --gid ${BLOCKSCOUT_GID} ${BLOCKSCOUT_GROUP} && \
+    adduser --system --uid ${BLOCKSCOUT_UID} --ingroup ${BLOCKSCOUT_GROUP} ${BLOCKSCOUT_USER}
 
 WORKDIR /app
 
@@ -92,3 +98,7 @@ COPY --from=builder /app/apps/explorer/node_modules ./node_modules
 COPY --from=builder /app/config/config_helper.exs ./config/config_helper.exs
 COPY --from=builder /app/config/config_helper.exs /app/releases/${RELEASE_VERSION}/config_helper.exs
 COPY --from=builder /app/config/assets/precompiles-arbitrum.json ./config/assets/precompiles-arbitrum.json
+
+RUN chown --recursive ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app
+
+USER ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP}


### PR DESCRIPTION
*NOTE*: perhaps it's safer to make a separate Dockerfile for this and then integrate this into your CI/CD with a non-root tag. Happy to help update your GitHub Actions workflows if interested.

## Motivation

See [feature request](https://blockscout.canny.io/feature-requests/p/docker-container-running-as-non-root).

## Changelog

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

(NOTE: It's possible that this can break things, depending on someone's environment.)

- Add non-root user/group in Dockerfile.
- Set owner ship of /app to new non-root user/group.
- Run container with new non-root user/group.

## Checklist for your Pull Request (PR)

I did do a build for this in my own CI and confirmed that it ran and that the /app was owned by  blockscout:blockscout (new default user).

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
