### PR TITLE
fix: Fix sitemap timeout; optimize OrderedCache preloads

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/robots/sitemap.xml.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/robots/sitemap.xml.eex
@@ -2,7 +2,7 @@
 <% host = APIDocsView.blockscout_url(true) %>
 <% date = to_string(Date.utc_today()) %>
 <% non_parameterized_urls = ["/", "/txs", "/blocks", "/accounts", "/verified-contracts", "/tokens", "/apps", "/stats", "/api-docs", "/graphiql", "/search-results", "/withdrawals", "/l2-deposits", "/l2-output-roots", "/l2-txn-batches", "/l2-withdrawals"] %>
-<% params = [paging_options: %PagingOptions{page_size: limit()}] %>
+<% params = [paging_options: %PagingOptions{page_size: limit()}, necessity_by_association: %{}] %>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <%= for url <- non_parameterized_urls do %>
     <url>

--- a/apps/block_scout_web/lib/block_scout_web/views/robots_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/robots_view.ex
@@ -5,6 +5,6 @@ defmodule BlockScoutWeb.RobotsView do
   alias Explorer.{Chain, PagingOptions}
   alias Explorer.Chain.{Address, Token}
 
-  @limit 200
+  @limit 50
   defp limit, do: @limit
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -795,7 +795,7 @@ defmodule Explorer.Chain do
       from(contract in SmartContract,
         inner_join: address in Address,
         on: contract.address_hash == address.hash,
-        order_by: [desc: address.transactions_count],
+        order_by: [desc: address.fetched_coin_balance],
         limit: ^limit,
         select: contract.address_hash
       )

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -247,9 +247,10 @@ defmodule Explorer.Chain.OrderedCache do
         ConCache.update(cache_name(), ids_list_key(), fn ids ->
           updated_list =
             elements
+            |> Enum.sort_by(&element_to_id(&1), &prevails?(&1, &2))
+            |> Enum.take(max_size())
             |> do_preloads()
             |> Enum.map(&{element_to_id(&1), &1})
-            |> Enum.sort(&prevails?(&1, &2))
             |> merge_and_update(ids || [], max_size())
 
           # ids_list is set to never expire

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -207,10 +207,14 @@ defmodule Explorer.Chain.Token do
     token_type = Keyword.get(options, :token_type, nil)
     sorting = Keyword.get(options, :sorting, [])
 
-    query = from(t in Token, preload: [:contract_address])
+    necessity_by_association =
+      Keyword.get(options, :necessity_by_association, %{
+        :contract_address => :optional
+      })
 
     sorted_paginated_query =
-      query
+      Token
+      |> Chain.join_associations(necessity_by_association)
       |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash)
       |> apply_filter(token_type)
       |> SortingHelper.apply_sorting(sorting, @default_sorting)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -201,6 +201,7 @@ defmodule Explorer.Chain.Token do
           Chain.paging_options()
           | {:sorting, SortingHelper.sorting_params()}
           | {:token_type, [String.t()]}
+          | {:necessity_by_association, map()}
         ]) :: [Token.t()]
   def list_top(filter, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11134

## Motivation
https://eth.blockscout.com/sitemap.xml - 503

## Changelog
- reduce number of elements from 200 to 50
- get rid of unnecessary preloads
- optimize preloads in ordered cache: 
  - sort
  - trim extra elements (which are out of max_size of cache)
  - and only then, do preloads

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
