### PR TITLE
chore: Remove shorthands-duplicates from API responses

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -510,9 +510,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         token_balances: :token_balances_count,
         logs: :logs_count,
         withdrawals: :withdrawals_count,
-        # todo: support of 2 props in API endpoint is for compatibility with the current version of frontend.
-        # It should be ultimately removed.
-        internal_transactions: [:internal_transactions_count, :internal_txs_count],
+        internal_transactions: :internal_transactions_count,
         celo_election_rewards: :celo_election_rewards_count
       }
 
@@ -524,15 +522,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           |> Map.fetch(counter_name)
           |> case do
             {:ok, json_field_name} ->
-              # todo: array-type value processing here is temporary. Please remove it with updating frontend to the new version.
-              if is_list(json_field_name) do
-                # credo:disable-for-next-line
-                Enum.reduce(json_field_name, acc, fn field_name, acc2 ->
-                  Map.put(acc2, field_name, counter_value)
-                end)
-              else
-                Map.put(acc, json_field_name, counter_value)
-              end
+              Map.put(acc, json_field_name, counter_value)
 
             :error ->
               acc

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -109,8 +109,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
     transaction_history_data =
       date_range
       |> Enum.map(fn row ->
-        # todo: keep `tx_count` for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-        %{date: row.date, transaction_count: row.number_of_transactions, tx_count: row.number_of_transactions}
+        %{date: row.date, transaction_count: row.number_of_transactions}
       end)
 
     json(conn, %{

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -178,8 +178,6 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
         value: transaction_with_meta.value,
         method: Transaction.method_name(transaction_with_meta, Transaction.format_decoded_input(decoded_input)),
         status: transaction_with_meta.status,
-        # todo: keep `tx_types` for compatibility with interpreter and remove when new interpreter is bound to `transaction_types` property
-        tx_types: TransactionView.transaction_types(transaction_with_meta),
         transaction_types: TransactionView.transaction_types(transaction_with_meta),
         raw_input: transaction_with_meta.input,
         decoded_input: decoded_input_data,

--- a/apps/block_scout_web/lib/block_scout_web/views/account/api/v2/tags_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/account/api/v2/tags_view.ex
@@ -13,8 +13,6 @@ defmodule BlockScoutWeb.Account.API.V2.TagsView do
       }) do
     %{
       personal_transaction_tag: prepare_transaction_tag(personal_transaction_tag),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `personal_transaction_tag` property
-      personal_tx_tag: prepare_transaction_tag(personal_transaction_tag),
       personal_tags: personal_tags,
       watchlist_names: watchlist_names,
       common_tags: common_tags

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -81,8 +81,6 @@ defmodule BlockScoutWeb.API.V2.AddressView do
   def prepare_address({address, transaction_count}) do
     nil
     |> Helper.address_with_info(address, address.hash, true)
-    # todo: keep `tx_count` for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-    |> Map.put(:tx_count, to_string(transaction_count))
     |> Map.put(:transaction_count, to_string(transaction_count))
     |> Map.put(:coin_balance, if(address.fetched_coin_balance, do: address.fetched_coin_balance.value))
   end
@@ -106,8 +104,6 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       Map.merge(base_info, %{
         "creator_address_hash" => creator_hash && Address.checksum(creator_hash),
         "creation_transaction_hash" => creation_transaction_hash,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `creation_transaction_hash` property
-        "creation_tx_hash" => creation_transaction_hash,
         "token" => token,
         "coin_balance" => balance,
         "exchange_rate" => exchange_rate,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -419,8 +419,6 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     out
     |> Map.merge(%{
       "height" => Map.get(da_info, "height"),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-      "tx_commitment" => Map.get(da_info, "transaction_commitment"),
       "transaction_commitment" => Map.get(da_info, "transaction_commitment")
     })
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -37,8 +37,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "height" => block.number,
       "timestamp" => block.timestamp,
       "transaction_count" => count_transactions(block),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-      "tx_count" => count_transactions(block),
       "miner" => Helper.address_with_info(nil, block.miner, block.miner_hash, false),
       "size" => block.size,
       "hash" => block.hash,
@@ -60,8 +58,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "burnt_fees_percentage" => burnt_fees_percentage(burnt_fees, transaction_fees),
       "type" => block |> BlockView.block_type() |> String.downcase(),
       "transaction_fees" => transaction_fees,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_fees` property
-      "tx_fees" => transaction_fees,
       "withdrawals_count" => count_withdrawals(block)
     }
     |> chain_type_fields(block, single_block?)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
@@ -48,8 +48,6 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
           false
         ),
       "value" => internal_transaction.value,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `block_number` property
-      "block" => internal_transaction.block_number,
       "block_number" => internal_transaction.block_number,
       "timestamp" => (block && block.timestamp) || internal_transaction.block.timestamp,
       "index" => internal_transaction.index,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
@@ -83,8 +83,6 @@ defmodule BlockScoutWeb.API.V2.MudView do
   defp prepare_world_for_list(%Address{} = address) do
     %{
       "address" => Helper.address_with_info(address, address.hash),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-      "tx_count" => address.transactions_count,
       "transaction_count" => address.transactions_count,
       "coin_balance" => if(address.fetched_coin_balance, do: address.fetched_coin_balance.value)
     }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -36,11 +36,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           %{
             "l2_block_number" => batch.l2_block_number,
             "transaction_count" => transaction_count,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-            "tx_count" => transaction_count,
             "l1_transaction_hashes" => batch.frame_sequence.l1_transaction_hashes,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
-            "l1_tx_hashes" => batch.frame_sequence.l1_transaction_hashes,
             "l1_timestamp" => batch.frame_sequence.l1_timestamp
           }
         end)
@@ -97,8 +93,6 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
             "l2_output_index" => r.l2_output_index,
             "l2_block_number" => r.l2_block_number,
             "l1_transaction_hash" => r.l1_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hash` property
-            "l1_tx_hash" => r.l1_transaction_hash,
             "l1_timestamp" => r.l1_timestamp,
             "l1_block_number" => r.l1_block_number,
             "output_root" => r.output_root
@@ -154,16 +148,8 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           %{
             "l1_block_number" => deposit.l1_block_number,
             "l2_transaction_hash" => deposit.l2_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l2_transaction_hash` property
-            "l2_tx_hash" => deposit.l2_transaction_hash,
             "l1_block_timestamp" => deposit.l1_block_timestamp,
             "l1_transaction_hash" => deposit.l1_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hash` property
-            "l1_tx_hash" => deposit.l1_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_origin` property
-            "l1_tx_origin" => deposit.l1_transaction_origin,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l2_transaction_gas_limit` property
-            "l2_tx_gas_limit" => deposit.l2_transaction.gas,
             "l1_transaction_origin" => deposit.l1_transaction_origin,
             "l2_transaction_gas_limit" => deposit.l2_transaction.gas
           }
@@ -180,10 +166,6 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
       %{
         "l1_block_number" => deposit.l1_block_number,
         "l1_block_timestamp" => deposit.l1_block_timestamp,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hash` property
-        "l1_tx_hash" => deposit.l1_transaction_hash,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l2_transaction_hash` property
-        "l2_tx_hash" => deposit.l2_transaction_hash,
         "l1_transaction_hash" => deposit.l1_transaction_hash,
         "l2_transaction_hash" => deposit.l2_transaction_hash
       }
@@ -239,13 +221,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
             "msg_nonce_version" => msg_nonce_version,
             "from" => Helper.address_with_info(conn, from_address, from_address_hash, w.from),
             "l2_transaction_hash" => w.l2_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l2_transaction_hash` property
-            "l2_tx_hash" => w.l2_transaction_hash,
             "l2_timestamp" => w.l2_timestamp,
             "status" => status,
             "l1_transaction_hash" => w.l1_transaction_hash,
-            # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hash` property
-            "l1_tx_hash" => w.l1_transaction_hash,
             "challenge_period_end" => challenge_period_end
           }
         end),
@@ -288,11 +266,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           :l2_block_start => non_neg_integer(),
           :l2_block_end => non_neg_integer(),
           :transaction_count => non_neg_integer(),
-          # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-          :tx_count => non_neg_integer(),
           :l1_transaction_hashes => list(),
-          # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
-          :l1_tx_hashes => list(),
           :batch_data_container => :in_blob4844 | :in_celestia | :in_calldata | nil
         }
   defp render_base_info_for_batch(internal_id, l2_block_number_from, l2_block_number_to, transaction_count, batch) do
