### PR TITLE
fix: Fix ETH JSON RPC deriving for Stylus verification

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/stylus/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/stylus/verifier.ex
@@ -68,7 +68,7 @@ defmodule Explorer.SmartContract.Stylus.Verifier do
           {:ok, map()} | {:error, any()}
   defp evaluate_authenticity_inner(true, address_hash, params) do
     transaction_hash = fetch_data_for_stylus_verification(address_hash)
-    rpc_endpoint = Application.get_env(:explorer, :json_rpc_named_arguments)[:transport_options][:url]
+    rpc_endpoint = Application.get_env(:explorer, :json_rpc_named_arguments)[:transport_options][:urls] |> List.first()
 
     params
     |> Map.take(["cargo_stylus_version", "repository_url", "commit", "path_prefix"])


### PR DESCRIPTION
## Motivation
Changed `json_rpc_named_arguments` schema

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
