### PR TITLE
fix: Addressing performance of Internal transactions list API v2 endpoint

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -818,7 +818,7 @@ defmodule Explorer.Chain.InternalTransaction do
   end
 
   @doc """
-  Returns the ordered paginated list of internal transactions (consensus blocks only) from the DB with address, block preloads
+  Returns the ordered paginated list of internal transactions (consensus blocks only and different from parent transaction) from the DB with address, block preloads
   """
   @spec fetch([paging_options | api?]) :: []
   def fetch(options) do
@@ -838,6 +838,7 @@ defmodule Explorer.Chain.InternalTransaction do
 
         __MODULE__
         |> where_nonpending_block()
+        |> where_is_different_from_parent_transaction()
         |> Chain.page_internal_transaction(paging_options, %{index_internal_transaction_desc_order: true})
         |> order_by([internal_transaction],
           desc: internal_transaction.block_number,


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/10994

## Motivation

`/api/v2/internal-transactions` endpoint is timeouting.

## Changelog

Add 'where' clause to return only different from parent transaction internal transactions in the endpoint in the attempt to improve execution plan of underlying query.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
