### PR TITLE
feat: Add PendingTransactionOperation

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -31,6 +31,15 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     end
   end
 
+  @spec filter_by_height_range([any()], (any() -> boolean())) :: [any()]
+  def filter_by_height_range(elements, filter_func) do
+    if trace_ranges_present?() do
+      Enum.filter(elements, &filter_func.(&1))
+    else
+      elements
+    end
+  end
+
   @doc """
   Checks if trace ranges are defined via env variables
   """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -31,6 +31,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     end
   end
 
+  @doc """
+  Filters elements with `filter_func` if `TRACE_BLOCK_RANGES` is set
+  """
   @spec filter_by_height_range([any()], (any() -> boolean())) :: [any()]
   def filter_by_height_range(elements, filter_func) do
     if trace_ranges_present?() do

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -225,7 +225,8 @@ defmodule Explorer.Application do
           :indexer
         ),
         Explorer.Migrator.RefetchContractCodes |> configure() |> configure_chain_type_dependent_process(:zksync),
-        configure(Explorer.Chain.Fetcher.AddressesBlacklist)
+        configure(Explorer.Chain.Fetcher.AddressesBlacklist),
+        Explorer.Migrator.SwitchPendingOperations
       ]
       |> List.flatten()
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -58,6 +58,7 @@ defmodule Explorer.Chain do
     InternalTransaction,
     Log,
     PendingBlockOperation,
+    PendingOperationsHelper,
     PendingTransactionOperation,
     SmartContract,
     Token,
@@ -89,7 +90,6 @@ defmodule Explorer.Chain do
 
   alias Explorer.Market.MarketHistoryCache
   alias Explorer.MicroserviceInterfaces.MultichainSearch
-  alias Explorer.Utility.SwitchPendingOperations
   alias Explorer.{PagingOptions, Repo}
 
   alias Dataloader.Ecto, as: DataloaderEcto
@@ -859,7 +859,7 @@ defmodule Explorer.Chain do
       RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :trace_block_ranges))
 
     %{max: max_saved_block_number} = BlockNumber.get_all()
-    pending_ops_entity = SwitchPendingOperations.actual_entity()
+    pending_ops_entity = PendingOperationsHelper.actual_entity()
     pbo_count = pending_ops_entity.blocks_count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
 
     if pbo_count <
@@ -1572,7 +1572,7 @@ defmodule Explorer.Chain do
           full_blocks_range =
             max_saved_block_number - min_blockchain_trace_block_number - BlockNumberHelper.null_rounds_count() + 1
 
-          pending_ops_entity = SwitchPendingOperations.actual_entity()
+          pending_ops_entity = PendingOperationsHelper.actual_entity()
 
           pbo_count =
             pending_ops_entity.blocks_count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
@@ -1972,7 +1972,7 @@ defmodule Explorer.Chain do
 
   def remove_nonconsensus_blocks_from_pending_ops(block_hashes) do
     query =
