### PR TITLE
fix: Fix certified flag in the search API v2 endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -64,6 +64,7 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
+      "certified" => if(search_result.certified, do: search_result.certified, else: false),
       "priority" => search_result.priority
     }
   end

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -375,11 +375,12 @@ defmodule Explorer.Chain.Search do
       {:ok, address_hash} ->
         address_search_fields =
           search_fields()
-          |> Map.put(:address_hash, dynamic([address, _], address.hash))
+          |> Map.put(:address_hash, dynamic([address, _, _], address.hash))
           |> Map.put(:type, "address")
-          |> Map.put(:name, dynamic([_, address_name], address_name.name))
-          |> Map.put(:inserted_at, dynamic([_, address_name], address_name.inserted_at))
-          |> Map.put(:verified, dynamic([address, _], address.verified))
+          |> Map.put(:name, dynamic([_, address_name, _], address_name.name))
+          |> Map.put(:inserted_at, dynamic([_, address_name, _], address_name.inserted_at))
+          |> Map.put(:verified, dynamic([address, _, _], address.verified))
+          |> Map.put(:certified, dynamic([_, _, smart_contract], smart_contract.certified))
 
         from(address in Address,
           left_join:
@@ -391,6 +392,8 @@ defmodule Explorer.Chain.Search do
               )
             ),
           on: address.hash == address_name.address_hash,
+          left_join: smart_contract in SmartContract,
+          on: address.hash == smart_contract.address_hash,
           where: address.hash == ^address_hash,
           select: ^address_search_fields
         )


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10092

## Motivation

Certified flag is not returned in search API endpoints in some circumstances.


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
