### PR TITLE
chore: fix flaking explorer tests

### DIFF
--- a/apps/explorer/test/explorer/migrator/sanitize_incorrect_weth_token_transfers_test.exs
+++ b/apps/explorer/test/explorer/migrator/sanitize_incorrect_weth_token_transfers_test.exs
@@ -132,7 +132,7 @@ defmodule Explorer.Migrator.SanitizeIncorrectWETHTokenTransfersTest do
                %{token_contract_address_hash: ^whitelisted_token_address_hash},
                %{token_contract_address_hash: ^whitelisted_token_address_hash},
                %{token_contract_address_hash: ^whitelisted_token_address_hash}
-             ] = transfers = Repo.all(TokenTransfer)
+             ] = transfers = Repo.all(TokenTransfer, order_by: [asc: :block_number, asc: :log_index])
 
       withdrawal = Enum.at(transfers, 1)
       deposit = Enum.at(transfers, 2)

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -915,6 +915,8 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                   "image" => "https://ipfs.io/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"
                 }
               }} == MetadataRetriever.fetch_json(data)
+
+      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "Fetches metadata from ipfs" do


### PR DESCRIPTION
## Motivation

* Fix some flaking tests in Explorer app

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
