### PR TITLE
fix: Handle import exceptions in MassiveBlocksFetcher

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/massive_blocks_fetcher.ex
@@ -58,7 +58,7 @@ defmodule Indexer.Block.Catchup.MassiveBlocksFetcher do
   defp process_block(block_fetcher, number) do
     case Fetcher.fetch_and_import_range(block_fetcher, number..number, %{timeout: :infinity}) do
       {:ok, _result} ->
-        Logger.info("MassiveBlockFetcher successfully proceed block #{inspect(number)}")
+        Logger.info("MassiveBlockFetcher successfully processed block #{inspect(number)}")
         MassiveBlock.delete_block_number(number)
         []
 
@@ -66,6 +66,10 @@ defmodule Indexer.Block.Catchup.MassiveBlocksFetcher do
         Logger.error("MassiveBlockFetcher failed: #{inspect(error)}")
         [number]
     end
+  rescue
+    error ->
+      Logger.error("MassiveBlockFetcher failed: #{inspect(error)}")
+      [number]
   end
 
   defp generate_block_fetcher do


### PR DESCRIPTION
## Motivation

In case of `MassiveBlocksFetcher` crashes frequently, the `Catchup.Supervisor` will be terminated when `max_restarts` reached. It means that its other children (`MissingRangesCollector` and catchup fetcher) will be terminated as well.

## Changelog

Handle `MassiveBlocksFetcher` exceptions so the `Catchup.Supervisor`'s children won't be unnecessary restarted.