### PR TITLE
fix: Preload additional sources for bytecode twin smart-contract

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -257,17 +257,18 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
   end
 
   @doc """
-  Returns additional sources of the smart-contract from bytecode twin
+  Returns additional sources of the smart-contract or from its bytecode twin
   """
   @spec get_additional_sources(SmartContract.t(), boolean, SmartContract.t() | nil) ::
           [SmartContractAdditionalSource.t()] | nil
   def get_additional_sources(smart_contract, smart_contract_verified, bytecode_twin_contract) do
     cond do
+      smart_contract_verified && is_list(smart_contract.smart_contract_additional_sources) &&
+          !Enum.empty?(smart_contract.smart_contract_additional_sources) ->
+        smart_contract.smart_contract_additional_sources
+
       !is_nil(bytecode_twin_contract) ->
         bytecode_twin_contract.smart_contract_additional_sources
-
-      smart_contract_verified ->
-        smart_contract.smart_contract_additional_sources
 
       true ->
         []

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -699,6 +699,10 @@ defmodule Explorer.Chain.SmartContract do
   """
   @spec get_verified_bytecode_twin_contract(Address.t(), any()) :: SmartContract.t() | nil
   def get_verified_bytecode_twin_contract(%Address{} = target_address, options \\ []) do
+    necessity_by_association = %{
+      :smart_contract_additional_sources => :optional
+    }
+
     case target_address do
       %{contract_code: %Chain.Data{bytes: contract_code_bytes}} ->
         target_address_hash = target_address.hash
@@ -715,6 +719,7 @@ defmodule Explorer.Chain.SmartContract do
           )
 
         verified_bytecode_twin_contract_query
+        |> Chain.join_associations(necessity_by_association)
         |> Chain.select_repo(options).one(timeout: 10_000)
 
       _ ->


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10161

## Motivation

- Additional sources are not preloaded when bytecode twin is found.
- We shouldn't set additional sources from twin, if proxy smart-contract has been verified.

## Changelog

- Add preload of `:smart_contract_additional_sources` association in `get_verified_bytecode_twin_contract /2` function.
- Change priority in getting additional sources: firstly get from verified smart-contract. In other cases take from bytecode twin.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
