### PR TITLE
fix: logs list serialization

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -256,6 +256,7 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
       insert(:log,
         block: block,
+        block_number: block.number,
         address: address,
         transaction: transaction,
         data: "0x020202",
@@ -333,13 +334,37 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
       transaction4 = insert(:transaction, from_address: address) |> with_block(block4)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
+      insert(:log,
+        address: address,
+        transaction: transaction1,
+        data: "0x010101",
+        block: block1,
+        block_number: block1.number
+      )
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
+      insert(:log,
+        address: address,
+        transaction: transaction2,
+        data: "0x020202",
+        block: block2,
+        block_number: block2.number
+      )
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
+      insert(:log,
+        address: address,
+        transaction: transaction3,
+        data: "0x030303",
+        block: block3,
+        block_number: block3.number
+      )
 
-      insert(:log, address: address, transaction: transaction4, data: "0x040404", block_number: block4.number)
+      insert(:log,
+        address: address,
+        transaction: transaction4,
+        data: "0x040404",
+        block: block4,
+        block_number: block4.number
+      )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "fromBlock" => 1, "toBlock" => 2}])
 
@@ -363,11 +388,29 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
+      insert(:log,
+        address: address,
+        transaction: transaction1,
+        data: "0x010101",
+        block: block1,
+        block_number: block1.number
+      )
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
+      insert(:log,
+        address: address,
+        transaction: transaction2,
+        data: "0x020202",
+        block: block2,
+        block_number: block2.number
+      )
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
+      insert(:log,
+        address: address,
+        transaction: transaction3,
+        data: "0x030303",
+        block: block3,
+        block_number: block3.number
+      )
 
       params = params(api_params, [%{"address" => to_string(address.hash), "blockHash" => to_string(block2.hash)}])
 
@@ -391,11 +434,29 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       transaction2 = insert(:transaction, from_address: address) |> with_block(block2)
       transaction3 = insert(:transaction, from_address: address) |> with_block(block3)
 
-      insert(:log, address: address, transaction: transaction1, data: "0x010101", block_number: block1.number)
+      insert(:log,
+        address: address,
+        transaction: transaction1,
+        data: "0x010101",
+        block: block1,
+        block_number: block1.number
+      )
 
-      insert(:log, address: address, transaction: transaction2, data: "0x020202", block_number: block2.number)
+      insert(:log,
+        address: address,
+        transaction: transaction2,
+        data: "0x020202",
+        block: block2,
+        block_number: block2.number
+      )
 
-      insert(:log, address: address, transaction: transaction3, data: "0x030303", block_number: block3.number)
+      insert(:log,
+        address: address,
+        transaction: transaction3,
+        data: "0x030303",
+        block: block3,
+        block_number: block3.number
+      )
 
       params =
         params(api_params, [%{"address" => to_string(address.hash), "fromBlock" => "earliest", "toBlock" => "earliest"}])

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/logs_controller_test.exs
@@ -296,7 +296,13 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      log = insert(:log, address: contract_address, transaction: transaction, block_number: transaction.block_number)
+      log =
+        insert(:log,
+          address: contract_address,
+          transaction: transaction,
+          block: block,
+          block_number: transaction.block_number
+        )
 
       params = %{
         "module" => "logs",
@@ -353,12 +359,14 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       insert(:log,
         address: contract_address,
         transaction: transaction_block1,
+        block: transaction_block1.block,
         block_number: transaction_block1.block_number
       )
 
       insert(:log,
         address: contract_address,
         transaction: transaction_block2,
+        block: transaction_block2.block,
         block_number: transaction_block2.block_number
       )
 
@@ -406,12 +414,14 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       insert(:log,
         address: contract_address,
         transaction: transaction_block1,
+        block: transaction_block1.block,
         block_number: transaction_block1.block_number
       )
 
       insert(:log,
         address: contract_address,
         transaction: transaction_block2,
+        block: transaction_block2.block,
         block_number: transaction_block2.block_number
       )
 
@@ -450,12 +460,16 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_2)
       ]
 
