### PR TITLE
feat: Multiple json rpc urls

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -226,11 +226,14 @@ defmodule BlockScoutWeb.SmartContractView do
   def cut_rpc_url(error) do
     transport_options = Application.get_env(:explorer, :json_rpc_named_arguments)[:transport_options]
 
-    error
-    |> String.replace(transport_options[:url], "rpc_url")
-    |> (&if(transport_options[:fallback_url],
-          do: String.replace(&1, transport_options[:fallback_url], "rpc_url"),
-          else: &1
-        )).()
+    all_urls =
+      (transport_options[:urls] || []) ++
+        (transport_options[:trace_urls] || []) ++
+        (transport_options[:eth_call_urls] || []) ++
+        (transport_options[:fallback_urls] || []) ++
+        (transport_options[:fallback_trace_urls] || []) ++
+        (transport_options[:fallback_eth_call_urls] || [])
+
+    String.replace(error, Enum.reject(all_urls, &(&1 in [nil, ""])), "rpc_url")
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -552,7 +552,7 @@ defmodule EthereumJSONRPC do
     CommonHelper.put_in_keyword_nested(
       json_rpc_named_arguments,
       [:transport_options, :method_to_url, :eth_getBalance],
-      System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+      :trace
     )
   end
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/common_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/common_helper.ex
@@ -30,6 +30,17 @@ defmodule EthereumJSONRPC.Utility.CommonHelper do
     Keyword.put(keyword || [], nearest_path, put_in_keyword_nested(keyword[nearest_path], rest_path, value))
   end
 
+  @doc """
+  Extracts urls corresponding to `url_type` from json rpc transport options
+  """
+  @spec url_type_to_urls(atom(), Keyword.t(), atom() | String.t()) :: [String.t()]
+  def url_type_to_urls(url_type, json_rpc_transport_options, subtype \\ nil) do
+    key_prefix = (subtype && "#{subtype}_") || ""
+    url_prefix = (url_type == :http && "") || "#{url_type}_"
+    urls_key = String.to_existing_atom("#{key_prefix}#{url_prefix}urls")
+    json_rpc_transport_options[urls_key]
+  end
+
   defp convert_to_ms(number, "s"), do: :timer.seconds(number)
   defp convert_to_ms(number, "m"), do: :timer.minutes(number)
   defp convert_to_ms(number, "h"), do: :timer.hours(number)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
@@ -40,8 +40,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
           {:ok, _number} ->
             url = json_rpc_named_arguments[:transport_options][:url]
 
-            EndpointAvailabilityObserver.enable_endpoint(url, url_type)
-            log_url_available(url, url_type, json_rpc_named_arguments)
+            EndpointAvailabilityObserver.enable_endpoint(url, url_type, json_rpc_named_arguments)
             acc
 
           _ ->
@@ -54,17 +53,8 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
     {:noreply, %{state | unavailable_endpoints_arguments: new_unavailable_endpoints}}
   end
 
-  defp log_url_available(url, url_type, json_rpc_named_arguments) do
-    message_extra =
-      if EndpointAvailabilityObserver.fallback_url_set?(url_type, json_rpc_named_arguments),
-        do: ", switching back to it",
-        else: ""
-
-    Logger.info("URL #{inspect(url)} is available now#{message_extra}")
-  end
-
   defp fetch_latest_block_number(json_rpc_named_arguments) do
