### PR TITLE
fix: add preloads for tx summary endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -139,10 +139,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     full_options =
       [
         necessity_by_association: %{
-          [from_address: :smart_contract] => :optional,
-          [to_address: :smart_contract] => :optional,
-          [from_address: :names] => :optional,
-          [to_address: :names] => :optional
+          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)
@@ -158,9 +156,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     log_options =
       [
         necessity_by_association: %{
-          [address: :names] => :optional,
-          [address: :smart_contract] => :optional,
-          address: :optional
+          [address: [:names, :smart_contract, :proxy_implementations]] => :optional
         },
         limit: @items_limit
       ]
@@ -180,10 +176,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     token_transfer_options =
       [
         necessity_by_association: %{
-          [from_address: :smart_contract] => :optional,
-          [to_address: :smart_contract] => :optional,
-          [from_address: :names] => :optional,
-          [to_address: :names] => :optional,
+          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
           :token => :optional
         }
       ]
@@ -203,9 +197,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     full_options =
       [
         necessity_by_association: %{
-          [address: :names] => :optional,
-          [address: :smart_contract] => :optional,
-          address: :optional
+          [address: [:names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)
@@ -253,7 +245,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
           [
             necessity_by_association: %{
               :names => :optional,
-              :smart_contract => :optional
+              :smart_contract => :optional,
+              :proxy_implementations => :optional
             },
             api?: true
           ],

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -169,7 +169,14 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
                  {:ok, address} <-
                    Chain.hash_to_address(
                      w.from,
-                     [necessity_by_association: %{:names => :optional, :smart_contract => :optional}, api?: true],
+                     [
+                       necessity_by_association: %{
+                         :names => :optional,
+                         :smart_contract => :optional,
+                         :proxy_implementations => :optional
+                       },
+                       api?: true
+                     ],
                      false
                    ) do
               {address, address.hash}

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_edge_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_edge_view.ex
@@ -86,7 +86,14 @@ defmodule BlockScoutWeb.API.V2.PolygonEdgeView do
          {:ok, address} <-
            Chain.hash_to_address(
              hash,
-             [necessity_by_association: %{:names => :optional, :smart_contract => :optional}, api?: true],
+             [
+               necessity_by_association: %{
+                 :names => :optional,
+                 :smart_contract => :optional,
+                 :proxy_implementations => :optional
+               },
+               api?: true
+             ],
              false
            ) do
       {address, address.hash}

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
@@ -59,7 +59,11 @@ defmodule BlockScoutWeb.API.V2.ShibariumView do
     |> Enum.reject(&is_nil(&1))
     |> Enum.uniq()
     |> Chain.hashes_to_addresses(
-      necessity_by_association: %{:names => :optional, :smart_contract => :optional},
+      necessity_by_association: %{
+        :names => :optional,
+        :smart_contract => :optional,
+        :proxy_implementations => :optional
+      },
       api?: true
     )
     |> Enum.into(%{}, &{&1.hash, Helper.address_with_info(conn, &1, &1.hash, true)})


### PR DESCRIPTION
## Motivation
Missing preloads in `TransactionInterpretation` module

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
