### PR TITLE
fix: advanced-filters csv format

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
@@ -73,7 +73,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
       |> Stream.map(fn advanced_filter ->
         method_id =
           case advanced_filter.input do
-            %{bytes: <<method_id::binary-size(4), _::binary>>} -> method_id
+            %{bytes: <<method_id::binary-size(4), _::binary>>} -> "0x" <> Base.encode16(method_id, case: :lower)
             _ -> nil
           end
 
@@ -87,18 +87,21 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
           Address.checksum(advanced_filter.from_address_hash),
           Address.checksum(advanced_filter.to_address_hash),
           Address.checksum(advanced_filter.created_contract_address_hash),
-          advanced_filter.value,
+          decimal_to_string_xsd(advanced_filter.value),
           if(advanced_filter.type != "coin_transfer",
-            do: advanced_filter.token_transfer.token.contract_address_hash,
+            do: Address.checksum(advanced_filter.token_transfer.token.contract_address_hash),
             else: nil
           ),
-          if(advanced_filter.type != "coin_transfer", do: advanced_filter.token_transfer.token.decimals, else: nil),
+          if(advanced_filter.type != "coin_transfer",
+            do: decimal_to_string_xsd(advanced_filter.token_transfer.token.decimals),
+            else: nil
+          ),
           if(advanced_filter.type != "coin_transfer", do: advanced_filter.token_transfer.token.symbol, else: nil),
           advanced_filter.block_number,
-          advanced_filter.fee,
-          exchange_rate.usd_value,
-          opening_price,
-          closing_price
+          decimal_to_string_xsd(advanced_filter.fee),
+          decimal_to_string_xsd(exchange_rate.usd_value),
+          decimal_to_string_xsd(opening_price),
+          decimal_to_string_xsd(closing_price)
         ]
       end)
 
@@ -178,4 +181,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
 
     %{methods: method_ids, tokens: tokens_map}
   end
+
+  defp decimal_to_string_xsd(nil), do: nil
+  defp decimal_to_string_xsd(decimal), do: Decimal.to_string(decimal, :xsd)
 end


### PR DESCRIPTION
- wrong method id encoding, for example: iuè
- scientific notation for value and other numeric fields

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced CSV export functionality for advanced filters, including hexadecimal string formatting for method IDs.
	- Improved handling and formatting of attributes such as value, fee, and market prices.

- **Bug Fixes**
	- Adjusted logic for populating CSV rows to ensure consistent formatting of contract addresses and decimal values.

- **Refactor**
	- Introduced a new helper function for decimal to string conversions to improve code readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->