### PR TITLE
chore: Move eth_bytecode_db_lookup_started event to smart contract related event handler

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/realtime_event_handler.ex
@@ -42,7 +42,6 @@ defmodule BlockScoutWeb.RealtimeEventHandler do
     Subscriber.to(:changed_bytecode, :on_demand)
     Subscriber.to(:fetched_bytecode, :on_demand)
     Subscriber.to(:fetched_token_instance_metadata, :on_demand)
-    Subscriber.to(:eth_bytecode_db_lookup_started, :on_demand)
     Subscriber.to(:zkevm_confirmed_batches, :realtime)
     # Does not come from the indexer
     Subscriber.to(:exchange_rate)

--- a/apps/block_scout_web/lib/block_scout_web/smart_contract_realtime_event_handler.ex
+++ b/apps/block_scout_web/lib/block_scout_web/smart_contract_realtime_event_handler.ex
@@ -17,6 +17,7 @@ defmodule BlockScoutWeb.SmartContractRealtimeEventHandler do
     Subscriber.to(:contract_verification_result, :on_demand)
     Subscriber.to(:smart_contract_was_verified, :on_demand)
     Subscriber.to(:smart_contract_was_not_verified, :on_demand)
+    Subscriber.to(:eth_bytecode_db_lookup_started, :on_demand)
     {:ok, []}
   end
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/9018