### PR TITLE
chore: convinient way to manage known_hosts within devcontainer

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -42,13 +42,14 @@ Key benefits include:
    c. Uncomment the `mounts` section:
       ```json
       "mounts": [
-        "source=${localEnv:HOME}/.ssh/known_hosts,target=/home/vscode/.ssh/known_hosts,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.ssh/config,target=/home/vscode/.ssh/config,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.ssh/id_rsa,target=/home/vscode/.ssh/id_rsa,type=bind,consistency=cached"
       ],
       ```
    
    d. Adjust the paths if your SSH keys are stored in a different location.
+
+   e. Use `git update-index --assume-unchanged .devcontainer/devcontainer.json` to prevent the changes to `devcontainer.json` from appearing in `git status` and VS Code's Source Control. To undo the changes, use `git update-index --no-assume-unchanged .devcontainer/devcontainer.json`.
 
 4. When prompted, click "Reopen in Container". If not prompted, press `F1`, type "Remote-Containers: Reopen in Container", and press Enter.
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
 	"workspaceFolder": "/workspace",
 	"postCreateCommand": {
 		"safe-directory": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-		"deps": "mix deps.get"
+		"deps": "mix deps.get",
+		"known_hosts": "sudo chown vscode:vscode /home/vscode/.ssh && ssh-keyscan github.com > /home/vscode/.ssh/known_hosts"
 	},
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/.devcontainer/bin"
@@ -37,7 +38,6 @@
 	// Uncomment and adjust the private key path to the one you use to authenticate on GitHub
 	// if you want to have ability to push to GitHub from the container.
 	// "mounts": [
-	// 	"source=${localEnv:HOME}/.ssh/known_hosts,target=/home/vscode/.ssh/known_hosts,type=bind,consistency=cached",
 	// 	"source=${localEnv:HOME}/.ssh/config,target=/home/vscode/.ssh/config,type=bind,consistency=cached",
 	// 	// Make sure that the private key can be used to authenticate on GitHub
 	// 	"source=${localEnv:HOME}/.ssh/id_rsa,target=/home/vscode/.ssh/id_rsa,type=bind,consistency=cached"

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ dump.rdb
 *.iml
 
 .vscode
+.cursorignore
+.cursorrules
 
 **.dec**
 


### PR DESCRIPTION
## Motivation

During the use of the devcontainer VSCode feature, it was found that access to GitHub servers via SSH is re-requested if `known_hosts` on the local machine contains ambiguous records. Another issue is that it could be excessive to share all the records in the local `known_hosts` with the guest system of the devcontainer.

## Changelog

### Bug Fixes

Instead of mounting `known_hosts` from the local machine, the file is created from scratch in the guest system with only records related to GitHub servers.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