@@ -336,8 +310,6 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           "internal_id" => frame_sequence.id,
           "l1_timestamp" => frame_sequence.l1_timestamp,
           "l1_transaction_hashes" => frame_sequence.l1_transaction_hashes,
-          # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
-          "l1_tx_hashes" => frame_sequence.l1_transaction_hashes,
           "batch_data_container" => batch_data_container
         }
         |> extend_batch_info_by_blobs(blobs, "blobs")

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_zkevm_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_zkevm_view.ex
@@ -33,10 +33,6 @@ defmodule BlockScoutWeb.API.V2.PolygonZkevmView do
       "acc_input_hash" => batch.acc_input_hash,
       "sequence_transaction_hash" => sequence_transaction_hash,
       "verify_transaction_hash" => verify_transaction_hash,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `sequence_transaction_hash` property
-      "sequence_tx_hash" => sequence_transaction_hash,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `verify_transaction_hash` property
-      "verify_tx_hash" => verify_transaction_hash,
       "state_root" => batch.state_root
     }
   end
@@ -160,12 +156,6 @@ defmodule BlockScoutWeb.API.V2.PolygonZkevmView do
         "status" => batch_status(batch),
         "timestamp" => batch.timestamp,
         "transaction_count" => batch.l2_transactions_count,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-        "tx_count" => batch.l2_transactions_count,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `sequence_transaction_hash` property
