### PR TITLE
fix: do not include unrelated token transfers in `tokenTransferTxs`

### DIFF
--- a/.github/workflows/publish-docker-image-for-celo.yml
+++ b/.github/workflows/publish-docker-image-for-celo.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            API_GRAPHQL_MAX_COMPLEXITY=6650
+            API_GRAPHQL_MAX_COMPLEXITY=10400
             CACHE_EXCHANGE_RATES_PERIOD=
             API_V1_READ_METHODS_DISABLED=false
             DISABLE_WEBAPP=false

--- a/apps/block_scout_web/lib/block_scout_web/graphql/celo/resolvers/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/celo/resolvers/token_transfer.ex
@@ -7,11 +7,10 @@ defmodule BlockScoutWeb.GraphQL.Celo.Resolvers.TokenTransfer do
   alias Explorer.GraphQL.Celo, as: GraphQL
   alias Explorer.Repo
 
-  def get_by(_, args, _) do
-    connection_args = Map.take(args, [:after, :before, :first, :last])
-
-    GraphQL.token_tx_transfers_query()
-    |> Connection.from_query(&Repo.all/1, connection_args, options(args))
+  def get_by(%{transaction_hash: hash}, args, _) do
+    hash
+    |> GraphQL.token_tx_transfers_query_by_txhash()
+    |> Connection.from_query(&Repo.all/1, args, options(args))
   end
 
   defp options(%{before: _}), do: []

--- a/apps/block_scout_web/lib/block_scout_web/graphql/celo/resolvers/token_transfer_tx.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/celo/resolvers/token_transfer_tx.ex
@@ -19,13 +19,6 @@ defmodule BlockScoutWeb.GraphQL.Celo.Resolvers.TokenTransferTx do
     |> Connection.from_query(&Repo.all/1, connection_args, options(args))
   end
 
-  def get_by(_, args, _) do
-    connection_args = Map.take(args, [:after, :before, :first, :last])
-
-    GraphQL.token_tx_transfers_query()
-    |> Connection.from_query(&Repo.all/1, connection_args, options(args))
-  end
-
   defp options(%{before: _}), do: []
 
   defp options(%{count: count}), do: [count: count]

--- a/apps/explorer/lib/explorer/graphql/celo.ex
+++ b/apps/explorer/lib/explorer/graphql/celo.ex
@@ -86,6 +86,16 @@ defmodule Explorer.GraphQL.Celo do
     )
   end
 
+  @doc """
+  Constructs a query to fetch token transfers within a given transaction.
+
+  ## Parameters
+    - tx_hash: the hash of the transaction
+
+  ## Returns
+   - Ecto query
+  """
+  @spec token_tx_transfers_query_by_txhash(Hash.Full.t()) :: Ecto.Query.t()
   def token_tx_transfers_query_by_txhash(tx_hash) do
     query = token_tx_transfers_query()
 

--- a/apps/explorer/lib/explorer/graphql/celo.ex
+++ b/apps/explorer/lib/explorer/graphql/celo.ex
@@ -76,12 +76,23 @@ defmodule Explorer.GraphQL.Celo do
       )
 
     query
-    |> order_by([transaction: t],
+    |> order_by(
+      [transaction: t],
       desc: t.block_number,
       desc: t.hash,
       asc: t.nonce,
       desc: t.from_address_hash,
       desc: t.to_address_hash
+    )
+  end
+
+  def token_tx_transfers_query_by_txhash(tx_hash) do
+    query = token_tx_transfers_query()
+
+    from(
+      t in subquery(query),
+      where: t.transaction_hash == ^tx_hash,
+      order_by: [t.log_index]
     )
   end
 


### PR DESCRIPTION
## Motivation

Fix issue when `tokenTransferTxs` GraphQL query returned unrelated token transfers in the response.

## Changelog

### Bug Fixes

- Change the clause for the query
- Increase `API_GRAPHQL_MAX_COMPLEXITY`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