-      case SwitchPendingOperations.pending_operations_type() do
+      case PendingOperationsHelper.pending_operations_type() do
         "blocks" ->
           from(
             pbo in PendingBlockOperation,
@@ -1994,7 +1994,7 @@ defmodule Explorer.Chain do
 
   def remove_nonconsensus_blocks_from_pending_ops do
     query =
-      case SwitchPendingOperations.pending_operations_type() do
+      case PendingOperationsHelper.pending_operations_type() do
         "blocks" ->
           from(
             pbo in PendingBlockOperation,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1823,6 +1823,15 @@ defmodule Explorer.Chain do
   end
 
   @doc """
+  Finds all transactions of a certain block numbers
+  """
+  def get_transactions_of_block_numbers(block_numbers) do
+    block_numbers
+    |> Transaction.transactions_for_block_numbers()
+    |> Repo.all()
+  end
+
+  @doc """
   Finds all Blocks validated by the address with the given hash.
 
     ## Options
@@ -1946,86 +1955,6 @@ defmodule Explorer.Chain do
   def stream_unfetched_token_balances(initial, reducer, limited? \\ false) when is_function(reducer, 2) do
     TokenBalance.unfetched_token_balances()
     |> add_token_balances_fetcher_limit(limited?)
-    |> Repo.stream_reduce(initial, reducer)
-  end
-
-  @doc """
-  Returns a stream of all blocks with unfetched internal transactions, using
-  the `pending_block_operation` table.
-
-      iex> unfetched = insert(:block)
-      iex> insert(:pending_block_operation, block: unfetched, block_number: unfetched.number)
-      iex> {:ok, number_set} = Explorer.Chain.stream_blocks_with_unfetched_internal_transactions(
-      ...>   MapSet.new(),
-      ...>   fn number, acc ->
-      ...>     MapSet.put(acc, number)
-      ...>   end
-      ...> )
-      iex> unfetched.number in number_set
-      true
-
-  """
-  @spec stream_blocks_with_unfetched_internal_transactions(
-          initial :: accumulator,
-          reducer :: (entry :: term(), accumulator -> accumulator),
-          limited? :: boolean()
-        ) :: {:ok, accumulator}
-        when accumulator: term()
-  def stream_blocks_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
-      when is_function(reducer, 2) do
-    direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
-
-    query =
-      from(
-        po in PendingBlockOperation,
-        where: not is_nil(po.block_number),
-        select: po.block_number,
-        order_by: [{^direction, po.block_number}]
-      )
-
-    query
-    |> add_fetcher_limit(limited?)
-    |> Repo.stream_reduce(initial, reducer)
-  end
-
-  @doc """
-  Returns a stream of all transactions with unfetched internal transactions, using
-  the `pending_transaction_operation` table.
-      iex> unfetched_block = insert(:block)
-      iex> unfetched_transaction = insert(:transaction) |> with_block(unfetched_block)
-      iex> insert(:pending_transaction_operation, transaction: unfetched_transaction)
-      iex> {:ok, transaction_params_set} = Explorer.Chain.stream_transactions_with_unfetched_internal_transactions(
-      ...>   MapSet.new(),
-      ...>   fn transaction_params, acc ->
-      ...>     MapSet.put(acc, transaction_params)
-      ...>   end
-      ...> )
-      iex> %{
-      ...>   block_number: unfetched_transaction.block_number,
-      ...>   hash: unfetched_transaction.hash,
-      ...>   index: unfetched_transaction.index
-      ...> } in transaction_params_set
-      true
-  """
-  @spec stream_transactions_with_unfetched_internal_transactions(
-          initial :: accumulator,
-          reducer :: (entry :: term(), accumulator -> accumulator)
-        ) :: {:ok, accumulator}
-        when accumulator: term()
-  def stream_transactions_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
-      when is_function(reducer, 2) do
-    direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
-
-    query =
-      from(
-        po in PendingTransactionOperation,
-        join: t in assoc(po, :transaction),
-        select: %{block_number: t.block_number, hash: t.hash, index: t.index},
-        order_by: [{^direction, t.block_number}]
-      )
-
-    query
-    |> add_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -58,6 +58,7 @@ defmodule Explorer.Chain do
     InternalTransaction,
     Log,
     PendingBlockOperation,
+    PendingTransactionOperation,
     SmartContract,
     Token,
     TokenTransfer,
@@ -82,13 +83,13 @@ defmodule Explorer.Chain do
 
   alias Explorer.Chain.Cache.Block, as: BlockCache
   alias Explorer.Chain.Cache.Helper, as: CacheHelper
-  alias Explorer.Chain.Cache.PendingBlockOperation, as: PendingBlockOperationCache
   alias Explorer.Chain.Fetcher.{CheckBytecodeMatchingOnDemand, LookUpSmartContractSourcesOnDemand}
   alias Explorer.Chain.InternalTransaction.{CallType, Type}
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
 
   alias Explorer.Market.MarketHistoryCache
   alias Explorer.MicroserviceInterfaces.MultichainSearch
+  alias Explorer.Utility.SwitchPendingOperations
   alias Explorer.{PagingOptions, Repo}
 
   alias Dataloader.Ecto, as: DataloaderEcto
@@ -854,7 +855,10 @@ defmodule Explorer.Chain do
   end
 
   defp check_indexing_internal_transactions_threshold do
-    pbo_count = PendingBlockOperationCache.estimated_count()
+    min_blockchain_trace_block_number = Application.get_env(:indexer, :trace_first_block)
+    %{max: max_saved_block_number} = BlockNumber.get_all()
+    pending_ops_entity = SwitchPendingOperations.actual_entity()
+    pbo_count = pending_ops_entity.blocks_count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
 
     if pbo_count <
          Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction)[:indexing_finished_threshold] do
@@ -1566,7 +1570,10 @@ defmodule Explorer.Chain do
           full_blocks_range =
             max_saved_block_number - min_blockchain_trace_block_number - BlockNumberHelper.null_rounds_count() + 1
 
-          pbo_count = PendingBlockOperation.count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
+          pending_ops_entity = SwitchPendingOperations.actual_entity()
+
+          pbo_count =
+            pending_ops_entity.blocks_count_in_range(min_blockchain_trace_block_number, max_saved_block_number)
 
           processed_int_transactions_for_blocks_count = max(0, full_blocks_range - pbo_count)
 
@@ -1981,12 +1988,63 @@ defmodule Explorer.Chain do
     |> Repo.stream_reduce(initial, reducer)
   end
 
-  def remove_nonconsensus_blocks_from_pending_ops(block_hashes) do
+  @doc """
+  Returns a stream of all transactions with unfetched internal transactions, using
+  the `pending_transaction_operation` table.
+      iex> unfetched_block = insert(:block)
+      iex> unfetched_transaction = insert(:transaction) |> with_block(unfetched_block)
+      iex> insert(:pending_transaction_operation, transaction: unfetched_transaction)
+      iex> {:ok, transaction_params_set} = Explorer.Chain.stream_transactions_with_unfetched_internal_transactions(
+      ...>   MapSet.new(),
+      ...>   fn transaction_params, acc ->
+      ...>     MapSet.put(acc, transaction_params)
+      ...>   end
+      ...> )
+      iex> %{
+      ...>   block_number: unfetched_transaction.block_number,
+      ...>   hash: unfetched_transaction.hash,
+      ...>   index: unfetched_transaction.index
+      ...> } in transaction_params_set
+      true
+  """
+  @spec stream_transactions_with_unfetched_internal_transactions(
+          initial :: accumulator,
+          reducer :: (entry :: term(), accumulator -> accumulator)
+        ) :: {:ok, accumulator}
+        when accumulator: term()
+  def stream_transactions_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
+      when is_function(reducer, 2) do
+    direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
+
     query =
       from(
-        po in PendingBlockOperation,
-        where: po.block_hash in ^block_hashes
+        po in PendingTransactionOperation,
+        join: t in assoc(po, :transaction),
+        select: %{block_number: t.block_number, hash: t.hash, index: t.index},
+        order_by: [{^direction, t.block_number}]
       )
+
+    query
+    |> add_fetcher_limit(limited?)
+    |> Repo.stream_reduce(initial, reducer)
+  end
+
+  def remove_nonconsensus_blocks_from_pending_ops(block_hashes) do
+    query =
+      case SwitchPendingOperations.pending_operations_type() do
+        "blocks" ->
+          from(
+            po in PendingBlockOperation,
+            where: po.block_hash in ^block_hashes
+          )
+
+        "transactions" ->
+          from(
+            po in PendingTransactionOperation,
+            join: t in assoc(po, :transaction),
+            where: t.block_hash in ^block_hashes
+          )
+      end
 
     {_, _} = Repo.delete_all(query)
 
@@ -1995,12 +2053,22 @@ defmodule Explorer.Chain do
 
   def remove_nonconsensus_blocks_from_pending_ops do
     query =
-      from(
-        po in PendingBlockOperation,
-        inner_join: block in Block,
-        on: block.hash == po.block_hash,
-        where: block.consensus == false
-      )
+      case SwitchPendingOperations.pending_operations_type() do
+        "blocks" ->
+          from(
+            po in PendingBlockOperation,
+            inner_join: block in Block,
+            on: block.hash == po.block_hash,
+            where: block.consensus == false
+          )
+
+        "transactions" ->
+          from(
+            po in PendingTransactionOperation,
+            join: t in assoc(po, :transaction),
+            where: t.block_consensus == false
+          )
+      end
 
     {_, _} = Repo.delete_all(query)
 

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -33,7 +33,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Chain.Import.Runner.{Addresses, TokenInstances, Tokens}
   alias Explorer.Prometheus.Instrumenter
-  alias Explorer.Utility.MissingRangesManipulator
+  alias Explorer.Utility.{MissingRangesManipulator, SwitchPendingOperations}
 
   @behaviour Runner
 
@@ -74,7 +74,9 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       {:ok, nonconsensus_items} = lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
 
       {:ok,
-       filter_by_height_range(nonconsensus_items, fn {number, _hash} -> RangesHelper.traceable_block_number?(number) end)}
+       RangesHelper.filter_by_height_range(nonconsensus_items, fn {number, _hash} ->
+         RangesHelper.traceable_block_number?(number)
+       end)}
     end
 
     multi
@@ -97,14 +99,14 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :blocks
       )
     end)
-    |> Multi.run(:new_pending_operations, fn repo, %{blocks: blocks} ->
+    |> Multi.run(:new_pending_block_operations, fn repo, %{blocks: blocks} ->
       Instrumenter.block_import_stage_runner(
         fn ->
-          new_pending_operations(repo, blocks, insert_options)
+          new_pending_block_operations(repo, blocks, insert_options)
         end,
         :address_referencing,
         :blocks,
-        :new_pending_operations
+        :new_pending_block_operations
       )
     end)
     |> Multi.run(:uncle_fetched_block_second_degree_relations, fn repo, _ ->
@@ -461,24 +463,30 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       {:error, %{exception: postgrex_error, consensus_block_numbers: consensus_block_numbers}}
   end
 
-  defp new_pending_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
-    sorted_pending_ops =
-      inserted_blocks
-      |> filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
-      |> Enum.filter(& &1.consensus)
-      |> Enum.map(&%{block_hash: &1.hash, block_number: &1.number})
-      |> Enum.sort()
+  defp new_pending_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
+    case SwitchPendingOperations.pending_operations_type() do
+      "blocks" ->
+        sorted_pending_ops =
+          inserted_blocks
+          |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
+          |> Enum.filter(& &1.consensus)
+          |> Enum.map(&%{block_hash: &1.hash, block_number: &1.number})
+          |> Enum.sort()
 
-    Import.insert_changes_list(
-      repo,
-      sorted_pending_ops,
-      conflict_target: :block_hash,
-      on_conflict: :nothing,
-      for: PendingBlockOperation,
-      returning: true,
-      timeout: timeout,
-      timestamps: timestamps
-    )
+        Import.insert_changes_list(
+          repo,
+          sorted_pending_ops,
+          conflict_target: :block_hash,
+          on_conflict: :nothing,
+          for: PendingBlockOperation,
+          returning: true,
+          timeout: timeout,
+          timestamps: timestamps
+        )
+
+      _other_type ->
+        {:ok, []}
+    end
   end
 
   defp delete_address_coin_balances(_repo, [], _options), do: {:ok, []}
@@ -1029,14 +1037,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       end)
 
     where(invalid_neighbors_query, [block], block.consensus)
-  end
-
-  defp filter_by_height_range(blocks, filter_func) do
-    if RangesHelper.trace_ranges_present?() do
-      Enum.filter(blocks, &filter_func.(&1))
-    else
-      blocks
-    end
   end
 
   defp celo_pending_epoch_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     DenormalizationHelper,
     Import,
     PendingBlockOperation,
+    PendingOperationsHelper,
     Token,
     Token.Instance,
     TokenTransfer,
@@ -33,7 +34,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Chain.Import.Runner.{Addresses, TokenInstances, Tokens}
   alias Explorer.Prometheus.Instrumenter
-  alias Explorer.Utility.{MissingRangesManipulator, SwitchPendingOperations}
+  alias Explorer.Utility.MissingRangesManipulator
 
   @behaviour Runner
 
@@ -464,7 +465,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   end
 
   defp new_pending_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
-    case SwitchPendingOperations.pending_operations_type() do
+    case PendingOperationsHelper.pending_operations_type() do
       "blocks" ->
         sorted_pending_ops =
           inserted_blocks

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -16,6 +16,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     Import,
     InternalTransaction,
     PendingBlockOperation,
+    PendingOperationsHelper,
     PendingTransactionOperation,
     Transaction
   }
@@ -24,7 +25,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   alias Explorer.Chain.Import.Runner
   alias Explorer.Prometheus.Instrumenter
   alias Explorer.Repo, as: ExplorerRepo
-  alias Explorer.Utility.{MissingRangesManipulator, SwitchPendingOperations}
+  alias Explorer.Utility.MissingRangesManipulator
 
   import Ecto.Query
 
@@ -320,7 +321,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   end
 
   defp acquire_pending_internal_transactions(repo, block_hashes) do
-    case SwitchPendingOperations.pending_operations_type() do
+    case PendingOperationsHelper.pending_operations_type() do
       "blocks" ->
         query =
           from(

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -9,10 +9,11 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
   import Ecto.Query, only: [from: 2]
 
   alias Ecto.{Multi, Repo}
-  alias Explorer.Chain.{Block, Hash, Import, Transaction}
+  alias EthereumJSONRPC.Utility.RangesHelper
+  alias Explorer.Chain.{Block, Hash, Import, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Import.Runner.TokenTransfers
   alias Explorer.Prometheus.Instrumenter
-  alias Explorer.Utility.MissingRangesManipulator
+  alias Explorer.Utility.{MissingRangesManipulator, SwitchPendingOperations}
 
   @behaviour Import.Runner
 
@@ -65,6 +66,16 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
         :transactions
       )
     end)
+    |> Multi.run(:new_pending_transaction_operations, fn repo, %{transactions: transactions} ->
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          new_pending_transaction_operations(repo, transactions, insert_options)
+        end,
+        :block_referencing,
+        :transactions,
+        :new_pending_transaction_operations
+      )
+    end)
   end
 
   @impl Import.Runner
@@ -106,6 +117,31 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
       timeout: timeout,
       timestamps: timestamps
     )
+  end
+
+  defp new_pending_transaction_operations(repo, inserted_transactions, %{timeout: timeout, timestamps: timestamps}) do
+    case SwitchPendingOperations.pending_operations_type() do
+      "transactions" ->
+        sorted_pending_ops =
+          inserted_transactions
+          |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
+          |> Enum.map(&%{transaction_hash: &1.hash})
+          |> Enum.sort()
+
+        Import.insert_changes_list(
+          repo,
+          sorted_pending_ops,
+          conflict_target: :transaction_hash,
+          on_conflict: :nothing,
+          for: PendingTransactionOperation,
+          returning: true,
+          timeout: timeout,
+          timestamps: timestamps
+        )
+
+      _other_type ->
+        {:ok, []}
+    end
   end
 
   # todo: avoid code duplication

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -125,6 +125,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
         sorted_pending_ops =
           inserted_transactions
           |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
+          |> Enum.reject(&is_nil(&1.block_number))
           |> Enum.map(&%{transaction_hash: &1.hash})
           |> Enum.sort()
 

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -10,10 +10,10 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
 
   alias Ecto.{Multi, Repo}
   alias EthereumJSONRPC.Utility.RangesHelper
-  alias Explorer.Chain.{Block, Hash, Import, PendingTransactionOperation, Transaction}
+  alias Explorer.Chain.{Block, Hash, Import, PendingOperationsHelper, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Import.Runner.TokenTransfers
   alias Explorer.Prometheus.Instrumenter
-  alias Explorer.Utility.{MissingRangesManipulator, SwitchPendingOperations}
+  alias Explorer.Utility.MissingRangesManipulator
 
   @behaviour Import.Runner
 
@@ -120,7 +120,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
   end
 
   defp new_pending_transaction_operations(repo, inserted_transactions, %{timeout: timeout, timestamps: timestamps}) do
-    case SwitchPendingOperations.pending_operations_type() do
+    case PendingOperationsHelper.pending_operations_type() do
       "transactions" ->
         sorted_pending_ops =
           inserted_transactions

--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -47,8 +47,8 @@ defmodule Explorer.Chain.PendingBlockOperation do
     Returns the count of pending block operations in provided blocks range
     (between `from_block_number` and `to_block_number`).
   """
-  @spec count_in_range(integer(), integer()) :: integer()
-  def count_in_range(from_block_number, to_block_number) when from_block_number <= to_block_number do
+  @spec blocks_count_in_range(integer(), integer()) :: integer()
+  def blocks_count_in_range(from_block_number, to_block_number) when from_block_number <= to_block_number do
     __MODULE__
     |> where([pbo], pbo.block_number >= ^from_block_number)
     |> where([pbo], pbo.block_number <= ^to_block_number)

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -1,4 +1,4 @@
-defmodule Explorer.Utility.SwitchPendingOperations do
+defmodule Explorer.Chain.PendingOperationsHelper do
   @moduledoc false
 
   import Ecto.Query

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -61,7 +61,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
         :finish
 
       pbo_params ->
-        Repo.insert_all(PendingBlockOperation, pbo_params, on_conflict: :nothing)
+        Repo.insert_all(PendingBlockOperation, add_timestamps(pbo_params), on_conflict: :nothing)
 
         block_numbers_to_delete = Enum.map(pbo_params, & &1.block_number)
 
@@ -94,6 +94,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
           |> where([t], t.block_number in ^pbo_block_numbers)
           |> select([t], %{transaction_hash: t.hash})
           |> Repo.all()
+          |> add_timestamps()
 
         Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
 
@@ -103,5 +104,11 @@ defmodule Explorer.Chain.PendingOperationsHelper do
 
         :continue
     end
+  end
+
+  defp add_timestamps(params) do
+    now = DateTime.utc_now()
+
+    Enum.map(params, &Map.merge(&1, %{inserted_at: now, updated_at: now}))
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
@@ -5,6 +5,8 @@ defmodule Explorer.Chain.PendingTransactionOperation do
 
   use Explorer.Schema
 
+  import Explorer.Chain, only: [add_fetcher_limit: 2]
+
   alias Explorer.Chain.{Hash, Transaction}
   alias Explorer.Repo
 
@@ -44,5 +46,46 @@ defmodule Explorer.Chain.PendingTransactionOperation do
     |> where([_pto, t], t.block_number <= ^to_block_number)
     |> select([_pto, t], count(t.block_number, :distinct))
     |> Repo.one()
+  end
+
+  @doc """
+  Returns a stream of all transactions with unfetched internal transactions, using
+  the `pending_transaction_operation` table.
+      iex> unfetched_block = insert(:block)
+      iex> unfetched_transaction = insert(:transaction) |> with_block(unfetched_block)
+      iex> insert(:pending_transaction_operation, transaction: unfetched_transaction)
+      iex> {:ok, transaction_params_set} = Explorer.Chain.stream_transactions_with_unfetched_internal_transactions(
+      ...>   MapSet.new(),
+      ...>   fn transaction_params, acc ->
+      ...>     MapSet.put(acc, transaction_params)
+      ...>   end
+      ...> )
+      iex> %{
+      ...>   block_number: unfetched_transaction.block_number,
+      ...>   hash: unfetched_transaction.hash,
+      ...>   index: unfetched_transaction.index
+      ...> } in transaction_params_set
+      true
+  """
+  @spec stream_transactions_with_unfetched_internal_transactions(
+          initial :: accumulator,
+          reducer :: (entry :: term(), accumulator -> accumulator)
+        ) :: {:ok, accumulator}
+        when accumulator: term()
+  def stream_transactions_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
+      when is_function(reducer, 2) do
+    direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
+
+    query =
+      from(
+        po in __MODULE__,
+        join: t in assoc(po, :transaction),
+        select: %{block_number: t.block_number, hash: t.hash, index: t.index},
+        order_by: [{^direction, t.block_number}]
+      )
+
+    query
+    |> add_fetcher_limit(limited?)
+    |> Repo.stream_reduce(initial, reducer)
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
@@ -1,0 +1,48 @@
+defmodule Explorer.Chain.PendingTransactionOperation do
+  @moduledoc """
+  Tracks a transaction that has pending operations.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, Transaction}
+  alias Explorer.Repo
+
+  @required_attrs ~w(transaction_hash)a
+
+  @typedoc """
+   * `transaction_hash` - the hash of the transaction that has pending operations.
+  """
+  @primary_key false
+  typed_schema "pending_transaction_operations" do
+    timestamps()
+
+    belongs_to(:transaction, Transaction,
+      foreign_key: :transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full,
+      null: false
+    )
+  end
+
+  def changeset(%__MODULE__{} = pending_ops, attrs) do
+    pending_ops
+    |> cast(attrs, @required_attrs)
+    |> validate_required(@required_attrs)
+  end
+
+  @doc """
+    Returns the count of pending blocks in provided range
+    (between `from_block_number` and `to_block_number`).
+  """
+  @spec blocks_count_in_range(integer(), integer()) :: integer()
+  def blocks_count_in_range(from_block_number, to_block_number) when from_block_number <= to_block_number do
+    __MODULE__
+    |> join(:inner, [pto], t in assoc(pto, :transaction))
+    |> where([_pto, t], t.block_number >= ^from_block_number)
+    |> where([_pto, t], t.block_number <= ^to_block_number)
+    |> select([_pto, t], count(t.block_number, :distinct))
+    |> Repo.one()
+  end
+end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -17,6 +17,7 @@ defmodule Explorer.Chain.Transaction.Schema do
     Hash,
     InternalTransaction,
     Log,
+    PendingTransactionOperation,
     SignedAuthorization,
     TokenTransfer,
     TransactionAction,
@@ -285,6 +286,8 @@ defmodule Explorer.Chain.Transaction.Schema do
           foreign_key: :transaction_hash,
           references: :hash
         )
+
+        has_one(:pending_operation, PendingTransactionOperation, foreign_key: :transaction_hash, references: :hash)
 
         unquote_splicing(@chain_type_fields)
       end

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1317,10 +1317,22 @@ defmodule Explorer.Chain.Transaction do
   @doc """
   Builds an `Ecto.Query` to fetch transactions for the specified block_numbers
   """
+  @spec transactions_for_block_numbers([non_neg_integer()]) :: Ecto.Query.t()
   def transactions_for_block_numbers(block_numbers) do
     from(
       t in Transaction,
       where: t.block_number in ^block_numbers
+    )
+  end
+
+  @doc """
+  Builds an `Ecto.Query` to fetch transactions by hashes
+  """
+  @spec transactions_by_hashes([Hash.t()]) :: Ecto.Query.t()
+  def transactions_by_hashes(hashes) do
+    from(
+      t in Transaction,
+      where: t.hash in ^hashes
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -1315,6 +1315,16 @@ defmodule Explorer.Chain.Transaction do
   end
 
   @doc """
+  Builds an `Ecto.Query` to fetch transactions for the specified block_numbers
+  """
+  def transactions_for_block_numbers(block_numbers) do
+    from(
+      t in Transaction,
+      where: t.block_number in ^block_numbers
+    )
+  end
+
+  @doc """
   Builds an `Ecto.Query` to fetch the last nonce from the given address hash.
 
   The last nonce value means the total of transactions that the given address has sent through the

--- a/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
@@ -1,16 +1,17 @@
 defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
   @moduledoc """
   Searches for all failed transactions for which all internal transactions are successful
-  and adds block numbers of these transactions to pending_block_operations.
+  and adds them to pending_block_operations or pending_transaction_operations.
   """
 
   use Explorer.Migrator.FillingMigration
 
   import Ecto.Query
 
-  alias Explorer.Chain.{Block, InternalTransaction, PendingBlockOperation, Transaction}
+  alias Explorer.{Chain, Repo}
+  alias Explorer.Chain.{Block, InternalTransaction, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Migrator.FillingMigration
-  alias Explorer.Repo
+  alias Explorer.Utility.SwitchPendingOperations
   alias Indexer.Fetcher.InternalTransaction, as: InternalTransactionFetcher
 
   @migration_name "reindex_internal_transactions_with_incompatible_status"
@@ -24,7 +25,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
 
     ids =
       unprocessed_data_query()
-      |> select([t], t.block_number)
+      |> select_query()
       |> distinct(true)
       |> limit(^limit)
       |> Repo.all(timeout: :infinity)
@@ -67,28 +68,60 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
   end
 
   @impl FillingMigration
-  def update_batch(block_numbers) do
+  def update_batch(block_numbers_or_transaction_hashes) do
     now = DateTime.utc_now()
 
-    params =
-      Block
-      |> where([b], b.number in ^block_numbers)
-      |> where([b], b.consensus == true)
-      |> select([b], %{block_hash: b.hash, block_number: b.number})
-      |> Repo.all()
-      |> Enum.uniq_by(& &1.block_number)
-      |> Enum.map(&Map.merge(&1, %{inserted_at: now, updated_at: now}))
+    pending_operations_type = SwitchPendingOperations.pending_operations_type()
 
     {_total, inserted} =
-      Repo.insert_all(PendingBlockOperation, params, on_conflict: :nothing, returning: [:block_number])
+      case pending_operations_type do
+        "blocks" ->
+          params =
+            Block
+            |> where([b], b.number in ^block_numbers_or_transaction_hashes)
+            |> where([b], b.consensus == true)
+            |> select([b], %{block_hash: b.hash, block_number: b.number})
+            |> Repo.all()
+            |> Enum.uniq_by(& &1.block_number)
+            |> Enum.map(&Map.merge(&1, %{inserted_at: now, updated_at: now}))
+
+          Repo.insert_all(PendingBlockOperation, params, on_conflict: :nothing, returning: [:block_number])
+
+        "transactions" ->
+          params =
+            Enum.map(block_numbers_or_transaction_hashes, fn transaction_hash ->
+              %{transaction_hash: transaction_hash, inserted_at: now, updated_at: now}
+            end)
+
+          Repo.insert_all(PendingTransactionOperation, params, on_conflict: :nothing, returning: [:transaction_hash])
+      end
 
     unless is_nil(Process.whereis(InternalTransactionFetcher)) do
-      inserted
-      |> Enum.map(& &1.block_number)
-      |> InternalTransactionFetcher.async_fetch(false)
+      {block_numbers, transactions} =
+        case pending_operations_type do
+          "blocks" ->
+            {Enum.map(inserted, & &1.block_number), []}
+
+          "transactions" ->
+            transactions =
+              inserted
+              |> Enum.map(& &1.transaction_hash)
+              |> Chain.get_transactions_by_hashes()
+
+            {[], transactions}
+        end
+
+      InternalTransactionFetcher.async_fetch(block_numbers, transactions, false)
     end
   end
 
   @impl FillingMigration
   def update_cache, do: :ok
+
+  defp select_query(query) do
+    case SwitchPendingOperations.pending_operations_type() do
+      "blocks" -> select(query, [t], t.block_number)
+      "transactions" -> select(query, [t], t.hash)
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
@@ -9,9 +9,17 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
   import Ecto.Query
 
   alias Explorer.{Chain, Repo}
-  alias Explorer.Chain.{Block, InternalTransaction, PendingBlockOperation, PendingTransactionOperation, Transaction}
+
+  alias Explorer.Chain.{
+    Block,
+    InternalTransaction,
+    PendingBlockOperation,
+    PendingOperationsHelper,
+    PendingTransactionOperation,
+    Transaction
+  }
+
   alias Explorer.Migrator.FillingMigration
-  alias Explorer.Utility.SwitchPendingOperations
   alias Indexer.Fetcher.InternalTransaction, as: InternalTransactionFetcher
 
   @migration_name "reindex_internal_transactions_with_incompatible_status"
@@ -71,7 +79,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
   def update_batch(block_numbers_or_transaction_hashes) do
     now = DateTime.utc_now()
 
-    pending_operations_type = SwitchPendingOperations.pending_operations_type()
+    pending_operations_type = PendingOperationsHelper.pending_operations_type()
 
     {_total, inserted} =
       case pending_operations_type do
@@ -119,7 +127,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
   def update_cache, do: :ok
 
   defp select_query(query) do
-    case SwitchPendingOperations.pending_operations_type() do
+    case PendingOperationsHelper.pending_operations_type() do
       "blocks" -> select(query, [t], t.block_number)
       "transactions" -> select(query, [t], t.hash)
     end

--- a/apps/explorer/lib/explorer/migrator/switch_pending_operations.ex
+++ b/apps/explorer/lib/explorer/migrator/switch_pending_operations.ex
@@ -1,0 +1,22 @@
+defmodule Explorer.Migrator.SwitchPendingOperations do
+  @moduledoc false
+
+  use GenServer, restart: :transient
+
+  alias Explorer.Chain.PendingOperationsHelper
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, %{}, {:continue, :ok}}
+  end
+
+  @impl true
+  def handle_continue(:ok, state) do
+    PendingOperationsHelper.maybe_transfuse_data()
+    {:stop, :normal, state}
+  end
+end

--- a/apps/explorer/lib/explorer/utility/switch_pending_operations.ex
+++ b/apps/explorer/lib/explorer/utility/switch_pending_operations.ex
@@ -1,0 +1,107 @@
+defmodule Explorer.Utility.SwitchPendingOperations do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias Explorer.Chain.{PendingBlockOperation, PendingTransactionOperation, Transaction}
+  alias Explorer.Repo
+
+  @transactions_batch_size 1000
+  @blocks_batch_size 100
+
+  def pending_operations_type do
+    if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.Geth and
+         not Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)[:block_traceable?],
+       do: "transactions",
+       else: "blocks"
+  end
+
+  def actual_entity do
+    case pending_operations_type() do
+      "blocks" -> PendingBlockOperation
+      "transactions" -> PendingTransactionOperation
+    end
+  end
+
+  def maybe_transfuse_data do
+    case {pending_operations_type(), data_exists?(PendingBlockOperation), data_exists?(PendingTransactionOperation)} do
+      {"blocks", _blocks_data_exists?, true} -> do_transfuse(&from_transactions_to_blocks_function/0)
+      {"transactions", true, _transactions_data_exists?} -> do_transfuse(&from_blocks_to_transactions_function/0)
+      {_entity, _blocks_data_exists?, _transactions_data_exists?} -> :ok
+    end
+  end
+
+  defp data_exists?(entity) do
+    entity
+    |> select([_], 1)
+    |> limit(1)
+    |> Repo.one()
+    |> is_nil()
+    |> Kernel.not()
+  end
+
+  defp do_transfuse(transfuse_function) do
+    case Repo.transaction(transfuse_function) do
+      {:ok, :finish} -> :ok
+      {:ok, :continue} -> do_transfuse(transfuse_function)
+    end
+  end
+
+  defp from_transactions_to_blocks_function do
+    pbo_params_query =
+      from(
+        pto in PendingTransactionOperation,
+        join: t in assoc(pto, :transaction),
+        select: %{block_hash: t.block_hash, block_number: t.block_number},
+        limit: @transactions_batch_size
+      )
+
+    case Repo.all(pbo_params_query) do
+      [] ->
+        :finish
+
+      pbo_params ->
+        Repo.insert_all(PendingBlockOperation, pbo_params, on_conflict: :nothing)
+
+        block_numbers_to_delete = Enum.map(pbo_params, & &1.block_number)
+
+        delete_query =
+          from(
+            pto in PendingTransactionOperation,
+            join: t in assoc(pto, :transaction),
+            where: t.block_number in ^block_numbers_to_delete
+          )
+
+        Repo.delete_all(delete_query)
+
+        :continue
+    end
+  end
+
+  defp from_blocks_to_transactions_function do
+    pbo_block_numbers_query =
+      PendingBlockOperation
+      |> limit(@blocks_batch_size)
+      |> select([pbo], pbo.block_number)
+
+    case Repo.all(pbo_block_numbers_query) do
+      [] ->
+        :finish
+
+      pbo_block_numbers ->
+        pto_params =
+          Transaction
+          |> where([t], t.block_number in ^pbo_block_numbers)
+          |> select([t], %{transaction_hash: t.hash})
+          |> Repo.all()
+
+        Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
+
+        PendingBlockOperation
+        |> where([pbo], pbo.block_number in ^pbo_block_numbers)
+        |> Repo.delete_all()
+
+        :continue
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20241031110127_create_pending_transaction_operations.exs
+++ b/apps/explorer/priv/repo/migrations/20241031110127_create_pending_transaction_operations.exs
@@ -1,0 +1,14 @@
+defmodule Explorer.Repo.Migrations.CreatePendingTransactionOperations do
+  use Ecto.Migration
+
+  def change do
+    create table(:pending_transaction_operations, primary_key: false) do
+      add(:transaction_hash, references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false,
+        primary_key: true
+      )
+
+      timestamps()
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -420,6 +420,11 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, new_block)
       %Ecto.Changeset{valid?: true, changes: block_changes1} = Block.changeset(%Block{}, new_block1)
 
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+
       Multi.new()
       |> Blocks.run([block_changes, block_changes1], options)
       |> Repo.transaction()
