### PR TITLE
fix: handle excessive otp confirmations

### DIFF
--- a/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
@@ -481,6 +481,16 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
        }} ->
         {:error, "Wrong verification code."}
 
+      {:error,
+       %OAuth2.Response{
+         status_code: 403,
+         body: %{
+           "error" => "invalid_grant",
+           "error_description" => "You've reached the maximum number of attempts. Please try to login again."
+         }
+       }} ->
+        {:error, "Max attempts reached. Please resend code."}
+
       other ->
         Logger.error("Error while confirming otp: #{inspect(other)}")
 


### PR DESCRIPTION
## Motivation
Auth0 restricts more than 3 retries and user get such error
![image](https://github.com/user-attachments/assets/90c17a78-fdc7-4a63-8b86-9dd81c2eb4ed)

## Changelog
Handle such scenario appropriately and send a proper error
![image](https://github.com/user-attachments/assets/901393dc-9179-4b47-8cd2-41ec09bd3ca5)


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
