### PR TITLE
fix: Filter out tokens with skip_metadata: true from token fetcher

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3672,6 +3672,7 @@ defmodule Explorer.Chain do
       from(
         token in Token,
         where: token.cataloged == false or is_nil(token.cataloged),
+        where: is_nil(token.skip_metadata) or token.skip_metadata == false,
         select: token.contract_address_hash
       )
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10493

## Motivation

In case when token fetcher fails to get functions of token, it doesn't set `cataloged: true` to it and therefore the fetcher will constantly try to process this token again. But in such cases the token is marked as `skip_metadata: true`. So we should skip tokens with this setting from token fetcher query.