### PR TITLE
feat: more descriptive status for Arbitrum message for the transaction view

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -528,14 +528,14 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
 
   # Determines if an Arbitrum transaction contains a cross-chain message and extends
   # the incoming map with fields related to the cross-chain message to reflect the
-  # direction of the message and the associated L1 transaction.
+  # direction of the message, its status and the associated L1 transaction.
   #
   # ## Parameters
   # - `arbitrum_tx`: An Arbitrum transaction.
   #
   # ## Returns
-  # - A map extended with fields indicating the direction of the message and
-  #   the associated L1 transaction.
+  # - A map extended with fields indicating the direction of the message, its status
+  #   and the associated L1 transaction.
   @spec extend_if_message(map(), %{
           :__struct__ => Transaction,
           :arbitrum_message_to_l2 => any(),
@@ -543,22 +543,56 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
           optional(any()) => any()
         }) :: map()
   defp extend_if_message(arbitrum_json, %Transaction{} = arbitrum_tx) do
-    {message_type, l1_tx} =
+    {message_type, message_data} =
       case {APIV2Helper.specified?(Map.get(arbitrum_tx, :arbitrum_message_to_l2)),
             APIV2Helper.specified?(Map.get(arbitrum_tx, :arbitrum_message_from_l2))} do
         {true, false} ->
-          {"incoming", APIV2Helper.get_2map_data(arbitrum_tx, :arbitrum_message_to_l2, :originating_transaction_hash)}
+          {"incoming", l1_tx_and_status_for_message(arbitrum_tx, :incoming)}
 
         {false, true} ->
-          {"outcoming", APIV2Helper.get_2map_data(arbitrum_tx, :arbitrum_message_from_l2, :completion_transaction_hash)}
+          {"outcoming", l1_tx_and_status_for_message(arbitrum_tx, :outcoming)}
 
         _ ->
-          {nil, nil}
+          {nil, %{}}
       end
 
     arbitrum_json
     |> Map.put("contains_message", message_type)
-    |> Map.put("message_related_l1_transaction", l1_tx)
+    |> Map.put("message_related_info", message_data)
+  end
+
+  # Determines the associated L1 transaction and its status for the given message direction.
+  @spec l1_tx_and_status_for_message(Transaction.t(), :incoming | :outcoming) :: map()
+  defp l1_tx_and_status_for_message(arbitrum_tx, message_direction) do
+    {l1_tx, status} =
+      case message_direction do
+        :incoming ->
+          l1_tx = APIV2Helper.get_2map_data(arbitrum_tx, :arbitrum_message_to_l2, :originating_transaction_hash)
+
+          if is_nil(l1_tx) do
+            {nil, "Syncing with base layer"}
+          else
+            {l1_tx, "Relayed"}
+          end
+
+        :outcoming ->
+          case APIV2Helper.get_2map_data(arbitrum_tx, :arbitrum_message_from_l2, :status) do
+            :initiated ->
+              {nil, "Settlement pending"}
+
+            :sent ->
+              {nil, "Waiting for confirmation"}
+
+            :confirmed ->
+              {nil, "Ready for relay"}
+
+            :relayed ->
+              {APIV2Helper.get_2map_data(arbitrum_tx, :arbitrum_message_from_l2, :completion_transaction_hash),
+               "Relayed"}
+          end
+      end
+
+    %{"associated_l1_transaction" => l1_tx, "message_status" => status}
   end
 
   # Extends the output JSON with information from Arbitrum-specific fields of the transaction.

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -562,7 +562,15 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   end
 
   # Determines the associated L1 transaction and its status for the given message direction.
-  @spec l1_tx_and_status_for_message(Transaction.t(), :incoming | :outcoming) :: map()
+  @spec l1_tx_and_status_for_message(
+          %{
+            :__struct__ => Transaction,
+            :arbitrum_message_to_l2 => any(),
+            :arbitrum_message_from_l2 => any(),
+            optional(any()) => any()
+          },
+          :incoming | :outcoming
+        ) :: map()
   defp l1_tx_and_status_for_message(arbitrum_tx, message_direction) do
     {l1_tx, status} =
       case message_direction do


### PR DESCRIPTION
## Motivation

Although the changes to provide an associated L1 transaction for rollup transactions containing a cross-chain message were already made in https://github.com/blockscout/blockscout/pull/10590, it was found that for scenarios where the rollup transaction contains a message but there is no associated L1 transaction, there should be a more descriptive response to display the correct status to the end user in the UI.

## Changelog

### Enhancements

The function `l1_tx_and_status_for_message` provides a map containing the L1 transaction and status of the message, which can be used in cases where the L1 transaction is not yet associated.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
