### PR TITLE
chore: Add primary key to address_tags table

### DIFF
--- a/apps/explorer/lib/explorer/tags/address_tag.ex
+++ b/apps/explorer/lib/explorer/tags/address_tag.ex
@@ -1,6 +1,6 @@
 defmodule Explorer.Tags.AddressTag do
   @moduledoc """
-  Represents a Tag object.
+  Represents an address Tag object.
   """
 
   use Explorer.Schema
@@ -9,11 +9,12 @@ defmodule Explorer.Tags.AddressTag do
 
   import Ecto.Query,
     only: [
-      from: 2
+      from: 2,
+      select: 3
     ]
 
   alias Explorer.Repo
-  alias Explorer.Tags.{AddressTag, AddressToTag}
+  alias Explorer.Tags.AddressToTag
 
   @typedoc """
   * `:id` - id of Tag
@@ -21,7 +22,7 @@ defmodule Explorer.Tags.AddressTag do
   * `:display_name` - Label's display name
   """
   typed_schema "address_tags" do
-    field(:label, :string, null: false)
+    field(:label, :string, primary_key: true, null: false)
     field(:display_name, :string, null: false)
     has_many(:tag_id, AddressToTag, foreign_key: :id)
 
@@ -38,55 +39,61 @@ defmodule Explorer.Tags.AddressTag do
     |> unique_constraint(:label, name: :address_tags_label_index)
   end
 
-  def set_tag(name, display_name) do
-    tag = get_tag(name)
+  @spec set(String.t() | nil, String.t() | nil) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()} | :invalid
+  def set(name, display_name)
+
+  def set(nil, _), do: :invalid
+
+  def set(_, nil), do: :invalid
+
+  def set(name, display_name) do
+    tag = get_by_label(name)
 
     if tag do
       tag
-      |> AddressTag.changeset(%{display_name: display_name})
+      |> __MODULE__.changeset(%{display_name: display_name})
       |> Repo.update()
     else
-      %AddressTag{}
-      |> AddressTag.changeset(%{label: name, display_name: display_name})
+      %__MODULE__{}
+      |> __MODULE__.changeset(%{label: name, display_name: display_name})
       |> Repo.insert()
     end
   end
 
-  def get_tag_id(nil), do: nil
+  @doc """
+   Fetches AddressTag.t() by label name from the DB
+  """
+  @spec get_id_by_label(String.t()) :: non_neg_integer()
+  def get_id_by_label(nil), do: nil
 
-  def get_tag_id(label) do
-    query =
-      from(
-        tag in AddressTag,
-        where: tag.label == ^label,
-        select: tag.id
-      )
-
-    query
+  def get_id_by_label(label) do
+    label
+    |> get_by_label_query()
+    |> select([tag], tag.id)
     |> Repo.one()
   end
 
-  def get_tag(nil), do: nil
-
-  def get_tag(label) do
-    query =
-      from(
-        tag in AddressTag,
-        where: tag.label == ^label
-      )
-
-    query
-    |> Repo.one()
-  end
-
-  def get_all_tags do
-    query =
-      from(
-        tag in AddressTag,
-        select: tag
-      )
-
-    query
+  @doc """
+   Fetches all AddressTag.t() from the DB
+  """
+  @spec get_all() :: __MODULE__.t()
+  def get_all do
+    __MODULE__
     |> Repo.all()
+  end
+
+  defp get_by_label(nil), do: nil
+
+  defp get_by_label(label) do
+    label
+    |> get_by_label_query()
+    |> Repo.one()
+  end
+
+  defp get_by_label_query(label) do
+    from(
+      tag in __MODULE__,
+      where: tag.label == ^label
+    )
   end
 end

--- a/apps/explorer/lib/explorer/tags/address_to_tag.ex
+++ b/apps/explorer/lib/explorer/tags/address_to_tag.ex
@@ -1,6 +1,6 @@
 defmodule Explorer.Tags.AddressToTag do
   @moduledoc """
-  Represents ann Address to Tag relation.
+  Represents Address to Tag relation.
   """
 
   use Explorer.Schema
@@ -9,7 +9,7 @@ defmodule Explorer.Tags.AddressToTag do
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Address, Hash}
-  alias Explorer.Tags.{AddressTag, AddressToTag}
+  alias Explorer.Tags.AddressTag
 
   # Notation.import_types(BlockScoutWeb.GraphQL.Schema.Types)
 
@@ -53,7 +53,7 @@ defmodule Explorer.Tags.AddressToTag do
   defp get_address_hashes_mapped_to_tag(tag_id) do
     query =
       from(
-        att in AddressToTag,
+        att in __MODULE__,
         where: att.tag_id == ^tag_id,
         select: att.address_hash
       )
@@ -62,6 +62,7 @@ defmodule Explorer.Tags.AddressToTag do
     |> Repo.all()
   end
 
+  @spec set_tag_to_addresses(non_neg_integer(), list()) :: any()
   def set_tag_to_addresses(tag_id, address_hash_string_list) do
     current_address_hashes = get_address_hashes_mapped_to_tag(tag_id)
 
@@ -105,10 +106,10 @@ defmodule Explorer.Tags.AddressToTag do
         end)
         |> Enum.filter(&(!is_nil(&1)))
 
-      if not Enum.empty?(addresses_to_delete) do
+      unless Enum.empty?(addresses_to_delete) do
         delete_query_base =
           from(
-            att in AddressToTag,
+            att in __MODULE__,
             where: att.tag_id == ^tag_id
           )
 
@@ -119,7 +120,7 @@ defmodule Explorer.Tags.AddressToTag do
         Repo.delete_all(delete_query)
       end
 
-      Repo.insert_all(AddressToTag, changeset_to_add_list,
+      Repo.insert_all(__MODULE__, changeset_to_add_list,
         on_conflict: :nothing,
         conflict_target: [:address_hash, :tag_id]
       )

--- a/apps/explorer/priv/repo/migrations/20240923173516_address_tags_add_primary_key.exs
+++ b/apps/explorer/priv/repo/migrations/20240923173516_address_tags_add_primary_key.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddressTagsAddPrimaryKey do
+  use Ecto.Migration
+
+  def change do
+    alter table(:address_tags) do
+      modify(:label, :string, null: false, primary_key: true)
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10817

## Motivation

`address_tags` table has no primary key, which leads to the problem with ORM [usage](https://github.com/SeaQL/sea-orm/issues/485).

## Changelog

This PR sets `label` as a primary keyat `address_tags` table.

Chore:
- remove unused functions.
- change visibility to private for functions unused outside the module.
- add specifications and document public functions related to "Assigning tags to addresses" functionality.
- light code refactoring.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
