### PR TITLE
feat: EIP-7702 support

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -77,7 +77,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       :names => :optional,
       :scam_badge => :optional,
       :token => :optional,
-      :proxy_implementations => :optional
+      :proxy_implementations => :optional,
+      :signed_authorization => :optional
     },
     api?: true
   ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -117,7 +117,9 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   @spec transaction(Plug.Conn.t(), map()) :: Plug.Conn.t() | {atom(), any()}
   def transaction(conn, %{"transaction_hash_param" => transaction_hash_string} = params) do
     necessity_by_association_with_actions =
-      Map.put(@transaction_necessity_by_association, :transaction_actions, :optional)
+      @transaction_necessity_by_association
+      |> Map.put(:transaction_actions, :optional)
+      |> Map.put(:signed_authorizations, :optional)
 
     necessity_by_association =
       case Application.get_env(:explorer, :chain_type) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   alias BlockScoutWeb.TransactionStateView
   alias Ecto.Association.NotLoaded
   alias Explorer.{Chain, Market}
-  alias Explorer.Chain.{Address, Block, Log, Token, Transaction, Wei}
+  alias Explorer.Chain.{Address, Block, Log, SignedAuthorization, Token, Transaction, Wei}
   alias Explorer.Chain.Block.Reward
   alias Explorer.Chain.Transaction.StateChange
   alias Explorer.Counters.AverageBlockTime
@@ -342,6 +342,16 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     }
   end
 
+  @doc """
+    Extracts the necessary fields from the signed authorization for the API response.
+
+    ## Parameters
+    - `signed_authorization`: A `SignedAuthorization.t()` struct containing the signed authorization data.
+
+    ## Returns
+    - A map with the necessary fields for the API response.
+  """
+  @spec prepare_signed_authorization(SignedAuthorization.t()) :: map()
   def prepare_signed_authorization(signed_authorization) do
     %{
       "address" => signed_authorization.address,
@@ -504,6 +514,16 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   def authorization_list(nil), do: []
   def authorization_list(%NotLoaded{}), do: []
 
+  @doc """
+    Renders the authorization list for a transaction.
+
+    ## Parameters
+    - `signed_authorizations`: A list of `SignedAuthorization.t()` structs.
+
+    ## Returns
+    - A list of maps with the necessary fields for the API response.
+  """
+  @spec authorization_list([SignedAuthorization.t()]) :: [map()]
   def authorization_list(signed_authorizations) do
     render("authorization_list.json", %{signed_authorizations: signed_authorizations})
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -520,7 +520,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     ## Returns
     - A list of maps with the necessary fields for the API response.
   """
-  @spec authorization_list([SignedAuthorization.t()]) :: [map()]
+  @spec authorization_list(nil | NotLoaded.t() | [SignedAuthorization.t()]) :: [map()]
   def authorization_list(nil), do: []
   def authorization_list(%NotLoaded{}), do: []
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -511,9 +511,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     render("transaction_actions.json", %{actions: actions})
   end
 
-  def authorization_list(nil), do: []
-  def authorization_list(%NotLoaded{}), do: []
-
   @doc """
     Renders the authorization list for a transaction.
 
@@ -524,6 +521,9 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     - A list of maps with the necessary fields for the API response.
   """
   @spec authorization_list([SignedAuthorization.t()]) :: [map()]
+  def authorization_list(nil), do: []
+  def authorization_list(%NotLoaded{}), do: []
+
   def authorization_list(signed_authorizations) do
     render("authorization_list.json", %{signed_authorizations: signed_authorizations})
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -354,13 +354,13 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   @spec prepare_signed_authorization(SignedAuthorization.t()) :: map()
   def prepare_signed_authorization(signed_authorization) do
     %{
-      "address" => signed_authorization.address,
+      "address" => Address.checksum(signed_authorization.address),
       "chain_id" => signed_authorization.chain_id,
       "nonce" => signed_authorization.nonce,
       "r" => signed_authorization.r,
       "s" => signed_authorization.s,
       "v" => signed_authorization.v,
-      "authority" => signed_authorization.authority
+      "authority" => Address.checksum(signed_authorization.authority)
     }
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -144,18 +144,6 @@ defmodule EthereumJSONRPC do
   """
   @type request_id :: String.t() | non_neg_integer()
 
-  @typedoc """
-  EIP-7702 signed authorization data.
-  """
-  @type signed_authorization :: %{
-          chain_id: non_neg_integer(),
-          address: address(),
-          nonce: non_neg_integer(),
-          r: non_neg_integer(),
-          s: non_neg_integer(),
-          v: non_neg_integer()
-        }
-
   @doc """
   Execute smart contract functions.
 
@@ -536,21 +524,6 @@ defmodule EthereumJSONRPC do
 
   def integer_to_quantity(integer) when is_binary(integer) do
     integer
-  end
-
-  @doc """
-  Converts `map()/0` to `t:signed_authorization/0`
-  """
-  @spec to_signed_authorization(map()) :: signed_authorization()
-  def to_signed_authorization(map) do
-    %{
-      chain_id: quantity_to_integer(map["chainId"]),
-      address: map["address"],
-      nonce: quantity_to_integer(map["nonce"]),
-      r: quantity_to_integer(map["r"]),
-      s: quantity_to_integer(map["s"]),
-      v: quantity_to_integer(map["v"])
-    }
   end
 
   @doc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -144,6 +144,18 @@ defmodule EthereumJSONRPC do
   """
   @type request_id :: String.t() | non_neg_integer()
 
+  @typedoc """
+  EIP-7702 signed authorization data.
+  """
+  @type signed_authorization :: %{
+          chain_id: non_neg_integer(),
+          address: address(),
+          nonce: non_neg_integer(),
+          r: non_neg_integer(),
+          s: non_neg_integer(),
+          v: non_neg_integer()
+        }
+
   @doc """
   Execute smart contract functions.
 
@@ -524,6 +536,21 @@ defmodule EthereumJSONRPC do
 
   def integer_to_quantity(integer) when is_binary(integer) do
     integer
+  end
+
+  @doc """
+  Converts `map()/0` to `t:signed_authorization/0`
+  """
+  @spec to_signed_authorization(map()) :: signed_authorization()
+  def to_signed_authorization(map) do
+    %{
+      chain_id: quantity_to_integer(map["chainId"]),
+      address: map["address"],
+      nonce: quantity_to_integer(map["nonce"]),
+      r: quantity_to_integer(map["r"]),
+      s: quantity_to_integer(map["s"]),
+      v: quantity_to_integer(map["v"])
+    }
   end
 
   @doc """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -222,7 +222,26 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
-  Fetches code for each given `address` at the `block_number`.
+    Fetches contract code for multiple addresses at specified block numbers.
+
+    This function takes a list of parameters, each containing an address and a
+    block number, and retrieves the contract code for each address at the
+    specified block.
+
+    ## Parameters
+    - `params_list`: A list of maps, each containing:
+      - `:block_quantity`: The block number (as a quantity string) at which to fetch the code.
+      - `:address`: The address of the contract to fetch the code for.
+    - `json_rpc_named_arguments`: A keyword list of JSON-RPC configuration options.
+
+    ## Returns
+    - `{:ok, fetched_codes}`, where `fetched_codes` is a `FetchedCodes.t()` struct containing:
+      - `params_list`: A list of successfully fetched code parameters, each containing:
+        - `address`: The contract address.
+        - `block_number`: The block number at which the code was fetched.
+        - `code`: The fetched contract code in hexadecimal format.
+      - `errors`: A list of errors encountered during the fetch operation.
+    - `{:error, reason}`: An error occurred during the fetch operation.
   """
   @spec fetch_codes(
           [%{required(:block_quantity) => quantity, required(:address) => address()}],
@@ -407,7 +426,21 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
-  Assigns an id to each set of params in `params_list` for batch request-response correlation
+    Assigns a unique integer ID to each set of parameters in the given list.
+
+    This function is used to prepare parameters for batch request-response
+    correlation in JSON-RPC calls.
+
+    ## Parameters
+    - `params_list`: A list of parameter sets, where each set can be of any type.
+
+    ## Returns
+    A map where the keys are integer IDs (starting from 0) and the values are
+    the corresponding parameter sets from the input list.
+
+    ## Example
+      iex> id_to_params([%{block: 1}, %{block: 2}])
+      %{0 => %{block: 1}, 1 => %{block: 2}}
   """
   @spec id_to_params([params]) :: %{id => params} when id: non_neg_integer(), params: any()
   def id_to_params(params_list) do
@@ -417,8 +450,27 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
-  Assigns not matched ids between requests and responses to responses with incorrect ids
+   Sanitizes responses by assigning unmatched IDs to responses with missing IDs.
+
+   This function processes a list of responses and a map of expected IDs to
+   parameters. It handles cases where responses have missing (nil) IDs by
+   assigning them unmatched IDs from the id_to_params map.
+
+   ## Parameters
+   - `responses`: A list of response maps from a batch JSON-RPC call.
+   - `id_to_params`: A map of request IDs to their corresponding parameters.
+
+   ## Returns
+   A list of sanitized response maps where each response has a valid ID.
+
+   ## Example
+      iex> responses = [%{id: 1, result: "ok"}, %{id: nil, result: "error"}]
+      iex> id_to_params = %{1 => %{}, 2 => %{}, 3 => %{}}
+      iex> EthereumJSONRPC.sanitize_responses(responses, id_to_params)
+      [%{id: 1, result: "ok"}, %{id: 2, result: "error"}]
   """
+  @spec sanitize_responses(Transport.batch_response(), %{id => params}) :: Transport.batch_response()
+        when id: EthereumJSONRPC.request_id(), params: any()
   def sanitize_responses(responses, id_to_params) do
     responses
     |> Enum.reduce(

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/fetched_code.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/fetched_code.ex
@@ -9,9 +9,37 @@ defmodule EthereumJSONRPC.FetchedCode do
   @type error :: %{code: integer(), message: String.t(), data: %{block_quantity: String.t(), address: String.t()}}
 
   @doc """
-  Converts `response` to code params or annotated error.
-  """
+    Converts a JSON-RPC response of `eth_getCode` to code params or an annotated error.
 
+    This function handles two types of responses:
+    1. Successful responses with fetched code.
+    2. Error responses.
+
+    ## Parameters
+    - `response`: A map containing either a successful result or an error.
+    - `id_to_params`: A map of request IDs to their corresponding parameters.
+
+    ## Returns
+    - `{:ok, params()}` for successful responses, where `params()` is a map
+      containing the address, block number, and fetched code.
+    - `{:error, error()}` for error responses, where `error()` is a map
+      containing the error code, message, and additional data.
+
+    ## Examples
+        iex> # Successful response:
+        iex> response = %{id: 1, result: "0x123"}
+        iex> id_to_params = %{1 => %{block_quantity: "0x1", address: "0xabc"}}
+        iex> FetchedCode.from_response(response, id_to_params)
+        {:ok, %{address: "0xabc", block_number: 1, code: "0x123"}}
+        iex> # Error response:
+        iex> response = %{id: 1, error: %{code: 100, message: "Error"}}
+        iex> id_to_params = %{1 => %{block_quantity: "0x1", address: "0xabc"}}
+        iex> FetchedCode.from_response(response, id_to_params)
+        {:error, %{code: 100, message: "Error", data: %{block_quantity: "0x1", address: "0xabc"}}}
+  """
+  @spec from_response(%{id: EthereumJSONRPC.request_id(), result: String.t()}, %{
+          non_neg_integer() => %{block_quantity: String.t(), address: String.t()}
+        }) :: {:ok, params()}
   def from_response(%{id: id, result: fetched_code}, id_to_params) when is_map(id_to_params) do
     %{block_quantity: block_quantity, address: address} = Map.fetch!(id_to_params, id)
 
@@ -23,9 +51,9 @@ defmodule EthereumJSONRPC.FetchedCode do
      }}
   end
 
