### PR TITLE
refactor: cspell configuration

### DIFF
--- a/.devcontainer/bin/bs
+++ b/.devcontainer/bin/bs
@@ -146,7 +146,7 @@ recompile() {
 
 # Define the spellcheck subroutine
 spellcheck() {
-    cspell --config cspell.json "**/*.ex*" "**/*.eex" "**/*.js" --gitignore | less
+    cspell | less
 }
 
 # Define the dialyzer subroutine

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -347,7 +347,9 @@ jobs:
             ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-blockscoutweb-npm-
 
       - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v2
+        uses: streetsidesoftware/cspell-action@v6
+        with:
+          use_cspell_files: true
 
   eslint:
     name: ESLint

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -348,11 +348,6 @@ jobs:
 
       - name: Run cspell
         uses: streetsidesoftware/cspell-action@v2
-        with:
-          files: |
-            **/*.ex*
-            **/*.eex
-            **/*.js"
 
   eslint:
     name: ESLint

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -350,6 +350,7 @@ jobs:
         uses: streetsidesoftware/cspell-action@v6
         with:
           use_cspell_files: true
+          incremental_files_only: false
 
   eslint:
     name: ESLint

--- a/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
@@ -12,7 +12,9 @@ defmodule BlockScoutWeb.NFTHelperTest do
     end
 
     test "transforms ipfs link like ipfs://ipfs" do
+      # cspell: disable
       url = "ipfs://ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4"
+      # cspell: enable
 
       assert "https://ipfs.io/ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4" ==
                NFTHelper.compose_ipfs_url(url)

--- a/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
@@ -12,9 +12,8 @@ defmodule BlockScoutWeb.NFTHelperTest do
     end
 
     test "transforms ipfs link like ipfs://ipfs" do
-      # cspell: disable
+      # cspell:disable-next-line
       url = "ipfs://ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4"
-      # cspell: enable
 
       assert "https://ipfs.io/ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4" ==
                NFTHelper.compose_ipfs_url(url)

--- a/apps/explorer/priv/repo/migrations/20230815131151_drop_logs_address_hash_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230815131151_drop_logs_address_hash_foreign_key.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropLogsAddressHashForeignKey do
   use Ecto.Migration
 

--- a/apps/explorer/priv/repo/migrations/20230816061723_drop_token_transfers_and_transactions_address_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230816061723_drop_token_transfers_and_transactions_address_foreign_key.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropTokenTransfersAndTransactionsAddressForeignKey do
   use Ecto.Migration
 

--- a/apps/explorer/priv/repo/migrations/20230817061317_drop_address_foreign_keys.exs
+++ b/apps/explorer/priv/repo/migrations/20230817061317_drop_address_foreign_keys.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropAddressForeignKeys do
   use Ecto.Migration
 

--- a/apps/explorer/priv/repo/migrations/20230821120625_drop_rest_address_foreign_keys.exs
+++ b/apps/explorer/priv/repo/migrations/20230821120625_drop_rest_address_foreign_keys.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropRestAddressForeignKeys do
   use Ecto.Migration
 

--- a/apps/explorer/priv/repo/migrations/20230831122819_drop_current_token_balances_tokens_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230831122819_drop_current_token_balances_tokens_foreign_key.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropCurrentTokenBalancesTokensForeignKey do
   use Ecto.Migration
 

--- a/apps/explorer/priv/repo/migrations/20230905085809_drop_token_balances_tokens_foreign_key.exs
+++ b/apps/explorer/priv/repo/migrations/20230905085809_drop_token_balances_tokens_foreign_key.exs
@@ -1,4 +1,3 @@
-# cspell:ignore fkey
 defmodule Explorer.Repo.Migrations.DropTokenBalancesTokensForeignKey do
   use Ecto.Migration
 

--- a/cspell.json
+++ b/cspell.json
@@ -1,9 +1,18 @@
 // cSpell Settings
 {
+    "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
     // Version of the setting file.  Always 0.2
     "version": "0.2",
     // language - current active spelling language
     "language": "en",
+    // files - glob patterns of files to be checked
+    "files": [
+        "**/*.ex*",
+        "**/*.eex",
+        "**/*.js"
+    ],
+    // useGitignore - use .gitignore to exclude files from checking
+    "useGitignore": true,
     // words - list of words to be always considered correct
     "ignorePaths": [
         "apps/block_scout_web/assets/js/lib/ace/src-min/*.js"

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
         "apps/block_scout_web/assets/js/lib/ace/src-min/*.js"
     ],
     "ignoreRegExpList": [
+        // Ignore filecoin f410f-like native addresses
         "f410f[a-z2-7]{39}"
     ],
     "words": [

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,9 @@
     "ignorePaths": [
         "apps/block_scout_web/assets/js/lib/ace/src-min/*.js"
     ],
+    "ignoreRegExpList": [
+        "f410f[a-z2-7]{39}"
+    ],
     "words": [
         "aave",
         "absname",

--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,8 @@
     "version": "0.2",
     // language - current active spelling language
     "language": "en",
+    // enabled - enable code editor suggestions
+    "enabled": true,
     // files - glob patterns of files to be checked
     "files": [
         "**/*.ex*",
@@ -660,5 +662,5 @@
         "dotenv",
         "html-eex",
         "makefile"
-    ]
+    ],
 }


