### PR TITLE
Fix missing expectation in mock_beacon_storage_pointer_request

### DIFF
--- a/apps/block_scout_web/config/runtime/test.exs
+++ b/apps/block_scout_web/config/runtime/test.exs
@@ -2,6 +2,7 @@ import Config
 
 alias EthereumJSONRPC.Variant
 
+config :ethereum_jsonrpc, EthereumJSONRPC.Utility.EndpointAvailabilityChecker, enabled: false
 config :explorer, Explorer.ExchangeRates, enabled: false, store: :none
 
 config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
@@ -16,7 +16,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   end
 
   def init(_) do
-    if Application.get_env(:explorer, __MODULE__)[:enabled] do
+    if Application.get_env(:ethereum_jsonrpc, __MODULE__)[:enabled] do
       schedule_next_check()
 
       {:ok, %{unavailable_endpoints_arguments: []}}

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
@@ -16,9 +16,13 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   end
 
   def init(_) do
-    schedule_next_check()
+    if Application.get_env(:explorer, __MODULE__)[:enabled] do
+      schedule_next_check()
 
-    {:ok, %{unavailable_endpoints_arguments: []}}
+      {:ok, %{unavailable_endpoints_arguments: []}}
+    else
+      :ignore
+    end
   end
 
   def add_endpoint(json_rpc_named_arguments, url_type) do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -200,6 +200,8 @@ config :ethereum_jsonrpc, EthereumJSONRPC.PendingTransaction,
 config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
   wait_per_timeout: ConfigHelper.parse_time_env_var("ETHEREUM_JSONRPC_WAIT_PER_TIMEOUT", "20s")
 
+config :ethereum_jsonrpc, EthereumJSONRPC.Utility.EndpointAvailabilityChecker, enabled: true
+
 ################
 ### Explorer ###
 ################


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347


## Motivation

Flickering tests in different locations with the same error message:
```
1) test /smart-contracts/{address_hash} get smart-contract (BlockScoutWeb.API.V2.SmartContractControllerTest) Error: test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs:97 ** (EXIT from #PID<0.16767.0>) an exception was raised:
        ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Explorer.TestHelper.mock_beacon_storage_pointer_request/3

        The following arguments were given to anonymous fn/2 in Explorer.TestHelper.mock_beacon_storage_pointer_request/3:

            # 1
            %{id: 0, params: [%Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 56, 54>>}, "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc", "latest"], method: "eth_getStorageAt", jsonrpc: "2.0"}

            # 2
            []

        stacktrace:
          (explorer 6.7.2) lib/test_helper.ex:36: anonymous fn/2 in Explorer.TestHelper.mock_beacon_storage_pointer_request/3
          (ethereum_jsonrpc 6.7.2) lib/ethereum_jsonrpc/request_coordinator.ex:89: anonymous fn/4 in EthereumJSONRPC.RequestCoordinator.perform/4
          (ethereum_jsonrpc 6.7.2) lib/ethereum_jsonrpc/request_coordinator.ex:109: EthereumJSONRPC.RequestCoordinator.trace_request/2
          (ethereum_jsonrpc 6.7.2) lib/ethereum_jsonrpc.ex:454: EthereumJSONRPC.json_rpc/2
          (explorer 6.7.2) lib/explorer/chain/smart_contract/proxy.ex:185: Explorer.Chain.SmartContract.Proxy.get_implementation_from_storage/3
          (explorer 6.7.2) lib/explorer/chain/smart_contract/proxy/eip_1967.ex:39: Explorer.Chain.SmartContract.Proxy.EIP1967.get_implementation_address_hash_string/1
          (explorer 6.7.2) lib/explorer/chain/smart_contract/proxy.ex:298: Explorer.Chain.SmartContract.Proxy.get_implementation_address_hash_string_by_module/4
          (explorer 6.7.2) lib/explorer/chain/smart_contract/proxy.ex:61: Explorer.Chain.SmartContract.Proxy.fetch_implementation_address_hash/3
          (explorer 6.7.2) lib/explorer/chain/smart_contract/proxy/models/implementation.ex:175: anonymous fn/3 in Explorer.Chain.SmartContract.Proxy.Models.Implementation.get_implementation/2
          (elixir 1.16.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
          (elixir 1.16.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
```

## Changelog

The root cause of the error was the enabled http endpoints availability checker in the tests. This PR disables it for all tests.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
