### PR TITLE
fix: Fix gettext usage warning

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web.ex
+++ b/apps/block_scout_web/lib/block_scout_web.ex
@@ -25,7 +25,7 @@ defmodule BlockScoutWeb do
       import BlockScoutWeb.Controller
       import BlockScoutWeb.Router.Helpers
       import BlockScoutWeb.Routers.WebRouter.Helpers, except: [static_path: 2]
-      import BlockScoutWeb.Gettext
+      use Gettext, backend: BlockScoutWeb.Gettext
       import BlockScoutWeb.ErrorHelper
       import BlockScoutWeb.Routers.AccountRouter.Helpers, except: [static_path: 2]
       import Plug.Conn
@@ -49,13 +49,14 @@ defmodule BlockScoutWeb do
       import BlockScoutWeb.{
         CurrencyHelper,
         ErrorHelper,
-        Gettext,
         Router.Helpers,
         TabHelper,
         Tokens.Helper,
         Views.ScriptHelper,
         WeiHelper
       }
+
+      use Gettext, backend: BlockScoutWeb.Gettext
 
       import BlockScoutWeb.Routers.AccountRouter.Helpers, except: [static_path: 2]
 
@@ -78,7 +79,7 @@ defmodule BlockScoutWeb do
     quote do
       use Phoenix.Channel
 
-      import BlockScoutWeb.Gettext
+      use Gettext, backend: BlockScoutWeb.Gettext
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/gettext.ex
+++ b/apps/block_scout_web/lib/block_scout_web/gettext.ex
@@ -20,5 +20,5 @@ defmodule BlockScoutWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
-  use Gettext, otp_app: :block_scout_web
+  use Gettext.Backend, otp_app: :block_scout_web
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/block_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/block_transaction_view.ex
@@ -1,7 +1,7 @@
 defmodule BlockScoutWeb.BlockTransactionView do
   use BlockScoutWeb, :view
 
-  import BlockScoutWeb.Gettext, only: [gettext: 1]
+  use Gettext, backend: BlockScoutWeb.Gettext
 
   def block_not_found_message({:ok, true}) do
     gettext("Easy Cowboy! This block does not exist yet!")

--- a/apps/block_scout_web/lib/block_scout_web/views/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/internal_transaction_view.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.InternalTransactionView do
 
   alias Explorer.Chain.InternalTransaction
 
-  import BlockScoutWeb.Gettext
+  use Gettext, backend: BlockScoutWeb.Gettext
 
   @doc """
   Returns the formatted string for the type of the internal transaction.

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_view.ex
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.TransactionView do
   alias Explorer.ExchangeRates.Token
   alias Timex.Duration
 
-  import BlockScoutWeb.Gettext
+  use Gettext, backend: BlockScoutWeb.Gettext
   import BlockScoutWeb.AddressView, only: [from_address_hash: 1, short_token_id: 2, tag_name_to_label: 1]
   import BlockScoutWeb.Tokens.Helper
 

--- a/apps/block_scout_web/lib/block_scout_web/views/wei_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/wei_helper.ex
@@ -3,7 +3,7 @@ defmodule BlockScoutWeb.WeiHelper do
   Helper functions for interacting with `t:Explorer.Chain.Wei.t/0` values.
   """
 
-  import BlockScoutWeb.Gettext
+  use Gettext, backend: BlockScoutWeb.Gettext
 
   alias BlockScoutWeb.CldrHelper
   alias Explorer.Chain.Wei


### PR DESCRIPTION
https://github.com/blockscout/blockscout/pull/10657

## Motivation

```
warning: defining a Gettext backend by calling

    use Gettext, otp_app: ...

is deprecated. To define a backend, call:

    use Gettext.Backend, otp_app: :my_app

Then, instead of importing your backend, call this in your module:

    use Gettext, backend: MyApp.Gettext

  lib/block_scout_web/gettext.ex:23: BlockScoutWeb.Gettext (module)
```

## Changelog

Define Gettext dependency, as it is suggested nowadays https://hexdocs.pm/gettext/0.26.1/Gettext.html#module-gettext-api.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
