### PR TITLE
fix: add token instances preloads

### DIFF
--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -142,6 +142,17 @@ defmodule Explorer.Chain.Address do
     |> unique_constraint(:hash)
   end
 
+  @spec get(Hash.Address.t(), [Chain.necessity_by_association_option() | Chain.api?()]) :: t() | nil
+  def get(hash, options) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+    query = from(address in Address, where: address.hash == ^hash)
+
+    query
+    |> Chain.join_associations(necessity_by_association)
+    |> Chain.select_repo(options).one()
+  end
+
   def checksum(address_or_hash, iodata? \\ false)
 
   def checksum(nil, _iodata?), do: ""


### PR DESCRIPTION
## Motivation

```
{"time":"2024-06-20T10:46:10.881Z","severity":"error","message": "#PID<0.25537.554> running BlockScoutWeb.Endpoint (connection #PID<0.25555.554>, stream id 1) terminated\nServer: eth-sepolia.k8s-dev.blockscout.com:80 (http)\nRequest: GET /api/v2/tokens/0xcE818599DaBa7e1e7B1bcc1Ce0607010ff4e0B83/instances\n** (exit) an exception was raised:\n    ** (RuntimeError) proxy_implementations is not loaded for address\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:61: BlockScoutWeb.API.V2.Helper.address_with_info/2\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:35: BlockScoutWeb.API.V2.Helper.address_with_info/5\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/token_view.ex:110: BlockScoutWeb.API.V2.TokenView.prepare_token_instance/2\n        (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n        (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/token_view.ex:72: BlockScoutWeb.API.V2.TokenView.render/2\n        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3\n        (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4","metadata":{"error":{"initial_call":null,"reason":"** (RuntimeError) proxy_implementations is not loaded for address\n    (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:61: BlockScoutWeb.API.V2.Helper.address_with_info/2\n    (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:35: BlockScoutWeb.API.V2.Helper.address_with_info/5\n    (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/token_view.ex:110: BlockScoutWeb.API.V2.TokenView.prepare_token_instance/2\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/token_view.ex:72: BlockScoutWeb.API.V2.TokenView.render/2\n    (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3\n    (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4\n"}}}
```

## Changelog

add necessary preloads to token instances endpoint 

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
