### PR TITLE
fix: Return `l1_tx_hashes` in the response of /batches/da/celestia/... API endpoint

### DIFF
--- a/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
@@ -119,6 +119,8 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
         # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
         "tx_count" => transaction_count,
         "l1_transaction_hashes" => batch.l1_transaction_hashes,
+        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
+        "l1_tx_hashes" => batch.l1_transaction_hashes,
         "batch_data_container" => batch_data_container
       }
 


### PR DESCRIPTION
## Motivation

Incompatible changes were introduced in the endpoint at https://github.com/blockscout/blockscout/pull/10913.


## Changelog

Temporarily return `l1_tx_hashes` into the response of /batches/da/celestia/... API endpoint until the new version of the frontend is released with the binding to new props (https://github.com/blockscout/frontend/issues/2374).

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
