### PR TITLE
feature: Detect Diamond proxy pattern on unverified proxy smart-contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🚀 Features
 
+- Detect Diamond proxy pattern on unverified proxy smart-contract ([#10665](https://github.com/blockscout/blockscout/pull/10665))
 - Support smart-contract verification in zkSync ([#10500](https://github.com/blockscout/blockscout/issues/10500))
 - Add icon for secondary coin ([#10241](https://github.com/blockscout/blockscout/issues/10241))
 - Integrate Cryptorank API ([#10550](https://github.com/blockscout/blockscout/issues/10550))

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -954,7 +954,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         assert response ==
                  %{
-                   "proxy_type" => nil,
+                   "proxy_type" => "unknown",
                    "implementations" => [],
                    "has_custom_methods_read" => false,
                    "has_custom_methods_write" => false,
@@ -1159,8 +1159,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         assert response ==
                  %{
-                   "proxy_type" => nil,
-                   "implementations" => [],
+                   "proxy_type" => "eip1967",
+                   "implementations" => [%{"address" => formatted_implementation_address_hash_string, "name" => nil}],
                    "has_custom_methods_read" => false,
                    "has_custom_methods_write" => false,
                    "is_self_destructed" => false,
@@ -1284,8 +1284,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         assert response ==
                  %{
-                   "proxy_type" => nil,
-                   "implementations" => [],
+                   "proxy_type" => "eip1967",
+                   "implementations" => [%{"address" => formatted_implementation_address_hash_string, "name" => nil}],
                    "has_custom_methods_read" => false,
                    "has_custom_methods_write" => false,
                    "is_self_destructed" => false,
@@ -1409,8 +1409,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         assert response ==
                  %{
-                   "proxy_type" => nil,
-                   "implementations" => [],
+                   "proxy_type" => "eip1967",
+                   "implementations" => [%{"address" => formatted_implementation_address_hash_string, "name" => nil}],
                    "has_custom_methods_read" => false,
                    "has_custom_methods_write" => false,
                    "is_self_destructed" => false,

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -292,14 +292,64 @@ defmodule Explorer.Chain.SmartContract.Proxy do
           proxy_type: atom()
         }
   def get_implementation_address_hash_string_eip1822(proxy_address_hash, proxy_abi, go_to_fallback?) do
-    get_implementation_address_hash_string_by_module(EIP1822, :eip1822, [proxy_address_hash, proxy_abi, go_to_fallback?])
+    get_implementation_address_hash_string_by_module(
+      EIP1822,
+      :eip1822,
+      [
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?
+      ],
+      :get_implementation_address_hash_string_eip2535
+    )
+  end
+
+  @doc """
+  Returns EIP-2535 implementation address or tries next proxy pattern
+  """
+  @spec get_implementation_address_hash_string_eip2535(Hash.Address.t(), any(), bool()) :: %{
+          implementation_address_hash_strings: [String.t() | :error | nil],
+          proxy_type: atom()
+        }
+  def get_implementation_address_hash_string_eip2535(proxy_address_hash, proxy_abi, go_to_fallback?) do
+    get_implementation_address_hash_string_by_module(EIP2535, :eip2535, [proxy_address_hash, proxy_abi, go_to_fallback?])
+  end
+
+  defp get_implementation_address_hash_string_by_module(
+         module,
+         proxy_type,
+         args,
+         next_func \\ :fallback_proxy_detection
+       )
+
+  defp get_implementation_address_hash_string_by_module(
+         EIP2535 = module,
+         :eip2535 = proxy_type,
+         [proxy_address_hash, proxy_abi, go_to_fallback?] = args,
+         next_func
+       ) do
+    implementation_address_hash_strings = module.get_implementation_address_hash_strings(proxy_address_hash)
+
+    if !is_nil(implementation_address_hash_strings) && implementation_address_hash_strings !== [] &&
+         implementation_address_hash_strings !== :error do
+      %{implementation_address_hash_strings: implementation_address_hash_strings, proxy_type: proxy_type}
+    else
+      do_get_implementation_address_hash_string_by_module(
+        implementation_address_hash_strings,
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?,
+        next_func,
+        args
+      )
+    end
   end
 
   defp get_implementation_address_hash_string_by_module(
          module,
          proxy_type,
          [proxy_address_hash, proxy_abi, go_to_fallback?] = args,
-         next_func \\ :fallback_proxy_detection
+         next_func
        ) do
     implementation_address_hash_string = module.get_implementation_address_hash_string(proxy_address_hash)
 
@@ -307,23 +357,41 @@ defmodule Explorer.Chain.SmartContract.Proxy do
          implementation_address_hash_string !== :error do
       %{implementation_address_hash_strings: [implementation_address_hash_string], proxy_type: proxy_type}
     else
-      cond do
-        next_func !== :fallback_proxy_detection ->
-          apply(__MODULE__, next_func, args)
-
-        go_to_fallback? && next_func == :fallback_proxy_detection ->
-          fallback_value = implementation_fallback_value(implementation_address_hash_string)
-
-          apply(__MODULE__, :fallback_proxy_detection, [proxy_address_hash, proxy_abi, fallback_value])
-
-        true ->
-          implementation_fallback_value(implementation_address_hash_string)
-      end
+      do_get_implementation_address_hash_string_by_module(
+        implementation_address_hash_string,
+        proxy_address_hash,
+        proxy_abi,
+        go_to_fallback?,
+        next_func,
+        args
+      )
     end
   end
 
-  defp implementation_fallback_value(implementation_address_hash_string) do
-    value = if implementation_address_hash_string == :error, do: :error, else: []
+  defp do_get_implementation_address_hash_string_by_module(
+         implementation_value,
+         proxy_address_hash,
+         proxy_abi,
+         go_to_fallback?,
+         next_func,
+         args
+       ) do
+    cond do
+      next_func !== :fallback_proxy_detection ->
+        apply(__MODULE__, next_func, args)
+
+      go_to_fallback? && next_func == :fallback_proxy_detection ->
+        fallback_value = implementation_fallback_value(implementation_value)
+
+        apply(__MODULE__, :fallback_proxy_detection, [proxy_address_hash, proxy_abi, fallback_value])
+
+      true ->
+        implementation_fallback_value(implementation_value)
+    end
+  end
+
+  defp implementation_fallback_value(implementation_value) do
+    value = if implementation_value == :error, do: :error, else: []
 
     %{implementation_address_hash_strings: value, proxy_type: :unknown}
   end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/basic.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/basic.ex
@@ -9,7 +9,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
   @doc """
   Gets implementation hash string of proxy contract from getter.
   """
-  @spec get_implementation_address_hash_string(binary, binary, SmartContract.abi()) :: nil | binary() | [binary()]
+  @spec get_implementation_address_hash_string(binary, binary, SmartContract.abi()) ::
+          nil | :error | binary() | [binary()]
   def get_implementation_address_hash_string(signature, proxy_address_hash, abi) do
     implementation_address =
       case Reader.query_contract(
@@ -20,8 +21,14 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
              },
              false
            ) do
-        %{^signature => {:ok, [result]}} -> result
-        _ -> nil
+        %{^signature => {:ok, [result]}} ->
+          result
+
+        %{^signature => {:error, _}} ->
+          :error
+
+        _ ->
+          nil
       end
 
     adds_0x_to_address(implementation_address)
@@ -30,8 +37,10 @@ defmodule Explorer.Chain.SmartContract.Proxy.Basic do
   @doc """
   Adds 0x to address at the beginning
   """
-  @spec adds_0x_to_address(nil | binary()) :: nil | binary() | [binary()]
+  @spec adds_0x_to_address(nil | :error | binary()) :: nil | :error | binary() | [binary()]
   def adds_0x_to_address(nil), do: nil
+
+  def adds_0x_to_address(:error), do: :error
 
   def adds_0x_to_address(addresses) when is_list(addresses) do
     addresses

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
     }
   ]
 
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: nil | [binary]
+  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: nil | :error | [binary]
   def get_implementation_address_hash_strings(proxy_address_hash) do
     case @facet_addresses_signature
          |> Basic.get_implementation_address_hash_string(
@@ -28,6 +28,9 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
          ) do
       implementation_addresses when is_list(implementation_addresses) ->
         implementation_addresses
+
+      :error ->
+        :error
 
       _ ->
         nil

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -94,7 +94,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
   @doc """
   Returns the last implementation updated_at for the given smart-contract address hash
   """
-  @spec get_proxy_implementation_updated_at(Hash.Address.t() | nil, Keyword.t()) :: DateTime.t()
+  @spec get_proxy_implementation_updated_at(Hash.Address.t() | nil, Keyword.t()) :: DateTime.t() | nil
   def get_proxy_implementation_updated_at(proxy_address_hash, options) do
     proxy_address_hash
     |> get_proxy_implementations_query()
@@ -140,9 +140,20 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
 
     {updated_smart_contract, implementation_address_fetched?} =
       if check_implementation_refetch_necessity(implementation_updated_at) do
-        SmartContract.address_hash_to_smart_contract_with_bytecode_twin(address_hash, options)
+        {smart_contract_with_bytecode_twin, implementation_address_fetched?} =
+          SmartContract.address_hash_to_smart_contract_with_bytecode_twin(address_hash, options)
+
+        if smart_contract_with_bytecode_twin do
+          {smart_contract_with_bytecode_twin, implementation_address_fetched?}
+        else
+          {smart_contract, implementation_address_fetched?}
+        end
       else
-        {smart_contract, false}
+        if implementation_updated_at do
+          {smart_contract, true}
+        else
+          {smart_contract, false}
+        end
       end
 
     get_implementation(

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -89,6 +89,43 @@ defmodule Explorer.TestHelper do
     end)
   end
 
+  def mock_eip_2535_storage_pointer_request(
+        mox,
+        error?,
+        resp \\ "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
+      ) do
+    response =
+      if error?,
+        do: {:error, "error"},
+        else:
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: resp
+             }
+           ]}
+
+    expect(mox, :json_rpc, fn [
+                                %{
+                                  id: 0,
+                                  jsonrpc: "2.0",
+                                  method: "eth_call",
+                                  params: [
+                                    %{
+                                      data: "0x52ef6b2c",
+                                      to: _
+                                    },
+                                    "latest"
+                                  ]
+                                }
+                              ],
+                              _options ->
+      response
+    end)
+  end
+
   def get_eip1967_implementation_non_zero_address(address_hash_string) do
     EthereumJSONRPC.Mox
     |> mock_logic_storage_pointer_request(false)
@@ -102,6 +139,7 @@ defmodule Explorer.TestHelper do
     |> mock_beacon_storage_pointer_request(false)
     |> mock_oz_storage_pointer_request(false)
     |> mock_eip_1822_storage_pointer_request(false)
+    |> mock_eip_2535_storage_pointer_request(false)
   end
 
   def get_eip1967_implementation_error_response do
@@ -110,6 +148,7 @@ defmodule Explorer.TestHelper do
     |> mock_beacon_storage_pointer_request(true)
     |> mock_oz_storage_pointer_request(true)
     |> mock_eip_1822_storage_pointer_request(true)
+    |> mock_eip_2535_storage_pointer_request(true)
   end
 
   def fetch_token_uri_mock(url, token_contract_address_hash_string) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10151

## Motivation

Diamond proxy pattern is undetected on proxy smart-contracts, that are not verified itself or verified and do not contain `facetAddresses` getter in the ABI.

## Changelog

Enable detection of EIP-2535 (Diamond proxy standard) no matter proxy smart-contract is verified or not and no matter where is `facetAddresses` getter is defined: in proxy or in implementation.
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
