### PR TITLE
chore: Remove beta suffix from releases

### DIFF
--- a/.github/workflows/pre-release-optimism.yml
+++ b/.github/workflows/pre-release-optimism.yml
@@ -91,7 +91,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -109,7 +109,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -127,7 +127,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/pre-release-polygon-zkevm.yml
+++ b/.github/workflows/pre-release-polygon-zkevm.yml
@@ -91,7 +91,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -108,7 +108,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -48,7 +48,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build and push Docker image (indexer)
@@ -69,7 +69,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build and push Docker image (API)
@@ -90,7 +90,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build and push Docker image for frontend
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             SESSION_COOKIE_DOMAIN=k8s-dev.blockscout.com
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
   deploy_e2e:
     needs: push_to_registry

--- a/.github/workflows/publish-docker-image-for-arbitrum.yml
+++ b/.github/workflows/publish-docker-image-for-arbitrum.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-blackfort.yml
+++ b/.github/workflows/publish-docker-image-for-blackfort.yml
@@ -39,6 +39,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=blackfort

--- a/.github/workflows/publish-docker-image-for-celo.yml
+++ b/.github/workflows/publish-docker-image-for-celo.yml
@@ -38,7 +38,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -56,7 +56,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -74,7 +74,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -91,7 +91,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -110,7 +110,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -129,7 +129,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-core.yml
+++ b/.github/workflows/publish-docker-image-for-core.yml
@@ -36,5 +36,5 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-docker-image-for-eth-sepolia.yml
+++ b/.github/workflows/publish-docker-image-for-eth-sepolia.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}-shrink-internal-txs
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-eth.yml
+++ b/.github/workflows/publish-docker-image-for-eth.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -70,6 +70,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum

--- a/.github/workflows/publish-docker-image-for-filecoin.yml
+++ b/.github/workflows/publish-docker-image-for-filecoin.yml
@@ -35,7 +35,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -52,7 +52,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
     
@@ -69,7 +69,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -85,7 +85,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -103,7 +103,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -121,7 +121,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-fuse.yml
+++ b/.github/workflows/publish-docker-image-for-fuse.yml
@@ -37,5 +37,5 @@ jobs:
             linux/arm64/v8
           build-args: |
             BRIDGED_TOKENS_ENABLED=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-docker-image-for-gnosis-chain.yml
+++ b/.github/workflows/publish-docker-image-for-gnosis-chain.yml
@@ -37,6 +37,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             BRIDGED_TOKENS_ENABLED=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum

--- a/.github/workflows/publish-docker-image-for-l2-staging.yml
+++ b/.github/workflows/publish-docker-image-for-l2-staging.yml
@@ -36,5 +36,5 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-docker-image-for-lukso.yml
+++ b/.github/workflows/publish-docker-image-for-lukso.yml
@@ -36,5 +36,5 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-docker-image-for-optimism.yml
+++ b/.github/workflows/publish-docker-image-for-optimism.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-polygon-edge.yml
+++ b/.github/workflows/publish-docker-image-for-polygon-edge.yml
@@ -36,6 +36,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_edge

--- a/.github/workflows/publish-docker-image-for-redstone.yml
+++ b/.github/workflows/publish-docker-image-for-redstone.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             MUD_INDEXER_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-rootstock.yml
+++ b/.github/workflows/publish-docker-image-for-rootstock.yml
@@ -36,6 +36,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=rsk

--- a/.github/workflows/publish-docker-image-for-scroll.yml
+++ b/.github/workflows/publish-docker-image-for-scroll.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-shibarium.yml
+++ b/.github/workflows/publish-docker-image-for-shibarium.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium

--- a/.github/workflows/publish-docker-image-for-stability.yml
+++ b/.github/workflows/publish-docker-image-for-stability.yml
@@ -39,6 +39,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=stability

--- a/.github/workflows/publish-docker-image-for-suave.yml
+++ b/.github/workflows/publish-docker-image-for-suave.yml
@@ -39,6 +39,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=suave

--- a/.github/workflows/publish-docker-image-for-zetachain.yml
+++ b/.github/workflows/publish-docker-image-for-zetachain.yml
@@ -36,6 +36,6 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zetachain

