### PR TITLE
fix: Set min query length in the search API endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
@@ -8,6 +8,16 @@ defmodule BlockScoutWeb.API.V2.SearchController do
   alias Explorer.PagingOptions
 
   @api_true [api?: true]
+  @min_query_length 3
+
+  def search(conn, %{"q" => query}) when byte_size(query) < @min_query_length do
+    conn
+    |> put_status(200)
+    |> render(:search_results, %{
+      search_results: [],
+      next_page_params: nil
+    })
+  end
 
   def search(conn, %{"q" => query} = params) do
     [paging_options: paging_options] = paging_options(params)
@@ -29,6 +39,12 @@ defmodule BlockScoutWeb.API.V2.SearchController do
     })
   end
 
+  def check_redirect(conn, %{"q" => query}) when byte_size(query) < @min_query_length do
+    conn
+    |> put_status(200)
+    |> render(:search_results, %{result: {:error, :not_found}})
+  end
+
   def check_redirect(conn, %{"q" => query}) do
     result =
       query
@@ -38,6 +54,12 @@ defmodule BlockScoutWeb.API.V2.SearchController do
     conn
     |> put_status(200)
     |> render(:search_results, %{result: result})
+  end
+
+  def quick_search(conn, %{"q" => query}) when byte_size(query) < @min_query_length do
+    conn
+    |> put_status(200)
+    |> render(:search_results, %{search_results: []})
   end
 
   def quick_search(conn, %{"q" => query}) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/search_controller.ex
@@ -7,6 +7,18 @@ defmodule BlockScoutWeb.SearchController do
   alias Explorer.Chain.Search
   alias Phoenix.View
 
+  @min_query_length 3
+
+  def search_results(conn, %{"q" => query, "type" => "JSON"}) when byte_size(query) < @min_query_length do
+    json(
+      conn,
+      %{
+        items: [],
+        next_page_path: nil
+      }
+    )
+  end
+
   def search_results(conn, %{"q" => query, "type" => "JSON"} = params) do
     [paging_options: paging_options] = paging_options(params)
     offset = (max(paging_options.page_number, 1) - 1) * paging_options.page_size


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10575

## Motivation

Search is started even with 1 letter provided by the user.

## Changelog

Don't start search unless less 3 letters provided in the query.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
