### PR TITLE
refactor: Improve response of address API to return multiple implementations for Diamond proxy

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -95,24 +95,24 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
     is_proxy = AddressView.smart_contract_is_proxy?(address_with_smart_contract, @api_true)
 
-    {implementation_addresses, implementation_names} =
+    implementations =
       with true <- is_proxy,
            {addresses, names} <-
              Implementation.get_implementation(address_with_smart_contract.smart_contract, @api_true),
            false <- addresses && Enum.empty?(addresses) do
         addresses
         |> Enum.zip(names)
-        |> Enum.reduce({[], []}, fn {address, name}, {addresses, names} = acc ->
+        |> Enum.reduce([], fn {address, name}, acc ->
           with {:ok, address_hash} <- Chain.string_to_address_hash(address),
                checksummed_address <- Address.checksum(address_hash) do
-            {[checksummed_address | addresses], [name | names]}
+            [%{"address" => checksummed_address, "name" => name} | acc]
           else
             _ -> acc
           end
         end)
       else
         _ ->
-          {[], []}
+          []
       end
 
     balance = address.fetched_coin_balance && address.fetched_coin_balance.value
@@ -123,8 +123,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     token = address.token && TokenView.render("token.json", %{token: address.token})
 
     # todo: added for backward compatibility, remove when frontend unbound from these props
-    {implementation_address, implementation_name} =
-      single_implementation(implementation_addresses, implementation_names)
+    {implementation_address, implementation_name} = single_implementation(implementations)
 
     Map.merge(base_info, %{
       "creator_address_hash" => creator_hash && Address.checksum(creator_hash),
@@ -133,10 +132,9 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "coin_balance" => balance,
       "exchange_rate" => exchange_rate,
       # todo: added for backward compatibility, remove when frontend unbound from these props
-      "implementation_name" => implementation_name,
-      "implementation_names" => implementation_names,
       "implementation_address" => implementation_address,
-      "implementation_addresses" => implementation_addresses,
+      "implementation_name" => implementation_name,
+      "implementations" => implementations,
       "block_number_balance_updated_at" => address.fetched_coin_balance_block_number,
       "has_decompiled_code" => AddressView.has_decompiled_code?(address),
       "has_validated_blocks" => Counters.check_if_validated_blocks_at_address(address.hash, @api_true),
@@ -148,19 +146,12 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     })
   end
 
-  defp single_implementation(implementation_addresses, implementation_names) do
-    implementation_name =
-      if implementation_names && !Enum.empty?(implementation_names) do
-        implementation_names |> Enum.at(0)
+  defp single_implementation(implementations) do
+    %{"address" => implementation_address, "name" => implementation_name} =
+      if implementations && !Enum.empty?(implementations) do
+        implementations |> Enum.at(0)
       else
-        nil
-      end
-
-    implementation_address =
-      if implementation_addresses && !Enum.empty?(implementation_addresses) do
-        implementation_addresses |> Enum.at(0)
-      else
-        nil
+        %{"address" => nil, "name" => nil}
       end
 
     {implementation_address, implementation_name}

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -56,6 +56,12 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def address_with_info(%Address{} = address, _address_hash) do
     implementation_names = Implementation.names(address)
 
+    formatted_implementation_names =
+      implementation_names
+      |> Enum.map(fn name ->
+        %{"name" => name}
+      end)
+
     implementation_name =
       if Enum.empty?(implementation_names) do
         nil
@@ -69,7 +75,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
       "name" => address_name(address),
       # todo: added for backward compatibility, remove when frontend unbound from these props
       "implementation_name" => implementation_name,
-      "implementation_names" => implementation_names,
+      "implementations" => formatted_implementation_names,
       "is_verified" => verified?(address),
       "ens_domain_name" => address.ens_domain_name,
       "metadata" => address.metadata
@@ -98,7 +104,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
       "name" => nil,
       # todo: added for backward compatibility, remove when frontend unbound from these props
       "implementation_name" => nil,
-      "implementation_names" => [],
+      "implementations" => [],
       "is_verified" => nil,
       "ens_domain_name" => nil,
       "metadata" => nil

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
@@ -153,7 +153,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
                "hash" => Address.checksum(addr),
                # todo: added for backward compatibility, remove when frontend unbound from these props
                "implementation_name" => nil,
-               "implementation_names" => [],
+               "implementations" => [],
                "is_contract" => false,
                "is_verified" => false,
                "name" => nil,
@@ -209,7 +209,7 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
                "hash" => Address.checksum(addr),
                # todo: added for backward compatibility, remove when frontend unbound from these props
                "implementation_name" => nil,
-               "implementation_names" => [],
+               "implementations" => [],
                "is_contract" => false,
                "is_verified" => false,
                "name" => nil,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -74,9 +74,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "exchange_rate" => nil,
         # todo: added for backward compatibility, remove when frontend unbound from these props
         "implementation_name" => nil,
-        "implementation_names" => [],
         "implementation_address" => nil,
-        "implementation_addresses" => [],
+        "implementations" => [],
         "block_number_balance_updated_at" => nil,
         "has_decompiled_code" => false,
         "has_validated_blocks" => false,
@@ -136,7 +135,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "creator_address_hash" => ^from,
                "creation_tx_hash" => ^tx_hash,
                "implementation_address" => ^implementation_address_hash_string,
-               "implementation_addresses" => [^implementation_address_hash_string]
+               "implementations" => [%{"address" => ^implementation_address_hash_string, "name" => nil}]
              } = json_response(request, 200)
     end
 


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/10034

## Motivation

Improve address API response in case of Diamond proxy.

## Changelog

Return multiple implementations in a single property `implementations`:
```
implementations: [
 "address": "0x...",
 "name": ""
]
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
