### PR TITLE
feat: Add DELETE /api/v2/import/token-info method

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/import_controller.ex
@@ -3,9 +3,10 @@ defmodule BlockScoutWeb.API.V2.ImportController do
 
   alias BlockScoutWeb.API.V2.ApiView
   alias Explorer.Chain
-  alias Explorer.Chain.{Data, SmartContract}
+  alias Explorer.Chain.{Data, SmartContract, Token}
   alias Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand
   alias Explorer.SmartContract.EthBytecodeDBInterface
+  alias Indexer.Fetcher.TokenUpdater
 
   import Explorer.SmartContract.Helper, only: [prepare_bytecode_for_microservice: 3, contract_creation_input: 1]
 
@@ -18,17 +19,12 @@ defmodule BlockScoutWeb.API.V2.ImportController do
         conn,
         %{
           "iconUrl" => icon_url,
-          "tokenAddress" => token_address_hash_string,
+          "tokenAddress" => _token_address_hash_string,
           "tokenSymbol" => token_symbol,
           "tokenName" => token_name
         } = params
       ) do
-    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
-           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
-         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
-         {:format_address, {:ok, address_hash}} <-
-           {:format_address, Chain.string_to_address_hash(token_address_hash_string)},
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
+    with {:ok, token} <- validate_api_key_address_hash_and_token(params) do
       changeset =
         %{is_verified_via_admin_panel: true}
         |> put_icon_url(icon_url)
@@ -96,6 +92,32 @@ defmodule BlockScoutWeb.API.V2.ImportController do
     end
   end
 
+  def delete_token_info(
+        conn,
+        %{
+          "tokenAddress" => _token_address_hash_string
+        } = params
+      ) do
+    with {:ok, token} <- validate_api_key_address_hash_and_token(params) do
+      case Token.drop_token_info(token) do
+        {:ok, _} ->
+          TokenUpdater.run([token], [])
+
+          conn
+          |> put_view(ApiView)
+          |> render(:message, %{message: "Success"})
+
+        error ->
+          Logger.warning(fn -> ["Error on deleting token info: ", inspect(error)] end)
+
+          conn
+          |> put_view(ApiView)
+          |> put_status(:bad_request)
+          |> render(:message, %{message: "Error"})
+      end
+    end
+  end
+
   defp params_to_contract_search_options(%{"import_from" => "verifier_alliance"}) do
     [only_verifier_alliance?: true]
   end
@@ -140,6 +162,21 @@ defmodule BlockScoutWeb.API.V2.ImportController do
 
       _ ->
         nil
+    end
+  end
+
+  defp validate_api_key_address_hash_and_token(
+         %{
+           "tokenAddress" => token_address_hash_string
+         } = params
+       ) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:format_address, {:ok, address_hash}} <-
+           {:format_address, Chain.string_to_address_hash(token_address_hash_string)},
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
+      {:ok, token}
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -93,6 +93,8 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     pipe_through(:api_v2_no_session)
 
     post("/token-info", V2.ImportController, :import_token_info)
+    delete("/token-info", V2.ImportController, :delete_token_info)
+
     get("/smart-contracts/:address_hash_param", V2.ImportController, :try_to_search_contract)
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
@@ -80,7 +80,7 @@ defmodule BlockScoutWeb.API.V2.ImportControllerTest do
     test "return error on misconfigured api key", %{conn: conn} do
       request =
         delete(conn, "/api/v2/import/token-info", %{
-          "tokenAddress" => build(:address).hash
+          "token_address_hash" => build(:address).hash
         })
 
       assert %{"message" => "API key not configured on the server"} = json_response(request, 403)
@@ -88,7 +88,7 @@ defmodule BlockScoutWeb.API.V2.ImportControllerTest do
 
     test "return error on wrong api key", %{conn: conn} do
       Application.put_env(:block_scout_web, :sensitive_endpoints_api_key, "abc")
