### PR TITLE
chore: Remove raise in case if ETHEREUM_JSONRPC_HTTP_URL is not provided

### DIFF
--- a/apps/explorer/test/explorer/config_helper_test.exs
+++ b/apps/explorer/test/explorer/config_helper_test.exs
@@ -31,17 +31,6 @@ defmodule ConfigHelperTest do
       assert ConfigHelper.parse_urls_list(:fallback_eth_call) == ["test"]
     end
 
-    test "raise if ETHEREUM_JSONRPC_HTTP_URL and ETHEREUM_JSONRPC_HTTP_URLS are not provided" do
-      refute System.get_env("ETHEREUM_JSONRPC_HTTP_URLS")
-      refute System.get_env("ETHEREUM_JSONRPC_HTTP_URL")
-
-      assert_raise RuntimeError,
-                   "ETHEREUM_JSONRPC_HTTP_URL (or ETHEREUM_JSONRPC_HTTP_URLS) env variable is required",
-                   fn ->
-                     ConfigHelper.parse_urls_list(:trace)
-                   end
-    end
-
     test "base http urls are used if fallback is not provided" do
       System.put_env("ETHEREUM_JSONRPC_HTTP_URL", "test")
       refute System.get_env("ETHEREUM_JSONRPC_FALLBACK_TRACE_URLS")

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -375,7 +375,8 @@ defmodule ConfigHelper do
          "" <- safe_get_env(url_var, default_url) do
       case urls_type do
         :http ->
-          raise "ETHEREUM_JSONRPC_HTTP_URL (or ETHEREUM_JSONRPC_HTTP_URLS) env variable is required"
+          Logger.warning("ETHEREUM_JSONRPC_HTTP_URL (or ETHEREUM_JSONRPC_HTTP_URLS) env variable is required")
+          []
 
         :fallback_http ->
           parse_urls_list(:http)


### PR DESCRIPTION
## Changelog

Allow application to start without `ETHEREUM_JSONRPC_HTTP_URL` and `ETHEREUM_JSONRPC_HTTP_URLS` env vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted error handling to log a warning and return an empty list when required environment variables are not set, instead of raising an error.

- **Tests**
	- Removed a test case that checked for a `RuntimeError` when environment variables are missing.

- **Style**
	- Minor formatting adjustments made for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->