### PR TITLE
Fix missing `signers` field in nested quorum certificate

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/zilliqa_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/zilliqa_view.ex
@@ -77,7 +77,8 @@ if Application.compile_env(:explorer, :chain_type) == :zilliqa do
             &%{
               view: &1.view,
               signature: &1.signature,
-              proposed_by_validator_index: &1.proposed_by_validator_index
+              proposed_by_validator_index: &1.proposed_by_validator_index,
+              signers: &1.signers
             }
           )
       })


### PR DESCRIPTION
Fix missing `signers` field in nested quorum certificate

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
