### PR TITLE
fix: Fix flickering /stats/charts/market test

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/stats_controller_test.exs
@@ -38,13 +38,13 @@ defmodule BlockScoutWeb.API.V2.StatsControllerTest do
 
   describe "/stats/charts/market" do
     setup do
-      configuration = Application.get_env(:explorer, Explorer.ExchangeRates)
-      Application.put_env(:explorer, Explorer.ExchangeRates, enabled: false)
+      configuration = Application.get_env(:explorer, Explorer.Market.MarketHistoryCache)
+      Application.put_env(:explorer, Explorer.Market.MarketHistoryCache, cache_period: 0)
 
       :ok
 
       on_exit(fn ->
-        Application.put_env(:explorer, Explorer.ExchangeRates, configuration)
+        Application.put_env(:explorer, Explorer.Market.MarketHistoryCache, configuration)
       end)
     end
 


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347
Finalization of https://github.com/blockscout/blockscout/pull/10383/files

## Motivation

Previous attempt #10383 didn't help since `ExchangeRates` module is disabled globally in tests. This test, seems, flickering because of not empty exchange rates cache. This PR sets `MarketHistoryCache`'s `cache_period` to 0 for the test in order to exclude using cached values.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
