### PR TITLE
fix: add missing block timestamp in election rewards for address

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
@@ -221,11 +221,12 @@ defmodule BlockScoutWeb.API.V2.CeloView do
     }
   end
 
-  defp prepare_election_reward(%ElectionReward{token: %Token{}} = reward) do
+  defp prepare_election_reward(%ElectionReward{token: %Token{}, block: %Block{}} = reward) do
     %{
       amount: reward.amount,
       block_number: reward.block.number,
       block_hash: reward.block_hash,
+      block_timestamp: reward.block.timestamp,
       epoch_number: reward.block.number |> CeloHelper.block_number_to_epoch_number(),
       account:
         Helper.address_with_info(


### PR DESCRIPTION
We need to display when the block appeared for Election rewards tab on Address view.

![image](https://github.com/user-attachments/assets/959dbe82-4d38-44f8-8bc4-e8c671286d24)

**TODO:** create task on frontend to support this change.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
