### PR TITLE
fix: `entry/1` in token balance fetcher 

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance.ex
@@ -259,14 +259,15 @@ defmodule Indexer.Fetcher.TokenBalance do
     end
   end
 
-  defp entry(%{
-         token_contract_address_hash: token_contract_address_hash,
-         address_hash: address_hash,
-         block_number: block_number,
-         token_type: token_type,
-         token_id: token_id,
-         retries_count: retries_count
-       }) do
+  defp entry(
+         %{
+           token_contract_address_hash: token_contract_address_hash,
+           address_hash: address_hash,
+           block_number: block_number,
+           token_type: token_type,
+           token_id: token_id
+         } = params
+       ) do
     token_id_int =
       case token_id do
         %Decimal{} -> Decimal.to_integer(token_id)
@@ -274,7 +275,14 @@ defmodule Indexer.Fetcher.TokenBalance do
         _ -> token_id
       end
 
-    {address_hash.bytes, token_contract_address_hash.bytes, block_number, token_type, token_id_int, retries_count || 0}
+    {
+      address_hash.bytes,
+      token_contract_address_hash.bytes,
+      block_number,
+      token_type,
+      token_id_int,
+      Map.get(params, :retries_count) || 0
+    }
   end
 
   defp format_params(


### PR DESCRIPTION
Should be merged after #11195. 

Closes #11205.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
