### PR TITLE
fix: Import blocks before coin balances

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/stage/block_related.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/block_related.ex
@@ -10,8 +10,8 @@ defmodule Explorer.Chain.Import.Stage.BlockRelated do
   @addresses_runner Runner.Addresses
 
   @rest_runners [
-    Runner.Address.CoinBalances,
     Runner.Blocks,
+    Runner.Address.CoinBalances,
     Runner.Address.CoinBalancesDaily,
     Runner.Transactions,
     Runner.TokenTransfers


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10879

## Motivation

In case of reorg, coin balances are deleted in blocks runner, but coin balances runner is located before blocks runner. It means that correct coin balances will be deleted along with reorged ones.