### PR TITLE
fix: Exclude system transactions from Indexer.Fetcher.ReplacedTransaction module

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/pending_transaction_controller.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
 
   alias BlockScoutWeb.{Controller, TransactionView}
   alias Explorer.Chain
+  alias Explorer.Chain.Transaction
   alias Phoenix.View
 
   {:ok, burn_address_hash} = Chain.string_to_address_hash(burn_address_hash_string())
@@ -64,7 +65,7 @@ defmodule BlockScoutWeb.PendingTransactionController do
   end
 
   defp get_pending_transactions_and_next_page(options) do
-    transactions_plus_one = Chain.recent_pending_transactions(options, true)
+    transactions_plus_one = Transaction.recent_pending_transactions(options, true)
     split_list_by_page(transactions_plus_one)
   end
 end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -329,6 +329,9 @@ defmodule Explorer.Chain.Transaction do
 
   @required_attrs ~w(from_address_hash gas hash input nonce value)a
 
+  @default_page_size 50
+  @default_paging_options %PagingOptions{page_size: @default_page_size}
+
   @typedoc """
   X coordinate module n in
   [Elliptic Curve Digital Signature Algorithm](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
@@ -1955,5 +1958,204 @@ defmodule Explorer.Chain.Transaction do
 
   def method_name(_, _, _) do
     nil
+  end
+
+  @doc """
+  Return the list of pending transactions that occurred recently.
+
+      iex> 2 |> insert_list(:transaction)
+      iex> :transaction |> insert() |> with_block()
+      iex> 8 |> insert_list(:transaction)
+      iex> recent_pending_transactions = Explorer.Chain.Transaction.recent_pending_transactions()
+      iex> length(recent_pending_transactions)
+      10
+      iex> Enum.all?(recent_pending_transactions, fn %Explorer.Chain.Transaction{block_hash: block_hash} ->
+      ...>   is_nil(block_hash)
+      ...> end)
+      true
+
+  ## Options
+
+    * `:necessity_by_association` - use to load `t:association/0` as `:required` or `:optional`.  If an association is
+      `:required`, and the `t:Explorer.Chain.Transaction.t/0` has no associated record for that association,
+      then the `t:Explorer.Chain.Transaction.t/0` will not be included in the list.
+    * `:paging_options` - a `t:Explorer.PagingOptions.t/0` used to specify the `:page_size` (defaults to
+    `#{@default_paging_options.page_size}`) and `:key` (a tuple of the lowest/oldest `{inserted_at, hash}`) and.
+      Results will be the transactions older than the `inserted_at` and `hash` that are passed.
+
+  """
+  @spec recent_pending_transactions([Chain.paging_options() | Chain.necessity_by_association_option()], true | false) ::
+          [
+            __MODULE__.t()
+          ]
+  def recent_pending_transactions(options \\ [], old_ui? \\ true)
+      when is_list(options) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+    method_id_filter = Keyword.get(options, :method)
+    type_filter = Keyword.get(options, :type)
+
+    __MODULE__
+    |> Transaction.page_pending_transaction(paging_options)
+    |> limit(^paging_options.page_size)
+    |> pending_transactions_query()
+    |> Chain.apply_filter_by_method_id_to_transactions(method_id_filter)
+    |> Chain.apply_filter_by_tx_type_to_transactions(type_filter)
+    |> order_by([transaction], desc: transaction.inserted_at, asc: transaction.hash)
+    |> Chain.join_associations(necessity_by_association)
+    |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()
+    |> Chain.select_repo(options).all()
+  end
+
+  @doc """
+  Query to return all pending transactions
+  """
+  @spec pending_transactions_query(Ecto.Queryable.t()) :: Ecto.Queryable.t()
+  def pending_transactions_query(query) do
+    from(transaction in query,
+      where: is_nil(transaction.block_hash) and (is_nil(transaction.error) or transaction.error != "dropped/replaced")
+    )
+  end
+
+  @doc """
+  Returns pending transactions list from the DB
+  """
+  @spec pending_transactions_list() :: Ecto.Schema.t() | term()
+  def pending_transactions_list do
+    Transaction
+    |> pending_transactions_query()
+    |> Repo.all(timeout: :infinity)
+  end
+
+  @doc """
+  Returns a lazy enumerable that emits all pending transactions query
+  """
+  @spec stream_pending_transactions(
+          fields :: [
+            :block_hash
+            | :created_contract_code_indexed_at
+            | :from_address_hash
+            | :gas
+            | :gas_price
+            | :hash
+            | :index
+            | :input
+            | :nonce
+            | :r
+            | :s
+            | :to_address_hash
+            | :v
+            | :value
+          ],
+          initial :: accumulator,
+          reducer :: (entry :: term(), accumulator -> accumulator),
+          limited? :: boolean()
+        ) :: {:ok, accumulator}
+        when accumulator: term()
+  def stream_pending_transactions(fields, initial, reducer, limited? \\ false) when is_function(reducer, 2) do
+    query =
+      Transaction
+      |> Transaction.pending_transactions_query()
+      |> select(^fields)
+      |> Chain.add_fetcher_limit(limited?)
+
+    Repo.stream_reduce(query, initial, reducer)
+  end
+
+  @doc """
+  Count of pending `t:Explorer.Chain.Transaction.t/0`.
+
+  A count of all pending transactions.
+
+      iex> insert(:transaction)
+      iex> :transaction |> insert() |> with_block()
+      iex> Explorer.Chain.Transaction.pending_transaction_count()
+      1
+
+  """
+  @spec pending_transaction_count() :: non_neg_integer()
+  def pending_transaction_count do
+    Transaction
+    |> Transaction.pending_transactions_query()
+    |> Repo.aggregate(:count, :hash)
+  end
+
+  @spec find_and_update_replaced_transactions([
+          %{
+            required(:nonce) => non_neg_integer,
+            required(:from_address_hash) => Hash.Address.t(),
+            required(:hash) => Hash.t()
+          }
+        ]) :: {integer(), nil | [term()]}
+  def find_and_update_replaced_transactions(pending_transactions, timeout \\ :infinity) do
+    query =
+      pending_transactions
+      |> Enum.reduce(
+        Transaction,
+        fn %{hash: hash, nonce: nonce, from_address_hash: from_address_hash}, query ->
+          from(t in query,
+            or_where:
+              t.nonce == ^nonce and t.from_address_hash == ^from_address_hash and t.hash != ^hash and
+                not is_nil(t.block_number)
+          )
+        end
+      )
+      # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+      |> order_by(asc: :hash)
+      |> lock("FOR NO KEY UPDATE")
+
+    hashes = Enum.map(pending_transactions, & &1.hash)
+
+    transactions_to_update =
+      from(pending in Transaction,
+        join: duplicate in subquery(query),
+        on: duplicate.nonce == pending.nonce,
+        on: duplicate.from_address_hash == pending.from_address_hash,
+        where: pending.hash in ^hashes and is_nil(pending.block_hash)
+      )
+
+    Repo.update_all(transactions_to_update, [set: [error: "dropped/replaced", status: :error]], timeout: timeout)
+  end
+
+  @spec update_replaced_transactions([
+          %{
+            required(:nonce) => non_neg_integer,
+            required(:from_address_hash) => Hash.Address.t(),
+            required(:block_hash) => Hash.Full.t()
+          }
+        ]) :: {integer(), nil | [term()]}
+  def update_replaced_transactions(transactions, timeout \\ :infinity) do
+    filters =
+      transactions
+      |> Enum.filter(fn transaction ->
+        transaction.block_hash && transaction.nonce && transaction.from_address_hash
+      end)
+      |> Enum.map(fn transaction ->
+        {transaction.nonce, transaction.from_address_hash}
+      end)
+      |> Enum.uniq()
+
+    if Enum.empty?(filters) do
+      {:ok, []}
+    else
+      query =
+        filters
+        |> Enum.reduce(Transaction, fn {nonce, from_address}, query ->
+          from(t in query,
+            or_where:
+              t.nonce == ^nonce and t.from_address_hash == ^from_address and is_nil(t.block_hash) and
+                is_nil(t.error)
+          )
+        end)
+        # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
+        |> order_by(asc: :hash)
+        |> lock("FOR NO KEY UPDATE")
+
+      Repo.update_all(
+        from(t in Transaction, join: s in subquery(query), on: t.hash == s.hash),
+        [set: [error: "dropped/replaced", status: :error]],
+        timeout: timeout
+      )
+    end
   end
 end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -465,7 +465,7 @@ defmodule Explorer.Etherscan do
 
     query
     |> where_address_match(address_hash, options)
-    |> Chain.pending_transactions_query()
+    |> Transaction.pending_transactions_query()
     |> order_by([transaction], desc: transaction.inserted_at, desc: transaction.hash)
     |> Repo.replica().all()
   end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -2195,13 +2195,13 @@ defmodule Explorer.ChainTest do
 
   describe "pending_transactions/0" do
     test "without transactions" do
-      assert [] = Chain.recent_pending_transactions()
+      assert [] = Transaction.recent_pending_transactions()
     end
 
     test "with transactions" do
       %Transaction{hash: hash} = insert(:transaction)
 
-      assert [%Transaction{hash: ^hash}] = Chain.recent_pending_transactions()
+      assert [%Transaction{hash: ^hash}] = Transaction.recent_pending_transactions()
     end
 
     test "with transactions can be paginated" do
@@ -2214,7 +2214,7 @@ defmodule Explorer.ChainTest do
 
       assert second_page_hashes ==
                [paging_options: %PagingOptions{key: {inserted_at, hash}, page_size: 50}]
-               |> Chain.recent_pending_transactions()
+               |> Transaction.recent_pending_transactions()
                |> Enum.map(& &1.hash)
                |> Enum.reverse()
     end
@@ -3355,76 +3355,6 @@ defmodule Explorer.ChainTest do
       assert balance_fields_list_by_address_hash[miner.hash] |> Enum.map(& &1.block_number) |> Enum.sort() == [
                block.number
              ]
-    end
-  end
-
-  describe "update_replaced_transactions/2" do
-    test "update replaced transactions" do
-      replaced_transaction_hash = "0x2a263224a95275d77bc30a7e131bc64d948777946a790c0915ab293791fbcb61"
-
-      address = insert(:address, hash: "0xb7cffe2ac19b9d5705a24cbe14fef5663af905a6")
-
-      insert(:transaction,
-        from_address: address,
-        nonce: 1,
-        block_hash: nil,
-        index: nil,
-        block_number: nil,
-        hash: replaced_transaction_hash
-      )
-
-      mined_transaction_hash = "0x1a263224a95275d77bc30a7e131bc64d948777946a790c0915ab293791fbcb61"
-      block = insert(:block)
-
-      mined_transaction =
-        insert(:transaction,
-          from_address: address,
-          nonce: 1,
-          index: 0,
-          block_hash: block.hash,
-          block_number: block.number,
-          cumulative_gas_used: 1,
-          gas_used: 1,
-          hash: mined_transaction_hash
-        )
-
-      second_mined_transaction_hash = "0x3a263224a95275d77bc30a7e131bc64d948777946a790c0915ab293791fbcb61"
-      second_block = insert(:block)
-
-      insert(:transaction,
-        from_address: address,
-        nonce: 1,
-        index: 0,
-        block_hash: second_block.hash,
-        block_number: second_block.number,
-        cumulative_gas_used: 1,
-        gas_used: 1,
-        hash: second_mined_transaction_hash
-      )
-
-      {1, _} =
-        Chain.update_replaced_transactions([
-          %{
-            block_hash: mined_transaction.block_hash,
-            nonce: mined_transaction.nonce,
-            from_address_hash: mined_transaction.from_address_hash
-          }
-        ])
-
-      replaced_transaction = Repo.get(Transaction, replaced_transaction_hash)
-
-      assert replaced_transaction.status == :error
-      assert replaced_transaction.error == "dropped/replaced"
-
-      found_mined_transaction = Repo.get(Transaction, mined_transaction_hash)
-
-      assert found_mined_transaction.status == nil
-      assert found_mined_transaction.error == nil
-
-      second_mined_transaction = Repo.get(Transaction, second_mined_transaction_hash)
-
-      assert second_mined_transaction.status == nil
-      assert second_mined_transaction.error == nil
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/replaced_transaction.ex
@@ -8,8 +8,7 @@ defmodule Indexer.Fetcher.ReplacedTransaction do
 
   require Logger
 
-  alias Explorer.Chain
-  alias Explorer.Chain.Hash
+  alias Explorer.Chain.{Hash, Transaction}
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.ReplacedTransaction.Supervisor, as: ReplacedTransactionSupervisor
 
@@ -58,7 +57,7 @@ defmodule Indexer.Fetcher.ReplacedTransaction do
   def init(initial, reducer, _) do
     {:ok, final} =
       [:block_hash, :nonce, :from_address_hash, :hash]
-      |> Chain.stream_pending_transactions(
+      |> Transaction.stream_pending_transactions(
         initial,
         fn transaction_fields, acc ->
           transaction_fields
@@ -115,11 +114,11 @@ defmodule Indexer.Fetcher.ReplacedTransaction do
 
       pending
       |> Enum.map(&pending_params/1)
-      |> Chain.find_and_update_replaced_transactions()
+      |> Transaction.find_and_update_replaced_transactions()
 
       realtime
       |> Enum.map(&params/1)
-      |> Chain.update_replaced_transactions()
+      |> Transaction.update_replaced_transactions()
 
       :ok
     rescue

--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -65,7 +65,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
 
   defp sanitize_pending_transactions(json_rpc_named_arguments) do
     receipts_batch_size = Application.get_env(:indexer, :receipts_batch_size)
-    pending_transactions_list_from_db = Chain.pending_transactions_list()
+    pending_transactions_list_from_db = Transaction.pending_transactions_list()
     id_to_params = id_to_params(pending_transactions_list_from_db)
 
     with {:ok, responses} <-


### PR DESCRIPTION
## Motivation

Arbitrum has system address `0x00000000000000000000000000000000000a4b05`, which generates a lot of transactions, which in turn are processed by `Indexer.Fetcher.ReplacedTransaction` module: those transactions are replaced by others with the same data, meaning we should set `dropped/replaced` status for the original ones. Processing of those transactions adds additional undesired pressure to the DB.

## Changelog

Excluding system transactions from processing by `Indexer.Fetcher.ReplacedTransaction` module.

`Indexer.PendingTransactionsSanitizer` will be responsible for removal such transactions from the DB since they're no longer visible at the JSON RPC node.

Chore:
- move pending transactions related functions from `Explorer.Chain` to `Explorer.Chain.Transaction` module.
- add spec/doc to those migrated public functions.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
