### PR TITLE
fix: Avoid key violation error in `Indexer.Fetcher.Optimism.TxnBatch`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -564,6 +564,7 @@
         "unfetched",
         "unfinalized",
         "unindexed",
+        "Unichain",
         "Unitarion",
         "Unitorius",
         "Unitorus",


### PR DESCRIPTION
## Motivation

On `Unichain Private Testnet` the following error was discovered:

```
{"time":"2024-09-10T12:28:16.062Z","severity":"error","message":"GenServer Indexer.Fetcher.Optimism.TxnBatch terminating\n** (Postgrex.Error) ERROR 23503 (foreign_key_violation) update or delete on table \"op_frame_sequences\" violates foreign key constraint \"op_transaction_batches_frame_sequence_id_fkey\" on table \"op_transaction_batches\"\n\n    table: op_transaction_batches\n    constraint: op_transaction_batches_frame_sequence_id_fkey\n\nKey (id)=(1) is still referenced from table \"op_transaction_batches\".\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:952: Ecto.Adapters.SQL.execute/6\n    (indexer 6.8.0) lib/indexer/fetcher/optimism/txn_batch.ex:283: anonymous fn/12 in Indexer.Fetcher.Optimism.TxnBatch.handle_info/2\n    (elixir 1.16.3) lib/range.ex:538: Enumerable.Range.reduce/5\n    (elixir 1.16.3) lib/enum.ex:2582: Enum.reduce_while/3\n    (indexer 6.8.0) lib/indexer/fetcher/optimism/txn_batch.ex:241: Indexer.Fetcher.Optimism.TxnBatch.handle_info/2\n    (stdlib 5.2.3) gen_server.erl:1095: :gen_server.try_handle_info/3\n    (stdlib 5.2.3) gen_server.erl:1183: :gen_server.handle_msg/6\nLast message: :continue\nState: %{chunk_size: 4, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: ..., http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]]], end_block: 6666562, start_block: 6592250, block_check_interval: 7620, json_rpc_named_arguments_l2: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.HTTPoison, url: ..., fallback_url: nil, fallback_trace_url: nil, fallback_eth_call_url: nil, method_to_url: [eth_call: ..., debug_traceTransaction: ..., debug_traceBlockByNumber: ...], http_options: [recv_timeout: 600000, timeout: 600000, hackney: [pool: :ethereum_jsonrpc]]], variant: EthereumJSONRPC.Geth], genesis_block_l2: 0, eip4844_blobs_api_url: ..., celestia_blobs_api_url: \"\", batch_inbox: \"0xff00000000000000000000000000000011155420\", batch_submitter: \"0x2a2e3bedfa7d00310f4edd89da436a161832509a\", incomplete_channels: %{}}","metadata":{"error":{"initial_call":null,"reason":"** (Postgrex.Error) ERROR 23503 (foreign_key_violation) update or delete on table \"op_frame_sequences\" violates foreign key constraint \"op_transaction_batches_frame_sequence_id_fkey\" on table \"op_transaction_batches\"\n\n    table: op_transaction_batches\n    constraint: op_transaction_batches_frame_sequence_id_fkey\n\nKey (id)=(1) is still referenced from table \"op_transaction_batches\".\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:1054: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.11.3) lib/ecto/adapters/sql.ex:952: Ecto.Adapters.SQL.execute/6\n    (indexer 6.8.0) lib/indexer/fetcher/optimism/txn_batch.ex:283: anonymous fn/12 in Indexer.Fetcher.Optimism.TxnBatch.handle_info/2\n    (elixir 1.16.3) lib/range.ex:538: Enumerable.Range.reduce/5\n    (elixir 1.16.3) lib/enum.ex:2582: Enum.reduce_while/3\n    (indexer 6.8.0) lib/indexer/fetcher/optimism/txn_batch.ex:241: Indexer.Fetcher.Optimism.TxnBatch.handle_info/2\n    (stdlib 5.2.3) gen_server.erl:1095: :gen_server.try_handle_info/3\n    (stdlib 5.2.3) gen_server.erl:1183: :gen_server.handle_msg/6\n"},"fetcher":"optimism_txn_batches"}}
```

The reason is that the chain restarted producing batches from beginning (from the first batch) after it has already produced some amount of batches. This fix allows to rewrite the old batches in the database.

## Upgrading

After installing this fix (on `Unichain Private Testnet`), all batches need to be reindexed. To do that, before updated Blockscout instance is started, the following database tables need to be truncated: `op_frame_sequence_blobs`, `op_frame_sequences`, and `op_transaction_batches`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
