### PR TITLE
fix: /addresses empty list flickering test fix

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2423,8 +2423,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       total_supply = to_string(Chain.total_supply())
 
-      assert %{"items" => [], "next_page_params" => nil, "exchange_rate" => nil, "total_supply" => ^total_supply} =
-               json_response(request, 200)
+      pattern_response = %{"items" => [], "next_page_params" => nil, "total_supply" => total_supply}
+      response = json_response(request, 200)
+
+      assert pattern_response["items"] == response["items"]
+      assert pattern_response["next_page_params"] == response["next_page_params"]
+      assert pattern_response["total_supply"] == response["total_supply"]
     end
 
     test "check pagination", %{conn: conn} do


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347

## Motivation

```
  1) test /addresses get empty list (BlockScoutWeb.API.V2.AddressControllerTest)
Error:      test/block_scout_web/controllers/api/v2/address_controller_test.exs:2421
     match (=) failed
     The following variables were pinned:
       total_supply = "252460800"
     code:  assert %{
              "items" => [],
              "next_page_params" => nil,
              "exchange_rate" => nil,
              "total_supply" => ^total_supply
            } = json_response(request, 200)
     left:  %{
              "items" => [],
              "next_page_params" => nil,
              "exchange_rate" => nil,
              "total_supply" => ^total_supply
            }
     right: %{
              "exchange_rate" => "2.5",
              "items" => [],
              "next_page_params" => nil,
              "total_supply" => "252460800"
            }
     stacktrace:
       test/block_scout_web/controllers/api/v2/address_controller_test.exs:2426: (test)
```

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
