### PR TITLE
fix: filter out incorrect L1-to-L2 Arbitrum messages 

### DIFF
--- a/apps/explorer/lib/explorer/chain/arbitrum/reader.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader.ex
@@ -21,7 +21,11 @@ defmodule Explorer.Chain.Arbitrum.Reader do
   alias Explorer.Chain.Block, as: FullBlock
   alias Explorer.Chain.{Hash, Log, Transaction}
 
-  @to_l2_messages_transaction_types [100, 105]
+  # https://github.com/OffchainLabs/go-ethereum/blob/dff302de66598c36b964b971f72d35a95148e650/core/types/transaction.go#L44C2-L50
+  @message_to_l2_eth_deposit 100
+  @message_to_l2_submit_retryable_tx 105
+
+  @zero_wei 0
 
   @doc """
     Retrieves the number of the latest L1 block where an L1-to-L2 message was discovered.
@@ -834,6 +838,10 @@ defmodule Explorer.Chain.Arbitrum.Reader do
   # table. A message is considered missed if there is a transaction without a
   # matching message record.
   #
+  # For transactions that could be considered ETH deposits, it checks
+  # that the message value is not zero, as transactions with a zero value
+  # cannot be a deposit.
+  #
   # ## Returns
   #   - A query to retrieve missed L1-to-L2 messages.
   @spec missed_messages_to_l2_query() :: Ecto.Query.t()
@@ -841,7 +849,10 @@ defmodule Explorer.Chain.Arbitrum.Reader do
     from(rollup_tx in Transaction,
       left_join: msg in Message,
       on: rollup_tx.hash == msg.completion_transaction_hash and msg.direction == :to_l2,
-      where: rollup_tx.type in @to_l2_messages_transaction_types and is_nil(msg.completion_transaction_hash)
+      where:
+        (rollup_tx.type == ^@message_to_l2_submit_retryable_tx or
+           (rollup_tx.type == ^@message_to_l2_eth_deposit and rollup_tx.value != ^@zero_wei)) and
+          is_nil(msg.completion_transaction_hash)
     )
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/messaging.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/messaging.ex
@@ -62,10 +62,10 @@ defmodule Indexer.Fetcher.Arbitrum.Messaging do
   @doc """
     Filters a list of rollup transactions to identify L1-to-L2 messages and composes a map for each with the related message information.
 
-    This function filters through a list of rollup transactions, selecting those
-    with a non-nil `request_id`, indicating they are L1-to-L2 message completions.
-    These filtered transactions are then processed to construct a detailed message
-    structure for each.
+    This function filters a list of rollup transactions, selecting those where
+    `request_id` is not nil and is below 2^31, indicating they are L1-to-L2
+    message completions. These filtered transactions are then processed to
+    construct a detailed message structure for each.
 
     ## Parameters
     - `transactions`: A list of rollup transaction entries.
@@ -78,14 +78,14 @@ defmodule Indexer.Fetcher.Arbitrum.Messaging do
       this context are considered `:relayed` as they represent completed actions from
       L1 to L2.
   """
-  @spec filter_l1_to_l2_messages(maybe_improper_list(min_transaction, [])) :: [arbitrum_message]
-  @spec filter_l1_to_l2_messages(maybe_improper_list(min_transaction, []), boolean()) :: [arbitrum_message]
+  @spec filter_l1_to_l2_messages([min_transaction()]) :: [arbitrum_message]
+  @spec filter_l1_to_l2_messages([min_transaction()], boolean()) :: [arbitrum_message]
   def filter_l1_to_l2_messages(transactions, report \\ true)
       when is_list(transactions) and is_boolean(report) do
     messages =
       transactions
       |> Enum.filter(fn tx ->
-        tx[:request_id] != nil
+        tx[:request_id] != nil and Bitwise.bsr(tx[:request_id], 31) == 0
       end)
       |> handle_filtered_l1_to_l2_messages()
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/historical_messages_on_l2.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/historical_messages_on_l2.ex
@@ -273,6 +273,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.HistoricalMessagesOnL2 do
           messages ++ messages_acc
         end)
 
+      # Logging of zero messages is left by intent to reveal potential cases when
+      # not all transactions are recognized as completed L1-to-L2 messages.
       log_info("#{length(messages)} completions of L1-to-L2 messages will be imported")
       import_to_db(messages)
     end


### PR DESCRIPTION
## Motivation

During synchronization of the Blockscout instance for Arbitrum One, it was found that not all transactions with the type `100` can be considered as deposit L1->L2 messages.

First of all, the following error occurred on the system when attempting to insert the message into the database.
```
** (DBConnection.EncodeError) Postgrex expected an integer in -2147483648..2147483647, got 71052128300123780255705434601148651469646560887648206875893026519230861104461. Please make sure the value you are passing matches the definition in your table or in your query or convert the value accordingly.
    (postgrex 0.18.0) lib/postgrex/type_module.ex:947: Postgrex.DefaultTypes.encode_params/3
    (postgrex 0.18.0) lib/postgrex/query.ex:75: DBConnection.Query.Postgrex.Query.encode/3
    (db_connection 2.7.0) lib/db_connection.ex:1449: DBConnection.encode/5
    (db_connection 2.7.0) lib/db_connection.ex:1549: DBConnection.run_prepare_execute/5
    (db_connection 2.7.0) lib/db_connection.ex:772: DBConnection.parsed_prepare_execute/5
    (db_connection 2.7.0) lib/db_connection.ex:764: DBConnection.prepare_execute/4
    (postgrex 0.18.0) lib/postgrex.ex:295: Postgrex.query/4
    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:519: Ecto.Adapters.SQL.query!/4
```
Next, the investigation showed that although the transaction `0x81ac0561f2272b92d430e99f7bce2d1a8082801d7c075fbabed05709b5bc1bd2` has the type `100` (`0x64`), the `requestId` field contains a byte sequence that is much higher than the expected identifier of a L1->L2 message. Analysis proved that Ethereum Mainnet does not contain any transaction that emitted the corresponding message. The discussion with the Arbitrum team has not yet clarified the nature of this message.

## Changelog

### Bug Fixes

1. To work around the database issue, it is necessary to filter out transactions that are not ETH deposit messages before they are handled for import.
2. The process of identifying missing messages is changed to exclude false transactions in the lookup of missing L1->L2 messages.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
