### PR TITLE
feat: Address badges

### DIFF
--- a/apps/block_scout_web/.sobelow-conf
+++ b/apps/block_scout_web/.sobelow-conf
@@ -9,6 +9,8 @@
   ignore_files: [
     "apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex",
     "apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex",
-    "apps/block_scout_web/lib/block_scout_web/routers/utils_api_v2_router.ex"
+    "apps/block_scout_web/lib/block_scout_web/routers/utils_api_v2_router.ex",
+    "apps/block_scout_web/lib/block_scout_web/routers/address_badges_v2_router.ex",
+    "apps/block_scout_web/lib/block_scout_web/routers/api_router.ex"
   ]
 ]

--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -50,8 +50,18 @@ defmodule BlockScoutWeb.AddressChannel do
 
   @transaction_associations [
                               from_address: [:names, :smart_contract, :proxy_implementations],
-                              to_address: [:names, :smart_contract, :proxy_implementations],
-                              created_contract_address: [:names, :smart_contract, :proxy_implementations]
+                              to_address: [
+                                [badges: [:badge, :address]],
+                                :names,
+                                :smart_contract,
+                                :proxy_implementations
+                              ],
+                              created_contract_address: [
+                                [badges: [:badge, :address]],
+                                :names,
+                                :smart_contract,
+                                :proxy_implementations
+                              ]
                             ] ++
                               @chain_type_transaction_associations
 
@@ -404,8 +414,8 @@ defmodule BlockScoutWeb.AddressChannel do
           token_transfers
           |> Repo.preload([
             [
-              from_address: [:names, :smart_contract, :proxy_implementations],
-              to_address: [:names, :smart_contract, :proxy_implementations]
+              from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+              to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
             ]
           ]),
         conn: nil

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/fallback_controller.ex
@@ -85,7 +85,6 @@ defmodule BlockScoutWeb.Account.Api.V2.FallbackController do
 
   def call(conn, {:api_key, _}) do
     conn
-    |> put_status(:unauthorized)
     |> put_view(UserView)
     |> render(:message, %{message: "Wrong API key"})
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
@@ -53,7 +53,7 @@ defmodule BlockScoutWeb.API.V2.AddressBadgeController do
 
   def create_badge(_, _), do: {:error, :not_found}
 
