### PR TITLE
fix: add preloads to summary and tokens endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -468,7 +468,14 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
   def summary(conn, %{"transaction_hash_param" => transaction_hash_string, "just_request_body" => "true"} = params) do
     with {:tx_interpreter_enabled, true} <- {:tx_interpreter_enabled, TransactionInterpretationService.enabled?()},
-         {:ok, transaction, _transaction_hash} <- validate_transaction(transaction_hash_string, params) do
+         {:ok, transaction, _transaction_hash} <-
+           validate_transaction(transaction_hash_string, params,
+             necessity_by_association: %{
+               [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+               [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+             },
+             api?: true
+           ) do
       conn
       |> json(TransactionInterpretationService.get_request_body(transaction))
     end
@@ -485,7 +492,14 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
           | Plug.Conn.t()
   def summary(conn, %{"transaction_hash_param" => transaction_hash_string} = params) do
     with {:tx_interpreter_enabled, true} <- {:tx_interpreter_enabled, TransactionInterpretationService.enabled?()},
-         {:ok, transaction, _transaction_hash} <- validate_transaction(transaction_hash_string, params) do
+         {:ok, transaction, _transaction_hash} <-
+           validate_transaction(transaction_hash_string, params,
+             necessity_by_association: %{
+               [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+               [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+             },
+             api?: true
+           ) do
       {response, code} =
         case TransactionInterpretationService.interpret(transaction) do
           {:ok, response} -> {response, 200}

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -85,7 +85,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   def token_holders_ordered_by_value(token_contract_address_hash, options \\ []) do
     token_contract_address_hash
     |> token_holders_ordered_by_value_query_without_address_preload(options)
-    |> preload(address: :smart_contract)
+    |> preload(address: [:names, :smart_contract, :proxy_implementations])
   end
 
   @doc """
@@ -131,7 +131,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       _ ->
         token_contract_address_hash
         |> token_holders_by_token_id_query(token_id)
-        |> preload(:address)
+        |> preload(address: [:names, :smart_contract, :proxy_implementations])
         |> order_by([tb], desc: :value, desc: :address_hash)
         |> Chain.page_token_balances(paging_options)
         |> limit(^paging_options.page_size)

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -173,8 +173,8 @@ defmodule Explorer.Chain.TokenTransfer do
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
             :token,
-            [from_address: :smart_contract],
-            [to_address: :smart_contract]
+            [from_address: [:names, :smart_contract, :proxy_implementations]],
+            [to_address: [:names, :smart_contract, :proxy_implementations]]
           ])
 
         only_consensus_transfers_query()
@@ -196,7 +196,13 @@ defmodule Explorer.Chain.TokenTransfer do
         []
 
       _ ->
-        preloads = DenormalizationHelper.extend_transaction_preload([:transaction, :token, :from_address, :to_address])
+        preloads =
+          DenormalizationHelper.extend_transaction_preload([
+            :transaction,
+            :token,
+            [from_address: [:names, :smart_contract, :proxy_implementations]],
+            [to_address: [:names, :smart_contract, :proxy_implementations]]
+          ])
 
         only_consensus_transfers_query()
         |> where([tt], tt.token_contract_address_hash == ^token_address_hash)


### PR DESCRIPTION
## Motivation
500 in `/api/v2/transactions/{}/summary` and `api/v2/tokens/{}/transfers?apikey={}`

## Changelog

Added necessary preloads

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
