### PR TITLE
fix: FunctionClauseError caused by blockTimestamp in reth v0.2.0-beta.6

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -163,7 +163,7 @@ defmodule EthereumJSONRPC.Log do
   end
 
   defp entry_to_elixir({key, _} = entry)
-       when key in ~w(address blockHash data removed topics transactionHash timestamp),
+       when key in ~w(address blockHash data removed topics transactionHash blockTimestamp timestamp),
        do: entry
 
   defp entry_to_elixir({key, quantity}) when key in ~w(blockNumber logIndex transactionIndex transactionLogIndex) do

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/log_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/log_test.exs
@@ -28,5 +28,28 @@ defmodule EthereumJSONRPC.LogTest do
       assert result["blockNumber"] == nil
       assert result["blockHash"] == nil
     end
+
+    test "handles reth-specific fields correctly" do
+      input = %{
+        "address" => "0xda8b3276cde6d768a44b9dac659faa339a41ac55",
+        "blockHash" => nil,
+        "blockNumber" => nil,
+        "data" => "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
+        "blockTimestamp" => "0x66475806",
+        "logIndex" => "0x0",
+        "removed" => false,
+        "topics" => [
+          "0xadc1e8a294f8415511303acc4a8c0c5906c7eb0bf2a71043d7f4b03b46a39130",
+          "0x000000000000000000000000c15bf627accd3b054075c7880425f903106be72a",
+          "0x000000000000000000000000a59eb37750f9c8f2e11aac6700e62ef89187e4ed"
+        ],
+        "transactionHash" => "0xf9b663b4e9b1fdc94eb27b5cfba04eb03d2f7b3fa0b24eb2e1af34f823f2b89e",
+        "transactionIndex" => "0x0"
+      }
+
+      result = Log.to_elixir(input)
+
+      assert result["blockTimestamp"] == "0x66475806"
+    end
   end
 end


### PR DESCRIPTION
## Motivation

In reth v0.2.0-beta.6, the `blockTimestamp` was added to the meta information (see [commit ca82ff5](https://github.com/paradigmxyz/reth/commit/ca82ff5be635caea3ee8408640bce85cb35ad77c)). This change leads to an error:

```
(FunctionClauseError) no function clause matching in EthereumJSONRPC.Log.entry_to_elixir/1
(ethereum_jsonrpc 6.5.0) lib/ethereum_jsonrpc/log.ex:165: EthereumJSONRPC.Log.entry_to_elixir({"blockTimestamp", "0x6647620b"})
```

This PR addresses and resolves the issue by ensuring proper handling of the `blockTimestamp` in the `eth_getTransactionReceipt` function.

## Changelog

### Enhancements

- Added handling for `blockTimestamp` in the `eth_getTransactionReceipt` function to prevent errors when parsing logs.

### Bug Fixes

- Fixed the `(FunctionClauseError) no function clause matching in EthereumJSONRPC.Log.entry_to_elixir/1` error caused by the inclusion of `blockTimestamp` in the meta information.

### Incompatible Changes

- None

## Upgrading

- No special upgrade steps are required.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
