### PR TITLE
fix(search): support emoji in domain name search (#9344)

### DIFF
--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -618,7 +618,7 @@ defmodule Explorer.Chain.Search do
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 
-    with true <- Regex.match?(~r/\w+\.\w+/, trimmed_query),
+        with true <- Regex.match?(~r/[a-zA-Z0-9\p{Emoji}]+\.[a-zA-Z0-9\p{Emoji}]+/, trimmed_query),
          %{address_hash: _address_hash} = result <- ens_domain_name_lookup(search_query) do
       result
     else


### PR DESCRIPTION
## Motivation

Fixes the issue where the search fails to return results for domain names containing emojis, as outlined in [#9344](https://github.com/blockscout/blockscout/issues/9344).

## Changelog

### Enhancements

- Updated the search regex pattern to support domain names containing emojis. This ensures that domain names such as `😎😎😎.eth` are processed correctly by the search functionality.

### Bug Fixes

- Fixed the issue where the `/api/v2/search/quick` endpoint failed to return correct results for domain names containing emojis.

### Incompatible Changes

- None.

## Upgrading

- No upgrades required for this change.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs
