### PR TITLE
feature: Detect Diamond proxy pattern on unverified proxy smart-contract

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -605,10 +605,10 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
 
     result =
       case SmartContract.address_hash_to_smart_contract_with_bytecode_twin(address_hash) do
-        {nil, _} ->
+        nil ->
           :not_found
 
-        {contract, _} ->
+        contract ->
           {:ok, SmartContract.preload_decompiled_smart_contract(contract)}
       end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -332,7 +332,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   defp validate_smart_contract(params, address_hash_string) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         {:not_found, {smart_contract, _}} when not is_nil(smart_contract) <-
+         {:not_found, smart_contract} when not is_nil(smart_contract) <-
            {:not_found, SmartContract.address_hash_to_smart_contract_with_bytecode_twin(address_hash, @api_true)} do
       {:ok, address_hash, smart_contract}
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/utils_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/utils_controller.ex
@@ -19,10 +19,7 @@ defmodule BlockScoutWeb.API.V2.UtilsController do
          {:format, true} <- {:format, match?({:ok, _hash}, address_hash) || is_nil(address_hash)} do
       smart_contract =
         if address_hash do
-          {updated_smart_contract, _} =
-            SmartContract.address_hash_to_smart_contract_with_bytecode_twin(elem(address_hash, 1), @api_true)
-
-          updated_smart_contract
+          SmartContract.address_hash_to_smart_contract_with_bytecode_twin(elem(address_hash, 1), @api_true)
         end
 
       {decoded_input, _abi_acc, _methods_acc} =

--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -212,7 +212,7 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   def decode_revert_reason(to_address, revert_reason, options \\ []) do
-    {smart_contract, _} = SmartContract.address_hash_to_smart_contract_with_bytecode_twin(to_address, options)
+    smart_contract = SmartContract.address_hash_to_smart_contract_with_bytecode_twin(to_address, options)
 
     Transaction.decoded_revert_reason(
       %Transaction{to_address: %{smart_contract: smart_contract}, hash: to_address},

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -292,14 +292,63 @@ defmodule Explorer.Chain.SmartContract.Proxy do
           proxy_type: atom()
         }
   def get_implementation_address_hash_string_eip1822(proxy_address_hash, proxy_abi, go_to_fallback?) do
-    get_implementation_address_hash_string_by_module(EIP1822, :eip1822, [proxy_address_hash, proxy_abi, go_to_fallback?])
+    get_implementation_address_hash_string_by_module(
+      EIP1822,
+      :eip1822,
+      [
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?
+      ],
+      :get_implementation_address_hash_string_eip2535
+    )
+  end
+
+  @doc """
+  Returns EIP-2535 implementation address or tries next proxy pattern
+  """
+  @spec get_implementation_address_hash_string_eip2535(Hash.Address.t(), any(), bool()) :: %{
+          implementation_address_hash_strings: [String.t() | :error | nil],
+          proxy_type: atom()
+        }
+  def get_implementation_address_hash_string_eip2535(proxy_address_hash, proxy_abi, go_to_fallback?) do
+    get_implementation_address_hash_string_by_module(EIP2535, :eip2535, [proxy_address_hash, proxy_abi, go_to_fallback?])
+  end
+
+  defp get_implementation_address_hash_string_by_module(
+         module,
+         proxy_type,
+         args,
+         next_func \\ :fallback_proxy_detection
+       )
+
+  defp get_implementation_address_hash_string_by_module(
+         EIP2535 = module,
+         :eip2535 = proxy_type,
+         [proxy_address_hash, proxy_abi, go_to_fallback?] = args,
+         next_func
+       ) do
+    implementation_address_hash_strings = module.get_implementation_address_hash_strings(proxy_address_hash)
+
+    if !is_nil(implementation_address_hash_strings) && implementation_address_hash_strings !== :error do
+      %{implementation_address_hash_strings: implementation_address_hash_strings, proxy_type: proxy_type}
+    else
+      do_get_implementation_address_hash_string_by_module(
+        implementation_address_hash_strings,
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?,
+        next_func,
+        args
+      )
+    end
   end
 
   defp get_implementation_address_hash_string_by_module(
          module,
          proxy_type,
          [proxy_address_hash, proxy_abi, go_to_fallback?] = args,
-         next_func \\ :fallback_proxy_detection
+         next_func
        ) do
     implementation_address_hash_string = module.get_implementation_address_hash_string(proxy_address_hash)
 
@@ -307,18 +356,36 @@ defmodule Explorer.Chain.SmartContract.Proxy do
          implementation_address_hash_string !== :error do
       %{implementation_address_hash_strings: [implementation_address_hash_string], proxy_type: proxy_type}
     else
-      cond do
-        next_func !== :fallback_proxy_detection ->
-          apply(__MODULE__, next_func, args)
+      do_get_implementation_address_hash_string_by_module(
+        implementation_address_hash_string,
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?,
+        next_func,
+        args
+      )
+    end
+  end
 
-        go_to_fallback? && next_func == :fallback_proxy_detection ->
-          fallback_value = implementation_fallback_value(implementation_address_hash_string)
+  defp do_get_implementation_address_hash_string_by_module(
+         implementation_value,
+         proxy_address_hash,
+         proxy_abi,
+         go_to_fallback?,
+         next_func,
+         args
+       ) do
+    cond do
+      next_func !== :fallback_proxy_detection ->
+        apply(__MODULE__, next_func, args)
 
-          apply(__MODULE__, :fallback_proxy_detection, [proxy_address_hash, proxy_abi, fallback_value])
+      go_to_fallback? && next_func == :fallback_proxy_detection ->
+        fallback_value = implementation_fallback_value(implementation_value)
 
-        true ->
-          implementation_fallback_value(implementation_address_hash_string)
-      end
+        apply(__MODULE__, :fallback_proxy_detection, [proxy_address_hash, proxy_abi, fallback_value])
+
+      true ->
+        implementation_fallback_value(implementation_value)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -330,7 +330,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
        ) do
     implementation_address_hash_strings = module.get_implementation_address_hash_strings(proxy_address_hash)
 
-    if !is_nil(implementation_address_hash_strings) && implementation_address_hash_strings !== :error do
+    if !is_nil(implementation_address_hash_strings) && implementation_address_hash_strings !== [] &&
+         implementation_address_hash_strings !== :error do
       %{implementation_address_hash_strings: implementation_address_hash_strings, proxy_type: proxy_type}
     else
       do_get_implementation_address_hash_string_by_module(
@@ -389,8 +390,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     end
   end
 
-  defp implementation_fallback_value(implementation_address_hash_string) do
-    value = if implementation_address_hash_string == :error, do: :error, else: []
+  defp implementation_fallback_value(implementation_value) do
+    value = if implementation_value == :error, do: :error, else: []
 
     %{implementation_address_hash_strings: value, proxy_type: :unknown}
   end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/basic.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/basic.ex
@@ -9,7 +9,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
   @doc """
   Gets implementation hash string of proxy contract from getter.
   """
-  @spec get_implementation_address_hash_string(binary, binary, SmartContract.abi()) :: nil | binary() | [binary()]
+  @spec get_implementation_address_hash_string(binary, binary, SmartContract.abi()) ::
+          nil | :error | binary() | [binary()]
   def get_implementation_address_hash_string(signature, proxy_address_hash, abi) do
     implementation_address =
       case Reader.query_contract(
@@ -20,8 +21,14 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
              },
              false
            ) do
-        %{^signature => {:ok, [result]}} -> result
-        _ -> nil
+        %{^signature => {:ok, [result]}} ->
+          result
+
+        %{^signature => {:error, _}} ->
+          :error
+
+        _ ->
+          nil
       end
 
     adds_0x_to_address(implementation_address)
@@ -30,8 +37,10 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
   @doc """
   Adds 0x to address at the beginning
   """
-  @spec adds_0x_to_address(nil | binary()) :: nil | binary() | [binary()]
+  @spec adds_0x_to_address(nil | :error | binary()) :: nil | :error | binary() | [binary()]
   def adds_0x_to_address(nil), do: nil
+
+  def adds_0x_to_address(:error), do: :error
 
   def adds_0x_to_address(addresses) when is_list(addresses) do
     addresses

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
     }
   ]
 
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: nil | [binary]
+  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: nil | :error | [binary]
   def get_implementation_address_hash_strings(proxy_address_hash) do
     case @facet_addresses_signature
          |> Basic.get_implementation_address_hash_string(
@@ -28,6 +28,9 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
          ) do
       implementation_addresses when is_list(implementation_addresses) ->
         implementation_addresses
+
+      :error ->
+        :error
 
       _ ->
         nil

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -99,7 +99,7 @@ defmodule Explorer.SmartContract.Reader do
   end
 
   defp prepare_abi(nil, address_hash) do
-    {smart_contract, _} =
+    smart_contract =
       address_hash
       |> SmartContract.address_hash_to_smart_contract_with_bytecode_twin()
 
@@ -680,7 +680,7 @@ defmodule Explorer.SmartContract.Reader do
   end
 
   defp get_abi(contract_address_hash, type, options) do
-    {contract, _} = SmartContract.address_hash_to_smart_contract_with_bytecode_twin(contract_address_hash, options)
+    contract = SmartContract.address_hash_to_smart_contract_with_bytecode_twin(contract_address_hash, options)
 
     if type == :proxy do
       Proxy.get_implementation_abi_from_proxy(contract, options)

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -89,6 +89,43 @@ defmodule Explorer.TestHelper do
     end)
   end
 
+  def mock_eip_2535_storage_pointer_request(
+        mox,
+        error?,
+        resp \\ "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
+      ) do
+    response =
+      if error?,
+        do: {:error, "error"},
+        else:
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: resp
+             }
+           ]}
+
+    expect(mox, :json_rpc, fn [
+                                %{
+                                  id: 0,
+                                  jsonrpc: "2.0",
+                                  method: "eth_call",
+                                  params: [
+                                    %{
+                                      data: "0x52ef6b2c",
+                                      to: _
+                                    },
+                                    "latest"
+                                  ]
+                                }
+                              ],
+                              _options ->
+      response
+    end)
+  end
+
   def get_eip1967_implementation_non_zero_address(address_hash_string) do
     EthereumJSONRPC.Mox
     |> mock_logic_storage_pointer_request(false)
@@ -102,6 +139,7 @@ defmodule Explorer.TestHelper do
     |> mock_beacon_storage_pointer_request(false)
     |> mock_oz_storage_pointer_request(false)
     |> mock_eip_1822_storage_pointer_request(false)
+    |> mock_eip_2535_storage_pointer_request(false)
   end
 
   def get_eip1967_implementation_error_response do
@@ -110,6 +148,7 @@ defmodule Explorer.TestHelper do
     |> mock_beacon_storage_pointer_request(true)
     |> mock_oz_storage_pointer_request(true)
     |> mock_eip_1822_storage_pointer_request(true)
+    |> mock_eip_2535_storage_pointer_request(true)
   end
 
   def fetch_token_uri_mock(url, token_contract_address_hash_string) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10151

## Motivation

Diamond proxy pattern is undetected on proxy smart-contracts, that are not verified itself or verified and do not contain `facetAddresses` getter in the ABI.

## Changelog

Enable detection of EIP-2535 (Diamond proxy standard) no matter proxy smart-contract is verified or not and no matter where is `facetAddresses` getter is defined: in proxy or in implementation.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
