### PR TITLE
fix(nginx-conf): Redirect `/api-docs` to frontend.

### DIFF
--- a/docker-compose/proxy/default.conf.template
+++ b/docker-compose/proxy/default.conf.template
@@ -9,7 +9,7 @@ server {
     server_name  localhost;
     proxy_http_version 1.1;
 
-    location ~ ^/(api|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
+    location ~ ^/(api(?!-docs$)|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
         proxy_pass            ${BACK_PROXY_PASS};
         proxy_http_version    1.1;
         proxy_set_header      Host "$host";

--- a/docker-compose/proxy/explorer.conf.template
+++ b/docker-compose/proxy/explorer.conf.template
@@ -9,7 +9,7 @@ server {
     server_name  localhost;
     proxy_http_version 1.1;
 
-    location ~ ^/(api|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
+    location ~ ^/(api(?!-docs$)|socket|sitemap.xml|auth/auth0|auth/auth0/callback|auth/logout) {
         proxy_pass            ${BACK_PROXY_PASS};
         proxy_http_version    1.1;
         proxy_set_header      Host "$host";


### PR DESCRIPTION
## Motivation

Previously, when navigating to `/api-docs`, the nginx configuration mistakenly routed the request to the backend because it matched the `api` regex pattern.

We've now refined the regex to match requests to `/api` only if not immediately followed by `-docs`.

Examples:
- **Matches**: `"api/v1"`, `"api-test"`, `"apixyz"`, `"apiDocs"` (anything without `"-docs"` directly after `"api"`)
- **Doesn't Match**: `"api-docs"`, `"api-docs-v2"` (where `"api"` is directly followed by `"-docs"`)

## Changelog

### Bug Fixes

- Redirect `/api-docs` to frontend.
