### PR TITLE
fix: Fix verifyproxycontract endpoint

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/verification_status.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/verification_status.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.VerificationStatus do
   import Ecto.Changeset
 
   alias Explorer.Chain.Hash
+  alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias Explorer.{Chain, Repo}
 
   @typep status :: integer() | atom()
@@ -109,13 +110,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.VerificationStatus do
   @doc """
     Sets proxy verification result
   """
-  @spec set_proxy_verification_result({[String.t()] | :empty | :error, [String.t()] | :empty | :error}, String.t()) ::
-          __MODULE__.t()
-  def set_proxy_verification_result({empty_or_error, _}, uid) when empty_or_error in [:empty, :error],
-    do: update_status(uid, :fail)
+  @spec set_proxy_verification_result(Implementation.t() | :empty | :error, String.t()) :: __MODULE__.t()
+  def set_proxy_verification_result(%Implementation{}, uid), do: update_status(uid, :pass)
 
-  def set_proxy_verification_result({[], _}, uid),
-    do: update_status(uid, :fail)
-
-  def set_proxy_verification_result({_, _}, uid), do: update_status(uid, :pass)
+  def set_proxy_verification_result(_empty_or_error, uid), do: update_status(uid, :fail)
 end


### PR DESCRIPTION
Closes #11096 
## Motivation
```
2024-12-23T16:02:02.089 [error] Task #PID<0.10290.0> started from #PID<0.10074.0> terminating
** (FunctionClauseError) no function clause matching in Explorer.Chain.SmartContract.Proxy.VerificationStatus.set_proxy_verification_result/2
    (explorer 6.10.0) lib/explorer/chain/smart_contract/proxy/verification_status.ex:114: Explorer.Chain.SmartContract.Proxy.VerificationStatus.set_proxy_verification_result(%Explorer.Chain.SmartContract.Proxy.Models.Implementation{__meta__: #Ecto.Schema.Metadata<:loaded, "proxy_implementations">, proxy_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<3, 5, 234, 10, 75, 67, 161, 46, 61, 19, 4, 72, 233, 180, 113, 25, 50, 35, 30, 131>>}, proxy_type: :eip1967, address_hashes: [%Explorer.Chain.Hash{byte_count: 20, bytes: <<165, 0, 164, 66, 68, 25, 30, 223, 59, 26, 36, 4, 225, 91, 172, 158, 51, 62, 0, 83>>}], names: [nil], addresses: #Ecto.Association.NotLoaded<association :addresses is not loaded>, address: #Ecto.Association.NotLoaded<association :address is not loaded>, inserted_at: ~U[2024-11-27 20:53:34.238385Z], updated_at: ~U[2024-11-27 20:53:34.238385Z]}, "0305ea0a4b43a12e3d130448e9b4711932231e8367695f49")
    (explorer 6.10.0) lib/explorer/chain/smart_contract/proxy/models/implementation.ex:219: anonymous fn/3 in Explorer.Chain.SmartContract.Proxy.Models.Implementation.get_implementation/2
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: #Function<2.89501155/0 in Explorer.Chain.SmartContract.Proxy.Models.Implementation.get_implementation/2>
    Args: []
```
## Changelog
- Fix bug
- Add regression test
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test suite for verifying proxy contracts and their verification status.
	- Added a test for verifying a proxy contract within the new suite.

- **Bug Fixes**
	- Simplified the logic for setting proxy verification results, improving accuracy and reducing complexity.

- **Refactor**
	- Updated the method signature for setting proxy verification results for better clarity and usability.
	- Enhanced code readability by restructuring input handling in the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->