### PR TITLE
chore: Change shrink internal transactions migration default batch_size

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -617,7 +617,7 @@ config :explorer, Explorer.Migrator.RestoreOmittedWETHTransfers,
 
 config :explorer, Explorer.Migrator.ShrinkInternalTransactions,
   enabled: ConfigHelper.parse_bool_env_var("SHRINK_INTERNAL_TRANSACTIONS_ENABLED"),
-  batch_size: ConfigHelper.parse_integer_env_var("SHRINK_INTERNAL_TRANSACTIONS_BATCH_SIZE", 1000),
+  batch_size: ConfigHelper.parse_integer_env_var("SHRINK_INTERNAL_TRANSACTIONS_BATCH_SIZE", 100),
   concurrency: ConfigHelper.parse_integer_env_var("SHRINK_INTERNAL_TRANSACTIONS_CONCURRENCY", 10)
 
 config :explorer, Explorer.Chain.BridgedToken,


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10567

Docs update: https://github.com/blockscout/docs/pull/318