-  @spec from_response(%{id: id, result: String.t()}, %{id => %{block_quantity: block_quantity, address: address}}) ::
-          {:ok, params()}
-        when id: non_neg_integer(), block_quantity: String.t(), address: String.t()
+  @spec from_response(%{id: EthereumJSONRPC.request_id(), error: %{code: integer(), message: String.t()}}, %{
+          non_neg_integer() => %{block_quantity: String.t(), address: String.t()}
+        }) :: {:error, error()}
   def from_response(%{id: id, error: %{code: code, message: message} = error}, id_to_params)
       when is_integer(code) and is_binary(message) and is_map(id_to_params) do
     %{block_quantity: block_quantity, address: address} = Map.fetch!(id_to_params, id)
@@ -35,6 +63,22 @@ defmodule EthereumJSONRPC.FetchedCode do
     {:error, annotated_error}
   end
 
+  @doc """
+    Creates a standardized JSON-RPC request structure to fetch contract code using `eth_getCode`.
+
+    ## Parameters
+    - `id`: The request identifier.
+    - `block_quantity`: The block number or tag (e.g., "latest") for which to
+      fetch the code.
+    - `address`: The address of the contract whose code is to be fetched.
+
+    ## Returns
+    A map representing a JSON-RPC request with the following structure:
+    - `jsonrpc`: The JSON-RPC version (always "2.0").
+    - `id`: The request identifier passed in.
+    - `method`: The RPC method name (always "eth_getCode").
+    - `params`: A list containing the contract address and block identifier.
+  """
   @spec request(%{id: id, block_quantity: block_quantity, address: address}) :: %{
           jsonrpc: String.t(),
           id: id,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
@@ -18,6 +18,14 @@ defmodule EthereumJSONRPC.SignedAuthorization do
           String.t() => EthereumJSONRPC.address() | EthereumJSONRPC.quantity()
         }
 
+  @typedoc """
+  * `"chain_id"` - specifies the chain for which the authorization was created.
+  * `"address"` - address of the delegate contract.
+  * `"nonce"` - signature nonce.
+  * `"v"` - v component of the signature.
+  * `"r"` - r component of the signature.
+  * `"s"` - s component of the signature.
+  """
   @type params :: %{
           chain_id: non_neg_integer(),
           address: EthereumJSONRPC.address(),

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
@@ -28,7 +28,13 @@ defmodule EthereumJSONRPC.SignedAuthorization do
         }
 
   @doc """
-  Converts `t:t/0` to `t:params/0`
+    Converts a signed authorization map into its corresponding parameters map format.
+
+    ## Parameters
+    - `raw`: Map with signed authorization data.
+
+    ## Returns
+    - Parameters map in the `params()` format.
   """
   @spec to_params(t()) :: params()
   def to_params(raw) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
