### PR TITLE
fix: simplify query for weekly_deployed_smart_contracts_number public metric

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics/queries.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries.ex
@@ -72,23 +72,24 @@ defmodule Explorer.Chain.Metrics.Queries do
         |> select([tx, block], tx.created_contract_address_hash)
       end
 
-    internal_transactions_query =
-      InternalTransaction
-      |> join(:inner, [it], transaction in assoc(it, :transaction))
-      |> where([it, tx], not is_nil(it.created_contract_address_hash))
-      |> where([it, tx], tx.block_timestamp >= ago(7, "day"))
-      |> where([it, tx], tx.block_consensus == true)
-      |> where([it, tx], tx.status == ^1)
-      |> select([it, tx], it.created_contract_address_hash)
-      |> wrapped_union_subquery()
+    # todo: this part is too slow, need to optimize
+    # internal_transactions_query =
+    #   InternalTransaction
+    #   |> join(:inner, [it], transaction in assoc(it, :transaction))
+    #   |> where([it, tx], not is_nil(it.created_contract_address_hash))
+    #   |> where([it, tx], tx.block_timestamp >= ago(7, "day"))
+    #   |> where([it, tx], tx.block_consensus == true)
+    #   |> where([it, tx], tx.status == ^1)
+    #   |> select([it, tx], it.created_contract_address_hash)
+    #   |> wrapped_union_subquery()
 
-    query =
-      transactions_query
-      |> wrapped_union_subquery()
-      |> union(^internal_transactions_query)
+    # query =
+    #   transactions_query
+    #   |> wrapped_union_subquery()
+    #   |> union(^internal_transactions_query)
 
     from(
-      q in subquery(query),
+      q in subquery(transactions_query),
       select: fragment("COUNT(DISTINCT(?))", q.created_contract_address_hash)
     )
   end

--- a/apps/explorer/lib/explorer/prometheus/instrumenter.ex
+++ b/apps/explorer/lib/explorer/prometheus/instrumenter.ex
@@ -21,7 +21,8 @@ defmodule Explorer.Prometheus.Instrumenter do
 
   @gauge [
     name: :weekly_deployed_smart_contracts_number,
-    help: "Number of deployed smart-contracts in the last 7 days",
+    help:
+      "Number of deployed smart-contracts (smart-contracts from internal transactions are not accounted) in the last 7 days",
     registry: :public
   ]
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10063

## Motivation

The current query for fetching deployed smart-contracts from transactions and internal transactions is not performant.

## Changelog

Remove join with `internal_transactions` table. Thus, we'll consider only smart-contracts created from regular transactions in that metric.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
