### PR TITLE
fix: handle "null" in paging options

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -347,6 +347,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
   defp paging_options(_), do: [paging_options: default_paging_options()]
 
   defp parse_nullable_integer_paging_parameter(""), do: {:ok, nil}
+  defp parse_nullable_integer_paging_parameter("null"), do: {:ok, nil}
 
   defp parse_nullable_integer_paging_parameter(string) when is_binary(string) do
     case Integer.parse(string) do


### PR DESCRIPTION
## Motivation

https://review-advanced-filter.k8s-dev.blockscout.com/advanced-filter?from_address_hashes_to_include=0x8a258309B8177Df36c48de82885A56cCF576979C&page=2&next_page_params=%257B%2522block_number%2522%253A5803620%252C%2522transaction_index%2522%253A28%252C%2522internal_transaction_index%2522%253Anull%252C%2522token_transfer_batch_index%2522%253Anull%252C%2522token_transfer_index%2522%253Anull%252C%2522items_count%2522%253A50%257D

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for nullable integer paging parameters.
	- Improved robustness in extracting paging options with support for `"null"` inputs.

- **Bug Fixes**
	- Corrected handling of invalid paging parameter inputs to ensure proper error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->