### PR TITLE
perf: Improve performance of transactions list page

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_token_transfer_controller_test.exs
@@ -159,8 +159,6 @@ defmodule BlockScoutWeb.TransactionTokenTransferControllerTest do
     end
 
     test "preloads to_address smart contract verified", %{conn: conn} do
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
       transaction = insert(:transaction_to_verified_contract)
 
       conn = get(conn, transaction_token_transfer_path(BlockScoutWeb.Endpoint, :index, transaction.hash))

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -61,7 +61,6 @@ defmodule Explorer.Chain.Address do
            ]}
 
   @timeout :timer.minutes(1)
-  @api_true [api?: true]
 
   @typedoc """
    * `fetched_coin_balance` - The last fetched balance from Nethermind
@@ -483,21 +482,5 @@ defmodule Explorer.Chain.Address do
       _ ->
         {[], nil}
     end
-  end
-
-  @doc """
-  Get multiple addresses by hashes with preloaded smart-contract
-  """
-  @spec get_multiple_addresses([Hash.Address.t()]) :: [Address.t()]
-  def get_multiple_addresses(address_hashes) do
-    query =
-      from(
-        address in Address,
-        where: address.hash in ^address_hashes
-      )
-
-    query
-    |> Chain.select_repo(@api_true).all()
-    |> Repo.preload([:smart_contract])
   end
 end

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -61,6 +61,7 @@ defmodule Explorer.Chain.Address do
            ]}
 
   @timeout :timer.minutes(1)
+  @api_true [api?: true]
 
   @typedoc """
    * `fetched_coin_balance` - The last fetched balance from Nethermind
@@ -482,5 +483,21 @@ defmodule Explorer.Chain.Address do
       _ ->
         {[], nil}
     end
+  end
+
+  @doc """
+  Get multiple addresses by hashes with preloaded smart-contract
+  """
+  @spec get_multiple_addresses([Hash.Address.t()]) :: [Address.t()]
+  def get_multiple_addresses(address_hashes) do
+    query =
+      from(
+        address in Address,
+        where: address.hash in ^address_hashes
+      )
+
+    query
+    |> Chain.select_repo(@api_true).all()
+    |> Repo.preload([:smart_contract])
   end
 end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -224,7 +224,7 @@ defmodule Explorer.Chain.Log do
     else
       case Chain.find_contract_address(address_hash, address_options, false) do
         {:ok, %{smart_contract: smart_contract}} ->
-          full_abi = Proxy.combine_proxy_implementation_abi(smart_contract, options)
+          full_abi = Proxy.combine_proxy_implementation_abi(smart_contract, [], true, options)
           {full_abi, Map.put(acc, address_hash, full_abi)}
 
         _ ->

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -224,7 +224,7 @@ defmodule Explorer.Chain.Log do
     else
       case Chain.find_contract_address(address_hash, address_options, false) do
         {:ok, %{smart_contract: smart_contract}} ->
-          full_abi = Proxy.combine_proxy_implementation_abi(smart_contract, [], true, options)
+          full_abi = Proxy.combine_proxy_implementation_abi(smart_contract, %{}, true, options)
           {full_abi, Map.put(acc, address_hash, full_abi)}
 
         _ ->

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -512,7 +512,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
       proxy_implementation_addresses_tuple =
         proxy_implementation_addresses_tuple_list
         |> Enum.find(fn {proxy_address_hash, _implementations} ->
-          proxy_address_hash.bytes == (smart_contract.address_hash && smart_contract.address_hash.bytes)
+          proxy_address_hash == smart_contract.address_hash
         end)
 
       parse_abi_from_proxy_implementations(proxy_implementation_addresses_tuple)

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -521,9 +521,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   defp parse_abi_from_proxy_implementations(nil), do: []
 
