### PR TITLE
fix: 403 instead of 404 on wrong captcha in api/v1

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -11,7 +11,7 @@ defmodule BlockScoutWeb.AddressTransactionController do
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
 
   alias BlockScoutWeb.{AccessHelper, CaptchaHelper, Controller, TransactionView}
-  alias BlockScoutWeb.API.V2.CSVExportController
+  alias BlockScoutWeb.API.V2.{ApiView, CSVExportController}
   alias Explorer.{Chain, Market}
   alias Explorer.Chain.Address
 
@@ -205,7 +205,10 @@ defmodule BlockScoutWeb.AddressTransactionController do
         not_found(conn)
 
       {:recaptcha, false} ->
-        not_found(conn)
+        conn
+        |> put_status(:forbidden)
+        |> put_view(ApiView)
+        |> render(:message, %{message: "Invalid reCAPTCHA response"})
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_transaction_controller_test.exs
@@ -186,7 +186,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
           "to_period" => to_period
         })
 
-      assert conn.status == 404
+      assert conn.status == 403
     end
 
     test "do not export token transfers to csv without recaptcha passed", %{
@@ -221,7 +221,7 @@ defmodule BlockScoutWeb.AddressTransactionControllerTest do
           "recaptcha_response" => "123"
         })
 
-      assert conn.status == 404
+      assert conn.status == 403
     end
 
     test "exports token transfers to csv without recaptcha if recaptcha is disabled", %{conn: conn} do


### PR DESCRIPTION
Fix #11347

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
