### PR TITLE
fix: Fix logs sorting in API v1

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -83,7 +83,6 @@ defmodule Explorer.Etherscan.Logs do
         |> where([log], log.block_number >= ^prepared_filter.from_block)
         |> where([log], log.block_number <= ^prepared_filter.to_block)
         |> limit(1000)
-        |> order_by([log], asc: log.block_number, asc: log.index)
         |> page_logs(paging_options)
 
       all_transaction_logs_query =
@@ -105,7 +104,6 @@ defmodule Explorer.Etherscan.Logs do
       query_with_blocks =
         from(log_transaction_data in subquery(all_transaction_logs_query),
           where: log_transaction_data.address_hash == ^address_hash,
-          order_by: log_transaction_data.block_number,
           select_merge: %{
             block_consensus: log_transaction_data.block_consensus
           }
@@ -121,6 +119,7 @@ defmodule Explorer.Etherscan.Logs do
         end
 
       query_with_consensus
+      |> order_by([log], asc: log.block_number, asc: log.index)
       |> Repo.replica().all()
     else
       logs_query = where_topic_match(Log, prepared_filter)


### PR DESCRIPTION
Part of #9347
`test list_logs/1 paginates logs (test/explorer/etherscan/logs_test.exs:181)`
## Changelog
- Fix order for query in case transaction denormalization is finished
## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
