### PR TITLE
fix: Fix metrics modules warnings

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -6,16 +6,12 @@ defmodule BlockScoutWeb.Application do
   use Application
 
   alias BlockScoutWeb.Endpoint
-  alias BlockScoutWeb.Prometheus.Exporter, as: PrometheusExporter
-  alias BlockScoutWeb.Prometheus.PublicExporter, as: PrometheusPublicExporter
 
   def start(_type, _args) do
     base_children = [Supervisor.child_spec(Endpoint, [])]
     api_children = setup_and_define_children()
     all_children = base_children ++ api_children
     opts = [strategy: :one_for_one, name: BlockScoutWeb.Supervisor, max_restarts: 1_000]
-    PrometheusExporter.setup()
-    PrometheusPublicExporter.setup()
     Supervisor.start_link(all_children, opts)
   end
 
@@ -32,13 +28,14 @@ defmodule BlockScoutWeb.Application do
     defp setup_and_define_children do
       alias BlockScoutWeb.API.APILogger
       alias BlockScoutWeb.Counters.{BlocksIndexedCounter, InternalTransactionsIndexedCounter}
-      alias BlockScoutWeb.Prometheus.{Exporter, PhoenixInstrumenter}
+      alias BlockScoutWeb.Prometheus.{Exporter, PhoenixInstrumenter, PublicExporter}
       alias BlockScoutWeb.{MainPageRealtimeEventHandler, RealtimeEventHandler, SmartContractRealtimeEventHandler}
       alias BlockScoutWeb.Utility.EventHandlersMetrics
       alias Explorer.Chain.Metrics, as: ChainMetrics
 
       PhoenixInstrumenter.setup()
       Exporter.setup()
+      PublicExporter.setup()
 
       APILogger.message(
         "Current global API rate limit #{inspect(Application.get_env(:block_scout_web, :api_rate_limit)[:global_limit])} reqs/sec"

--- a/apps/explorer/lib/explorer/chain/metrics/queries.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries.ex
@@ -1,6 +1,6 @@
 defmodule Explorer.Chain.Metrics.Queries do
   @moduledoc """
-  Module for DB queries to get chain metrics exposed at /metrics endpoint
+  Module for DB queries to get chain metrics exposed at /public-metrics endpoint
   """
 
   import Ecto.Query,


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11339

## Motivation

Eliminate compile warnings related to metrics.


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
