### PR TITLE
fix: Indexer memory limit for api instance

### DIFF
--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -47,10 +47,16 @@ defmodule Indexer.Memory.Monitor do
 
   @impl GenServer
   def init(options) when is_map(options) do
-    state = struct!(__MODULE__, Map.put_new(options, :limit, define_memory_limit()))
-    {:ok, timer_reference} = :timer.send_interval(state.timer_interval, :check)
+    case Application.get_env(:explorer, :mode) do
+      :api ->
+        :ignore
 
-    {:ok, %__MODULE__{state | timer_reference: timer_reference}}
+      _other_mode ->
+        state = struct!(__MODULE__, Map.put_new(options, :limit, define_memory_limit()))
+        {:ok, timer_reference} = :timer.send_interval(state.timer_interval, :check)
+
+        {:ok, %__MODULE__{state | timer_reference: timer_reference}}
+    end
   end
 
   @impl GenServer


### PR DESCRIPTION
## Motivation

`Indexer.Memory.Monitor` is started even in `api` mode even though there is no `shrinkable` processes started in this case

## Changelog

Don't start `Indexer.Memory.Monitor` in `api` mode

Docs update: https://github.com/blockscout/docs/pull/336
