### PR TITLE
fix: handle simultaneous account entities creation

### DIFF
--- a/apps/explorer/priv/account/migrations/20241128100836_remove_abused_custom_abis.exs
+++ b/apps/explorer/priv/account/migrations/20241128100836_remove_abused_custom_abis.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.Account.Migrations.RemoveAbusedCustomAbis do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    WITH ranked_abis AS (SELECT id,
+                                identity_id,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY identity_id
+                                    ) as row_number
+                        FROM account_custom_abis)
+    DELETE
+    FROM account_custom_abis
+    WHERE id IN (SELECT id
+                FROM ranked_abis
+                WHERE row_number > 15)
+    """)
+  end
+end

--- a/apps/explorer/priv/account/migrations/20241204093817_remove_abused_public_tags_request.exs
+++ b/apps/explorer/priv/account/migrations/20241204093817_remove_abused_public_tags_request.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.Account.Migrations.RemoveAbusedPublicTagsRequest do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    WITH ranked_public_tags_requests AS (SELECT id,
+                                                identity_id,
+                                                ROW_NUMBER() OVER (
+                                                    PARTITION BY identity_id
+                                                    ) as row_number
+                                        FROM account_public_tags_requests)
+    DELETE
+    FROM account_public_tags_requests
+    WHERE id IN (SELECT id
+                FROM ranked_public_tags_requests
+                WHERE row_number > 15)
+    """)
+  end
+end


### PR DESCRIPTION
Fix #11241

## Changelog
- Perform operations of creating `custom_abi`, `public_tags_request`, `tag_address`, `tag_transaction` and `watchlsit_address` with database lock
- Migration for `custom_abi` and `public_tags_request`

Note:
Migrations for `tag_address`, `tag_transaction` and `watchlsit_address` are omitted since the limit for them is runtime configurable and these entities actually are not so harmful, watchlsit is protected with email notification limit, `tag`s do not take much space and can be removed by hand in certain cases

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
