### PR TITLE
feat: add celo epoch number to `/api/v2/stats` response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -196,6 +196,12 @@ defmodule BlockScoutWeb.API.V2.StatsController do
         response |> Map.put("last_output_root_size", fetch(@api_true))
       end
 
+    :celo ->
+      defp add_chain_type_fields(response) do
+        import Explorer.Chain.Celo.Reader, only: [last_block_epoch_number: 0]
+        response |> Map.put("celo", %{"epoch_number" => last_block_epoch_number()})
+      end
+
     _ ->
       defp add_chain_type_fields(response), do: response
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -190,7 +190,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
         end
       end
 
-    "optimism" ->
+    :optimism ->
       defp add_chain_type_fields(response) do
         import Explorer.Counters.LastOutputRootSizeCounter, only: [fetch: 1]
         response |> Map.put("last_output_root_size", fetch(@api_true))


### PR DESCRIPTION
Closes #10607.

## Motivation

It would be convenient for frontend to get current epoch number from stats endpoint.  

## Changelog

### Enhancements

Under `:celo` chain type, the `/api/v2/stats` is extended with `celo.epoch.number`. See example:

```jsonc
{
	"average_block_time": 5.0e3,
	"celo": {
		"epoch_number": 1431 // <- here it is
	},
	"coin_image": null,
	"coin_price": null,
	"coin_price_change_percentage": null,
	"gas_price_updated_at": null,
	"gas_prices": {
		"slow": null,
		"average": null,
		"fast": null
	},
	"gas_prices_update_in": 32000,
	"gas_used_today": null,
	"market_cap": "0",
	"network_utilization_percentage": 1.4027809714285715,
	"secondary_coin_image": null,
	"secondary_coin_price": null,
	"static_gas_price": null,
	"total_addresses": "27237",
	"total_blocks": "113175",
	"total_gas_used": "0",
	"total_transactions": "224169",
	"transactions_today": "0",
	"tvl": null
}
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
