### PR TITLE
Corrected missing .yml extension in Nethermind example

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -45,7 +45,7 @@ The repo contains built-in configs for different JSON RPC clients without need t
 | Erigon  | `docker-compose -f erigon.yml up -d`    |
 | Geth (suitable for Reth as well) | `docker-compose -f geth.yml up -d`     |
 | Geth Clique    | `docker-compose -f geth-clique-consensus.yml up -d`    |
-| Nethermind, OpenEthereum    | `docker-compose -f nethermind up -d`    |
+| Nethermind, OpenEthereum    | `docker-compose -f nethermind.yml up -d`    |
 | Ganache    | `docker-compose -f ganache.yml up -d`    |
 | HardHat network    | `docker-compose -f hardhat-network.yml up -d`    |
 


### PR DESCRIPTION
This change fixes a small but significant inconsistency in the documentation. The command for launching Nethermind using `docker-compose` was missing the `.yml` extension:  

```bash
docker-compose -f nethermind up -d
```  

All other examples in the same list follow the standard naming convention of including the `.yml` extension. This fix updates the command to:  

```bash
docker-compose -f nethermind.yml up -d
```  

**Why this is important:**  

1. **Consistency:** All other commands in the list use the `.yml` extension, so this fix aligns the example with the expected format.  
2. **Usability:** Without the `.yml` extension, users might encounter errors or confusion when trying to run the command. Docker Compose expects a valid configuration file name, and omitting the extension could disrupt workflows for users unfamiliar with the issue.  

This adjustment ensures the documentation is accurate and user-friendly, reducing potential friction for developers setting up their environment.