### PR TITLE
fix: Fix internal transactions runner test for zetachain

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -49,7 +49,7 @@ jobs:
 
             // Add/remove CI matrix chain types here
             const defaultChainTypes = ["default"];
-            const chainTypes = ["ethereum", "polygon_zkevm", "rsk", "stability", "filecoin", "optimism", "arbitrum", "celo"];
+            const chainTypes = ["ethereum", "polygon_zkevm", "rsk", "stability", "filecoin", "optimism", "arbitrum", "celo", "zetachain"];
             const extraChainTypes = ["suave", "polygon_edge"];
 
             // Chain type matrix we use in master branch


### PR DESCRIPTION
## Motivation

There are internal transactions runner tests that follow the logic of considering `there are no internal txs for some transactions` case as invalid while for zetachain it's a valid case.

## Changelog

- Moved tests that follow mentioned logic to non-zetachain chain types
- Added an adaptation of these tests for zetachain