### PR TITLE
fix: Fix get_media_url_from_metadata_for_nft_media_handler/1

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -721,16 +721,16 @@ defmodule Explorer.Chain.Token.Instance do
   def get_media_url_from_metadata_for_nft_media_handler(metadata) when is_map(metadata) do
     result =
       cond do
-        metadata["image_url"] ->
+        is_binary(metadata["image_url"]) ->
           metadata["image_url"]
 
-        metadata["image"] ->
+        is_binary(metadata["image"]) ->
           metadata["image"]
 
         is_map(metadata["properties"]) && is_binary(metadata["properties"]["image"]) ->
           metadata["properties"]["image"]
 
-        metadata["animation_url"] ->
+        is_binary(metadata["animation_url"]) ->
           metadata["animation_url"]
 
         true ->


### PR DESCRIPTION
## Motivation
```
{"time":"2024-12-16T10:08:59.790Z","severity":"error","message":"Task #PID<0.79216042.0> started from Indexer.NFTMediaHandler.Backfiller terminating\n** (FunctionClauseError) no function clause matching in String.trim/1\n    (elixir 1.17.3) String.trim(%{})\n    (explorer 6.10.0) lib/explorer/chain/token/instance.ex:740: Explorer.Chain.Token.Instance.get_media_url_from_metadata_for_nft_media_handler/1\n    (indexer 6.10.0) lib/indexer/nft_media_handler/backfiller.ex:45: Indexer.NFTMediaHandler.Backfiller.enqueue_if_queue_is_not_full/1\n    (elixir 1.17.3) lib/enum.ex:992: anonymous fn/3 in Enum.each/2\n    (elixir 1.17.3) lib/enum.ex:4423: anonymous fn/3 in Enum.each/2\n    (elixir 1.17.3) lib/stream.ex:1879: anonymous fn/3 in Enumerable.Stream.reduce/3\n    (elixir 1.17.3) lib/enum.ex:4858: Enumerable.List.reduce/3\n    (elixir 1.17.3) lib/stream.ex:1027: Stream.do_transform_inner_list/7\nFunction: #Function<0.38850889/0 in Indexer.NFTMediaHandler.Backfiller.init/1>\n    Args: []","metadata":{"error":{"initial_call":null,"reason":"** (FunctionClauseError) no function clause matching in String.trim/1\n    (elixir 1.17.3) String.trim(%{})\n    (explorer 6.10.0) lib/explorer/chain/token/instance.ex:740: Explorer.Chain.Token.Instance.get_media_url_from_metadata_for_nft_media_handler/1\n    (indexer 6.10.0) lib/indexer/nft_media_handler/backfiller.ex:45: Indexer.NFTMediaHandler.Backfiller.enqueue_if_queue_is_not_full/1\n    (elixir 1.17.3) lib/enum.ex:992: anonymous fn/3 in Enum.each/2\n    (elixir 1.17.3) lib/enum.ex:4423: anonymous fn/3 in Enum.each/2\n    (elixir 1.17.3) lib/stream.ex:1879: anonymous fn/3 in Enumerable.Stream.reduce/3\n    (elixir 1.17.3) lib/enum.ex:4858: Enumerable.List.reduce/3\n    (elixir 1.17.3) lib/stream.ex:1027: Stream.do_transform_inner_list/7\n"}}}
```

## Changelog
- add is_binary check
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced type checking for media URL fields in NFT metadata to prevent errors.
	- Added a check to return `nil` for empty strings after trimming, ensuring consistent function behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->