### PR TITLE
fix: Fix flickering transaction_estimated_count/1 test

### DIFF
--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2221,6 +2221,12 @@ defmodule Explorer.ChainTest do
   end
 
   describe "transaction_estimated_count/1" do
+    setup do
+      Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Transaction.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Transaction.child_id())
+      :ok
+    end
+
     test "returns integer" do
       assert is_integer(TransactionCache.estimated_count())
     end


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347

## Motivation

Flickering test:
```
  2) test transaction_estimated_count/1 returns integer (Explorer.ChainTest)
Error:      test/explorer/chain_test.exs:2224
     ** (exit) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
     code: assert is_integer(TransactionCache.estimated_count())
     stacktrace:
       (con_cache 1.1.0) lib/con_cache/owner.ex:14: ConCache.Owner.cache/1
       (con_cache 1.1.0) lib/con_cache.ex:228: ConCache.get/2
       (explorer 6.7.2) lib/explorer/chain/cache/transaction.ex:6: Explorer.Chain.Cache.Transaction.get/1
       (explorer 6.7.2) lib/explorer/chain/cache/transaction.ex:27: Explorer.Chain.Cache.Transaction.estimated_count/0
       test/explorer/chain_test.exs:2225: (test)
```


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