@@ -438,6 +443,11 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
 
       %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, new_block)
       %Ecto.Changeset{valid?: true, changes: block_changes1} = Block.changeset(%Block{}, new_block1)
+
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
 
       Multi.new()
       |> Blocks.run([block_changes, block_changes1], options)

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -5,6 +5,13 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
   alias Explorer.Chain.{Block, Data, Wei, PendingBlockOperation, Transaction, InternalTransaction}
   alias Explorer.Chain.Import.Runner.InternalTransactions
 
+  setup do
+    config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+    on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+  end
+
   describe "run/1" do
     test "transaction's status doesn't become :error when its internal_transaction has an error" do
       transaction = insert(:transaction) |> with_block(status: :ok)

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -680,6 +680,11 @@ defmodule Explorer.Chain.ImportTest do
         }
       }
 
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+
       assert {:ok, _} = Import.all(options)
 
       {:ok, block_hash_casted} = Explorer.Chain.Hash.Full.cast(block_hash)
@@ -769,6 +774,11 @@ defmodule Explorer.Chain.ImportTest do
           with: :blockless_changeset
         }
       }
+
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
 
       assert {:ok, _} = Import.all(options)
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -56,6 +56,11 @@ defmodule Explorer.ChainTest do
       nonconsensus_block = insert(:block, consensus: false)
       insert(:pending_block_operation, block: nonconsensus_block, block_number: nonconsensus_block.number)
 
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops()
 
       assert Repo.get(PendingBlockOperation, block.hash)
