### PR TITLE
chore: Extend error message on updating token balance with token id

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -195,9 +195,16 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
   end
 
   defp prepare_updated_balance({{:error, error}, ctb}, block_number) do
+    error_message =
+      if ctb.id do
+        "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} and token id #{to_string(ctb.id)} at block number #{block_number}: "
+      else
+        "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} at block number #{block_number}: "
+      end
+
     Logger.warning(fn ->
       [
-        "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} at block number #{block_number}: ",
+        error_message,
         inspect(error)
       ]
     end)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -196,8 +196,8 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
 
   defp prepare_updated_balance({{:error, error}, ctb}, block_number) do
     error_message =
-      if ctb.id do
-        "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} and token id #{to_string(ctb.id)} at block number #{block_number}: "
+      if ctb.token_id do
+        "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} and token id #{to_string(ctb.token_id)} at block number #{block_number}: "
       else
         "Error on updating current token #{to_string(ctb.token_contract_address_hash)} balance for address #{to_string(ctb.address_hash)} at block number #{block_number}: "
       end


### PR DESCRIPTION
## Motivation

Error message on updating token balances of ERC-1155 tokens doesn't contain token id info:
```
"Error on updating current token 0x1506029886642F1C2E20BC404B91B68E65A00853 balance for address 0xCF466EDBE1CA3B3D09E949A35B69E65F28371471 at block number 24077843
```


## Changelog

Extend message with token id:
```
"Error on updating current token 0x1506029886642F1C2E20BC404B91B68E65A00853 balance for address 0xCF466EDBE1CA3B3D09E949A35B69E65F28371471 and token id 100500 at block number 24077843
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for token balance updates, providing more informative error messages for better debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->