### PR TITLE
fix: cannot truncate chardata

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3009,7 +3009,7 @@ defmodule Explorer.Chain do
 
         {:error, reason} ->
           Logger.error(fn ->
-            ["Error while fetching first trace for tx: #{hash_string} error reason: ", reason]
+            ["Error while fetching first trace for tx: #{hash_string} error reason: ", to_string(reason)]
           end)
 
           fetch_tx_revert_reason_using_call(transaction)


### PR DESCRIPTION
## Motivation

`2024-06-10T19:46:58.168 application=explorer request_id=F9eyeGtaxOZUv_QAANfB [error] cannot truncate chardata because it contains something that is not valid chardata: :connect_timeout`

## Changelog

Added `to_string` for the reason

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
