### PR TITLE
feat: Set dynamic ttl of cache modules derived from MapCache

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -10,9 +10,10 @@ defmodule Explorer.Chain.Cache.AddressSum do
     key: :sum,
     key: :async_task,
     ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    global_ttl: :infinity,
     callback: &async_task_on_deletion(&1)
 
+  alias Explorer.Chain.Cache.Helper
   alias Explorer.Etherscan
 
   defp handle_fallback(:sum) do
@@ -31,7 +32,7 @@ defmodule Explorer.Chain.Cache.AddressSum do
         try do
           result = Etherscan.fetch_sum_coin_total_supply()
 
-          set_sum(result)
+          set_sum(%ConCache.Item{ttl: Helper.ttl(__MODULE__, "CACHE_ADDRESS_SUM_PERIOD"), value: result})
         rescue
           e ->
             Logger.debug([

--- a/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
@@ -10,10 +10,11 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
     key: :sum_minus_burnt,
     key: :async_task,
     ttl_check_interval: Application.get_env(:explorer, __MODULE__)[:ttl_check_interval],
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    global_ttl: :infinity,
     callback: &async_task_on_deletion(&1)
 
   alias Explorer.{Chain, Etherscan}
+  alias Explorer.Chain.Cache.Helper
 
   defp handle_fallback(:sum_minus_burnt) do
     # This will get the task PID if one exists and launch a new task if not
@@ -38,7 +39,7 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
 
           Chain.upsert_last_fetched_counter(params)
 
-          set_sum_minus_burnt(result)
+          set_sum_minus_burnt(%ConCache.Item{ttl: Helper.ttl(__MODULE__, "CACHE_ADDRESS_SUM_PERIOD"), value: result})
         rescue
           e ->
             Logger.debug([

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Chain.Cache.Block do
     name: :block_count,
     key: :count,
     key: :async_task,
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    global_ttl: :infinity,
     ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
@@ -78,7 +78,7 @@ defmodule Explorer.Chain.Cache.Block do
 
           Chain.upsert_last_fetched_counter(params)
 
-          set_count(result)
+          set_count(%ConCache.Item{ttl: Helper.ttl(__MODULE__, "CACHE_BLOCK_COUNT_PERIOD"), value: result})
         rescue
           e ->
             Logger.debug([

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -17,10 +17,11 @@ defmodule Explorer.Chain.Cache.GasUsage do
     name: :gas_usage,
     key: :sum,
     key: :async_task,
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    global_ttl: :infinity,
     ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
+  alias Explorer.Chain.Cache.Helper
   alias Explorer.Chain.Transaction
   alias Explorer.Repo
 
@@ -52,7 +53,7 @@ defmodule Explorer.Chain.Cache.GasUsage do
           try do
             result = fetch_sum_gas_used()
 
-            set_sum(result)
+            set_sum(%ConCache.Item{ttl: Helper.ttl(__MODULE__, "CACHE_TOTAL_GAS_USAGE_PERIOD"), value: result})
           rescue
             e ->
               Logger.debug([

--- a/apps/explorer/lib/explorer/chain/cache/helper.ex
+++ b/apps/explorer/lib/explorer/chain/cache/helper.ex
@@ -53,15 +53,12 @@ defmodule Explorer.Chain.Cache.Helper do
     blocks_amount = max_block_number - min_blockchain_block_number
     global_ttl_from_var = Application.get_env(:explorer, module)[:global_ttl]
 
-    if System.get_env(management_variable) do
-      global_ttl_from_var
-    else
-      cond do
-        blocks_amount < @block_number_threshold_1 -> :timer.seconds(10)
-        blocks_amount >= @block_number_threshold_1 and blocks_amount < @block_number_threshold_2 -> :timer.seconds(30)
-        blocks_amount >= @block_number_threshold_2 and blocks_amount < @block_number_threshold_3 -> :timer.minutes(2)
-        true -> global_ttl_from_var
-      end
+    cond do
+      System.get_env(management_variable) not in ["", nil] -> global_ttl_from_var
+      blocks_amount < @block_number_threshold_1 -> :timer.seconds(10)
+      blocks_amount >= @block_number_threshold_1 and blocks_amount < @block_number_threshold_2 -> :timer.seconds(30)
+      blocks_amount >= @block_number_threshold_2 and blocks_amount < @block_number_threshold_3 -> :timer.minutes(2)
+      true -> global_ttl_from_var
     end
   end
 end

--- a/apps/explorer/lib/explorer/chain/cache/helper.ex
+++ b/apps/explorer/lib/explorer/chain/cache/helper.ex
@@ -4,6 +4,10 @@ defmodule Explorer.Chain.Cache.Helper do
   """
   alias Explorer.Chain
 
+  @block_number_threshold_1 10_000
+  @block_number_threshold_2 50_000
+  @block_number_threshold_3 150_000
+
   @doc """
     Estimates the row count of a given table using PostgreSQL system catalogs.
 
@@ -27,5 +31,37 @@ defmodule Explorer.Chain.Cache.Helper do
       )
 
     count
+  end
+
+  @doc """
+    Calculates the time-to-live (TTL) for a given module in the cache.
+
+    ## Parameters
+
+      * `module` - The module for which to calculate the TTL.
+      * `management_variable` - The management environment variable.
+
+    ## Returns
+
+    The TTL for the module.
+
+  """
+  @spec ttl(atom, String.t()) :: non_neg_integer()
+  def ttl(module, management_variable) do
+    min_blockchain_block_number = Application.get_env(:indexer, :first_block)
+    max_block_number = Chain.fetch_max_block_number()
+    blocks_amount = max_block_number - min_blockchain_block_number
+    global_ttl_from_var = Application.get_env(:explorer, module)[:global_ttl]
+
+    if System.get_env(management_variable) do
+      global_ttl_from_var
+    else
+      cond do
+        blocks_amount < @block_number_threshold_1 -> :timer.seconds(10)
+        blocks_amount >= @block_number_threshold_1 and blocks_amount < @block_number_threshold_2 -> :timer.seconds(30)
+        blocks_amount >= @block_number_threshold_2 and blocks_amount < @block_number_threshold_3 -> :timer.minutes(2)
+        true -> global_ttl_from_var
+      end
+    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Cache.Transaction do
     name: :transaction_count,
     key: :count,
     key: :async_task,
-    global_ttl: Application.get_env(:explorer, __MODULE__)[:global_ttl],
+    global_ttl: :infinity,
     ttl_check_interval: :timer.seconds(1),
     callback: &async_task_on_deletion(&1)
 
@@ -51,7 +51,7 @@ defmodule Explorer.Chain.Cache.Transaction do
         try do
           result = Repo.aggregate(Transaction, :count, :hash, timeout: :infinity)
 
-          set_count(result)
+          set_count(%ConCache.Item{ttl: Helper.ttl(__MODULE__, "CACHE_TXS_COUNT_PERIOD"), value: result})
         rescue
           e ->
             Logger.debug([


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10110

## Motivation

Gradually increase ttl for counters on the main page.

## Changelog

Set gradually increasing ttl for counters based on MapCache module:
- total block count
- total txs count
- total gas usage
- address sum
- address sum minus burnt

Disclosing "gradually":
`n < 10k blocks` -> 10 sec
`10k blocks <= n < 50k blocks` -> 30 sec
`50k blocks <= n < 150k blocks` -> 2 min
`n >= 150k blocks` -> default value for the given chache module

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. https://github.com/blockscout/docs/pull/283
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
