### PR TITLE
feat: Decode revert reason based on error ABI candidates from the DB

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -773,6 +773,7 @@ defmodule Explorer.Chain.Transaction do
         proxy_implementation_addresses_map \\ %{}
       )
 
+  # skip decoding if there is no to_address
   def decoded_input_data(
         %__MODULE__{to_address: nil},
         _,
@@ -783,9 +784,11 @@ defmodule Explorer.Chain.Transaction do
       ),
       do: {{:error, :no_to_address}, full_abi_acc, methods_acc}
 
+  # skip decoding if transaction is not loaded
   def decoded_input_data(%NotLoaded{}, _, _, full_abi_acc, methods_acc, _proxy_implementation_addresses_map),
     do: {{:error, :not_loaded}, full_abi_acc, methods_acc}
 
+  # skip decoding if input is empty
   def decoded_input_data(
         %__MODULE__{input: %{bytes: bytes}},
         _,
@@ -798,6 +801,7 @@ defmodule Explorer.Chain.Transaction do
     {{:error, :no_input_data}, full_abi_acc, methods_acc}
   end
 
+  # skip decoding if to_address is not a contract unless DECODE_NOT_A_CONTRACT_CALLS is set
   if not Application.compile_env(:explorer, :decode_not_a_contract_calls) do
     def decoded_input_data(
           %__MODULE__{to_address: %{contract_code: nil}},
@@ -810,6 +814,7 @@ defmodule Explorer.Chain.Transaction do
         do: {{:error, :not_a_contract_call}, full_abi_acc, methods_acc}
   end
 
+  # if to_address's smart_contract is nil reduce to the case when to_address is not loaded
   def decoded_input_data(
         %__MODULE__{
           to_address: %{smart_contract: nil},
@@ -836,6 +841,7 @@ defmodule Explorer.Chain.Transaction do
     )
   end
 
+  # if to_address's smart_contract is not loaded reduce to the case when to_address is not loaded
   def decoded_input_data(
         %__MODULE__{
           to_address: %{smart_contract: %NotLoaded{}},
@@ -862,6 +868,7 @@ defmodule Explorer.Chain.Transaction do
     )
   end
 
+  # if to_address is not loaded try decoding by method candidates in the DB
   def decoded_input_data(
         %__MODULE__{
           to_address: %NotLoaded{},
@@ -899,6 +906,7 @@ defmodule Explorer.Chain.Transaction do
      full_abi_acc, methods_acc}
   end
 
+  # if to_address is not loaded and input is not a method call return error
   def decoded_input_data(
         %__MODULE__{to_address: %NotLoaded{}},
         _,
@@ -931,7 +939,7 @@ defmodule Explorer.Chain.Transaction do
            proxy_implementation_addresses_map
          ) do
       # In some cases transactions use methods of some unpredictable contracts, so we can try to look up for method in a whole DB
-      {{:error, :could_not_decode}, full_abi_acc} ->
+      {{:error, error}, full_abi_acc} when error in [:could_not_decode, :no_matching_function] ->
         case decoded_input_data(
                %__MODULE__{
                  to_address: %NotLoaded{},

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -258,7 +258,7 @@ defmodule Explorer.Chain.TransactionTest do
     test "that a contract call transaction that has no verified contract returns a commensurate error" do
       transaction =
         :transaction
-        |> insert(to_address: insert(:contract_address))
+        |> insert(to_address: insert(:contract_address), input: "0x1234567891")
         |> Repo.preload(to_address: :smart_contract)
 
       assert {{:error, :contract_not_verified, []}, _, _} = Transaction.decoded_input_data(transaction, [])


### PR DESCRIPTION
## Motivation

Revert reason remains undecoded at Redstone instance https://explorer.garnetchain.com/tx/0xc8949a914aeb985292112dd1d835195a3e97dc78acb56d7f6a02a0d227b4fee8.

## Changelog

Trying to find error ABI in the instance DB by revert reason 4 bytes signature and use it to decode revert reason.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
