### PR TITLE
perf: Speed-up query execution for weekly_new_token_transfers_number_query

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics/queries.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain.Metrics.Queries do
       distinct: 2,
       from: 2,
       join: 4,
+      join: 5,
       select: 3,
       subquery: 1,
       union: 2,
@@ -127,7 +128,7 @@ defmodule Explorer.Chain.Metrics.Queries do
   @spec weekly_new_token_transfers_number_query() :: Ecto.Query.t()
   def weekly_new_token_transfers_number_query do
     TokenTransfer
-    |> join(:inner, [tt], block in assoc(tt, :block))
+    |> join(:inner, [tt], block in Block, on: block.number == tt.block_number)
     |> where([tt, block], block.timestamp >= ago(7, "day"))
     |> where([tt, block], block.consensus == true)
     |> select([tt, block], fragment("COUNT(*)"))


### PR DESCRIPTION
## Motivation

<img width="1183" alt="Screenshot 2024-06-20 at 14 12 31" src="https://github.com/blockscout/blockscout/assets/4341812/5ef8fe3f-0d3b-49ff-bae2-b576cf3fdb59">

```
eth_sepolia=> EXPLAIN SELECT COUNT(*)
  FROM "token_transfers" AS t0 INNER JOIN "blocks" AS b1 ON b1."hash" = t0."block_hash"
 WHERE (b1."timestamp" >= now()::timestamp - interval '7 days') AND (b1."consensus" = true);
                                                           QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=16222495.56..16222495.57 rows=1 width=8)
   ->  Gather  (cost=16222495.34..16222495.55 rows=2 width=8)
         Workers Planned: 2
         ->  Partial Aggregate  (cost=16221495.34..16221495.35 rows=1 width=8)
               ->  Parallel Hash Join  (cost=75404.73..16219207.30 rows=915218 width=0)
                     Hash Cond: (t0.block_hash = b1.hash)
                     ->  Parallel Seq Scan on token_transfers t0  (cost=0.00..15625808.47 rows=197330947 width=33)
                     ->  Parallel Hash  (cost=75258.26..75258.26 rows=11718 width=33)
                           ->  Parallel Bitmap Heap Scan on blocks b1  (cost=828.36..75258.26 rows=11718 width=33)
                                 Recheck Cond: ("timestamp" >= ((now())::timestamp without time zone - '7 days'::interval))
                                 Filter: consensus
                                 ->  Bitmap Index Scan on blocks_timestamp_index  (cost=0.00..821.33 rows=28385 width=0)
                                       Index Cond: ("timestamp" >= ((now())::timestamp without time zone - '7 days'::interval))
```

## Changelog

Change join to blocks by `hash` to `number`.

```
eth_sepolia=> EXPLAIN SELECT COUNT(*)
  FROM "token_transfers" AS t0 INNER JOIN "blocks" AS b1 ON b1."number" = t0."block_number"
 WHERE (b1."timestamp" >= now()::timestamp - interval '7 days') AND (b1."consensus" = true);
                                                                   QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=10590087.05..10590087.06 rows=1 width=8)
   ->  Gather  (cost=10590086.84..10590087.05 rows=2 width=8)
         Workers Planned: 2
         ->  Partial Aggregate  (cost=10589086.84..10589086.85 rows=1 width=8)
               ->  Nested Loop  (cost=828.93..10586798.79 rows=915218 width=0)
                     ->  Parallel Bitmap Heap Scan on blocks b1  (cost=828.36..75258.26 rows=11718 width=8)
                           Recheck Cond: ("timestamp" >= ((now())::timestamp without time zone - '7 days'::interval))
                           Filter: consensus
                           ->  Bitmap Index Scan on blocks_timestamp_index  (cost=0.00..821.33 rows=28385 width=0)
                                 Index Cond: ("timestamp" >= ((now())::timestamp without time zone - '7 days'::interval))
                     ->  Index Only Scan using token_transfers_block_number_index on token_transfers t0  
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
