### PR TITLE
fix: Update Vyper inner compilers list to support all compilers

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
+++ b/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
@@ -59,7 +59,7 @@ defmodule Explorer.SmartContract.CompilerVersion do
 
   @spec vyper_releases_url :: String.t()
   def vyper_releases_url do
-    "https://api.github.com/repos/vyperlang/vyper/releases"
+    "https://api.github.com/repos/vyperlang/vyper/releases?per_page=100"
   end
 
   defp format_data(json, compiler) do


### PR DESCRIPTION
## Motivation
For the list of available vyper contracts for internal verification, the default number of items retrieved is 30, which is less than total number of currently existing Vyper releases (46). This makes the oldest compilers unavailable when using vyper verificaiton method.

Should fix the failing `/api/v2/smart-contracts/{address_hash}/verification/via/vyper-code success verification` test

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Bug Fixes
Increases the number of items retrieved for Vyper releases to 100. Allows to get the oldest vyper compilers when using internal verification (i.e., sc_verifier is disabled)

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
