### PR TITLE
fix: divide by `10^decimals` when calculating token supply in CMC format

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -14,7 +14,15 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
       if Map.get(params, "cmc") == "true" do
         conn
         |> put_resp_content_type("text/plain")
-        |> send_resp(200, token.total_supply && to_cmc_total_supply(token.total_supply))
+        |> send_resp(
+          200,
+          token.total_supply &&
+            token.decimals &&
+            to_cmc_total_supply(
+              token.total_supply,
+              token.decimals
+            )
+        )
       else
         conn
         |> render(
@@ -89,11 +97,10 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     {:format, Chain.string_to_address_hash(address_hash_string)}
   end
 
-  @spec to_cmc_total_supply(Decimal.t()) :: String.t()
-  defp to_cmc_total_supply(total_supply) do
+  @spec to_cmc_total_supply(Decimal.t(), Decimal.t()) :: String.t()
+  defp to_cmc_total_supply(total_supply, decimals) do
     total_supply
-    |> Wei.from(:wei)
-    |> Wei.to(:ether)
+    |> Decimal.div(Decimal.new(1, 1, Decimal.to_integer(decimals)))
     |> Decimal.round(@cmc_token_supply_precision)
     |> Decimal.to_string()
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -99,8 +99,13 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
 
   @spec to_cmc_total_supply(Decimal.t(), Decimal.t()) :: String.t()
   defp to_cmc_total_supply(total_supply, decimals) do
+    divider =
+      1
+      |> Decimal.new(1, Decimal.to_integer(decimals))
+      |> Decimal.to_integer()
+
     total_supply
-    |> Decimal.div(Decimal.new(1, 1, Decimal.to_integer(decimals)))
+    |> Decimal.div(divider)
     |> Decimal.round(@cmc_token_supply_precision)
     |> Decimal.to_string()
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/stats_controller.ex
@@ -17,7 +17,6 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
         |> send_resp(
           200,
           token.total_supply &&
-            token.decimals &&
             to_cmc_total_supply(
               token.total_supply,
               token.decimals
@@ -97,11 +96,11 @@ defmodule BlockScoutWeb.API.RPC.StatsController do
     {:format, Chain.string_to_address_hash(address_hash_string)}
   end
 
-  @spec to_cmc_total_supply(Decimal.t(), Decimal.t()) :: String.t()
+  @spec to_cmc_total_supply(Decimal.t(), Decimal.t() | nil) :: String.t()
   defp to_cmc_total_supply(total_supply, decimals) do
     divider =
       1
-      |> Decimal.new(1, Decimal.to_integer(decimals))
+      |> Decimal.new(1, Decimal.to_integer(decimals || Decimal.new(0)))
       |> Decimal.to_integer()
 
     total_supply

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -125,6 +125,28 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
     end
   end
 
+  test "with null decimals and cmc format", %{conn: conn} do
+    token =
+      insert(:token,
+        total_supply: 1_234_567_890,
+        decimals: nil
+      )
+
+    params = %{
+      "module" => "stats",
+      "action" => "tokensupply",
+      "contractaddress" => to_string(token.contract_address_hash),
+      "cmc" => "true"
+    }
+
+    assert response =
+             conn
+             |> get("/api", params)
+             |> text_response(200)
+
+    assert response == "1234567890.000000000"
+  end
+
   describe "ethsupplyexchange" do
     test "returns total supply from exchange", %{conn: conn} do
       params = %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/stats_controller_test.exs
@@ -101,6 +101,28 @@ defmodule BlockScoutWeb.API.RPC.StatsControllerTest do
 
       assert response == "110052089.716627912"
     end
+
+    test "with custom decimals and cmc format", %{conn: conn} do
+      token =
+        insert(:token,
+          total_supply: 1_234_567_890,
+          decimals: 6
+        )
+
+      params = %{
+        "module" => "stats",
+        "action" => "tokensupply",
+        "contractaddress" => to_string(token.contract_address_hash),
+        "cmc" => "true"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> text_response(200)
+
+      assert response == "1234.567890000"
+    end
   end
 
   describe "ethsupplyexchange" do


### PR DESCRIPTION
This PR resolves an issue with calculating token supply for CMC format by properly taking into account token decimals. Previously, we divided total_supply by $10^{18}$, regardless of the token's actual decimals, which led to incorrect values. Now, the division correctly uses $10^{\texttt{decimals}}$, aligning with the real token supply values.

### Changelog

- Updated token supply calculations to divide by $10^{\texttt{decimals}}$ instead of the hardcoded $10^{18}$.
- Added regression tests to ensure accurate handling of decimals in future calculations.

Additional Notes: This fix was prompted by a requirement from the Celo team, but the improvement is universally applied rather than restricted to Celo chains.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
