### PR TITLE
fix: allow fetching image from "properties" -> "image" prop in token instance metadata

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.NFTHelper do
 
   def get_media_src(nil, _), do: nil
 
+  # credo:disable-for-next-line /Complexity/
   def get_media_src(metadata, high_quality_media?) do
     result =
       cond do
@@ -18,8 +19,8 @@ defmodule BlockScoutWeb.NFTHelper do
         metadata["image"] ->
           retrieve_image(metadata["image"])
 
-        metadata["properties"]["image"]["description"] ->
-          metadata["properties"]["image"]["description"]
+        image = metadata["properties"]["image"] ->
+          if is_map(image), do: image["description"], else: image
 
         true ->
           nil


### PR DESCRIPTION
Superseed of https://github.com/blockscout/blockscout/pull/10317

## Motivation

Allow fetching of token instance image from "properties" -> "image" property of the metadata JSON.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