@@ -1,0 +1,44 @@
+defmodule EthereumJSONRPC.SignedAuthorization do
+  @moduledoc """
+  The format of authorization tuples returned for
+  set code transactions [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702).
+  """
+
+  import EthereumJSONRPC, only: [quantity_to_integer: 1]
+
+  @typedoc """
+  * `"chainId"` - specifies the chain for which the authorization was created `t:EthereumJSONRPC.quantity/0`.
+  * `"address"` - `t:EthereumJSONRPC.address/0` of the delegate contract.
+  * `"nonce"` - signature nonce `t:EthereumJSONRPC.quantity/0`.
+  * `"v"` - v component of the signature `t:EthereumJSONRPC.quantity/0`.
+  * `"r"` - r component of the signature `t:EthereumJSONRPC.quantity/0`.
+  * `"s"` - s component of the signature `t:EthereumJSONRPC.quantity/0`.
+  """
+  @type t :: %{
+          String.t() => EthereumJSONRPC.address() | EthereumJSONRPC.quantity()
+        }
+
+  @type params :: %{
+          chain_id: non_neg_integer(),
+          address: EthereumJSONRPC.address(),
+          nonce: non_neg_integer(),
+          r: non_neg_integer(),
+          s: non_neg_integer(),
+          v: non_neg_integer()
+        }
+
+  @doc """
+  Converts `t:t/0` to `t:params/0`
+  """
+  @spec to_params(t()) :: params()
+  def to_params(raw) do
+    %{
+      chain_id: quantity_to_integer(raw["chainId"]),
+      address: raw["address"],
+      nonce: quantity_to_integer(raw["nonce"]),
+      r: quantity_to_integer(raw["r"]),
+      s: quantity_to_integer(raw["s"]),
+      v: quantity_to_integer(raw["v"])
+    }
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transaction.ex
@@ -16,6 +16,7 @@ defmodule EthereumJSONRPC.Transaction do
     ]
 
   alias EthereumJSONRPC
+  alias EthereumJSONRPC.SignedAuthorization
 
   case Application.compile_env(:explorer, :chain_type) do
     :ethereum ->
@@ -74,8 +75,16 @@ defmodule EthereumJSONRPC.Transaction do
       @chain_type_fields quote(do: [])
   end
 
+  # todo: Check if it's possible to simplify by avoiding t -> elixir -> params conversions
+  # and directly convert t -> params.
   @type elixir :: %{
-          String.t() => EthereumJSONRPC.address() | EthereumJSONRPC.hash() | String.t() | non_neg_integer() | nil
+          String.t() =>
+            EthereumJSONRPC.address()
+            | EthereumJSONRPC.hash()
+            | String.t()
+            | non_neg_integer()
+            | [SignedAuthorization.params()]
+            | nil
         }
 
   @typedoc """
@@ -105,6 +114,7 @@ defmodule EthereumJSONRPC.Transaction do
    * `"maxPriorityFeePerGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote max priority fee per unit of gas used. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
    * `"maxFeePerGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote max fee per unit of gas used. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
    * `"type"` - `t:EthereumJSONRPC.quantity/0` denotes transaction type. Introduced in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md)
+   * `"authorizationList"` - `t:list/0` of `t:EthereumJSONRPC.SignedAuthorization.t/0` authorization tuples. Introduced in [EIP-7702](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md)
    #{case Application.compile_env(:explorer, :chain_type) do
     :ethereum -> """
        * `"maxFeePerBlobGas"` - `t:EthereumJSONRPC.quantity/0` of wei to denote max fee per unit of blob gas used. Introduced in [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md)
@@ -128,7 +138,12 @@ defmodule EthereumJSONRPC.Transaction do
   """
   @type t :: %{
           String.t() =>
-            EthereumJSONRPC.address() | EthereumJSONRPC.hash() | EthereumJSONRPC.quantity() | String.t() | nil
+            EthereumJSONRPC.address()
+            | EthereumJSONRPC.hash()
+            | EthereumJSONRPC.quantity()
+            | String.t()
+            | [SignedAuthorization.t()]
+            | nil
         }
 
   @type params :: %{
@@ -150,7 +165,8 @@ defmodule EthereumJSONRPC.Transaction do
           transaction_index: non_neg_integer(),
           max_priority_fee_per_gas: non_neg_integer(),
           max_fee_per_gas: non_neg_integer(),
-          type: non_neg_integer()
+          type: non_neg_integer(),
+          authorization_list: [SignedAuthorization.params()]
         }
 
   @doc """
@@ -322,7 +338,8 @@ defmodule EthereumJSONRPC.Transaction do
       {"block_timestamp", :block_timestamp},
       {"r", :r},
       {"s", :s},
-      {"v", :v}
+      {"v", :v},
+      {"authorizationList", :authorization_list}
     ])
   end
 
@@ -368,7 +385,8 @@ defmodule EthereumJSONRPC.Transaction do
       {"block_timestamp", :block_timestamp},
       {"r", :r},
       {"s", :s},
-      {"v", :v}
+      {"v", :v},
+      {"authorizationList", :authorization_list}
     ])
   end
 
@@ -699,6 +717,9 @@ defmodule EthereumJSONRPC.Transaction do
       _ -> {key, quantity_to_integer(chain_id)}
     end
   end
+
+  defp entry_to_elixir({"authorizationList" = key, value}),
+    do: {key, value |> Enum.map(&SignedAuthorization.to_params/1)}
 
   # Celo-specific fields
   if Application.compile_env(:explorer, :chain_type) == :celo do

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -428,7 +428,18 @@ defmodule Explorer.Chain.Address do
   end
 
   @doc """
-  Checks if given address is smart-contract
+    Determines if the given address is a smart contract.
+
+    This function checks the contract code of an address to determine if it's a
+    smart contract.
+
+    ## Parameters
+    - `address`: The address to check. Can be an `Address` struct or any other value.
+
+    ## Returns
+    - `true` if the address is a smart contract
+    - `false` if the address is not a smart contract
+    - `nil` if the contract code hasn't been loaded
   """
   @spec smart_contract?(any()) :: boolean() | nil
   def smart_contract?(%__MODULE__{contract_code: nil}), do: false
@@ -437,7 +448,21 @@ defmodule Explorer.Chain.Address do
   def smart_contract?(_), do: false
 
   @doc """
-  Checks if given address is EOA with code (EIP-7702)
+    Checks if the given address is an Externally Owned Account (EOA) with code,
+    as defined in EIP-7702.
+
+    This function determines whether an address represents an EOA that has
+    associated code, which is a special case introduced by EIP-7702. It checks
+    the contract code of the address for the presence of a delegate address
+    according to the EIP-7702 specification.
+
+    ## Parameters
+    - `address`: The address to check. Can be an `Address` struct or any other value.
+
+    ## Returns
+    - `true` if the address is an EOA with code (EIP-7702 compliant)
+    - `false` if the address is not an EOA with code
+    - `nil` if the contract code hasn't been loaded
   """
   @spec eoa_with_code?(any()) :: boolean() | nil
   def eoa_with_code?(%__MODULE__{contract_code: %Data{bytes: code}}) do
@@ -546,7 +571,18 @@ defmodule Explorer.Chain.Address do
   end
 
   @doc """
-  Sets contract_code for the given Explorer.Chain.Address
+   Sets the contract code for the given address.
+
+   This function updates the contract code and the `updated_at` timestamp for an
+   address in the database.
+
+   ## Parameters
+   - `address_hash`: The hash of the address to update.
+   - `contract_code`: The new contract code to set.
+
+   ## Returns
+   A tuple `{count, nil}`, where `count` is the number of rows updated
+   (typically 1 if the address exists, 0 otherwise).
   """
   @spec set_contract_code(Hash.Address.t(), binary()) :: {non_neg_integer(), nil}
   def set_contract_code(address_hash, contract_code) when not is_nil(address_hash) and is_binary(contract_code) do

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -228,7 +228,7 @@ defmodule Explorer.Chain.Address.Counters do
 
   @spec address_to_gas_usage_count(Address.t()) :: Decimal.t() | nil
   def address_to_gas_usage_count(address) do
