### PR TITLE
chore: Return old response format in /api/v1/health endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/health_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v1/health_controller.ex
@@ -10,6 +10,78 @@ defmodule BlockScoutWeb.API.V1.HealthController do
   @ok_message "OK"
   @backfill_multichain_search_db_migration_name "backfill_multichain_search_db"
 
+  # todo: remove *_old functions in the next releases when dependent parties start using new endpoint /api/health
+  def health_old(conn, params) do
+    health_old(conn, params, Application.get_env(:nft_media_handler, :standalone_media_worker?))
+  end
+
+  defp health_old(conn, _params, false) do
+    with {:ok, number, timestamp} <- Chain.last_db_block_status(),
+         {:ok, cache_number, cache_timestamp} <- Chain.last_cache_block_status() do
+      send_resp(conn, :ok, result_old(number, timestamp, cache_number, cache_timestamp))
+    else
+      status -> send_resp(conn, :internal_server_error, error_old(status))
+    end
+  end
+
+  defp health_old(conn, _params, true) do
+    send_resp(
+      conn,
+      :ok,
+      %{
+        "healthy" => true,
+        "data" => %{}
+      }
+      |> Jason.encode!()
+    )
+  end
+
+  def result_old(number, timestamp, cache_number, cache_timestamp) do
+    %{
+      "healthy" => true,
+      "data" => %{
+        "latest_block_number" => to_string(number),
+        "latest_block_inserted_at" => to_string(timestamp),
+        "cache_latest_block_number" => to_string(cache_number),
+        "cache_latest_block_inserted_at" => to_string(cache_timestamp)
+      }
+    }
+    |> Jason.encode!()
+  end
+
+  defp error_old({:error, :no_blocks}) do
+    %{
+      "healthy" => false,
+      "error_code" => 5002,
+      "error_title" => "no blocks in db",
+      "error_description" => "There are no blocks in the DB"
+    }
+    |> Jason.encode!()
+  end
+
+  defp error_old({:stale, number, timestamp}) do
+    healthy_blocks_period = Application.get_env(:explorer, :healthy_blocks_period)
+
+    healthy_blocks_period_formatted =
+      healthy_blocks_period
+      |> Duration.from_milliseconds()
+      |> Duration.to_minutes()
+      |> trunc()
+
+    %{
+      "healthy" => false,
+      "error_code" => 5001,
+      "error_title" => "blocks fetching is stuck",
+      "error_description" =>
+        "There are no new blocks in the DB for the last #{healthy_blocks_period_formatted} mins. Check the healthiness of Ethereum archive node or the Blockscout DB instance",
+      "data" => %{
+        "latest_block_number" => to_string(number),
+        "latest_block_inserted_at" => to_string(timestamp)
+      }
+    }
+    |> Jason.encode!()
+  end
+
   @doc """
   Handles health checks for the application.
 

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -481,7 +481,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
 
     # todo: remove it in the future. Path /api/health should be used instead.
     scope "/health" do
-      get("/", HealthController, :health)
+      get("/", HealthController, :health_old)
       get("/liveness", HealthController, :liveness)
       get("/readiness", HealthController, :readiness)
     end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/pull/11139#discussion_r1891627643

## Motivation

Return the old response format in `/api/v1/health` endpoint.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a legacy health check endpoint to support older systems.
	- Added functionality to format responses for health check results and errors.

- **Bug Fixes**
	- Updated health check routing for backward compatibility, ensuring existing clients can still access the service.

- **Chores**
	- Enhanced routing structure to maintain compatibility with legacy API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->