### PR TITLE
fix: add proxy_implementations preloads

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -146,6 +146,7 @@ defmodule BlockScoutWeb.AddressChannel do
     {:noreply, socket}
   end
 
+  # TODO: fix or remove, "internal_transaction.json" clause does not exist
   def handle_out(
         "internal_transaction",
         %{address: _address, internal_transaction: internal_transaction},
@@ -330,7 +331,19 @@ defmodule BlockScoutWeb.AddressChannel do
         event
       )
       when is_list(transactions) do
-    transaction_json = TransactionViewAPI.render("transactions.json", %{transactions: transactions, conn: nil})
+    transaction_json =
+      TransactionViewAPI.render("transactions.json", %{
+        transactions:
+          transactions
+          |> Repo.preload([
+            [
+              from_address: [:names],
+              to_address: [:names, :smart_contract, :proxy_implementations],
+              created_contract_address: [:names, :smart_contract, :proxy_implementations]
+            ]
+          ]),
+        conn: nil
+      })
 
     push(socket, event, %{transactions: transaction_json})
 
@@ -375,7 +388,17 @@ defmodule BlockScoutWeb.AddressChannel do
       )
       when is_list(token_transfers) do
     token_transfer_json =
-      TransactionViewAPI.render("token_transfers.json", %{token_transfers: token_transfers, conn: nil})
+      TransactionViewAPI.render("token_transfers.json", %{
+        token_transfers:
+          token_transfers
+          |> Repo.preload([
+            [
+              from_address: [:names, :smart_contract, :proxy_implementations],
+              to_address: [:names, :smart_contract, :proxy_implementations]
+            ]
+          ]),
+        conn: nil
+      })
 
     push(socket, event, %{token_transfers: token_transfer_json})
 

--- a/apps/block_scout_web/lib/block_scout_web/channels/block_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/block_channel.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.BlockChannel do
 
   alias BlockScoutWeb.API.V2.BlockView, as: BlockViewAPI
   alias BlockScoutWeb.{BlockView, ChainView}
+  alias Explorer.Repo
   alias Phoenix.View
   alias Timex.Duration
 
@@ -24,7 +25,11 @@ defmodule BlockScoutWeb.BlockChannel do
         %{block: block, average_block_time: average_block_time},
         %Phoenix.Socket{handler: BlockScoutWeb.UserSocketV2} = socket
       ) do
