### PR TITLE
fix: Fix internal transaction validation

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -580,15 +580,43 @@ defmodule EthereumJSONRPC do
   defp chunk_requests(requests, nil), do: requests
   defp chunk_requests(requests, chunk_size), do: Enum.chunk_every(requests, chunk_size)
 
-  def put_if_present(result, map, keys) do
-    Enum.reduce(keys, result, fn {from_key, to_key}, acc ->
-      value = map[from_key]
+  def put_if_present(result, transaction, keys) do
+    Enum.reduce(keys, result, fn key, acc ->
+      key_list = key |> Tuple.to_list()
+      from_key = Enum.at(key_list, 0)
+      to_key = Enum.at(key_list, 1)
+      opts = if Enum.count(key_list) > 2, do: Enum.at(key_list, 2), else: %{}
 
-      if value do
-        Map.put(acc, to_key, value)
-      else
-        acc
-      end
+      value = transaction[from_key]
+
+      validate_key(acc, to_key, value, opts)
     end)
+  end
+
+  defp validate_key(acc, _to_key, nil, _opts), do: acc
+
+  defp validate_key(acc, to_key, value, %{:validation => validation}) do
+    case validation do
+      :address_hash ->
+        if address_correct?(value), do: Map.put(acc, to_key, value), else: acc
+
+      _ ->
+        Map.put(acc, to_key, value)
+    end
+  end
+
+  defp validate_key(acc, to_key, value, _validation) do
+    Map.put(acc, to_key, value)
+  end
+
+  # todo: The similar function exists in Indexer application:
+  # Here is the room for future refactoring to keep a single function.
+  @spec address_correct?(binary()) :: boolean()
+  defp address_correct?(address) when is_binary(address) do
+    String.match?(address, ~r/^0x[[:xdigit:]]{40}$/i)
+  end
+
+  defp address_correct?(_address) do
+    false
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
@@ -363,6 +363,38 @@ defmodule EthereumJSONRPC.Geth.Call do
     ])
   end
 
+  # failed internal transaction
+  defp elixir_to_internal_transaction_params(%{
+         "blockNumber" => block_number,
+         "transactionIndex" => transaction_index,
+         "transactionHash" => transaction_hash,
+         "index" => index,
+         "traceAddress" => trace_address,
+         "type" => type,
+         "from" => from_address_hash,
+         "gas" => gas,
+         "gasUsed" => gas_used,
+         "init" => init,
+         "value" => value,
+         "error" => error
+       })
+       when type in ~w(create create2) and not is_nil(error) do
+    %{
+      block_number: block_number,
+      transaction_index: transaction_index,
+      transaction_hash: transaction_hash,
+      index: index,
+      trace_address: trace_address,
+      type: type,
+      from_address_hash: from_address_hash,
+      gas: gas,
+      gas_used: gas_used,
+      init: init,
+      value: value,
+      error: error
+    }
+  end
+
   defp elixir_to_internal_transaction_params(
          %{
            "blockNumber" => block_number,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
@@ -394,7 +394,7 @@ defmodule EthereumJSONRPC.Geth.Call do
     }
     |> put_if_present(params, [
       {"error", :error},
-      {"createdContractAddressHash", :created_contract_address_hash},
+      {"createdContractAddressHash", :created_contract_address_hash, %{validation: :address_hash}},
       {"createdContractCode", :created_contract_code}
     ])
   end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10442

## Motivation

Some transaction traces are transformed to internal transactions and addresses, which cannot pass validation before insertion into the DB.

## Changelog

trace with an error in smart-contract (create2) creation (see trace response from the node in the linked issue) generates such address among others:
```
%{
    hash: "0x",
    fetched_coin_balance_block_number: 17237541,
    contract_code: "0x"
  }
```

and such internal transaction with invalid created_contract_address_hash: `created_contract_address_hash: "0x"`:
```
%{
    error: "execution reverted",
    index: 0,
    init: "0x...",
    type: "create",
    value: 100000000000000,
    block_number: 17237541,
    from_address_hash: "0xcfe6ab9f66c0abba8081ff0789272ee4688a5d0c",
    gas: 1148773,
    transaction_index: 23,
    created_contract_address_hash: "0x",
    trace_address: [],
    transaction_hash: "0xc0644eb8c3601c878027eafd5ce5ac91c8f87f00403be3ff0a3753ce4b18034b",
    gas_used: 1142607,
    created_contract_code: "0x"
  }
```

The fix is to add address validation in internal transactions params before import.

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