@@ -71,6 +76,11 @@ defmodule Explorer.ChainTest do
 
       nonconsensus_block1 = insert(:block, consensus: false)
       insert(:pending_block_operation, block: nonconsensus_block1, block_number: nonconsensus_block1.number)
+
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
 
       :ok = Chain.remove_nonconsensus_blocks_from_pending_ops([nonconsensus_block1.hash])
 
@@ -1002,6 +1012,11 @@ defmodule Explorer.ChainTest do
           insert(:pending_block_operation, block: block, block_number: block.number)
         end
       end
+
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
 
       Chain.indexed_ratio_internal_transactions()
 

--- a/apps/explorer/test/explorer/migrator/reindex_internal_transactions_with_incompatible_status_test.exs
+++ b/apps/explorer/test/explorer/migrator/reindex_internal_transactions_with_incompatible_status_test.exs
@@ -6,6 +6,13 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatusTes
   alias Explorer.Repo
 
   describe "Migrate incorrect internal transactions" do
+    setup do
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+    end
+
     test "Adds new pbo for incorrect internal transactions" do
       incorrect_block_numbers =
         Enum.map(1..5, fn i ->

--- a/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
+++ b/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
@@ -1,0 +1,87 @@
+defmodule Explorer.Migrator.SwitchPendingOperationsTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.{PendingBlockOperation, PendingTransactionOperation}
+  alias Explorer.Migrator.SwitchPendingOperations
+  alias Explorer.Repo
+
+  describe "transfuse data" do
+    setup do
+      initial_config_json_rpc = Application.get_env(:explorer, :json_rpc_named_arguments)
+      initial_config_geth = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, :json_rpc_named_arguments, initial_config_json_rpc)
+        Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, initial_config_geth)
+      end)
+    end
+
+    test "from pbo to pto" do
+      first_block = insert(:block)
+      second_block = insert(:block)
+      insert(:pending_block_operation, block_number: first_block.number, block_hash: first_block.hash)
+      insert(:pending_block_operation, block_number: second_block.number, block_hash: second_block.hash)
+
+      2
+      |> insert_list(:transaction)
+      |> with_block(first_block)
+
+      3
+      |> insert_list(:transaction)
+      |> with_block(second_block)
+
+      json_rpc_config = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+      Application.put_env(
+        :explorer,
+        :json_rpc_named_arguments,
+        Keyword.put(json_rpc_config, :variant, EthereumJSONRPC.Geth)
+      )
+
+      geth_config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(geth_config, :block_traceable?, false))
+
+      SwitchPendingOperations.start_link([])
+      Process.sleep(100)
+
+      assert [] = Repo.all(PendingBlockOperation)
+      assert [_, _, _, _, _] = Repo.all(PendingTransactionOperation)
+    end
+
+    test "from pto to pbo" do
+      first_block = insert(:block)
+      second_block = insert(:block)
+
+      transactions_1 =
+        2
+        |> insert_list(:transaction)
+        |> with_block(first_block)
+
+      transactions_2 =
+        3
+        |> insert_list(:transaction)
+        |> with_block(second_block)
+
+      Enum.each(transactions_1 ++ transactions_2, fn %{hash: transaction_hash} ->
+        insert(:pending_transaction_operation, transaction_hash: transaction_hash)
+      end)
+
+      json_rpc_config = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+      Application.put_env(
+        :explorer,
+        :json_rpc_named_arguments,
+        Keyword.put(json_rpc_config, :variant, EthereumJSONRPC.Geth)
+      )
+
+      geth_config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(geth_config, :block_traceable?, true))
+
+      SwitchPendingOperations.start_link([])
+      Process.sleep(100)
+
+      assert [] = Repo.all(PendingTransactionOperation)
+      assert [_, _] = Repo.all(PendingBlockOperation)
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -41,6 +41,7 @@ defmodule Explorer.Factory do
     InternalTransaction,
     Log,
     PendingBlockOperation,
