### PR TITLE
chore: add version bump script

### DIFF
--- a/.github/workflows/pre-release-arbitrum.yml
+++ b/.github/workflows/pre-release-arbitrum.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-blackfort.yml
+++ b/.github/workflows/pre-release-blackfort.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-celo.yml
+++ b/.github/workflows/pre-release-celo.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-eth.yml
+++ b/.github/workflows/pre-release-eth.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-optimism.yml
+++ b/.github/workflows/pre-release-optimism.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-redstone.yml
+++ b/.github/workflows/pre-release-redstone.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-shibarium.yml
+++ b/.github/workflows/pre-release-shibarium.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release-zksync.yml
+++ b/.github/workflows/pre-release-zksync.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -11,7 +11,7 @@ on:
 env:
   OTP_VERSION: ${{ vars.OTP_VERSION }}
   ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
-  RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+  RELEASE_VERSION: 6.8.1
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-docker-image-for-arbitrum.yml
+++ b/.github/workflows/publish-docker-image-for-arbitrum.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: arbitrum
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-blackfort.yml
+++ b/.github/workflows/publish-docker-image-for-blackfort.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: blackfort
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-celo.yml
+++ b/.github/workflows/publish-docker-image-for-celo.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: celo
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-core.yml
+++ b/.github/workflows/publish-docker-image-for-core.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: poa
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-eth-sepolia.yml
+++ b/.github/workflows/publish-docker-image-for-eth-sepolia.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: eth-sepolia
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-eth.yml
+++ b/.github/workflows/publish-docker-image-for-eth.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: mainnet
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-filecoin.yml
+++ b/.github/workflows/publish-docker-image-for-filecoin.yml
@@ -9,7 +9,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: filecoin
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-fuse.yml
+++ b/.github/workflows/publish-docker-image-for-fuse.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: fuse
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-gnosis-chain.yml
+++ b/.github/workflows/publish-docker-image-for-gnosis-chain.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: xdai
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-l2-staging.yml
+++ b/.github/workflows/publish-docker-image-for-l2-staging.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: optimism-l2-advanced
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-lukso.yml
+++ b/.github/workflows/publish-docker-image-for-lukso.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: lukso
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-optimism.yml
+++ b/.github/workflows/publish-docker-image-for-optimism.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: optimism
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-polygon-edge.yml
+++ b/.github/workflows/publish-docker-image-for-polygon-edge.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: polygon-edge
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-redstone.yml
+++ b/.github/workflows/publish-docker-image-for-redstone.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: redstone
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-rootstock.yml
+++ b/.github/workflows/publish-docker-image-for-rootstock.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: rsk
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-shibarium.yml
+++ b/.github/workflows/publish-docker-image-for-shibarium.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: shibarium
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-stability.yml
+++ b/.github/workflows/publish-docker-image-for-stability.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: stability
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-suave.yml
+++ b/.github/workflows/publish-docker-image-for-suave.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: suave
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-zetachain.yml
+++ b/.github/workflows/publish-docker-image-for-zetachain.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: zetachain
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-zkevm.yml
+++ b/.github/workflows/publish-docker-image-for-zkevm.yml
@@ -10,7 +10,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: zkevm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-for-zksync.yml
+++ b/.github/workflows/publish-docker-image-for-zksync.yml
@@ -9,7 +9,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
       DOCKER_CHAIN_NAME: zksync
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-docker-image-staging-on-demand.yml
+++ b/.github/workflows/publish-docker-image-staging-on-demand.yml
@@ -12,7 +12,7 @@ on:
 env:
   OTP_VERSION: ${{ vars.OTP_VERSION }}
   ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
-  RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+  RELEASE_VERSION: 6.8.1
 
 jobs:
   push_to_registry:

--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -5,7 +5,7 @@ on:
 env:
   OTP_VERSION: ${{ vars.OTP_VERSION }}
   ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
-  RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+  RELEASE_VERSION: 6.8.1
 
 jobs:
   push_to_registry:

