### PR TITLE
fix: Fix mode dependent processes starting

### DIFF
--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -210,7 +210,7 @@ defmodule Explorer.Application do
   end
 
   defp configure_mode_dependent_process(process, mode) do
-    if Application.get_env(:explorer, :mode) in [mode, :all] do
+    if should_start?(process) and Application.get_env(:explorer, :mode) in [mode, :all] do
       process
     else
       []


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10631

## Changelog

Add the `should_start?/1` missing condition to `configure_mode_dependent_process/2`