-        "sequence_tx_hash" => sequence_transaction_hash,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `verify_transaction_hash` property
-        "verify_tx_hash" => verify_transaction_hash,
         "sequence_transaction_hash" => sequence_transaction_hash,
         "verify_transaction_hash" => verify_transaction_hash
       }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -100,8 +100,6 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{
       "type" => search_result.type,
       "transaction_hash" => transaction_hash,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_hash` property
-      "tx_hash" => transaction_hash,
       "url" => transaction_path(Endpoint, :show, transaction_hash),
       "timestamp" => search_result.timestamp,
       "priority" => search_result.priority

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -346,8 +346,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         "compiler_version" => smart_contract.compiler_version,
         "optimization_enabled" => smart_contract.optimization,
         "transaction_count" => smart_contract.address.transactions_count,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-        "tx_count" => smart_contract.address.transactions_count,
         "language" => smart_contract_language(smart_contract),
         "verified_at" => smart_contract.inserted_at,
         "market_cap" => token && token.circulating_market_cap,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -46,8 +46,6 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
   def prepare_token_transfer(token_transfer, _conn, decoded_input) do
     %{
       "transaction_hash" => token_transfer.transaction_hash,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_hash` property
-      "tx_hash" => token_transfer.transaction_hash,
       "from" => Helper.address_with_info(nil, token_transfer.from_address, token_transfer.from_address_hash, false),
       "to" => Helper.address_with_info(nil, token_transfer.to_address, token_transfer.to_address_hash, false),
       "total" => prepare_token_transfer_total(token_transfer),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -257,8 +257,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
     %{
       "transaction_hash" => get_transaction_hash(transaction_or_hash),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_hash` property
-      "tx_hash" => get_transaction_hash(transaction_or_hash),
       "address" => Helper.address_with_info(nil, log.address, log.address_hash, tags_for_address_needed?),
       "topics" => [
         log.first_topic,
@@ -373,8 +371,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "result" => status,
       "status" => transaction.status,
       "block_number" => transaction.block_number,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `block_number` property
-      "block" => transaction.block_number,
       "timestamp" => block_timestamp(transaction),
       "from" =>
         Helper.address_with_info(
@@ -424,14 +420,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "exchange_rate" => Market.get_coin_exchange_rate().usd_value,
       "method" => Transaction.method_name(transaction, decoded_input),
       "transaction_types" => transaction_types(transaction),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_types` property
-      "tx_types" => transaction_types(transaction),
       "transaction_tag" =>
         GetTransactionTags.get_transaction_tags(transaction.hash, current_user(single_transaction? && conn)),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_tag` property
-      "tx_tag" => GetTransactionTags.get_transaction_tags(transaction.hash, current_user(single_transaction? && conn)),
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `has_error_in_internal_transactions` property
-      "has_error_in_internal_txs" => transaction.has_error_in_internal_transactions,
       "has_error_in_internal_transactions" => transaction.has_error_in_internal_transactions,
       "authorization_list" => authorization_list(transaction.signed_authorizations)
     }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/zksync_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/zksync_view.ex
@@ -17,10 +17,6 @@ defmodule BlockScoutWeb.API.V2.ZkSyncView do
       "root_hash" => batch.root_hash,
       "l1_transaction_count" => batch.l1_transaction_count,
       "l2_transaction_count" => batch.l2_transaction_count,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_count` property
-      "l1_tx_count" => batch.l1_transaction_count,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l2_transaction_count` property
-      "l2_tx_count" => batch.l2_transaction_count,
       "l1_gas_price" => batch.l1_gas_price,
       "l2_fair_gas_price" => batch.l2_fair_gas_price,
       "start_block" => batch.start_block,
@@ -68,8 +64,6 @@ defmodule BlockScoutWeb.API.V2.ZkSyncView do
       %{
         "number" => batch.number,
         "timestamp" => batch.timestamp,
-        # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-        "tx_count" => batch.l1_transaction_count + batch.l2_transaction_count,
         "transaction_count" => batch.l1_transaction_count + batch.l2_transaction_count
       }
       |> add_l1_transactions_info_and_status(batch)

--- a/apps/explorer/lib/explorer/account/notifier/email.ex
+++ b/apps/explorer/lib/explorer/account/notifier/email.ex
@@ -35,8 +35,6 @@ defmodule Explorer.Account.Notifier.Email do
     |> add_dynamic_field("block_number", notification.block_number)
     |> add_dynamic_field("amount", amount(notification))
     |> add_dynamic_field("name", notification.name)
-    # todo: keep next line for compatibility with old version of SendGrid template. Remove it when the changes released and Sendgrid template updated.
-    |> add_dynamic_field("tx_fee", notification.transaction_fee)
     |> add_dynamic_field("transaction_fee", notification.transaction_fee)
     |> add_dynamic_field("direction", direction(notification))
     |> add_dynamic_field("method", notification.method)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -258,8 +258,7 @@ defmodule Explorer.Chain do
   defp common_where_limit_order(query, paging_options) do
     query
     |> InternalTransaction.where_is_different_from_parent_transaction()
-    # todo: replace `index_int_tx_desc_order` with `index_internal_transaction_desc_order` in the next line when new frontend is bound to `index_internal_transaction_desc_order` property
-    |> page_internal_transaction(paging_options, %{index_int_tx_desc_order: true})
+    |> page_internal_transaction(paging_options, %{index_internal_transaction_desc_order: true})
     |> limit(^paging_options.page_size)
     |> order_by(
       [it],
@@ -3429,17 +3428,9 @@ defmodule Explorer.Chain do
     where(query, [coin_balance], coin_balance.block_number < ^block_number)
   end
 
-  # todo: replace `index_int_tx_desc_order` with `index_internal_transaction_desc_order` in the next clause when new frontend is bound to `index_internal_transaction_desc_order` property
-  def page_internal_transaction(_, _, _ \\ %{index_int_tx_desc_order: false})
+  def page_internal_transaction(_, _, _ \\ %{index_internal_transaction_desc_order: false})
 
   def page_internal_transaction(query, %PagingOptions{key: nil}, _), do: query
-
-  # todo: keep next clause for compatibility with frontend and remove when new frontend is bound to `index_internal_transaction_desc_order` property
-  def page_internal_transaction(query, %PagingOptions{key: {block_number, transaction_index, index}}, %{
-        index_int_tx_desc_order: desc_order
-      }) do
-    hardcoded_where_for_page_internal_transaction(query, block_number, transaction_index, index, desc_order)
-  end
 
   def page_internal_transaction(query, %PagingOptions{key: {block_number, transaction_index, index}}, %{
         index_internal_transaction_desc_order: desc_order
@@ -3447,29 +3438,11 @@ defmodule Explorer.Chain do
     hardcoded_where_for_page_internal_transaction(query, block_number, transaction_index, index, desc_order)
   end
 
-  # todo: keep next clause for compatibility with frontend and remove when new frontend is bound to `index_internal_transaction_desc_order` property
-  def page_internal_transaction(query, %PagingOptions{key: {0}}, %{index_int_tx_desc_order: desc_order}) do
-    if desc_order do
-      query
-    else
-      where(query, [internal_transaction], internal_transaction.index > 0)
-    end
-  end
-
   def page_internal_transaction(query, %PagingOptions{key: {0}}, %{index_internal_transaction_desc_order: desc_order}) do
     if desc_order do
       query
     else
       where(query, [internal_transaction], internal_transaction.index > 0)
-    end
-  end
-
-  # todo: keep next clause for compatibility with frontend and remove when new frontend is bound to `index_internal_transaction_desc_order` property
-  def page_internal_transaction(query, %PagingOptions{key: {index}}, %{index_int_tx_desc_order: desc_order}) do
-    if desc_order do
-      where(query, [internal_transaction], internal_transaction.index < ^index)
-    else
-      where(query, [internal_transaction], internal_transaction.index > ^index)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
@@ -167,11 +167,7 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
           :l2_block_start => non_neg_integer(),
           :l2_block_end => non_neg_integer(),
           :transaction_count => non_neg_integer(),
-          # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-          :tx_count => non_neg_integer(),
           :l1_transaction_hashes => list(),
-          # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
-          :l1_tx_hashes => list(),
           :batch_data_container => :in_blob4844 | :in_celestia | :in_calldata | nil
         }
   def prepare_base_info_for_batch(
@@ -188,11 +184,7 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
       :l2_block_start => l2_block_number_from,
       :l2_block_end => l2_block_number_to,
       :transaction_count => transaction_count,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_count` property
-      :tx_count => transaction_count,
       :l1_transaction_hashes => batch.l1_transaction_hashes,
-      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `l1_transaction_hashes` property
-      :l1_tx_hashes => batch.l1_transaction_hashes,
       :batch_data_container => batch_data_container
     }
   end

--- a/apps/explorer/test/explorer/account/notifier/email_test.exs
+++ b/apps/explorer/test/explorer/account/notifier/email_test.exs
@@ -110,8 +110,6 @@ defmodule Explorer.Account.Notifier.EmailTest do
                        "transaction_url" =>
                          "https://eth.blockscout.com/tx/0x5d5ff210261f1b2d6e4af22ea494f428f9997d4ab614a629d4f1390004b3e80d",
                        "transaction_fee" => Decimal.new(210_000),
-                       # todo: keep next line for compatibility with old version of SendGrid template. Remove it when the changes released and Sendgrid template updated.
-                       "tx_fee" => Decimal.new(210_000),
                        "username" => "John Snow"
                      },
                      template_id: "d-666"


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/10913

## Motivation

This PR finalizes work on API props renaming for consistency purposes started in #10913.
Since dependent services are bound to new props
- fronted starting from v1.36.4
- interpreter service starting from v2.1.2.

## Changelog

Shorthand props (old) are removed from API responses. Full props (new) are left intact.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
