### PR TITLE
fix: Fix ERROR 42703 (undefined_column) column tx_hash_hash does not …

### DIFF
--- a/apps/explorer/priv/account/migrations/20240913194307_account_v2.exs
+++ b/apps/explorer/priv/account/migrations/20240913194307_account_v2.exs
@@ -38,7 +38,7 @@ defmodule Explorer.Repo.Account.Migrations.AccountV2 do
 
     create(unique_index(:account_tag_addresses, [:identity_id, :address_hash_hash], where: "user_created = true"))
 
-    create(unique_index(:account_tag_transactions, [:identity_id, :tx_hash_hash], where: "user_created = true"))
+    create(unique_index(:account_tag_transactions, [:identity_id, :transaction_hash_hash], where: "user_created = true"))
 
     create(
       unique_index(:account_watchlist_addresses, [:watchlist_id, :address_hash_hash],


### PR DESCRIPTION
…exist

## Motivation
error on `Running 20240913194307 Explorer.Repo.Account.Migrations.AccountV2.change/0 forward`

```
12:25:11.722 [info] create index account_tag_transactions_identity_id_tx_hash_hash_index
** (Postgrex.Error) ERROR 42703 (undefined_column) column "tx_hash_hash" does not exist
    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1096: Ecto.Adapters.SQL.raise_sql_call_error/1
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1203: Ecto.Adapters.SQL.execute_ddl/4
    (ecto_sql 3.12.1) lib/ecto/migration/runner.ex:348: Ecto.Migration.Runner.log_and_execute_ddl/3
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.12.1) lib/ecto/migration/runner.ex:311: Ecto.Migration.Runner.perform_operation/3
    (stdlib 6.1) timer.erl:590: :timer.tc/2
```

## Changelog
- rename column in migration

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
