### PR TITLE
fix: race condition in cache tests

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -28,7 +28,7 @@ defmodule Explorer.Chain.Cache.AddressSum do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           result = Etherscan.fetch_sum_coin_total_supply()
 

--- a/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
@@ -28,7 +28,7 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           result = Etherscan.fetch_sum_coin_total_supply_minus_burnt()
 

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
   }
 
   defp handle_fallback(:transactions_denormalization_finished) do
-    Task.start(fn ->
+    Task.start_link(fn ->
       set_transactions_denormalization_finished(TransactionsDenormalization.migration_finished?())
     end)
 
@@ -30,7 +30,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
   end
 
   defp handle_fallback(:tb_token_type_finished) do
-    Task.start(fn ->
+    Task.start_link(fn ->
       set_tb_token_type_finished(AddressTokenBalanceTokenType.migration_finished?())
     end)
 
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
   end
 
   defp handle_fallback(:ctb_token_type_finished) do
-    Task.start(fn ->
+    Task.start_link(fn ->
       set_ctb_token_type_finished(AddressCurrentTokenBalanceTokenType.migration_finished?())
     end)
 
@@ -46,7 +46,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
   end
 
   defp handle_fallback(:tt_denormalization_finished) do
-    Task.start(fn ->
+    Task.start_link(fn ->
       set_tt_denormalization_finished(TokenTransferTokenType.migration_finished?())
     end)
 

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -67,7 +67,7 @@ defmodule Explorer.Chain.Cache.Block do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           result = fetch_count_consensus_block()
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -321,7 +321,7 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           {result, acc} = get_average_gas_price(num_of_blocks(), safelow(), average(), fast())
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -49,7 +49,7 @@ defmodule Explorer.Chain.Cache.GasUsage do
       # If this gets called it means an async task was requested, but none exists
       # so a new one needs to be launched
       {:ok, task} =
-        Task.start(fn ->
+        Task.start_link(fn ->
           try do
             result = fetch_sum_gas_used()
 

--- a/apps/explorer/lib/explorer/chain/cache/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/cache/pending_block_operation.ex
@@ -46,7 +46,7 @@ defmodule Explorer.Chain.Cache.PendingBlockOperation do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           result = Repo.aggregate(PendingBlockOperation, :count, timeout: :infinity)
 

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -47,7 +47,7 @@ defmodule Explorer.Chain.Cache.Transaction do
     # If this gets called it means an async task was requested, but none exists
     # so a new one needs to be launched
     {:ok, task} =
-      Task.start(fn ->
+      Task.start_link(fn ->
         try do
           result = Repo.aggregate(Transaction, :count, :hash, timeout: :infinity)
 

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -290,7 +290,7 @@ defmodule Explorer.Chain.OrderedCache do
         # Different updates cannot interfere with the removed element because
         # if this was scheduled for removal it means it is too old, so following
         # updates cannot insert it in the future.
-        Task.start(fn ->
+        Task.start_link(fn ->
           Process.sleep(100)
 
           if is_list(key) do

--- a/apps/explorer/test/explorer/chain/cache/block_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/block_test.exs
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Cache.BlockTest do
 
     _result = Block.get_count()
 
-    Process.sleep(2000)
+    Process.sleep(1000)
 
     updated_value = Block.get_count()
 

--- a/apps/explorer/test/explorer/chain/cache/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/transaction_test.exs
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Cache.TransactionTest do
 
     _result = Transaction.get_count()
 
-    Process.sleep(2000)
+    Process.sleep(1000)
 
     updated_value = Transaction.get_count()
 


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347

Fix flaking test
> test/explorer/chain/cache/block_test.exs:18

## Motivation

When cache process is restarted each time in the tests, it leaves an async task hanging, as it's not attached to the parent cache process. Result from this hanging task then re-appear in the newly relaunched cache process, along with the following error.

<img width="911" alt="image" src="https://github.com/user-attachments/assets/8e85a6d4-1aad-4aa9-9835-08562df60d5a">

Proposed solution is to use `Task.start_link` instead of `Task.start` to link the async task with the cache process, so that it's killed whenever cache process is terminated.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