@@ -508,6 +522,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1)
       ]
@@ -515,6 +531,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2)
       ]
@@ -557,6 +575,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1)
       ]
@@ -564,6 +584,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2)
       ]
@@ -605,6 +627,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -614,6 +638,8 @@ defmodule BlockScoutWeb.API.RPC.LogsControllerTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -103,6 +103,7 @@ defmodule Explorer.Etherscan.Logs do
         )
 
       all_transaction_logs_query
+      |> Chain.wrapped_union_subquery()
       |> order_by([log], asc: log.block_number, asc: log.index)
       |> Repo.replica().all()
     else

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -280,9 +280,7 @@ defmodule Explorer.ChainTest do
         |> insert(to_address: address)
         |> with_block()
 
-      _log1 = insert(:log, transaction: transaction, index: 1, address: address, block_number: transaction.block_number)
-
-      2..51
+      1..51
       |> Enum.map(fn index ->
         insert(:log,
           block: transaction.block,
@@ -292,7 +290,6 @@ defmodule Explorer.ChainTest do
           block_number: transaction.block_number
         )
       end)
-      |> Enum.map(& &1.index)
 
       paging_options1 = %PagingOptions{page_size: 1}
 
@@ -3039,7 +3036,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(block)
 
-      insert(:log, address: address, transaction: transaction)
+      insert(:log, address: address, transaction: transaction, block: block, block_number: block.number)
 
       balance = insert(:unfetched_balance, address_hash: address.hash, block_number: block.number)
 
@@ -3229,7 +3226,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(log_block)
 
-      insert(:log, address: miner, transaction: log_transaction)
+      insert(:log, address: miner, transaction: log_transaction, block: log_block, block_number: log_block.number)
       insert(:unfetched_balance, address_hash: miner.hash, block_number: log_block.number)
 
       from_internal_transaction_block = insert(:block)
@@ -3310,7 +3307,7 @@ defmodule Explorer.ChainTest do
         |> insert()
         |> with_block(block)
 
-      insert(:log, address: miner, transaction: log_transaction)
+      insert(:log, address: miner, transaction: log_transaction, block: block, block_number: block.number)
 
       from_internal_transaction_transaction =
         :transaction

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -99,7 +99,12 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      insert_list(2, :log, address: contract_address, transaction: transaction, block_number: block.number, block: block)
+      insert_list(2, :log,
+        address: contract_address,
+        transaction: transaction,
+        block_number: block.number,
+        block: block
+      )
 
       filter = %{
         from_block: block.number,
@@ -210,7 +215,12 @@ defmodule Explorer.Etherscan.LogsTest do
         |> with_block()
 
       inserted_records =
-        insert_list(2000, :log, address: contract_address, transaction: transaction, block_number: block.number, block: block)
+        insert_list(2000, :log,
+          address: contract_address,
+          transaction: transaction,
+          block_number: block.number,
+          block: block
+        )
 
       filter = %{
         from_block: block.number,

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -65,7 +65,7 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address, block_timestamp: block.timestamp)
         |> with_block(block)
 
-      log = insert(:log, address: contract_address, block_number: block.number, transaction: transaction)
+      log = insert(:log, address: contract_address, block: block, block_number: block.number, transaction: transaction)
 
       filter = %{
         from_block: block.number,
@@ -99,7 +99,7 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block()
 
-      insert_list(2, :log, address: contract_address, transaction: transaction, block_number: block.number)
+      insert_list(2, :log, address: contract_address, transaction: transaction, block_number: block.number, block: block)
 
       filter = %{
         from_block: block.number,
@@ -130,8 +130,19 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1, block_number: first_block.number)
-      insert(:log, address: contract_address, transaction: transaction_block2, block_number: second_block.number)
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block1,
+        block: first_block,
+        block_number: first_block.number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block2,
+        block: second_block,
+        block_number: second_block.number
+      )
 
       filter = %{
         from_block: second_block.number,
@@ -163,8 +174,19 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block(second_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block1, block_number: first_block.number)
-      insert(:log, address: contract_address, transaction: transaction_block2, block_number: second_block.number)
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block1,
+        block: first_block,
+        block_number: first_block.number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block2,
+        block: second_block,
+        block_number: second_block.number
+      )
 
       filter = %{
         from_block: first_block.number,
@@ -188,7 +210,7 @@ defmodule Explorer.Etherscan.LogsTest do
         |> with_block()
 
       inserted_records =
-        insert_list(2000, :log, address: contract_address, transaction: transaction, block_number: block.number)
+        insert_list(2000, :log, address: contract_address, transaction: transaction, block_number: block.number, block: block)
 
       filter = %{
         from_block: block.number,
@@ -230,12 +252,16 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1)
       ]
 
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_2)
       ]
 
