### PR TITLE
fix: filter out nil implementations from combine_proxy_implementation_addresses_map function

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2058,6 +2058,7 @@ defmodule Explorer.Chain.Transaction do
         |> Enum.map(fn implementation_address_hash ->
           Map.get(implementation_addresses_with_smart_contracts, implementation_address_hash)
         end)
+        |> Enum.filter(&(!is_nil(&1)))
 
       proxy_implementation_addresses_map
       |> Map.put(proxy_implementations.proxy_address_hash, implementation_addresses_with_smart_contract_preload)


### PR DESCRIPTION
## Motivation

Resolve https://github.com/blockscout/blockscout/issues/10942

## Changelog

Filter out nil implementations from the result of `combine_proxy_implementation_addresses_map/1` function.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
