### PR TITLE
fix: Insert coin balances placeholders in internal transactions fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -24,7 +24,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
   alias Indexer.Transform.Celo.TransactionTokenTransfers, as: CeloTransactionTokenTransfers
-  alias Indexer.Transform.{Addresses, AddressTokenBalances}
+  alias Indexer.Transform.{AddressCoinBalances, Addresses, AddressTokenBalances}
 
   @behaviour BufferedTask
 
@@ -278,6 +278,9 @@ defmodule Indexer.Fetcher.InternalTransaction do
         {String.downcase(hash), block_number}
       end)
 
+    address_coin_balances_params_set =
+      AddressCoinBalances.params_set(%{internal_transactions_params: internal_transactions_params_marked})
+
     empty_block_numbers =
       unique_numbers
       |> MapSet.new()
@@ -310,6 +313,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
         token_transfers: %{params: celo_token_transfers},
         tokens: %{params: celo_tokens},
         addresses: %{params: addresses_params},
+        address_coin_balances: %{params: address_coin_balances_params_set},
         internal_transactions: %{params: internal_transactions_and_empty_block_numbers, with: :blockless_changeset},
         timeout: :infinity
       })

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -27,16 +27,24 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       assert MapSet.size(params_set) == 0
     end
 
-    test "with call internal transaction extracts nothing" do
+    test "with call internal transaction extracts from_address_hash and to_address_hash" do
+      block_number = 1
+      from_address_hash = to_string(Factory.address_hash())
+      to_address_hash = to_string(Factory.address_hash())
+
       internal_transaction_params =
         :internal_transaction
         |> Factory.params_for()
-        |> Map.update!(:type, &to_string/1)
-        |> Map.put(:block_number, 1)
+        |> Map.put(:type, "call")
+        |> Map.put(:block_number, block_number)
+        |> Map.put(:from_address_hash, from_address_hash)
+        |> Map.put(:to_address_hash, to_address_hash)
 
       params_set = AddressCoinBalances.params_set(%{internal_transactions_params: [internal_transaction_params]})
 
-      assert MapSet.size(params_set) == 0
+      assert MapSet.size(params_set) == 2
+      assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+      assert MapSet.member?(params_set, %{address_hash: to_address_hash, block_number: block_number})
     end
 
     test "with create internal transaction with error extracts nothing" do
@@ -69,7 +77,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       params_set = AddressCoinBalances.params_set(%{internal_transactions_params: [internal_transaction_params]})
 
       assert MapSet.size(params_set) == 1
-      assert %{address_hash: created_contract_address_hash, block_number: block_number}
+      assert MapSet.member?(params_set, %{address_hash: created_contract_address_hash, block_number: block_number})
     end
 
     test "with self-destruct internal transaction extracts from_address_hash and to_address_hash" do
@@ -94,8 +102,8 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       params_set = AddressCoinBalances.params_set(%{internal_transactions_params: [internal_transaction_params]})
 
       assert MapSet.size(params_set) == 2
-      assert %{address_hash: from_address_hash, block_number: block_number}
-      assert %{address_hash: to_address_hash, block_number: block_number}
+      assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+      assert MapSet.member?(params_set, %{address_hash: to_address_hash, block_number: block_number})
     end
 
     test "with log extracts address_hash" do
@@ -162,7 +170,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
 
       assert MapSet.size(params_set) == 1
-      assert %{address_hash: from_address_hash, block_number: block_number}
+      assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
     end
 
     test "with transaction with to_address_hash extracts from_address_hash and to_address_hash" do
@@ -186,8 +194,8 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
 
       assert MapSet.size(params_set) == 2
-      assert %{address_hash: from_address_hash, block_number: block_number}
-      assert %{address_hash: to_address_hash, block_number: block_number}
+      assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+      assert MapSet.member?(params_set, %{address_hash: to_address_hash, block_number: block_number})
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9455
Resolves https://github.com/blockscout/blockscout/issues/10592

## Motivation

Coin balances params that collected during internal transactions fetcher process are only stored in the coin balances fetcher state. It means that if coin balances fetcher crashes, these balances will never be fetched.

## Changelog

- Add an insertion of token balances placeholders to the internal transactions fetcher so if coin balances fetcher crashes, they will be eventually fetched anyway
- Fix coin balances params fetching from internal transactions