-    rendered_block = BlockViewAPI.render("block.json", %{block: block, socket: nil})
+    rendered_block =
+      BlockViewAPI.render("block.json", %{
+        block: block |> Repo.preload(miner: [:names, :smart_contract, :proxy_implementations]),
+        socket: nil
+      })
 
     push(socket, "new_block", %{
       average_block_time: to_string(Duration.to_milliseconds(average_block_time)),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -36,23 +36,18 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   @transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: :names] => :optional,
-      [from_address: :names] => :optional,
-      [to_address: [:names, :proxy_implementations]] => :optional,
-      :block => :optional,
-      [created_contract_address: :smart_contract] => :optional,
-      [from_address: :smart_contract] => :optional,
-      [to_address: :smart_contract] => :optional
+      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [:names, :smart_contract]] => :optional,
+      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      :block => :optional
     },
     api?: true
   ]
 
   @token_transfer_necessity_by_association [
     necessity_by_association: %{
-      [to_address: :smart_contract] => :optional,
-      [from_address: :smart_contract] => :optional,
-      [to_address: :names] => :optional,
-      [from_address: :names] => :optional,
+      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
       :block => :optional,
       :transaction => :optional,
       :token => :optional
@@ -63,7 +58,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @address_options [
     necessity_by_association: %{
       :names => :optional,
-      :token => :optional
+      :token => :optional,
+      :proxy_implementations => :optional
     },
     api?: true
   ]
@@ -172,10 +168,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       options =
         [
           necessity_by_association: %{
-            [to_address: :smart_contract] => :optional,
-            [from_address: :smart_contract] => :optional,
-            [to_address: :names] => :optional,
-            [from_address: :names] => :optional,
+            [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+            [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
             :block => :optional,
             :token => :optional,
             :transaction => :optional
@@ -246,12 +240,9 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       full_options =
         [
           necessity_by_association: %{
-            [created_contract_address: :names] => :optional,
-            [from_address: :names] => :optional,
-            [to_address: :names] => :optional,
-            [created_contract_address: :smart_contract] => :optional,
-            [from_address: :smart_contract] => :optional,
-            [to_address: :smart_contract] => :optional
+            [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+            [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+            [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
           }
         ]
         |> Keyword.merge(paging_options(params))
@@ -280,7 +271,14 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
       formatted_topic = if String.starts_with?(prepared_topic, "0x"), do: prepared_topic, else: "0x" <> prepared_topic
 
-      options = params |> paging_options() |> Keyword.merge(topic: formatted_topic) |> Keyword.merge(@api_true)
+      options =
+        params
+        |> paging_options()
+        |> Keyword.merge(topic: formatted_topic)
+        |> Keyword.merge(
+          necessity_by_association: %{[address: [:names, :smart_contract, :proxy_implementations]] => :optional}
+        )
+        |> Keyword.merge(@api_true)
 
       results_plus_one = Chain.address_to_logs(address_hash, false, options)
 
@@ -323,6 +321,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       full_options =
         [
           necessity_by_association: %{
+            [miner: :proxy_implementations] => :optional,
             miner: :required,
             nephews: :optional,
             transactions: :optional,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -56,25 +56,19 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   @transaction_necessity_by_association [
     necessity_by_association:
       %{
-        [created_contract_address: :names] => :optional,
-        [from_address: :names] => :optional,
-        [to_address: :names] => :optional,
-        :block => :optional,
-        [created_contract_address: :smart_contract] => :optional,
-        [from_address: :smart_contract] => :optional,
-        [to_address: :smart_contract] => :optional
+        [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        :block => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association)
   ]
 
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: :names] => :optional,
-      [from_address: :names] => :optional,
-      [to_address: :names] => :optional,
-      [created_contract_address: :smart_contract] => :optional,
-      [from_address: :smart_contract] => :optional,
-      [to_address: :smart_contract] => :optional
+      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
     }
   ]
 
@@ -83,7 +77,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   @block_params [
     necessity_by_association:
       %{
-        [miner: :names] => :optional,
+        [miner: [:names, :smart_contract, :proxy_implementations]] => :optional,
         :uncles => :optional,
         :nephews => :optional,
         :rewards => :optional,
@@ -257,7 +251,10 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   def withdrawals(conn, %{"block_hash_or_number" => block_hash_or_number} = params) do
     with {:ok, block} <- block_param_to_block(block_hash_or_number) do
       full_options =
-        [necessity_by_association: %{address: :optional}, api?: true]
+        [
+          necessity_by_association: %{[address: [:names, :smart_contract, :proxy_implementations]] => :optional},
+          api?: true
+        ]
         |> Keyword.merge(paging_options(params))
 
       withdrawals_plus_one = Chain.block_to_withdrawals(block.hash, full_options)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -13,12 +13,9 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
   @transactions_options [
     necessity_by_association: %{
       :block => :required,
-      [created_contract_address: :names] => :optional,
-      [from_address: :names] => :optional,
-      [to_address: :names] => :optional,
-      [created_contract_address: :smart_contract] => :optional,
-      [from_address: :smart_contract] => :optional,
-      [to_address: :smart_contract] => :optional
+      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [:names, :smart_contract]] => :optional,
+      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
     },
     paging_options: %PagingOptions{page_size: 6},
     api?: true
@@ -30,7 +27,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     blocks =
       [paging_options: %PagingOptions{page_size: 4}, api?: true]
       |> Chain.list_blocks()
-      |> Repo.replica().preload([[miner: :names], :transactions, :rewards])
+      |> Repo.replica().preload([[miner: [:names, :smart_contract, :proxy_implementations]], :transactions, :rewards])
 
     conn
     |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
@@ -157,7 +157,8 @@ defmodule BlockScoutWeb.API.V2.Proxy.AccountAbstractionController do
       |> Chain.hashes_to_addresses(
         necessity_by_association: %{
           :names => :optional,
-          :smart_contract => :optional
+          :smart_contract => :optional,
+          :proxy_implementations => :optional
         },
         api?: true
       )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -55,38 +55,35 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   # TODO might be redundant to preload blob fields in some of the endpoints
   @transaction_necessity_by_association %{
                                           :block => :optional,
-                                          [created_contract_address: :names] => :optional,
-                                          [created_contract_address: :token] => :optional,
-                                          [created_contract_address: :smart_contract] => :optional,
+                                          [
+                                            created_contract_address: [
+                                              :names,
+                                              :token,
+                                              :smart_contract,
+                                              :proxy_implementations
+                                            ]
+                                          ] => :optional,
                                           [from_address: :names] => :optional,
-                                          [to_address: :names] => :optional,
-                                          [to_address: :smart_contract] => :optional
+                                          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
                                         }
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)
 
   @token_transfers_necessity_by_association %{
-    [from_address: :smart_contract] => :optional,
-    [to_address: :smart_contract] => :optional,
-    [from_address: :names] => :optional,
-    [to_address: :names] => :optional
+    [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+    [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
   }
 
   @token_transfers_in_tx_necessity_by_association %{
-    [from_address: :smart_contract] => :optional,
-    [to_address: :smart_contract] => :optional,
-    [from_address: :names] => :optional,
-    [to_address: :names] => :optional,
+    [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+    [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
     token: :required
   }
 
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: :names] => :optional,
-      [from_address: :names] => :optional,
-      [to_address: :names] => :optional,
-      [created_contract_address: :smart_contract] => :optional,
-      [from_address: :smart_contract] => :optional,
-      [to_address: :smart_contract] => :optional
+      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
     }
   ]
 
@@ -387,9 +384,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       full_options =
         [
           necessity_by_association: %{
-            [address: :names] => :optional,
-            [address: :smart_contract] => :optional,
-            address: :optional
+            [address: [:names, :smart_contract, :proxy_implementations]] => :optional
           }
         ]
         |> Keyword.merge(paging_options(params))
@@ -421,7 +416,9 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     with {:ok, transaction, _transaction_hash} <-
            validate_transaction(transaction_hash_string, params,
              necessity_by_association:
-               Map.merge(@transaction_necessity_by_association, %{[block: [miner: :names]] => :optional}),
+               Map.merge(@transaction_necessity_by_association, %{
+                 [block: [miner: [:names, :smart_contract, :proxy_implementations]]] => :optional
+               }),
              api?: true
            ) do
       state_changes_plus_next_page =

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
     options =
       [
         necessity_by_association: %{
-          :address => :optional
+          [address: [:names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/withdrawal_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/withdrawal_controller.ex
@@ -12,7 +12,13 @@ defmodule BlockScoutWeb.API.V2.WithdrawalController do
 
   def withdrawals_list(conn, params) do
     full_options =
-      [necessity_by_association: %{address: :optional, block: :optional}, api?: true]
+      [
+        necessity_by_association: %{
+          [address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+          block: :optional
+        },
+        api?: true
+      ]
       |> Keyword.merge(paging_options(params))
 
     withdrawals_plus_one = Chain.list_withdrawals(full_options)

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.Endpoint do
     plug(BlockScoutWeb.Prometheus.Exporter)
 
     # 'x-apollo-tracing' header for https://www.graphqlbin.com to work with our GraphQL endpoint
-    plug(CORSPlug, headers: ["x-apollo-tracing" | CORSPlug.defaults()[:headers]])
+    plug(CORSPlug, origin: :self, headers: ["x-apollo-tracing" | CORSPlug.defaults()[:headers]])
 
     plug(BlockScoutWeb.Router)
   end

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -158,7 +158,7 @@ defmodule BlockScoutWeb.PagingHelper do
         [
           necessity_by_association: %{
             :transactions => :optional,
-            [miner: :names] => :optional,
+            [miner: [:names, :smart_contract, :proxy_implementations]] => :optional,
             :nephews => :required,
             :rewards => :optional
           },
@@ -169,7 +169,7 @@ defmodule BlockScoutWeb.PagingHelper do
         [
           necessity_by_association: %{
             :transactions => :optional,
-            [miner: :names] => :optional,
+            [miner: [:names, :smart_contract, :proxy_implementations]] => :optional,
             :rewards => :optional
           },
           block_type: "Reorg"
@@ -184,7 +184,7 @@ defmodule BlockScoutWeb.PagingHelper do
     do: [
       necessity_by_association: %{
         :transactions => :optional,
-        [miner: :names] => :optional,
+        [miner: [:names, :smart_contract, :proxy_implementations]] => :optional,
         :rewards => :optional
       },
       block_type: "Block"

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1676,7 +1676,7 @@ defmodule Explorer.Chain do
         elements
 
       blocks ->
-        blocks
+        blocks |> Repo.preload(Map.keys(necessity_by_association))
     end
   end
 


### PR DESCRIPTION
## Changelog

Added `proxy_implementations` preload to every (hopefully) needed endpoint

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
