### PR TITLE
docs: Fix minor grammar and phrasing inconsistencies Update README.md

### DIFF
--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -104,9 +104,9 @@ Additionally:
 These workers are created for fetching information, which previously wasn't fetched in existing fetchers, or was fetched incorrectly.
 After all deployed instances get all needed data, these fetchers should be deprecated and removed.
 
-- `uncataloged_token_transfers`: extracts token transfers from logs, which previously weren't parsed due to unknown format
+- `uncataloged_token_transfers`: extracts token transfers from logs, which weren't parsed due to an unknown format
 - `uncles_without_index`: adds previously unfetched `index` field for unfetched blocks in `block_second_degree_relations`
-- `blocks_transactions_mismatch`: refetches each block once and revokes consensus to those whose transaction number mismatches with the number currently stored. This is meant to force the correction of a race condition that caused successfully fetched transactions to be overwritten by a following non-consensus block: [#1911](https://github.com/blockscout/blockscout/issues/1911).
+- `blocks_transactions_mismatch`: refetches each block once and revokes consensus for those whose transaction number mismatches with the number currently stored. This is meant to force the correction of a race condition that caused successfully fetched transactions to be overwritten by a following non-consensus block: [#1911](https://github.com/blockscout/blockscout/issues/1911).
 
 ## Memory Usage
 


### PR DESCRIPTION
## Motivation

I’ve made a small but important adjustment to the wording in the error messages. Specifically: 

1. "which weren't parsed due to unknown format" has been updated to "which weren't parsed due to an unknown format" to make it grammatically correct.
2. "and revokes consensus to those whose transaction number mismatches" is now "and revokes consensus for those whose transaction number mismatches," which I believe reads more clearly.

These changes improve the clarity and accuracy of the messages. 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved grammatical clarity in the README.md for the indexer, specifically in the descriptions of temporary workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->