### PR TITLE
fix: Fix flickering "updates cache if initial value is zero" test

### DIFF
--- a/apps/explorer/test/explorer/chain/cache/block_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/block_test.exs
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Cache.BlockTest do
 
     _result = Block.get_count()
 
-    Process.sleep(1000)
+    Process.sleep(2000)
 
     updated_value = Block.get_count()
 

--- a/apps/explorer/test/explorer/chain/cache/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/transaction_test.exs
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Cache.TransactionTest do
 
     _result = Transaction.get_count()
 
-    Process.sleep(1000)
+    Process.sleep(2000)
 
     updated_value = Transaction.get_count()
 


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347

## Motivation

```
Error: test/explorer/chain/cache/block_test.exs:32
Assertion with == failed
code: assert updated_value == 2
left: 0
right: 2
stacktrace:
test/explorer/chain/cache/block_test.exs:43: (test)
```

## Changelog

Double sleep timeout.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
