### PR TITLE
fix: extend block search range for `getblocknobytime` method

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
@@ -344,6 +344,38 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
       schema = resolve_getblockreward_schema()
       assert :ok = ExJsonSchema.Validator.validate(schema, response)
     end
+
+    test "returns any nearest block within arbitrary range of time", %{conn: conn} do
+      timestamp_string = "1617020209"
+      {:ok, timestamp} = Chain.param_to_block_timestamp(timestamp_string)
+      block = insert(:block, timestamp: timestamp)
+
+      {timestamp_int, _} = Integer.parse(timestamp_string)
+
+      timestamp_in_the_past_str =
+        (timestamp_int - 2 * 60)
+        |> to_string()
+
+      expected_result = %{
+        "blockNumber" => "#{block.number}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", %{
+                 "module" => "block",
+                 "action" => "getblocknobytime",
+                 "timestamp" => "#{timestamp_in_the_past_str}",
+                 "closest" => "after"
+               })
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      schema = resolve_getblockreward_schema()
+      assert :ok = ExJsonSchema.Validator.validate(schema, response)
+    end
   end
 
   defp resolve_getblockreward_schema() do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2500,18 +2500,21 @@ defmodule Explorer.Chain do
   end
 
   @doc """
-    Finds the block number closest to a given timestamp, with a one-minute buffer, optionally
-    adjusting based on whether the block should be before or after the timestamp.
+    Finds the block number closest to a given timestamp, optionally adjusting
+    based on whether the block should be before or after the timestamp.
 
     ## Parameters
-    - `given_timestamp`: The timestamp for which the closest block number is being sought.
-    - `closest`: A direction indicator (`:before` or `:after`) specifying whether the block number
-                returned should be before or after the given timestamp.
-    - `from_api`: A boolean flag indicating whether to use the replica database or the primary one
-                  for the query.
+    - `given_timestamp`: The timestamp for which the closest block number is
+      being sought.
+    - `closest`: A direction indicator (`:before` or `:after`) specifying
+                whether the block number returned should be before or after the
+                given timestamp.
+    - `from_api`: A boolean flag indicating whether to use the replica database
+                  or the primary one for the query.
 
     ## Returns
-    - `{:ok, block_number}` where `block_number` is the block number closest to the specified timestamp.
+    - `{:ok, block_number}` where `block_number` is the block number closest to
+      the specified timestamp.
     - `{:error, :not_found}` if no block is found within the specified criteria.
   """
   @spec timestamp_to_block_number(DateTime.t(), :before | :after, boolean()) ::
@@ -2519,19 +2522,10 @@ defmodule Explorer.Chain do
   def timestamp_to_block_number(given_timestamp, closest, from_api) do
     {:ok, t} = Timex.format(given_timestamp, "%Y-%m-%d %H:%M:%S", :strftime)
 
