### PR TITLE
fix: public metrics enabling

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics.ex
+++ b/apps/explorer/lib/explorer/chain/metrics.ex
@@ -18,10 +18,8 @@ defmodule Explorer.Chain.Metrics do
     :weekly_verified_smart_contracts_number,
     :weekly_new_addresses_number,
     :weekly_new_tokens_number,
-    :weekly_new_token_transfers_number
-    # todo; this metric causes increasing of AccessShareLocks
-    # which increases DB loading. Disabling this metric for now.
-    # :weekly_active_addresses_number
+    :weekly_new_token_transfers_number,
+    :weekly_simplified_active_addresses_number
   ]
 
   @spec start_link(term()) :: GenServer.on_start()

--- a/apps/explorer/lib/explorer/chain/metrics.ex
+++ b/apps/explorer/lib/explorer/chain/metrics.ex
@@ -30,7 +30,7 @@ defmodule Explorer.Chain.Metrics do
   end
 
   def init(_) do
-    if Application.get_env(:explorer, __MODULE__, :disabled?) do
+    if Application.get_env(:explorer, __MODULE__)[:disabled?] do
       :ignore
     else
       send(self(), :set_metrics)

--- a/apps/explorer/lib/explorer/chain/metrics/queries.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Metrics.Queries do
 
   alias Explorer.Chain.{
     Address,
+    Block,
     DenormalizationHelper,
     InternalTransaction,
     SmartContract,

--- a/apps/explorer/lib/explorer/chain/metrics/queries.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries.ex
@@ -136,7 +136,27 @@ defmodule Explorer.Chain.Metrics.Queries do
   end
 
   @doc """
-  Retrieves the query for the number of active EOA and smart-contract addresses in the current week.
+  Retrieves the query for the number of addresses initiated transactions in the current week.
+  """
+  @spec weekly_simplified_active_addresses_number_query() :: Ecto.Query.t()
+  def weekly_simplified_active_addresses_number_query do
+    if DenormalizationHelper.transactions_denormalization_finished?() do
+      Transaction
+      |> where([tx], tx.block_timestamp >= ago(7, "day"))
+      |> where([tx], tx.block_consensus == true)
+      |> select([tx], fragment("COUNT(DISTINCT(?))", tx.from_address_hash))
+    else
+      Transaction
+      |> join(:inner, [tx], block in assoc(tx, :block))
+      |> where([tx, block], block.timestamp >= ago(7, "day"))
+      |> where([tx, block], block.consensus == true)
+      |> select([tx], fragment("COUNT(DISTINCT(?))", tx.from_address_hash))
+    end
+  end
+
+  @doc """
+  Retrieves the query for the number of active EOA and smart-contract addresses (from/to/contract participated in transactions, internal transactions, token transfers) in the current week.
+  This query is currently unused since the very low performance: it doesn't return results in 1 hour.
   """
   @spec weekly_active_addresses_number_query() :: Ecto.Query.t()
   def weekly_active_addresses_number_query do

--- a/apps/explorer/lib/explorer/prometheus/instrumenter.ex
+++ b/apps/explorer/lib/explorer/prometheus/instrumenter.ex
@@ -49,13 +49,11 @@ defmodule Explorer.Prometheus.Instrumenter do
     registry: :public
   ]
 
-  # todo; this metric causes increasing of AccessShareLocks
-  # which increases DB loading. Disabling this metric for now.
-  # @gauge [
-  #   name: :weekly_active_addresses_number,
-  #   help: "Number of active EOA addresses (participated in transactions in to/from) in the last 7 days",
-  #   registry: :public
-  # ]
+  @gauge [
+    name: :weekly_active_addresses_number,
+    help: "Number of active EOA addresses (participated in transactions in to/from) in the last 7 days",
+    registry: :public
+  ]
 
   def block_import_stage_runner(function, stage, runner, step) do
     {time, result} = :timer.tc(function)
@@ -89,9 +87,7 @@ defmodule Explorer.Prometheus.Instrumenter do
     Gauge.set([name: :weekly_new_token_transfers_number, registry: :public], number)
   end
 
-  # todo; this metric causes increasing of AccessShareLocks
-  # which increases DB loading. Disabling this metric for now.
-  # def weekly_active_addresses_number(number) do
-  #   Gauge.set([name: :weekly_active_addresses_number, registry: :public], number)
-  # end
+  def weekly_simplified_active_addresses_number(number) do
+    Gauge.set([name: :weekly_active_addresses_number, registry: :public], number)
+  end
 end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10279
Related to https://github.com/blockscout/blockscout/pull/10063

## Motivation

Public metrics are not calculated despite they are being enabled.

## Changelog

- Fix condition to enable calculation of public metrics
- Add a simplified query to calculate and enable "Active accounts" metric back.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
