### PR TITLE
fix: missing onlyTopCall option on some geth networks

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -69,15 +69,20 @@ defmodule EthereumJSONRPC.Geth do
            id_to_params
            |> debug_trace_transaction_requests(true)
            |> json_rpc(json_rpc_named_arguments_corrected_timeout),
-         {:ok, [first_trace]} <-
+         {:ok, traces} <-
            debug_trace_transaction_responses_to_internal_transactions_params(
              responses,
              id_to_params,
              json_rpc_named_arguments_corrected_timeout
            ) do
-      %{block_hash: block_hash} = transactions_params |> Enum.at(0)
+      case {traces, transactions_params} do
+        {[%{} = first_trace | _], [%{block_hash: block_hash} | _]} ->
+          {:ok,
+           [%{first_trace: first_trace, block_hash: block_hash, json_rpc_named_arguments: json_rpc_named_arguments}]}
 
-      {:ok, [%{first_trace: first_trace, block_hash: block_hash, json_rpc_named_arguments: json_rpc_named_arguments}]}
+        _ ->
+          {:error, :not_found}
+      end
     end
   end
 


### PR DESCRIPTION
Closes #10251
Closes #10276

## Changelog

### Bug Fixes

Fix revert reasons behavior in Geth's `fetch_first_trace` implementation on networks without support for `onlyTopCall`. New code ignores any extra received traces, or fallback to `eth_call` revert reason resolution if something when wrong.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
