### PR TITLE
fix: proper default value of gas used for dropped Arbitrum transactions

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -617,8 +617,8 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     # for the transaction prior to the migration to Arbitrum specific BS build.
     gas_used_for_l1 = Map.get(arbitrum_tx, :gas_used_for_l1, 0) || 0
 
-    gas_used = Map.get(arbitrum_tx, :gas_used, 0)
-    gas_price = Map.get(arbitrum_tx, :gas_price, 0)
+    gas_used = Map.get(arbitrum_tx, :gas_used, 0) || 0
+    gas_price = Map.get(arbitrum_tx, :gas_price, 0) || 0
 
     gas_used_for_l2 =
       gas_used


### PR DESCRIPTION
## Motivation

The following code raises an exception while Arbitrum-specific values are calculated to render the transaction view page:

https://github.com/blockscout/blockscout/blob/a9c2a08716941db3363f8016ce37dbf638a08c1d/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex#L623-L625

The reason for this behavior is that the `gas_used` field in the database is `null` for dropped/replaced transactions. When the field is extracted from the transaction data, it is `null` as well:

https://github.com/blockscout/blockscout/blob/a9c2a08716941db3363f8016ce37dbf638a08c1d/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex#L620-L621

As a result, the further usage of the `nil` value is not accepted in the `Decimal.sub` function.

## Changelog

### Bug Fixes

Apply a default value of `0` for the value extracted from the transaction data if `null` is returned by `Map.get`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
