### PR TITLE
Add API endpoint for OP batch blocks

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -21,6 +21,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias Explorer.Chain
   alias Explorer.Chain.Arbitrum.Reader, as: ArbitrumReader
   alias Explorer.Chain.InternalTransaction
+  alias Explorer.Chain.Optimism.TxnBatch, as: OptimismTxnBatch
 
   case Application.compile_env(:explorer, :chain_type) do
     :ethereum ->
@@ -165,6 +166,33 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     {blocks, next_page} =
       batch_number
       |> ArbitrumReader.batch_blocks(full_options)
+      |> split_list_by_page()
+
+    next_page_params = next_page |> next_page_params(blocks, delete_parameters_from_next_page_params(params))
+
+    conn
+    |> put_status(200)
+    |> render(:blocks, %{
+      blocks: blocks |> maybe_preload_ens() |> maybe_preload_metadata(),
+      next_page_params: next_page_params
+    })
+  end
+
+  @doc """
+    Function to handle GET requests to `/api/v2/blocks/optimism-batch/:batch_number` endpoint.
+    It renders the list of L2 blocks bound to the specified batch.
+  """
+  @spec optimism_batch(Plug.Conn.t(), any()) :: Plug.Conn.t()
+  def optimism_batch(conn, %{"batch_number" => batch_number} = params) do
+    full_options =
+      params
+      |> select_block_type()
+      |> Keyword.merge(paging_options(params))
+      |> Keyword.merge(@api_true)
+
+    {blocks, next_page} =
+      batch_number
+      |> OptimismTxnBatch.batch_blocks(full_options)
       |> split_list_by_page()
 
     next_page_params = next_page |> next_page_params(blocks, delete_parameters_from_next_page_params(params))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -15,7 +15,16 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
 
   alias Explorer.Chain
   alias Explorer.Chain.Transaction
-  alias Explorer.Chain.Optimism.{Deposit, DisputeGame, FrameSequence, OutputRoot, TxnBatch, Withdrawal}
+
+  alias Explorer.Chain.Optimism.{
+    Deposit,
+    DisputeGame,
+    FrameSequence,
+    FrameSequenceBlob,
+    OutputRoot,
+    TxnBatch,
+    Withdrawal
+  }
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -74,10 +83,12 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
           l2_block_number_from = TxnBatch.edge_l2_block_number(fs.id, :min)
           l2_block_number_to = TxnBatch.edge_l2_block_number(fs.id, :max)
           tx_count = Transaction.tx_count_for_block_range(l2_block_number_from..l2_block_number_to)
+          {batch_data_container, _} = FrameSequenceBlob.list(fs.id, api?: true)
 
           fs
           |> Map.put(:l2_block_range, l2_block_number_from..l2_block_number_to)
           |> Map.put(:tx_count, tx_count)
+          |> Map.put(:batch_data_container, batch_data_container)
         end)
       end)
       |> Task.yield_many(:infinity)

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -157,6 +157,10 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       if Application.compile_env(:explorer, :chain_type) == :arbitrum do
         get("/arbitrum-batch/:batch_number", V2.BlockController, :arbitrum_batch)
       end
+
+      if Application.compile_env(:explorer, :chain_type) == :optimism do
+        get("/optimism-batch/:batch_number", V2.BlockController, :optimism_batch)
+      end
     end
 
     scope "/addresses" do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -68,7 +68,8 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           "l2_block_start" => from,
           "l2_block_end" => to,
           "tx_count" => batch.tx_count,
-          "l1_tx_hashes" => batch.l1_transaction_hashes
+          "l1_tx_hashes" => batch.l1_transaction_hashes,
+          "batch_data_container" => batch.batch_data_container
         }
       end)
 

--- a/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/txn_batch.ex
@@ -16,8 +16,9 @@ defmodule Explorer.Chain.Optimism.TxnBatch do
 
   use Explorer.Schema
 
-  import Explorer.Chain, only: [default_paging_options: 0, join_association: 3, select_repo: 1]
+  import Explorer.Chain, only: [default_paging_options: 0, join_association: 3, join_associations: 2, select_repo: 1]
 
+  alias Explorer.Chain.Block
   alias Explorer.Chain.Optimism.FrameSequence
   alias Explorer.{PagingOptions, Repo}
 
@@ -134,6 +135,53 @@ defmodule Explorer.Chain.Optimism.TxnBatch do
         |> limit(^paging_options.page_size)
         |> select_repo(options).all()
     end
