### PR TITLE
feat: (celo) include token information in API response for address epoch rewards

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
@@ -221,7 +221,7 @@ defmodule BlockScoutWeb.API.V2.CeloView do
     }
   end
 
-  defp prepare_election_reward(%ElectionReward{} = reward) do
+  defp prepare_election_reward(%ElectionReward{token: %Token{}} = reward) do
     %{
       amount: reward.amount,
       block_number: reward.block.number,
@@ -237,7 +237,12 @@ defmodule BlockScoutWeb.API.V2.CeloView do
           reward.associated_account_address,
           reward.associated_account_address_hash
         ),
-      type: reward.type
+      type: reward.type,
+      token:
+        TokenView.render("token.json", %{
+          token: reward.token,
+          contract_address_hash: reward.token.contract_address_hash
+        })
     }
   end
 

--- a/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
+++ b/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
@@ -223,6 +223,23 @@ defmodule Explorer.Chain.Cache.CeloCoreContracts do
     end
   end
 
+  @doc """
+  Retrieves the block number of the first address update for a given core
+  contract.
+
+  ## Parameters
+
+  - `contract_atom` (`atom()`): The atom representing the core contract.
+
+  ## Returns
+
+  - `{:ok, Block.block_number()}`: The block number of the first update.
+  - `{:error, :contract_atom_not_found}`: If the contract atom is not
+    recognized.
+  """
+  @spec get_first_update_block_number(atom()) ::
+          {:ok, Block.block_number() | nil}
+          | {:error, :contract_atom_not_found}
   def get_first_update_block_number(contract_atom) do
     with {:ok, address_updates} <- get_address_updates(contract_atom),
          %{"updated_at_block_number" => updated_at_block_number} <-

--- a/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
+++ b/apps/explorer/lib/explorer/chain/cache/celo_core_contracts.ex
@@ -161,7 +161,33 @@ defmodule Explorer.Chain.Cache.CeloCoreContracts do
     end
   end
 
-  defp get_address_updates(contract_atom) do
+  @doc """
+  Retrieves all address updates for a specified core contract.
+
+  ## Parameters
+
+  - `contract_atom` (`atom()`): The atom representing the core contract (e.g.,
+    `:accounts`, `:validators`).
+
+  ## Returns
+
+  - `{:ok, [map()]}`: On success, returns a list of maps containing address
+    updates for the contract.
+  - `{:error, reason}`: Returns an error tuple with one of the following
+    reasons: `:contract_atom_not_found`, `:contract_name_not_found`
+
+  ## Examples
+
+      iex> Explorer.Chain.Cache.CeloCoreContracts.get_address_updates(:validators)
+      {:ok, [%{"address" => "0x123...", "updated_at_block_number" => 1000000}, ...]}
+
+      iex> Explorer.Chain.Cache.CeloCoreContracts.get_address_updates(:unknown_contract)
+      {:error, :contract_atom_not_found}
+
+  """
+  @spec get_address_updates(atom()) ::
+          {:ok, [map()]} | {:error, :contract_atom_not_found | :contract_name_not_found}
+  def get_address_updates(contract_atom) do
     with {:atom, {:ok, contract_name}} <-
            {:atom, Map.fetch(@atom_to_contract_name, contract_atom)},
          {:addresses, {:ok, contract_name_to_addresses}} <-

--- a/apps/explorer/lib/explorer/chain/celo/reader.ex
+++ b/apps/explorer/lib/explorer/chain/celo/reader.ex
@@ -52,6 +52,7 @@ defmodule Explorer.Chain.Celo.Reader do
 
     address_hash
     |> ElectionReward.address_hash_to_ordered_rewards_query()
+    |> ElectionReward.join_token()
     |> ElectionReward.paginate(paging_options)
     |> limit(^paging_options.page_size)
     |> join_associations(necessity_by_association)


### PR DESCRIPTION
Closes #10785.

## Changelog

### Enhancements

Include token information in API response for address epoch rewards.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
