### PR TITLE
fix: Add rescue on tx revert reason fetching

### DIFF
--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -2,12 +2,9 @@ name: Publish regular Docker image on demand
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - np-hf-revert-reason-1
 env:
-  OTP_VERSION: 25.3.2.8
-  ELIXIR_VERSION: 1.14.5
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
   RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
 
 jobs:

--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -1,0 +1,108 @@
+name: Publish regular Docker image on demand
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - np-hf-revert-reason-1
+env:
+  OTP_VERSION: 25.3.2.8
+  ELIXIR_VERSION: 1.14.5
+  RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+
+      - name: Build and push Docker image (indexer + API)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          cache-from: type=registry,ref=blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          tags: blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_WEBAPP=false
+            API_V1_READ_METHODS_DISABLED=false
+            API_V1_WRITE_METHODS_DISABLED=false
+            CACHE_EXCHANGE_RATES_PERIOD=
+            CACHE_TOTAL_GAS_USAGE_COUNTER_ENABLED=
+            CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            ADMIN_PANEL_ENABLED=false
+            DECODE_NOT_A_CONTRACT_CALLS=false
+            MIXPANEL_URL=
+            MIXPANEL_TOKEN=
+            AMPLITUDE_URL=
+            AMPLITUDE_API_KEY=
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+
+      - name: Build and push Docker image (indexer)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            DISABLE_WEBAPP=true
+            CACHE_EXCHANGE_RATES_PERIOD=
+            CACHE_TOTAL_GAS_USAGE_COUNTER_ENABLED=
+            CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            ADMIN_PANEL_ENABLED=false
+            DECODE_NOT_A_CONTRACT_CALLS=false
+            MIXPANEL_URL=
+            MIXPANEL_TOKEN=
+            AMPLITUDE_URL=
+            AMPLITUDE_API_KEY=
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+
+      - name: Build and push Docker image (API)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}-api
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_INDEXER=true
+            DISABLE_WEBAPP=true
+            CACHE_EXCHANGE_RATES_PERIOD=
+            CACHE_TOTAL_GAS_USAGE_COUNTER_ENABLED=
+            CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
+            ADMIN_PANEL_ENABLED=false
+            DECODE_NOT_A_CONTRACT_CALLS=false
+            MIXPANEL_URL=
+            MIXPANEL_TOKEN=
+            AMPLITUDE_URL=
+            AMPLITUDE_API_KEY=
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -518,6 +518,9 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
           render(__MODULE__, "revert_reason.json", raw: hex)
       end
     end
+  rescue
+    _ ->
+      nil
   end
 
   @doc """


### PR DESCRIPTION
## Motivation
```
{"time":"2024-07-01T11:27:25.102Z","severity":"error","message":"#PID<0.16749.440> running BlockScoutWeb.Endpoint (connection #PID<0.14932.440>, stream id 1) terminated\nServer: explorer.evm.shimmer.network:80 (http)\nRequest: GET /api/v2/transactions?block_number=5132212&index=0&items_count=200&filter=validated\n** (exit) an exception was raised:\n    ** (MatchError) no match of right hand side value: {:error, [%{code: -32601, message: \"the method debug_traceBlockByNumber does not exist/is not available\"}]}\n        (explorer 6.7.1) lib/explorer/chain.ex:4924: Explorer.Chain.get_block_index/1\n        (explorer 6.7.1) lib/explorer/chain.ex:4884: Explorer.Chain.format_tx_first_trace/3\n        (explorer 6.7.1) lib/explorer/chain.ex:2995: Explorer.Chain.fetch_tx_revert_reason/1\n        (block_scout_web 6.7.1) lib/block_scout_web/views/transaction_view.ex:354: BlockScoutWeb.TransactionView.transaction_revert_reason/2\n        (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/transaction_view.ex:508: BlockScoutWeb.API.V2.TransactionView.revert_reason/2\n        (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/transaction_view.ex:403: BlockScoutWeb.API.V2.TransactionView.prepare_transaction/6\n        (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n        (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2","metadata":{"error":{"initial_call":null,"reason":"** (MatchError) no match of right hand side value: {:error, [%{code: -32601, message: \"the method debug_traceBlockByNumber does not exist/is not available\"}]}\n    (explorer 6.7.1) lib/explorer/chain.ex:4924: Explorer.Chain.get_block_index/1\n    (explorer 6.7.1) lib/explorer/chain.ex:4884: Explorer.Chain.format_tx_first_trace/3\n    (explorer 6.7.1) lib/explorer/chain.ex:2995: Explorer.Chain.fetch_tx_revert_reason/1\n    (block_scout_web 6.7.1) lib/block_scout_web/views/transaction_view.ex:354: BlockScoutWeb.TransactionView.transaction_revert_reason/2\n    (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/transaction_view.ex:508: BlockScoutWeb.API.V2.TransactionView.revert_reason/2\n    (block_scout_web 6.7.1) lib/block_scout_web/views/api/v2/transaction_view.ex:403: BlockScoutWeb.API.V2.TransactionView.prepare_transaction/6\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n    (elixir 1.14.5) lib/enum.ex:1658: Enum.\"-map/2-lists^map/1-0-\"/2\n"}}}
```
## Changelog
- Add rescue on tx revert reason preparing


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
