### PR TITLE
fix: Handle stalled async task in MapCache

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/address_sum.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum.ex
@@ -17,9 +17,10 @@ defmodule Explorer.Chain.Cache.AddressSum do
   alias Explorer.Etherscan
 
   defp handle_fallback(:sum) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, Decimal.new(0)}
   end
@@ -49,7 +50,7 @@ defmodule Explorer.Chain.Cache.AddressSum do
 
   # By setting this as a `callback` an async task will be started each time the
   # `sum` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :sum}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :sum}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 end

--- a/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
+++ b/apps/explorer/lib/explorer/chain/cache/address_sum_minus_burnt.ex
@@ -17,9 +17,10 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
   alias Explorer.Chain.Cache.Helper
 
   defp handle_fallback(:sum_minus_burnt) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, Decimal.new(0)}
   end
@@ -56,7 +57,7 @@ defmodule Explorer.Chain.Cache.AddressSumMinusBurnt do
 
   # By setting this as a `callback` an async task will be started each time the
   # `sum_minus_burnt` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :sum_minus_burnt}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :sum_minus_burnt}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 end

--- a/apps/explorer/lib/explorer/chain/cache/block.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block.ex
@@ -56,9 +56,10 @@ defmodule Explorer.Chain.Cache.Block do
   end
 
   defp handle_fallback(:count) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, nil}
   end
@@ -95,7 +96,7 @@ defmodule Explorer.Chain.Cache.Block do
 
   # By setting this as a `callback` an async task will be started each time the
   # `count` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :count}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :count}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 

--- a/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_price_oracle.ex
@@ -310,9 +310,10 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
   defp fast_time_coefficient, do: Application.get_env(:explorer, __MODULE__)[:fast_time_coefficient]
 
   defp handle_fallback(:gas_prices) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, get_old_gas_prices()}
   end
@@ -353,7 +354,7 @@ defmodule Explorer.Chain.Cache.GasPriceOracle do
   # `gas_prices` expires (unless there is one already running)
   defp async_task_on_deletion({:delete, _, :gas_prices}) do
     set_old_gas_prices(get_gas_prices())
-    get_async_task()
+    safe_get_async_task()
   end
 
   defp async_task_on_deletion(_data), do: nil

--- a/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
+++ b/apps/explorer/lib/explorer/chain/cache/gas_usage.ex
@@ -37,9 +37,10 @@ defmodule Explorer.Chain.Cache.GasUsage do
   end
 
   defp handle_fallback(:sum) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, nil}
   end
@@ -73,7 +74,7 @@ defmodule Explorer.Chain.Cache.GasUsage do
 
   # By setting this as a `callback` an async task will be started each time the
   # `sum` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :sum}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :sum}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 

--- a/apps/explorer/lib/explorer/chain/cache/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/cache/pending_block_operation.ex
@@ -35,9 +35,10 @@ defmodule Explorer.Chain.Cache.PendingBlockOperation do
   end
 
   defp handle_fallback(:count) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, nil}
   end
@@ -67,7 +68,7 @@ defmodule Explorer.Chain.Cache.PendingBlockOperation do
 
   # By setting this as a `callback` an async task will be started each time the
   # `count` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :count}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :count}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 end

--- a/apps/explorer/lib/explorer/chain/cache/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/cache/transaction.ex
@@ -36,9 +36,10 @@ defmodule Explorer.Chain.Cache.Transaction do
   end
 
   defp handle_fallback(:count) do
-    # This will get the task PID if one exists and launch a new task if not
+    # This will get the task PID if one exists, check if it's running and launch
+    # a new task if task doesn't exist or it's not running.
     # See next `handle_fallback` definition
-    get_async_task()
+    safe_get_async_task()
 
     {:return, nil}
   end
@@ -68,7 +69,7 @@ defmodule Explorer.Chain.Cache.Transaction do
 
   # By setting this as a `callback` an async task will be started each time the
   # `count` expires (unless there is one already running)
-  defp async_task_on_deletion({:delete, _, :count}), do: get_async_task()
+  defp async_task_on_deletion({:delete, _, :count}), do: safe_get_async_task()
 
   defp async_task_on_deletion(_data), do: nil
 end


### PR DESCRIPTION
Fix #10787
Fix #11026

## Changelog

Check if async task in cache executes at the moment, delete it from cache and create a new one otherwise


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
