### PR TITLE
fix(address-contract): hide contract creation bytecode for failed transactions (#9397)

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_contract_view.ex
@@ -109,13 +109,24 @@ defmodule BlockScoutWeb.AddressContractView do
 
   def contract_creation_code(%Address{
         contract_code: %Data{bytes: <<>>},
-        contracts_creation_internal_transaction: %InternalTransaction{init: init}
+        contracts_creation_internal_transaction: %InternalTransaction{init: init, status: 0}
+      }) do
+    nil
+  end
+
+  def contract_creation_code(%Address{
+        contract_code: %Data{bytes: <<>>},
+        contracts_creation_internal_transaction: %InternalTransaction{init: init, status: 1}
       }) do
     {:selfdestructed, init}
   end
 
-  def contract_creation_code(%Address{contract_code: contract_code}) do
+  def contract_creation_code(%Address{contract_code: contract_code, contracts_creation_transaction: %Transaction{status: 1}}) do
     {:ok, contract_code}
+  end
+
+  def contract_creation_code(%Address{contract_code: contract_code, contracts_creation_transaction: %Transaction{status: 0}}) do
+    nil
   end
 
   def creation_code(%Address{contracts_creation_internal_transaction: %InternalTransaction{}} = address) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -280,16 +280,24 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         %{
           "is_self_destructed" => true,
           "deployed_bytecode" => nil,
-          "creation_bytecode" => init
+          "creation_bytecode" => nil  # Do not include creation bytecode for selfdestructed contracts
         }
-
+      
       {:ok, contract_code} ->
         %{
           "is_self_destructed" => false,
           "deployed_bytecode" => contract_code,
-          "creation_bytecode" => AddressContractView.creation_code(address)
+          "creation_bytecode" => nil  # Do not include creation bytecode if the creation transaction failed
+        }
+      
+      nil ->
+        %{
+          "is_self_destructed" => false,
+          "deployed_bytecode" => nil,
+          "creation_bytecode" => nil  # No bytecode information for failed contract creation
         }
     end
+  end
   end
 
   defp add_zksync_info(smart_contract_info, target_contract) do


### PR DESCRIPTION
Title:
fix(address-contract): hide contract creation bytecode for failed transactions (#9397)

Motivation
The contract creation bytecode was incorrectly displayed for failed contract creation transactions. This change resolves the issue by ensuring that the creation bytecode is hidden for failed transactions, making the UI and API responses more accurate. Additionally, it ensures that no bytecode information is shown for self-destructed contracts.

Fixes [#9397](https://github.com/blockscout/blockscout/issues/9397).

Changelog
Enhancements
Updated the logic in AddressContractView and SmartContractView to hide contract creation bytecode when the creation transaction has failed or the contract has self-destructed.
Added checks for the status field in contract creation transactions to determine whether the bytecode should be displayed.
Bug Fixes
Fixed the issue where contract creation bytecode was being incorrectly displayed for contracts that failed during creation or were self-destructed.
Ensured consistency in the contract creation information between the UI and the JSON-RPC, particularly hiding creation bytecode for failed transactions.
Incompatible Changes
None.

Upgrading
No breaking changes are introduced by this PR. No special upgrade instructions are necessary for users upgrading from previous versions.

Checklist for your Pull Request (PR)
 I will add test coverage for these changes in a future commit.
 If I fixed a bug, I will add a regression test to prevent the bug from silently reappearing again.
 I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
 If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to master in the Version column. If I removed a variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page.
 If I added new DB indices, I checked that they are not redundant, with PGHero or other tools.
 If I added/removed a chain type, I modified the Github CI matrix and PR labels accordingly.