### PR TITLE
fix: Delete incorrect coin balances on reorg

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Import.Runner do
   @type changes_list :: [changes]
 
   @type changeset_function_name :: atom
-  @type on_conflict :: :nothing | :replace_all | Ecto.Query.t()
+  @type on_conflict :: :nothing | :replace_all | {:replace, [atom()]} | Ecto.Query.t()
 
   @typedoc """
   Runner-specific options under `c:option_key/0` in all options passed to `c:run/3`.

--- a/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/addresses.ex
@@ -168,8 +168,8 @@ defmodule Explorer.Chain.Import.Runner.Addresses do
           required(:timeout) => timeout,
           required(:timestamps) => Import.timestamps()
         }) :: {:ok, [Address.t()]}
-  defp insert(repo, ordered_changes_list, %{timeout: timeout, timestamps: timestamps} = options)
-       when is_list(ordered_changes_list) do
+  def insert(repo, ordered_changes_list, %{timeout: timeout, timestamps: timestamps} = options)
+      when is_list(ordered_changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     Import.insert_changes_list(


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9342

## Changelog

- Added deletion of coin balances related to blocks that lost consensus
- Added deriving new values of `fetched_coin_balance` and `fetched_coin_balance_block_number` fields for affected addresses

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
