### PR TITLE
fix: Wrong usage of env in TokenInstanceMetadataRefetch

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
@@ -46,7 +46,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch do
   end
 
   defp fetch_and_broadcast_metadata(token_instance, _state) do
-    from_base_uri? = Application.get_env(:indexer, __MODULE__)[:base_uri_retry?]
+    from_base_uri? = Application.get_env(:indexer, TokenInstanceHelper)[:base_uri_retry?]
 
     token_id = TokenInstanceHelper.prepare_token_id(token_instance.token_id)
     contract_address_hash_string = to_string(token_instance.token_contract_address_hash)


### PR DESCRIPTION
## Motivation


## Changelog
- Use proper module in Application.get_env in TokenInstanceMetadataRefetch

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
