### PR TITLE
typo config_helper.exs

### DIFF
--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -117,7 +117,7 @@ defmodule ConfigHelper do
   def parse_catalog_value(env_var, catalog, shutdown_on_wrong_value?, default_value \\ nil) do
     value = env_var |> safe_get_env(default_value)
 
-    if value !== "" do
+    if value != "" do
       if value in catalog do
         String.to_atom(value)
       else


### PR DESCRIPTION
### Fixes Incorrect Usage of `!==` Operator in Multiple Places

In the code, the `!==` operator was used several times to compare values. However, in Elixir, the correct operator for inequality comparison is `!=`, not `!==`.

For example, the following line:
```elixir
if value !== "" do
```
has been corrected to:
```elixir
if value != "" do
```

This fix is important because using the incorrect inequality operator could lead to runtime errors or unexpected behavior in the application, as Elixir does not support `!==` for comparisons. By ensuring the correct operator is used, we can avoid potential issues and ensure the code runs as expected.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