-      body = %{"tokenAddress" => build(:address).hash}
+      body = %{"token_address_hash" => build(:address).hash}
       request = delete(conn, "/api/v2/import/token-info", Map.merge(body, %{"api_key" => "123"}))
 
       assert %{"message" => "Wrong API key"} = json_response(request, 401)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule BlockScoutWeb.API.V2.ImportControllerTest do
   use BlockScoutWeb.ConnCase
 
+  import Mox
+
   describe "/import/token-info" do
     test "return error on misconfigured api key", %{conn: conn} do
       request =
@@ -65,6 +67,73 @@ defmodule BlockScoutWeb.API.V2.ImportControllerTest do
       }
 
       request = post(conn, "/api/v2/import/token-info", Map.merge(body, %{"api_key" => api_key}))
+      assert %{"message" => "Success"} = json_response(request, 200)
+
+      request = get(conn, "/api/v2/tokens/#{token_address}")
+      assert %{"icon_url" => ^icon_url, "name" => ^token_name, "symbol" => ^token_symbol} = json_response(request, 200)
+
+      Application.put_env(:block_scout_web, :sensitive_endpoints_api_key, nil)
+    end
+
+    test "success delete token info", %{conn: conn} do
+      insert(:token,
+        name: "old",
+        symbol: "OLD",
+        decimals: 10,
+        cataloged: true,
+        updated_at: DateTime.add(DateTime.utc_now(), -:timer.hours(50), :millisecond)
+      )
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        1,
+        fn requests, _opts ->
+          {:ok,
+           Enum.map(requests, fn
+             %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result: "0x0000000000000000000000000000000000000000000000000000000000000012"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result:
+                   "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000096e657720746f6b656e0000000000000000000000000000000000000000000000"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result:
+                   "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000034e45570000000000000000000000000000000000000000000000000000000000"
+               }
+
+             %{id: id, method: "eth_call", params: [%{data: "0x18160ddd", to: _}, "latest"]} ->
+               %{
+                 id: id,
+                 result: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+               }
+           end)}
+        end
+      )
+
+      api_key = "abc123"
+      icon_url = nil
+      token_symbol = "NEW"
+      token_name = "new token"
+
+      Application.put_env(:block_scout_web, :sensitive_endpoints_api_key, api_key)
+
+      token_address = to_string(insert(:token).contract_address_hash)
+
+      body = %{
+        "tokenAddress" => token_address
+      }
+
+      request = delete(conn, "/api/v2/import/token-info", Map.merge(body, %{"api_key" => api_key}))
       assert %{"message" => "Success"} = json_response(request, 200)
 
       request = get(conn, "/api/v2/tokens/#{token_address}")

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/import_controller_test.exs
@@ -151,7 +151,7 @@ defmodule BlockScoutWeb.API.V2.ImportControllerTest do
       token_address = to_string(insert(:token).contract_address_hash)
 
       body = %{
-        "tokenAddress" => token_address
+        "token_address_hash" => token_address
       }
 
       request = delete(conn, "/api/v2/import/token-info", Map.merge(body, %{"api_key" => api_key}))

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -278,4 +278,10 @@ defmodule Explorer.Chain.Token do
       timeout: @timeout
     )
   end
+
+  def drop_token_info(token) do
+    token
+    |> Changeset.change(%{is_verified_via_admin_panel: false, icon_url: nil, symbol: nil, name: nil})
+    |> Repo.update()
+  end
 end

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -279,6 +279,12 @@ defmodule Explorer.Chain.Token do
     )
   end
 
+  @doc """
+  Drops token info for the given token:
+  Sets is_verified_via_admin_panel to false, icon_url to nil, symbol to nil, name to nil.
+  Don't forget to set/update token's symbol and name after this function.
+  """
+  @spec drop_token_info(t()) :: {:ok, t()} | {:error, Changeset.t()}
   def drop_token_info(token) do
     token
     |> Changeset.change(%{is_verified_via_admin_panel: false, icon_url: nil, symbol: nil, name: nil})


### PR DESCRIPTION
Closes #8963 

## Changelog
- Add DELETE `/api/v2/import/token-info method` (expects `token_address_hash` and `api_key` as input parameters)
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
