### PR TITLE
fix: Take into account several proofs in OP Withdrawals

### DIFF
--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -320,7 +320,7 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
               post_fault_proofs_status(l1_timestamp, game)
           end
 
-        if status == @withdrawal_status_ready_for_relay do
+        if elem(status, 0) == @withdrawal_status_ready_for_relay do
           {:halt, [status]}
         else
           {:cont, [status | acc]}

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
@@ -22,7 +22,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     field(:withdrawal_hash, Hash.Full, primary_key: true)
     field(:l1_event_type, Ecto.Enum, values: [:WithdrawalProven, :WithdrawalFinalized], primary_key: true)
     field(:l1_timestamp, :utc_datetime_usec)
-    field(:l1_transaction_hash, Hash.Full)
+    field(:l1_transaction_hash, Hash.Full, primary_key: true)
     field(:l1_block_number, :integer)
     field(:game_index, :integer)
 

--- a/apps/explorer/priv/optimism/migrations/20241209101134_op_withdrawal_events_key.exs
+++ b/apps/explorer/priv/optimism/migrations/20241209101134_op_withdrawal_events_key.exs
@@ -1,0 +1,21 @@
+defmodule Explorer.Repo.Optimism.Migrations.OPWithdrawalEventsKey do
+  use Ecto.Migration
+
+  def change do
+  	drop table(:op_withdrawal_events)
+
+    create table(:op_withdrawal_events, primary_key: false) do
+      add(:withdrawal_hash, :bytea, null: false, primary_key: true)
+      add(:l1_event_type, :withdrawal_event_type, null: false, primary_key: true)
+      add(:l1_timestamp, :"timestamp without time zone", null: false)
+      add(:l1_transaction_hash, :bytea, null: false, primary_key: true)
+      add(:l1_block_number, :bigint, null: false)
+      add(:game_index, :integer, null: true)
+
+      timestamps(null: false, type: :utc_datetime_usec)
+    end
+
+    create(index(:op_withdrawal_events, :l1_timestamp))
+    create(index(:op_withdrawal_events, :l1_block_number))
+  end
+end

--- a/apps/explorer/priv/optimism/migrations/20241209101134_op_withdrawal_events_key.exs
+++ b/apps/explorer/priv/optimism/migrations/20241209101134_op_withdrawal_events_key.exs
@@ -2,7 +2,7 @@ defmodule Explorer.Repo.Optimism.Migrations.OPWithdrawalEventsKey do
   use Ecto.Migration
 
   def change do
-  	drop table(:op_withdrawal_events)
+    drop(table(:op_withdrawal_events))
 
     create table(:op_withdrawal_events, primary_key: false) do
       add(:withdrawal_hash, :bytea, null: false, primary_key: true)


### PR DESCRIPTION
## Motivation

The current implementation of the OP Withdrawal module didn't take into account that a withdrawal can have more than one proof events, so statuses for some withdrawals could display incorrectly. This PR fixes that by allowing the module to handle a few proofs for the same withdrawal.

## Upgrading

After installing this change, the `op_withdrawal_events` database table will be cleaned and recreated. The `Indexer.Fetcher.Optimism.WithdrawalEvent` module will reindex L1 withdrawal transactions and refill the table, so some time right after the installation the withdrawal statuses can be incorrect (during the reindexing process).

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