+    PendingTransactionOperation,
     SmartContract,
     SmartContractAdditionalSource,
     Token,
@@ -736,6 +737,10 @@ defmodule Explorer.Factory do
 
   def pending_block_operation_factory do
     %PendingBlockOperation{}
+  end
+
+  def pending_transaction_operation_factory do
+    %PendingTransactionOperation{}
   end
 
   def internal_transaction_factory() do

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -527,10 +527,10 @@ defmodule Indexer.Block.Fetcher do
 
   def async_import_created_contract_codes(_, _), do: :ok
 
-  def async_import_internal_transactions(%{blocks: blocks}, realtime?) do
+  def async_import_internal_transactions(%{blocks: blocks, transactions: transactions}, realtime?) do
     blocks
     |> Enum.map(fn %Block{number: block_number} -> block_number end)
-    |> InternalTransaction.async_fetch(realtime?, 10_000)
+    |> InternalTransaction.async_fetch(transactions, realtime?, 10_000)
   end
 
   def async_import_internal_transactions(_, _), do: :ok

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -15,7 +15,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   alias EthereumJSONRPC.Block.ByNumber
   alias EthereumJSONRPC.Blocks
   alias Explorer.Repo
-  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, Transaction}
   alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Utility.SwitchPendingOperations
 
@@ -202,10 +202,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
         |> Repo.delete_all()
 
       "transactions" ->
