### PR TITLE
fix: ignore unknown transaction receipt fields

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -424,43 +424,7 @@ defmodule EthereumJSONRPC.Receipt do
     end
   end
 
-  # fixes for latest ganache JSON RPC
-  defp entry_to_elixir({key, _}) when key in ~w(r s v) do
+  defp entry_to_elixir({_, _}) do
     :ignore
-  end
-
-  # Nethermind field
-  defp entry_to_elixir({"error", _}) do
-    :ignore
-  end
-
-  # Arbitrum fields
-  defp entry_to_elixir({key, _}) when key in ~w(returnData returnCode feeStats l1BlockNumber) do
-    :ignore
-  end
-
-  # Metis fields
-  defp entry_to_elixir({key, _}) when key in ~w(l1GasUsed l1GasPrice l1FeeScalar l1Fee) do
-    :ignore
-  end
-
-  # GoQuorum specific transaction receipt fields
-  defp entry_to_elixir({key, _}) when key in ~w(isPrivacyMarkerTransaction) do
-    :ignore
-  end
-
-  # Optimism specific transaction receipt fields
-  defp entry_to_elixir({key, _}) when key in ~w(depositNonce depositReceiptVersion) do
-    :ignore
-  end
-
-  # zkSync specific transaction receipt fields
-  defp entry_to_elixir({key, _})
-       when key in ~w(l1BatchNumber l1BatchTxIndex l2ToL1Logs) do
-    :ignore
-  end
-
-  defp entry_to_elixir({key, value}) do
-    {:error, {:unknown_key, %{key: key, value: value}}}
   end
 end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/receipt_test.exs
@@ -6,23 +6,13 @@ defmodule EthereumJSONRPC.ReceiptTest do
   doctest Receipt
 
   describe "to_elixir/1" do
