### PR TITLE
fix: reth compatibility

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/log.ex
@@ -174,9 +174,8 @@ defmodule EthereumJSONRPC.Log do
     end
   end
 
-  # zkSync specific log fields
-  defp entry_to_elixir({key, _}) when key in ~w(l1BatchNumber logType) do
-    {nil, nil}
+  defp entry_to_elixir(_) do
+    {:ignore, :ignore}
   end
 
   defp put_topics(params, topics) when is_map(params) and is_list(topics) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -673,13 +673,8 @@ defmodule EthereumJSONRPC.Transaction do
     end
   end
 
-  # ZkSync fields
-  defp entry_to_elixir({key, _}) when key in ~w(l1BatchNumber l1BatchTxIndex) do
-    {:ignore, :ignore}
-  end
-
   defp entry_to_elixir(_) do
-    {nil, nil}
+    {:ignore, :ignore}
   end
 
   def put_if_present(result, transaction, keys) do


### PR DESCRIPTION
Supersedes #10085

## Motivation

We should ignore unknown fields in json rpc response parsers by default, as it's unfeasible to keep up with api spec changes across all json rpc implementations.

This PR just fixes the reth compatibility problem, the separate issue is created for refactoring the rest of the parsers - #10334.

## Changelog

### Bug Fixes
* Fix reth compatibility

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
