### PR TITLE
feat: Open access to re-fetch metadata button for token instances without metadata initially fetched

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
@@ -20,9 +20,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch do
 
   @spec trigger_refetch(TokenInstance.t()) :: :ok
   def trigger_refetch(token_instance) do
-    unless is_nil(token_instance.metadata) do
-      GenServer.cast(__MODULE__, {:refetch, token_instance})
-    end
+    GenServer.cast(__MODULE__, {:refetch, token_instance})
   end
 
   defp fetch_metadata(token_instance, state) do

--- a/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
@@ -87,7 +87,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
-    test "don't run the update on the token instance with no metadata fetched initially" do
+    test "do run the update on the token instance with no metadata fetched initially" do
       token = insert(:token, name: "Super Token", type: "ERC-721")
       token_id = 1
 
@@ -100,9 +100,19 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
         |> Repo.preload(:token)
 
       metadata = %{"name" => "Super Token"}
+      url = "http://metadata.endpoint.com"
       token_contract_address_hash_string = to_string(token.contract_address_hash)
 
-      assert TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance) == nil
+      TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
+
+      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
+
+      Explorer.Mox.HTTPoison
+      |> expect(:get, fn ^url, _headers, _options ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
+      end)
+
+      assert TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance) == :ok
 
       :timer.sleep(100)
 
@@ -110,7 +120,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
         Repo.get_by(TokenInstance, token_id: token_id, token_contract_address_hash: token.contract_address_hash)
 
       assert(token_instance_from_db)
-      assert is_nil(token_instance_from_db.metadata)
+      assert token_instance_from_db.metadata == metadata
 
       assert is_nil(
                Repo.get_by(TokenInstanceMetadataRefetchAttempt,
@@ -119,10 +129,12 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
                )
              )
 
-      refute_receive(
+      assert_receive(
         {:chain_event, :fetched_token_instance_metadata, :on_demand,
-         [^token_contract_address_hash_string, ^token_id, %{metadata: ^metadata}]}
+         [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
+
+      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "updates token_instance_metadata_refetch_attempts table" do

--- a/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
@@ -89,7 +89,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       )
     end
 
-    test "do run the update on the token instance with no metadata fetched initially" do
+    test "run the update on the token instance with no metadata fetched initially" do
       token = insert(:token, name: "Super Token", type: "ERC-721")
       token_id = 1
 

--- a/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
@@ -33,6 +33,12 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
     setup do
       Subscriber.to(:fetched_token_instance_metadata, :on_demand)
 
+      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, :http_adapter, HTTPoison)
+      end)
+
       :ok
     end
 
@@ -53,8 +59,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       token_contract_address_hash_string = to_string(token.contract_address_hash)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
-
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
 
       Explorer.Mox.HTTPoison
       |> expect(:get, fn ^url, _headers, _options ->
@@ -83,8 +87,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
         {:chain_event, :fetched_token_instance_metadata, :on_demand,
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "do run the update on the token instance with no metadata fetched initially" do
@@ -104,8 +106,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       token_contract_address_hash_string = to_string(token.contract_address_hash)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
-
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
 
       Explorer.Mox.HTTPoison
       |> expect(:get, fn ^url, _headers, _options ->
@@ -133,8 +133,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
         {:chain_event, :fetched_token_instance_metadata, :on_demand,
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "updates token_instance_metadata_refetch_attempts table" do
@@ -154,8 +152,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       token_contract_address_hash_string = to_string(token.contract_address_hash)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
-
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
 
       Explorer.Mox.HTTPoison
       |> expect(:get, fn ^url, _headers, _options ->
@@ -186,8 +182,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
         {:chain_event, :fetched_token_instance_metadata, :on_demand,
          [^token_contract_address_hash_string, ^token_id, %{metadata: ^metadata}]}
       )
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
   end
 end


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/10877

## Changelog

Remove condition that metadata initially exists for NFT metadata re-fetch functionality.

Todo: create the task for frontend team to enable "re-fetch metadata" button in such case.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
