### PR TITLE
perf: speed up worlds list query

### DIFF
--- a/apps/explorer/lib/explorer/chain/mud.ex
+++ b/apps/explorer/lib/explorer/chain/mud.ex
@@ -69,8 +69,9 @@ defmodule Explorer.Chain.Mud do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
     Mud
-    |> select([r], r.address)
     |> distinct(true)
+    |> select([r], r.address)
+    |> where([r], r.table_id == ^@store_tables_table_id)
     |> page_worlds(paging_options)
     |> limit(^paging_options.page_size)
     |> Repo.Mud.all()


### PR DESCRIPTION
## Motivation

* Speed up `/api/v2/mud/worlds` performance

## Changelog

### Enhancements

Postgres does not have an efficient "index skip scan" implementation, thus searching for distinct values requires a large seq scan. A workaround has been found through use of a secondary index together with a table id filter:
```
+------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                      |
+------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=0.56..195702.49 rows=26 width=21) (actual time=2.227..22.875 rows=50 loops=1)                                                      |
|  ->  Unique  (cost=0.56..195702.49 rows=26 width=21) (actual time=0.041..20.684 rows=50 loops=1)                                               |
|        ->  Index Only Scan using key1_index on records  (cost=0.56..195697.89 rows=1840 width=21) (actual time=0.040..20.521 rows=2319 loops=1)|
|              Index Cond: (table_id = '\x746273746f72650000000000000000005461626c657300000000000000000000'::bytea)                              |
|              Heap Fetches: 366                                                                                                                 |
|Planning Time: 0.106 ms                                                                                                                         |
|JIT:                                                                                                                                            |
|  Functions: 4                                                                                                                                  |
|  Options: Inlining false, Optimization false, Expressions true, Deforming true                                                                 |
|  Timing: Generation 0.252 ms, Inlining 0.000 ms, Optimization 0.118 ms, Emission 2.069 ms, Total 2.439 ms                                      |
|Execution Time: 23.214 ms                                                                                                                       |
+------------------------------------------------------------------------------------------------------------------------------------------------+
```

Compared to the old execution plan:
```
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                  |
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=620417.73..620418.01 rows=28 width=21) (actual time=58747.346..58755.030 rows=50 loops=1)                                                      |
|  ->  Unique  (cost=620417.73..620418.01 rows=28 width=21) (actual time=58677.592..58685.274 rows=50 loops=1)                                               |
|        ->  Sort  (cost=620417.73..620417.87 rows=56 width=21) (actual time=58677.590..58685.263 rows=98 loops=1)                                           |
|              Sort Key: address                                                                                                                             |
|              Sort Method: quicksort  Memory: 32kB                                                                                                          |
|              ->  Gather  (cost=620410.22..620416.10 rows=56 width=21) (actual time=58677.412..58685.195 rows=117 loops=1)                                  |
|                    Workers Planned: 2                                                                                                                      |
|                    Workers Launched: 2                                                                                                                     |
|                    ->  HashAggregate  (cost=619410.22..619410.50 rows=28 width=21) (actual time=58633.162..58633.168 rows=39 loops=3)                      |
|                          Group Key: address                                                                                                                |
|                          Batches: 1  Memory Usage: 24kB                                                                                                    |
|                          Worker 0:  Batches: 1  Memory Usage: 32kB                                                                                         |
|                          Worker 1:  Batches: 1  Memory Usage: 32kB                                                                                         |
|                          ->  Parallel Seq Scan on records  (cost=0.00..602803.97 rows=6642498 width=21) (actual time=8.811..58010.571 rows=5313998 loops=3)|
|Planning Time: 0.052 ms                                                                                                                                     |
|JIT:                                                                                                                                                        |
|  Functions: 20                                                                                                                                             |
|  Options: Inlining true, Optimization true, Expressions true, Deforming true                                                                               |
|  Timing: Generation 0.592 ms, Inlining 100.385 ms, Optimization 59.510 ms, Emission 27.500 ms, Total 187.987 ms                                            |
|Execution Time: 58755.668 ms                                                                                                                                |
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

The resulting record set would be the same, as all worlds are required to have a system table `tb.store.Tables`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
