### PR TITLE
fix: proper handling of old batches on Arbitrum Nova

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/anytrust.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/anytrust.ex
@@ -124,6 +124,25 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Anytrust do
      }}
   end
 
+  def parse_batch_accompanying_data(batch_number, <<
+        keyset_hash::binary-size(32),
+        data_hash::binary-size(32),
+        timeout::big-unsigned-integer-size(64),
+        signers_mask::big-unsigned-integer-size(64),
+        bls_signature::binary-size(96)
+      >>) do
+    # https://github.com/OffchainLabs/nitro/blob/ad9ab00723e13cf98307b9b65774ad455594ef7b/arbstate/das_reader.go#L95-L151
+    {:ok, :in_anytrust,
+     %__MODULE__{
+       batch_number: batch_number,
+       keyset_hash: keyset_hash,
+       data_hash: data_hash,
+       timeout: IndexerHelper.timestamp_to_datetime(timeout),
+       signers_mask: signers_mask,
+       bls_signature: bls_signature
+     }}
+  end
+
   def parse_batch_accompanying_data(_, _) do
     log_error("Can not parse Anytrust DA message.")
     {:error, nil, nil}

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
@@ -124,8 +124,7 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
         {:error, nil, nil}
 
       128 ->
-        log_error("DAS messages are not supported.")
-        {:error, nil, nil}
+        Anytrust.parse_batch_accompanying_data(batch_number, rest)
 
       136 ->
         Anytrust.parse_batch_accompanying_data(batch_number, rest)

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -646,7 +646,9 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
       # inspected block is in the boundary of the required batch: the current batch is the same
       # as one found in the previous iteration or the step is not the smallest possible.
 
-      next_block_to_inspect = max(1, inspected_block - new_step)
+      # it is OK to use the earliest block 0 as since the corresponding batch (0)
+      # will be returned by get_batch_number_for_rollup_block.
+      next_block_to_inspect = max(0, inspected_block - new_step)
 
       do_binary_search_of_opposite_block(
         next_block_to_inspect,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
@@ -1275,7 +1275,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
         {nil, nil}
 
       %Arbitrum.L1Batch{start_block: start_block, end_block: end_block} ->
-        {start_block - 1, div(end_block - start_block, 2)}
+        {start_block - 1, half_of_block_range(start_block, end_block, :descending)}
     end
   end
 
@@ -1289,7 +1289,26 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
         {nil, nil}
 
       %Arbitrum.L1Batch{start_block: start_block, end_block: end_block} ->
-        {end_block + 1, div(start_block - end_block, 2)}
+        {end_block + 1, half_of_block_range(start_block, end_block, :ascending)}
+    end
+  end
+
+  # Calculates half the range between two block numbers, with direction adjustment.
+  #
+  # ## Parameters
+  # - `start_block`: The starting block number.
+  # - `end_block`: The ending block number.
+  # - `direction`: The direction of calculation, either `:ascending` or `:descending`.
+  #
+  # ## Returns
+  # - An integer representing half the block range, adjusted for direction:
+  #   - For `:descending`, a positive integer >= 1.
+  #   - For `:ascending`, a negative integer <= -1.
+  @spec half_of_block_range(non_neg_integer(), non_neg_integer(), :ascending | :descending) :: integer()
+  defp half_of_block_range(start_block, end_block, direction) do
+    case direction do
+      :descending -> max(div(end_block - start_block + 1, 2), 1)
+      :ascending -> min(div(start_block - end_block - 1, 2), -1)
     end
   end
 


### PR DESCRIPTION
## Motivation

During indexing of the Arbitrum Nova Blockscout instance, it was found that the discovery of historical batches stuck on batch no. 145. During the investigation of the issue, three problems were identified:
- The approach to discover the blocks range in a batch does not work properly if the previously known batch contains 2 or 1 block.
- Since block 0 was excluded to discover the batch range, batch 1 cannot be indexed.
- The old version of AnyTrust DA certificates is not supported, although all batches below 119 are using this version.

## Changelog

### Bug Fixes

1. The length of the blocks range is now calculated properly in `apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex`.
2. The lower limit of block numbers which can be requested in `findBatchContainingBlock` of the `NodeInterface` contract is extended to include block 0.
3. If the type of a DA certificate is `0x80`, the certificate data are parsed as an old DA certificate (without the `version` field).

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
