### PR TITLE
chore: Public metrics config API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -16,4 +16,12 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
     |> put_status(200)
     |> json(%{limit: limit})
   end
+
+  def public_metrics(conn, _params) do
+    public_metrics_update_period_hours = Application.get_env(:explorer, Explorer.Chain.Metrics)[:update_period_hours]
+
+    conn
+    |> put_status(200)
+    |> json(%{update_period_hours: public_metrics_update_period_hours})
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -108,6 +108,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     scope "/config" do
       get("/backend-version", V2.ConfigController, :backend_version)
       get("/csv-export", V2.ConfigController, :csv_export)
+      get("/public-metrics", V2.ConfigController, :public_metrics)
     end
 
     scope "/transactions" do


### PR DESCRIPTION
## Motivation

Add config API endpoint for public metrics.

## Changelog

`/api/v2/config/public-metrics` endpoint is added.

Sample response (default update period is 24 hrs):
```
{"update_period_hours":24}
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
