### PR TITLE
chore: bump elixir to 1.17.3 and Erlang OTP to 27.1

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -4,10 +4,4 @@ lib/explorer/smart_contract/vyper/publisher_worker.ex:1
 lib/explorer/smart_contract/solidity/publisher_worker.ex:8
 lib/explorer/smart_contract/vyper/publisher_worker.ex:8
 lib/phoenix/router.ex:402
-lib/explorer/smart_contract/reader.ex:435
-lib/explorer/exchange_rates/source.ex:139
-lib/explorer/exchange_rates/source.ex:142
-lib/block_scout_web/cldr.ex:1
-lib/block_scout_web/views/api/v2/transaction_view.ex:431
-lib/block_scout_web/views/api/v2/transaction_view.ex:472
-lib/explorer/chain/transaction.ex:171
+lib/explorer/chain/cache/celo_core_contracts.ex:162

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Elixir & Erlang/OTP versions
       description: Elixir & Erlang/OTP versions.
-      placeholder: Elixir 1.16.3 (compiled with Erlang/OTP 26)
+      placeholder: Elixir 1.17.1 (compiled with Erlang/OTP 27)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Elixir & Erlang/OTP versions
       description: Elixir & Erlang/OTP versions.
-      placeholder: Elixir 1.17.1 (compiled with Erlang/OTP 27)
+      placeholder: Elixir 1.17.2 (compiled with Erlang/OTP 27)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,7 +81,7 @@ body:
     attributes:
       label: Elixir & Erlang/OTP versions
       description: Elixir & Erlang/OTP versions.
-      placeholder: Elixir 1.17.2 (compiled with Erlang/OTP 27)
+      placeholder: Elixir 1.17.3 (compiled with Erlang/OTP 27)
     validations:
       required: true
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,8 +32,8 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: ${{ github.ref_name == '9256/merge' && '26.2.5.1' || vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ github.ref_name == '9256/merge' && '1.16.3' || vars.ELIXIR_VERSION }}
+  OTP_VERSION: ${{ github.ref_name == '9256/merge' && '27.0' || vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ github.ref_name == '9256/merge' && '1.17.1' || vars.ELIXIR_VERSION }}
   ACCOUNT_AUTH0_DOMAIN: "blockscoutcom.us.auth0.com"
 
 jobs:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,8 +32,8 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: ${{ github.ref_name == '9256/merge' && '27.0' || vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ github.ref_name == '9256/merge' && '1.17.1' || vars.ELIXIR_VERSION }}
+  OTP_VERSION: ${{ github.ref_name == '10284/merge' && '27.0' || vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ github.ref_name == '10284/merge' && '1.17.1' || vars.ELIXIR_VERSION }}
   ACCOUNT_AUTH0_DOMAIN: "blockscoutcom.us.auth0.com"
 
 jobs:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,8 +32,8 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: ${{ github.ref_name == '10284/merge' && '27.0' || vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ github.ref_name == '10284/merge' && '1.17.1' || vars.ELIXIR_VERSION }}
+  OTP_VERSION: ${{ github.ref_name == '10284/merge' && '27.0.1' || vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ github.ref_name == '10284/merge' && '1.17.2' || vars.ELIXIR_VERSION }}
   ACCOUNT_AUTH0_DOMAIN: "blockscoutcom.us.auth0.com"
 
 jobs:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,8 +32,8 @@ on:
 
 env:
   MIX_ENV: test
-  OTP_VERSION: ${{ github.ref_name == '10284/merge' && '27.0.1' || vars.OTP_VERSION }}
-  ELIXIR_VERSION: ${{ github.ref_name == '10284/merge' && '1.17.2' || vars.ELIXIR_VERSION }}
+  OTP_VERSION: ${{ github.ref_name == '10284/merge' && '27.1' || vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ github.ref_name == '10284/merge' && '1.17.3' || vars.ELIXIR_VERSION }}
   ACCOUNT_AUTH0_DOMAIN: "blockscoutcom.us.auth0.com"
 
 jobs:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.16.3-otp-26
-erlang 26.2.5.1
+elixir 1.17.1-otp-27
+erlang 27.0
 nodejs 18.17.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.17.1-otp-27
