### PR TITLE
chore: Add test for broadcasting fetched_bytecode message

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -47,8 +47,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
     %{json_rpc_named_arguments: mocked_json_rpc_named_arguments}
 
-    Subscriber.to(:fetched_bytecode, :on_demand)
-
     :ok
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -7,6 +7,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   alias BlockScoutWeb.Models.UserFromAuth
   alias Explorer.{Chain, Repo, TestHelper}
   alias Explorer.Chain.Address.Counters
+  alias Explorer.Chain.Events.Subscriber
 
   alias Explorer.Chain.{
     Address,
@@ -24,6 +25,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
   alias Explorer.Account.WatchlistAddress
   alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Indexer.Fetcher.OnDemand.ContractCode, as: ContractCodeOnDemand
   alias Plug.Conn
 
   import Explorer.Chain, only: [hash_to_lower_case_string: 1]
@@ -35,6 +37,20 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   setup :set_mox_global
 
   setup :verify_on_exit!
+
+  setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+    mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
+
+    start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
+
+    start_supervised!({ContractCodeOnDemand, [mocked_json_rpc_named_arguments, [name: ContractCodeOnDemand]]})
+
+    %{json_rpc_named_arguments: mocked_json_rpc_named_arguments}
+
+    Subscriber.to(:fetched_bytecode, :on_demand)
+
+    :ok
+  end
 
   defp topic(topic_hex_string) do
     {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
@@ -283,6 +299,44 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response = json_response(request, 200)
 
       assert response["watchlist_address_id"] == watchlist_address.id
+    end
+
+    test "broadcasts fetched_bytecode event", %{conn: conn} do
+      address = insert(:address)
+      address_hash = address.hash
+      string_address_hash = to_string(address.hash)
+
+      contract_code = "0x6080"
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn [
+                                %{
+                                  id: id,
+                                  jsonrpc: "2.0",
+                                  method: "eth_getCode",
+                                  params: [^string_address_hash, "latest"]
+                                }
+                              ],
+                              _ ->
+        {:ok, [%{id: id, result: contract_code}]}
+      end)
+
+      topic = "addresses:#{address_hash}"
+
+      {:ok, _reply, _socket} =
+        BlockScoutWeb.UserSocketV2
+        |> socket("no_id", %{})
+        |> subscribe_and_join(topic)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}")
+      assert _response = json_response(request, 200)
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{fetched_bytecode: ^contract_code},
+                       event: "fetched_bytecode",
+                       topic: ^topic
+                     },
+                     :timer.seconds(1)
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -5,8 +5,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
   import Mox
 
-  alias BlockScoutWeb.Notifier
-
   alias Explorer.{Repo, TestHelper}
 
   alias Explorer.Chain.{Address, Token, Token.Instance, TokenTransfer}


### PR DESCRIPTION
## Motivation

We don't have a test for receiving `:fetched_bytecode` event on the websocket endpoint.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
