### PR TITLE
fix: decode addresses as checksummed

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/abi_encoded_value_view.ex
@@ -8,6 +8,7 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
   use BlockScoutWeb, :view
 
   alias ABI.FunctionSelector
+  alias Explorer.Chain.{Address, Hash}
   alias Phoenix.HTML
 
   require Logger
@@ -196,7 +197,10 @@ defmodule BlockScoutWeb.ABIEncodedValueView do
   end
 
   defp base_value_json(:address, value) do
-    hex_for_json(value)
+    case Hash.Address.cast(value) do
+      {:ok, address} -> Address.checksum(address)
+      :error -> "0x"
+    end
   end
 
   defp base_value_json(:bytes, value) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -263,7 +263,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "constructor_args" => target_contract.constructor_arguments,
         "decoded_constructor_args" => [
           ["0x0000000000000000000000000000000000000000", %{"name" => "_proxyStorage", "type" => "address"}],
-          ["0x2cf6e7c9ec35d0b08a1062e13854f74b1aaae54e", %{"name" => "_implementationAddress", "type" => "address"}]
+          ["0x2Cf6E7c9eC35D0B08A1062e13854f74b1aaae54e", %{"name" => "_implementationAddress", "type" => "address"}]
         ],
         "is_self_destructed" => false,
         "deployed_bytecode" =>
@@ -849,7 +849,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         assert response["decoded_constructor_args"] == [
                  [
-                   "0xc35dadb65012ec5796536bd9864ed8773abc74c4",
+                   "0xc35DADB65012eC5796536bD9864eD8773aBc74C4",
                    %{
                      "internalType" => "address",
                      "name" => "_factory",
@@ -857,7 +857,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    }
                  ],
                  [
-                   "0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6",
+                   "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
                    %{
                      "internalType" => "address",
                      "name" => "_WETH",


### PR DESCRIPTION
## Changelog

### Bug Fixes

* When ABI-decoding method calls and logs, all address fields should be auto-checksummed. Non-checksummed format also causes incorrect identicons being displayed on the UI.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