-erlang 27.0
+elixir 1.17.2-otp-27
+erlang 27.0.1
 nodejs 18.17.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.17.2-otp-27
-erlang 27.0.1
+elixir 1.17.3-otp-27
+erlang 27.1
 nodejs 18.17.1

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_validation_controller.ex
@@ -91,9 +91,6 @@ defmodule BlockScoutWeb.AddressValidationController do
 
       :error ->
         unprocessable_entity(conn)
-
-      {:error, :not_found} ->
-        not_found(conn)
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -101,17 +101,6 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
 
         render(conn, :error, error: "#{@smth_went_wrong}: #{inspect(error.errors)}")
 
-      {:publish, error} ->
-        Logger.error(fn ->
-          [
-            @smth_went_wrong,
-            ": ",
-            inspect(error)
-          ]
-        end)
-
-        render(conn, :error, error: @smth_went_wrong)
-
       {:format, :error} ->
         render(conn, :error, error: @invalid_address)
 
@@ -142,9 +131,6 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
           else
             {:error, error} ->
               render(conn, :error, error: error)
-
-            _ ->
-              render(conn, :error, error: "Invalid body")
           end
       end
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -217,7 +217,7 @@ defmodule BlockScoutWeb.SmartContractController do
       :error ->
         unprocessable_entity(conn)
 
-      :not_found ->
+      {:error, :not_found} ->
         not_found(conn)
 
       _ ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_controller.ex
@@ -174,12 +174,6 @@ defmodule BlockScoutWeb.TransactionController do
               )
           )
         else
-          :not_found ->
-            set_not_found_view(conn, id)
-
-          :error ->
-            unprocessable_entity(conn)
-
           {:error, :not_found} ->
             set_not_found_view(conn, id)
 
@@ -209,12 +203,6 @@ defmodule BlockScoutWeb.TransactionController do
               )
           )
         else
-          :not_found ->
-            set_not_found_view(conn, id)
-
-          :error ->
-            unprocessable_entity(conn)
-
           {:error, :not_found} ->
             set_not_found_view(conn, id)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_state_controller.ex
@@ -73,9 +73,6 @@ defmodule BlockScoutWeb.TransactionStateController do
 
       {:error, :not_found} ->
         TransactionController.set_not_found_view(conn, transaction_hash_string)
-
-      :not_found ->
-        TransactionController.set_not_found_view(conn, transaction_hash_string)
     end
   end
 
@@ -115,9 +112,6 @@ defmodule BlockScoutWeb.TransactionStateController do
         current_user: current_user(conn)
       )
     else
-      :not_found ->
-        TransactionController.set_not_found_view(conn, transaction_hash_string)
-
       :error ->
         unprocessable_entity(conn)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/transaction_token_transfer_controller.ex
@@ -120,9 +120,6 @@ defmodule BlockScoutWeb.TransactionTokenTransferController do
           )
       )
     else
-      :not_found ->
-        TransactionController.set_not_found_view(conn, transaction_hash_string)
-
       :error ->
         unprocessable_entity(conn)
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address_token_balance/_token_balances.html.eex
@@ -43,7 +43,7 @@
               :token_search,
               :name,
               class: "w-100 dropdown-search-field",
