### PR TITLE
fix: Handle eth rpc request without params

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -38,6 +38,19 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
     topic
   end
 
+  test "handles request without params if possible", %{conn: conn} do
+    assert response =
+             conn
+             |> post("/api/eth-rpc", %{
+               "method" => "eth_blockNumber",
+               "jsonrpc" => "2.0",
+               "id" => 0
+             })
+             |> json_response(200)
+
+    assert %{"id" => 0, "jsonrpc" => "2.0", "result" => "0x0"} == response
+  end
+
   describe "eth_get_logs" do
     setup do
       %{

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -1204,8 +1204,12 @@ defmodule Explorer.EthRPC do
     {:error, "Invalid params. Params must be a list."}
   end
 
+  defp do_eth_request(%{"jsonrpc" => jsonrpc, "method" => method}) do
+    do_eth_request(%{"jsonrpc" => jsonrpc, "method" => method, "params" => []})
+  end
+
   defp do_eth_request(_) do
-    {:error, "Method, params, and jsonrpc, are all required parameters."}
+    {:error, "Method, and jsonrpc are required parameters."}
   end
 
   defp get_action(action) do


### PR DESCRIPTION
Fix #11268

## Changelog

Assume `params` is empty list if it's not provided

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
