### PR TITLE
fix: Filter non-traceable blocks before inserting them to internal txs fetcher queue

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -56,7 +56,8 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     |> sanitize_ranges()
   end
 
-  defp number_in_ranges?(number, ranges) do
+  @spec number_in_ranges?(integer(), [Range.t()]) :: boolean()
+  def number_in_ranges?(number, ranges) do
     Enum.reduce_while(ranges, false, fn
       _from.._to//_ = range, _acc -> if number in range, do: {:halt, true}, else: {:cont, false}
       num_to_latest, _acc -> if number >= num_to_latest, do: {:halt, true}, else: {:cont, false}

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -76,13 +76,23 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @impl BufferedTask
   def init(initial, reducer, _json_rpc_named_arguments) do
-    {:ok, final} =
-      Chain.stream_blocks_with_unfetched_internal_transactions(
-        initial,
+    stream_reducer =
+      if RangesHelper.trace_ranges_present?() do
+        trace_block_ranges = RangesHelper.get_trace_block_ranges()
+
+        fn block_number, acc ->
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          if RangesHelper.number_in_ranges?(block_number, trace_block_ranges),
+            do: reducer.(block_number, acc),
+            else: acc
+        end
+      else
         fn block_number, acc ->
           reducer.(block_number, acc)
         end
-      )
+      end
+
+    {:ok, final} = Chain.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
 
     final
   end


### PR DESCRIPTION
## Motivation

In case when `TRACE_FIRST_BLOCK` or `TRACE_BLOCK_RANGES` env variable is present, internal transactions fetcher will add non-traceable blocks into its queue anyway, which means that it will do a lot of unnecessary work.
