### PR TITLE
chore: fix watchlist address flaking test

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
@@ -768,10 +768,10 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
             )
             |> Repo.preload([:token])
 
-          Decimal.div(
-            Decimal.mult(ctb.value, ctb.token.fiat_value),
-            Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals))
-          )
+          ctb.value
+          |> Decimal.mult(ctb.token.fiat_value)
+          |> Decimal.div(Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals)))
+          |> Decimal.round(16)
         end
 
       values_1 =
@@ -782,24 +782,24 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
             )
             |> Repo.preload([:token])
 
-          Decimal.div(
-            Decimal.mult(ctb.value, ctb.token.fiat_value),
-            Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals))
-          )
+          ctb.value
+          |> Decimal.mult(ctb.token.fiat_value)
+          |> Decimal.div(Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals)))
+          |> Decimal.round(16)
         end
         |> Enum.sort(fn x1, x2 -> Decimal.compare(x1, x2) in [:gt, :eq] end)
         |> Enum.take(150)
 
       [wa2, wa1] = conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items")
 
-      assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
-               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
+      assert wa1["tokens_fiat_value"] |> Decimal.new() ==
+               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end)
 
       assert wa1["tokens_count"] == 150
       assert wa1["tokens_overflow"] == false
 
-      assert wa2["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
-               values_1 |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
+      assert wa2["tokens_fiat_value"] |> Decimal.new() ==
+               values_1 |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end)
 
       assert wa2["tokens_count"] == 150
       assert wa2["tokens_overflow"] == true
@@ -824,10 +824,10 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
             )
             |> Repo.preload([:token])
 
-          Decimal.div(
-            Decimal.mult(ctb.value, ctb.token.fiat_value),
-            Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals))
-          )
+          ctb.value
+          |> Decimal.mult(ctb.token.fiat_value)
+          |> Decimal.div(Decimal.new(10 ** Decimal.to_integer(ctb.token.decimals)))
+          |> Decimal.round(16)
         end
 
       token = insert(:token, fiat_value: nil)
@@ -840,8 +840,8 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
 
       [wa1] = conn |> get("/api/account/v2/user/watchlist") |> json_response(200) |> Map.get("items")
 
-      assert wa1["tokens_fiat_value"] |> Decimal.new() |> Decimal.round(13) ==
-               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end) |> Decimal.round(13)
+      assert wa1["tokens_fiat_value"] |> Decimal.new() ==
+               values |> Enum.reduce(Decimal.new(0), fn x, acc -> Decimal.add(x, acc) end)
 
       assert wa1["tokens_count"] == 150
       assert wa1["tokens_overflow"] == false


### PR DESCRIPTION
## Changelog
In test we get balances with 19 decimals in API with 16 decimals, previously round was done after summation which caused error accumulation and different result of sum from API and test

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
