### PR TITLE
fix: Don't execute update missing_balance_of_tokens query for empty list

### DIFF
--- a/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
+++ b/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
@@ -46,6 +46,8 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
   Set currently_implemented: true for all provided token contract address hashes
   """
   @spec mark_as_implemented([Hash.Address.t()]) :: {non_neg_integer(), nil | [term()]}
+  def mark_as_implemented([]), do: :ok
+
   def mark_as_implemented(token_contract_address_hashes) do
     __MODULE__
     |> where([mbot], mbot.token_contract_address_hash in ^token_contract_address_hashes)


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10018