### PR TITLE
docs: Fixed incorrect usage of -d flag in stop containers command Upd…

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -57,7 +57,7 @@ The repo contains built-in configs for different JSON RPC clients without need t
 
 All of the configs assume the Ethereum JSON RPC is running at http://localhost:8545.
 
-In order to stop launched containers, run `docker-compose -d -f config_file.yml down`, replacing `config_file.yml` with the file name of the config which was previously launched.
+In order to stop launched containers, run `docker-compose -f config_file.yml down`, replacing `config_file.yml` with the file name of the config which was previously launched.
 
 You can adjust BlockScout environment variables:
 


### PR DESCRIPTION
## Motivation

Hey team! I noticed an issue in the script where the `-d` flag was incorrectly used when stopping the containers. The `-d` flag is meant for running containers in detached mode, but it's unnecessary when stopping them. I've removed the flag from the command to ensure it works as expected. Everything should now be in order!

## Checklist for your Pull Request (PR)

- [] If I added new functionality, I added tests covering it.
- [] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README documentation for Docker-compose configuration, correcting the command for stopping launched containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->