-        PendingTransactionOperation
-        |> join(:inner, [pto], t in assoc(pto, :transaction))
-        |> where([_pto, t], t.block_hash in ^block_hashes)
-        |> Repo.delete_all()
+        :ok
     end
   rescue
     postgrex_error in Postgrex.Error ->

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -9,14 +9,15 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
 
   require Logger
 
-  import Ecto.Query, only: [from: 2, subquery: 1, where: 3]
+  import Ecto.Query
   import EthereumJSONRPC, only: [id_to_params: 1, integer_to_quantity: 1, json_rpc: 2, quantity_to_integer: 1]
 
   alias EthereumJSONRPC.Block.ByNumber
   alias EthereumJSONRPC.Blocks
   alias Explorer.Repo
-  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Utility.SwitchPendingOperations
 
   @update_timeout 60_000
 
@@ -194,9 +195,18 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
       timeout: @update_timeout
     )
 
-    PendingBlockOperation
-    |> where([po], po.block_hash in ^block_hashes)
-    |> Repo.delete_all()
+    case SwitchPendingOperations.pending_operations_type() do
+      "blocks" ->
+        PendingBlockOperation
+        |> where([po], po.block_hash in ^block_hashes)
+        |> Repo.delete_all()
+
+      "transactions" ->
+        PendingTransactionOperation
+        |> join(:inner, [pto], t in assoc(pto, :transaction))
+        |> where([_pto, t], t.block_hash in ^block_hashes)
+        |> Repo.delete_all()
+    end
   rescue
     postgrex_error in Postgrex.Error ->
       {:error, %{exception: postgrex_error}}

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -15,9 +15,8 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   alias EthereumJSONRPC.Block.ByNumber
   alias EthereumJSONRPC.Blocks
   alias Explorer.Repo
-  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingOperationsHelper, Transaction}
   alias Explorer.Chain.Cache.BlockNumber
-  alias Explorer.Utility.SwitchPendingOperations
 
   @update_timeout 60_000
 
@@ -195,7 +194,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
       timeout: @update_timeout
     )
 
