### PR TITLE
fix: Truncate token symbol in `Explorer.Chain.PolygonZkevm.BridgeL1Token` module

### DIFF
--- a/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
+++ b/apps/explorer/lib/explorer/chain/polygon_zkevm/reader.ex
@@ -337,6 +337,14 @@ defmodule Explorer.Chain.PolygonZkevm.Reader do
     end
   end
 
+  @doc """
+    Filters token symbol (cannot be longer than 16 characters).
+  """
+  @spec sanitize_symbol(String.t()) :: String.t()
+  def sanitize_symbol(symbol) do
+    String.slice(symbol, 0, 16)
+  end
+
   defp page_batches(query, %PagingOptions{key: nil}), do: query
 
   defp page_batches(query, %PagingOptions{key: {number}}) do

--- a/apps/indexer/lib/indexer/fetcher/polygon_zkevm/bridge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_zkevm/bridge.ex
@@ -473,7 +473,7 @@ defmodule Indexer.Fetcher.PolygonZkevm.Bridge do
 
   defp get_new_data(data, request, response) do
     if atomized_key(request.method_id) == :symbol do
-      Map.put(data, :symbol, response)
+      Map.put(data, :symbol, Reader.sanitize_symbol(response))
     else
       Map.put(data, :decimals, Reader.sanitize_decimals(response))
     end


### PR DESCRIPTION
## Motivation

Polygon zkEVM bridge indexer throws the following error:

```
{"time":"2024-09-02T03:35:51.342Z","severity":"error","message":"GenServer Indexer.Fetcher.PolygonZkevm.BridgeL1 terminating\n** (Postgrex.Error) ERROR 22001 (string_data_right_truncation) value too long for type character varying(16)\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:925: Ecto.Adapters.SQL.insert_all/9\n    (ecto 3.11.2) lib/ecto/repo/schema.ex:59: Ecto.Repo.Schema.do_insert_all/7\n    (explorer 6.8.0) lib/explorer/repo.ex:47: anonymous fn/5 in Explorer.Repo.safe_insert_all/3\n    (elixir 1.16.3) lib/enum.ex:2528: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (explorer 6.8.0) lib/explorer/chain/import.ex:304: Explorer.Chain.Import.insert_changes_list/3\n    (explorer 6.8.0) lib/explorer/chain/import/runner/polygon_zkevm/bridge_l1_tokens.ex:68: Explorer.Chain.Import.Runner.PolygonZkevm.BridgeL1Tokens.insert/3\n    (stdlib 5.2.3) timer.erl:270: :timer.tc/2\nLast message: :continue\nState: %{json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: \"http://.../\", http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]]], start_block: 20364479, end_block: 20660197, block_check_interval: 6000, rollup_network_id_l1: 0, rollup_network_id_l2: 1, rollup_index_l2: 0, bridge_contract: \"0x2a3dd3eb832af982ec71669e178424b10dca2ede\", rollup_index_l1: nil}","metadata":{"error":{"initial_call":null,"reason":"** (Postgrex.Error) ERROR 22001 (string_data_right_truncation) value too long for type character varying(16)\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:925: Ecto.Adapters.SQL.insert_all/9\n    (ecto 3.11.2) lib/ecto/repo/schema.ex:59: Ecto.Repo.Schema.do_insert_all/7\n    (explorer 6.8.0) lib/explorer/repo.ex:47: anonymous fn/5 in Explorer.Repo.safe_insert_all/3\n    (elixir 1.16.3) lib/enum.ex:2528: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (explorer 6.8.0) lib/explorer/chain/import.ex:304: Explorer.Chain.Import.insert_changes_list/3\n    (explorer 6.8.0) lib/explorer/chain/import/runner/polygon_zkevm/bridge_l1_tokens.ex:68: Explorer.Chain.Import.Runner.PolygonZkevm.BridgeL1Tokens.insert/3\n    (stdlib 5.2.3) timer.erl:270: :timer.tc/2\n"},"fetcher":"polygon_zkevm_bridge_l1"}}
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