-    if Address.smart_contract?(address) do
+    if Address.smart_contract?(address) and not Address.eoa_with_code?(address) do
       incoming_transaction_gas_usage = address_to_incoming_transaction_gas_usage(address.hash)
 
       cond do

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -181,6 +181,20 @@ defmodule Explorer.Chain.Address.Counters do
     Repo.aggregate(to_address_query, :count, :hash, timeout: :infinity)
   end
 
+  @doc """
+    Calculates the total gas used by incoming transactions to a given address.
+
+    This function queries the database for all transactions where the
+    `to_address_hash` matches the provided `address_hash`, and sums up the
+    `gas_used` for these transactions.
+
+    ## Parameters
+    - `address_hash`: The address hash to query for incoming transactions.
+
+    ## Returns
+    - The total gas used by incoming transactions, or `nil` if no transactions
+      are found or if the sum is null.
+  """
   @spec address_to_incoming_transaction_gas_usage(Hash.Address.t()) :: Decimal.t() | nil
   def address_to_incoming_transaction_gas_usage(address_hash) do
     to_address_query =
@@ -192,6 +206,19 @@ defmodule Explorer.Chain.Address.Counters do
     Repo.aggregate(to_address_query, :sum, :gas_used, timeout: :infinity)
   end
 
+  @doc """
+    Calculates the total gas used by outgoing transactions from a given address.
+
+    This function queries the database for all transactions where the
+    `from_address_hash` matches the provided `address_hash`, and sums up the
+    `gas_used` for these transactions.
+
+    ## Parameters
+    - `address_hash`: the address to query.
+
+    ## Returns
+    - The total gas used, or `nil` if no transactions are found or if the sum is null.
+  """
   @spec address_to_outcoming_transaction_gas_usage(Hash.Address.t()) :: Decimal.t() | nil
   def address_to_outcoming_transaction_gas_usage(address_hash) do
     to_address_query =
@@ -226,6 +253,26 @@ defmodule Explorer.Chain.Address.Counters do
     )
   end
 
+  @doc """
+    Calculates the total gas usage for a given address.
+
+    This function determines the appropriate gas usage calculation based on the
+    address type:
+
+    - For smart contracts (excluding EOAs with code), it first checks the gas
+      usage of incoming transactions. If there are no incoming transactions or
+      their gas usage is zero, it falls back to the gas usage of outgoing
+      transactions.
+    - For regular addresses and EOAs with code, it calculates the gas usage of
+      outgoing transactions.
+
+    ## Parameters
+    - `address`: The address to calculate gas usage for.
+
+    ## Returns
+    - The total gas usage for the address.
+    - `nil` if no relevant transactions are found or if the sum is null.
+  """
   @spec address_to_gas_usage_count(Address.t()) :: Decimal.t() | nil
   def address_to_gas_usage_count(address) do
     if Address.smart_contract?(address) and not Address.eoa_with_code?(address) do

--- a/apps/explorer/lib/explorer/chain/import/runner/signed_authorizations.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/signed_authorizations.ex
@@ -1,0 +1,110 @@
+defmodule Explorer.Chain.Import.Runner.SignedAuthorizations do
+  @moduledoc """
+  Bulk imports `t:Explorer.Chain.SignedAuthorization.t/0`.
+  """
+
+  require Ecto.Query
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.{Changeset, Multi, Repo}
+  alias Explorer.Chain.{Import, SignedAuthorization}
+  alias Explorer.Prometheus.Instrumenter
+
+  @behaviour Import.Runner
+
+  # milliseconds
+  @timeout 60_000
+
+  @type imported :: [SignedAuthorization.t()]
+
+  @impl Import.Runner
+  def ecto_schema_module, do: SignedAuthorization
+
+  @impl Import.Runner
+  def option_key, do: :signed_authorizations
+
+  @impl Import.Runner
+  def imported_table_row do
+    %{
+      value_type: "[#{ecto_schema_module()}.t()]",
+      value_description: "List of `t:#{ecto_schema_module()}.t/0`s"
+    }
+  end
+
+  @impl Import.Runner
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(on_conflict timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
+
+    Multi.run(multi, :signed_authorizations, fn repo, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> insert(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :signed_authorizations,
+        :signed_authorizations
+      )
+    end)
+  end
+
+  @impl Import.Runner
+  def timeout, do: @timeout
+
+  @spec insert(Repo.t(), [map()], %{
+          optional(:on_conflict) => Import.Runner.on_conflict(),
+          required(:timeout) => timeout,
+          required(:timestamps) => Import.timestamps()
+        }) ::
+          {:ok, [SignedAuthorization.t()]}
+          | {:error, [Changeset.t()]}
+  defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
+    on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
+    conflict_target = [:transaction_hash, :index]
+
+    {:ok, _} =
+      Import.insert_changes_list(
+        repo,
+        changes_list,
+        for: SignedAuthorization,
+        on_conflict: on_conflict,
+        conflict_target: conflict_target,
+        returning: true,
+        timeout: timeout,
+        timestamps: timestamps
+      )
+  end
+
+  defp default_on_conflict do
+    from(
+      authorization in SignedAuthorization,
+      update: [
+        set: [
+          chain_id: fragment("EXCLUDED.chain_id"),
+          address: fragment("EXCLUDED.address"),
+          nonce: fragment("EXCLUDED.nonce"),
+          r: fragment("EXCLUDED.r"),
+          s: fragment("EXCLUDED.s"),
+          v: fragment("EXCLUDED.v"),
+          authority: fragment("EXCLUDED.authority"),
+          inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", authorization.inserted_at),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", authorization.updated_at)
+        ]
+      ],
+      where:
+        fragment(
+          "(EXCLUDED.chain_id, EXCLUDED.address, EXCLUDED.nonce, EXCLUDED.r, EXCLUDED.s, EXCLUDED.v, EXCLUDED.authority) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?)",
+          authorization.chain_id,
+          authorization.address,
+          authorization.nonce,
+          authorization.r,
+          authorization.s,
+          authorization.v,
+          authorization.authority
+        )
+    )
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_referencing.ex
@@ -14,7 +14,8 @@ defmodule Explorer.Chain.Import.Stage.BlockReferencing do
     Runner.Tokens,
     Runner.TokenInstances,
     Runner.TransactionActions,
