### PR TITLE
fix: Fix scam badge value in some API endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/address_channel.ex
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.AddressChannel do
   end
 
   @transaction_associations [
-                              from_address: [:names, :smart_contract, :proxy_implementations],
+                              from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
                               to_address: [
                                 :scam_badge,
                                 :names,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -53,7 +53,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     necessity_by_association:
       %{
         [created_contract_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
-        [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
         [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
         :block => :optional
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -85,7 +85,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     necessity_by_association:
       %{
         [created_contract_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
-        [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
         [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
         :block => :optional
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -25,7 +25,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
       %{
         :block => :required,
         [created_contract_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
-        [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+        [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
         [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association),

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -78,7 +78,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                               :proxy_implementations
                                             ]
                                           ] => :optional,
-                                          [from_address: [:names, :smart_contract, :proxy_implementations]] =>
+                                          [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] =>
                                             :optional,
                                           [
                                             to_address: [
@@ -573,7 +573,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     options =
       [
         necessity_by_association: %{
-          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+          [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
           [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
@@ -600,8 +600,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     options =
       [
         necessity_by_association: %{
-          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+          [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
+          [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -109,7 +109,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
       Chain.select_repo(@api_true).preload(transaction, [
         :block,
         to_address: [:scam_badge, :names, :smart_contract],
-        from_address: [:names, :smart_contract],
+        from_address: [:scam_badge, :names, :smart_contract],
         created_contract_address: [:scam_badge, :names, :token, :smart_contract]
       ])
 
@@ -176,8 +176,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     full_options =
       [
         necessity_by_association: %{
-          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional
+          [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
+          [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)
@@ -254,8 +254,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     token_transfer_options =
       [
         necessity_by_association: %{
-          [from_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
-          [to_address: [:names, :smart_contract, :proxy_implementations]] => :optional,
+          [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
+          [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]] => :optional,
           :token => :optional
         }
       ]

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -77,7 +77,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
           to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]
         ],
         block: [miner: [:names, :smart_contract, :proxy_implementations]],
-        from_address: [:names, :smart_contract, :proxy_implementations],
+        from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
         to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]
       )
 

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -206,7 +206,7 @@ defmodule BlockScoutWeb.Notifier do
     base_preloads = [
       :block,
       created_contract_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
-      from_address: [:names, :smart_contract, :proxy_implementations],
+      from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
       to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -159,6 +159,10 @@ defmodule BlockScoutWeb.API.V2.Helper do
 
   def address_name(_), do: nil
 
+  def address_marked_as_scam?(%Address{scam_badge: %Ecto.Association.NotLoaded{}}) do
+    false
+  end
+
   def address_marked_as_scam?(%Address{scam_badge: scam_badge}) when not is_nil(scam_badge) do
     true
   end

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -115,8 +115,8 @@ defmodule Explorer.Chain.AdvancedFilter do
     |> Enum.sort(&sort_function/2)
     |> take_page_size(paging_options)
     |> Chain.select_repo(options).preload(
-      from_address: [:names, :smart_contract, :proxy_implementations],
-      to_address: [:names, :smart_contract, :proxy_implementations],
+      from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
+      to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations],
       created_contract_address: [:names, :smart_contract, :proxy_implementations]
     )
   end

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -832,8 +832,8 @@ defmodule Explorer.Chain.InternalTransaction do
         preloads =
           DenormalizationHelper.extend_transaction_preload([
             :block,
-            [from_address: [:names, :smart_contract, :proxy_implementations]],
-            [to_address: [:names, :smart_contract, :proxy_implementations]]
+            [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]],
+            [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]]
           ])
 
         __MODULE__

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -239,7 +239,7 @@ defmodule Explorer.Chain.TokenTransfer do
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
             :token,
-            [from_address: [:names, :smart_contract, :proxy_implementations]],
+            [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]],
             [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]]
           ])
 
@@ -266,7 +266,7 @@ defmodule Explorer.Chain.TokenTransfer do
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
             :token,
-            [from_address: [:names, :smart_contract, :proxy_implementations]],
+            [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]],
             [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]]
           ])
 
@@ -299,8 +299,8 @@ defmodule Explorer.Chain.TokenTransfer do
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
             :token,
-            [from_address: [:names, :smart_contract, :proxy_implementations]],
-            [to_address: [:names, :smart_contract, :proxy_implementations]]
+            [from_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]],
+            [to_address: [:scam_badge, :names, :smart_contract, :proxy_implementations]]
           ])
 
         only_consensus_transfers_query()


### PR DESCRIPTION
## Motivation

Some API endpoints return `is_scam: true` for address, which actually is not marked as scam.

## Changelog

- return `is_scam: false`, if related association is not loaded `%Ecto.Association.NotLoaded{}}`.
- add `:scam_badge` association preload for address in some places in the code, where it was missing.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
