### PR TITLE
perf: Fix performance of Explorer.Counters.Transactions24hStats.consolidate/0 function

### DIFF
--- a/apps/explorer/lib/explorer/counters/transactions_24h_stats.ex
+++ b/apps/explorer/lib/explorer/counters/transactions_24h_stats.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Counters.Transactions24hStats do
   import Ecto.Query
 
   alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.Transaction
+  alias Explorer.Chain.{DenormalizationHelper, Transaction}
 
   @transaction_count_name "transaction_count_24h"
   @transaction_fee_sum_name "transaction_fee_sum_24h"
@@ -94,14 +94,17 @@ defmodule Explorer.Counters.Transactions24hStats do
     sum_query = dynamic([_, _], sum(^fee_query))
     avg_query = dynamic([_, _], avg(^fee_query))
 
-    query =
+    base_query =
       from(transaction in Transaction,
         join: block in assoc(transaction, :block),
-        where: block.timestamp >= ago(24, "hour"),
         select: %{count: count(transaction.hash)},
         select_merge: ^%{fee_sum: sum_query},
         select_merge: ^%{fee_average: avg_query}
       )
+
+    query =
+      base_query
+      |> where_block_timestamp_in_last_24_hours()
 
     %{
       count: count,
@@ -123,6 +126,14 @@ defmodule Explorer.Counters.Transactions24hStats do
       counter_type: @transaction_fee_average_name,
       value: fee_average
     })
+  end
+
+  defp where_block_timestamp_in_last_24_hours(query) do
+    if DenormalizationHelper.transactions_denormalization_finished?() do
+      where(query, [transaction, _block], transaction.block_timestamp >= ago(24, "hour"))
+    else
+      where(query, [_transaction, block], block.timestamp >= ago(24, "hour"))
+    end
   end
 
   @doc """


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11081

## Changelog

Change `where` clause in the query to use `transactions.block_timestamp` instead of `blocks.timestamp` when `transactions` table denormalization finished.

Execution plan after the changes:
```
explain analyze SELECT count(t0."hash"), sum(COALESCE(t0."gas_price", b1."base_fee_per_gas" + LEAST(t0."max_priority_fee_per_gas", t0."max_fee_per_gas" - b1.
"base_fee_per_gas")) * t0."gas_used"), avg(COALESCE(t0."gas_price", b1."base_fee_per_gas" + LEAST(t0."max_priority_fee_per_gas", t0."max_fee_per_gas" - b1."base_fee_per_gas")) 
* t0."gas_used") 
  FROM "transactions" AS t0 INNER JOIN "blocks" AS b1 ON b1."hash" = t0."block_hash" 
 WHERE t0."block_timestamp" >= (NOW() - INTERVAL '24 hour');
                                                                                      QUERY PLAN                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=3014199.38..3014199.39 rows=1 width=72) (actual time=40070.961..40070.972 rows=1 loops=1)
   ->  Nested Loop  (cost=1.16..3002673.33 rows=768403 width=62) (actual time=330.969..39833.821 rows=868273 loops=1)
         ->  Index Scan using transactions_block_timestamp_index on transactions t0  (cost=0.58..1838976.68 rows=768403 width=89) (actual time=330.871..27948.567 rows=868273 loops=1)
               Index Cond: (block_timestamp >= (now() - '24:00:00'::interval))
         ->  Memoize  (cost=0.58..8.18 rows=1 width=39) (actual time=0.013..0.013 rows=1 loops=868273)
               Cache Key: t0.block_hash
               Cache Mode: logical
               Hits: 825374  Misses: 42899  Evictions: 0  Overflows: 0  Memory Usage: 6997kB
               ->  Index Scan using blocks_pkey on blocks b1  (cost=0.57..8.17 rows=1 width=39) (actual time=0.266..0.266 rows=1 loops=42899)
                     Index Cond: (hash = t0.block_hash)
 Planning Time: 0.506 ms
 JIT:
   Functions: 17
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 3.413 ms, Inlining 59.297 ms, Optimization 173.986 ms, Emission 96.778 ms, Total 333.474 ms
 Execution Time: 40102.828 ms
(16 rows)
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