-    Runner.Withdrawals
+    Runner.Withdrawals,
+    Runner.SignedAuthorizations
   ]
 
   @extra_runners_by_chain_type %{

--- a/apps/explorer/lib/explorer/chain/signed_authorization.ex
+++ b/apps/explorer/lib/explorer/chain/signed_authorization.ex
@@ -21,15 +21,15 @@ defmodule Explorer.Chain.SignedAuthorization do
     * `authority` - the signer of the authorization.
   """
   @type to_import :: %__MODULE__{
-          transaction_hash: Hash.Full,
-          index: :integer,
-          chain_id: :integer,
-          address: Hash.Address,
-          nonce: :integer,
-          r: :decimal,
-          s: :decimal,
-          v: :integer,
-          authority: Hash.Address
+          transaction_hash: binary(),
+          index: non_neg_integer(),
+          chain_id: non_neg_integer(),
+          address: binary(),
+          nonce: non_neg_integer(),
+          r: non_neg_integer(),
+          s: non_neg_integer(),
+          v: non_neg_integer(),
+          authority: binary() | nil
         }
 
   @typedoc """

--- a/apps/explorer/lib/explorer/chain/signed_authorization.ex
+++ b/apps/explorer/lib/explorer/chain/signed_authorization.ex
@@ -8,7 +8,19 @@ defmodule Explorer.Chain.SignedAuthorization do
   @optional_attrs ~w(authority)a
   @required_attrs ~w(transaction_hash index chain_id address nonce r s v)a
 
-  @type t :: %__MODULE__{
+  @typedoc """
+  Descriptor of the signed authorization tuple from EIP-7702 set code transactions:
+    * `transaction_hash` - the hash of the associated transaction.
+    * `index` - the index of this authorization in the authorization list.
+    * `chain_id` - the ID of the chain for which the authorization was created.
+    * `address` - the address of the delegate contract.
+    * `nonce` - the signature nonce.
+    * `v` - the 'v' component of the signature.
+    * `r` - the 'r' component of the signature.
+    * `s` - the 's' component of the signature.
+    * `authority` - the signer of the authorization.
+  """
+  @type to_import :: %__MODULE__{
           transaction_hash: Hash.Full,
           index: :integer,
           chain_id: :integer,
@@ -20,16 +32,30 @@ defmodule Explorer.Chain.SignedAuthorization do
           authority: Hash.Address
         }
 
+  @typedoc """
+    * `transaction_hash` - the hash of the associated transaction.
+    * `index` - the index of this authorization in the authorization list.
+    * `chain_id` - the ID of the chain for which the authorization was created.
+    * `address` - the address of the delegate contract.
+    * `nonce` - the signature nonce.
+    * `v` - the 'v' component of the signature.
+    * `r` - the 'r' component of the signature.
+    * `s` - the 's' component of the signature.
+    * `authority` - the signer of the authorization.
+    * `inserted_at` - timestamp indicating when the signed authorization was created.
+    * `updated_at` - timestamp indicating when the signed authorization was last updated.
+    * `transaction` - an instance of `Explorer.Chain.Transaction` referenced by `transaction_hash`.
+  """
   @primary_key false
-  schema "signed_authorizations" do
-    field(:index, :integer, primary_key: true)
-    field(:chain_id, :integer)
-    field(:address, Hash.Address)
-    field(:nonce, :integer)
-    field(:r, :decimal)
-    field(:s, :decimal)
-    field(:v, :integer)
-    field(:authority, Hash.Address)
+  typed_schema "signed_authorizations" do
+    field(:index, :integer, primary_key: true, null: false)
+    field(:chain_id, :integer, null: false)
+    field(:address, Hash.Address, null: false)
+    field(:nonce, :integer, null: false)
+    field(:r, :decimal, null: false)
+    field(:s, :decimal, null: false)
+    field(:v, :integer, null: false)
+    field(:authority, Hash.Address, null: true)
 
     belongs_to(:transaction, Transaction,
       foreign_key: :transaction_hash,
@@ -47,11 +73,7 @@ defmodule Explorer.Chain.SignedAuthorization do
   @spec changeset(Ecto.Schema.t(), map()) :: Ecto.Schema.t()
   def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
     struct
-    |> cast(
-      attrs,
-      @required_attrs ++
-        @optional_attrs
-    )
+    |> cast(attrs, @required_attrs ++ @optional_attrs)
     |> validate_required(@required_attrs)
     |> foreign_key_constraint(:transaction_hash)
   end

--- a/apps/explorer/lib/explorer/chain/signed_authorization.ex
+++ b/apps/explorer/lib/explorer/chain/signed_authorization.ex
@@ -1,0 +1,58 @@
+defmodule Explorer.Chain.SignedAuthorization do
+  @moduledoc "Models a transaction extension with authorization tuples from eip7702 set code transactions."
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, Transaction}
+
+  @optional_attrs ~w(authority)a
+  @required_attrs ~w(transaction_hash index chain_id address nonce r s v)a
+
+  @type t :: %__MODULE__{
+          transaction_hash: Hash.Full,
+          index: :integer,
+          chain_id: :integer,
+          address: Hash.Address,
+          nonce: :integer,
+          r: :decimal,
+          s: :decimal,
+          v: :integer,
+          authority: Hash.Address
+        }
+
+  @primary_key false
+  schema "signed_authorizations" do
+    field(:index, :integer, primary_key: true)
+    field(:chain_id, :integer)
+    field(:address, Hash.Address)
+    field(:nonce, :integer)
+    field(:r, :decimal)
+    field(:s, :decimal)
+    field(:v, :integer)
+    field(:authority, Hash.Address)
+
+    belongs_to(:transaction, Transaction,
+      foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full
+    )
+
+    timestamps()
+  end
+
+  @doc """
+    Validates that the `attrs` are valid.
+  """
+  @spec changeset(Ecto.Schema.t(), map()) :: Ecto.Schema.t()
+  def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
+    struct
+    |> cast(
+      attrs,
+      @required_attrs ++
+        @optional_attrs
+    )
+    |> validate_required(@required_attrs)
+    |> foreign_key_constraint(:transaction_hash)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -117,7 +117,20 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   end
 
   @doc """
-  Decodes address output into 20 bytes address hash
+    Decodes and formats an address output from a smart contract ABI.
+
+    This function handles various input formats and edge cases when decoding
+    address outputs from smart contract function calls or events.
+
+    ## Parameters
+    - `address`: The address output to decode. Can be `nil`, `"0x"`, a binary string, or `:error`.
+
+    ## Returns
+    - `nil` if the input is `nil`.
+    - The burn address hash string if the input is `"0x"`.
+    - A formatted address string if the input is a valid binary string.
+    - `:error` if the input is `:error`.
+    - `nil` for any other input type.
   """
   @spec abi_decode_address_output(any()) :: nil | :error | binary()
   def abi_decode_address_output(nil), do: nil

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     EIP1822,
     EIP1967,
     EIP2535,
+    EIP7702,
     EIP930,
     MasterCopy
   }
@@ -260,6 +261,20 @@ defmodule Explorer.Chain.SmartContract.Proxy do
         proxy_abi,
         go_to_fallback?
       ],
+      :get_implementation_address_hash_string_eip7702
+    )
+  end
+
+  @doc """
+  Returns EIP-7702 implementation address or tries next proxy pattern
+  """
+  @spec get_implementation_address_hash_string_eip7702(Hash.Address.t(), any(), bool()) ::
+          %{implementation_address_hash_strings: [String.t()] | :error | nil, proxy_type: atom() | :unknown}
+  def get_implementation_address_hash_string_eip7702(proxy_address_hash, proxy_abi, go_to_fallback?) do
+    get_implementation_address_hash_string_by_module(
+      EIP7702,
+      :eip7702,
+      [proxy_address_hash, proxy_abi, go_to_fallback?],
       :get_implementation_address_hash_string_eip1967
     )
   end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
@@ -8,7 +8,19 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
   alias Explorer.Chain.SmartContract.Proxy
 
   @doc """
-  Get delegate address hash string following EIP-7702
+    Retrieves the delegate address hash string for an EIP-7702 compatible EOA.
+
+    This function fetches the contract code for the given address and extracts
+    the delegate address according to the EIP-7702 specification.
+
+    ## Parameters
+    - `address_hash`: The address of the contract to check.
+    - `options`: Optional keyword list of options (default: `[]`).
+
+    ## Returns
+    - The delegate address in the hex string format if found and successfully decoded.
+    - `nil` if the address doesn't exist, has no contract code, or the delegate address
+      couldn't be extracted or decoded.
   """
   @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: String.t() | nil
   def get_implementation_address_hash_string(address_hash, options \\ []) do
