### PR TITLE
chore: Remove single implementation name, address from API v2 response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -113,9 +113,6 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     creation_tx = creator_hash && AddressView.transaction_hash(address)
     token = address.token && TokenView.render("token.json", %{token: address.token})
 
-    # todo: added for backward compatibility, remove when frontend unbound from these props
-    {implementation_address, implementation_name} = single_implementation(implementations)
-
     extended_info =
       Map.merge(base_info, %{
         "creator_address_hash" => creator_hash && Address.checksum(creator_hash),
@@ -137,23 +134,9 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       extended_info
     else
       Map.merge(extended_info, %{
-        # todo: added for backward compatibility, remove when frontend unbound from these props
-        "implementation_address" => implementation_address,
-        "implementation_name" => implementation_name,
         "implementations" => implementations
       })
     end
-  end
-
-  defp single_implementation(implementations) do
-    %{"address" => implementation_address, "name" => implementation_name} =
-      if Enum.empty?(implementations) do
-        %{"address" => nil, "name" => nil}
-      else
-        implementations |> Enum.at(0)
-      end
-
-    {implementation_address, implementation_name}
   end
 
   @spec prepare_token_balance(Chain.Address.TokenBalance.t(), boolean()) :: map()

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -64,31 +64,25 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def address_with_info(%Address{} = address, _address_hash) do
     smart_contract? = Address.smart_contract?(address)
 
-    {proxy_implementations, implementation_address_hashes, implementation_names, implementation_address,
-     implementation_name} =
+    {proxy_implementations, implementation_address_hashes, implementation_names} =
       case address.proxy_implementations do
         %NotLoaded{} ->
-          {nil, [], [], nil, nil}
+          {nil, [], []}
 
         nil ->
-          {nil, [], [], nil, nil}
+          {nil, [], []}
 
         proxy_implementations ->
           address_hashes = proxy_implementations.address_hashes
           names = proxy_implementations.names
 
-          address_hash = Enum.at(address_hashes, 0) && address_hashes |> Enum.at(0) |> Address.checksum()
-
-          {proxy_implementations, address_hashes, names, address_hash, Enum.at(names, 0)}
+          {proxy_implementations, address_hashes, names}
       end
 
     %{
       "hash" => Address.checksum(address),
       "is_contract" => smart_contract?,
       "name" => address_name(address),
-      # todo: added for backward compatibility, remove when frontend unbound from these props
-      "implementation_address" => implementation_address,
-      "implementation_name" => implementation_name,
       "implementations" => proxy_object_info(implementation_address_hashes, implementation_names),
       "is_verified" => verified?(address) || verified_minimal_proxy?(proxy_implementations),
       "ens_domain_name" => address.ens_domain_name,
@@ -116,9 +110,6 @@ defmodule BlockScoutWeb.API.V2.Helper do
       "hash" => Address.checksum(address_hash),
       "is_contract" => false,
       "name" => nil,
-      # todo: added for backward compatibility, remove when frontend unbound from these props
-      "implementation_address" => nil,
-      "implementation_name" => nil,
       "implementations" => [],
       "is_verified" => nil,
       "ens_domain_name" => nil,

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
@@ -151,9 +151,6 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
              "name" => name,
              "address" => %{
                "hash" => Address.checksum(addr),
-               # todo: added for backward compatibility, remove when frontend unbound from these props
-               "implementation_address" => nil,
-               "implementation_name" => nil,
                "implementations" => [],
                "is_contract" => false,
                "is_verified" => false,
@@ -210,9 +207,6 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
              "name" => name,
              "address" => %{
                "hash" => Address.checksum(addr),
-               # todo: added for backward compatibility, remove when frontend unbound from these props
-               "implementation_address" => nil,
-               "implementation_name" => nil,
                "implementations" => [],
                "is_contract" => false,
                "is_verified" => false,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -71,9 +71,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "creation_tx_hash" => nil,
         "token" => nil,
         "coin_balance" => nil,
-        # todo: added for backward compatibility, remove when frontend unbound from these props
-        "implementation_address" => nil,
-        "implementation_name" => nil,
         "implementations" => [],
         "block_number_balance_updated_at" => nil,
         "has_decompiled_code" => false,
@@ -209,7 +206,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "watchlist_names" => [],
                "creator_address_hash" => ^from,
                "creation_tx_hash" => ^tx_hash,
-               "implementation_address" => ^checksummed_implementation_contract_address_hash,
                "implementations" => [
                  %{"address" => ^checksummed_implementation_contract_address_hash, "name" => ^name}
                ]
@@ -255,7 +251,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "watchlist_names" => [],
                "creator_address_hash" => ^from,
                "creation_tx_hash" => ^tx_hash,
-               "implementation_address" => ^implementation_address_hash_string,
                "implementations" => [%{"address" => ^implementation_address_hash_string, "name" => nil}]
              } = json_response(request, 200)
     end


### PR DESCRIPTION
## Motivation

Frontend since 1.31.0 doesn't use "implementation_name" and "implementation_address" props in API v2 endpoints.

## Changelog

Remove obsolete single properties:
- "implementation_name"
- "implementation_address"
in API v2 endpoints.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
