### PR TITLE
chore: Set Geth as default JSON RPC Variant

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/variant.ex
@@ -113,16 +113,9 @@ defmodule EthereumJSONRPC.Variant do
   # credo:disable-for-next-line
   defp get_default_variant do
     case Application.get_env(:explorer, :chain_type) do
-      :optimism -> "geth"
-      :polygon_zkevm -> "geth"
-      :zetachain -> "geth"
-      :shibarium -> "geth"
-      :stability -> "geth"
-      :zksync -> "geth"
-      :arbitrum -> "geth"
       :rsk -> "rsk"
       :filecoin -> "filecoin"
-      _ -> "nethermind"
+      _ -> "geth"
     end
   end
 end


### PR DESCRIPTION
## Motivation

Since most of the chain forks are based on Geth client, for maintainability purposes it is better to swap default JSON RPC variant to geth. 


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs). https://github.com/blockscout/docs/pull/305
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
