### PR TITLE
fix: add smart contracts preloads to from_address

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -337,7 +337,7 @@ defmodule BlockScoutWeb.AddressChannel do
           transactions
           |> Repo.preload([
             [
-              from_address: [:names],
+              from_address: [:names, :smart_contract, :proxy_implementations],
               to_address: [:names, :smart_contract, :proxy_implementations],
               created_contract_address: [:names, :smart_contract, :proxy_implementations]
             ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @transaction_necessity_by_association [
     necessity_by_association: %{
       [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract]] => :optional,
+      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
       [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
       :block => :optional
     },

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     necessity_by_association: %{
       :block => :required,
       [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract]] => :optional,
+      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
       [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
     },
     paging_options: %PagingOptions{page_size: 6},

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -63,7 +63,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                               :proxy_implementations
                                             ]
                                           ] => :optional,
-                                          [from_address: :names] => :optional,
+                                          [from_address: [:names, :smart_contract, :proxy_implementations]] =>
+                                            :optional,
                                           [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
                                         }
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)

--- a/apps/block_scout_web/lib/block_scout_web/endpoint.ex
+++ b/apps/block_scout_web/lib/block_scout_web/endpoint.ex
@@ -69,7 +69,7 @@ defmodule BlockScoutWeb.Endpoint do
     plug(BlockScoutWeb.Prometheus.Exporter)
 
     # 'x-apollo-tracing' header for https://www.graphqlbin.com to work with our GraphQL endpoint
-    plug(CORSPlug, origin: :self, headers: ["x-apollo-tracing" | CORSPlug.defaults()[:headers]])
+    plug(CORSPlug, headers: ["x-apollo-tracing" | CORSPlug.defaults()[:headers]])
 
     plug(BlockScoutWeb.Router)
   end

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -175,10 +175,8 @@ defmodule BlockScoutWeb.Notifier do
             DenormalizationHelper.extend_transaction_preload([
               :token,
               :transaction,
-              from_address: :smart_contract,
-              to_address: :smart_contract,
-              from_address: :names,
-              to_address: :names
+              from_address: [:names, :smart_contract, :proxy_implementations],
+              to_address: [:names, :smart_contract, :proxy_implementations]
             ])
           ))
       )
@@ -202,12 +200,9 @@ defmodule BlockScoutWeb.Notifier do
   def handle_event({:chain_event, :transactions, :realtime, transactions}) do
     base_preloads = [
       :block,
-      created_contract_address: :names,
-      from_address: :names,
-      to_address: :names,
-      created_contract_address: :smart_contract,
-      from_address: :smart_contract,
-      to_address: :smart_contract
+      created_contract_address: [:names, :smart_contract, :proxy_implementations],
+      from_address: [:names, :smart_contract, :proxy_implementations],
+      to_address: [:names, :smart_contract, :proxy_implementations]
     ]
 
     preloads = if API_V2.enabled?(), do: [:token_transfers | base_preloads], else: base_preloads

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -403,7 +403,7 @@ defmodule Explorer.Chain do
             base
           else
             base
-            |> preload(transaction: [:from_address, to_address: [:proxy_implementations]])
+            |> preload(transaction: [from_address: [:proxy_implementations], to_address: [:proxy_implementations]])
           end
 
         preloaded_query


### PR DESCRIPTION
## Motivation

Unexpectedly on some chains like Arbitrum from address in transaction could be a smart contract

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