-    {_, arguments_without_fallback} = pop_in(json_rpc_named_arguments, [:transport_options, :fallback_url])
+    {_, arguments_without_fallback} = pop_in(json_rpc_named_arguments, [:transport_options, :fallback_urls])
 
     %{id: 0, method: "eth_blockNumber", params: []}
     |> EthereumJSONRPC.request()

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
@@ -148,7 +148,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
 
       current_count + 1 >= @max_error_count ->
         EndpointAvailabilityChecker.add_endpoint(
-          put_in(json_rpc_named_arguments[:transport_options][:url], url),
+          put_in(json_rpc_named_arguments[:transport_options][:urls], [url]),
           url_type
         )
 

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -12,14 +12,33 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -12,14 +12,33 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/filecoin.exs
+++ b/apps/explorer/config/dev/filecoin.exs
@@ -12,13 +12,36 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:1234/rpc/v1",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_HTTP_URLS",
+          "ETHEREUM_JSONRPC_HTTP_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:1234/rpc/v1"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:1234/rpc/v1"
+        eth_call: :eth_call,
+        trace_block: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/ganache.exs
+++ b/apps/explorer/config/dev/ganache.exs
@@ -12,11 +12,23 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:7545"),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:7545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:7545")
+        eth_call: :eth_call
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -12,14 +12,33 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        debug_traceTransaction: :trace,
+        debug_traceBlockByNumber: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -12,14 +12,33 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -12,14 +12,33 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -12,14 +12,22 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -12,14 +12,22 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/filecoin.exs
+++ b/apps/explorer/config/prod/filecoin.exs
@@ -12,13 +12,21 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        trace_block: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/ganache.exs
+++ b/apps/explorer/config/prod/ganache.exs
@@ -12,11 +12,17 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url()
+        eth_call: :eth_call
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -12,14 +12,22 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        debug_traceTransaction: :trace,
+        debug_traceBlockByNumber: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -12,14 +12,22 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -12,14 +12,22 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
+++ b/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
@@ -42,7 +42,7 @@ defmodule Explorer.Chain.Cache.OptimismFinalizationPeriod do
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
         http: EthereumJSONRPC.HTTP.HTTPoison,
-        url: optimism_l1_rpc,
+        urls: [optimism_l1_rpc],
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -756,6 +756,13 @@ defmodule Explorer.ChainTest do
 
       insert(:pending_block_operation, block: block, block_number: block.number)
 
+      configuration = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: false)
+
+      on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, configuration)
+      end)
+
       refute Chain.finished_indexing_internal_transactions?()
     end
   end
@@ -1066,9 +1073,12 @@ defmodule Explorer.ChainTest do
     setup do
       Supervisor.terminate_child(Explorer.Supervisor, PendingBlockOperationCache.child_id())
       Supervisor.restart_child(Explorer.Supervisor, PendingBlockOperationCache.child_id())
+      configuration = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: false)
 
       on_exit(fn ->
         Application.put_env(:indexer, :trace_first_block, 0)
+        Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, configuration)
         Supervisor.terminate_child(Explorer.Supervisor, PendingBlockOperationCache.child_id())
       end)
     end

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -18,16 +18,35 @@ config :indexer,
     else: EthereumJSONRPC.IPC,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -18,16 +18,35 @@ config :indexer,
     else: EthereumJSONRPC.IPC,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/filecoin.exs
+++ b/apps/indexer/config/dev/filecoin.exs
@@ -17,13 +17,36 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:1234/rpc/v1",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_HTTP_URLS",
+          "ETHEREUM_JSONRPC_HTTP_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:1234/rpc/v1"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:1234/rpc/v1"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:1234/rpc/v1"
+        eth_call: :eth_call,
+        trace_block: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -17,11 +17,23 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:7545"),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:7545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:7545")
+        eth_call: :eth_call
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -17,14 +17,33 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        debug_traceTransaction: :trace,
+        debug_traceBlockByNumber: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -18,16 +18,35 @@ config :indexer,
     else: EthereumJSONRPC.IPC,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -19,16 +19,35 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:8545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:8545"),
+      trace_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_TRACE_URLS",
+          "ETHEREUM_JSONRPC_TRACE_URL",
+          "http://localhost:8545"
+        ),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:8545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:8545"),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545",
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL") || "http://localhost:8545"
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -17,16 +17,24 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -17,16 +17,24 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/filecoin.exs
+++ b/apps/indexer/config/prod/filecoin.exs
@@ -17,13 +17,21 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        trace_block: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -17,11 +17,23 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || "http://localhost:7545",
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL", "http://localhost:7545"),
+      eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_ETH_CALL_URL",
+          "http://localhost:7545"
+        ),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url("http://localhost:7545")
+        eth_call: :eth_call
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -17,14 +17,22 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        debug_traceTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        debug_traceBlockByNumber: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        debug_traceTransaction: :trace,
+        debug_traceBlockByNumber: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -17,16 +17,24 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -19,16 +19,24 @@ config :indexer,
       ),
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      url: System.get_env("ETHEREUM_JSONRPC_HTTP_URL"),
-      fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
-      fallback_trace_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
-      fallback_eth_call_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"),
+      urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_HTTP_URLS", "ETHEREUM_JSONRPC_HTTP_URL"),
+      trace_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_TRACE_URLS", "ETHEREUM_JSONRPC_TRACE_URL"),
+      eth_call_urls: ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_ETH_CALL_URLS", "ETHEREUM_JSONRPC_ETH_CALL_URL"),
+      fallback_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS", "ETHEREUM_JSONRPC_FALLBACK_HTTP_URL"),
+      fallback_trace_urls:
+        ConfigHelper.parse_urls_list("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS", "ETHEREUM_JSONRPC_FALLBACK_TRACE_URL"),
+      fallback_eth_call_urls:
+        ConfigHelper.parse_urls_list(
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS",
+          "ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL"
+        ),
       method_to_url: [
-        eth_call: ConfigHelper.eth_call_url(),
-        eth_getBalance: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_block: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayBlockTransactions: System.get_env("ETHEREUM_JSONRPC_TRACE_URL"),
-        trace_replayTransaction: System.get_env("ETHEREUM_JSONRPC_TRACE_URL")
+        eth_call: :eth_call,
+        eth_getBalance: :trace,
+        trace_block: :trace,
+        trace_replayBlockTransactions: :trace,
+        trace_replayTransaction: :trace
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -54,6 +54,13 @@ defmodule Indexer.Block.FetcherTest do
         poll: false
       )
 
