### PR TITLE
fix: Add no overlapping constraint to missing_block_ranges

### DIFF
--- a/apps/explorer/priv/repo/migrations/20240718150123_add_no_overlap_index_to_missing_block_ranges.exs
+++ b/apps/explorer/priv/repo/migrations/20240718150123_add_no_overlap_index_to_missing_block_ranges.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Migrations.AddNoOverlapIndexToMissingBlockRanges do
+  use Ecto.Migration
+
+  def change do
+    create(
+      constraint(:missing_block_ranges, :missing_block_ranges_no_overlap,
+        exclude: ~s|gist (int4range(to_number, from_number, '[]') WITH &&)|
+      )
+    )
+  end
+end

--- a/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
@@ -38,9 +38,9 @@ defmodule Indexer.Block.Catchup.MissingRangesCollectorTest do
       Application.put_env(:indexer, :last_block, 200)
 
       insert(:missing_block_range, from_number: 250, to_number: 220)
-      insert(:missing_block_range, from_number: 220, to_number: 190)
+      insert(:missing_block_range, from_number: 219, to_number: 190)
       insert(:missing_block_range, from_number: 120, to_number: 90)
-      insert(:missing_block_range, from_number: 90, to_number: 80)
+      insert(:missing_block_range, from_number: 89, to_number: 80)
 
       MissingRangesCollector.start_link([])
       Process.sleep(500)


### PR DESCRIPTION
## Motivation

Even though operations on `missing_block_ranges` are concurrent safe, there are situations when two instances of indexer is running at the same time (during deploy for example). This may cause ranges overlapping and therefore incorrect stored ranges.

## Changelog

Added no-overlapping ranges constraint to `missing_block_ranges`.