### PR TITLE
fix: Fix slow internal transactions query

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -576,8 +576,10 @@ defmodule Explorer.Chain.InternalTransaction do
   """
   def where_nonpending_block(query \\ nil) do
     (query || __MODULE__)
-    |> join(:left, [it], pending in assoc(it, :pending_block), as: :pending)
-    |> where([it, pending: pending], is_nil(pending.block_hash))
+    |> where(
+      [it],
+      fragment("(SELECT block_hash FROM pending_block_operations WHERE block_hash = ? LIMIT 1) IS NULL", it.block_hash)
+    )
   end
 
   def internal_transactions_to_raw(internal_transactions) when is_list(internal_transactions) do


### PR DESCRIPTION
Closes #10202 

## Changelog
- Replace `pending_block_operations` join with `WHERE (SELECT ...) IS NOT NULL`

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