@@ -266,6 +292,8 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1)
       ]
@@ -273,6 +301,8 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_2)
       ]
@@ -307,6 +337,8 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1)
       ]
@@ -314,6 +346,8 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
+        block_number: block.number,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2)
       ]
@@ -346,6 +380,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         block_number: block.number
       ]
@@ -353,6 +388,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_2),
         block_number: block.number
       ]
@@ -385,6 +421,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         block_number: block.number
@@ -393,6 +430,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2),
         block_number: block.number
@@ -428,6 +466,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -437,6 +476,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2),
         third_topic: topic(@third_topic_hex_string_2),
@@ -446,6 +486,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log3_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_3),
         second_topic: topic(@second_topic_hex_string_3),
         third_topic: topic(@third_topic_hex_string_3),
@@ -488,6 +529,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -497,6 +539,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2),
         third_topic: topic(@third_topic_hex_string_2),
@@ -506,6 +549,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log3_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_3),
         second_topic: topic(@second_topic_hex_string_3),
         third_topic: topic(@third_topic_hex_string_3),
@@ -548,6 +592,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -557,6 +602,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_2),
         third_topic: topic(@third_topic_hex_string_1),
@@ -566,6 +612,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log3_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -608,6 +655,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log1_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         block_number: block.number
@@ -616,6 +664,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log2_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_2),
         second_topic: topic(@second_topic_hex_string_2),
         third_topic: topic(@third_topic_hex_string_2),
@@ -626,6 +675,7 @@ defmodule Explorer.Etherscan.LogsTest do
       log3_details = [
         address: contract_address,
         transaction: transaction,
+        block: block,
         first_topic: topic(@first_topic_hex_string_1),
         second_topic: topic(@second_topic_hex_string_1),
         third_topic: topic(@third_topic_hex_string_1),
@@ -686,9 +736,26 @@ defmodule Explorer.Etherscan.LogsTest do
         |> insert(to_address: contract_address)
         |> with_block(third_block)
 
-      insert(:log, address: contract_address, transaction: transaction_block3)
-      insert(:log, address: contract_address, transaction: transaction_block1)
-      insert(:log, address: contract_address, transaction: transaction_block2)
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block3,
+        block: third_block,
+        block_number: third_block.number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block1,
+        block: first_block,
+        block_number: first_block.number
+      )
+
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_block2,
+        block: second_block,
+        block_number: second_block.number
+      )
 
       filter = %{
         from_block: first_block.number,

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -757,7 +757,7 @@ defmodule Explorer.Factory do
       index: sequence("log_index", & &1),
       second_topic: nil,
       third_topic: nil,
-      transaction: build(:transaction, block: block)
+      transaction: build(:transaction)
     }
   end
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -757,7 +757,7 @@ defmodule Explorer.Factory do
       index: sequence("log_index", & &1),
       second_topic: nil,
       third_topic: nil,
-      transaction: build(:transaction)
+      transaction: build(:transaction, block: block)
     }
   end
 


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9347

## Changelog

### Bug Fixes

* Fix tests failures related to faulty `log_factory`
* Fix type casting bug in RPC API, probably related to some underlying bug in Ecto
  * https://base.blockscout.com/api?module=logs&action=getLogs&fromBlock=18939002&toBlock=18939002&address=0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
