### PR TITLE
fix: Fix bridged tokens

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -48,6 +48,8 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   end
 
   if Application.compile_env(:explorer, Explorer.Chain.BridgedToken)[:enabled] do
+    alias Explorer.Repo
+
     defp token_response(conn, token, address_hash) do
       if token.bridged do
         bridged_token = Repo.get_by(BridgedToken, home_token_contract_address_hash: address_hash)


### PR DESCRIPTION
## Motivation
`** (UndefinedFunctionError) function Repo.get_by/2 is undefined (module Repo is not available)`

## Changelog
- Add alias of Repo

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
