### PR TITLE
fix: token instance preload

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -366,7 +366,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     case Chain.nft_instance_from_token_id_and_token_address(token_id, address_hash, @api_true) do
       {:ok, token_instance} ->
         token_instance
-        |> Chain.select_repo(@api_true).preload([:owner])
+        |> Chain.select_repo(@api_true).preload(owner: [:names, :smart_contract, :proxy_implementations])
         |> Chain.put_owner_to_token_instance(token, @api_true)
 
       {:error, :not_found} ->

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4388,7 +4388,7 @@ defmodule Explorer.Chain do
         owner_address_hash,
         options
         |> Keyword.merge(
-          necessity_by_association: %{[owner: [:names, :smart_contract, :proxy_implementations]] => :optional}
+          necessity_by_association: %{names: :optional, smart_contract: :optional, proxy_implementations: :optional}
         )
       )
 


### PR DESCRIPTION
## Motivation

```
{"time":"2024-06-20T10:46:10.881Z","severity":"error","message": "#PID[0.25537.554](https://app.slack.com/client/0.25537.554) running BlockScoutWeb.Endpoint (connection #PID[0.25555.554](https://app.slack.com/client/0.25555.554), stream id 1) terminated\nServer: [eth-sepolia.k8s-dev.blockscout.com:80](http://eth-sepolia.k8s-dev.blockscout.com/) (http)\nRequest: GET /api/v2/tokens/0xcE818599DaBa7e1e7B1bcc1Ce0607010ff4e0B83/instances\n** (exit) an exception was raised:\n    ** (RuntimeError) proxy_implementations is not loaded for address\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:61: BlockScoutWeb.API.V2.Helper.address_with_info/2\n        (block_scout_web 6.7.0) lib/block_scout_web/views/api/v2/helper.ex:35: BlockScoutWeb.API.V2.Helper.address_with_info/5\n        (block_scout_web 6.7.0) lib/bl…
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
