### PR TITLE
Fix: issue in db request during Arbitrum message claiming

### DIFF
--- a/apps/explorer/lib/explorer/chain/arbitrum/reader.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader.ex
@@ -671,7 +671,7 @@ defmodule Explorer.Chain.Arbitrum.Reader do
   def l2_to_l1_message_by_id(message_id, options) do
     query =
       from(message in Message,
-        where: message.message_id == ^message_id
+        where: message.direction == :from_l2 and message.message_id == ^message_id
       )
 
     select_repo(options).one(query)


### PR DESCRIPTION

## Motivation

The request to `/api/v2/arbitrum/messages/claim/:message_id` may result in an internal server error, leading to an HTTP 500 error code in response.

## Changelog

### Bug Fixes

Fixed an issue in the routine that retrieves L2->L1 crosschain messages from the database  (`l2_to_l1_message_by_id/1` in `Explorer.Chain.Arbitrum.Reader` module). Due to an error in the query, the response from the database also included L1->L2 messages.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved message retrieval logic to ensure only relevant messages from L2 are processed.

- **Documentation**
	- Updated documentation for the message retrieval function to reflect changes in query logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->