### PR TITLE
chore: Fix grammatical error in changelog section Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
-*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*
+*Things you changed that fix bugs.  If it fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*
 
 ### Incompatible Changes
 


### PR DESCRIPTION
**Description:** 

I noticed a small grammatical issue in the changelog section of the documentation. The sentence "If a fixes a bug" is incorrect and should be "If it fixes a bug". This was a simple mistake where "a" was used instead of "it," which affects readability and clarity.

It's important to correct such errors to maintain professionalism and ensure that the documentation is clear and accurate for all users.

