### PR TITLE
feat: get all Arbitrum batches that corresponds to an AnyTrust data blob

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/arbitrum_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/arbitrum_controller.ex
@@ -16,7 +16,8 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   alias Explorer.Chain.Hash
   alias Explorer.PagingOptions
 
-  alias Explorer.Chain.Arbitrum.Reader.API, as: Reader
+  alias Explorer.Chain.Arbitrum.Reader.API.Messages, as: MessagesReader
+  alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: SettlementReader
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -33,7 +34,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
 
     {messages, next_page} =
       direction
-      |> Reader.messages(options)
+      |> MessagesReader.messages(options)
       |> split_list_by_page()
 
     next_page_params =
@@ -59,7 +60,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   def messages_count(conn, %{"direction" => direction} = _params) do
     conn
     |> put_status(200)
-    |> render(:arbitrum_messages_count, %{count: Reader.messages_count(direction)})
+    |> render(:arbitrum_messages_count, %{count: MessagesReader.messages_count(direction)})
   end
 
   @doc """
@@ -125,7 +126,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   """
   @spec batch(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def batch(conn, %{"batch_number" => batch_number} = _params) do
-    case Reader.batch(batch_number, necessity_by_association: @batch_necessity_by_association) do
+    case SettlementReader.batch(batch_number, necessity_by_association: @batch_necessity_by_association) do
       {:ok, batch} ->
         conn
         |> put_status(200)
@@ -167,7 +168,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
     # In case of Celestia, `data_key` is the hash of the height and the commitment hash
     with {:ok, :hash, transaction_commitment_hash} <- parse_block_hash_or_number_param(transaction_commitment),
          key <- calculate_celestia_data_key(height, transaction_commitment_hash) do
-      case Reader.get_da_record_by_data_key(key) do
+      case SettlementReader.get_da_record_by_data_key(key) do
         {:ok, {batch_number, _}} ->
           batch(conn, %{"batch_number" => batch_number})
 
@@ -191,7 +192,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   # - The connection struct with rendered response
   @spec one_batch_by_data_availability_info(Plug.Conn.t(), binary(), map()) :: Plug.Conn.t()
   defp one_batch_by_data_availability_info(conn, data_hash, _params) do
-    case Reader.get_da_record_by_data_key(data_hash) do
+    case SettlementReader.get_da_record_by_data_key(data_hash) do
       {:ok, {batch_number, _}} ->
         batch(conn, %{"batch_number" => batch_number})
 
@@ -211,7 +212,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   # - The connection struct with rendered response
   @spec all_batches_by_data_availability_info(Plug.Conn.t(), binary(), map()) :: Plug.Conn.t()
   defp all_batches_by_data_availability_info(conn, data_hash, params) do
-    case Reader.get_all_da_records_by_data_key(data_hash) do
+    case SettlementReader.get_all_da_records_by_data_key(data_hash) do
       {:ok, {batch_numbers, _}} ->
         params = Map.put(params, "batch_numbers", batch_numbers)
         batches(conn, params)
@@ -228,7 +229,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   def batches_count(conn, _params) do
     conn
     |> put_status(200)
-    |> render(:arbitrum_batches_count, %{count: Reader.batches_count()})
+    |> render(:arbitrum_batches_count, %{count: SettlementReader.batches_count()})
   end
 
   @doc """
@@ -251,7 +252,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
       |> paging_options()
       |> maybe_add_batch_numbers(params)
       |> Keyword.put(:necessity_by_association, @batch_necessity_by_association)
-      |> Reader.batches()
+      |> SettlementReader.batches()
       |> split_list_by_page()
 
     next_page_params =
@@ -294,7 +295,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
       []
       |> Keyword.put(:necessity_by_association, @batch_necessity_by_association)
       |> Keyword.put(:committed?, true)
-      |> Reader.batches()
+      |> SettlementReader.batches()
 
     conn
     |> put_status(200)
@@ -312,7 +313,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   end
 
   defp batch_latest_number do
-    case Reader.batch(:latest) do
+    case SettlementReader.batch(:latest) do
       {:ok, batch} -> batch.number
       {:error, :not_found} -> 0
     end
@@ -323,7 +324,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   """
   @spec recent_messages_to_l2(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def recent_messages_to_l2(conn, _params) do
-    messages = Reader.relayed_l1_to_l2_messages(paging_options: %PagingOptions{page_size: 6})
+    messages = MessagesReader.relayed_l1_to_l2_messages(paging_options: %PagingOptions{page_size: 6})
 
     conn
     |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -31,7 +31,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   }
 
   alias Explorer.Chain
-  alias Explorer.Chain.Arbitrum.Reader.API, as: ArbitrumReader
+  alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
   alias Explorer.Chain.Celo.ElectionReward, as: CeloElectionReward
   alias Explorer.Chain.Celo.EpochReward, as: CeloEpochReward
   alias Explorer.Chain.Celo.Reader, as: CeloReader
@@ -196,7 +196,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
     {blocks, next_page} =
       batch_number
-      |> ArbitrumReader.batch_blocks(full_options)
+      |> ArbitrumSettlementReader.batch_blocks(full_options)
       |> split_list_by_page()
 
     next_page_params = next_page |> next_page_params(blocks, delete_parameters_from_next_page_params(params))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -40,7 +40,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation, as: TransactionInterpretationService
   alias BlockScoutWeb.Models.TransactionStateHelper
   alias Explorer.{Chain, PagingOptions, Repo}
-  alias Explorer.Chain.Arbitrum.Reader.API, as: ArbitrumReader
+  alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
   alias Explorer.Chain.Beacon.Reader, as: BeaconReader
   alias Explorer.Chain.{Hash, InternalTransaction, Transaction}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
@@ -252,7 +252,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   """
   @spec arbitrum_batch(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def arbitrum_batch(conn, params) do
-    handle_batch_transactions(conn, params, &ArbitrumReader.batch_transactions/2)
+    handle_batch_transactions(conn, params, &ArbitrumSettlementReader.batch_transactions/2)
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   alias BlockScoutWeb.API.V2.Helper, as: APIV2Helper
   alias Explorer.Chain.{Block, Hash, Transaction, Wei}
   alias Explorer.Chain.Arbitrum.{L1Batch, LifecycleTransaction}
-  alias Explorer.Chain.Arbitrum.Reader.API, as: Reader
+  alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: SettlementReader
 
   @doc """
     Function to render error\\text responses for GET requests
@@ -403,7 +403,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     out = %{"batch_data_container" => "in_anytrust"}
 
     da_info =
-      with raw_info <- Reader.get_da_info_by_batch_number(batch_number),
+      with raw_info <- SettlementReader.get_da_info_by_batch_number(batch_number),
            false <- Enum.empty?(raw_info) do
         prepare_anytrust_certificate(raw_info)
       else
@@ -430,7 +430,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   #   members who guaranteed availability of data for the specified timeout.
   @spec prepare_anytrust_certificate(map()) :: map()
   defp prepare_anytrust_certificate(da_info) do
-    keyset = Reader.get_anytrust_keyset(da_info["keyset_hash"])
+    keyset = SettlementReader.get_anytrust_keyset(da_info["keyset_hash"])
 
     signers =
       if Enum.empty?(keyset) do
@@ -458,7 +458,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   defp generate_celestia_da_info(batch_number) do
     out = %{"batch_data_container" => "in_celestia"}
 
-    da_info = Reader.get_da_info_by_batch_number(batch_number)
+    da_info = SettlementReader.get_da_info_by_batch_number(batch_number)
 
     out
     |> Map.merge(%{

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/README.md
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/README.md
@@ -4,7 +4,10 @@ This directory contains modules that provide structured access to Arbitrum-speci
 
 ## Module Overview
 
-- `api.ex` - API endpoint-specific functions
+- `api/` - API endpoint-specific functions:
+  - `messages.ex` - Cross-chain message queries
+  - `settlement.ex` - Batch management, DA blob data, and rollup blocks
+  - `general.ex` - General utility functions like transaction log queries
 - `common.ex` - Core query functionality shared between different components (API, Indexer) with configurable database selection
 - `indexer/messages.ex` - Cross-chain message handling
 - `indexer/parent_chain_transactions.ex` - L1 transaction lifecycle

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/api.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/api.ex
@@ -416,7 +416,6 @@ defmodule Explorer.Chain.Arbitrum.Reader.API do
   end
 
   def get_da_record_by_data_key(data_key) do
-    # TODO: implement the functionality to return all batch numbers that the data blob is associated with as soon as such functionality is implemented on UI side.
     case MigrationStatuses.get_arbitrum_da_records_normalization_finished() do
       true ->
         # Migration is complete, use new schema
@@ -490,7 +489,8 @@ defmodule Explorer.Chain.Arbitrum.Reader.API do
 
     with da_record when not is_nil(da_record) <- repo.one(build_da_records_by_data_key_query(data_key)),
          batch_number when not is_nil(batch_number) <-
-           build_batch_numbers_by_data_key_query(data_key)
+           data_key
+           |> build_batch_numbers_by_data_key_query()
            |> limit(1)
            |> repo.one() do
       {:ok, {batch_number, da_record.data}}

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/api/general.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/api/general.ex
@@ -1,0 +1,44 @@
+defmodule Explorer.Chain.Arbitrum.Reader.API.General do
+  @moduledoc """
+    Provides API-specific functions for querying general Arbitrum data from the database.
+
+    Below These functions that implement functionality not specific to Arbitrum. They are
+    candidates for moving to a chain-agnostic module as soon as such need arises. All
+    functions in this module enforce the use of replica databases for read
+    operations by automatically passing the `api?: true` option to database queries.
+
+    Note: If any function from this module needs to be used outside of API handlers,
+    it should be moved to `Explorer.Chain.Arbitrum.Reader.Common` with configurable
+    database selection, and a wrapper function should be created in this module
+    (see `Explorer.Chain.Arbitrum.Reader.API.Settlement.highest_confirmed_block/0` as an example).
+  """
+
+  import Ecto.Query, only: [order_by: 2, where: 3]
+  import Explorer.Chain, only: [select_repo: 1]
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Hash, Log}
+
+  @api_true [api?: true]
+
+  @doc """
+    Retrieves logs from a transaction that match a specific topic.
+
+    Fetches all logs emitted by the specified transaction that have the given topic
+    as their first topic, ordered by log index.
+
+    ## Parameters
+    - `transaction_hash`: The hash of the transaction to fetch logs from
+    - `topic0`: The first topic to filter logs by
+
+    ## Returns
+    - A list of matching logs ordered by index, or empty list if none found
+  """
+  @spec transaction_to_logs_by_topic0(Hash.Full.t(), binary()) :: [Log.t()]
+  def transaction_to_logs_by_topic0(transaction_hash, topic0) do
+    Chain.log_with_transactions_query()
+    |> where([log, transaction], transaction.hash == ^transaction_hash and log.first_topic == ^topic0)
+    |> order_by(asc: :index)
+    |> select_repo(@api_true).all()
+  end
+end

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/api/messages.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/api/messages.ex
@@ -1,0 +1,183 @@
+defmodule Explorer.Chain.Arbitrum.Reader.API.Messages do
+  @moduledoc """
+    Provides API-specific functions for querying Arbitrum cross-chain message data from the database.
+
+    This module contains functions specifically designed for Blockscout's API endpoints
+    that handle Arbitrum cross-chain message functionality. All functions in this module
+    enforce the use of replica databases for read operations by automatically passing
+    the `api?: true` option to database queries.
+
+    The module includes functions for retrieving:
+    - L2->L1 messages by transaction hash or message ID
+    - L1->L2 messages that have been relayed
+    - Message counts and paginated message lists
+
+    Note: If any function from this module needs to be used outside of API handlers,
+    it should be moved to `Explorer.Chain.Arbitrum.Reader.Common` with configurable
+    database selection, and a wrapper function should be created in this module
+    (see `Explorer.Chain.Arbitrum.Reader.API.Settlement.highest_confirmed_block/0` as an example).
+  """
+
+  import Ecto.Query, only: [from: 2, limit: 2, where: 3]
+  import Explorer.Chain, only: [select_repo: 1]
+
+  alias Explorer.Chain.Arbitrum.Message
+  alias Explorer.{Chain, PagingOptions}
+
+  @api_true [api?: true]
+
+  @doc """
+    Retrieves L2-to-L1 messages initiated by specified transaction.
+
+    The messages are filtered by the originating transaction hash (with any status).
+    In the common case a transaction can initiate several messages.
+
+    ## Parameters
+    - `transaction_hash`: The transaction hash which initiated the messages.
+
+    ## Returns
+    - Instances of `Explorer.Chain.Arbitrum.Message` initiated by the transaction
+      with the given hash, or `[]` if no messages with the given status are found.
+  """
+  @spec l2_to_l1_messages_by_transaction_hash(Chain.Hash.Full.t()) :: [Message.t()]
+  def l2_to_l1_messages_by_transaction_hash(transaction_hash) do
+    query =
+      from(msg in Message,
+        where: msg.direction == :from_l2 and msg.originating_transaction_hash == ^transaction_hash,
+        order_by: [desc: msg.message_id]
+      )
+
+    query
+    |> select_repo(@api_true).all()
+  end
+
+  @doc """
+    Retrieves L2-to-L1 message by message id.
+
+    ## Parameters
+    - `message_id`: message ID
+
+    ## Returns
+    - Instance of `Explorer.Chain.Arbitrum.Message` with the provided message id,
+      or nil if message with the given id doesn't exist.
+  """
+  @spec l2_to_l1_message_by_id(non_neg_integer()) :: Message.t() | nil
+  def l2_to_l1_message_by_id(message_id) do
+    query =
+      from(message in Message,
+        where: message.direction == :from_l2 and message.message_id == ^message_id
+      )
+
+    select_repo(@api_true).one(query)
+  end
+
+  @doc """
+    Retrieves the count of cross-chain messages either sent to or from the rollup.
+
+    ## Parameters
+    - `direction`: A string that specifies the message direction; can be "from-rollup" or "to-rollup".
+
+    ## Returns
+    - The total count of cross-chain messages.
+  """
+  @spec messages_count(binary()) :: non_neg_integer()
+  def messages_count(direction) when direction == "from-rollup" do
+    do_messages_count(:from_l2)
+  end
+
+  def messages_count(direction) when direction == "to-rollup" do
+    do_messages_count(:to_l2)
+  end
+
+  # Counts the number of cross-chain messages based on the specified direction.
+  @spec do_messages_count(:from_l2 | :to_l2) :: non_neg_integer()
+  defp do_messages_count(direction) do
+    Message
+    |> where([msg], msg.direction == ^direction)
+    |> select_repo(@api_true).aggregate(:count)
+  end
+
+  @doc """
+    Retrieves cross-chain messages based on the specified direction.
+
+    This function constructs and executes a query to retrieve messages either sent
+    to or from the rollup layer, applying pagination options. These options dictate
+    not only the number of items to retrieve but also how many items to skip from
+    the top.
+
+    ## Parameters
+    - `direction`: A string that can be "from-rollup" or "to-rollup", translated internally to `:from_l2` or `:to_l2`.
+    - `options`: A keyword list which may contain `paging_options` specifying pagination details
+
+    ## Returns
+    - A list of `Explorer.Chain.Arbitrum.Message` entries.
+  """
+  @spec messages(binary(), paging_options: PagingOptions.t()) :: [Message.t()]
+  def messages(direction, options) when direction == "from-rollup" do
+    do_messages(:from_l2, options)
+  end
+
+  def messages(direction, options) when direction == "to-rollup" do
+    do_messages(:to_l2, options)
+  end
+
+  # Executes the query to fetch cross-chain messages based on the specified direction.
+  #
+  # This function constructs and executes a query to retrieve messages either sent
+  # to or from the rollup layer, applying pagination options. These options dictate
+  # not only the number of items to retrieve but also how many items to skip from
+  # the top.
+  #
+  # ## Parameters
+  # - `direction`: Can be either `:from_l2` or `:to_l2`, indicating the direction of the messages.
+  # - `options`: A keyword list which may contain `paging_options` specifying pagination details
+  #
+  # ## Returns
+  # - A list of `Explorer.Chain.Arbitrum.Message` entries matching the specified direction.
+  @spec do_messages(:from_l2 | :to_l2, paging_options: PagingOptions.t()) :: [Message.t()]
+  defp do_messages(direction, options) do
+    base_query =
+      from(msg in Message,
+        where: msg.direction == ^direction,
+        order_by: [desc: msg.message_id]
+      )
+
+    paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
+
+    query =
+      base_query
+      |> page_messages(paging_options)
+      |> limit(^paging_options.page_size)
+
+    select_repo(@api_true).all(query)
+  end
+
+  defp page_messages(query, %PagingOptions{key: nil}), do: query
+
+  defp page_messages(query, %PagingOptions{key: {id}}) do
+    from(msg in query, where: msg.message_id < ^id)
+  end
+
+  @doc """
+    Retrieves a list of relayed L1 to L2 messages that have been completed.
+
+    ## Parameters
+    - `options`: A keyword list which may contain `paging_options` specifying pagination details
+
+    ## Returns
+    - A list of `Explorer.Chain.Arbitrum.Message` representing relayed messages from L1 to L2 that have been completed.
+  """
+  @spec relayed_l1_to_l2_messages(paging_options: PagingOptions.t()) :: [Message.t()]
+  def relayed_l1_to_l2_messages(options) do
+    paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
+
+    query =
+      from(msg in Message,
+        where: msg.direction == :to_l2 and not is_nil(msg.completion_transaction_hash),
+        order_by: [desc: msg.message_id],
+        limit: ^paging_options.page_size
+      )
+
+    select_repo(@api_true).all(query)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/api/settlement.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/api/settlement.ex
@@ -24,6 +24,7 @@ defmodule Explorer.Chain.Arbitrum.Reader.API.Settlement do
   import Explorer.Chain, only: [select_repo: 1]
 
   alias Explorer.Chain.Arbitrum.{
+    BatchBlock,
     BatchToDaBlob,
     BatchTransaction,
     DaMultiPurposeRecord,

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/common.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/common.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Arbitrum.Reader.Common do
     This module serves as a central location for core query functionality that needs to
     be accessed from different logical parts of the application, such as:
 
-    * Web API handlers (`Explorer.Chain.Arbitrum.Reader.API`)
+    * Web API handlers (e.g. `Explorer.Chain.Arbitrum.Reader.API.Settlement`)
     * Chain indexer components (e.g. `Explorer.Chain.Arbitrum.Reader.Indexer.Settlement`)
     * Other potential consumers
 


### PR DESCRIPTION
**This PR compliments the changes made under https://github.com/blockscout/blockscout/pull/11531, that is why is: the merge order #11541 first, then #11531**

## Motivation

In Arbitrum, the same AnyTrust data blob can be associated with different batches when these batches consist only of deposits from the parent chain. These deposits rely on data already present in the parent chain, and the batches merely advance the `delayedMessages` count (via the `addSequencerL2BatchFromOrigin` event) without introducing unique rollup-specific data. Consequently, the data blob hash remains identical across such batches, as it lacks new or time-dependent information. 

The database schema to support this Arbitrum behavior was extended in [PR #11485](https://github.com/blockscout/blockscout/pull/11485). However, changes to Blockscout’s API endpoint `/api/v2/arbitrum/batches/da/:data_hash` to accommodate this behavior—enabling the retrieval of multiple batches associated with a single data hash - were postponed and will be addressed in a separate PR.

## Proposed solution

The handler of the corresponding API endpoint will be changed to support two ways to be called:

`/api/v2/arbitrum/batches/da/anytrust/{data_hash}` - to gets most recent batch that corresponds to given data hash (default behavior)
`/api/v2/arbitrum/batches/da/anytrust/{data_hash}?type=all` - gets all batches that  corresponds to given data hash

The reason to not change the behaviour of the existing route `/api/v2/arbitrum/batches/da/anytrust/{data_hash}` is to not break the current functionality in Blockscout UI which assumes currently that this API endpoint returns the information for one batch similar to the endpoint `/api/v2/arbitrum/batches/:batch_number`. 

Calling the endpoint with `type=all` will return a list of batches with a limited amount of details, similar to how they are returned by `/api/v2/arbitrum/batches`.

## High level scope of changes

### Changes in the reader functionality (`apps/explorer/lib/explorer/chain/arbitrum/reader/api.ex`)

1. The query from `Explorer.Chain.Arbitrum.Reader.API.get_da_record_by_data_key_old_schema` is moved into a separate private function `build_da_records_by_data_key_query` since it could be reused. No other changes in `get_da_record_by_data_key_old_schema` since the situation when several batches could be referred by the same DA data blob is not supported in the old schema.

2. A private function `build_batch_numbers_by_data_key_query` to return a query that requests all the batch numbers for the given DA blob hash from `BatchToDaBlob` is created. The batches are sorted by numbers from highest to lowest.

3. The function `Explorer.Chain.Arbitrum.Reader.API.get_da_record_by_data_key` itself is not changed since it will continue to serve to get the batch number and the DA record corresponding to this batch. However, the function `Explorer.Chain.Arbitrum.Reader.API.get_da_record_by_data_key_new_schema` is changed to:
  - Get the DA blob description by executing the query returned by the function `build_da_records_by_data_key_query`
  - Extend the query returned by the function `build_batch_numbers_by_data_key_query` to return only the first element (the highest batch number)
  - Return the received batch number and DA blob descriptor from `get_da_record_by_data_key_new_schema`

4. The new public function `Explorer.Chain.Arbitrum.Reader.API.get_all_da_records_by_data_key` is created. It executes the queries from `build_da_records_by_data_key_query` and `build_batch_numbers_by_data_key_query` to receive the DA blob description and numbers of all batches associated with this DA blob. The function returns the list of batch numbers and the DA blob description. If execution of any of the queries returns `nil`, `get_all_da_records_by_data_key` must return `:error`. If `MigrationStatuses.get_arbitrum_da_records_normalization_finished()` returns `false`, the function must call `get_da_record_by_data_key` to get the DA blob description and batch number. In this case, the function will return a single-element list containing that batch number. If `get_da_record_by_data_key_new_schema` returns `:error`, `get_all_da_records_by_data_key` must return `:error` as well.

5. The function `Explorer.Chain.Arbitrum.Reader.API.batches` is extended to accept a list of batch numbers via the `batch_numbers` option in the keyword list. When this option is provided and its value is not `nil` or the empty list, the function returns the batches with the specified numbers. The same pagination operations that are applicable to the batches list received without the `batch_numbers` option will still apply.

### Changes in the controller (`apps/block_scout_web/lib/block_scout_web/controllers/api/v2/arbitrum_controller.ex`)

1. The function `BlockScoutWeb.API.V2.ArbitrumController.batches` must be extended to allow accept the list of the batches in the `batch_numbers` element of the `params` map. If the list exists it must be passed to the function `Explorer.Chain.Arbitrum.Reader.API.batches` as an option in the keyword list.

2. The function `BlockScoutWeb.API.V2.ArbitrumController.batch_by_data_availability_info` (it clause matching with the case when batch for AnyTrust DA blob is requested) calls one of the following new functions depending on the `type` element of the `params` map (there could be no such element in the map): `one_batch_by_data_availability_info` or `all_batches_by_data_availability_info`. Both function accepts the DA blob hash and the `params` map as well to forward it to the next function in the callflow if it is necessary.

3. The private function `one_batch_by_data_availability_info` receives the batch number by `Explorer.Chain.Arbitrum.Reader.API.get_da_record_by_data_key` and passes it to `BlockScoutWeb.API.V2.ArbitrumController.batch` in the element `batch_number` of the `params` map.

4. The private function `all_batches_by_data_availability_info` receives list of the batch numbers by calling `Explorer.Chain.Arbitrum.Reader.API.get_all_da_records_by_data_key` and passes it to `BlockScoutWeb.API.V2.ArbitrumController.batches` in the element `batch_numbers` of the `params` map.

### Changes in the view (`apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex`)

No changes are needed at this level since either `BlockScoutWeb.API.V2.ArbitrumController.batch` or `BlockScoutWeb.API.V2.ArbitrumController.batches` is called as the final step of the call flow initiated by `BlockScoutWeb.API.V2.ArbitrumController.batch_by_data_availability_info`. The final step of both `batch` and `batches` is to render JSONs: "arbitrum_batch.json" or "arbitrum_batches.json".

### Modules size management

Since the module `Explorer.Chain.Arbitrum.Reader.API` (in `apps/explorer/lib/explorer/chain/arbitrum/reader/api.ex`) is becoming too large. It contains more than 700 lines of code, which makes it difficult to maintain (see `apps/explorer/lib/explorer/chain/arbitrum/reader/README.md`).

Therefore the module is divided into three new modules:
- `Explorer.Chain.Arbitrum.Reader.API.Messages` in `apps/explorer/lib/explorer/chain/arbitrum/reader/api/messages.ex`; it will contain all the public and private functions that are responsible for querying DB data related to the cross-chain Arbitrum messages.
- `Explorer.Chain.Arbitrum.Reader.API.Settlement` in `apps/explorer/lib/explorer/chain/arbitrum/reader/api/settlement.ex`; it will contain all the public and private functions that are responsible for querying DB data related to the batches, DA blob data, rollup blocks and transactions included in batches, block confirmations on the parent chain and so on.
- `Explorer.Chain.Arbitrum.Reader.API.General` in `apps/explorer/lib/explorer/chain/arbitrum/reader/api/general.ex`; it will include `transaction_to_logs_by_topic0`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new modules for handling Arbitrum API functionalities: `messages`, `settlement`, and `general`.
	- Enhanced data retrieval methods for messages and settlements, including pagination and specific queries.
  
- **Bug Fixes**
	- Updated function calls to reflect new aliasing, ensuring proper data retrieval for transactions and messages.

- **Documentation**
	- Revised README and module documentation to clarify the structure and functionalities of the new API modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->