### PR TITLE
fix: invalid metadata requests

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -86,9 +86,8 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
   def preload_metadata_to_list(items) do
     address_hash_strings =
       items
-      |> Enum.reduce([], fn item, acc ->
-        item_to_address_hash_strings(item) ++ acc
-      end)
+      |> Enum.flat_map(&item_to_address_hash_strings/1)
+      |> Enum.filter(&(&1 != ""))
       |> Enum.uniq()
 
     case Metadata.get_addresses_tags(address_hash_strings) do

--- a/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
@@ -19,15 +19,17 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
   @request_error_msg "Error while sending request to Metadata microservice"
 
   @spec get_addresses_tags([String.t()]) :: {:error, :disabled | <<_::416>> | Jason.DecodeError.t()} | {:ok, any()}
+  def get_addresses_tags([]), do: {:ok, %{addresses: %{}}}
+
   def get_addresses_tags(addresses) do
     with :ok <- Microservice.check_enabled(__MODULE__) do
-      body = %{
+      params = %{
         addresses: Enum.join(addresses, ","),
         tags_limit: @tags_per_address_limit,
         chain_id: Application.get_env(:block_scout_web, :chain_id)
       }
 
-      http_get_request(addresses_metadata_url(), body)
+      http_get_request(addresses_metadata_url(), params)
     end
   end
 


### PR DESCRIPTION
Closes #10207 

## Motivation

Fix the issue with invalid metadata requests to the Rust microservice.

## Changelog

* Do not send requests to the service in case of an empty addresses batch and return a default value instead.
* Filter out invalid address hashes prior to sending the request. In the issue I provided an example with an empty string in the request. I am still not sure why this empty string is appearing, but probably `item_to_address_hash_strings` invokes `to_string` on a `nil` value somewhere.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
