### PR TITLE
fix: Fix nil abi issue in get_naive_implementation_abi and get_master_copy_pattern functions

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -385,12 +385,16 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     end
   end
 
+  defp get_naive_implementation_abi(nil, _getter_name), do: nil
+
   defp get_naive_implementation_abi(abi, getter_name) do
     abi
     |> Enum.find(fn method ->
       Map.get(method, "name") == getter_name && Map.get(method, "stateMutability") == "view"
     end)
   end
+
+  defp get_master_copy_pattern(nil), do: nil
 
   defp get_master_copy_pattern(abi) do
     abi


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10238

## Motivation

yul smart-contracts don't have ABI.

## Changelog

Missing clauses added to `get_naive_implementation_abi` and `get_master_copy_pattern` functions

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
