### PR TITLE
Flickering tests debug

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -164,9 +164,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       TestHelper.get_eip1967_implementation_non_zero_address(implementation_address_hash_string)
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(target_contract.address_hash)}")
-      response = json_response(request, 200)
 
-      assert correct_response == response
+      assert ^correct_response = json_response(request, 200)
     end
 
     test "get smart-contract with decoded constructor", %{conn: conn} do
@@ -268,9 +267,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       TestHelper.get_eip1967_implementation_error_response()
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(target_contract.address_hash)}")
-      response = json_response(request, 200)
 
-      assert correct_response == response
+      assert ^correct_response = json_response(request, 200)
     end
 
     test "get smart-contract data from bytecode twin without constructor args", %{conn: conn} do
@@ -374,9 +372,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       TestHelper.get_eip1967_implementation_zero_addresses()
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")
-      response = json_response(request, 200)
 
-      assert correct_response == response
+      assert ^correct_response = json_response(request, 200)
     end
 
     test "get smart-contract multiple additional sources from EIP-1167 implementation", %{conn: conn} do
@@ -494,9 +491,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       }
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(proxy_address.hash)}")
-      response = json_response(request, 200)
 
-      assert correct_response == response
+      assert ^correct_response = json_response(request, 200)
     end
 
     test "get smart-contract which is blueprint", %{conn: conn} do
@@ -562,9 +558,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       TestHelper.get_eip1967_implementation_zero_addresses()
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(target_contract.address_hash)}")
-      response = json_response(request, 200)
 
-      assert correct_response == response
+      assert ^correct_response = json_response(request, 200)
     end
   end
 
@@ -676,9 +671,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     }
 
     request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(proxy_address.hash)}")
-    response = json_response(request, 200)
 
-    assert correct_response == response
+    assert ^correct_response = json_response(request, 200)
   end
 
   describe "/smart-contracts/{address_hash} <> eth_bytecode_db" do

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -14,12 +14,13 @@ defmodule Explorer.TestHelper do
 
     expect(mox, :json_rpc, fn %{
                                 id: 0,
-                                method: "eth_getStorageAt",
                                 params: [
                                   _,
                                   "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc",
                                   "latest"
-                                ]
+                                ],
+                                method: "eth_getStorageAt",
+                                jsonrpc: "2.0"
                               },
                               _options ->
       response
@@ -35,12 +36,13 @@ defmodule Explorer.TestHelper do
 
     expect(mox, :json_rpc, fn %{
                                 id: 0,
-                                method: "eth_getStorageAt",
                                 params: [
                                   _,
                                   "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50",
                                   "latest"
-                                ]
+                                ],
+                                method: "eth_getStorageAt",
+                                jsonrpc: "2.0"
                               },
                               _options ->
       response

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2221,6 +2221,12 @@ defmodule Explorer.ChainTest do
   end
 
   describe "transaction_estimated_count/1" do
+    setup do
+      Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Transaction.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Transaction.child_id())
+      :ok
+    end
+
     test "returns integer" do
       assert is_integer(TransactionCache.estimated_count())
     end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
