### PR TITLE
fix: code compiler test

### DIFF
--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -14,6 +14,13 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
 
   describe "run/2" do
     setup do
+      configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+      Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+      end)
+
       {:ok,
        contract_code_info: Factory.contract_code_info(),
        contract_code_info_modern_compiler: Factory.contract_code_info_modern_compiler()}


### PR DESCRIPTION
Part of #9347 
> test/explorer/smart_contract/solidity/code_compiler_test.exs:159

## Motivation

`code_compiler_test.exs` is `async: true`, `RustVerifierInterfaceBehaviour` was not disabled explicitly there. Most of the time `RustVerifierInterfaceBehaviour` would be properly disabled by some other test running in parallel, but sometimes it wouldn't, which lead to one of the test failing. 

## Checklist for your Pull Request (PR)

  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I added new DB indices, I checked, that they are not redundant with PGHero or other tools.
  - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
