### PR TITLE
fix: Missing clauses in MetadataPreloader functions

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -285,8 +285,8 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     alter_address(address, address.hash, names, field_to_put_info)
   end
 
-  defp alter_address(_, nil, _names, _field) do
-    nil
+  defp alter_address(address, nil, _names, _field) do
+    address
   end
 
   defp alter_address(%NotLoaded{}, address_hash, names, field) do

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -301,6 +301,10 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     %Address{address | metadata: names[Address.checksum(address_hash)]}
   end
 
+  defp alter_address(nil, _address_hash, _names, _field) do
+    nil
+  end
+
   defp alter_address(map, address_hash, names, field) when is_map(map) do
     Map.put(map, field, names[Address.checksum(address_hash)])
   end

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -127,6 +127,8 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     end)
   end
 
+  defp item_to_address_hash_strings(nil), do: []
+
   defp item_to_address_hash_strings(%Transaction{
          to_address_hash: to_address_hash,
          created_contract_address_hash: created_contract_address_hash,
@@ -285,11 +287,13 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     alter_address(address, address.hash, names, field_to_put_info)
   end
 
-  defp alter_address(address, nil, _names, _field) do
-    address
-  end
+  defp alter_address(address, nil, _names, _field), do: address
 
   defp alter_address(%NotLoaded{}, address_hash, names, field) do
+    %{field => names[Address.checksum(address_hash)]}
+  end
+
+  defp alter_address(nil, address_hash, names, field) do
     %{field => names[Address.checksum(address_hash)]}
   end
 
@@ -299,10 +303,6 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
 
   defp alter_address(%Address{} = address, address_hash, names, :metadata) do
     %Address{address | metadata: names[Address.checksum(address_hash)]}
-  end
-
-  defp alter_address(nil, _address_hash, _names, _field) do
-    nil
   end
 
   defp alter_address(map, address_hash, names, field) when is_map(map) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10438


## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
