### PR TITLE
fix: proper hex-encoded transaction hash recognition in ZkSync batches status checker

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
@@ -4,7 +4,8 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
   """
 
   import EthereumJSONRPC, only: [json_rpc: 2, quantity_to_integer: 1]
-  import Indexer.Fetcher.ZkSync.Utils.Logging, only: [log_error: 1]
+
+  alias Indexer.Helper, as: IndexerHelper
 
   @zero_hash "0000000000000000000000000000000000000000000000000000000000000000"
   @zero_hash_binary <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
@@ -200,7 +201,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call zks_getL1BatchDetails. Error: #{inspect(&1)}"
 
-    {:ok, resp} = repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     transform_batch_details_to_map(resp)
   end
@@ -219,11 +220,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
   @spec fetch_tx_by_hash(binary(), EthereumJSONRPC.json_rpc_named_arguments()) :: map()
   def fetch_tx_by_hash(raw_hash, json_rpc_named_arguments)
       when is_binary(raw_hash) and is_list(json_rpc_named_arguments) do
-    hash =
-      case raw_hash do
-        "0x" <> _ -> raw_hash
-        _ -> "0x" <> Base.encode16(raw_hash)
-      end
+    hash = prepare_tx_hash(raw_hash)
 
     req =
       EthereumJSONRPC.request(%{
@@ -234,7 +231,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call eth_getTransactionByHash for hash #{hash}. Error: #{inspect(&1)}"
 
-    {:ok, resp} = repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     resp
   end
@@ -253,11 +250,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
   @spec fetch_tx_receipt_by_hash(binary(), EthereumJSONRPC.json_rpc_named_arguments()) :: map()
   def fetch_tx_receipt_by_hash(raw_hash, json_rpc_named_arguments)
       when is_binary(raw_hash) and is_list(json_rpc_named_arguments) do
-    hash =
-      case raw_hash do
-        "0x" <> _ -> raw_hash
-        _ -> "0x" <> Base.encode16(raw_hash)
-      end
+    hash = prepare_tx_hash(raw_hash)
 
     req =
       EthereumJSONRPC.request(%{
@@ -268,7 +261,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call eth_getTransactionReceipt for hash #{hash}. Error: #{inspect(&1)}"
 
-    {:ok, resp} = repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     resp
   end
@@ -289,7 +282,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call zks_L1BatchNumber. Error: #{inspect(&1)}"
 
-    {:ok, resp} = repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     quantity_to_integer(resp)
   end
@@ -318,7 +311,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call eth_getBlockByNumber. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     responses
   end
@@ -347,7 +340,7 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call zks_getL1BatchDetails. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     responses
   end
@@ -377,27 +370,17 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call zks_getL1BatchBlockRange. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     responses
   end
 
-  defp repeated_call(func, args, error_message, retries_left) do
-    case apply(func, args) do
-      {:ok, _} = res ->
-        res
-
-      {:error, message} = err ->
-        retries_left = retries_left - 1
-
-        if retries_left <= 0 do
-          log_error(error_message.(message))
-          err
-        else
-          log_error("#{error_message.(message)} Retrying...")
-          :timer.sleep(3000)
-          repeated_call(func, args, error_message, retries_left)
-        end
+  # Converts a transaction hash represented as binary to a hexadecimal string
+  @spec prepare_tx_hash(binary()) :: binary()
+  defp prepare_tx_hash(raw_hash) do
+    case raw_hash do
+      "0x" <> <<_::binary-size(64)>> -> raw_hash
+      _ -> "0x" <> Base.encode16(raw_hash, case: :lower)
     end
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
@@ -201,7 +201,8 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call zks_getL1BatchDetails. Error: #{inspect(&1)}"
 
-    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} =
+      IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     transform_batch_details_to_map(resp)
   end
@@ -231,7 +232,8 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call eth_getTransactionByHash for hash #{hash}. Error: #{inspect(&1)}"
 
-    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} =
+      IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     resp
   end
@@ -261,7 +263,8 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call eth_getTransactionReceipt for hash #{hash}. Error: #{inspect(&1)}"
 
-    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} =
+      IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     resp
   end
@@ -282,7 +285,8 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
     error_message = &"Cannot call zks_L1BatchNumber. Error: #{inspect(&1)}"
 
-    {:ok, resp} = IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+    {:ok, resp} =
+      IndexerHelper.repeated_call(&json_rpc/2, [req, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
 
     quantity_to_integer(resp)
   end
@@ -311,7 +315,12 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call eth_getBlockByNumber. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(
+        &json_rpc/2,
+        [requests_list, json_rpc_named_arguments],
+        error_message,
+        @rpc_resend_attempts
+      )
 
     responses
   end
@@ -340,7 +349,12 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call zks_getL1BatchDetails. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(
+        &json_rpc/2,
+        [requests_list, json_rpc_named_arguments],
+        error_message,
+        @rpc_resend_attempts
+      )
 
     responses
   end
@@ -370,7 +384,12 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
     error_message = &"Cannot call zks_getL1BatchBlockRange. Error: #{inspect(&1)}"
 
     {:ok, responses} =
-      IndexerHelper.repeated_call(&json_rpc/2, [requests_list, json_rpc_named_arguments], error_message, @rpc_resend_attempts)
+      IndexerHelper.repeated_call(
+        &json_rpc/2,
+        [requests_list, json_rpc_named_arguments],
+        error_message,
+        @rpc_resend_attempts
+      )
 
     responses
   end


### PR DESCRIPTION
## Motivation

There is a bug in the code responsible for getting the transaction body and receipts from L1 when the zkSync batch statuses are being explored. The code tries to match the binary with the expression `"0x" <> _` to identify if a transaction hash is already encoded in hexadecimal form.

Since 32 bytes (in raw form) representing a transaction hash can be anything, there could be a case where the clause above will match even though the transaction hash is not in encoded form.

## Changelog

### Bug Fixes
The fix for this issue is to check the length of the binary sequence so that the hash in its raw form will not match the clause.

Another change is to reuse `repeated_call` function from `Indexer.Helper` in order to reduce the code duplication.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
