### PR TITLE
fix: Sanitize topic value before making db query

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -353,11 +353,11 @@ defmodule Explorer.Etherscan.Logs do
         topic_value
 
       _ ->
-        string_string_topic_value(topic_value)
+        sanitize_string_topic_value(topic_value)
     end
   end
 
-  defp string_string_topic_value(topic_value) do
+  defp sanitize_string_topic_value(topic_value) do
     case Chain.string_to_block_hash(topic_value) do
       {:ok, _} ->
         topic_value

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -313,6 +313,8 @@ defmodule Explorer.Etherscan.Logs do
   }
 
   defp where_topic_match(query, filter) do
+    filter = sanitize_filter_topics(filter)
+
     case Enum.filter(@topics, &filter[&1]) do
       [] ->
         query
@@ -322,6 +324,46 @@ defmodule Explorer.Etherscan.Logs do
 
       _ ->
         where_multiple_topics_match(query, filter)
+    end
+  end
+
+  defp sanitize_filter_topics(filter) do
+    @topics
+    |> Enum.reduce(filter, fn topic, acc ->
+      topic_value = filter[topic]
+
+      sanitized_value =
+        topic_value
+        |> List.wrap()
+        |> Enum.map(&sanitize_topic_value/1)
+        |> Enum.reject(&is_nil/1)
+        |> case do
+          [] -> nil
+          [topic] -> topic
+          topics -> topics
+        end
+
+      Map.put(acc, topic, sanitized_value)
+    end)
+  end
+
+  defp sanitize_topic_value(topic_value) do
+    case topic_value do
+      %Explorer.Chain.Hash{} ->
+        topic_value
+
+      _ ->
+        string_string_topic_value(topic_value)
+    end
+  end
+
+  defp string_string_topic_value(topic_value) do
+    case Chain.string_to_block_hash(topic_value) do
+      {:ok, _} ->
+        topic_value
+
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10440

## Motivation

Events `Topic` filter in getLogs API v1 endpoint is not checked to be a valid hash value.

## Changelog

Casting event topic to hash object before preparing Db query.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
