### PR TITLE
fix: Sanitize replaced transactions migration

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -124,6 +124,7 @@ config :explorer, Explorer.Migrator.TransactionBlockConsensus, enabled: true
 config :explorer, Explorer.Migrator.TokenTransferBlockConsensus, enabled: true
 config :explorer, Explorer.Migrator.RestoreOmittedWETHTransfers, enabled: true
 config :explorer, Explorer.Migrator.SanitizeMissingTokenBalances, enabled: true
+config :explorer, Explorer.Migrator.SanitizeReplacedTransactions, enabled: true
 
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: true
 

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -50,6 +50,7 @@ config :explorer, Explorer.Migrator.TokenTransferBlockConsensus, enabled: false
 config :explorer, Explorer.Migrator.ShrinkInternalTransactions, enabled: false
 config :explorer, Explorer.Migrator.RestoreOmittedWETHTransfers, enabled: false
 config :explorer, Explorer.Migrator.SanitizeMissingTokenBalances, enabled: false
+config :explorer, Explorer.Migrator.SanitizeReplacedTransactions, enabled: false
 
 config :explorer,
   realtime_events_sender: Explorer.Chain.Events.SimpleSender

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -145,7 +145,8 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.FilecoinPendingAddressOperations),
         configure_mode_dependent_process(Explorer.Migrator.ShrinkInternalTransactions, :indexer),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, :stability),
-        configure_mode_dependent_process(Explorer.Migrator.SanitizeMissingTokenBalances, :indexer)
+        configure_mode_dependent_process(Explorer.Migrator.SanitizeMissingTokenBalances, :indexer),
+        configure_mode_dependent_process(Explorer.Migrator.SanitizeReplacedTransactions, :indexer)
       ]
       |> List.flatten()
 

--- a/apps/explorer/lib/explorer/migrator/sanitize_replaced_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_replaced_transactions.ex
@@ -1,0 +1,46 @@
+defmodule Explorer.Migrator.SanitizeReplacedTransactions do
+  @moduledoc """
+  Cleans the transactions that are related to non-consensus blocks.
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Transaction
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "sanitize_replaced_transactions"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(state) do
+    limit = batch_size() * concurrency()
+
+    ids =
+      unprocessed_data_query()
+      |> select([t], t.hash)
+      |> limit(^limit)
+      |> Repo.all(timeout: :infinity)
+
+    {ids, state}
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    from(t in Transaction, where: t.block_consensus == false)
+  end
+
+  @impl FillingMigration
+  def update_batch(transaction_hashes) do
+    query = from(t in Transaction, where: t.hash in ^transaction_hashes)
+
+    Repo.delete_all(query, timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8186

## Motivation

There was a possible race condition in case of reorg is processed at about the same time with the new block on the same height. In that case, if a new block import `fork_transactions` step was executed before the reorg's transactions are inserted, the reorg-related transactions weren't cleared and therefore reorg would have transactions. This race condition was already fixed in https://github.com/blockscout/blockscout/pull/10285 but there are still transactions in the DB that were affected by this before the fix is applied.

## Changelog

Added the background migration that cleans up such reorg-related transactions.