### PR TITLE
fix: Fix 500 on disabled metadata service

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
@@ -17,6 +17,7 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
   @tags_per_address_limit 5
   @page_size 50
   @request_error_msg "Error while sending request to Metadata microservice"
+  @service_disabled "Service is disabled"
 
   @doc """
   Retrieves tags for a list of addresses.
@@ -61,6 +62,9 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
         |> Map.put("chain_id", Application.get_env(:block_scout_web, :chain_id))
 
       http_get_request_for_proxy_method(addresses_url(), params, &prepare_addresses_response/1)
+    else
+      _ ->
+        {501, %{error: @service_disabled}}
     end
   end
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
@@ -55,14 +55,15 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
   """
   @spec get_addresses(map()) :: {:error | integer(), any()}
   def get_addresses(params) do
-    with :ok <- Microservice.check_enabled(__MODULE__) do
-      params =
-        params
-        |> Map.put("page_size", @page_size)
-        |> Map.put("chain_id", Application.get_env(:block_scout_web, :chain_id))
+    case Microservice.check_enabled(__MODULE__) do
+      :ok ->
+        params =
+          params
+          |> Map.put("page_size", @page_size)
+          |> Map.put("chain_id", Application.get_env(:block_scout_web, :chain_id))
 
-      http_get_request_for_proxy_method(addresses_url(), params, &prepare_addresses_response/1)
-    else
+        http_get_request_for_proxy_method(addresses_url(), params, &prepare_addresses_response/1)
+
       _ ->
         {501, %{error: @service_disabled}}
     end


### PR DESCRIPTION
## Motivation
```
{"time":"2024-12-14T08:15:10.433Z","severity":"error","message":"#PID<0.45296492.0> running BlockScoutWeb.Endpoint (connection #PID<0.45295021.0>, stream id 13) terminated\nServer: filecoin.blockscout.com:80 (http)\nRequest: GET /api/v2/proxy/metadata/addresses?slug=metamask-user&tag_type=generic\n** (exit) an exception was raised:\n    ** (FunctionClauseError) no function clause matching in Plug.Conn.Status.code/1\n        (plug 1.16.1) lib/plug/conn/status.ex:114: Plug.Conn.Status.code(:error)\n        (plug 1.16.1) lib/plug/conn.ex:411: Plug.Conn.put_status/2\n        (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:25: BlockScoutWeb.API.V2.Proxy.MetadataController.addresses/2\n        (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:1: BlockScoutWeb.API.V2.Proxy.MetadataController.action/2\n        (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:1: BlockScoutWeb.API.V2.Proxy.MetadataController.phoenix_controller_pipeline/2\n        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2\n        (phoenix 1.5.14) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2\n        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2","metadata":{"error":{"initial_call":null,"reason":"** (FunctionClauseError) no function clause matching in Plug.Conn.Status.code/1\n    (plug 1.16.1) lib/plug/conn/status.ex:114: Plug.Conn.Status.code(:error)\n    (plug 1.16.1) lib/plug/conn.ex:411: Plug.Conn.put_status/2\n    (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:25: BlockScoutWeb.API.V2.Proxy.MetadataController.addresses/2\n    (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:1: BlockScoutWeb.API.V2.Proxy.MetadataController.action/2\n    (block_scout_web 6.10.0) lib/block_scout_web/controllers/api/v2/proxy/metadata_controller.ex:1: BlockScoutWeb.API.V2.Proxy.MetadataController.phoenix_controller_pipeline/2\n    (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2\n    (phoenix 1.5.14) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2\n    (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2\n"}}}
```
## Changelog
- return 501 on disabled service
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced error handling for the `get_addresses` function, providing a clear response when the service is disabled.

- **Bug Fixes**
	- Improved error response structure to include specific messages when the service is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->