### PR TITLE
feat: add CSV export of epoch transactions for address

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -227,7 +227,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
     items_csv(conn, params, AddressLogCsvExporter)
   end
 
-  @spec celo_election_rewards_csv(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec celo_election_rewards_csv(Conn.t(), map()) :: Conn.t()
   def celo_election_rewards_csv(conn, params) do
     items_csv(conn, params, CeloAddressElectionRewardsCsvExporter)
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -22,6 +22,9 @@ defmodule BlockScoutWeb.AddressTransactionController do
     AddressTransactionCsvExporter
   }
 
+  alias Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter,
+    as: CeloAddressElectionRewardsCsvExporter
+
   alias Explorer.Chain.{DenormalizationHelper, Transaction, Wei}
 
   alias Indexer.Fetcher.OnDemand.CoinBalance, as: CoinBalanceOnDemand
@@ -222,5 +225,10 @@ defmodule BlockScoutWeb.AddressTransactionController do
 
   def logs_csv(conn, params) do
     items_csv(conn, params, AddressLogCsvExporter)
+  end
+
+  @spec celo_election_rewards_csv(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def celo_election_rewards_csv(conn, params) do
+    items_csv(conn, params, CeloAddressElectionRewardsCsvExporter)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -479,7 +479,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
   defp celo_reward_type_to_atom(reward_type_string) do
     reward_type_string
-    |> CeloElectionReward.type_from_string()
+    |> CeloElectionReward.type_from_url_string()
     |> case do
       {:ok, type} -> {:ok, type}
       :error -> {:error, {:invalid, :celo_election_reward_type}}

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -463,6 +463,10 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
 
     get("/logs-csv", AddressTransactionController, :logs_csv)
 
+    if Application.compile_env(:explorer, :chain_type) == :celo do
+      get("/celo-election-rewards-csv", AddressTransactionController, :celo_election_rewards_csv)
+    end
+
     scope "/health" do
       get("/", HealthController, :health)
       get("/liveness", HealthController, :liveness)

--- a/apps/explorer/lib/explorer/chain/celo/election_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/election_reward.ex
@@ -98,6 +98,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     )
 
     field(:token, :any, virtual: true) :: Token.t() | nil
+    field(:block_number, :integer, virtual: true)
 
     timestamps()
   end
@@ -113,12 +114,6 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     |> foreign_key_constraint(:block_hash)
     |> foreign_key_constraint(:account_address_hash)
     |> foreign_key_constraint(:associated_account_address_hash)
-
-    # todo: do I need to set this unique constraint here? or it is redundant?
-    # |> unique_constraint(
-    #   [:block_hash, :type, :account_address_hash, :associated_account_address_hash],
-    #   name: :celo_election_rewards_pkey
-    # )
   end
 
   @doc """
@@ -237,6 +232,9 @@ defmodule Explorer.Chain.Celo.ElectionReward do
       preload: [block: b],
       where: r.account_address_hash == ^address_hash,
       select: r,
+      select_merge: %{
+        block_number: b.number
+      },
       order_by: [
         desc: b.number,
         desc: r.amount,

--- a/apps/explorer/lib/explorer/chain/celo/election_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/election_reward.ex
@@ -46,6 +46,13 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     "delegated-payment" => :delegated_payment
   }
 
+  @reward_type_string_to_atom %{
+    "voter" => :voter,
+    "validator" => :validator,
+    "group" => :group,
+    "delegated_payment" => :delegated_payment
+  }
+
   @reward_type_atom_to_token_atom %{
     :voter => :celo_token,
     :validator => :usd_token,
@@ -335,7 +342,6 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     end
   end
 
-  # sobelow_skip ["DOS.StringToAtom"]
   @doc """
   Makes Explorer.PagingOptions map for election rewards.
   """
@@ -355,7 +361,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
          {amount, ""} <- Decimal.parse(amount_string),
          {:ok, associated_account_address_hash} <-
            Hash.Address.cast(associated_account_address_hash_string),
-         type when type in @types_enum <- String.to_atom(type_string) do
+         {:ok, type} <- Map.fetch(@reward_type_string_to_atom, type_string) do
       [
         paging_options: %{
           default_paging_options()
@@ -524,6 +530,11 @@ defmodule Explorer.Chain.Celo.ElectionReward do
   TODO: Consider reusing `Chain.where_block_number_in_period/3`. This would
   require storing or making `merge_select` of `block_number`.
   """
+  @spec where_block_number_in_period(
+          Ecto.Query.t(),
+          String.t() | integer() | nil,
+          String.t() | integer() | nil
+        ) :: Ecto.Query.t()
   def where_block_number_in_period(base_query, from_block, to_block)
       when is_nil(from_block) and not is_nil(to_block),
       do: where(base_query, [_, block], block.number <= ^to_block)

--- a/apps/explorer/lib/explorer/chain/celo/election_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/election_reward.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
   @type type :: :voter | :validator | :group | :delegated_payment
   @types_enum ~w(voter validator group delegated_payment)a
 
