### PR TITLE
chore: Run shrink internal transactions migration for indexer instance only

### DIFF
--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -143,7 +143,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.TokenTransferBlockConsensus),
         configure(Explorer.Migrator.RestoreOmittedWETHTransfers),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, :stability),
-        configure(Explorer.Migrator.ShrinkInternalTransactions)
+        configure_mode_dependent_process(Explorer.Migrator.ShrinkInternalTransactions, :indexer)
       ]
       |> List.flatten()
 
@@ -203,6 +203,14 @@ defmodule Explorer.Application do
 
   defp configure_chain_type_dependent_process(process, chain_type) do
     if Application.get_env(:explorer, :chain_type) == chain_type do
+      process
+    else
+      []
+    end
+  end
+
+  defp configure_mode_dependent_process(process, mode) do
+    if Application.get_env(:explorer, :mode) in [mode, :all] do
       process
     else
       []

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -322,6 +322,11 @@ defmodule ConfigHelper do
   @spec chain_type() :: atom() | nil
   def chain_type, do: parse_catalog_value("CHAIN_TYPE", @supported_chain_types, true, "default")
 
+  @supported_modes ["all", "indexer", "api"]
+
+  @spec mode :: atom()
+  def mode, do: parse_catalog_value("MODE", @supported_modes, true, "all")
+
   @spec eth_call_url(String.t() | nil) :: String.t() | nil
   def eth_call_url(default \\ nil) do
     System.get_env("ETHEREUM_JSONRPC_ETH_CALL_URL") || System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || default

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -218,6 +218,7 @@ checksum_function = System.get_env("CHECKSUM_FUNCTION")
 exchange_rates_coin = System.get_env("EXCHANGE_RATES_COIN")
 
 config :explorer,
+  mode: ConfigHelper.mode(),
   coin: System.get_env("COIN") || exchange_rates_coin || "ETH",
   coin_name: System.get_env("COIN_NAME") || exchange_rates_coin || "ETH",
   allowed_solidity_evm_versions:


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10567

## Changelog

- Added `MODE` env variable so the application can configure which processes to run on the current instance
- Move `ShrinkInternalTransactions` migration under `indexer` or `all` mode so it will be executed on one instance only

Docs update: https://github.com/blockscout/docs/pull/312