### PR TITLE
doc: Move note in README.md higher for visibility

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -10,6 +10,8 @@ Runs Blockscout locally in Docker containers with [docker-compose](https://githu
 
 ## Building Docker containers from source
 
+**Note**: in all below examples, you can use `docker compose` instead of `docker-compose`, if compose v2 plugin is installed in Docker.
+
 ```bash
 cd ./docker-compose
 docker-compose up --build
@@ -37,8 +39,6 @@ and 5 containers for microservices (written in Rust):
 ## Configs for different Ethereum clients
 
 The repo contains built-in configs for different JSON RPC clients without need to build the image.
-
-**Note**: in all below examples, you can use `docker compose` instead of `docker-compose`, if compose v2 plugin is installed in Docker.
 
 | __JSON RPC Client__    | __Docker compose launch command__ |
 | -------- | ------- |


### PR DESCRIPTION
The note detailing `docker compose` use for Docker's compose v2 plugin should be higher in the README since the document's first bash snippet includes `docker-compose up --build` which uses the "docker-compose" syntax.

This way the relevant note is readily visible above the first mention of "docker-compose" so skimmers trying to get the explorer up and running are immediately informed of the difference

*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
