### PR TITLE
fix: Fix MarketHistory flickering test

### DIFF
--- a/apps/explorer/test/explorer/market/history/cataloger_test.exs
+++ b/apps/explorer/test/explorer/market/history/cataloger_test.exs
@@ -2,7 +2,7 @@ defmodule Explorer.Market.History.CatalogerTest do
   use Explorer.DataCase, async: false
 
   import Mox
-  import Ecto.Query, only: [order_by: 2]
+  import Ecto.Query, only: [limit: 2, order_by: 2]
 
   alias Explorer.Market.MarketHistory
   alias Explorer.Market.History.Cataloger
@@ -222,7 +222,7 @@ defmodule Explorer.Market.History.CatalogerTest do
              %Explorer.Market.MarketHistory{
                date: ~D[2018-04-02]
              } = second_entry
-           ] = MarketHistory |> order_by(asc: :date) |> Repo.all()
+           ] = MarketHistory |> order_by(asc: :date) |> limit(2) |> Repo.all()
 
     assert Decimal.eq?(first_entry.closing_price, Decimal.new(10))
     assert Decimal.eq?(second_entry.closing_price, Decimal.new(20))


### PR DESCRIPTION
https://github.com/blockscout/blockscout/issues/9347

## Motivation

Flickering test:
```
  1) test current day values are saved in state (Explorer.Market.History.CatalogerTest)
Error:      test/explorer/market/history/cataloger_test.exs:167
     match (=) failed
     code:  assert [
              %Explorer.Market.MarketHistory{date: ~D"2018-04-01"} = first_entry,
              %Explorer.Market.MarketHistory{date: ~D"2018-04-02"} = second_entry
            ] = MarketHistory |> order_by(asc: :date) |> Repo.all()
     left:  [
              %Explorer.Market.MarketHistory{date: ~D[2018-04-01]} = first_entry,
              %Explorer.Market.MarketHistory{date: ~D[2018-04-02]} = second_entry
            ]
     right: [
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 4,
                closing_price: Decimal.new("10"),
                date: ~D[2018-04-01],
                opening_price: Decimal.new("5"),
                market_cap: nil,
                tvl: nil,
                secondary_coin: false
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 173,
                closing_price: Decimal.new("20"),
                date: ~D[2018-04-02],
                opening_price: Decimal.new("5"),
                market_cap: nil,
                tvl: nil,
                secondary_coin: false
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 60,
                closing_price: nil,
                date: ~D[2024-07-12],
                opening_price: nil,
                market_cap: Decimal.new("0.0"),
                tvl: nil,
                secondary_coin: false
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 66,
                closing_price: nil,
                date: ~D[2024-07-13],
                opening_price: nil,
                market_cap: Decimal.new("0.0"),
                tvl: nil,
                secondary_coin: false
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 72,
                closing_price: nil,
                date: ~D[2024-07-14],
                ...
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 133,
                closing_price: nil,
                date: ~D[2024-08-24],
                ...
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 139,
                closing_price: nil,
                ...
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                id: 145,
                ...
              },
              %Explorer.Market.MarketHistory{
                __meta__: #Ecto.Schema.Metadata<:loaded, "market_history">,
                ...
              },
              %Explorer.Market.MarketHistory{...},
              ...
            ]
     stacktrace:
       test/explorer/market/history/cataloger_test.exs:218: (test)
```


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the test for market history to limit results to the first two entries, ensuring accurate state representation for current day values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->