### PR TITLE
chore: Remove deprecated single implementation property of the smart-contract from the API response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -162,7 +162,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         conn
       ) do
     bytecode_twin = SmartContract.get_address_verified_bytecode_twin_contract(address.hash, @api_true)
-    minimal_proxy_address_hash = address.implementation
     bytecode_twin_contract = bytecode_twin.verified_contract
     smart_contract_verified = AddressView.smart_contract_verified?(address)
     fully_verified = SmartContract.verified_with_full_match?(address.hash, @api_true)
@@ -203,9 +202,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
       "has_methods_write" => write_methods?,
       "has_methods_read_proxy" => is_proxy,
       "has_methods_write_proxy" => is_proxy && write_methods?,
-      # todo: remove this property once frontend is bound to "implementations"
-      "minimal_proxy_address_hash" =>
-        minimal_proxy_address_hash && Address.checksum(minimal_proxy_address_hash.address_hash),
       "proxy_type" => proxy_type,
       "implementations" => implementations,
       "sourcify_repo_url" =>

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -82,9 +82,6 @@ defmodule Explorer.Chain.Address.Schema do
         field(:ens_domain_name, :string, virtual: true)
         field(:metadata, :any, virtual: true)
 
-        # todo: remove virtual field for a single implementation when frontend is bound to "implementations" object value in API
-        field(:implementation, :any, virtual: true)
-
         has_one(:smart_contract, SmartContract, references: :hash)
         has_one(:token, Token, foreign_key: :contract_address_hash, references: :hash)
         has_one(:proxy_implementations, Implementation, foreign_key: :proxy_address_hash, references: :hash)


### PR DESCRIPTION
## Motivation

Remove deprecated single implementation property of the smart-contract from the API response.

⚠️ It should be merged after https://github.com/blockscout/frontend/issues/2209 is released.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