+      configuration = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor)
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: false)
+
+      on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction.Supervisor, configuration)
+      end)
+
       ContractCode.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
       Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -337,4 +337,13 @@ defmodule ConfigHelper do
   def eth_call_url(default \\ nil) do
     System.get_env("ETHEREUM_JSONRPC_ETH_CALL_URL") || System.get_env("ETHEREUM_JSONRPC_HTTP_URL") || default
   end
+
+  def parse_urls_list(urls_var, url_var, default_url \\ nil) do
+    default = default_url || System.get_env("ETHEREUM_JSONRPC_HTTP_URL")
+
+    case parse_list_env_var(urls_var) do
+      [] -> [safe_get_env(url_var, default)]
+      urls -> urls
+    end
+  end
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -175,10 +175,13 @@ config :ueberauth, Ueberauth, logout_url: "https://#{System.get_env("ACCOUNT_AUT
 ### Ethereum JSONRPC ###
 ########################
 
+trace_url_missing? = System.get_env("ETHEREUM_JSONRPC_TRACE_URL") in ["", nil]
+
 config :ethereum_jsonrpc,
   rpc_transport: if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http", do: :http, else: :ipc),
   ipc_path: System.get_env("IPC_PATH"),
-  disable_archive_balances?: ConfigHelper.parse_bool_env_var("ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES"),
+  disable_archive_balances?:
+    trace_url_missing? or ConfigHelper.parse_bool_env_var("ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES"),
   archive_balances_window: ConfigHelper.parse_integer_env_var("ETHEREUM_JSONRPC_ARCHIVE_BALANCES_WINDOW", 200)
 
 config :ethereum_jsonrpc, EthereumJSONRPC.HTTP,
@@ -761,7 +764,7 @@ config :indexer, Indexer.Fetcher.BlockReward.Supervisor,
   disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_BLOCK_REWARD_FETCHER")
 
 config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor,
-  disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
+  disabled?: trace_url_missing? or ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
 
 disable_coin_balances_fetcher? = ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ADDRESS_COIN_BALANCE_FETCHER")
 


### PR DESCRIPTION
## Changelog

Introduced an ability to specify json rpc urls as a list. Each json rpc request will pick a random url from this list. All json rpc url env variables have been replaced with analogues for multiple use:
```
ETHEREUM_JSONRPC_HTTP_URL -> ETHEREUM_JSONRPC_HTTP_URLS
ETHEREUM_JSONRPC_TRACE_URL -> ETHEREUM_JSONRPC_TRACE_URLS
ETHEREUM_JSONRPC_ETH_CALL_URL -> ETHEREUM_JSONRPC_ETH_CALL_URLS
ETHEREUM_JSONRPC_FALLBACK_HTTP_URL -> ETHEREUM_JSONRPC_FALLBACK_HTTP_URLS
ETHEREUM_JSONRPC_FALLBACK_TRACE_URL -> ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS
ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL -> ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URLS
```
All previous variables names are kept for backwards compatibility.

Fallback urls usage logic now follows these rules:
- If some of primary json rpc url is unavailable, it is disabled until it will be available again (grouped by type: `http`, `trace`, `eth_call`)
- If all of the primary urls of some group are unavailable, fallback urls for this group are used

Docs update: https://github.com/blockscout/docs/pull/332
