### PR TITLE
fix: Disable archive balances only if latest block is available

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -189,8 +189,8 @@ defmodule EthereumJSONRPC do
   def fetch_balances(params_list, json_rpc_named_arguments, chunk_size \\ nil)
       when is_list(params_list) and is_list(json_rpc_named_arguments) do
     filtered_params =
-      if Application.get_env(:ethereum_jsonrpc, :disable_archive_balances?) do
-        {:ok, max_block_number} = fetch_block_number_by_tag("latest", json_rpc_named_arguments)
+      with true <- Application.get_env(:ethereum_jsonrpc, :disable_archive_balances?),
+           {:ok, max_block_number} <- fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
         window = Application.get_env(:ethereum_jsonrpc, :archive_balances_window)
 
         params_list
@@ -200,7 +200,7 @@ defmodule EthereumJSONRPC do
           _ -> false
         end)
       else
-        params_list
+        _ -> params_list
       end
 
     filtered_params_in_range =

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc_test.exs
@@ -1058,7 +1058,7 @@ defmodule EthereumJSONRPCSyncTest do
            ]}
       end)
 
-      Application.put_env(:ethereum_jsonrpc, :disable_archive_balances?, "true")
+      Application.put_env(:ethereum_jsonrpc, :disable_archive_balances?, true)
       Application.put_env(:ethereum_jsonrpc, :archive_balances_window, 1)
 
       assert EthereumJSONRPC.fetch_balances(


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/8673

## Changelog

Check that the `latest` block is available before filtering archive balances