--- a/.github/workflows/publish-docker-image-for-zilliqa.yml
+++ b/.github/workflows/publish-docker-image-for-zilliqa.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=${{ env.DOCKER_CHAIN_NAME }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-zkevm.yml
+++ b/.github/workflows/publish-docker-image-for-zkevm.yml
@@ -36,7 +36,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
 
@@ -53,7 +53,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
 
@@ -70,7 +70,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
 
@@ -86,7 +86,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -104,7 +104,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -122,7 +122,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/publish-docker-image-for-zksync.yml
+++ b/.github/workflows/publish-docker-image-for-zksync.yml
@@ -35,7 +35,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -52,7 +52,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -69,7 +69,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -85,7 +85,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -102,7 +102,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -119,6 +119,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync

--- a/.github/workflows/publish-docker-image-staging-on-demand.yml
+++ b/.github/workflows/publish-docker-image-staging-on-demand.yml
@@ -50,5 +50,5 @@ jobs:
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
             CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -42,7 +42,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build and push Docker image (indexer)
@@ -63,7 +63,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build and push Docker image (API)
@@ -84,5 +84,5 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-arbitrum.yml
+++ b/.github/workflows/release-arbitrum.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=arbitrum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-blackfort.yml
+++ b/.github/workflows/release-blackfort.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=blackfort
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=blackfort
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=blackfort

--- a/.github/workflows/release-celo.yml
+++ b/.github/workflows/release-celo.yml
@@ -41,7 +41,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
 
@@ -59,7 +59,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
 
@@ -77,7 +77,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
 
@@ -94,7 +94,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -113,7 +113,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -132,7 +132,7 @@ jobs:
           build-args: |
             API_GRAPHQL_MAX_COMPLEXITY=${{ env.API_GRAPHQL_MAX_COMPLEXITY }}
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=celo
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-eth.yml
+++ b/.github/workflows/release-eth.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=ethereum
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-filecoin.yml
+++ b/.github/workflows/release-filecoin.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=filecoin
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-fuse.yml
+++ b/.github/workflows/release-fuse.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true

--- a/.github/workflows/release-gnosis.yml
+++ b/.github/workflows/release-gnosis.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true
             CHAIN_TYPE=ethereum
@@ -57,7 +57,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true
             CHAIN_TYPE=ethereum
@@ -75,7 +75,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             BRIDGED_TOKENS_ENABLED=true
             CHAIN_TYPE=ethereum

--- a/.github/workflows/release-optimism.yml
+++ b/.github/workflows/release-optimism.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-polygon-edge.yml
+++ b/.github/workflows/release-polygon-edge.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_edge
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_edge
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_edge

--- a/.github/workflows/release-polygon-zkevm.yml
+++ b/.github/workflows/release-polygon-zkevm.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
     
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=polygon_zkevm
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-redstone.yml
+++ b/.github/workflows/release-redstone.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             MUD_INDEXER_ENABLED=true
@@ -57,7 +57,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             MUD_INDEXER_ENABLED=true
@@ -75,7 +75,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=optimism
             MUD_INDEXER_ENABLED=true

--- a/.github/workflows/release-rootstock.yml
+++ b/.github/workflows/release-rootstock.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=rsk
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=rsk
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=rsk

--- a/.github/workflows/release-scroll.yml
+++ b/.github/workflows/release-scroll.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=scroll
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-shibarium.yml
+++ b/.github/workflows/release-shibarium.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=shibarium
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-stability.yml
+++ b/.github/workflows/release-stability.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=stability
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=stability
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=stability

--- a/.github/workflows/release-suave.yml
+++ b/.github/workflows/release-suave.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=suave
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=suave
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=suave

--- a/.github/workflows/release-zetachain.yml
+++ b/.github/workflows/release-zetachain.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zetachain
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zetachain
 
@@ -73,6 +73,6 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zetachain

--- a/.github/workflows/release-zilliqa.yml
+++ b/.github/workflows/release-zilliqa.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zilliqa
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release-zksync.yml
+++ b/.github/workflows/release-zksync.yml
@@ -39,7 +39,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -56,7 +56,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -73,7 +73,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
 
@@ -89,7 +89,7 @@ jobs:
             linux/amd64
             linux/arm64/v8
           build-args: |
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -107,7 +107,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_API=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
@@ -125,7 +125,7 @@ jobs:
             linux/arm64/v8
           build-args: |
             DISABLE_INDEXER=true
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             CHAIN_TYPE=zksync
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build & Push Core Docker image (indexer)
@@ -69,7 +69,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build & Push Core Docker image (API)
@@ -92,7 +92,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       - name: Build & Push Core Docker image (indexer + API + shrink internal transactions)
@@ -114,7 +114,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
     
@@ -138,7 +138,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
 
@@ -162,7 +162,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             SHRINK_INTERNAL_TRANSACTIONS_ENABLED=true
 
@@ -185,7 +185,7 @@ jobs:
             MIXPANEL_TOKEN=
             AMPLITUDE_URL=
             AMPLITUDE_API_KEY=
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
 
       # - name: Send release announcement to Slack workflow
@@ -195,7 +195,7 @@ jobs:
       #     payload: |
       #       {
       #         "release-version": "${{ env.RELEASE_VERSION }}",
-      #         "release-link": "https://github.com/blockscout/blockscout/releases/tag/v${{ env.RELEASE_VERSION }}-beta"
+      #         "release-link": "https://github.com/blockscout/blockscout/releases/tag/v${{ env.RELEASE_VERSION }}"
       #       }
       #   env:
       #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -71,7 +71,7 @@ end
 # will be used by default
 
 release :blockscout do
-  set version: "6.10.0-beta"
+  set version: "6.10.0"
   set applications: [
     :runtime_tools,
     block_scout_web: :permanent,


### PR DESCRIPTION
## Motivation

Remove beta suffix from releases

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
