### PR TITLE
Fix minor grammatical issue Update README.md

### DIFF
--- a/apps/ethereum_jsonrpc/README.md
+++ b/apps/ethereum_jsonrpc/README.md
@@ -15,7 +15,7 @@ config :ethereum_jsonrpc,
 ```
 
 Note: the tracing node URL is provided separately from `:url`,
-via `:trace_url`. The trace URL and is used for
+via `:trace_url`. The trace URL is used for
 `fetch_internal_transactions`, which is only a supported method on
 tracing nodes. The `:http` option is passed directly to the HTTP
 library (`HTTPoison`), which forwards the options down to `:hackney`.


### PR DESCRIPTION
## Motivation

I noticed a grammatical mistake in the documentation for EthereumJSONRPC. Specifically, in the sentence:

*“The trace URL and is used for…”*

The word "and" was incorrectly placed, making the sentence a bit unclear. I’ve removed the unnecessary "and" to make the sentence flow correctly:

*“The trace URL is used for…”*

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a minor textual error in the README for the Ethereum JSONRPC client to improve clarity regarding the trace URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->