### PR TITLE
fix: Apply Ecto set explicit ssl_opts: [verify: :verify_none] to all prod repos

### DIFF
--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -4,69 +4,85 @@ import Config
 config :explorer, Explorer.Repo,
   prepare: :unnamed,
   timeout: :timer.seconds(60),
-  migration_lock: nil
+  migration_lock: nil,
+  ssl_opts: [verify: :verify_none]
 
 # Configures API the database
 config :explorer, Explorer.Repo.Replica1,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 # Configures Account database
 config :explorer, Explorer.Repo.Account,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Optimism,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.PolygonEdge,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.PolygonZkevm,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.ZkSync,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.RSK,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Shibarium,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Suave,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Beacon,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Arbitrum,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.BridgedTokens,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Filecoin,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Stability,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Repo.Mud,
   prepare: :unnamed,
-  timeout: :timer.seconds(60)
+  timeout: :timer.seconds(60),
+  ssl_opts: [verify: :verify_none]
 
 config :explorer, Explorer.Tracer, env: "production", disabled?: true
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/9256

## Motivation

Error while running DB migrations in prod env:
```
{"time":"2024-07-02T13:56:58.020Z","severity":"warn","message":"setting ssl: true on your database connection offers only limited protection, as the server's certificate is not verified. Set \"ssl: [cacertfile: path/to/file]\" instead","metadata":{}}
{"time":"2024-07-02T13:56:58.025Z","severity":"error","message":"Postgrex.Protocol (#PID<0.211.0>) failed to connect: ** (DBConnection.ConnectionError) ssl connect: Options (or their values) can not be combined: [{verify,verify_peer},\n                                                {cacerts,undefined}] - {:options, :incompatible, [verify: :verify_peer, cacerts: :undefined]}","metadata":{"error":{"initial_call":null,"reason":"** (DBConnection.ConnectionError) ssl connect: Options (or their values) can not be combined: [{verify,verify_peer},\n                                                {cacerts,undefined}] - {:options, :incompatible, [verify: :verify_peer, cacerts: :undefined]}"}}}
{"time":"2024-07-02T13:56:58.213Z","severity":"error","message":"Could not create schema migrations table. This error usually happens due to the following:\n\n  * The database does not exist\n  * The \"schema_migrations\" table, which Ecto uses for managing\n    migrations, was defined by another library\n  * There is a deadlock while migrating (such as using concurrent\n    indexes with a migration_lock)\n\nTo fix the first issue, run \"mix ecto.create\" for the desired MIX_ENV.\n\nTo address the second, you can run \"mix ecto.drop\" followed by\n\"mix ecto.create\", both for the desired MIX_ENV. Alternatively you may\nconfigure Ecto to use another table and/or repository for managing\nmigrations:\n\n    config :explorer, Explorer.Repo,\n      migration_source: \"some_other_table_for_schema_migrations\",\n      migration_repo: AnotherRepoForSchemaMigrations\n\nThe full error report is shown below.\n","metadata":{}}
** (DBConnection.ConnectionError) connection not available and request was dropped from queue after 2917ms. This means requests are coming in and your connection pool cannot serve them fast enough. You can address this by:

  1. Ensuring your database is available and that you can connect to it
  2. Tracking down slow queries and making sure they are running fast enough
  3. Increasing the pool_size (although this increases resource consumption)
  4. Allowing requests to wait longer by increasing :queue_target and :queue_interval

See DBConnection.start_link/2 for more information

    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1161: Ecto.Adapters.SQL.execute_ddl/4
    (ecto_sql 3.11.3) lib/ecto/migrator.ex:755: Ecto.Migrator.verbose_schema_migration/3
    (ecto_sql 3.11.3) lib/ecto/migrator.ex:563: Ecto.Migrator.lock_for_migrations/4
    (ecto_sql 3.11.3) lib/ecto/migrator.ex:432: Ecto.Migrator.run/4
    (elixir 1.16.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    nofile:1: (file)
```

## Changelog

Default option for `ssl_opts` is changed in Erlang OTP 26:
https://www.erlang.org/blog/otp-26-highlights/#ssl-safer-defaults
> In OTP 26, the default value for the verify option is now verify_peer instead of verify_none. Host verification requires trusted CA certificates to be supplied using one of the options cacerts or cacertsfile. Therefore, a connection attempt with an empty option list will fail in OTP 26:

It is required to explicitly set `ssl_opts: [verify: :verify_none]` for all Ecto repos in compile time.


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