-  def add_addresses_to_badge(
+  def assign_badge_to_address(
         conn,
         %{
           "badge_id" => badge_id_string,
@@ -82,9 +82,9 @@ defmodule BlockScoutWeb.API.V2.AddressBadgeController do
     end
   end
 
-  def add_addresses_to_badge(_, _), do: {:error, :not_found}
+  def assign_badge_to_address(_, _), do: {:error, :not_found}
 
-  def remove_addresses_to_badge(
+  def unassign_badge_from_address(
         conn,
         %{
           "badge_id" => badge_id_string,
@@ -113,7 +113,7 @@ defmodule BlockScoutWeb.API.V2.AddressBadgeController do
     end
   end
 
-  def remove_addresses_to_badge(_, _), do: {:error, :not_found}
+  def unassign_badge_from_address(_, _), do: {:error, :not_found}
 
   def show_badge_addresses(conn, %{"badge_id" => badge_id_string}) do
     with {:ok, body, _conn} <- Conn.read_body(conn, []),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
@@ -1,0 +1,190 @@
+defmodule BlockScoutWeb.API.V2.AddressBadgeController do
+  require Logger
+  use BlockScoutWeb, :controller
+
+  alias Explorer.Chain.Address.{Badge, BadgeToAddress}
+  alias Plug.Conn
+
+  @api_true [api?: true]
+
+  action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  def badge(conn, %{"badge_id" => badge_id_string}) do
+    with {:ok, body, _conn} <- Conn.read_body(conn, []),
+         {:ok, %{"api_key" => provided_api_key}} <- Jason.decode(body),
+         {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, provided_api_key},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         badge = Badge.get(badge_id, @api_true),
+         false <- is_nil(badge) do
+      conn
+      |> put_status(200)
+      |> render(:badge, %{
+        badge: badge
+      })
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def badge(_, _), do: {:error, :not_found}
+
+  def create_badge(conn, %{"category" => category, "content" => content} = params) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:ok, new_badge} <- Badge.create(category, content) do
+      conn
+      |> put_status(200)
+      |> render(:badge, %{
+        badge: new_badge,
+        status: "created"
+      })
+    else
+      {:error, error} ->
+        Logger.error(fn -> ["Address badge creation failed: ", inspect(error)] end)
+        {:error, :badge_creation_failed}
+
+      _ ->
+        {:api_key, :wrong}
+    end
+  end
+
+  def create_badge(_, _), do: {:error, :not_found}
+
+  def add_addresses_to_badge(
+        conn,
+        %{
+          "badge_id" => badge_id_string,
+          "address_hashes" => address_hashes
+        } = params
+      )
+      when is_list(address_hashes) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         {_num_of_inserted, badge_to_address_list} <- BadgeToAddress.create(badge_id, address_hashes) do
+      conn
+      |> put_status(200)
+      |> render(:badge_to_address, %{
+        badge_to_address_list: badge_to_address_list,
+        status: if(Enum.empty?(badge_to_address_list), do: "update skipped", else: "added")
+      })
+    else
+      {:error, error} ->
+        Logger.error(fn -> ["Badge addresses addition failed: ", inspect(error)] end)
+        {:error, :badge_creation_failed}
+
+      _ ->
+        {:api_key, :wrong}
+    end
+  end
+
+  def add_addresses_to_badge(_, _), do: {:error, :not_found}
+
+  def remove_addresses_to_badge(
+        conn,
+        %{
+          "badge_id" => badge_id_string,
+          "address_hashes" => address_hashes
+        } = params
+      )
+      when is_list(address_hashes) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         {_num_of_deleted, badge_to_address_list} <- BadgeToAddress.delete(badge_id, address_hashes) do
+      conn
+      |> put_status(200)
+      |> render(:badge_to_address, %{
+        badge_to_address_list: badge_to_address_list,
+        status: if(Enum.empty?(badge_to_address_list), do: "update skipped", else: "removed")
+      })
+    else
+      {:error, error} ->
+        Logger.error(fn -> ["Badge addresses addition failed: ", inspect(error)] end)
+        {:error, :badge_creation_failed}
+
+      _ ->
+        {:api_key, :wrong}
+    end
+  end
+
+  def remove_addresses_to_badge(_, _), do: {:error, :not_found}
+
+  def show_badge_addresses(conn, %{"badge_id" => badge_id_string}) do
+    with {:ok, body, _conn} <- Conn.read_body(conn, []),
+         {:ok, %{"api_key" => provided_api_key}} <- Jason.decode(body),
+         {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, provided_api_key},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         badge_to_address_list = BadgeToAddress.get(badge_id, @api_true),
+         false <- is_nil(badge_to_address_list) do
+      conn
+      |> put_status(200)
+      |> render(:badge_to_address, %{
+        badge_to_address_list: badge_to_address_list
+      })
+    else
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  def show_badge_addresses(_, _), do: {:error, :not_found}
+
+  def update_badge(
+        conn,
+        %{
+          "badge_id" => badge_id_string,
+          "category" => category,
+          "content" => content
+        } = params
+      ) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         badge = Badge.get(badge_id, @api_true),
+         {:ok, new_badge} <- Badge.update(badge, category, content) do
+      conn
+      |> put_status(200)
+      |> render(:badge, %{
+        badge: new_badge,
+        status: "updated"
+      })
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def update_badge(_, _) do
+    {:error, :not_found}
+  end
+
+  def delete_badge(conn, %{"badge_id" => badge_id_string} = params) do
+    with {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
+           {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
+         {:api_key, ^api_key} <- {:api_key, params["api_key"]},
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
+         badge = Badge.get(badge_id, @api_true),
+         {:ok, deleted_badge} <- Badge.delete(badge) do
+      conn
+      |> put_status(200)
+      |> render(:badge, %{
+        badge: deleted_badge,
+        status: "deleted"
+      })
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def delete_badge(_, _) do
+    {:error, :not_found}
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_badge_controller.ex
@@ -121,9 +121,9 @@ defmodule BlockScoutWeb.API.V2.AddressBadgeController do
          {:sensitive_endpoints_api_key, api_key} when not is_nil(api_key) <-
            {:sensitive_endpoints_api_key, Application.get_env(:block_scout_web, :sensitive_endpoints_api_key)},
          {:api_key, ^api_key} <- {:api_key, provided_api_key},
-         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)},
-         badge_to_address_list = BadgeToAddress.get(badge_id, @api_true),
-         false <- is_nil(badge_to_address_list) do
+         {:param, {badge_id, _}} <- {:param, Integer.parse(badge_id_string)} do
+      badge_to_address_list = BadgeToAddress.get(badge_id, @api_true)
+
       conn
       |> put_status(200)
       |> render(:badge_to_address, %{

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -52,9 +52,10 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @transaction_necessity_by_association [
     necessity_by_association:
       %{
-        [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+          :optional,
         [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-        [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
         :block => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association),
@@ -63,8 +64,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   @token_transfer_necessity_by_association [
     necessity_by_association: %{
-      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+      [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
       :block => :optional,
       :transaction => :optional,
       :token => :optional
@@ -213,8 +214,9 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       options =
         [
           necessity_by_association: %{
-            [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-            [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+            [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+            [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+              :optional,
             :block => :optional,
             :token => :optional,
             :transaction => :optional
@@ -285,9 +287,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       full_options =
         [
           necessity_by_association: %{
-            [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-            [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-            [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+            [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+              :optional,
+            [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+              :optional,
+            [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
           }
         ]
         |> Keyword.merge(paging_options(params))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -75,6 +75,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @address_options [
     necessity_by_association: %{
       :names => :optional,
+      [badges: [:badge, :address]] => :optional,
       :token => :optional,
       :proxy_implementations => :optional
     },

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -83,9 +83,10 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   @transaction_necessity_by_association [
     necessity_by_association:
       %{
-        [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+          :optional,
         [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-        [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
         :block => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association)
@@ -93,9 +94,10 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+      [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+        :optional,
+      [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
     }
   ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -133,6 +133,13 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> render(:changeset_errors, changeset: changeset)
   end
 
+  def call(conn, {:error, :badge_creation_failed}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(UserView)
+    |> render(:message, %{message: "Badge creation failed"})
+  end
+
   def call(conn, {:restricted_access, true}) do
     Logger.error(fn ->
       ["#{@restricted_access}"]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -24,9 +24,10 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     necessity_by_association:
       %{
         :block => :required,
-        [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+          :optional,
         [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-        [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+        [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association),
     paging_options: %PagingOptions{page_size: 6},

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -70,6 +70,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                           :block => :optional,
                                           [
                                             created_contract_address: [
+                                              [badges: [:badge, :address]],
                                               :names,
                                               :token,
                                               :smart_contract,
@@ -78,26 +79,34 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                           ] => :optional,
                                           [from_address: [:names, :smart_contract, :proxy_implementations]] =>
                                             :optional,
-                                          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+                                          [
+                                            to_address: [
+                                              [badges: [:badge, :address]],
+                                              :names,
+                                              :smart_contract,
+                                              :proxy_implementations
+                                            ]
+                                          ] => :optional
                                         }
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)
 
   @token_transfers_necessity_by_association %{
-    [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-    [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+    [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+    [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
   }
 
   @token_transfers_in_tx_necessity_by_association %{
-    [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-    [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+    [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+    [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
     token: :required
   }
 
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+      [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+        :optional,
+      [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
     }
   ]
 
@@ -515,7 +524,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
            validate_transaction(transaction_hash_string, params,
              necessity_by_association: %{
                [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-               [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+               [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+                 :optional
              },
              api?: true
            ) do

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -19,9 +19,10 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   @items_limit 50
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
-      [created_contract_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-      [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+      [created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] =>
+        :optional,
+      [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional,
+      [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]] => :optional
     }
   ]
 
@@ -108,9 +109,9 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
       Chain.select_repo(@api_true).preload(transaction, [
         :transaction_actions,
         :block,
-        to_address: [:names, :smart_contract],
+        to_address: [[badges: [:badge, :address]], :names, :smart_contract],
         from_address: [:names, :smart_contract],
-        created_contract_address: [:names, :token, :smart_contract]
+        created_contract_address: [[badges: [:badge, :address]], :names, :token, :smart_contract]
       ])
 
     skip_sig_provider? = false

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -69,16 +69,16 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
       |> Enum.find(&(&1.hash == transaction.hash))
       |> Repo.preload(
         token_transfers: [
-          from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations]
+          from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
         ],
         internal_transactions: [
-          from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations]
+          from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
         ],
         block: [miner: [:names, :smart_contract, :proxy_implementations]],
         from_address: [:names, :smart_contract, :proxy_implementations],
-        to_address: [:names, :smart_contract, :proxy_implementations]
+        to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
       )
 
     previous_block_number = BlockNumberHelper.previous_block_number(transaction.block_number)

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -181,8 +181,8 @@ defmodule BlockScoutWeb.Notifier do
         DenormalizationHelper.extend_transaction_preload([
           :token,
           :transaction,
-          from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations]
+          from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
         ])
       )
 
@@ -205,9 +205,9 @@ defmodule BlockScoutWeb.Notifier do
   def handle_event({:chain_event, :transactions, :realtime, transactions}) do
     base_preloads = [
       :block,
-      created_contract_address: [:names, :smart_contract, :proxy_implementations],
+      created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
       from_address: [:names, :smart_contract, :proxy_implementations],
-      to_address: [:names, :smart_contract, :proxy_implementations]
+      to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
     ]
 
     preloads = if API_V2.enabled?(), do: [:token_transfers | base_preloads], else: base_preloads

--- a/apps/block_scout_web/lib/block_scout_web/routers/address_badges_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/address_badges_v2_router.ex
@@ -1,0 +1,62 @@
+# This file in ignore list of `sobelow`, be careful while adding new endpoints here
+defmodule BlockScoutWeb.Routers.AddressBadgesApiV2Router do
+  @moduledoc """
+    Router for /api/v2/address-badges. This route has separate router in order to ignore sobelow's warning about missing CSRF protection
+  """
+  use BlockScoutWeb, :router
+  alias BlockScoutWeb.API.V2
+  alias BlockScoutWeb.Plug.{CheckApiV2, RateLimit}
+
+  @max_query_string_length 5_000
+
+  pipeline :api_v2 do
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      query_string_length: @max_query_string_length,
+      pass: ["*/*"],
+      json_decoder: Poison
+    )
+
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
+    plug(:accepts, ["json"])
+    plug(CheckApiV2)
+    plug(:fetch_session)
+    plug(:protect_from_forgery)
+    plug(RateLimit)
+  end
+
+  pipeline :api_v2_no_forgery_protect do
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      length: 20_000_000,
+      query_string_length: 5_000,
+      pass: ["*/*"],
+      json_decoder: Poison
+    )
+
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
+    plug(:accepts, ["json"])
+    plug(CheckApiV2)
+    plug(RateLimit)
+    plug(:fetch_session)
+  end
+
+  scope "/", as: :api_v2 do
+    pipe_through(:api_v2_no_forgery_protect)
+
+    post("/", V2.AddressBadgeController, :create_badge)
+    post("/:badge_id/addresses/add", V2.AddressBadgeController, :add_addresses_to_badge)
+    post("/:badge_id/addresses/remove", V2.AddressBadgeController, :remove_addresses_to_badge)
+    patch("/:badge_id", V2.AddressBadgeController, :update_badge)
+    delete("/:badge_id", V2.AddressBadgeController, :delete_badge)
+  end
+
+  scope "/", as: :api_v2 do
+    pipe_through(:api_v2)
+
+    get("/:badge_id", V2.AddressBadgeController, :badge)
+    get("/:badge_id/addresses/show", V2.AddressBadgeController, :show_badge_addresses)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/routers/address_badges_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/address_badges_v2_router.ex
@@ -47,16 +47,16 @@ defmodule BlockScoutWeb.Routers.AddressBadgesApiV2Router do
     pipe_through(:api_v2_no_forgery_protect)
 
     post("/", V2.AddressBadgeController, :create_badge)
-    post("/:badge_id/addresses/add", V2.AddressBadgeController, :add_addresses_to_badge)
-    post("/:badge_id/addresses/remove", V2.AddressBadgeController, :remove_addresses_to_badge)
     patch("/:badge_id", V2.AddressBadgeController, :update_badge)
     delete("/:badge_id", V2.AddressBadgeController, :delete_badge)
+    post("/:badge_id/addresses", V2.AddressBadgeController, :assign_badge_to_address)
+    delete("/:badge_id/addresses", V2.AddressBadgeController, :unassign_badge_from_address)
   end
 
   scope "/", as: :api_v2 do
     pipe_through(:api_v2)
 
     get("/:badge_id", V2.AddressBadgeController, :badge)
-    get("/:badge_id/addresses/show", V2.AddressBadgeController, :show_badge_addresses)
+    get("/:badge_id/addresses", V2.AddressBadgeController, :show_badge_addresses)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_badge_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_badge_view.ex
@@ -1,0 +1,57 @@
+defmodule BlockScoutWeb.API.V2.AddressBadgeView do
+  use BlockScoutWeb, :view
+
+  def render("badge.json", %{badge: badge, status: status}) do
+    prepare_badge(badge, status)
+  end
+
+  def render("badge.json", %{badge: badge}) do
+    prepare_badge(badge)
+  end
+
+  def render("badge_to_address.json", %{badge_to_address_list: badge_to_address_list, status: status}) do
+    prepare_badge_to_address(badge_to_address_list, status)
+  end
+
+  def render("badge_to_address.json", %{badge_to_address_list: badge_to_address_list}) do
+    prepare_badge_to_address(badge_to_address_list)
+  end
+
+  defp prepare_badge(badge) do
+    %{
+      id: badge.id,
+      content: badge.content
+    }
+  end
+
+  defp prepare_badge(badge, status) do
+    %{
+      id: badge.id,
+      content: badge.content,
+      status: status
+    }
+  end
+
+  defp prepare_badge_to_address(badge_to_address_list) do
+    %{
+      badge_to_address_list: format_badge_to_address_list(badge_to_address_list)
+    }
+  end
+
+  defp prepare_badge_to_address(badge_to_address_list, status) do
+    %{
+      badge_to_address_list: format_badge_to_address_list(badge_to_address_list),
+      status: status
+    }
+  end
+
+  defp format_badge_to_address_list(badge_to_address_list) do
+    badge_to_address_list
+    |> Enum.map(fn badge_to_address ->
+      %{
+        badge_id: badge_to_address.badge_id,
+        address_hash: "0x" <> Base.encode16(badge_to_address.address_hash.bytes)
+      }
+    end)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -84,6 +84,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
       "hash" => Address.checksum(address),
       "is_contract" => smart_contract?,
       "name" => address_name(address),
+      "badges" => address_badges(address),
       "proxy_type" => proxy_type,
       "implementations" => Proxy.proxy_object_info(implementation_address_hashes, implementation_names),
       "is_verified" => verified?(address) || verified_minimal_proxy?(proxy_implementations),
@@ -157,6 +158,20 @@ defmodule BlockScoutWeb.API.V2.Helper do
   end
 
   def address_name(_), do: nil
+
+  def address_badges(%Address{badges: badge_mappings}) when is_list(badge_mappings) do
+    badge_mappings
+    |> Enum.map(fn badge_mapping ->
+      %{
+        :category => badge_mapping.badge.category,
+        :content => badge_mapping.badge.content
+      }
+    end)
+  end
+
+  def address_badges(_) do
+    []
+  end
 
   def verified?(%Address{smart_contract: nil}), do: false
   def verified?(%Address{smart_contract: %{metadata_from_verified_bytecode_twin: true}}), do: false

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -103,6 +103,7 @@ defmodule Explorer.Chain.Address.Schema do
         )
 
         has_many(:names, Address.Name, foreign_key: :address_hash, references: :hash)
+        has_many(:badges, Address.BadgeToAddress, foreign_key: :address_hash, references: :hash)
         has_many(:decompiled_smart_contracts, DecompiledSmartContract, foreign_key: :address_hash, references: :hash)
         has_many(:withdrawals, Withdrawal, foreign_key: :address_hash, references: :hash)
 
@@ -181,6 +182,7 @@ defmodule Explorer.Chain.Address do
      Solidity source code is in `smart_contract` `t:Explorer.Chain.SmartContract.t/0` `contract_source_code` *if* the
     contract has been verified
    * `names` - names known for the address
+   * `badges` - badges applied for the address
    * `inserted_at` - when this address was inserted
    * `updated_at` - when this address was last updated
    * `ens_domain_name` - virtual field for ENS domain name passing

--- a/apps/explorer/lib/explorer/chain/address/badge.ex
+++ b/apps/explorer/lib/explorer/chain/address/badge.ex
@@ -1,0 +1,76 @@
+defmodule Explorer.Chain.Address.Badge do
+  @moduledoc """
+  Defines Address.t() badges
+  """
+
+  use Explorer.Schema
+
+  import Ecto.Changeset
+
+  alias Ecto.Changeset
+  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.Address
+
+  import Ecto.Query, only: [from: 2]
+
+  @typedoc """
+  * `id` - id of the badge.
+  * `category` - category of the badge.
+  * `content` - content of the badge.
+  """
+  @primary_key false
+  typed_schema "address_badges" do
+    field(:id, :integer, primary_key: true, null: false)
+
+    field(:category, Ecto.Enum,
+      values: [
+        :scam
+      ],
+      null: false
+    )
+
+    field(:content, :string, null: false)
+
+    has_many(:address_to_badges, Address.BadgeToAddress, foreign_key: :badge_id, references: :id)
+
+    timestamps()
+  end
+
+  @required_fields ~w(category content)a
+  @allowed_fields @required_fields
+
+  def changeset(%__MODULE__{} = struct, params \\ %{}) do
+    struct
+    |> cast(params, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint([:category, :content],
+      message: "Address badge has been created before"
+    )
+  end
+
+  @spec get(non_neg_integer(), [Chain.necessity_by_association_option() | Chain.api?()]) :: t() | nil
+  def get(badge_id, options) do
+    query = from(badge in __MODULE__, where: badge.id == ^badge_id)
+
+    query
+    |> Chain.select_repo(options).one()
+  end
+
+  def create(category, content) do
+    %__MODULE__{}
+    |> __MODULE__.changeset(%{category: category, content: content})
+    |> Repo.insert(returning: [:id, :category, :content])
+  end
+
+  def update(badge, category, content) do
+    badge
+    |> __MODULE__.changeset(%{category: category, content: content})
+    |> Repo.update()
+  end
+
+  def delete(badge) do
+    badge
+    |> Changeset.change()
+    |> Repo.delete()
+  end
+end

--- a/apps/explorer/lib/explorer/chain/address/badge.ex
+++ b/apps/explorer/lib/explorer/chain/address/badge.ex
@@ -1,6 +1,7 @@
 defmodule Explorer.Chain.Address.Badge do
   @moduledoc """
-  Defines Address.t() badges
+  Defines Address.t() badges, which will allow to display them on the address page,
+  e.g. for scam contracts, EoA associated with bad actors etc.
   """
 
   use Explorer.Schema
@@ -48,7 +49,10 @@ defmodule Explorer.Chain.Address.Badge do
     )
   end
 
-  @spec get(non_neg_integer(), [Chain.necessity_by_association_option() | Chain.api?()]) :: t() | nil
+  @doc """
+  Gets Address.Badge.t() by its id
+  """
+  @spec get(non_neg_integer(), [Chain.necessity_by_association_option() | Chain.api?()]) :: __MODULE__.t() | nil
   def get(badge_id, options) do
     query = from(badge in __MODULE__, where: badge.id == ^badge_id)
 
@@ -56,18 +60,30 @@ defmodule Explorer.Chain.Address.Badge do
     |> Chain.select_repo(options).one()
   end
 
+  @doc """
+  Creates new Address.Badge.t() with provided category and content
+  """
+  @spec create(String.t(), String.t()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def create(category, content) do
     %__MODULE__{}
     |> __MODULE__.changeset(%{category: category, content: content})
     |> Repo.insert(returning: [:id, :category, :content])
   end
 
+  @doc """
+  Updates existing Address.Badge.t() by badge_id with provided category and content
+  """
+  @spec update(__MODULE__.t(), String.t(), String.t()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def update(badge, category, content) do
     badge
     |> __MODULE__.changeset(%{category: category, content: content})
     |> Repo.update()
   end
 
+  @doc """
+  Deletes existing Address.Badge.t()
+  """
+  @spec delete(__MODULE__.t()) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def delete(badge) do
     badge
     |> Changeset.change()

--- a/apps/explorer/lib/explorer/chain/address/badge_to_address.ex
+++ b/apps/explorer/lib/explorer/chain/address/badge_to_address.ex
@@ -1,0 +1,75 @@
+defmodule Explorer.Chain.Address.BadgeToAddress do
+  @moduledoc """
+  Defines Address.Badge.t() mapping with Address.t()
+  """
+
+  use Explorer.Schema
+
+  import Ecto.Changeset
+
+  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.{Address, Hash}
+  alias Explorer.Chain.Address.Badge
+
+  import Ecto.Query, only: [from: 2]
+
+  @typedoc """
+  * `address` - the `t:Explorer.Chain.Address.t/0`.
+  * `address_hash` - foreign key for `address`.
+  * `badge` - the `t:Explorer.Chain.Address.Badge.t/0`.
+  * `badge_id` - foreign key for `badge`.
+  """
+  @primary_key false
+  typed_schema "address_badge_mappings" do
+    belongs_to(:badge, Badge, foreign_key: :badge_id, type: :integer, null: false)
+    belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address, null: false)
+
+    timestamps()
+  end
+
+  @required_fields ~w(address_hash badge_id)a
+  @allowed_fields @required_fields
+
+  def changeset(%__MODULE__{} = struct, params \\ %{}) do
+    struct
+    |> cast(params, @allowed_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:address_hash)
+    |> foreign_key_constraint(:badge_id)
+  end
+
+  def create(badge_id, address_hashes) do
+    now = DateTime.utc_now()
+
+    insert_params =
+      address_hashes
+      |> Enum.map(fn address_hash_string ->
+        case Chain.string_to_address_hash(address_hash_string) do
+          {:ok, address_hash} -> %{badge_id: badge_id, address_hash: address_hash, inserted_at: now, updated_at: now}
+          :error -> nil
+        end
+      end)
+      |> Enum.filter(&(!is_nil(&1)))
+
+    Repo.insert_all(__MODULE__, insert_params, on_conflict: :nothing, returning: [:badge_id, :address_hash])
+  end
+
+  def delete(badge_id, address_hashes) do
+    query =
+      from(
+        bta in __MODULE__,
+        where: bta.badge_id == ^badge_id,
+        where: bta.address_hash in ^address_hashes,
+        select: bta
+      )
+
+    Repo.delete_all(query)
+  end
+
+  def get(badge_id, options) do
+    query = from(badge_to_address in __MODULE__, where: badge_to_address.badge_id == ^badge_id)
+
+    query
+    |> Chain.select_repo(options).all()
+  end
+end

--- a/apps/explorer/lib/explorer/chain/address/badge_to_address.ex
+++ b/apps/explorer/lib/explorer/chain/address/badge_to_address.ex
@@ -38,6 +38,10 @@ defmodule Explorer.Chain.Address.BadgeToAddress do
     |> foreign_key_constraint(:badge_id)
   end
 
+  @doc """
+  Creates Address.BadgeToAddress.t() by Address.Badge.t() id and list of Hash.Address.t()
+  """
+  @spec create(non_neg_integer(), [Hash.Address.t()]) :: {non_neg_integer(), [__MODULE__.t()]}
   def create(badge_id, address_hashes) do
     now = DateTime.utc_now()
 
@@ -54,6 +58,10 @@ defmodule Explorer.Chain.Address.BadgeToAddress do
     Repo.insert_all(__MODULE__, insert_params, on_conflict: :nothing, returning: [:badge_id, :address_hash])
   end
 
+  @doc """
+  Deletes Address.BadgeToAddress.t() by Address.Badge.t() id and list of Hash.Address.t()
+  """
+  @spec delete(non_neg_integer(), [Hash.Address.t()]) :: {non_neg_integer(), [__MODULE__.t()]}
   def delete(badge_id, address_hashes) do
     query =
       from(
@@ -66,6 +74,10 @@ defmodule Explorer.Chain.Address.BadgeToAddress do
     Repo.delete_all(query)
   end
 
+  @doc """
+  Gets Address.BadgeToAddress.t() by Address.Badge.t() id
+  """
+  @spec get(non_neg_integer(), [Chain.necessity_by_association_option() | Chain.api?()]) :: [__MODULE__.t()]
   def get(badge_id, options) do
     query = from(badge_to_address in __MODULE__, where: badge_to_address.badge_id == ^badge_id)
 

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -252,8 +252,8 @@ defmodule Explorer.Chain.AdvancedFilter do
         preload: [
           :block,
           from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations],
-          created_contract_address: [:names, :smart_contract, :proxy_implementations]
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
         ],
         order_by: [
           desc: transaction.block_number,
@@ -289,8 +289,8 @@ defmodule Explorer.Chain.AdvancedFilter do
         as: :transaction,
         preload: [
           from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations],
-          created_contract_address: [:names, :smart_contract, :proxy_implementations],
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          created_contract_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
           transaction: transaction
         ],
         order_by: [
@@ -703,8 +703,8 @@ defmodule Explorer.Chain.AdvancedFilter do
         preload: [
           :transaction,
           :token,
-          from_address: [:names, :smart_contract, :proxy_implementations],
-          to_address: [:names, :smart_contract, :proxy_implementations]
+          from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations],
+          to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]
         ],
         select_merge: %{
           token_ids: [token_transfer.token_id],

--- a/apps/explorer/lib/explorer/chain/celo/epoch_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/epoch_reward.ex
@@ -101,8 +101,8 @@ defmodule Explorer.Chain.Celo.EpochReward do
         select: {tt.log_index, tt},
         preload: [
           :token,
-          [from_address: [:names, :smart_contract, :proxy_implementations]],
-          [to_address: [:names, :smart_contract, :proxy_implementations]]
+          [from_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]],
+          [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]]
         ]
       )
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -240,7 +240,7 @@ defmodule Explorer.Chain.TokenTransfer do
             :transaction,
             :token,
             [from_address: [:names, :smart_contract, :proxy_implementations]],
-            [to_address: [:names, :smart_contract, :proxy_implementations]]
+            [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]]
           ])
 
         only_consensus_transfers_query()
@@ -267,7 +267,7 @@ defmodule Explorer.Chain.TokenTransfer do
             :transaction,
             :token,
             [from_address: [:names, :smart_contract, :proxy_implementations]],
-            [to_address: [:names, :smart_contract, :proxy_implementations]]
+            [to_address: [[badges: [:badge, :address]], :names, :smart_contract, :proxy_implementations]]
           ])
 
         only_consensus_transfers_query()

--- a/apps/explorer/priv/repo/migrations/20240910095635_add_address_badges_tables.exs
+++ b/apps/explorer/priv/repo/migrations/20240910095635_add_address_badges_tables.exs
@@ -1,0 +1,36 @@
+defmodule Explorer.Repo.Migrations.AddAddressBadgesTables do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE TYPE address_badge_category AS ENUM ('scam')",
+      "DROP TYPE address_badge_category"
+    )
+
+    create table(:address_badges, primary_key: false) do
+      add(:id, :serial, null: false, primary_key: true)
+      add(:category, :address_badge_category, null: false)
+      add(:content, :string, null: false)
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:address_badges, [:category, :content]))
+
+    create table(:address_badge_mappings, primary_key: false) do
+      add(:badge_id, references(:address_badges, column: :id, type: :integer, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      add(:address_hash, references(:addresses, column: :hash, type: :bytea, on_delete: :delete_all),
+        null: false,
+        primary_key: true
+      )
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
+
+    create(index(:address_badge_mappings, [:address_hash]))
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10677

## Motivation

Implementing address badges functionality.

## Changelog

`badges` array passed to all API endpoints, which return address info:
```
"badges": [
            {
                "category": "scam",
                "content": "test2"
            }
        ]
```

Management API:

<img width="226" alt="Screenshot 2024-09-12 at 10 40 08" src="https://github.com/user-attachments/assets/55ce86ef-885e-4fb1-bb1f-d1588f525c4d">


[Blockscout API v2 address badges.postman_collection.json](https://github.com/user-attachments/files/16975522/Blockscout.API.v2.address.badges.postman_collection.json)


Badges live examples:
https://eth-sepolia.k8s-dev.blockscout.com/api/v2/addresses/0x2a202d07f520f6aaee68d2dac9b2ef35834d5923
https://eth-sepolia.k8s-dev.blockscout.com/api/v2/transactions/0x6e8adcb2c078e6689236ef7afe3a02d86707815537a05f38598d5eba24a64b8a


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
