### PR TITLE
fix: Get rid of scientific notation in CSV token holders export

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -348,7 +348,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       |> Stream.map(fn ctb ->
         [
           Address.checksum(ctb.address_hash),
-          CurrencyHelper.divide_decimals(ctb.value, token.decimals)
+          CurrencyHelper.divide_decimals(ctb.value, token.decimals) |> Decimal.to_string(:xsd)
         ]
       end)
 

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -348,7 +348,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       |> Stream.map(fn ctb ->
         [
           Address.checksum(ctb.address_hash),
-          CurrencyHelper.divide_decimals(ctb.value, token.decimals) |> Decimal.to_string(:xsd)
+          ctb.value |> CurrencyHelper.divide_decimals(token.decimals) |> Decimal.to_string(:xsd)
         ]
       end)
 


### PR DESCRIPTION
Closes #10075 

## Changelog
Before
```
HolderAddress,Balance
0xAee8E96bED6c5445658447fdeE8EdD12A1fD79b4,2130924.609038455654704294
0xd460Ba0BDbF8670eC6890e20119d43f9cB627129,5171
0xC56C22f97b0f91d4e3Dad5853F6f4D6A1d67377a,5091
0x5568E298A1220Ca83f018cb81f8da3B3e617e7dC,5075
0xCF744120e164A5003DB4FaF8594939f3b8228c09,5043
0xfB7a13a7A09FAcf66857c7b229B250a847FBcB59,3451.409244135902436952
0x55dFa13f7e409560eA7d774F82BDCB90C2222222,2E+3
0xD0081080Ae8493cf7340458Eaf4412030df5FEEb,1352.35182255553852181
0xC57B48e66789045973A2891492fd1F504ef03EeA,1260.190650757137264076
0xD6Fde32dBa6d4E51023cd6581b2F8E304Cbf2dca,829.873098013376209106
```
After:
```
HolderAddress,Balance
0xAee8E96bED6c5445658447fdeE8EdD12A1fD79b4,2130924.609038455654704294
0xd460Ba0BDbF8670eC6890e20119d43f9cB627129,5171.0
0xC56C22f97b0f91d4e3Dad5853F6f4D6A1d67377a,5091.0
0x5568E298A1220Ca83f018cb81f8da3B3e617e7dC,5075.0
0xCF744120e164A5003DB4FaF8594939f3b8228c09,5043.0
0xfB7a13a7A09FAcf66857c7b229B250a847FBcB59,3451.409244135902436952
0x55dFa13f7e409560eA7d774F82BDCB90C2222222,2000.0
0xD0081080Ae8493cf7340458Eaf4412030df5FEEb,1352.35182255553852181
0xC57B48e66789045973A2891492fd1F504ef03EeA,1260.190650757137264076
0xD6Fde32dBa6d4E51023cd6581b2F8E304Cbf2dca,829.873098013376209106
```
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
