### PR TITLE
fix: Filter out internal transactions belonging to reorg

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -778,7 +778,8 @@ defmodule Explorer.Chain.InternalTransaction do
     from(
       child in query,
       inner_join: transaction in assoc(child, :transaction),
-      where: transaction.hash == ^hash
+      where: transaction.hash == ^hash,
+      where: child.block_hash == transaction.block_hash
     )
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10281