### PR TITLE
chore: add next_page_params clause with log

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -3,6 +3,8 @@ defmodule BlockScoutWeb.Chain do
   Converts the `param` to the corresponding resource that uses that format of param.
   """
 
+  require Logger
+
   import Explorer.Chain,
     only: [
       find_or_insert_address_from_hash: 1,
@@ -116,7 +118,7 @@ defmodule BlockScoutWeb.Chain do
 
   def next_page_params([], _list, _params, _), do: nil
 
-  def next_page_params(_, list, params, paging_function) do
+  def next_page_params(_, list, params, paging_function) when is_list(list) and length(list) > 0 do
     paging_params = paging_function.(List.last(list))
 
     next_page_params = Map.merge(params, paging_params)
@@ -131,6 +133,15 @@ defmodule BlockScoutWeb.Chain do
       end
 
     Map.put(next_page_params, "items_count", items_count)
+  end
+
+  def next_page_params(next_page, list, params, _function) do
+    Logger.error("""
+    Missing BlockScoutWeb.Chain.next_page_params/4 clause:
+    next_page: #{inspect(next_page)}
+    list: #{inspect(list)}
+    params: #{inspect(params)}
+    """)
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -118,7 +118,16 @@ defmodule BlockScoutWeb.Chain do
 
   def next_page_params([], _list, _params, _), do: nil
 
-  def next_page_params(_, list, params, paging_function) when is_list(list) and length(list) > 0 do
+  def next_page_params(next_page, list, params, paging_function) when is_list(list) and length(list) > 0 do
+    if is_nil(List.last(list)) do
+      Logger.error("""
+      nil in BlockScoutWeb.Chain.next_page_params/4 params:
+      next_page: #{inspect(next_page)}
+      list: #{inspect(list)}
+      params: #{inspect(params)}
+      """)
+    end
+
     paging_params = paging_function.(List.last(list))
 
     next_page_params = Map.merge(params, paging_params)


### PR DESCRIPTION
## Motivation
https://github.com/blockscout/blockscout/issues/10445


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
