### PR TITLE
fix: Limit max decimals value

### DIFF
--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -356,6 +356,7 @@ defmodule Explorer.Token.MetadataRetriever do
     contract_functions
     |> handle_invalid_strings(contract_address_hash)
     |> handle_large_strings
+    |> limit_decimals
   end
 
   defp atomized_key(@name_signature), do: :name
@@ -436,6 +437,16 @@ defmodule Explorer.Token.MetadataRetriever do
     do: string |> binary_part(0, 255) |> String.chunk(:valid) |> List.first()
 
   defp handle_large_string(string, _size), do: string
+
+  defp limit_decimals(%{decimals: decimals} = contract_functions) do
+    if decimals > 78 do
+      %{contract_functions | decimals: nil}
+    else
+      contract_functions
+    end
+  end
+
+  defp limit_decimals(contract_functions), do: contract_functions
 
   defp remove_null_bytes(string) do
     String.replace(string, "\0", "")

--- a/apps/explorer/priv/repo/migrations/20241219102223_remove_large_decimals.exs
+++ b/apps/explorer/priv/repo/migrations/20241219102223_remove_large_decimals.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.RemoveLargeDecimals do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    UPDATE tokens SET decimals = NULL WHERE decimals > 78;
+    """)
+  end
+end


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a mechanism to limit the `decimals` field in smart contract metadata, ensuring values do not exceed 78.
	- Introduced a migration to update existing records in the database, setting `decimals` to `NULL` for values over 78.

- **Bug Fixes**
	- Enhanced handling of contract function results to improve metadata accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->