--- a/.github/workflows/release-arbitrum.yml
+++ b/.github/workflows/release-arbitrum.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-blackfort.yml
+++ b/.github/workflows/release-blackfort.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-celo.yml
+++ b/.github/workflows/release-celo.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-eth.yml
+++ b/.github/workflows/release-eth.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-filecoin.yml
+++ b/.github/workflows/release-filecoin.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-fuse.yml
+++ b/.github/workflows/release-fuse.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-gnosis.yml
+++ b/.github/workflows/release-gnosis.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-optimism.yml
+++ b/.github/workflows/release-optimism.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-polygon-edge.yml
+++ b/.github/workflows/release-polygon-edge.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-polygon-zkevm.yml
+++ b/.github/workflows/release-polygon-zkevm.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-redstone.yml
+++ b/.github/workflows/release-redstone.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-rootstock.yml
+++ b/.github/workflows/release-rootstock.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-shibarium.yml
+++ b/.github/workflows/release-shibarium.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-stability.yml
+++ b/.github/workflows/release-stability.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-suave.yml
+++ b/.github/workflows/release-suave.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-zetachain.yml
+++ b/.github/workflows/release-zetachain.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release-zksync.yml
+++ b/.github/workflows/release-zksync.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ vars.RELEASE_VERSION }}
+      RELEASE_VERSION: 6.8.1
     steps:
       - uses: actions/checkout@v4
       - name: Setup repo

