### PR TITLE
fix: proper handling of Arbitrum transactions without gas_used_for_l1

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -385,9 +385,11 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
           optional(any()) => any()
         }) :: map()
   defp extend_with_transaction_info(out_json, %Transaction{} = arbitrum_tx) do
-    # These checks are only needed for the case when the module is compiled with
-    # chain_type different from "arbitrum"
-    gas_used_for_l1 = Map.get(arbitrum_tx, :gas_used_for_l1, 0)
+    # Map.get is only needed for the case when the module is compiled with
+    # chain_type different from "arbitrum", `|| 0` is used to avoid nil values
+    # for the transaction prior to the migration to Arbitrum specific BS build.
+    gas_used_for_l1 = Map.get(arbitrum_tx, :gas_used_for_l1, 0) || 0
+
     gas_used = Map.get(arbitrum_tx, :gas_used, 0)
     gas_price = Map.get(arbitrum_tx, :gas_price, 0)
 


### PR DESCRIPTION
## Motivation

For transactions indexed before the Arbitrum-specific changes were deployed, the `api/v2/transactions/{tx_hash}` endpoint raises an error:
```
Request: GET /api/v2/transactions/0xf863e6b2b655e51e4e9f148c646b3d022125e7fc7277476f623510263beb8f54
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Decimal.decimal/1
        (decimal 2.1.1) lib/decimal.ex:1910: Decimal.decimal(nil)
        (decimal 2.1.1) lib/decimal.ex:302: Decimal.sub/2
        (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/arbitrum_view.ex:396: BlockScoutWeb.API.V2.ArbitrumView.extend_with_transaction_info/2
        (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/arbitrum_view.ex:161: BlockScoutWeb.API.V2.ArbitrumView.extend_transaction_json_response/2
        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
        (block_scout_web 6.7.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.action/2
        (block_scout_web 6.7.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.phoenix_controller_pipeline/2
```

## Changeling

### Bug Fixes

It makes sense to handle the value `nil` in the field `gas_used_for_l1` when the Arbitrum-specific information is being rendered for the transaction view. In such cases, it will be considered as `0`. The back filler for already indexed block transactions will be prepared in a separate PR.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
