### PR TITLE
chore: Rename tx_burnt_fee prop in API v2 endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -194,8 +194,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
 
   defp extract_filters(params) do
     [
-      # TODO: remove when frontend is adopted to new naming
-      transaction_types: prepare_transaction_types(params["transaction_types"] || params["tx_types"]),
+      transaction_types: prepare_transaction_types(params["transaction_types"]),
       methods: params["methods"] |> prepare_methods(),
       age: prepare_age(params["age_from"], params["age_to"]),
       from_address_hashes:

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -409,7 +409,9 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "max_priority_fee_per_gas" => transaction.max_priority_fee_per_gas,
       "base_fee_per_gas" => base_fee_per_gas,
       "priority_fee" => priority_fee_per_gas && Wei.mult(priority_fee_per_gas, transaction.gas_used),
+      # todo: keep next line for compatibility with frontend and remove when new frontend is bound to `transaction_burnt_fee` property
       "tx_burnt_fee" => burnt_fees,
+      "transaction_burnt_fee" => burnt_fees,
       "nonce" => transaction.nonce,
       "position" => transaction.index,
       "revert_reason" => revert_reason,


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10913

## Motivation

One more property in the response in API v2 doesn't follow [new naming convention](https://github.com/blockscout/blockscout/pull/10913).

## Changelog

- In addition to `tx_burnt_fee` add `transaction_burnt_fee` property in transaction view. (tx_burnt_fee will be removed after frontend will bind to the new prop).
- Remove usage of `tx_types` prop - frontend is bound to `transaction_types` property.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