--- a/bin/version_bump.sh
+++ b/bin/version_bump.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Path to the mix.exs file
+MIX_FILES=(
+    "$(pwd)/mix.exs"
+    "$(pwd)/apps/block_scout_web/mix.exs"
+    "$(pwd)/apps/explorer/mix.exs"
+    "$(pwd)/apps/indexer/mix.exs"
+    "$(pwd)/apps/ethereum_jsonrpc/mix.exs"
+)
+CONFIG_FILE="$(pwd)/rel/config.exs"
+DOCKER_COMPOSE_FILE="$(pwd)/docker-compose/docker-compose.yml"
+MAKE_FILE="$(pwd)/docker/Makefile"
+WORKFLOW_FILES=($(find "$(pwd)/.github/workflows" -type f \( -name "pre-release-*" -o -name "release-*" -o -name "publish-docker-image-*" \)))
+
+# Function to bump version
+bump_version() {
+    local type=$1
+    local custom_version=$2
+
+    # Extract the current version
+    MIX_FILE="${MIX_FILES[0]}"
+    current_version=$(grep -o 'version: "[0-9]\+\.[0-9]\+\.[0-9]\+"' "$MIX_FILE" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+    echo "Current version: $current_version"
+
+    # Split the version into its components
+    IFS='.' read -r -a version_parts <<< "$current_version"
+
+    # Check if the --patch flag is provided
+    if [[ "$type" == "--patch" ]]; then
+        # Increment the patch version
+        version_parts[2]=$((version_parts[2] + 1))
+    elif [[ "$type" == "--minor" ]]; then
+        # Increment the minor version and reset the patch version
+        version_parts[1]=$((version_parts[1] + 1))
+        version_parts[2]=0
+    elif [[ "$type" == "--major" ]]; then
+        # Increment the major version and reset the minor and patch versions
+        version_parts[0]=$((version_parts[0] + 1))
+        version_parts[1]=0
+        version_parts[2]=0
+    elif [[ "$type" == "--update-to-version" ]]; then
+        # Apply the version from the 3rd argument
+        if [[ -z "$2" ]]; then
+            echo "Error: No version specified for --update-to-version."
+            exit 1
+        fi
+        new_version="$custom_version"
+        IFS='.' read -r -a version_parts <<< "$new_version"
+    else
+        echo "No --patch flag provided. Exiting."
+        exit 1
+    fi
+
+    # Join the version parts back together
+    new_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
+
+    # Replace the old version with the new version in the mix.exs files
+    for MIX_FILE in "${MIX_FILES[@]}"; do
+        sed -i '' "s/version: \"$current_version\"/version: \"$new_version\"/" "$MIX_FILE"
+    done
+
+    sed -i '' "s/version: \"$current_version/version: \"$new_version/" "$CONFIG_FILE"
+    sed -i '' "s/RELEASE_VERSION: $current_version/RELEASE_VERSION: $new_version/" "$DOCKER_COMPOSE_FILE"
+    sed -i '' "s/RELEASE_VERSION ?= '$current_version'/RELEASE_VERSION ?= '$new_version'/" "$MAKE_FILE"
+
+    # Replace the old version with the new version in the GitHub workflows files
+    for WORKFLOW_FILE in "${WORKFLOW_FILES[@]}"; do
+        sed -i '' "s/RELEASE_VERSION: $current_version/RELEASE_VERSION: $new_version/" "$WORKFLOW_FILE"
+    done
+
+    echo "Version bumped from $current_version to $new_version"
+}
+
+# Call the function
+bump_version "$1" "$2"


### PR DESCRIPTION
## Motivation

Addition of a script to bump the application version on releases.

## Changelog

This pull request adds script `bin/version_bump.sh` for version bumps in the codebase and updates the `RELEASE_VERSION` to `6.8.1` across multiple GitHub workflow files to ensure consistency in the Docker image version being pushed. Versions in all those workflow files are updated with the script as well.

Version updates in GitHub workflows:

* [`.github/workflows/pre-release-arbitrum.yml`](diffhunk://#diff-7cd3f8b468295722f8171b8a54d8d22acd5fc733a31316480d7e0c475d3ae29bL19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-blackfort.yml`](diffhunk://#diff-0602d9b8d9ff44c55bea71d3eb369aea3a42195ed8ca5df3f6b7877c5901beafL19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-celo.yml`](diffhunk://#diff-939082057c114c7762f629dec17b4092e2074aa7e0dfa0960bd20c89fc04e568L19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-eth.yml`](diffhunk://#diff-f5586ef379ef9fd05f7407c7bc4e8d8c9efd8d2e0e7edbfb62f19bd73a15e8baL19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-optimism.yml`](diffhunk://#diff-a70a0b49061fb0bc6841f4713ff5f37da77227a3d184bfa70c40ae76e61c1b29L19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-redstone.yml`](diffhunk://#diff-a397614663196c32c7d19f3d1d2c1956aa5bdf5e6756cb0cf48a46125baf9a59L19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-shibarium.yml`](diffhunk://#diff-801aab6ee39f0bdeb43625354d0f9fd2c8b6dbc98a278acf895d4a2dd0e1a07eL19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release-zksync.yml`](diffhunk://#diff-4e459cfc1177032529977def69a19ac299c8e377ea2b6c16780b2b91ff473428L19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/pre-release.yml`](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L19-R19): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-every-push.yml`](diffhunk://#diff-8a68ab14e3a2e99e92dcfa39924ecc69425b180c3f554411f76a6c37f9f1d621L14-R14): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-arbitrum.yml`](diffhunk://#diff-f1e05e2302890e481a8042b2970118d4ec035bf31edd93f8afc23bab3ad5f71aL13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-blackfort.yml`](diffhunk://#diff-593fed96239427bc5318b7d7345b92c71b6e9555cb7f7716ce8245c60977f24aL16-R16): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-celo.yml`](diffhunk://#diff-3ad867dd3a18c14071c0fdce07ddc542d0c8b57dc4bda3a18ef8aa5189f315f0L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-core.yml`](diffhunk://#diff-896816a29e3aa6bd145588466825b9e3173805b213270ada616e64f0b48ed3f8L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-eth-sepolia.yml`](diffhunk://#diff-a4c8616056175c0853bcb04e3989c26902e0087a676693fff6794b95550bad40L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-eth.yml`](diffhunk://#diff-9abb48237b57b93664fd21ddbf9c1f434f14f1bcd8a19f0ddabf4693e5579e49L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-filecoin.yml`](diffhunk://#diff-d5da332ff8ca5f433c266b6312af62c395182b35c8d43dd45eb4909da4c546b3L12-R12): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-fuse.yml`](diffhunk://#diff-2512158d54e76a0b8437b1d37659b0b1f853a90a4f9b78c036e7cfc811aac833L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-gnosis-chain.yml`](diffhunk://#diff-e9135f37c6b71034db07e03837a731054298c39426ea69fffc2b5759c3c29325L13-R13): Updated `RELEASE_VERSION` to `6.8.1`.
* [`.github/workflows/publish-docker-image-for-l2-staging.yml`](diffhunk://#diff-1af027fbb00f091a3d609eda6d2d6797d044884155feef525f0ffc12ebca6decL13-R13): Updated `RELEASE_VERSION` to `6.8.1`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
