### PR TITLE
chore: Fixate Postgres 17 version in Docker compose and Github Actions workflows

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     command: sleep infinity
 
   db:
-    image: postgres:latest
+    image: postgres:17
     command: postgres -c 'max_connections=250'
     restart: unless-stopped
     volumes:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -470,7 +470,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -533,7 +533,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -608,7 +608,7 @@ jobs:
       - matrix-builder
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test
@@ -680,7 +680,7 @@ jobs:
           - 6379:6379
 
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           # Match apps/explorer/config/test.exs config :explorer, Explorer.Repo, database
           POSTGRES_DB: explorer_test

--- a/docker-compose/services/db.yml
+++ b/docker-compose/services/db.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db-init:
-    image: postgres:15
+    image: postgres:17
     volumes:
       - ./blockscout-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -12,7 +12,7 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   db:
-    image: postgres:15
+    image: postgres:17
     user: 2000:2000
     shm_size: 256m
     restart: always

--- a/docker-compose/services/stats.yml
+++ b/docker-compose/services/stats.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   stats-db-init:
-    image: postgres:15
+    image: postgres:17
     volumes:
       - ./stats-db-data:/var/lib/postgresql/data
     entrypoint:
@@ -12,7 +12,7 @@ services:
         chown -R 2000:2000 /var/lib/postgresql/data
 
   stats-db:
-    image: postgres:15
+    image: postgres:17
     user: 2000:2000
     shm_size: 256m
     restart: always


### PR DESCRIPTION
## Motivation

Migrate from Postgres 15 -> 17 version.

## Changelog

Docker compose setup and Github Actions workflows are affected.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
