### PR TITLE
feat: Switch DB requests from replica to master in case of replica inaccessibility

### DIFF
--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -82,7 +82,8 @@ defmodule Explorer.Application do
       con_cache_child_spec(MarketHistoryCache.cache_name()),
       con_cache_child_spec(RSK.cache_name(), ttl_check_interval: :timer.minutes(1), global_ttl: :timer.minutes(30)),
       {Redix, redix_opts()},
-      {Explorer.Utility.MissingRangesManipulator, []}
+      {Explorer.Utility.MissingRangesManipulator, []},
+      {Explorer.Utility.ReplicaAccessibilityManager, []}
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -111,8 +111,10 @@ defmodule Explorer.Repo do
   if Mix.env() == :test do
     def replica, do: __MODULE__
   else
-    def replica, do: Explorer.Repo.Replica1
+    def replica, do: (Application.get_env(:explorer, :replica_inaccessible?) && Explorer.Repo) || replica_repo()
   end
+
+  def replica_repo, do: Explorer.Repo.Replica1
 
   def account_repo, do: Explorer.Repo.Account
 

--- a/apps/explorer/lib/explorer/utility/replica_accessibility_manager.ex
+++ b/apps/explorer/lib/explorer/utility/replica_accessibility_manager.ex
@@ -1,0 +1,65 @@
+defmodule Explorer.Utility.ReplicaAccessibilityManager do
+  @moduledoc """
+  Module responsible for periodically checking replica accessibility.
+  """
+
+  use GenServer
+
+  alias Explorer.Repo
+
+  @interval :timer.seconds(10)
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    if System.get_env("DATABASE_READ_ONLY_API_URL") do
+      schedule_next_check(0)
+
+      {:ok, %{}}
+    else
+      :ignore
+    end
+  end
+
+  def handle_info(:check, state) do
+    check()
+    schedule_next_check(@interval)
+
+    {:noreply, state}
+  end
+
+  defp check do
+    case Repo.replica_repo().query(query()) do
+      {:ok, %{rows: [[is_slave, lag]]}} ->
+        replica_inaccessible? = is_slave and :timer.seconds(lag || 0) > max_lag()
+        set_replica_inaccessibility(replica_inaccessible?)
+
+      _ ->
+        set_replica_inaccessibility(true)
+    end
+  end
+
+  defp query do
+    """
+    SELECT pg_is_in_recovery(), (
+       EXTRACT(EPOCH FROM now()) -
+       EXTRACT(EPOCH FROM pg_last_xact_replay_timestamp())
+      )::int;
+    """
+  end
+
+  defp max_lag do
+    Application.get_env(:explorer, :replica_max_lag)
+  end
+
+  defp set_replica_inaccessibility(inaccessible?) do
+    Application.put_env(:explorer, :replica_inaccessible?, inaccessible?)
+  end
+
+  defp schedule_next_check(interval) do
+    Process.send_after(self(), :check, interval)
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -242,7 +242,8 @@ config :explorer,
   elasticity_multiplier: ConfigHelper.parse_integer_env_var("EIP_1559_ELASTICITY_MULTIPLIER", 2),
   base_fee_max_change_denominator: ConfigHelper.parse_integer_env_var("EIP_1559_BASE_FEE_MAX_CHANGE_DENOMINATOR", 8),
   csv_export_limit: ConfigHelper.parse_integer_env_var("CSV_EXPORT_LIMIT", 10_000),
-  shrink_internal_transactions_enabled: ConfigHelper.parse_bool_env_var("SHRINK_INTERNAL_TRANSACTIONS_ENABLED")
+  shrink_internal_transactions_enabled: ConfigHelper.parse_bool_env_var("SHRINK_INTERNAL_TRANSACTIONS_ENABLED"),
+  replica_max_lag: ConfigHelper.parse_time_env_var("REPLICA_MAX_LAG", "5m")
 
 config :explorer, :proxy,
   caching_implementation_data_enabled: true,

--- a/cspell.json
+++ b/cspell.json
@@ -619,6 +619,7 @@
         "whereis",
         "whiler",
         "wysdvjkizxonu",
+        "xact",
         "xakgj",
         "xbaddress",
         "xdai",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8111

## Changelog

- Added `ReplicaAccessibilityManager` module that periodically checks the accessibility of replica and sets the result to application variable
- All requests to replica are redirected to main DB depending on the value of the mentioned variable
- Added env variable `REPLICA_MAX_LAG` (check issue for details)

Docs update: https://github.com/blockscout/docs/pull/334