### PR TITLE
chore: Exclude write methods from read tabs

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -5,6 +5,7 @@ defmodule Explorer.SmartContract.Helper do
 
   alias Explorer.{Chain, Helper}
   alias Explorer.Chain.{Hash, SmartContract}
+  alias Explorer.SmartContract.Writer
   alias Phoenix.HTML
 
   def queriable_method?(method) do
@@ -25,7 +26,7 @@ defmodule Explorer.SmartContract.Helper do
   def read_with_wallet_method?(function),
     do:
       !error?(function) && !event?(function) && !constructor?(function) &&
-        !empty_outputs?(function)
+        !empty_outputs?(function) && !Writer.write_function?(function)
 
   def empty_outputs?(function), do: is_nil(function["outputs"]) || function["outputs"] == []
 

--- a/apps/explorer/test/explorer/smart_contract/helper_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/helper_test.exs
@@ -126,7 +126,7 @@ defmodule Explorer.SmartContract.HelperTest do
   end
 
   describe "read_with_wallet_method?" do
-    test "returns payable method with output in the read tab" do
+    test "doesn't return payable method with output in the read tab" do
       function = %{
         "type" => "function",
         "stateMutability" => "payable",
@@ -135,7 +135,7 @@ defmodule Explorer.SmartContract.HelperTest do
         "inputs" => []
       }
 
-      assert Helper.read_with_wallet_method?(function)
+      refute Helper.read_with_wallet_method?(function)
     end
 
     test "doesn't return payable method with no output in the read tab" do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9915

## Motivation

Remove write methods from read tabs.

## Changelog

Exclude from read tabs functions, for which `Writer.write_function?(function)` is true.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
