### PR TITLE
fix: Rename zksync l1/l2 _tx_count columns

### DIFF
--- a/apps/explorer/priv/zk_sync/migrations/20241028102407_rename_tx_count_fields_zksync.exs
+++ b/apps/explorer/priv/zk_sync/migrations/20241028102407_rename_tx_count_fields_zksync.exs
@@ -1,0 +1,8 @@
+defmodule Explorer.Repo.ZkSync.Migrations.RenameTxCountFieldsZksync do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:zksync_transaction_batches), :l1_tx_count, to: :l1_transaction_count)
+    rename(table(:zksync_transaction_batches), :l2_tx_count, to: :l2_transaction_count)
+  end
+end


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/10913

## Motivation

```
{"time":"2024-10-28T10:17:43.227Z","severity":"error","message":"GenServer Indexer.Fetcher.ZkSync.TransactionBatch terminating\n** (Postgrex.Error) ERROR 42703 (undefined_column) column \"l1_transaction_count\" of relation \"zksync_transaction_batches\" does not exist\n\n    query: INSERT INTO \"zksync_transaction_batches\" AS z0 (\"timestamp\",\"number\",\"inserted_at\",\"updated_at\",\"end_block\",\"start_block\",\"l1_transaction_count\",\"l2_transaction_count\",\"root_hash\",\"l1_gas_price\",\"l2_fair_gas_price\") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) ON CONFLICT (\"number\") DO UPDATE SET \"timestamp\" = EXCLUDED.timestamp, \"l1_transaction_count\" = EXCLUDED.l1_transaction_count, \"l2_transaction_count\" = EXCLUDED.l2_transaction_count, \"root_hash\" = EXCLUDED.root_hash, \"l1_gas_price\" = EXCLUDED.l1_gas_price, \"l2_fair_gas_price\" = EXCLUDED.l2_fair_gas_price, \"start_block\" = EXCLUDED.start_block, \"end_block\" = EXCLUDED.end_block, \"commit_id\" = EXCLUDED.commit_id, \"prove_id\" = EXCLUDED.prove_id, \"execute_id\" = EXCLUDED.execute_id, \"inserted_at\" = LEAST(z0.\"inserted_at\", EXCLUDED.inserted_at), \"updated_at\" = GREATEST(z0.\"updated_at\", EXCLUDED.updated_at) WHERE ((EXCLUDED.timestamp, EXCLUDED.l1_transaction_count, EXCLUDED.l2_transaction_count, EXCLUDED.root_hash, EXCLUDED.l1_gas_price, EXCLUDED.l2_fair_gas_price, EXCLUDED.start_block, EXCLUDED.end_block, EXCLUDED.commit_id, EXCLUDED.prove_id, EXCLUDED.execute_id) IS DISTINCT FROM (z0.\"timestamp\", z0.\"l1_transaction_count\", z0.\"l2_transaction_count\", z0.\"root_hash\", z0.\"l1_gas_price\", z0.\"l2_fair_gas_price\", z0.\"start_block\", z0.\"end_block\", z0.\"commit_id\", z0.\"prove_id\", z0.\"execute_id\")) RETURNING \"updated_at\",\"inserted_at\",\"execute_id\",\"prove_id\",\"commit_id\",\"end_block\",\"start_block\",\"l2_fair_gas_price\",\"l1_gas_price\",\"root_hash\",\"l2_transaction_count\",\"l1_transaction_count\",\"timestamp\",\"number\"\n    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1096: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:967: Ecto.Adapters.SQL.insert_all/9\n    (ecto 3.12.4) lib/ecto/repo/schema.ex:59: Ecto.Repo.Schema.do_insert_all/7\n    (explorer 6.9.0) lib/explorer/repo.ex:47: anonymous fn/5 in Explorer.Repo.safe_insert_all/3\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (explorer 6.9.0) lib/explorer/chain/import.ex:305: Explorer.Chain.Import.insert_changes_list/3\n    (explorer 6.9.0) lib/explorer/chain/import/runner/zksync/transaction_batches.ex:70: Explorer.Chain.Import.Runner.ZkSync.TransactionBatches.insert/3\n    (stdlib 6.1) timer.erl:590: :timer.tc/2\nLast message: ...
```

## Changelog

DB migration yo rename `l1_tx_count` and `l2_tx_count` columns in `zksync_transaction_batches` table. to `l1_transaction_count` and `l2_transaction_count` respectively.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
