### PR TITLE
Fix "key :bytes not found in: nil" issue

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -44,10 +44,7 @@ defmodule Explorer.SmartContract.Helper do
   def add_contract_code_md5(%{address_hash: address_hash_string} = attrs) when is_binary(address_hash_string) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:ok, address} <- Chain.hash_to_address(address_hash) do
-      contract_code_md5 = contract_code_md5(address.contract_code.bytes)
-
-      attrs
-      |> Map.put_new(:contract_code_md5, contract_code_md5)
+      attrs_extend_with_contract_code_md5(attrs, address)
     else
       _ -> attrs
     end
@@ -56,14 +53,7 @@ defmodule Explorer.SmartContract.Helper do
   def add_contract_code_md5(%{address_hash: address_hash} = attrs) do
     case Chain.hash_to_address(address_hash) do
       {:ok, address} ->
-        if address.contract_code do
-          contract_code_md5 = contract_code_md5(address.contract_code.bytes)
-
-          attrs
-          |> Map.put_new(:contract_code_md5, contract_code_md5)
-        else
-          attrs
-        end
+        attrs_extend_with_contract_code_md5(attrs, address)
 
       _ ->
         attrs
@@ -76,6 +66,17 @@ defmodule Explorer.SmartContract.Helper do
     :md5
     |> :crypto.hash(bytes)
     |> Base.encode16(case: :lower)
+  end
+
+  defp attrs_extend_with_contract_code_md5(attrs, address) do
+    if address.contract_code do
+      contract_code_md5 = contract_code_md5(address.contract_code.bytes)
+
+      attrs
+      |> Map.put_new(:contract_code_md5, contract_code_md5)
+    else
+      attrs
+    end
   end
 
   def sanitize_input(nil), do: nil


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10434

## Motivation

Resolve "key :bytes not found in: nil" error in the logs.


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
