### PR TITLE
chore: Token transfers broadcast optimization

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -177,16 +177,13 @@ defmodule BlockScoutWeb.Notifier do
   def handle_event({:chain_event, :token_transfers, :realtime, all_token_transfers}) do
     all_token_transfers_full =
       all_token_transfers
-      |> Enum.map(
-        &(&1
-          |> Repo.preload(
-            DenormalizationHelper.extend_transaction_preload([
-              :token,
-              :transaction,
-              from_address: [:names, :smart_contract, :proxy_implementations],
-              to_address: [:names, :smart_contract, :proxy_implementations]
-            ])
-          ))
+      |> Repo.preload(
+        DenormalizationHelper.extend_transaction_preload([
+          :token,
+          :transaction,
+          from_address: [:names, :smart_contract, :proxy_implementations],
+          to_address: [:names, :smart_contract, :proxy_implementations]
+        ])
       )
 
     transfers_by_token = Enum.group_by(all_token_transfers_full, fn tt -> to_string(tt.token_contract_address_hash) end)


### PR DESCRIPTION
## Changelog

Preload token transfers associations by one query instead of multiple