-    inner_query =
+    query =
       from(
         block in Block,
         where: block.consensus == true,
-        where:
-          fragment("? <= TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS') + (1 * interval '1 minute')", block.timestamp, ^t),
-        where:
-          fragment("? >= TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS') - (1 * interval '1 minute')", block.timestamp, ^t)
-      )
-
-    query =
-      from(
-        block in subquery(inner_query),
         select: block,
         order_by:
           fragment("abs(extract(epoch from (? - TO_TIMESTAMP(?, 'YYYY-MM-DD HH24:MI:SS'))))", block.timestamp, ^t),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2583,11 +2583,11 @@ defmodule Explorer.Chain do
         end
 
       :after ->
-        if DateTime.compare(timestamp, given_timestamp) == :lt ||
+        if DateTime.compare(timestamp, given_timestamp) == :gt ||
              DateTime.compare(timestamp, given_timestamp) == :eq do
-          BlockNumberHelper.next_block_number(number)
-        else
           number
+        else
+          BlockNumberHelper.next_block_number(number)
         end
     end
   end

--- a/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/history/historian.ex
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Transaction.History.Historian do
       from_api = false
 
       with {:ok, min_block} <- Chain.timestamp_to_block_number(earliest, :after, from_api),
-           {:ok, max_block} <- Chain.timestamp_to_block_number(latest, :after, from_api) do
+           {:ok, max_block} <- Chain.timestamp_to_block_number(latest, :before, from_api) do
         record =
           min_block
           |> compile_records_in_range(max_block)

--- a/apps/explorer/test/explorer/chain/transaction/history/historian_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction/history/historian_test.exs
@@ -18,14 +18,14 @@ defmodule Explorer.Chain.Transaction.History.HistorianTest do
   describe "compile_records/1" do
     test "fetches transactions, total gas, total fee from blocks mined in the past num_days" do
       blocks = [
+        # 1970-01-02 00:00:00
+        insert(:block, timestamp: DateTime.from_unix!(days_to_secs(1))),
+
         # 1970-01-03 00:00:60
         insert(:block, timestamp: DateTime.from_unix!(days_to_secs(2) + 60)),
 
         # 1970-01-03 04:00:00
         insert(:block, timestamp: DateTime.from_unix!(days_to_secs(2) + 4 * 60 * 60)),
-
-        # 1970-01-02 00:00:00
-        insert(:block, timestamp: DateTime.from_unix!(days_to_secs(1)))
       ]
 
       transaction_1 = insert(:transaction) |> with_block(Enum.at(blocks, 0), status: :ok)
@@ -38,31 +38,31 @@ defmodule Explorer.Chain.Transaction.History.HistorianTest do
 
       assert {:ok, ^expected} = Historian.compile_records(1)
 
-      total_gas_used_1 = Decimal.add(transaction_1.gas_used, transaction_2.gas_used)
+      total_gas_used_01_03 = Decimal.add(transaction_2.gas_used, transaction_3.gas_used)
 
       %Explorer.Chain.Wei{value: transaction_1_gas_price_value} = transaction_1.gas_price
       %Explorer.Chain.Wei{value: transaction_2_gas_price_value} = transaction_2.gas_price
       %Explorer.Chain.Wei{value: transaction_3_gas_price_value} = transaction_3.gas_price
 
-      total_fee_1 =
+      total_fee_01_03 =
         Decimal.add(
-          Decimal.mult(transaction_1.gas_used, transaction_1_gas_price_value),
-          Decimal.mult(transaction_2.gas_used, transaction_2_gas_price_value)
+          Decimal.mult(transaction_2.gas_used, transaction_2_gas_price_value),
+          Decimal.mult(transaction_3.gas_used, transaction_3_gas_price_value)
         )
 
-      total_fee_3 = Decimal.mult(transaction_3.gas_used, transaction_3_gas_price_value)
+      total_fee_01_02 = Decimal.mult(transaction_1.gas_used, transaction_1_gas_price_value)
 
       expected = [
         %{date: ~D[1970-01-04], number_of_transactions: 0, gas_used: 0, total_fee: 0},
-        %{date: ~D[1970-01-03], gas_used: total_gas_used_1, number_of_transactions: 2, total_fee: total_fee_1}
+        %{date: ~D[1970-01-03], gas_used: total_gas_used_01_03, number_of_transactions: 2, total_fee: total_fee_01_03}
       ]
 
       assert {:ok, ^expected} = Historian.compile_records(2)
 
       expected = [
         %{date: ~D[1970-01-04], number_of_transactions: 0, gas_used: 0, total_fee: 0},
-        %{date: ~D[1970-01-03], gas_used: total_gas_used_1, number_of_transactions: 2, total_fee: total_fee_1},
-        %{date: ~D[1970-01-02], gas_used: transaction_3.gas_used, number_of_transactions: 1, total_fee: total_fee_3}
+        %{date: ~D[1970-01-03], gas_used: total_gas_used_01_03, number_of_transactions: 2, total_fee: total_fee_01_03},
+        %{date: ~D[1970-01-02], gas_used: transaction_1.gas_used, number_of_transactions: 1, total_fee: total_fee_01_02}
       ]
 
       assert {:ok, ^expected} = Historian.compile_records(3)

--- a/apps/explorer/test/explorer/chain/transaction/history/historian_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction/history/historian_test.exs
@@ -25,7 +25,7 @@ defmodule Explorer.Chain.Transaction.History.HistorianTest do
         insert(:block, timestamp: DateTime.from_unix!(days_to_secs(2) + 60)),
 
         # 1970-01-03 04:00:00
-        insert(:block, timestamp: DateTime.from_unix!(days_to_secs(2) + 4 * 60 * 60)),
+        insert(:block, timestamp: DateTime.from_unix!(days_to_secs(2) + 4 * 60 * 60))
       ]
 
       transaction_1 = insert(:transaction) |> with_block(Enum.at(blocks, 0), status: :ok)

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -4335,4 +4335,16 @@ defmodule Explorer.ChainTest do
              }
     end
   end
+
+  describe "timestamp_to_block_number/3" do
+    test "returns correct block number when given timestamp is equal to block timestamp" do
+      timestamp = DateTime.from_unix!(60 * 60 * 24 * 1, :second)
+      block = insert(:block, timestamp: timestamp)
+      expected = {:ok, block.number}
+
+      assert ^expected = Chain.timestamp_to_block_number(timestamp, :after, true)
+
+      assert ^expected = Chain.timestamp_to_block_number(timestamp, :before, true)
+    end
+  end
 end


### PR DESCRIPTION
Closes #9742.

## Changelog

### Enhancements

Regression test for Bug Fix

### Bug Fixes

Initially, the timestamp_to_block_number function filtered blocks to include only those with timestamps differing by no more than one minute from the given timestamp. This PR removes that filtering, allowing for an indefinite range of search. Testing on the Sepolia database shows that the new query performs similarly to the previous one with filtering in terms of execution time.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