+  end
+
+  @doc """
+    Retrieves a list of rollup blocks included into a specified batch.
+
+    This function constructs and executes a database query to retrieve a list of rollup blocks,
+    considering pagination options specified in the `options` parameter. These options dictate
+    the number of items to retrieve and how many items to skip from the top.
+
+    ## Parameters
+    - `batch_number`: The batch number whose transactions are included on L1.
+    - `options`: A keyword list of options specifying pagination, association necessity, and
+      whether to use a replica database.
+
+    ## Returns
+    - A list of `Explorer.Chain.Block` entries belonging to the specified batch.
+  """
+  @spec batch_blocks(non_neg_integer() | binary(),
+          necessity_by_association: %{atom() => :optional | :required},
+          api?: boolean(),
+          paging_options: PagingOptions.t()
+        ) :: [Block.t()]
+  def batch_blocks(batch_number, options) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+    paging_options = Keyword.get(options, :paging_options, default_paging_options())
+
+    query =
+      from(
+        b in Block,
+        inner_join: tb in __MODULE__,
+        on: tb.l2_block_number == b.number and tb.frame_sequence_id == ^batch_number,
+        select: b,
+        where: b.consensus == true
+      )
+
+    query
+    |> page_blocks(paging_options)
+    |> limit(^paging_options.page_size)
+    |> order_by(desc: :number)
+    |> join_associations(necessity_by_association)
+    |> select_repo(options).all()
+  end
+
+  defp page_blocks(query, %PagingOptions{key: nil}), do: query
+
+  defp page_blocks(query, %PagingOptions{key: {block_number}}) do
+    where(query, [block], block.number < ^block_number)
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

Blockscout UI needs to display some entities that are not available in API for OP batches and blocks.

## Changelog

This PR extends https://github.com/blockscout/blockscout/pull/10199 by adding the two new changes to API:
- a new `batch_data_container` field has been added to the item of `/api/v2/optimism/batches` (for the possible values see the description of https://github.com/blockscout/blockscout/pull/10199)
- a new `/api/v2/blocks/optimism-batch/:batch_number` endpoint to output L2 blocks related to the specified OP batch by its number

Example of `/api/v2/optimism/batches` output:

```
{
  "items": [
    {
      "batch_data_container": "in_calldata",
      "internal_id": 3598,
      "l1_timestamp": "2024-01-06T03:30:24.000000Z",
      "l1_tx_hashes": [
        "0x7b4d25f95f480bcf90dcce0432e6512949ccf6cf01afb52d49f72091a0256f0e"
      ],
      "l2_block_end": 759859,
      "l2_block_start": 759697,
      "tx_count": 0
    },
    ...
    {
      "batch_data_container": "in_celestia",
      "internal_id": 3542,
      "l1_timestamp": "2024-01-05T23:07:36.000000Z",
      "l1_tx_hashes": [
        "0x647ab763cda30f6e3847e7184ab507d75e029337419c3220b4fbb2372dc88b53"
      ],
      "l2_block_end": 751968,
      "l2_block_start": 751813,
      "tx_count": 0
    }
  ],
  "next_page_params": {
    "id": 3536,
    "items_count": 50
  }
}
```

Example of `/api/v2/blocks/optimism-batch/:batch_number` output:

```
{
  "items": [
    {
      "base_fee_per_gas": "50",
      "burnt_fees": "2344450",
      "burnt_fees_percentage": null,
      "difficulty": "0",
      "gas_limit": "30000000",
      "gas_target_percentage": -99.68740666666666,
      "gas_used": "46889",
      "gas_used_percentage": 0.15629666666666667,
      "hash": "0x9aa2ed2d9393a281868de580eecb256bd6d2135100e67384946902674a4c1933",
      "height": 33082,
      "miner": {
        "ens_domain_name": null,
        "hash": "0x4200000000000000000000000000000000000011",
        "implementations": [],
        "is_contract": false,
        "is_verified": false,
        "metadata": null,
        "name": null,
        "private_tags": [],
        "public_tags": [],
        "watchlist_names": []
      },
      "nonce": "0x0000000000000000",
      "parent_hash": "0xa84e01a064464a77c5c0ebc0bbcbe4def573e605b8750887dd2a5fee7136d422",
      "priority_fee": "0",
      "rewards": [],
      "size": 868,
      "timestamp": "2023-12-20T07:44:20.000000Z",
      "total_difficulty": "0",
      "tx_count": 1,
      "tx_fees": "0",
      "type": "block",
      "uncles_hashes": [],
      "withdrawals_count": null
    },
    ...
    {
      "base_fee_per_gas": "50",
      "burnt_fees": "3199450",
      "burnt_fees_percentage": null,
      "difficulty": "0",
      "gas_limit": "30000000",
      "gas_target_percentage": -99.57340666666667,
      "gas_used": "63989",
      "gas_used_percentage": 0.21329666666666666,
      "hash": "0xab2cce0d08912c538e74d1010d29df802e8a86402020aa2d11eac3c3f8ad9210",
      "height": 33033,
      "miner": {
        "ens_domain_name": null,
        "hash": "0x4200000000000000000000000000000000000011",
        "implementations": [],
        "is_contract": false,
        "is_verified": false,
        "metadata": null,
        "name": null,
        "private_tags": [],
        "public_tags": [],
        "watchlist_names": []
      },
      "nonce": "0x0000000000000000",
      "parent_hash": "0xed1237e1832c15e0c9e7171df7f0aafb5f95ca74a35aa531b6eee83535ee630c",
      "priority_fee": "0",
      "rewards": [],
      "size": 868,
      "timestamp": "2023-12-20T07:42:42.000000Z",
      "total_difficulty": "0",
      "tx_count": 1,
      "tx_fees": "0",
      "type": "block",
      "uncles_hashes": [],
      "withdrawals_count": null
    }
  ],
  "next_page_params": {
    "block_number": 33033,
    "items_count": 50
  }
}
```


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
