### PR TITLE
fix: Omit pbo for blocks lower than trace first block for indexing status

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1467,7 +1467,6 @@ defmodule Explorer.Chain do
   def indexed_ratio_internal_transactions do
     if indexer_running?() and internal_transactions_fetcher_running?() do
       %{max: max_saved_block_number} = BlockNumber.get_all()
-      pbo_count = PendingBlockOperationCache.estimated_count()
 
       min_blockchain_trace_block_number = Application.get_env(:indexer, :trace_first_block)
 
@@ -1478,6 +1477,8 @@ defmodule Explorer.Chain do
         _ ->
           full_blocks_range =
             max_saved_block_number - min_blockchain_trace_block_number - BlockNumberHelper.null_rounds_count() + 1
+
+          pbo_count = PendingBlockOperation.count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
 
           processed_int_transactions_for_blocks_count = max(0, full_blocks_range - pbo_count)
 

--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -6,6 +6,7 @@ defmodule Explorer.Chain.PendingBlockOperation do
   use Explorer.Schema
 
   alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Repo
 
   @required_attrs ~w(block_hash block_number)a
 
@@ -40,5 +41,18 @@ defmodule Explorer.Chain.PendingBlockOperation do
       pending_ops in __MODULE__,
       select: pending_ops.block_hash
     )
+  end
+
+  @doc """
+    Returns the count of pending block operations in provided blocks range
+    (between `from_block_number` and `to_block_number`).
+  """
+  @spec count_in_range(integer(), integer()) :: integer()
+  def count_in_range(from_block_number, to_block_number) when from_block_number <= to_block_number do
+    __MODULE__
+    |> where([pbo], pbo.block_number >= ^from_block_number)
+    |> where([pbo], pbo.block_number <= ^to_block_number)
+    |> select([pbo], count(pbo.block_number))
+    |> Repo.one()
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10890

## Motivation

Estimated count of pending block operations is not suitable for indexed internal transactions ratio calculation because it should filter out those records that belong to non-traceable blocks (lower than `TRACE_FIRST_BLOCK`).

## Changelog

Count pending block operations for the same blocks range that considered as **full blocks range** in `indexed_ratio_internal_transactions/0`