@@ -30,7 +42,24 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
   end
 
   @doc """
-  Extracts the EIP-7702 delegate address from the bytecode
+    Extracts the EIP-7702 delegate address from the bytecode.
+
+    This function analyzes the given bytecode to identify and extract the delegate
+    address according to the EIP-7702 specification.
+
+    ## Parameters
+    - `contract_code_bytes`: The binary representation of the contract bytecode.
+
+    ## Returns
+    - A string representation of the delegate address prefixed with "0x" if found.
+    - `nil` if the delegate address is not present in the bytecode.
+
+    ## Examples
+      iex> get_delegate_address(<<239, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20>>)
+      "0x0102030405060708090a0b0c0d0e0f10111213"
+
+      iex> get_delegate_address(<<1, 2, 3>>)
+      nil
   """
   @spec get_delegate_address(binary()) :: String.t() | nil
   def get_delegate_address(contract_code_bytes) do

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
@@ -23,6 +23,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
       couldn't be extracted or decoded.
   """
   @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: String.t() | nil
+  @spec get_implementation_address_hash_string(Hash.Address.t()) :: String.t() | nil
   def get_implementation_address_hash_string(address_hash, options \\ []) do
     case Chain.select_repo(options).get(Address, address_hash) do
       nil ->

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
@@ -1,0 +1,43 @@
+defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
+  @moduledoc """
+  Module for fetching EOA delegate from https://eips.ethereum.org/EIPS/eip-7702
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Address, Hash}
+  alias Explorer.Chain.SmartContract.Proxy
+
+  @doc """
+  Get delegate address hash string following EIP-7702
+  """
+  @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: String.t() | nil
+  def get_implementation_address_hash_string(address_hash, options \\ []) do
+    case Chain.select_repo(options).get(Address, address_hash) do
+      nil ->
+        nil
+
+      target_address ->
+        contract_code = target_address.contract_code
+
+        case contract_code do
+          %Chain.Data{bytes: contract_code_bytes} ->
+            contract_code_bytes |> get_delegate_address() |> Proxy.abi_decode_address_output()
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  @doc """
+  Extracts the EIP-7702 delegate address from the bytecode
+  """
+  @spec get_delegate_address(binary()) :: String.t() | nil
+  def get_delegate_address(contract_code_bytes) do
+    case contract_code_bytes do
+      # 0xef0100 <> address
+      <<239, 1, 0>> <> <<address::binary-size(20)>> -> "0x" <> Base.encode16(address, case: :lower)
+      _ -> nil
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -49,6 +49,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
         :comptroller,
         :eip2535,
         :clone_with_immutable_arguments,
+        :eip7702,
         :unknown
       ],
       null: true

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1964,12 +1964,13 @@ defmodule Explorer.Chain.Transaction do
 
   @doc """
   Dynamically adds to/from for `transactions` query based on whether the target address EOA or smart-contract
-  todo: pay attention to [EIP-5003](https://eips.ethereum.org/EIPS/eip-5003): if it will be included, this logic should be rolled back.
+  EOAs with code (EIP-7702) are treated as regular EOAs.
   """
   @spec where_transactions_to_from(Hash.Address.t()) :: any()
   def where_transactions_to_from(address_hash) do
     with {:ok, address} <- Chain.hash_to_address(address_hash),
-         true <- Address.smart_contract?(address) do
+         true <- Address.smart_contract?(address),
+         false <- Address.eoa_with_code?(address) do
       dynamic([transaction], transaction.to_address_hash == ^address_hash)
     else
       _ ->

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -16,6 +16,7 @@ defmodule Explorer.Chain.Transaction.Schema do
     Hash,
     InternalTransaction,
     Log,
+    SignedAuthorization,
     TokenTransfer,
     TransactionAction,
     Wei
@@ -268,6 +269,11 @@ defmodule Explorer.Chain.Transaction.Schema do
           foreign_key: :created_contract_address_hash,
           references: :hash,
           type: Hash.Address
+        )
+
+        has_many(:signed_authorizations, SignedAuthorization,
+          foreign_key: :transaction_hash,
+          references: :hash
         )
 
         unquote_splicing(@chain_type_fields)

--- a/apps/explorer/lib/explorer/counters/helper.ex
+++ b/apps/explorer/lib/explorer/counters/helper.ex
@@ -10,6 +10,16 @@ defmodule Explorer.Counters.Helper do
     read_concurrency: true
   ]
 
+  @doc """
+    Returns the current time in milliseconds since the Unix epoch.
+
+    This function retrieves the current UTC time and converts it to Unix
+    timestamp in milliseconds.
+
+    ## Returns
+    - The number of millisecondssince the Unix epoch.
+  """
+  @spec current_time() :: non_neg_integer()
   def current_time do
     utc_now = DateTime.utc_now()
 

--- a/apps/explorer/lib/explorer/counters/helper.ex
+++ b/apps/explorer/lib/explorer/counters/helper.ex
@@ -17,7 +17,7 @@ defmodule Explorer.Counters.Helper do
     timestamp in milliseconds.
 
     ## Returns
-    - The number of millisecondssince the Unix epoch.
+    - The number of milliseconds since the Unix epoch.
   """
   @spec current_time() :: non_neg_integer()
   def current_time do

--- a/apps/explorer/lib/explorer/utility/address_contract_code_fetch_attempt.ex
+++ b/apps/explorer/lib/explorer/utility/address_contract_code_fetch_attempt.ex
@@ -23,7 +23,15 @@ defmodule Explorer.Utility.AddressContractCodeFetchAttempt do
   end
 
   @doc """
-  Gets retries number and updated_at for the Explorer.Chain.Address
+    Retrieves the number of retries and the last update timestamp for a given address.
+
+    ## Parameters
+    - `address_hash`: The address to query.
+
+    ## Returns
+    - `{retries_number, updated_at}`: A tuple containing the number of retries and
+      the last update timestamp.
+    - `nil`: If no record is found for the given address.
   """
   @spec get_retries_number(Hash.Address.t()) :: {non_neg_integer(), DateTime.t()} | nil
   def get_retries_number(address_hash) do
@@ -37,7 +45,15 @@ defmodule Explorer.Utility.AddressContractCodeFetchAttempt do
   end
 
   @doc """
-  Deletes row from address_contract_code_fetch_attempts table for the given address
+    Deletes the entry from the `address_contract_code_fetch_attempts` table that corresponds to the provided address hash.
+
+    ## Parameters
+    - `address_hash`: The `t:Explorer.Chain.Hash.Address.t/0` of the address
+      whose fetch attempt record should be deleted.
+
+    ## Returns
+    A tuple `{count, nil}`, where `count` is the number of records deleted
+    (typically 1 if the record existed, 0 otherwise).
   """
   @spec delete(Hash.Address.t()) :: {non_neg_integer(), nil}
   def delete(address_hash) do
@@ -47,14 +63,13 @@ defmodule Explorer.Utility.AddressContractCodeFetchAttempt do
   end
 
   @doc """
-  Inserts the number of retries for fetching contract code for a given address.
+    Inserts the number of retries for fetching contract code for a given address.
 
-  ## Parameters
+    ## Parameters
     - `address_hash` - The hash of the address for which the retries number is to be inserted.
 
-  ## Returns
+    ## Returns
     The result of the insertion operation.