-  @reward_type_string_to_atom %{
+  @reward_type_url_string_to_atom %{
     "voter" => :voter,
     "validator" => :validator,
     "group" => :group,
@@ -123,7 +123,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
   def types, do: @types_enum
 
   @doc """
-  Converts a reward type string to its corresponding atom.
+  Converts a reward type url string to its corresponding atom.
 
   ## Parameters
   - `type_string` (`String.t()`): The string representation of the reward type.
@@ -133,15 +133,15 @@ defmodule Explorer.Chain.Celo.ElectionReward do
 
   ## Examples
 
-      iex> ElectionReward.type_from_string("voter")
+      iex> ElectionReward.type_from_url_string("voter")
       {:ok, :voter}
 
-      iex> ElectionReward.type_from_string("invalid")
+      iex> ElectionReward.type_from_url_string("invalid")
       :error
   """
-  @spec type_from_string(String.t()) :: {:ok, type} | :error
-  def type_from_string(type_string) do
-    Map.fetch(@reward_type_string_to_atom, type_string)
+  @spec type_from_url_string(String.t()) :: {:ok, type} | :error
+  def type_from_url_string(type_string) do
+    Map.fetch(@reward_type_url_string_to_atom, type_string)
   end
 
   @doc """
@@ -339,6 +339,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     end
   end
 
+  # sobelow_skip ["DOS.StringToAtom"]
   @doc """
   Makes Explorer.PagingOptions map for election rewards.
   """
@@ -358,7 +359,7 @@ defmodule Explorer.Chain.Celo.ElectionReward do
          {amount, ""} <- Decimal.parse(amount_string),
          {:ok, associated_account_address_hash} <-
            Hash.Address.cast(associated_account_address_hash_string),
-         {:ok, type} <- type_from_string(type_string) do
+         type when type in @types_enum <- String.to_atom(type_string) do
       [
         paging_options: %{
           default_paging_options()

--- a/apps/explorer/lib/explorer/chain/celo/reader.ex
+++ b/apps/explorer/lib/explorer/chain/celo/reader.ex
@@ -5,12 +5,6 @@ defmodule Explorer.Chain.Celo.Reader do
 
   import Ecto.Query, only: [limit: 2]
 
-  import Explorer.Chain,
-    only: [
-      select_repo: 1,
-      join_associations: 2
-    ]
-
   alias Explorer.Chain
   alias Explorer.Chain.Block
   alias Explorer.Chain.Cache.{Blocks, CeloCoreContracts}
@@ -58,8 +52,8 @@ defmodule Explorer.Chain.Celo.Reader do
     |> ElectionReward.join_token()
     |> ElectionReward.paginate(paging_options)
     |> limit(^paging_options.page_size)
-    |> join_associations(necessity_by_association)
-    |> select_repo(options).all()
+    |> Chain.join_associations(necessity_by_association)
+    |> Chain.select_repo(options).all()
   end
 
   @doc """
@@ -97,8 +91,8 @@ defmodule Explorer.Chain.Celo.Reader do
     |> ElectionReward.block_hash_to_rewards_by_type_query(reward_type)
     |> ElectionReward.paginate(paging_options)
     |> limit(^paging_options.page_size)
-    |> join_associations(necessity_by_association)
-    |> select_repo(options).all()
+    |> Chain.join_associations(necessity_by_association)
+    |> Chain.select_repo(options).all()
   end
 
   @doc """
@@ -135,7 +129,7 @@ defmodule Explorer.Chain.Celo.Reader do
     reward_type_to_aggregated_rewards =
       block_hash
       |> ElectionReward.block_hash_to_aggregated_rewards_by_type_query()
-      |> select_repo(options).all()
+      |> Chain.select_repo(options).all()
       |> Map.new(fn {type, total, count} ->
         {type, %{total: total, count: count}}
       end)

--- a/apps/explorer/lib/explorer/chain/celo/reader.ex
+++ b/apps/explorer/lib/explorer/chain/celo/reader.ex
@@ -54,7 +54,7 @@ defmodule Explorer.Chain.Celo.Reader do
 
     address_hash
     |> ElectionReward.address_hash_to_ordered_rewards_query()
-    |> Chain.where_block_number_in_period(from_block, to_block)
+    |> ElectionReward.where_block_number_in_period(from_block, to_block)
     |> ElectionReward.join_token()
     |> ElectionReward.paginate(paging_options)
     |> limit(^paging_options.page_size)

--- a/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
@@ -38,8 +38,6 @@ defmodule Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter do
       "ValidatorGroupAddress",
       "ToAddress",
       "Type",
-      "LockedGold",
-      "VotingGold",
       "Value",
       "ValueInWei",
       "TokenSymbol",
@@ -73,10 +71,6 @@ defmodule Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter do
           reward.account_address_hash,
           # Type
           "IN",
-          # LockedGold
-          "N/A",
-          # VotingGold
-          "N/A",
           # Value
           reward.amount |> Wei.to(:ether),
           # ValueInWei

--- a/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
@@ -1,0 +1,93 @@
+defmodule Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter do
+  @moduledoc """
+  Exports Celo election rewards to a csv file.
+  """
+  import Explorer.Chain.Celo.Helper,
+    only: [
+      block_number_to_epoch_number: 1
+    ]
+
+  alias Explorer.Chain.Celo.Reader
+  alias Explorer.Chain.CSVExport.Helper
+  alias Explorer.Chain.{Hash, Wei}
+
+  @spec export(Hash.Address.t(), String.t() | nil, String.t() | nil, any(), any()) :: Enumerable.t()
+  def export(address_hash, from_period, to_period, _filter_type, _filter_value) do
+    {from_block, to_block} = Helper.block_from_period(from_period, to_period)
+
+    options = [
+      paging_options: Helper.paging_options(),
+      from_block: from_block,
+      to_block: to_block
+    ]
+
+    address_hash
+    |> Reader.address_hash_to_election_rewards(options)
+    |> to_csv_format()
+    |> Helper.dump_to_stream()
+  end
+
+  @spec to_csv_format(Enumerable.t()) :: Enumerable.t()
+  defp to_csv_format(election_rewards) do
+    column_names = [
+      "EpochNumber",
+      "BlockNumber",
+      "TimestampUTC",
+      "EpochTxType",
+      "ValidatorAddress",
+      "ValidatorGroupAddress",
+      "ToAddress",
+      "Type",
+      "LockedGold",
+      "VotingGold",
+      "Value",
+      "ValueInWei",
+      "TokenSymbol",
+      "TokenContractAddress"
+    ]
+
+    reward_type_to_human_readable = %{
+      voter: "Voter Rewards",
+      validator: "Validator Rewards",
+      group: "Validator Group Rewards",
+      delegated_payment: "Delegated Validator Rewards"
+    }
+
+    rows =
+      election_rewards
+      |> Stream.map(fn reward ->
+        [
+          # EpochNumber
+          reward.block.number |> block_number_to_epoch_number(),
+          # BlockNumber
+          reward.block.number,
+          # TimestampUTC
+          reward.block.timestamp,
+          # EpochTxType
+          Map.get(reward_type_to_human_readable, reward.type, "N/A"),
+          # ValidatorAddress
+          (reward.type in ~w(group delegated_payment) && reward.associated_account_address_hash) || "N/A",
+          # ValidatorGroupAddress
+          (reward.type in ~w(validator voter) && reward.associated_account_address_hash) || "N/A",
+          # ToAddress
+          reward.account_address_hash,
+          # Type
+          "IN",
+          # LockedGold
+          "N/A",
+          # VotingGold
+          "N/A",
+          # Value
+          reward.amount |> Wei.to(:ether),
+          # ValueInWei
+          reward.amount |> Wei.to(:wei),
+          # TokenSymbol
+          reward.token.symbol,
+          # TokenContractAddress
+          reward.token.contract_address_hash
+        ]
+      end)
+
+    Stream.concat([column_names], rows)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
@@ -64,9 +64,9 @@ defmodule Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter do
           # EpochTxType
           Map.get(reward_type_to_human_readable, reward.type, "N/A"),
           # ValidatorAddress
-          (reward.type in ~w(group delegated_payment) && reward.associated_account_address_hash) || "N/A",
+          (reward.type in ~w(group delegated_payment)a && reward.associated_account_address_hash) || "N/A",
           # ValidatorGroupAddress
-          (reward.type in ~w(validator voter) && reward.associated_account_address_hash) || "N/A",
+          (reward.type in ~w(validator voter)a && reward.associated_account_address_hash) || "N/A",
           # ToAddress
           reward.account_address_hash,
           # Type

--- a/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/celo/address_election_rewards_csv_exporter.ex
@@ -72,9 +72,9 @@ defmodule Explorer.Chain.CSVExport.Celo.AddressElectionRewardsCsvExporter do
           # Type
           "IN",
           # Value
-          reward.amount |> Wei.to(:ether),
+          reward.amount |> Wei.to(:ether) |> Decimal.to_string(:normal),
           # ValueInWei
-          reward.amount |> Wei.to(:wei),
+          reward.amount |> Wei.to(:wei) |> Decimal.to_string(:normal),
           # TokenSymbol
           reward.token.symbol,
           # TokenContractAddress


### PR DESCRIPTION
Closes #11194, closes #11201.

## Motivation

The Celo community requested that validators retain the ability to export epoch transaction data when migrating to our instance. This feature is crucial for calculating earnings from participating in validator groups within the Celo protocol.

For context, the legacy Celo explorer provides a similar feature on the [validator address page](https://explorer.celo.org/mainnet/address/0xc24baeac0Fd189637112B7e33d22FfF2730aF993/epoch-transactions), where users can generate a [CSV export](https://explorer.celo.org/mainnet/csv-export?address=0xc24baeac0Fd189637112B7e33d22FfF2730aF993&type=epoch-transactions) for this data.

## Changelog

### Enhancements

- Introduced a new `/api/v1/celo-election-rewards-csv` endpoint and the `AddressElectionRewardsCsvExporter` module.

**⚠️ Note**: The exported table does not preserve the "LockedGold" and "VotingGold" fields, since this data is not indexed.

### Bug fixes

- Pagination of election rewards when the type of reward is `delegated_payment`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