### PR DESCRIPTION
## Motivation

If you run `cspell --config cspell.json "**/*.ex*" "**/*.eex" "**/*.js" --gitignore`, you see errors related because cspell treats Filecoin native addresses as words.

<details>

```
apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs:15:46 - Unknown word (Fgqz)
apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs:15:57 - Unknown word (Rten)
1135/2176 apps/explorer/lib/explorer/chain/filecoin/native_address.ex 2.92ms X
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:132:36 - Unknown word (fabpafjfjgqkc)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:132:50 - Unknown word (douo)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:132:55 - Unknown word (yzfug)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:132:64 - Unknown word (bwfvuhsewxji)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:335:12 - Unknown word (fabpafjfjgqkc)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:335:26 - Unknown word (douo)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:335:31 - Unknown word (yzfug)
apps/explorer/lib/explorer/chain/filecoin/native_address.ex:335:40 - Unknown word (bwfvuhsewxji)
1560/2176 apps/explorer/priv/repo/migrations/20190208143201_add_index_on_address_hash_block_number_and_token_contract_address_hash_for_current_token_balan1560/2176 apps/explorer/priv/repo/migrations/20190208143201_add_index_on_address_hash_block_number_and_token_contract_address_hash_for_current_token_balan
1651/2176 apps/explorer/priv/repo/migrations/20211018170533_add_address_token_balances_address_hash_token_contract_address_hash_block_number_index.exs 0.4
1840/2176 apps/explorer/test/explorer/chain/filecoin/native_address_test.exs 2.00ms X
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:66:22 - Unknown word (fabpafjfjgqkc)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:66:36 - Unknown word (douo)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:66:41 - Unknown word (yzfug)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:66:50 - Unknown word (bwfvuhsewxji)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:93:22 - Unknown word (fabpafjfjgqkc)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:93:36 - Unknown word (douo)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:93:41 - Unknown word (yzfug)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:93:50 - Unknown word (bwfvuhsewxji)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:128:22 - Unknown word (fabpafjfjgqkc)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:128:36 - Unknown word (douo)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:128:41 - Unknown word (yzfug)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:128:50 - Unknown word (bwfvuhsewxji)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:162:22 - Unknown word (fabpafjfjgqkc)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:162:36 - Unknown word (douo)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:162:41 - Unknown word (yzfug)
apps/explorer/test/explorer/chain/filecoin/native_address_test.exs:162:50 - Unknown word (bwfvuhsewxji) 
```
</details>

Also, passing the same CLI options every run is a useless effort, so after this PR lands, you can simply run `cspell` and that's it.

## Changelog

### Enhancements

- Configure all cspell options in `cspell.json`

### Bug Fixes

- Add regex to ignore addresses during cspell check
- Do not check spelling for weird IPFS url in test

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
