### PR TITLE
Introducing Blockscout Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Blockscout](https://github.com/blockscout/blockscout/workflows/Blockscout/badge.svg?branch=master)](https://github.com/blockscout/blockscout/actions)
 [![](https://dcbadge.vercel.app/api/server/blockscout?style=flat)](https://discord.gg/blockscout)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Blockscout%20Guru-006BFF)](https://gurubase.io/g/blockscout)
 
 </div>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Blockscout Guru](https://gurubase.io/g/blockscout) to Gurubase. Blockscout Guru uses the data from this repo and data from the [docs](https://docs.blockscout.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Blockscout Guru", which highlights that Blockscout now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Blockscout Guru in Gurubase, just let me know that's totally fine.
