### PR TITLE
fix: rename field containing the number of blocks in the Arbitrum batch

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -125,7 +125,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
       %{
         "number" => batch.number,
         "transactions_count" => batch.transactions_count,
-        "block_count" => batch.end_block - batch.start_block + 1
+        "blocks_count" => batch.end_block - batch.start_block + 1
       }
       |> add_l1_tx_info(batch)
     end)


### PR DESCRIPTION
## Motivation

During writing of documentation for new Arbitrum endpoint it was discovered that the field reflecting the number of blocks in the batch was named incorrectly: `block_count` instead of `blocks_count`

## Changelog

### Bug Fixes
The name of the field was changed.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
