### PR TITLE
chore: Show request headers in the error when Blockscout failed to decode Ethereum JSONRPC response

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/decode_error.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/decode_error.ex
@@ -11,8 +11,8 @@ defmodule EthereumJSONRPC.DecodeError do
     Ethereum JSONRPC request whose `EthereumJSONRPC.DecodeError.Response` had a decode error.
     """
 
-    @enforce_keys [:url, :body]
-    defstruct [:url, :body]
+    @enforce_keys [:url, :body, :headers]
+    defstruct [:url, :body, :headers]
   end
 
   defmodule Response do
@@ -40,7 +40,7 @@ defmodule EthereumJSONRPC.DecodeError do
   @impl Exception
   def message(
         %EthereumJSONRPC.DecodeError{
-          request: %EthereumJSONRPC.DecodeError.Request{url: request_url, body: request_body},
+          request: %EthereumJSONRPC.DecodeError.Request{url: request_url, body: request_body, headers: headers},
           response: %EthereumJSONRPC.DecodeError.Response{status_code: response_status_code, body: response_body}
         } = decode_error
       ) do
@@ -64,6 +64,8 @@ defmodule EthereumJSONRPC.DecodeError do
         url: #{if hide_url, do: "rpc_url", else: request_url}
 
         body: #{truncated_request_body}
+
+        headers: #{inspect(headers)}
 
       response:
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -28,7 +28,8 @@ defmodule EthereumJSONRPC.HTTP do
     http_options = Keyword.fetch!(options, :http_options)
 
     with {:ok, %{body: body, status_code: code}} <- http.json_rpc(url, json, headers(), http_options),
-         {:ok, json} <- decode_json(request: [url: url, body: json], response: [status_code: code, body: body]),
+         {:ok, json} <-
+           decode_json(request: [url: url, body: json, headers: headers()], response: [status_code: code, body: body]),
          {:ok, response} <- handle_response(json, code) do
       {:ok, response}
     else
@@ -77,7 +78,10 @@ defmodule EthereumJSONRPC.HTTP do
 
       {:ok, %{body: body, status_code: status_code}} ->
         with {:ok, decoded_body} <-
-               decode_json(request: [url: url, body: json], response: [status_code: status_code, body: body]) do
+               decode_json(
+                 request: [url: url, body: json, headers: headers()],
+                 response: [status_code: status_code, body: body]
+               ) do
           chunked_json_rpc(tail, options, [decoded_body | decoded_response_bodies])
         end
 


### PR DESCRIPTION
## Motivation

Headers are not shown in the error when Blockscout failed to decode Ethereum JSONRPC response.

## Changelog

Show request headers together with URL and body in the error when Blockscout failed to decode Ethereum JSONRPC response

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