-              'data-filter-dropdown-tokens': true,
+              "data-filter-dropdown-tokens": true,
               placeholder: gettext("Search tokens")
             ) %>
       </div>

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -60,7 +60,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     items =
       batches
       |> Enum.map(fn batch ->
-        from..to = batch.l2_block_range
+        from..to//_ = batch.l2_block_range
 
         %{
           "internal_id" => batch.id,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -270,7 +270,7 @@ defmodule EthereumJSONRPC do
   Fetches blocks by block number range.
   """
   @spec fetch_blocks_by_range(Range.t(), json_rpc_named_arguments) :: {:ok, Blocks.t()} | {:error, reason :: term}
-  def fetch_blocks_by_range(_first.._last = range, json_rpc_named_arguments) do
+  def fetch_blocks_by_range(_first.._last//_ = range, json_rpc_named_arguments) do
     range
     |> Enum.map(fn number -> %{number: number} end)
     |> fetch_blocks_by_params(&Block.ByNumber.request/1, json_rpc_named_arguments)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/ipc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/ipc.ex
@@ -84,7 +84,6 @@ defmodule EthereumJSONRPC.IPC do
     else
       {:error, %Jason.DecodeError{data: ""}} -> {:error, :empty_response}
       {:error, error} -> {:error, {:invalid_json, error}}
-      {:error, error} -> {:error, error}
     end
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -58,7 +58,7 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
 
   defp number_in_ranges?(number, ranges) do
     Enum.reduce_while(ranges, false, fn
-      _from.._to = range, _acc -> if number in range, do: {:halt, true}, else: {:cont, false}
+      _from.._to//_ = range, _acc -> if number in range, do: {:halt, true}, else: {:cont, false}
       num_to_latest, _acc -> if number >= num_to_latest, do: {:halt, true}, else: {:cont, false}
     end)
   end
@@ -78,7 +78,7 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(
       fn
-        from.._to -> from
+        from.._to//_ -> from
         el -> el
       end,
       :asc
@@ -86,10 +86,10 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     |> Enum.chunk_while(
       nil,
       fn
-        _from.._to = chunk, nil ->
+        _from.._to//_ = chunk, nil ->
           {:cont, chunk}
 
-        _ch_from..ch_to = chunk, acc_from..acc_to = acc ->
+        _ch_from..ch_to//_ = chunk, acc_from..acc_to//_ = acc ->
           if Range.disjoint?(chunk, acc),
             do: {:cont, acc, chunk},
             else: {:cont, acc_from..max(ch_to, acc_to)}
@@ -97,7 +97,7 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
         num, nil ->
           {:halt, num}
 
-        num, acc_from.._ = acc ->
+        num, acc_from.._//_ = acc ->
           if Range.disjoint?(num..num, acc), do: {:cont, acc, num}, else: {:halt, acc_from}
 
         _, num ->
@@ -113,7 +113,7 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
   @spec split([Range.t()], integer) :: [Range.t()]
   def split(ranges, size) do
     ranges
-    |> Enum.reduce([], fn from..to = range, acc ->
+    |> Enum.reduce([], fn from..to//_ = range, acc ->
       range_size = Range.size(range)
 
       if range_size > size do

--- a/apps/explorer/lib/explorer/account/watchlist_address.ex
+++ b/apps/explorer/lib/explorer/account/watchlist_address.ex
@@ -112,9 +112,6 @@ defmodule Explorer.Account.WatchlistAddress do
     else
       {:error, reason} ->
         add_error(changeset, :address_hash, reason)
-
-      _ ->
-        add_error(changeset, :address_hash, "Address error")
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2281,15 +2281,15 @@ defmodule Explorer.Chain do
       iex> insert(:block, number: 0)
       iex> insert(:block, number: 2)
       iex> insert(:block, number: 5)
-      iex> Explorer.Chain.missing_block_number_ranges(5..0)
-      [4..3, 1..1]
+      iex> Explorer.Chain.missing_block_number_ranges(5..0//-1)
+      [4..3//-1, 1..1]
 
   If only non-consensus blocks exist for a number, the number still counts as missing.
 
       iex> insert(:block, number: 0)
       iex> insert(:block, number: 1, consensus: false)
       iex> insert(:block, number: 2)
-      iex> Explorer.Chain.missing_block_number_ranges(2..0)
+      iex> Explorer.Chain.missing_block_number_ranges(2..0//-1)
       [1..1]
 
   if range starts with non-consensus block in the middle of the chain, it returns missing numbers.

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2311,7 +2311,7 @@ defmodule Explorer.Chain do
   @spec missing_block_number_ranges(Range.t()) :: [Range.t()]
   def missing_block_number_ranges(range)
 
-  def missing_block_number_ranges(range_start..range_end) do
+  def missing_block_number_ranges(range_start..range_end//_) do
     range_min = min(range_start, range_end)
     range_max = max(range_start, range_end)
 

--- a/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
+++ b/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
@@ -142,9 +142,6 @@ defmodule Explorer.Chain.Cache.CeloCoreContracts do
 
         {:error, :event_name_not_found}
 
-      nil ->
-        {:error, :event_does_not_exist}
-
       {:contract_address, :error} ->
         Logger.error(fn ->
           [

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -809,7 +809,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       block_ranges = RangesHelper.get_trace_block_ranges()
 
       Enum.reduce(block_ranges, dynamic([_], false), fn
-        _from.._to = range, acc -> dynamic([block], ^acc or block.number in ^range)
+        _from.._to//_ = range, acc -> dynamic([block], ^acc or block.number in ^range)
         num_to_latest, acc -> dynamic([block], ^acc or block.number >= ^num_to_latest)
       end)
     else

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1971,7 +1971,7 @@ defmodule Explorer.Chain.Transaction do
     Only consensus blocks are taken into account.
   """
   @spec tx_count_for_block_range(Range.t()) :: non_neg_integer()
-  def tx_count_for_block_range(from..to) do
+  def tx_count_for_block_range(from..to//_) do
     Repo.replica().aggregate(
       from(
         t in Transaction,

--- a/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/sourcify.ex
@@ -399,7 +399,7 @@ defmodule Explorer.ThirdPartyIntegrations.Sourcify do
     trimmed_path =
       path
       |> String.split("/")
-      |> Enum.slice(9..-1)
+      |> Enum.slice(9..-1//-1)
       |> Enum.join("/")
 
     %{

--- a/apps/explorer/lib/explorer/utility/address_contract_code_fetch_attempt.ex
+++ b/apps/explorer/lib/explorer/utility/address_contract_code_fetch_attempt.ex
@@ -25,7 +25,7 @@ defmodule Explorer.Utility.AddressContractCodeFetchAttempt do
   @doc """
   Gets retries number and updated_at for the Explorer.Chain.Address
   """
-  @spec get_retries_number(Hash.Address.t()) :: {non_neg_integer(), DateTime.t()}
+  @spec get_retries_number(Hash.Address.t()) :: {non_neg_integer(), DateTime.t()} | nil
   def get_retries_number(address_hash) do
     __MODULE__
     |> where([address_contract_code_fetch_attempt], address_contract_code_fetch_attempt.address_hash == ^address_hash)

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -55,7 +55,7 @@ defmodule Explorer.Utility.MissingBlockRange do
     |> save_batch()
   end
 
-  def save_range(from..to) do
+  def save_range(from..to//_) do
     min_number = min(from, to)
     max_number = max(from, to)
 
@@ -84,7 +84,7 @@ defmodule Explorer.Utility.MissingBlockRange do
     end
   end
 
-  def delete_range(from..to) do
+  def delete_range(from..to//_) do
     min_number = min(from, to)
     max_number = max(from, to)
 
@@ -294,7 +294,7 @@ defmodule Explorer.Utility.MissingBlockRange do
         number, nil ->
           {:cont, number..number}
 
-        number, first..last when number == last + 1 ->
+        number, first..last//_ when number == last + 1 ->
           {:cont, first..number}
 
         number, range ->

--- a/apps/explorer/lib/fetch_celo_core_contracts.ex
+++ b/apps/explorer/lib/fetch_celo_core_contracts.ex
@@ -156,10 +156,10 @@ defmodule Mix.Tasks.FetchCeloCoreContracts do
     IO.puts("CELO_CORE_CONTRACTS=#{core_contracts_json}")
   end
 
-  defp fetch_logs_by_chunks(from_block..to_block, requests_func, json_rpc_named_arguments) do
+  defp fetch_logs_by_chunks(from_block..to_block//_, requests_func, json_rpc_named_arguments) do
     from_block..to_block
     |> IndexerHelper.range_chunk_every(@chunk_size)
-    |> Enum.reduce([], fn chunk_start..chunk_end, acc ->
+    |> Enum.reduce([], fn chunk_start..chunk_end//_, acc ->
       IndexerHelper.log_blocks_chunk_handling(chunk_start, chunk_end, 0, to_block, nil, :L1)
 
       requests = requests_func.(chunk_start, chunk_end)

--- a/apps/explorer/test/explorer/chain/address_test.exs
+++ b/apps/explorer/test/explorer/chain/address_test.exs
@@ -72,7 +72,7 @@ defmodule Explorer.Chain.AddressTest do
 
     test "with top addresses in order" do
       address_hashes =
-        4..1
+        4..1//-1
         |> Enum.map(&insert(:address, fetched_coin_balance: &1))
         |> Enum.map(& &1.hash)
 

--- a/apps/explorer/test/explorer/chain_spec/parity/importer_test.exs
+++ b/apps/explorer/test/explorer/chain_spec/parity/importer_test.exs
@@ -108,9 +108,9 @@ defmodule Explorer.ChainSpec.Parity.ImporterTest do
       assert %{
                address_hash: %Hash{
                  byte_count: 20,
-                 bytes: <<167, 105, 41, 137, 10, 123, 71, 251, 133, 145, 150, 1, 108, 111, 221, 130, 137, 206, 183, 85>>
+                 bytes: <<25, 104, 125, 170, 57, 195, 104, 19, 155, 110, 123, 230, 13, 193, 117, 58, 159, 12, 190, 163>>
                },
-               value: 5_000_000_000_000_000_000_000,
+               value: 8_000_000_000_000_000_000_000,
                contract_code: nil,
                nonce: 0
              } ==

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -58,8 +58,8 @@ defmodule Indexer.Block.Catchup.Fetcher do
         }
 
       missing_ranges ->
-        first.._ = List.first(missing_ranges)
-        _..last = List.last(missing_ranges)
+        first.._//_ = List.first(missing_ranges)
+        _..last//_ = List.last(missing_ranges)
 
         Logger.metadata(first_block_number: first, last_block_number: last)
 
@@ -165,7 +165,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
             )
   defp fetch_and_import_missing_range(
          %__MODULE__{block_fetcher: %Block.Fetcher{} = block_fetcher},
-         first..last = range
+         first..last//_ = range
        ) do
     Logger.metadata(fetcher: :block_catchup, first_block_number: first, last_block_number: last)
     Process.flag(:trap_exit, true)
@@ -270,7 +270,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
         number, nil ->
           {:cont, number..number}
 
-        number, first..last when number == last - 1 ->
+        number, first..last//_ when number == last - 1 ->
           {:cont, first..number}
 
         number, range ->

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -60,7 +60,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
 
     ranges
     |> Enum.reverse()
-    |> Enum.flat_map(fn f..l -> Chain.missing_block_number_ranges(l..f) end)
+    |> Enum.flat_map(fn f..l//_ -> Chain.missing_block_number_ranges(l..f) end)
     |> MissingRangesManipulator.save_batch()
 
     if not is_nil(max_fetched_block_number) do
@@ -246,7 +246,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
       |> RangesHelper.sanitize_ranges()
 
     case List.last(ranges) do
-      _from.._to ->
+      _from.._to//_ ->
         {:finite_ranges, ranges}
 
       nil ->

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -137,7 +137,7 @@ defmodule Indexer.Block.Fetcher do
           callback_module: callback_module,
           json_rpc_named_arguments: json_rpc_named_arguments
         } = state,
-        _.._ = range,
+        _.._//_ = range,
         additional_options \\ %{}
       )
       when callback_module != nil do

--- a/apps/indexer/lib/indexer/bound_interval.ex
+++ b/apps/indexer/lib/indexer/bound_interval.ex
@@ -8,7 +8,7 @@ defmodule Indexer.BoundInterval do
             current: 1,
             maximum: nil
 
-  def within(minimum..maximum) when is_integer(minimum) and is_integer(maximum) and minimum <= maximum do
+  def within(minimum..maximum//_) when is_integer(minimum) and is_integer(maximum) and minimum <= maximum do
     %__MODULE__{minimum: minimum, current: minimum, maximum: maximum}
   end
 

--- a/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
@@ -133,7 +133,7 @@ defmodule Indexer.Fetcher.Celo.ValidatorGroupVotes do
     end
   end
 
-  defp process_chunk(_..chunk_to_block = chunk, block_range, json_rpc_named_arguments) do
+  defp process_chunk(_..chunk_to_block//_ = chunk, block_range, json_rpc_named_arguments) do
     validator_group_votes =
       chunk
       |> fetch_logs_chunk(block_range, json_rpc_named_arguments)
@@ -156,8 +156,8 @@ defmodule Indexer.Fetcher.Celo.ValidatorGroupVotes do
   end
 
   defp fetch_logs_chunk(
-         chunk_from_block..chunk_to_block,
-         from_block..to_block,
+         chunk_from_block..chunk_to_block//_,
+         from_block..to_block//_,
          json_rpc_named_arguments
        ) do
     IndexerHelper.log_blocks_chunk_handling(chunk_from_block, chunk_to_block, from_block, to_block, nil, :L1)

--- a/apps/indexer/lib/indexer/fetcher/optimism/txn_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/txn_batch.ex
@@ -96,7 +96,8 @@ defmodule Indexer.Fetcher.Optimism.TxnBatch do
            {:reorg_monitor_started, !is_nil(Process.whereis(RollupL1ReorgMonitor))},
          {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(optimism_l1_rpc)},
          json_rpc_named_arguments = Optimism.json_rpc_named_arguments(optimism_l1_rpc),
-         {start_block_l1, batch_inbox, batch_submitter} = read_system_config(system_config, json_rpc_named_arguments),
+         {:system_config_read, {start_block_l1, batch_inbox, batch_submitter}} <-
+           {:system_config_read, read_system_config(system_config, json_rpc_named_arguments)},
          {:batch_inbox_valid, true} <- {:batch_inbox_valid, Helper.address_correct?(batch_inbox)},
          {:batch_submitter_valid, true} <-
            {:batch_submitter_valid, Helper.address_correct?(batch_submitter)},
@@ -179,7 +180,7 @@ defmodule Indexer.Fetcher.Optimism.TxnBatch do
 
         {:stop, :normal, state}
 
-      nil ->
+      {:system_config_read, nil} ->
         Logger.error("Cannot read SystemConfig contract.")
         {:stop, :normal, state}
 

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -220,7 +220,7 @@ defmodule Indexer.Helper do
       [1..3, 4..6, 7..9, 10..10]
   """
   @spec range_chunk_every(Range.t(), non_neg_integer()) :: Enum.t()
-  def range_chunk_every(from..to, chunk_size) do
+  def range_chunk_every(from..to//_, chunk_size) do
     chunks_number = floor((to - from + 1) / chunk_size)
 
     0..chunks_number

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM hexpm/elixir:1.16.3-erlang-26.2.5.1-alpine-3.18.7 AS builder
 WORKDIR /app
 
 ENV MIX_ENV="prod"
+ENV ERL_FLAGS="+JPperf fp"
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3 file gcompat
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM hexpm/elixir:1.16.3-erlang-26.2.5.1-alpine-3.18.7 AS builder
 WORKDIR /app
 
 ENV MIX_ENV="prod"
-ENV ERL_FLAGS="+JPperf fp"
 
 RUN apk --no-cache --update add alpine-sdk gmp-dev automake libtool inotify-tools autoconf python3 file gcompat
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.16.3-erlang-26.2.5.1-alpine-3.18.7 AS builder
+FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6 AS builder
 
 WORKDIR /app
 
@@ -70,7 +70,7 @@ RUN mkdir -p /opt/release \
   && mv _build/${MIX_ENV}/rel/blockscout /opt/release
 
 ##############################################################
-FROM hexpm/elixir:1.16.3-erlang-26.2.5.1-alpine-3.18.7
+FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6
 
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6 AS builder
+FROM hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.18.7 AS builder
 
 WORKDIR /app
 
@@ -70,7 +70,7 @@ RUN mkdir -p /opt/release \
   && mv _build/${MIX_ENV}/rel/blockscout /opt/release
 
 ##############################################################
-FROM hexpm/elixir:1.17.1-erlang-27.0-alpine-3.18.6
+FROM hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.18.7
 
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.18.7 AS builder
+FROM hexpm/elixir:1.17.3-erlang-27.1-alpine-3.20.3 AS builder
 
 WORKDIR /app
 
@@ -70,7 +70,7 @@ RUN mkdir -p /opt/release \
   && mv _build/${MIX_ENV}/rel/blockscout /opt/release
 
 ##############################################################
-FROM hexpm/elixir:1.17.2-erlang-27.0.1-alpine-3.18.7
+FROM hexpm/elixir:1.17.3-erlang-27.1-alpine-3.20.3
 
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=${RELEASE_VERSION}


### PR DESCRIPTION
## Changelog

* Migrate to the latest elixir stack versions:
  * Elixir 1.17.3
  * Erlang OTP 27.1
* Fix various compilation/linter/credo/dialyzer warnings

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
