### PR TITLE
fix: Return 404 instead of 200 for nonexistent NFT

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1050,7 +1050,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       assert Address.checksum(instance.owner_address_hash) == data["owner"]["hash"]
     end
 
-    test "get token instance by token id which is not presented in DB", %{conn: conn} do
+    test "get 404 on token instance which is not presented in DB", %{conn: conn} do
       token = insert(:token, type: "ERC-721")
 
       request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/0")

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1054,20 +1054,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       token = insert(:token, type: "ERC-721")
 
       request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/0")
-      token_address = Address.checksum(token.contract_address.hash)
-      token_name = token.name
-      token_type = token.type
 
-      assert %{
-               "animation_url" => nil,
-               "external_app_url" => nil,
-               "id" => "0",
-               "image_url" => nil,
-               "is_unique" => true,
-               "metadata" => nil,
-               "owner" => nil,
-               "token" => %{"address" => ^token_address, "name" => ^token_name, "type" => ^token_type}
-             } = json_response(request, 200)
+      assert %{"message" => "Not found"} = json_response(request, 404)
     end
 
     # https://github.com/blockscout/blockscout/issues/9906


### PR DESCRIPTION
Closes #11239 

## Changelog
- Return 404 instead of 200 for nonexistent NFT

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
