### PR TITLE
fix: Hotfix for Indexer.Fetcher.Optimism.WithdrawalEvent and EthereumJSONRPC.Receipt

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -369,7 +369,8 @@ defmodule EthereumJSONRPC.Receipt do
 
   defp entry_to_elixir({key, quantity})
        when key in ~w(blockNumber cumulativeGasUsed gasUsed transactionIndex blobGasUsed
-                      blobGasPrice l1Fee l1GasPrice l1GasUsed effectiveGasPrice gasUsedForL1) do
+                      blobGasPrice l1Fee l1GasPrice l1GasUsed effectiveGasPrice gasUsedForL1
+                      l1BlobBaseFeeScalar l1BlobBaseFee l1BaseFeeScalar) do
     result =
       if is_nil(quantity) do
         nil

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -207,7 +207,8 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
         Map.put(acc, block_number, timestamp)
       end)
 
-    Enum.map(events, fn event ->
+    events
+    |> Enum.map(fn event ->
       tx_hash = event["transactionHash"]
 
       {l1_event_type, game_index} =
@@ -233,6 +234,11 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
         game_index: game_index
       }
     end)
+    |> Enum.sort(fn e1, e2 -> e1.game_index < e2.game_index end)
+    |> Enum.reduce(%{}, fn e, acc ->
+      Map.put(acc, {e.withdrawal_hash, e.l1_event_type}, e)
+    end)
+    |> Map.values()
   end
 
   def get_last_l1_item do

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -236,8 +236,9 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
     end)
     |> Enum.reduce(%{}, fn e, acc ->
       key = {e.withdrawal_hash, e.l1_event_type}
+      prev_game_index = Map.get(acc, key, %{game_index: 0}).game_index
 
-      if Map.get(acc, key, %{game_index: 0}).game_index < e.game_index do
+      if prev_game_index < e.game_index or is_nil(prev_game_index) do
         Map.put(acc, key, e)
       else
         acc

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -234,9 +234,14 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
         game_index: game_index
       }
     end)
-    |> Enum.sort(fn e1, e2 -> e1.game_index > e2.game_index end)
     |> Enum.reduce(%{}, fn e, acc ->
-      Map.put_new(acc, {e.withdrawal_hash, e.l1_event_type}, e)
+      key = {e.withdrawal_hash, e.l1_event_type}
+
+      if Map.get(acc, key, %{game_index: 0}).game_index < e.game_index do
+        Map.put(acc, key, e)
+      else
+        acc
+      end
     end)
     |> Map.values()
   end

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -234,9 +234,9 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
         game_index: game_index
       }
     end)
-    |> Enum.sort(fn e1, e2 -> e1.game_index < e2.game_index end)
+    |> Enum.sort(fn e1, e2 -> e1.game_index > e2.game_index end)
     |> Enum.reduce(%{}, fn e, acc ->
-      Map.put(acc, {e.withdrawal_hash, e.l1_event_type}, e)
+      Map.put_new(acc, {e.withdrawal_hash, e.l1_event_type}, e)
     end)
     |> Map.values()
   end


### PR DESCRIPTION
## Motivation

The `Indexer.Fetcher.Optimism.WithdrawalEvent` module doesn't handle overlapped `WithdrawalProven` events (when the same withdrawal is proven more than once and so the next event overwrites the previous one). This PR fixes it.

Also, the new three fields were added to `EthereumJSONRPC.Receipt` (related to Optimism Fjord).

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
