### PR TITLE
chore: Refactor OrderedCache preloads

### DIFF
--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -247,6 +247,7 @@ defmodule Explorer.Chain.OrderedCache do
         ConCache.update(cache_name(), ids_list_key(), fn ids ->
           updated_list =
             elements
+            |> do_preloads()
             |> Enum.map(&{element_to_id(&1), &1})
             |> Enum.sort(&prevails?(&1, &2))
             |> merge_and_update(ids || [], max_size())
@@ -257,6 +258,14 @@ defmodule Explorer.Chain.OrderedCache do
       end
 
       def update(element), do: update([element])
+
+      defp do_preloads(elements) do
+        if Enum.empty?(preloads()) do
+          elements
+        else
+          Explorer.Repo.preload(elements, preloads())
+        end
+      end
 
       defp merge_and_update(_candidates, existing, 0) do
         # if there is no more space in the list remove the remaining existing
@@ -323,17 +332,10 @@ defmodule Explorer.Chain.OrderedCache do
       end
 
       defp put_element(element_id, element) do
-        full_element =
-          if Enum.empty?(preloads()) do
-            element
-          else
-            Explorer.Repo.preload(element, preloads())
-          end
-
         # dirty puts are a little faster than puts with locks.
         # this is not a problem because this is the only function modifying rows
         # and it only gets called inside `update`, which works isolated
-        ConCache.dirty_put(cache_name(), element_id, full_element)
+        ConCache.dirty_put(cache_name(), element_id, element)
       end
 
       ### Supervisor's child specification


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10790

## Changelog

Updated the `OrderedCache` preload logic to execute a single time for all new elements instead of per-element execution.
