### PR TITLE
feat: Add protocol icon to the search result

### DIFF
--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -769,8 +769,13 @@ defmodule Explorer.Chain.Search do
   """
   @spec search_ens_name_in_bens(binary()) ::
           nil
-          | {%{address_hash: binary(), expiry_date: any(), name: any(), names_count: non_neg_integer()},
-             Hash.Address.t()}
+          | {%{
+               address_hash: binary(),
+               expiry_date: any(),
+               name: any(),
+               names_count: non_neg_integer(),
+               protocol: any()
+             }, Hash.Address.t()}
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -84,7 +84,7 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
     Request for ENS name via GET {{baseUrl}}/api/v1/:chainId/domains:lookup
   """
   @spec ens_domain_name_lookup(binary()) ::
-          nil | %{address_hash: binary(), expiry_date: any(), name: any(), names_count: integer()}
+          nil | %{address_hash: binary(), expiry_date: any(), name: any(), names_count: integer(), protocol: any()}
   def ens_domain_name_lookup(domain) do
     domain |> ens_domain_lookup() |> parse_lookup_response()
   end
@@ -175,7 +175,12 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
           %{
             "items" =>
               [
-                %{"name" => name, "expiry_date" => expiry_date, "resolved_address" => %{"hash" => address_hash_string}}
+                %{
+                  "name" => name,
+                  "expiry_date" => expiry_date,
+                  "resolved_address" => %{"hash" => address_hash_string},
+                  "protocol" => protocol
+                }
                 | _other
               ] = items
           }}
@@ -186,7 +191,8 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
       name: name,
       expiry_date: expiry_date,
       names_count: Enum.count(items),
-      address_hash: Address.checksum(hash)
+      address_hash: Address.checksum(hash),
+      protocol: protocol
     }
   end
 


### PR DESCRIPTION
Closes #10218 

## Changelog
- Added `protocol` field in ENS search response item:
```
 {
            "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
            "certified": false,
            "ens_info": {
                "name": "vitalik.eth",
                "protocol": {
                    "deployment_blockscout_base_url": "https://eth-sepolia.blockscout.com/",
                    "description": "The Ethereum Name Service (ENS) is a distributed, open, and extensible naming system based on the Ethereum blockchain.",
                    "docs_url": "https://docs.ens.domains/",
                    "icon_url": "https://i.imgur.com/GOfUwCb.jpeg",
                    "id": "ens-sepolia",
                    "short_name": "ENS (Testnet)",
                    "title": "Ethereum Name Service (Testnet)",
                    "tld_list": [
                        "eth"
                    ]
                },
                "address_hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
                "expiry_date": "2026-11-14T14:53:36.000Z",
                "names_count": 1
            },
            "is_smart_contract_verified": false,
            "name": null,
            "priority": 2,
            "type": "ens_domain",
            "url": "/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
        }
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality now includes a `protocol` field in the returned data for ENS domain resolution.
	- Updated response structure for the ENS domain name lookup to include a `protocol` field.

- **Bug Fixes**
	- Adjusted internal logic to ensure proper handling of the new `protocol` field without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->