-
   """
   @spec insert_retries_number(Hash.Address.t()) :: {non_neg_integer(), nil | [term()]}
   def insert_retries_number(address_hash) do

--- a/apps/explorer/priv/repo/migrations/20240904161254_create_signed_authorizations.exs
+++ b/apps/explorer/priv/repo/migrations/20240904161254_create_signed_authorizations.exs
@@ -19,5 +19,7 @@ defmodule Explorer.Repo.Migrations.CreateSignedAuthorizations do
 
       timestamps(null: false, type: :utc_datetime_usec)
     end
+
+    create(index(:signed_authorizations, [:authority, :nonce]))
   end
 end

--- a/apps/explorer/priv/repo/migrations/20240904161254_create_signed_authorizations.exs
+++ b/apps/explorer/priv/repo/migrations/20240904161254_create_signed_authorizations.exs
@@ -1,0 +1,23 @@
+defmodule Explorer.Repo.Migrations.CreateSignedAuthorizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:signed_authorizations, primary_key: false) do
+      add(:transaction_hash, references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false,
+        primary_key: true
+      )
+
+      add(:index, :integer, null: false, primary_key: true)
+      add(:chain_id, :bigint, null: false)
+      add(:address, :bytea, null: false)
+      add(:nonce, :integer, null: false)
+      add(:v, :integer, null: false)
+      add(:r, :numeric, precision: 100, null: false)
+      add(:s, :numeric, precision: 100, null: false)
+      add(:authority, :bytea, null: true)
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20240918104231_new_proxy_type_eip7702.exs
+++ b/apps/explorer/priv/repo/migrations/20240918104231_new_proxy_type_eip7702.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.NewProxyTypeEip7702 do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TYPE proxy_type ADD VALUE 'eip7702' BEFORE 'unknown'")
+  end
+end

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -44,6 +44,7 @@ defmodule Indexer.Block.Fetcher do
     Addresses,
     AddressTokenBalances,
     MintTransfers,
+    SignedAuthorizations,
     TokenInstances,
     TokenTransfers,
     TransactionActions
@@ -237,7 +238,7 @@ defmodule Indexer.Block.Fetcher do
            transactions: %{params: transactions_with_receipts},
            withdrawals: %{params: withdrawals_params},
            token_instances: %{params: token_instances},
-           signed_authorizations: %{params: extract_signed_authorizations(transactions_with_receipts)}
+           signed_authorizations: %{params: SignedAuthorizations.parse(transactions_with_receipts)}
          },
          chain_type_import_options = %{
            transactions_with_receipts: transactions_with_receipts,
@@ -744,52 +745,6 @@ defmodule Indexer.Block.Fetcher do
 
       Map.put(token_transfer, :token, token)
     end)
-  end
-
-  defp extract_signed_authorizations(transactions_with_receipts) do
-    transactions_with_receipts
-    |> Enum.filter(&Map.has_key?(&1, :authorization_list))
-    |> Enum.flat_map(
-      &(&1.authorization_list
-        |> Enum.with_index()
-        |> Enum.map(fn {authorization, index} ->
-          authorization
-          |> Map.merge(%{
-            transaction_hash: &1.hash,
-            index: index,
-            authority: recover_authority(authorization)
-          })
-        end))
-    )
-  end
-
-  defp recover_authority(signed_authorization) do
-    eip7702_magic = 0x5
-    {:ok, %{bytes: address}} = Hash.Address.cast(signed_authorization.address)
-
-    signed_message =
-      ExKeccak.hash_256(
-        <<eip7702_magic>> <> ExRLP.encode([signed_authorization.chain_id, address, signed_authorization.nonce])
-      )
-
-    authority =
-      ec_recover(signed_message, signed_authorization.r, signed_authorization.s, signed_authorization.v)
-
-    authority
-  end
-
-  defp ec_recover(signed_message, r, s, v) do
-    r_bytes = <<r::integer-size(256)>>
-    s_bytes = <<s::integer-size(256)>>
-
-    with {:ok, <<_compression::bytes-size(1), public_key::binary>>} <-
-           ExSecp256k1.recover(signed_message, r_bytes, s_bytes, v),
-         <<_::bytes-size(12), hash::binary>> <- ExKeccak.hash_256(public_key) do
-      address = Base.encode16(hash, case: :lower)
-      "0x" <> address
-    else
-      _ -> nil
-    end
   end
 
   # Asynchronously schedules matching of Arbitrum L1-to-L2 messages where the message ID is hashed.

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -236,7 +236,8 @@ defmodule Indexer.Block.Fetcher do
            tokens: %{params: tokens},
            transactions: %{params: transactions_with_receipts},
            withdrawals: %{params: withdrawals_params},
-           token_instances: %{params: token_instances}
+           token_instances: %{params: token_instances},
+           signed_authorizations: %{params: extract_signed_authorizations(transactions_with_receipts)}
          },
          chain_type_import_options = %{
            transactions_with_receipts: transactions_with_receipts,
@@ -743,6 +744,52 @@ defmodule Indexer.Block.Fetcher do
 
       Map.put(token_transfer, :token, token)
     end)
+  end
+
+  defp extract_signed_authorizations(transactions_with_receipts) do
+    transactions_with_receipts
+    |> Enum.filter(&Map.has_key?(&1, :authorization_list))
+    |> Enum.flat_map(
+      &(&1.authorization_list
+        |> Enum.with_index()
+        |> Enum.map(fn {authorization, index} ->
+          authorization
+          |> Map.merge(%{
+            transaction_hash: &1.hash,
+            index: index,
+            authority: recover_authority(authorization)
+          })
+        end))
+    )
+  end
+
+  defp recover_authority(signed_authorization) do
+    eip7702_magic = 0x5
+    {:ok, %{bytes: address}} = Hash.Address.cast(signed_authorization.address)
+
+    signed_message =
+      ExKeccak.hash_256(
+        <<eip7702_magic>> <> ExRLP.encode([signed_authorization.chain_id, address, signed_authorization.nonce])
+      )
+
+    authority =
+      ec_recover(signed_message, signed_authorization.r, signed_authorization.s, signed_authorization.v)
+
+    authority
+  end
+
+  defp ec_recover(signed_message, r, s, v) do
+    r_bytes = <<r::integer-size(256)>>
+    s_bytes = <<s::integer-size(256)>>
+
+    with {:ok, <<_compression::bytes-size(1), public_key::binary>>} <-
+           ExSecp256k1.recover(signed_message, r_bytes, s_bytes, v),
+         <<_::bytes-size(12), hash::binary>> <- ExKeccak.hash_256(public_key) do
+      address = Base.encode16(hash, case: :lower)
+      "0x" <> address
+    else
+      _ -> nil
+    end
   end
 
   # Asynchronously schedules matching of Arbitrum L1-to-L2 messages where the message ID is hashed.

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_code.ex
@@ -24,6 +24,21 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
     end
   end
 
+  # Attempts to fetch the contract code for a given address.
+  #
+  # This function checks if the contract code needs to be fetched and if enough time
+  # has passed since the last attempt. If conditions are met, it triggers the fetch
+  # and broadcast process.
+  #
+  # ## Parameters
+  #   address: The address of the contract.
+  #   state: The current state of the fetcher, containing JSON-RPC configuration.
+  #
+  # ## Returns
+  #   `:ok` in all cases.
+  @spec fetch_contract_code(Address.t(), %{
+          json_rpc_named_arguments: EthereumJSONRPC.json_rpc_named_arguments()
+        }) :: :ok
   defp fetch_contract_code(address, state) do
     with {:need_to_fetch, true} <- {:need_to_fetch, fetch?(address)},
          {:retries_number, {retries_number, updated_at}} <-
@@ -47,13 +62,35 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
     end
   end
 
+  # Determines if contract code should be fetched for an address
+  @spec fetch?(Address.t()) :: boolean()
   defp fetch?(address) when is_nil(address.nonce), do: true
   # if the address has a signed authorization, it might have a bytecode
   # according to EIP-7702
   defp fetch?(%{signed_authorization: %{authority: _}}), do: true
   defp fetch?(_), do: false
 
-  defp fetch_and_broadcast_bytecode(address_hash, state) do
+  # Fetches and broadcasts the bytecode for a given address.
+  #
+  # This function attempts to retrieve the contract bytecode for the specified address
+  # using the Ethereum JSON-RPC API. If successful, it updates the database as described below
+  # and broadcasts the result:
+  # 1. Updates the `addresses` table with the contract code if fetched successfully.
+  # 2. Modifies the `address_contract_code_fetch_attempts` table:
+  #    - Deletes the entry if the code is successfully set.
+  #    - Increments the retry count if the fetch fails or returns empty code.
+  # 3. Broadcasts a message with the fetched bytecode if successful.
+  #
+  # ## Parameters
+  #   address_hash: The `t:Explorer.Chain.Hash.Address.t/0` of the contract.
+  #   state: The current state of the fetcher, containing JSON-RPC configuration.
+  #
+  # ## Returns
+  #   `:ok` (the function always returns `:ok`, actual results are handled via side effects)
+  @spec fetch_and_broadcast_bytecode(Explorer.Chain.Hash.Address.t(), %{
+          json_rpc_named_arguments: EthereumJSONRPC.json_rpc_named_arguments()
+        }) :: :ok
+  defp fetch_and_broadcast_bytecode(address_hash, %{json_rpc_named_arguments: _} = state) do
     with {:fetched_code, {:ok, %EthereumJSONRPC.FetchedCodes{params_list: fetched_codes}}} <-
            {:fetched_code,
             fetch_codes(
@@ -96,10 +133,14 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
     {:noreply, state}
   end
 
+  # An initial threshold to fetch smart-contract bytecode on-demand
+  @spec update_threshold_ms() :: non_neg_integer()
   defp update_threshold_ms do
     Application.get_env(:indexer, __MODULE__)[:threshold]
   end
 
+  # Calculates the delay for the next fetch attempt based on the number of retries
+  @spec threshold(non_neg_integer()) :: non_neg_integer()
   defp threshold(retries_number) do
     delay_in_ms = trunc(update_threshold_ms() * :math.pow(2, retries_number))
 

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_code.ex
@@ -25,7 +25,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
   end
 
   defp fetch_contract_code(address, state) do
-    with {:empty_nonce, true} <- {:empty_nonce, is_nil(address.nonce)},
+    with {:need_to_fetch, true} <- {:need_to_fetch, fetch?(address)},
          {:retries_number, {retries_number, updated_at}} <-
            {:retries_number, AddressContractCodeFetchAttempt.get_retries_number(address.hash)},
          updated_at_ms = DateTime.to_unix(updated_at, :millisecond),
@@ -35,7 +35,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
               threshold(retries_number)} do
       fetch_and_broadcast_bytecode(address.hash, state)
     else
-      {:empty_nonce, false} ->
+      {:need_to_fetch, false} ->
         :ok
 
       {:retries_number, nil} ->
@@ -46,6 +46,12 @@ defmodule Indexer.Fetcher.OnDemand.ContractCode do
         :ok
     end
   end
+
+  defp fetch?(address) when is_nil(address.nonce), do: true
+  # if the address has a signed authorization, it might have a bytecode
+  # according to EIP-7702
+  defp fetch?(%{signed_authorization: %{authority: _}}), do: true
+  defp fetch?(_), do: false
 
   defp fetch_and_broadcast_bytecode(address_hash, state) do
     with {:fetched_code, {:ok, %EthereumJSONRPC.FetchedCodes{params_list: fetched_codes}}} <-

--- a/apps/indexer/lib/indexer/transform/signed_authorizations.ex
+++ b/apps/indexer/lib/indexer/transform/signed_authorizations.ex
@@ -57,7 +57,7 @@ defmodule Indexer.Transform.SignedAuthorizations do
     authority
   end
 
-  # This function uses eleptic curve recovery to get the address from the signed message and the signature.
+  # This function uses elliptic curve recovery to get the address from the signed message and the signature.
   @spec ec_recover(binary(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: EthereumJSONRPC.address() | nil
   defp ec_recover(signed_message, r, s, v) do
     r_bytes = <<r::integer-size(256)>>

--- a/apps/indexer/lib/indexer/transform/signed_authorizations.ex
+++ b/apps/indexer/lib/indexer/transform/signed_authorizations.ex
@@ -38,7 +38,8 @@ defmodule Indexer.Transform.SignedAuthorizations do
     )
   end
 
-  # authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]
+  # This function recovers the signer address from the signed authorization data using this formula:
+  #   authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]
   defp recover_authority(signed_authorization) do
     {:ok, %{bytes: address}} = Hash.Address.cast(signed_authorization.address)
 

--- a/apps/indexer/lib/indexer/transform/signed_authorizations.ex
+++ b/apps/indexer/lib/indexer/transform/signed_authorizations.ex
@@ -1,0 +1,69 @@
+defmodule Indexer.Transform.SignedAuthorizations do
+  @moduledoc """
+    Helper functions for extracting signed authorizations from EIP-7702 transactions.
+  """
+
+  alias Explorer.Chain.{Hash, SignedAuthorization}
+
+  # The magic number used in EIP-7702 to prefix the message to be signed.
+  @eip7702_magic 0x5
+
+  @doc """
+    Extracts signed authorizations from a list of transactions with receipts.
+
+    This function parses the authorization tuples from EIP-7702 set code transactions,
+    recovers the authority address from the signature, and prepares the data for database import.
+
+    ## Parameters
+    - `transactions_with_receipts`: A list of transactions with receipts.
+
+    ## Returns
+    A list of signed authorizations ready for database import.
+  """
+  @spec parse([map()]) :: [SignedAuthorization.to_import()]
+  def parse(transactions_with_receipts) do
+    transactions_with_receipts
+    |> Enum.filter(&Map.has_key?(&1, :authorization_list))
+    |> Enum.flat_map(
+      &(&1.authorization_list
+        |> Enum.with_index()
+        |> Enum.map(fn {authorization, index} ->
+          authorization
+          |> Map.merge(%{
+            transaction_hash: &1.hash,
+            index: index,
+            authority: recover_authority(authorization)
+          })
+        end))
+    )
+  end
+
+  # authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]
+  defp recover_authority(signed_authorization) do
+    {:ok, %{bytes: address}} = Hash.Address.cast(signed_authorization.address)
+
+    signed_message =
+      ExKeccak.hash_256(
+        <<@eip7702_magic>> <> ExRLP.encode([signed_authorization.chain_id, address, signed_authorization.nonce])
+      )
+
+    authority =
+      ec_recover(signed_message, signed_authorization.r, signed_authorization.s, signed_authorization.v)
+
+    authority
+  end
+
+  defp ec_recover(signed_message, r, s, v) do
+    r_bytes = <<r::integer-size(256)>>
+    s_bytes = <<s::integer-size(256)>>
+
+    with {:ok, <<_compression::bytes-size(1), public_key::binary>>} <-
+           ExSecp256k1.recover(signed_message, r_bytes, s_bytes, v),
+         <<_::bytes-size(12), hash::binary>> <- ExKeccak.hash_256(public_key) do
+      address = Base.encode16(hash, case: :lower)
+      "0x" <> address
+    else
+      _ -> nil
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/10774

## Motivation

This PR introduces initial support for EIP-7702 transactions and EOAs with code.

## Changelog
* Add the `signed_authorizations` table to store authorization tuples from EIP-7702 transactions.
* Enrich authorization tuples with the authority address recovered from the signature.
* Add `authorizationList` (including recovered authorities) to the `/transactions/:tx_hash` response.
* Add `set_code_transaction` tx type for EIP-7702 transactions.
* Preload one or zero signed authorization with `authority == :address` from the database during the `/address/:address` request. This preload is used solely to determine whether fetching the code is necessary.
* Fetch the contract code in the on-demand fetcher if the address has signed authorizations
* Add new proxy type `eip7702` for EOAs with code
* Modify changes from https://github.com/blockscout/blockscout/pull/9469 to handle EOAs with code correctly

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
