### PR TITLE
fix: Handle delegatecall in state changes

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -8,7 +8,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
 
   alias Explorer.Chain.Transaction.StateChange
   alias Explorer.{Chain, PagingOptions, Repo}
-  alias Explorer.Chain.{BlockNumberHelper, Transaction, Wei}
+  alias Explorer.Chain.{BlockNumberHelper, InternalTransaction, Transaction, Wei}
   alias Explorer.Chain.Cache.StateChanges
   alias Indexer.Fetcher.OnDemand.CoinBalance, as: CoinBalanceOnDemand
   alias Indexer.Fetcher.OnDemand.TokenBalance, as: TokenBalanceOnDemand
@@ -113,6 +113,8 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
       &internal_transaction_to_coin_balances(&1, previous_block_number, options, &2)
     )
   end
+
+  defp internal_transaction_to_coin_balances(%InternalTransaction{call_type: :delegatecall}, _, _, acc), do: acc
 
   defp internal_transaction_to_coin_balances(internal_transaction, previous_block_number, options, acc) do
     if internal_transaction.value |> Wei.to(:wei) |> Decimal.positive?() do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -1039,7 +1039,11 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       internal_transaction_from = insert(:address)
       internal_transaction_to = insert(:address)
 
+      internal_transaction_from_delegatecall = insert(:address)
+      internal_transaction_to_delegatecall = insert(:address)
+
       insert(:internal_transaction,
+        call_type: :call,
         transaction: transaction,
         index: 0,
         block_number: transaction.block_number,
@@ -1053,13 +1057,30 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         to_address: internal_transaction_to
       )
 
+      # must be ignored, hence we expect only 5 state changes
       insert(:internal_transaction,
+        call_type: :delegatecall,
         transaction: transaction,
         index: 1,
         block_number: transaction.block_number,
         transaction_index: transaction.index,
         block_hash: transaction.block_hash,
         block_index: 1,
+        value: %Wei{value: Decimal.new(7)},
+        from_address_hash: internal_transaction_from_delegatecall.hash,
+        from_address: internal_transaction_from_delegatecall,
+        to_address_hash: internal_transaction_to_delegatecall.hash,
+        to_address: internal_transaction_to_delegatecall
+      )
+
+      insert(:internal_transaction,
+        call_type: :call,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        block_hash: transaction.block_hash,
+        block_index: 2,
         value: %Wei{value: Decimal.new(7)},
         from_address_hash: internal_transaction_from.hash,
         from_address: internal_transaction_from,
@@ -1070,31 +1091,36 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       insert(:address_coin_balance,
         address: transaction.from_address,
         address_hash: transaction.from_address_hash,
-        block_number: block_before.number
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
       )
 
       insert(:address_coin_balance,
         address: transaction.to_address,
         address_hash: transaction.to_address_hash,
-        block_number: block_before.number
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
       )
 
       insert(:address_coin_balance,
         address: transaction.block.miner,
         address_hash: transaction.block.miner_hash,
-        block_number: block_before.number
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
       )
 
       insert(:address_coin_balance,
         address: internal_transaction_from,
         address_hash: internal_transaction_from.hash,
-        block_number: block_before.number
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
       )
 
       insert(:address_coin_balance,
         address: internal_transaction_to,
         address_hash: internal_transaction_to.hash,
-        block_number: block_before.number
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
       )
 
       request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/state-changes")

--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -56,6 +56,9 @@ defmodule Explorer.Chain.Transaction.StateChange do
     end
   end
 
+  defp update_coin_balances_from_internal_tx(%InternalTransaction{call_type: :delegatecall}, coin_balances),
+    do: coin_balances
+
   defp update_coin_balances_from_internal_tx(%InternalTransaction{index: 0}, coin_balances), do: coin_balances
 
   defp update_coin_balances_from_internal_tx(internal_tx, coin_balances) do


### PR DESCRIPTION
Fix #10821

## Changelog
Turned out that delegatecalls does not affect coin balances, so we need to ignore them in state changes calculations

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
