### PR TITLE
fix: Fix for metadata detection at ipfs protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix for metadata detection at ipfs protocol([#10646](https://github.com/blockscout/blockscout/pull/10646))
 - Change default shrink internal_transactions table migration params ([#10644](https://github.com/blockscout/blockscout/pull/10644))
 - Fix bug in update_replaced_transactions query ([#10634](https://github.com/blockscout/blockscout/issues/10634))
 - Fix mode dependent processes starting ([#10641](https://github.com/blockscout/blockscout/issues/10641))

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -579,14 +579,14 @@ defmodule Explorer.Token.MetadataRetriever do
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp fetch_from_ipfs?(token_uri_string, ipfs?, token_id, hex_token_id, from_base_uri?) do
     case URI.parse(token_uri_string) do
-      %URI{scheme: "ipfs", path: path} ->
+      %URI{scheme: "ipfs", host: host, path: path} ->
         resource_id =
-          case path do
-            "/ipfs/" <> resource_id ->
-              resource_id
-
-            "/" <> resource_id ->
-              resource_id
+          if host == "ipfs" do
+            "/" <> resource_id = path
+            resource_id
+          else
+            # credo:disable-for-next-line
+            if is_nil(path), do: host, else: host <> path
           end
 
         fetch_from_ipfs(resource_id, hex_token_id)


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10638

## Motivation

Fetching metadata from the URL like:
```
ipfs://QmRQkXzJu31dp5s4TaKwowNikxePRbiAWitxT5RDfZGoiV/3197
```

doesn't work.


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