-  defp parse_abi_from_proxy_implementations(proxy_implementation_addresses_tuple) do
-    proxy_implementation_addresses_tuple
-    |> elem(1)
+  defp parse_abi_from_proxy_implementations({_proxy_address_hash, implementations}) do
+    implementations
     |> Enum.reduce([], fn implementation, acc ->
       if implementation.smart_contract && implementation.smart_contract.abi do
         acc ++ implementation.smart_contract.abi

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -480,17 +480,57 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Returns combined ABI from proxy and implementation smart-contracts
   """
-  @spec combine_proxy_implementation_abi(any(), any()) :: SmartContract.abi()
-  def combine_proxy_implementation_abi(smart_contract, options \\ [])
+  @spec combine_proxy_implementation_abi(any(), list(), boolean(), any()) :: SmartContract.abi()
+  def combine_proxy_implementation_abi(
+        smart_contract,
+        proxy_implementation_addresses_tuple_list \\ [],
+        fetch_proxy?,
+        options \\ []
+      )
 
-  def combine_proxy_implementation_abi(%SmartContract{abi: abi} = smart_contract, options) when not is_nil(abi) do
-    implementation_abi = Proxy.get_implementation_abi_from_proxy(smart_contract, options)
+  def combine_proxy_implementation_abi(
+        %SmartContract{abi: abi} = smart_contract,
+        proxy_implementation_addresses_tuple_list,
+        fetch_proxy?,
+        options
+      )
+      when not is_nil(abi) do
+    implementation_abi =
+      get_implementation_abi(smart_contract, options, proxy_implementation_addresses_tuple_list, fetch_proxy?)
 
     if Enum.empty?(implementation_abi), do: abi, else: implementation_abi ++ abi
   end
 
-  def combine_proxy_implementation_abi(_, _) do
-    []
+  def combine_proxy_implementation_abi(smart_contract, proxy_implementation_addresses_tuple_list, fetch_proxy?, options) do
+    get_implementation_abi(smart_contract, options, proxy_implementation_addresses_tuple_list, fetch_proxy?)
+  end
+
+  defp get_implementation_abi(smart_contract, options, proxy_implementation_addresses_tuple_list, fetch_proxy?) do
+    if fetch_proxy? do
+      Proxy.get_implementation_abi_from_proxy(smart_contract, options)
+    else
+      proxy_implementation_addresses_tuple =
+        proxy_implementation_addresses_tuple_list
+        |> Enum.find(fn {proxy_address_hash, _implementations} ->
+          proxy_address_hash.bytes == smart_contract.address_hash.bytes
+        end)
+
+      parse_abi_from_proxy_implementations(proxy_implementation_addresses_tuple)
+    end
+  end
+
+  defp parse_abi_from_proxy_implementations(nil), do: []
+
+  defp parse_abi_from_proxy_implementations(proxy_implementation_addresses_tuple) do
+    proxy_implementation_addresses_tuple
+    |> elem(1)
+    |> Enum.reduce([], fn implementation, acc ->
+      if implementation.smart_contract && implementation.smart_contract.abi do
+        acc ++ implementation.smart_contract.abi
+      else
+        acc
+      end
+    end)
   end
 
   defp find_input_by_name(inputs, name) do

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -512,7 +512,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
       proxy_implementation_addresses_tuple =
         proxy_implementation_addresses_tuple_list
         |> Enum.find(fn {proxy_address_hash, _implementations} ->
-          proxy_address_hash.bytes == smart_contract.address_hash.bytes
+          proxy_address_hash.bytes == (smart_contract.address_hash && smart_contract.address_hash.bytes)
         end)
 
       parse_abi_from_proxy_implementations(proxy_implementation_addresses_tuple)

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -17,7 +17,6 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
 
   alias Explorer.Chain.{Address, Hash, SmartContract}
   alias Explorer.Chain.SmartContract.Proxy
-  alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias Explorer.Counters.AverageBlockTime
   alias Explorer.Repo
   alias Timex.Duration
@@ -92,6 +91,16 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
   end
 
   @doc """
+  Returns all implementations for the given smart-contract address hashes
+  """
+  @spec get_proxy_implementations_for_multiple_proxies([Hash.Address.t()], Keyword.t()) :: __MODULE__.t() | nil
+  def get_proxy_implementations_for_multiple_proxies(proxy_address_hashes, options \\ []) do
+    proxy_address_hashes
+    |> get_proxy_implementations_by_multiple_hashes_query()
+    |> select_repo(options).all()
+  end
+
+  @doc """
   Returns the last implementation updated_at for the given smart-contract address hash
   """
   @spec get_proxy_implementation_updated_at(Hash.Address.t() | nil, Keyword.t()) :: DateTime.t() | nil
@@ -106,6 +115,13 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     from(
       p in __MODULE__,
       where: p.proxy_address_hash == ^proxy_address_hash
+    )
+  end
+
+  defp get_proxy_implementations_by_multiple_hashes_query(proxy_address_hashes) do
+    from(
+      p in __MODULE__,
+      where: p.proxy_address_hash in ^proxy_address_hashes
     )
   end
 
@@ -210,7 +226,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
         {:ok, :error} ->
           format_proxy_implementations_response(proxy_implementations)
 
-        {:ok, %Implementation{} = result} ->
+        {:ok, %__MODULE__{} = result} ->
           format_proxy_implementations_response(result)
 
         _ ->
@@ -289,7 +305,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
   Saves proxy's implementation into the DB
   """
   @spec save_implementation_data([String.t()], Hash.Address.t(), atom() | nil, Keyword.t()) ::
-          Implementation.t() | :empty | :error
+          __MODULE__.t() | :empty | :error
   def save_implementation_data(:error, _proxy_address_hash, _proxy_type, _options) do
     :error
   end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2017,10 +2017,10 @@ defmodule Explorer.Chain.Transaction do
     unique_to_address_hashes =
       transactions
       |> Enum.filter(fn
-      %Transaction{to_address: %Address{}} -> true
-      %Transaction{created_contract_address: %Address{}} -> true
-      _ -> false
-    end)
+        %Transaction{to_address: %Address{}} -> true
+        %Transaction{created_contract_address: %Address{}} -> true
+        _ -> false
+      end)
       |> Enum.map(fn transaction ->
         (transaction.to_address && transaction.to_address.hash) ||
           (transaction.created_contract_address && transaction.created_contract_address.hash)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2016,28 +2016,11 @@ defmodule Explorer.Chain.Transaction do
     # parse unique address hashes of smart-contracts from to_address and created_contract_address properties of the transactions list
     unique_to_address_hashes =
       transactions
-      |> Enum.filter(fn transaction ->
-        case transaction do
-          %Transaction{
-            to_address: to_address,
-            created_contract_address: created_contract_address
-          } ->
-            case to_address do
-              %Address{} ->
-                true
-
-              _ ->
-                # credo:disable-for-next-line
-                case created_contract_address do
-                  %Address{} -> true
-                  _ -> false
-                end
-            end
-
-          _ ->
-            false
-        end
-      end)
+      |> Enum.filter(fn
+      %Transaction{to_address: %Address{}} -> true
+      %Transaction{created_contract_address: %Address{}} -> true
+      _ -> false
+    end)
       |> Enum.map(fn transaction ->
         (transaction.to_address && transaction.to_address.hash) ||
           (transaction.created_contract_address && transaction.created_contract_address.hash)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2029,39 +2029,27 @@ defmodule Explorer.Chain.Transaction do
     multiple_proxy_implementations =
       Implementation.get_proxy_implementations_for_multiple_proxies(unique_to_address_hashes)
 
-    # combine tuple {proxy_address_hash, implementation_address_hashes} and unique list of implementation addresses hashes
-    {proxy_implementation_addresses_tuple_list_raw, implementation_hashes} =
+    # combine unique list of implementation addresses hashes
+    implementation_hashes =
       multiple_proxy_implementations
-      |> Enum.reduce({[], []}, fn proxy_implementations,
-                                  {proxy_implementation_addresses_tuple_list_acc, implementation_hashes_acc} ->
-        proxy_implementation_addresses_tuple_list_new_acc = [
-          {proxy_implementations.proxy_address_hash, proxy_implementations.address_hashes}
-          | proxy_implementation_addresses_tuple_list_acc
-        ]
-
-        implementation_hashes_new_acc = implementation_hashes_acc ++ proxy_implementations.address_hashes
-
-        {proxy_implementation_addresses_tuple_list_new_acc, implementation_hashes_new_acc}
-      end)
+      |> Enum.flat_map(fn proxy_implementations -> proxy_implementations.address_hashes end)
 
     # query from the DB address objects with smart_contract preload for all found above implementation addresses
     implementation_addresses_with_smart_contracts =
       Chain.hashes_to_addresses(implementation_hashes, necessity_by_association: %{smart_contract: :optional})
 
-    # combine final tuple {proxy_address_hash, the list of implementations as Address.t() object with preloaded SmartContract.t()}
-    proxy_implementation_addresses_tuple_list_raw
-    |> Enum.map(fn proxy_implementation_addresses_tuple ->
-      {proxy_address_hash, implementation_address_hashes} = proxy_implementation_addresses_tuple
-
+    # combine tuple {proxy_address_hash, the list of implementations as Address.t() object with preloaded SmartContract.t()}
+    multiple_proxy_implementations
+    |> Enum.map(fn proxy_implementations ->
       implementation_addresses_with_smart_contract_preload =
-        implementation_address_hashes
+        proxy_implementations.address_hashes
         |> Enum.map(fn implementation_address_hash ->
           Enum.find(implementation_addresses_with_smart_contracts, fn address ->
             address.hash.bytes == implementation_address_hash.bytes
           end)
         end)
 
-      {proxy_address_hash, implementation_addresses_with_smart_contract_preload}
+      {proxy_implementations.proxy_address_hash, implementation_addresses_with_smart_contract_preload}
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2013,7 +2013,6 @@ defmodule Explorer.Chain.Transaction do
     {Enum.reverse(results), abi_acc, methods_acc}
   end
 
-  # credo:disable-for-next-line
   defp get_proxy_implementation_addresses_tuple_list(transactions) do
     # parse unique address hashes of smart-contracts from to_address and created_contract_address properties of the transactions list
     unique_to_address_hashes =

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2016,14 +2016,10 @@ defmodule Explorer.Chain.Transaction do
     # parse unique address hashes of smart-contracts from to_address and created_contract_address properties of the transactions list
     unique_to_address_hashes =
       transactions
-      |> Enum.filter(fn
-        %Transaction{to_address: %Address{}} -> true
-        %Transaction{created_contract_address: %Address{}} -> true
-        _ -> false
-      end)
-      |> Enum.map(fn transaction ->
-        (transaction.to_address && transaction.to_address.hash) ||
-          (transaction.created_contract_address && transaction.created_contract_address.hash)
+      |> Enum.flat_map(fn
+        %Transaction{to_address: %Address{hash: hash}} -> [hash]
+        %Transaction{created_contract_address: %Address{hash: hash}} -> [hash]
+        _ -> []
       end)
       |> Enum.uniq()
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2029,38 +2029,23 @@ defmodule Explorer.Chain.Transaction do
     multiple_proxy_implementations =
       Implementation.get_proxy_implementations_for_multiple_proxies(unique_to_address_hashes)
 
-    # combine tuple {proxy_address_hash, implementation_address_hashes} and unique list of implementation addresses hashes
-    {proxy_implementation_addresses_tuple_list_raw, implementation_hashes} =
-      multiple_proxy_implementations
-      |> Enum.reduce({[], []}, fn proxy_implementations,
-                                  {proxy_implementation_addresses_tuple_list_acc, implementation_hashes_acc} ->
-        proxy_implementation_addresses_tuple_list_new_acc = [
-          {proxy_implementations.proxy_address_hash, proxy_implementations.address_hashes}
-          | proxy_implementation_addresses_tuple_list_acc
-        ]
-
-        implementation_hashes_new_acc = implementation_hashes_acc ++ proxy_implementations.address_hashes
-        {proxy_implementation_addresses_tuple_list_new_acc, implementation_hashes_new_acc}
-      end)
-
     # query from the DB address objects with smart_contract preload for all found above implementation addresses
     implementation_addresses_with_smart_contracts =
-      Chain.hashes_to_addresses(implementation_hashes, necessity_by_association: %{smart_contract: :optional})
+      multiple_proxy_implementations
+      |> Enum.flat_map(fn proxy_implementations -> proxy_implementations.address_hashes end)
+      |> Chain.hashes_to_addresses(necessity_by_association: %{smart_contract: :optional})
+      |> Enum.into(%{}, &{&1.hash, &1})
 
     # combine final tuple {proxy_address_hash, the list of implementations as Address.t() object with preloaded SmartContract.t()}
-    proxy_implementation_addresses_tuple_list_raw
-    |> Enum.map(fn proxy_implementation_addresses_tuple ->
-      {proxy_address_hash, implementation_address_hashes} = proxy_implementation_addresses_tuple
-
+    multiple_proxy_implementations
+    |> Enum.map(fn proxy_implementations ->
       implementation_addresses_with_smart_contract_preload =
-        implementation_address_hashes
+        proxy_implementations.address_hashes
         |> Enum.map(fn implementation_address_hash ->
-          Enum.find(implementation_addresses_with_smart_contracts, fn address ->
-            address.hash.bytes == implementation_address_hash.bytes
-          end)
+          Map.get(implementation_addresses_with_smart_contracts, implementation_address_hash)
         end)
 
-      {proxy_address_hash, implementation_addresses_with_smart_contract_preload}
+      {proxy_implementations.proxy_address_hash, implementation_addresses_with_smart_contract_preload}
     end)
   end
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -6,6 +6,8 @@ defmodule Explorer.Chain.Transaction.Schema do
     - Explorer.Chain.Import.Runner.Transactions
   """
 
+  alias Explorer.Chain
+
   alias Explorer.Chain.{
     Address,
     Beacon.BlobTransaction,
@@ -2043,7 +2045,8 @@ defmodule Explorer.Chain.Transaction do
       end)
 
     # query from the DB address objects with smart_contract preload for all found above implementation addresses
-    implementation_addresses_with_smart_contracts = Address.get_multiple_addresses(implementation_hashes)
+    implementation_addresses_with_smart_contracts =
+      Chain.hashes_to_addresses(implementation_hashes, necessity_by_association: %{smart_contract: :optional})
 
     # combine final tuple {proxy_address_hash, the list of implementations as Address.t() object with preloaded SmartContract.t()}
     proxy_implementation_addresses_tuple_list_raw

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -136,7 +136,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
 
       assert Proxy.combine_proxy_implementation_abi(
                %SmartContract{address_hash: proxy_contract_address.hash, abi: nil},
-               [],
+               %{},
                false
              ) ==
                []
@@ -148,7 +148,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: [], contract_code_md5: "123")
 
-      assert Proxy.combine_proxy_implementation_abi(smart_contract, [], false) == []
+      assert Proxy.combine_proxy_implementation_abi(smart_contract, %{}, false) == []
     end
 
     test "combine_proxy_implementation_abi/4 returns proxy abi if implementation is not verified" do
@@ -157,7 +157,7 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: @proxy_abi, contract_code_md5: "123")
 
-      assert Proxy.combine_proxy_implementation_abi(smart_contract, [], false) == @proxy_abi
+      assert Proxy.combine_proxy_implementation_abi(smart_contract, %{}, false) == @proxy_abi
     end
 
     test "combine_proxy_implementation_abi/4 returns proxy + implementation abi if implementation is verified" do
@@ -189,10 +189,14 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       _implementation_contract_address_hash_string =
         Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
 
+      proxy_implementation_addresses_map =
+        %{}
+        |> Map.put(proxy_contract_address.hash, [implementation_contract_address_with_smart_contract_preload])
+
       combined_abi =
         Proxy.combine_proxy_implementation_abi(
           proxy_smart_contract,
-          [{proxy_contract_address.hash, [implementation_contract_address_with_smart_contract_preload]}],
+          proxy_implementation_addresses_map,
           false
         )
 

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -131,70 +131,70 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       }
     ]
 
-    test "combine_proxy_implementation_abi/2 returns empty [] abi if proxy abi is null" do
+    test "combine_proxy_implementation_abi/4 returns empty [] abi if proxy abi is null" do
       proxy_contract_address = insert(:contract_address)
 
-      assert Proxy.combine_proxy_implementation_abi(%SmartContract{address_hash: proxy_contract_address.hash, abi: nil}) ==
+      assert Proxy.combine_proxy_implementation_abi(
+               %SmartContract{address_hash: proxy_contract_address.hash, abi: nil},
+               [],
+               false
+             ) ==
                []
     end
 
-    test "combine_proxy_implementation_abi/2 returns [] abi for unverified proxy" do
+    test "combine_proxy_implementation_abi/4 returns [] abi for unverified proxy" do
       proxy_contract_address = insert(:contract_address)
 
       smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: [], contract_code_md5: "123")
 
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
-      assert Proxy.combine_proxy_implementation_abi(smart_contract) == []
+      assert Proxy.combine_proxy_implementation_abi(smart_contract, [], false) == []
     end
 
-    test "combine_proxy_implementation_abi/2 returns proxy abi if implementation is not verified" do
+    test "combine_proxy_implementation_abi/4 returns proxy abi if implementation is not verified" do
       proxy_contract_address = insert(:contract_address)
 
       smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: @proxy_abi, contract_code_md5: "123")
 
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
-      assert Proxy.combine_proxy_implementation_abi(smart_contract) == @proxy_abi
+      assert Proxy.combine_proxy_implementation_abi(smart_contract, [], false) == @proxy_abi
     end
 
-    test "combine_proxy_implementation_abi/2 returns proxy + implementation abi if implementation is verified" do
+    test "combine_proxy_implementation_abi/4 returns proxy + implementation abi if implementation is verified" do
       proxy_contract_address = insert(:contract_address)
 
-      smart_contract =
+      proxy_smart_contract =
         insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: @proxy_abi, contract_code_md5: "123")
 
       implementation_contract_address = insert(:contract_address)
 
-      insert(:smart_contract,
-        address_hash: implementation_contract_address.hash,
-        abi: @implementation_abi,
-        contract_code_md5: "123"
+      implementation_smart_contract =
+        insert(:smart_contract,
+          address_hash: implementation_contract_address.hash,
+          abi: @implementation_abi,
+          contract_code_md5: "123",
+          name: "impl"
+        )
+
+      implementation_contract_address_with_smart_contract_preload =
+        implementation_contract_address |> Repo.preload(:smart_contract)
+
+      insert(:proxy_implementation,
+        proxy_address_hash: proxy_contract_address.hash,
+        proxy_type: "eip1167",
+        address_hashes: [implementation_contract_address.hash],
+        names: [implementation_smart_contract.name]
       )
 
-      implementation_contract_address_hash_string =
+      _implementation_contract_address_hash_string =
         Base.encode16(implementation_contract_address.hash.bytes, case: :lower)
 
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
-      expect(
-        EthereumJSONRPC.Mox,
-        :json_rpc,
-        fn [%{id: id, method: _, params: [%{data: _, to: _}, _]}], _options ->
-          {:ok,
-           [
-             %{
-               id: id,
-               jsonrpc: "2.0",
-               result: "0x000000000000000000000000" <> implementation_contract_address_hash_string
-             }
-           ]}
-        end
-      )
-
-      combined_abi = Proxy.combine_proxy_implementation_abi(smart_contract)
+      combined_abi =
+        Proxy.combine_proxy_implementation_abi(
+          proxy_smart_contract,
+          [{proxy_contract_address.hash, [implementation_contract_address_with_smart_contract_preload]}],
+          false
+        )
 
       assert Enum.any?(@proxy_abi, fn el -> el == Enum.at(@implementation_abi, 0) end) == false
       assert Enum.any?(@proxy_abi, fn el -> el == Enum.at(@implementation_abi, 1) end) == false
@@ -210,17 +210,6 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
                []
              ) ==
                []
-    end
-
-    test "get_implementation_abi_from_proxy/2 returns [] abi for unverified proxy" do
-      proxy_contract_address = insert(:contract_address)
-
-      smart_contract =
-        insert(:smart_contract, address_hash: proxy_contract_address.hash, abi: [], contract_code_md5: "123")
-
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
-      assert Proxy.combine_proxy_implementation_abi(smart_contract) == []
     end
 
     test "get_implementation_abi_from_proxy/2 returns [] if implementation is not verified" do

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -270,8 +270,6 @@ defmodule Explorer.Chain.TransactionTest do
         |> insert()
         |> Repo.preload(to_address: :smart_contract)
 
-      TestHelper.get_eip1967_implementation_zero_addresses()
-
       assert {{:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 50}]}, _, _} =
                Transaction.decoded_input_data(transaction, [])
     end
@@ -292,8 +290,6 @@ defmodule Explorer.Chain.TransactionTest do
         :transaction
         |> insert(to_address: contract.address, input: "0x" <> input_data)
         |> Repo.preload(to_address: :smart_contract)
-
-      TestHelper.get_eip1967_implementation_zero_addresses()
 
       assert {{:ok, "60fe47b1", "set(uint256 x)", [{"x", "uint256", 10}]}, _, _} =
                Transaction.decoded_input_data(transaction, [])
@@ -326,8 +322,6 @@ defmodule Explorer.Chain.TransactionTest do
         :transaction
         |> insert(to_address: contract.address, input: "0x" <> input_data)
         |> Repo.preload(to_address: :smart_contract)
-
-      TestHelper.get_eip1967_implementation_zero_addresses()
 
       assert {{:ok, "60fe47b1", "set(uint256 arg0)", [{"arg0", "uint256", 10}]}, _, _} =
                Transaction.decoded_input_data(transaction, [])


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10735

## Motivation

/api/v2/transactions API endpoint low performance on transactions to smart-contracts
## Changelog

### Enhancements

Instead of sending DB query for fetching proxy implementation objects from the DB for each smart-contract from the transactions list, pre-processing is added which aggregates unique smart-contracts in the list and fetches proxy implementations for them in a single DB query.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