-    test "with new key raise ArgumentError with full receipt" do
-      assert_raise ArgumentError,
-                   """
-                   Could not convert receipt to elixir
-
-                   Receipt:
-                     %{"new_key" => "new_value", "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"}
-
-                   Errors:
-                     {:unknown_key, %{value: "new_value", key: "new_key"}}
-                   """,
-                   fn ->
-                     Receipt.to_elixir(%{
-                       "new_key" => "new_value",
-                       "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
-                     })
-                   end
+    test "ignores new key" do
+      assert Receipt.to_elixir(%{
+               "new_key" => "new_value",
+               "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+             }) == %{
+               "transactionHash" => "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+             }
     end
 
     # Regression test for https://github.com/poanetwork/blockscout/issues/638


### PR DESCRIPTION
## Motivation

If an unknown key is met in the transaction receipt, an import will fail with an error like this:

```
{"time":"2024-12-19T09:41:35.595Z","severity":"error","message":"Task #PID<0.66107815.0> started from #PID<0.66211938.0> terminating\n** (ArgumentError) Could not convert receipt to elixir\n\nReceipt:\n  %{\"blockHash\" => \"0x91c14345a072e82ae53c3d914c84183865244a6772d992ebdb8a54921e5ef776\", \"blockNumber\" => \"0x12626020\", \"contractAddress\" => nil, \"cumulativeGasUsed\" => \"0x2710\", \"effectiveGasPrice\" => \"0x3178d3de133\", \"from\" => \"0xA7fa116005b79D124855dC34008b6Ebdd1f9A688\", \"gas\" => 30000, \"gasUsed\" => \"0x2710\", \"logs\" => [], \"logsBloom\" => \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\", \"root\" => \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"scheduledChildTransactionHashes\" => [], \"scheduledParentTransactionHashes\" => [], \"status\" => \"0x0\", \"to\" => \"0x594e37B9F39f5D31DEc4a8c1cC4fe2E254153034\", \"transactionHash\" => \"0x4660c75251af78a6ec98e13128406978cfa1ad41886853955be161ace192f7de\", \"transactionIndex\" => \"0x0\", \"type\" => \"0x0\"}\n\nErrors:\n  {:unknown_key, %{value: [], key: \"scheduledParentTransactionHashes\"}}\n  {:unknown_key, %{value: [], key: \"scheduledChildTransactionHashes\"}}\n\n    (ethereum_jsonrpc 6.9.1) lib/ethereum_jsonrpc/receipt.ex:367: EthereumJSONRPC.Receipt.ok!/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (ethereum_jsonrpc 6.9.1) lib/ethereum_jsonrpc/receipts.ex:154: EthereumJSONRPC.Receipts.fetch/2\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\nFunction: &:erlang.apply/2\n    Args: [#Function<0.46700518/1 in Indexer.Block.Fetcher.Receipts.fetch/2>, [[%{index: 0, input: \"0x791ac9470000000000000000000000000000000000000000000000000000000000004124000000000000000000000000000000000000000000000000000e8ca980c02d0800000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000a7fa116005b79d124855dc34008b6ebdd1f9a688000000000000000000000000000000000000000000000000000000006763e72400000000000000000000000000000000000000000000000000000000000000020000000000000000000000005f0155d08ef4aae2b500aefb64a3419da8bb611a000000000000000000000000202c35e517fa803b537565c40f0a6965d7204609\", type: 0, value: 0, v: 490045904, s: 30915387996495526016510852300704478755445907626492657398445520790449941662801, r: 87895419712433228888820745099219184845216699214445315985664526743510469385345, hash: \"0x4660c75251af78a6ec98e13128406978cfa1ad41886853955be161ace192f7de\", nonce: 163, block_number: 308437024, from_address_hash: \"0xA7fa116005b79D124855dC34008b6Ebdd1f9A688\", gas: 30000, to_address_hash: \"0x594e37B9F39f5D31DEc4a8c1cC4fe2E254153034\", transaction_index: 0, block_hash: \"0x91c14345a072e82ae53c3d914c84183865244a6772d992ebdb8a54921e5ef776\", gas_price: 3399688773939, block_timestamp: ~U[2024-12-19 09:26:42Z]}]]]","metadata":{"error":{"initial_call":null,"reason":"** (ArgumentError) Could not convert receipt to elixir\n\nReceipt:\n  %{\"blockHash\" => \"0x91c14345a072e82ae53c3d914c84183865244a6772d992ebdb8a54921e5ef776\", \"blockNumber\" => \"0x12626020\", \"contractAddress\" => nil, \"cumulativeGasUsed\" => \"0x2710\", \"effectiveGasPrice\" => \"0x3178d3de133\", \"from\" => \"0xA7fa116005b79D124855dC34008b6Ebdd1f9A688\", \"gas\" => 30000, \"gasUsed\" => \"0x2710\", \"logs\" => [], \"logsBloom\" => \"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\", \"root\" => \"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\", \"scheduledChildTransactionHashes\" => [], \"scheduledParentTransactionHashes\" => [], \"status\" => \"0x0\", \"to\" => \"0x594e37B9F39f5D31DEc4a8c1cC4fe2E254153034\", \"transactionHash\" => \"0x4660c75251af78a6ec98e13128406978cfa1ad41886853955be161ace192f7de\", \"transactionIndex\" => \"0x0\", \"type\" => \"0x0\"}\n\nErrors:\n  {:unknown_key, %{value: [], key: \"scheduledParentTransactionHashes\"}}\n  {:unknown_key, %{value: [], key: \"scheduledChildTransactionHashes\"}}\n\n    (ethereum_jsonrpc 6.9.1) lib/ethereum_jsonrpc/receipt.ex:367: EthereumJSONRPC.Receipt.ok!/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (ethereum_jsonrpc 6.9.1) lib/ethereum_jsonrpc/receipts.ex:154: EthereumJSONRPC.Receipts.fetch/2\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\n"}}}
```

## Changelog

Ignore all unknown keys in the transaction receipt.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
