### PR TITLE
fix: Process foreign key violation in the Scam addresses assignment functionality

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -747,37 +747,6 @@ defmodule Explorer.Chain do
   def confirmations(nil, _), do: {:error, :pending}
 
   @doc """
-  Creates an address.
-
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
-      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"}
-      ...> )
-      ...> to_string(hash)
-      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
-
-  A `String.t/0` value for `Explorer.Chain.Address.t/0` `hash` must have 40 hexadecimal characters after the `0x` prefix
-  to prevent short- and long-hash transcription errors.
-
-      iex> {:error, %Ecto.Changeset{errors: errors}} = Explorer.Chain.create_address(
-      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0"}
-      ...> )
-      ...> errors
-      [hash: {"is invalid", [type: Explorer.Chain.Hash.Address, validation: :cast]}]
-      iex> {:error, %Ecto.Changeset{errors: errors}} = Explorer.Chain.create_address(
-      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0ba"}
-      ...> )
-      ...> errors
-      [hash: {"is invalid", [type: Explorer.Chain.Hash.Address, validation: :cast]}]
-
-  """
-  @spec create_address(map()) :: {:ok, Address.t()} | {:error, Ecto.Changeset.t()}
-  def create_address(attrs \\ %{}) do
-    %Address{}
-    |> Address.changeset(attrs)
-    |> Repo.insert()
-  end
-
-  @doc """
   Creates a decompiled smart contract.
   """
 
@@ -943,7 +912,7 @@ defmodule Explorer.Chain do
 
   Returns `{:ok, %Explorer.Chain.Address{}}` if found
 
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
       ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
       ...> )
       iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
@@ -1042,7 +1011,7 @@ defmodule Explorer.Chain do
 
   Returns `{:ok, %Explorer.Chain.Address{}}` if found
 
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
       ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
       ...> )
       iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
@@ -1051,7 +1020,7 @@ defmodule Explorer.Chain do
 
   Returns `{:error, address}` if not found but created an address
 
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
       ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
       ...> )
       iex> {:ok, %Explorer.Chain.Address{hash: found_hash}} = Explorer.Chain.hash_to_address(hash)
@@ -1088,7 +1057,7 @@ defmodule Explorer.Chain do
         {:ok, address}
 
       {:error, :not_found} ->
-        create_address(%{hash: to_string(hash)})
+        Address.create(%{hash: to_string(hash)})
         hash_to_address(hash, options, query_decompiled_code_flag)
     end
   end

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -205,6 +205,54 @@ defmodule Explorer.Chain.Address do
 
   @balance_changeset_required_attrs @required_attrs ++ ~w(fetched_coin_balance fetched_coin_balance_block_number)a
 
+  @doc """
+  Creates an address.
+
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
+      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"}
+      ...> )
+      ...> to_string(hash)
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+
+  A `String.t/0` value for `Explorer.Chain.Address.t/0` `hash` must have 40 hexadecimal characters after the `0x` prefix
+  to prevent short- and long-hash transcription errors.
+
+      iex> {:error, %Ecto.Changeset{errors: errors}} = Explorer.Chain.Address.create(
+      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0"}
+      ...> )
+      ...> errors
+      [hash: {"is invalid", [type: Explorer.Chain.Hash.Address, validation: :cast]}]
+      iex> {:error, %Ecto.Changeset{errors: errors}} = Explorer.Chain.Address.create(
+      ...>   %{hash: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0ba"}
+      ...> )
+      ...> errors
+      [hash: {"is invalid", [type: Explorer.Chain.Hash.Address, validation: :cast]}]
+
+  """
+  @spec create(map()) :: {:ok, __MODULE__.t()} | {:error, Ecto.Changeset.t()}
+  def create(attrs \\ %{}) do
+    %__MODULE__{}
+    |> changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Creates multiple instances of a `Explorer.Chain.Address`.
+
+  ## Parameters
+
+    - address_insert_params: List of address changesets to create.
+
+  ## Returns
+
+    - A list of created resource instances.
+
+  """
+  @spec create_multiple(list()) :: {non_neg_integer(), nil | [term()]}
+  def create_multiple(address_insert_params) do
+    Repo.insert_all(Address, address_insert_params, on_conflict: :nothing, returning: [:hash])
+  end
+
   def balance_changeset(%__MODULE__{} = address, attrs) do
     address
     |> cast(attrs, @allowed_attrs)
@@ -518,7 +566,7 @@ defmodule Explorer.Chain.Address do
 
   Returns `:ok` if found
 
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
       ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
       ...> )
       iex> Explorer.Address.check_address_exists(hash)
@@ -543,7 +591,7 @@ defmodule Explorer.Chain.Address do
 
   Returns `true` if found
 
-      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.create_address(
+      iex> {:ok, %Explorer.Chain.Address{hash: hash}} = Explorer.Chain.Address.create(
       ...>   %{hash: "0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"}
       ...> )
       iex> Explorer.Chain.Address.address_exists?(hash)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10976
Addition to https://github.com/blockscout/blockscout/pull/10763

## Motivation

Foreign key violation when assigning `scam` label to the address, which is not present in the `addresses` table.

## Changelog

If the foreign key violation error arose at the scam address assignment, insert missing addresses and then repeat the assignment.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