-    case SwitchPendingOperations.pending_operations_type() do
+    case PendingOperationsHelper.pending_operations_type() do
       "blocks" ->
         PendingBlockOperation
         |> where([po], po.block_hash in ^block_hashes)

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain
-  alias Explorer.Chain.{Block, Hash, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
@@ -91,10 +91,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
     {:ok, final} =
       case queue_data_type(json_rpc_named_arguments) do
         :block_number ->
-          Chain.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
+          PendingBlockOperation.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
 
         :transaction_params ->
-          Chain.stream_transactions_with_unfetched_internal_transactions(initial, stream_reducer)
+          PendingTransactionOperation.stream_transactions_with_unfetched_internal_transactions(initial, stream_reducer)
       end
 
     final

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain
-  alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Chain.{Block, Hash, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
@@ -47,12 +47,22 @@ defmodule Indexer.Fetcher.InternalTransaction do
   *Note*: The internal transactions for individual transactions cannot be paginated,
   so the total number of internal transactions that could be produced is unknown.
   """
-  @spec async_fetch([Block.block_number()], boolean()) :: :ok
-  def async_fetch(block_numbers, realtime?, timeout \\ 5000) when is_list(block_numbers) do
+  @spec async_fetch([Block.block_number()], [Transaction.t()], boolean()) :: :ok
+  def async_fetch(block_numbers, transactions, realtime?, timeout \\ 5000) when is_list(block_numbers) do
     if InternalTransactionSupervisor.disabled?() do
       :ok
     else
-      BufferedTask.buffer(__MODULE__, block_numbers, realtime?, timeout)
+      data = data_for_buffer(block_numbers, transactions)
+      BufferedTask.buffer(__MODULE__, data, realtime?, timeout)
+    end
+  end
+
+  defp data_for_buffer(block_numbers, transactions) do
+    json_rpc_named_arguments = Application.get_env(:indexer, :json_rpc_named_arguments)
+
+    case queue_data_type(json_rpc_named_arguments) do
+      :block_number -> block_numbers
+      :transaction_params -> Enum.map(transactions, &Map.take(&1, [:block_number, :hash, :index]))
     end
   end
 
@@ -75,10 +85,17 @@ defmodule Indexer.Fetcher.InternalTransaction do
   end
 
   @impl BufferedTask
-  def init(initial, reducer, _json_rpc_named_arguments) do
+  def init(initial, reducer, json_rpc_named_arguments) do
     stream_reducer = RangesHelper.stream_reducer_traceable(reducer)
 
-    {:ok, final} = Chain.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
+    {:ok, final} =
+      case queue_data_type(json_rpc_named_arguments) do
+        :block_number ->
+          Chain.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
+
+        :transaction_params ->
+          Chain.stream_transactions_with_unfetched_internal_transactions(initial, stream_reducer)
+      end
 
     final
   end
@@ -94,76 +111,73 @@ defmodule Indexer.Fetcher.InternalTransaction do
               service: :indexer,
               tracer: Tracer
             )
-  def run(block_numbers, json_rpc_named_arguments) do
-    unique_numbers =
-      block_numbers
-      |> Enum.uniq()
-      |> Chain.filter_non_refetch_needed_block_numbers()
+  def run(block_numbers_or_transactions, json_rpc_named_arguments) do
+    data_type = queue_data_type(json_rpc_named_arguments)
+    filtered_data = filter_block_numbers(block_numbers_or_transactions, data_type, json_rpc_named_arguments)
 
-    filtered_unique_numbers =
-      unique_numbers
-      |> RangesHelper.filter_traceable_block_numbers()
-      |> drop_genesis(json_rpc_named_arguments)
-
-    filtered_unique_numbers_count = Enum.count(filtered_unique_numbers)
-    Logger.metadata(count: filtered_unique_numbers_count)
-
-    Logger.debug("fetching internal transactions for blocks")
-
-    json_rpc_named_arguments
-    |> Keyword.fetch!(:variant)
-    |> fetch_internal_transactions(filtered_unique_numbers, json_rpc_named_arguments)
-    |> case do
+    case fetch_internal_transactions(filtered_data, json_rpc_named_arguments, data_type) do
       {:ok, internal_transactions_params} ->
-        safe_import_internal_transaction(internal_transactions_params, filtered_unique_numbers)
+        safe_import_internal_transaction(internal_transactions_params, filtered_data, data_type)
 
       {:error, reason} ->
         Logger.error(
           fn ->
             [
-              "failed to fetch internal transactions for blocks #{inspect(filtered_unique_numbers)}: ",
+              "failed to fetch internal transactions for #{data_type} #{inspect(filtered_data)}: ",
               Exception.format(:error, reason)
             ]
           end,
-          error_count: filtered_unique_numbers_count
+          error_count: Enum.count(filtered_data)
         )
 
         handle_not_found_transaction(reason)
 
         # re-queue the de-duped entries
-        {:retry, filtered_unique_numbers}
+        {:retry, filtered_data}
 
       {:error, reason, stacktrace} ->
         Logger.error(
           fn ->
             [
-              "failed to fetch internal transactions for blocks #{inspect(filtered_unique_numbers)}: ",
+              "failed to fetch internal transactions for #{data_type} #{inspect(filtered_data)}: ",
               Exception.format(:error, reason, stacktrace)
             ]
           end,
-          error_count: filtered_unique_numbers_count
+          error_count: Enum.count(filtered_data)
         )
 
         handle_not_found_transaction(reason)
 
         # re-queue the de-duped entries
-        {:retry, filtered_unique_numbers}
+        {:retry, filtered_data}
 
       :ignore ->
         :ok
     end
   end
 
-  defp fetch_internal_transactions(variant, block_numbers, json_rpc_named_arguments) do
-    if variant in block_traceable_variants() do
-      EthereumJSONRPC.fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments)
-    else
-      try do
-        fetch_block_internal_transactions_by_transactions(block_numbers, json_rpc_named_arguments)
-      rescue
-        error ->
-          {:error, error, __STACKTRACE__}
-      end
+  defp fetch_internal_transactions(block_numbers_or_transactions, json_rpc_named_arguments, data_type) do
+    Logger.metadata(count: Enum.count(block_numbers_or_transactions))
+
+    case data_type do
+      :block_number ->
+        Logger.debug("fetching internal transactions by blocks")
+
+        block_numbers_or_transactions
+        |> check_and_filter_block_numbers()
+        |> EthereumJSONRPC.fetch_block_internal_transactions(json_rpc_named_arguments)
+
+      :transaction_params ->
+        Logger.debug("fetching internal transactions by transactions")
+
+        try do
+          block_numbers_or_transactions
+          |> check_and_filter_transactions()
+          |> fetch_internal_transactions_by_transactions(json_rpc_named_arguments)
+        rescue
+          error ->
+            {:error, error, __STACKTRACE__}
+        end
     end
   end
 
@@ -216,33 +230,57 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end
   end
 
-  defp fetch_block_internal_transactions_by_transactions(unique_numbers, json_rpc_named_arguments) do
-    Enum.reduce(unique_numbers, {:ok, []}, fn
-      block_number, {:ok, acc_list} ->
-        block_number
-        |> Chain.get_transactions_of_block_number()
-        |> filter_non_traceable_transactions()
-        |> Enum.map(&params(&1))
-        |> case do
-          [] ->
-            {:ok, []}
+  defp filter_block_numbers(block_numbers, :block_number, json_rpc_named_arguments) do
+    block_numbers
+    |> Enum.uniq()
+    |> Chain.filter_non_refetch_needed_block_numbers()
+    |> RangesHelper.filter_traceable_block_numbers()
+    |> drop_genesis(json_rpc_named_arguments)
+  end
 
-          transactions ->
-            try do
-              EthereumJSONRPC.fetch_internal_transactions(transactions, json_rpc_named_arguments)
-            catch
-              :exit, error ->
-                {:error, error, __STACKTRACE__}
-            end
-        end
-        |> case do
-          {:ok, internal_transactions} -> {:ok, internal_transactions ++ acc_list}
-          error_or_ignore -> error_or_ignore
-        end
+  defp filter_block_numbers(transactions_params, :transaction_params, _json_rpc_named_arguments),
+    do: transactions_params
 
-      _, error_or_ignore ->
-        error_or_ignore
+  defp check_and_filter_block_numbers(block_numbers) do
+    Enum.reduce(block_numbers, [], fn number, acc ->
+      if is_integer(number) do
+        [number | acc]
+      else
+        Logger.error("InternalTransaction fetcher expected block number but got #{number}")
+        acc
+      end
     end)
+  end
+
+  defp check_and_filter_transactions(transactions) do
+    Enum.reduce(transactions, [], fn transaction, acc ->
+      case transaction do
+        %{block_number: block_number, hash: _hash, index: _index} when is_integer(block_number) ->
+          [transaction | acc]
+
+        _ ->
+          Logger.error("InternalTransaction fetcher expected transaction but got #{transaction}")
+          acc
+      end
+    end)
+  end
+
+  defp fetch_internal_transactions_by_transactions(transactions, json_rpc_named_arguments) do
+    transactions
+    |> filter_non_traceable_transactions()
+    |> Enum.map(&params/1)
+    |> case do
+      [] ->
+        {:ok, []}
+
+      transactions ->
+        try do
+          EthereumJSONRPC.fetch_internal_transactions(transactions, json_rpc_named_arguments)
+        catch
+          :exit, error ->
+            {:error, error, __STACKTRACE__}
+        end
+    end
   end
 
   @zetachain_non_traceable_type 88
@@ -253,15 +291,15 @@ defmodule Indexer.Fetcher.InternalTransaction do
     end
   end
 
-  defp safe_import_internal_transaction(internal_transactions_params, block_numbers) do
-    import_internal_transaction(internal_transactions_params, block_numbers)
+  defp safe_import_internal_transaction(internal_transactions_params, block_numbers, data_type) do
+    import_internal_transaction(internal_transactions_params, block_numbers, data_type)
   rescue
     Postgrex.Error ->
-      handle_foreign_key_violation(internal_transactions_params, block_numbers)
+      handle_foreign_key_violation(internal_transactions_params, block_numbers, data_type)
       {:retry, block_numbers}
   end
 
-  defp import_internal_transaction(internal_transactions_params, unique_numbers) do
+  defp import_internal_transaction(internal_transactions_params, transactions_params_or_unique_numbers, data_type) do
     internal_transactions_params_marked = mark_failed_transactions(internal_transactions_params)
 
     addresses_params =
@@ -278,10 +316,16 @@ defmodule Indexer.Fetcher.InternalTransaction do
       AddressCoinBalances.params_set(%{internal_transactions_params: internal_transactions_params_marked})
 
     empty_block_numbers =
-      unique_numbers
-      |> MapSet.new()
-      |> MapSet.difference(MapSet.new(internal_transactions_params_marked, & &1.block_number))
-      |> Enum.map(&%{block_number: &1})
+      case data_type do
+        :block_number ->
+          transactions_params_or_unique_numbers
+          |> MapSet.new()
+          |> MapSet.difference(MapSet.new(internal_transactions_params_marked, & &1.block_number))
+          |> Enum.map(&%{block_number: &1})
+
+        :transaction_params ->
+          []
+      end
 
     internal_transactions_and_empty_block_numbers = internal_transactions_params_marked ++ empty_block_numbers
 
@@ -289,7 +333,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
       %{token_transfers: celo_token_transfers, tokens: celo_tokens} =
       if Application.get_env(:explorer, :chain_type) == :celo do
         block_number_to_block_hash =
-          unique_numbers
+          transactions_params_or_unique_numbers
+          |> data_to_block_numbers(data_type)
           |> Chain.block_hash_by_number()
           |> Map.new(fn
             {block_number, block_hash} ->
@@ -329,18 +374,18 @@ defmodule Indexer.Fetcher.InternalTransaction do
         Logger.error(
           fn ->
             [
-              "failed to import internal transactions for blocks: ",
+              "failed to import internal transactions for #{data_type}: ",
               inspect(reason)
             ]
           end,
           step: step,
-          error_count: Enum.count(unique_numbers)
+          error_count: Enum.count(transactions_params_or_unique_numbers)
         )
 
-        handle_unique_key_violation(reason, unique_numbers)
+        handle_unique_key_violation(reason, transactions_params_or_unique_numbers, data_type)
 
         # re-queue the de-duped entries
-        {:retry, unique_numbers}
+        {:retry, transactions_params_or_unique_numbers}
     end
   end
 
@@ -380,20 +425,28 @@ defmodule Indexer.Fetcher.InternalTransaction do
   # don't count itself as a parent
   defp has_failed_parent?(_failed_parent_paths, [], _reverse_path_acc), do: false
 
-  defp handle_unique_key_violation(%{exception: %{postgres: %{code: :unique_violation}}}, block_numbers) do
+  defp handle_unique_key_violation(
+         %{exception: %{postgres: %{code: :unique_violation}}},
+         transactions_params_or_unique_numbers,
+         data_type
+       ) do
+    block_numbers = data_to_block_numbers(transactions_params_or_unique_numbers, data_type)
+
     Block.set_refetch_needed(block_numbers)
 
     Logger.error(fn ->
       [
-        "unique_violation on internal transactions import, block numbers: ",
-        inspect(block_numbers)
+        "unique_violation on internal transactions import, #{data_type} identifiers: ",
+        inspect(transactions_params_or_unique_numbers)
       ]
     end)
   end
 
-  defp handle_unique_key_violation(_reason, _block_numbers), do: :ok
+  defp handle_unique_key_violation(_reason, _identifiers, _data_type), do: :ok
 
-  defp handle_foreign_key_violation(internal_transactions_params, block_numbers) do
+  defp handle_foreign_key_violation(internal_transactions_params, block_numbers_or_transactions, data_type) do
+    block_numbers = data_to_block_numbers(block_numbers_or_transactions, data_type)
+
     Block.set_refetch_needed(block_numbers)
 
     transaction_hashes =
@@ -429,6 +482,24 @@ defmodule Indexer.Fetcher.InternalTransaction do
     do: Block.set_refetch_needed([block_number])
 
   defp invalidate_block_from_error(_error_data), do: :ok
+
+  defp queue_data_type(json_rpc_named_arguments) do
+    variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
+
+    if variant in block_traceable_variants() do
+      :block_number
+    else
+      :transaction_params
+    end
+  end
+
+  defp data_to_block_numbers(block_numbers, :block_number), do: block_numbers
+
+  defp data_to_block_numbers(transactions_params, :transaction_params) do
+    transactions_params
+    |> Enum.map(& &1.block_number)
+    |> Enum.uniq()
+  end
 
   def defaults do
     [

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -259,7 +259,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
           [transaction | acc]
 
         _ ->
-          Logger.error("InternalTransaction fetcher expected transaction but got #{transaction}")
+          Logger.error("InternalTransaction fetcher expected transaction but got #{inspect(transaction)}")
           acc
       end
     end)

--- a/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
@@ -60,7 +60,7 @@ defmodule Indexer.Fetcher.PendingBlockOperationsSanitizer do
       |> update([pbo, po, b], set: [block_number: b.number])
       |> Repo.update_all([], timeout: @timeout)
 
-    transactions = Enum.map(block_numbers, &Chain.get_transactions_of_block_number/1)
+    transactions = Chain.get_transactions_of_block_numbers(block_numbers)
 
     InternalTransaction.async_fetch(block_numbers, transactions, false)
 

--- a/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/pending_block_operations_sanitizer.ex
@@ -7,8 +7,8 @@ defmodule Indexer.Fetcher.PendingBlockOperationsSanitizer do
 
   import Ecto.Query
 
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.PendingBlockOperation
-  alias Explorer.Repo
   alias Indexer.Fetcher.InternalTransaction
 
   @interval :timer.seconds(1)
@@ -60,7 +60,9 @@ defmodule Indexer.Fetcher.PendingBlockOperationsSanitizer do
       |> update([pbo, po, b], set: [block_number: b.number])
       |> Repo.update_all([], timeout: @timeout)
 
-    InternalTransaction.async_fetch(block_numbers, false)
+    transactions = Enum.map(block_numbers, &Chain.get_transactions_of_block_number/1)
+
+    InternalTransaction.async_fetch(block_numbers, transactions, false)
 
     block_numbers
   end

--- a/apps/indexer/lib/indexer/prometheus/collector/pending_transaction_operations_collector.ex
+++ b/apps/indexer/lib/indexer/prometheus/collector/pending_transaction_operations_collector.ex
@@ -1,0 +1,29 @@
+defmodule Indexer.Prometheus.Collector.PendingTransactionOperations do
+  @moduledoc """
+  Custom collector to count number of records in pending_transaction_operations table.
+  """
+
+  use Prometheus.Collector
+
+  alias Explorer.Chain.PendingTransactionOperation
+  alias Explorer.Repo
+  alias Prometheus.Model
+
+  def collect_mf(_registry, callback) do
+    callback.(
+      create_gauge(
+        :pending_transaction_operations_count,
+        "Number of records in pending_transaction_operations table",
+        Repo.aggregate(PendingTransactionOperation, :count)
+      )
+    )
+  end
+
+  def collect_metrics(:pending_transaction_operations_count, count) do
+    Model.gauge_metrics([{count}])
+  end
+
+  defp create_gauge(name, help, data) do
+    Model.create_mf(name, help, :gauge, __MODULE__, data)
+  end
+end

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -506,6 +506,11 @@ defmodule Indexer.Block.FetcherTest do
         end
       end
 
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+
       case Keyword.fetch!(json_rpc_named_arguments, :variant) do
         EthereumJSONRPC.Geth ->
           block_number = 48230

--- a/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
+++ b/apps/indexer/test/indexer/pending_ops_cleaner_test.exs
@@ -5,6 +5,13 @@ defmodule Indexer.PendingOpsCleanerTest do
   alias Indexer.PendingOpsCleaner
 
   describe "init/1" do
+    setup do
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+    end
+
     test "deletes non-consensus pending ops on init" do
       block = insert(:block, consensus: false)
 


### PR DESCRIPTION
## Motivation

In case when internal transactions fetcher requests traces by transactions (via `debug_traceTransaction` method), there is no way to set its batch size correctly because it uses the `pending_block_operations` table to track blocks that aren't traced yet which means that the `INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE` defines it in blocks and every batch request to node will contain _batch_size * number of transactions in block_  requests instead of just _batch_size_.

## Changelog

Introduced `pending_transaction_operations` table. Its behaviour is similar to `pending_block_operations`.
When application is started it will check the current tracing schema (by transactions if `ETHEREUM_JSONRPC_VARIANT=geth` and `ETHEREUM_JSONRPC_GETH_TRACE_BY_BLOCK=false` and by blocks otherwise) and migrate the data between `pending_block_operations` and `pending_transaction_operations` if it's necessary.
All internal transactions related processes operates with according entity based on current tracing schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced filtering of blockchain data by height range, allowing improved visibility into transactions and blocks.
  - Enabled batch retrieval of transactions across blocks and added robust monitoring metrics for pending operations.
  - Added support for managing both block and transaction operations within the system.

- **Improvements**
  - Optimized the processing and management of pending operations for smoother data migration and more reliable performance.
  - Updated configuration handling to ensure consistent and accurate tracking of blockchain operations.
  - Enhanced test setups to ensure accurate testing environments for blockchain interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->