### PR TITLE
fix: Fix Noves.fi proxy for bulk transactions endpoint

### DIFF
--- a/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
@@ -79,11 +79,11 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
   end
 
   @doc """
-  Noves.fi /evm/:chain/transactions/:address_hash endpoint
+  Noves.fi /evm/:chain/txs/:address_hash endpoint
   """
   @spec address_transactions_url(String.t()) :: String.t()
   def address_transactions_url(address_hash_string) do
-    "#{base_url()}/evm/#{chain_name()}/transactions/#{address_hash_string}"
+    "#{base_url()}/evm/#{chain_name()}/txs/#{address_hash_string}"
   end
 
   defp base_url do


### PR DESCRIPTION
## Motivation

Noves.fi proxy for /txs path doesn't work. Proxy broke down in https://github.com/blockscout/blockscout/pull/10913.

## Changelog

Return ./txs path for Noves.fi instead of `./transactions`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the endpoint for fetching address transactions to reflect the new URL structure.

- **Documentation**
	- Revised documentation to clarify the changes in the URL format for the transactions endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->