### PR TITLE
fix: Sanitize contractURI response

### DIFF
--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -255,7 +255,8 @@ defmodule Explorer.Token.MetadataRetriever do
 
       case erc_1155_name_uri do
         %{:name => name} when is_binary(name) ->
-          uri = {:ok, [name]}
+          sanitized_name = String.trim(name)
+          uri = {:ok, [sanitized_name]}
 
           with {:ok, %{metadata: metadata}} <- fetch_json(uri, nil, nil, false),
                true <- Map.has_key?(metadata, "name"),


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10401

## Motivation

Sanitize response from `contractURI` property

## Changelog

In the given example the value in `contractURI` is " https://api-imx.boomland.io/api/v1/ticket".
We should trim whitespaces in the response.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
