### PR TITLE
fix: Repair /metrics endpoint

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/metrics_contoller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/metrics_contoller_test.exs
@@ -1,0 +1,11 @@
+defmodule BlockScoutWeb.MetricsControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  describe "/metrics page" do
+    test "renders /metrics page", %{conn: conn} do
+      conn = get(conn, "/metrics")
+
+      assert text_response(conn, 200)
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -142,7 +142,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.TransactionBlockConsensus),
         configure(Explorer.Migrator.TokenTransferBlockConsensus),
         configure(Explorer.Migrator.RestoreOmittedWETHTransfers),
-        configure_chain_type_dependent_process(Explorer.Migrator.FilecoinPendingAddressOperations, :filecoin),
+        configure(Explorer.Migrator.FilecoinPendingAddressOperations),
         configure_mode_dependent_process(Explorer.Migrator.ShrinkInternalTransactions, :indexer),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, :stability),
         configure_mode_dependent_process(Explorer.Migrator.SanitizeMissingTokenBalances, :indexer)

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -142,7 +142,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.TransactionBlockConsensus),
         configure(Explorer.Migrator.TokenTransferBlockConsensus),
         configure(Explorer.Migrator.RestoreOmittedWETHTransfers),
-        configure(Explorer.Migrator.FilecoinPendingAddressOperations),
+        configure_chain_type_dependent_process(Explorer.Migrator.FilecoinPendingAddressOperations, :filecoin),
         configure_mode_dependent_process(Explorer.Migrator.ShrinkInternalTransactions, :indexer),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.StabilityValidatorsCounters, :stability),
         configure_mode_dependent_process(Explorer.Migrator.SanitizeMissingTokenBalances, :indexer)

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -14,29 +14,8 @@ defmodule Indexer.Application do
   alias Indexer.Memory
   alias Prometheus.Registry
 
-  @default_prometheus_collectors [
-    Indexer.Prometheus.Collector.PendingBlockOperations
-  ]
-
-  case Application.compile_env(:explorer, :chain_type) do
-    :filecoin ->
-      @chain_type_prometheus_collectors [
-        Indexer.Prometheus.Collector.FilecoinPendingAddressOperations
-      ]
-
-    _ ->
-      @chain_type_prometheus_collectors []
-  end
-
-  @prometheus_collectors @default_prometheus_collectors ++
-                           @chain_type_prometheus_collectors
-
   @impl Application
   def start(_type, _args) do
-    for collector <- @prometheus_collectors do
-      Registry.register_collector(collector)
-    end
-
     memory_monitor_options =
       case Application.get_env(:indexer, :memory_limit) do
         nil -> %{}

--- a/apps/indexer/lib/indexer/prometheus/collector/filecoin_pending_address_operations_collector.ex
+++ b/apps/indexer/lib/indexer/prometheus/collector/filecoin_pending_address_operations_collector.ex
@@ -1,29 +1,31 @@
-defmodule Indexer.Prometheus.Collector.FilecoinPendingAddressOperations do
-  @moduledoc """
-  Custom collector to count number of records in filecoin_pending_address_operations table.
-  """
+if Application.compile_env(:explorer, :chain_type) == :filecoin do
+  defmodule Indexer.Prometheus.Collector.FilecoinPendingAddressOperations do
+    @moduledoc """
+    Custom collector to count number of records in filecoin_pending_address_operations table.
+    """
 
-  use Prometheus.Collector
+    use Prometheus.Collector
 
-  alias Explorer.Chain.Filecoin.PendingAddressOperation
-  alias Explorer.Repo
-  alias Prometheus.Model
+    alias Explorer.Chain.Filecoin.PendingAddressOperation
+    alias Explorer.Repo
+    alias Prometheus.Model
 
-  def collect_mf(_registry, callback) do
-    callback.(
-      create_gauge(
-        :filecoin_pending_address_operations,
-        "Number of records in filecoin_pending_address_operations table",
-        Repo.aggregate(PendingAddressOperation, :count, timeout: :infinity)
+    def collect_mf(_registry, callback) do
+      callback.(
+        create_gauge(
+          :filecoin_pending_address_operations,
+          "Number of records in filecoin_pending_address_operations table",
+          Repo.aggregate(PendingAddressOperation, :count, timeout: :infinity)
+        )
       )
-    )
-  end
+    end
 
-  def collect_metrics(:filecoin_pending_address_operations, count) do
-    Model.gauge_metrics([{count}])
-  end
+    def collect_metrics(:filecoin_pending_address_operations, count) do
+      Model.gauge_metrics([{count}])
+    end
 
-  defp create_gauge(name, help, data) do
-    Model.create_mf(name, help, :gauge, __MODULE__, data)
+    defp create_gauge(name, help, data) do
+      Model.create_mf(name, help, :gauge, __MODULE__, data)
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10812
Resolves https://github.com/blockscout/blockscout/issues/10824

## Motivation

After merging https://github.com/blockscout/blockscout/pull/10468, metrics at `/metrics` throw error.

## Changelog

- Configure `Explorer.Migrator.FilecoinPendingAddressOperations` module only for `:filecoin` chain type.
- Wrap `Indexer.Prometheus.Collector.FilecoinPendingAddressOperations` definition in case of `filecoin` compile time env only.
- Add test, that /metrics endpoint returns 200 HTTP status code.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
