### PR TITLE
feat: Add Arweave NFT image link parsing support

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
@@ -60,6 +60,24 @@ defmodule BlockScoutWeb.NFTHelper do
     |> compose_ipfs_url()
   end
 
+  @doc """
+  Composes a full IPFS URL from the given image URL.
+
+  ## Parameters
+
+    - image_url: The URL of the image to be composed into an IPFS URL. It can be nil.
+
+  ## Returns
+
+    - A string representing the full IPFS URL or nil.
+
+  ## Examples
+
+      iex> compose_ipfs_url("QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1")
+      "https://ipfs.io/ipfs/QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1"
+
+  """
+  @spec compose_ipfs_url(String.t() | nil) :: String.t() | nil
   def compose_ipfs_url(nil), do: nil
 
   def compose_ipfs_url(image_url) do

--- a/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
@@ -57,7 +57,7 @@ defmodule BlockScoutWeb.NFTHelper do
     image_url
     |> URI.decode()
     |> URI.encode()
-    |> compose_ipfs_url()
+    |> compose_resource_url()
   end
 
   @doc """
@@ -73,14 +73,14 @@ defmodule BlockScoutWeb.NFTHelper do
 
   ## Examples
 
-      iex> compose_ipfs_url("QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1")
+      iex> compose_resource_url("ipfs://QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1")
       "https://ipfs.io/ipfs/QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1"
 
   """
-  @spec compose_ipfs_url(String.t() | nil) :: String.t() | nil
-  def compose_ipfs_url(nil), do: nil
+  @spec compose_resource_url(String.t() | nil) :: String.t() | nil
+  def compose_resource_url(nil), do: nil
 
-  def compose_ipfs_url(image_url) do
+  def compose_resource_url(image_url) do
     image_url_downcase =
       image_url
       |> String.downcase()

--- a/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
@@ -3,12 +3,12 @@ defmodule BlockScoutWeb.NFTHelperTest do
 
   alias BlockScoutWeb.NFTHelper
 
-  describe "compose_ipfs_url/1" do
+  describe "compose_resource_url/1" do
     test "transforms ipfs link like ipfs://${id}" do
       url = "ipfs://QmYFf7D2UtqnNz8Lu57Gnk3dxgdAiuboPWMEaNNjhr29tS/hidden.png"
 
       assert "https://ipfs.io/ipfs/QmYFf7D2UtqnNz8Lu57Gnk3dxgdAiuboPWMEaNNjhr29tS/hidden.png" ==
-               NFTHelper.compose_ipfs_url(url)
+               NFTHelper.compose_resource_url(url)
     end
 
     test "transforms ipfs link like ipfs://ipfs" do
@@ -16,14 +16,14 @@ defmodule BlockScoutWeb.NFTHelperTest do
       url = "ipfs://ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4"
 
       assert "https://ipfs.io/ipfs/Qmbgk4Ps5kiVdeYCHufMFgqzWLFuovFRtenY5P8m9vr9XW/animation.mp4" ==
-               NFTHelper.compose_ipfs_url(url)
+               NFTHelper.compose_resource_url(url)
     end
 
     test "transforms ipfs link in different case" do
       url = "IpFs://baFybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json"
 
       assert "https://ipfs.io/ipfs/baFybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json" ==
-               NFTHelper.compose_ipfs_url(url)
+               NFTHelper.compose_resource_url(url)
     end
   end
 end

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -555,6 +555,22 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   @doc """
+  Returns the headers for making requests to Arweave.
+
+  ## Examples
+
+      iex> Explorer.Token.MetadataRetriever.ar_headers()
+      [
+        {"User-Agent", "blockscout-6.9.0"}
+      ]
+
+  """
+  @spec ar_headers() :: [{binary(), binary()}]
+  def ar_headers do
+    @default_headers
+  end
+
+  @doc """
     Fetch/parse metadata using smart-contract's response
   """
   @spec fetch_json(any, binary() | nil, binary() | nil, boolean) ::

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -761,6 +761,7 @@ defmodule Explorer.Token.MetadataRetriever do
       {:error, "ignored host localhost"}
 
   """
+  @spec fetch_metadata_from_uri(String.t(), boolean(), String.t() | nil) :: {:ok, %{metadata: any}} | {:error, binary}
   def fetch_metadata_from_uri(uri, ipfs?, hex_token_id \\ nil) do
     case Mix.env() != :test && URI.parse(uri) do
       %URI{host: host} when host in @ignored_hosts ->

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -458,6 +458,7 @@ defmodule Explorer.Token.MetadataRetriever do
   ## Parameters
 
     - uid: The unique identifier for which the IPFS link is to be generated.
+    - public_gateway?: A boolean indicating whether to use the public IPFS gateway.
 
   ## Returns
 
@@ -465,20 +466,48 @@ defmodule Explorer.Token.MetadataRetriever do
 
   ## Examples
 
-      iex> ipfs_link("QmTzQ1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5")
+      iex> ipfs_link("QmTzQ1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5", true)
       "https://ipfs.io/ipfs/QmTzQ1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5"
 
+      iex> ipfs_link("QmTzQ1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5", false)
+      "https://public_ipfs_gateway.io/QmTzQ1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5Q1N1z5"
   """
-  @spec ipfs_link(uid :: any()) :: String.t()
-  def ipfs_link(uid) do
+  @spec ipfs_link(uid :: any(), public_gateway? :: boolean) :: String.t()
+  def ipfs_link(uid, public_gateway? \\ false) do
+    key = if public_gateway?, do: :public_gateway_url, else: :gateway_url
+
     base_url =
       :indexer
       |> Application.get_env(:ipfs)
-      |> Keyword.get(:gateway_url)
+      |> Keyword.get(key)
       |> String.trim_trailing("/")
 
-    url = base_url <> "/" <> uid
+    url = "#{base_url}/#{uid}"
 
+    url |> maybe_add_ipfs_gateway_params_to_url?()
+  end
+
+  @doc """
+  Generates an Arweave link for the given UID.
+
+  ## Parameters
+  - uid: The unique identifier for the resource.
+
+  ## Returns
+  - A string representing the full URL to the resource on Arweave.
+
+  ## Examples
+
+      iex> arweave_link("some-uid")
+      "https://arweave.net/some-uid"
+
+  """
+  @spec arweave_link(uid :: any()) :: String.t()
+  def arweave_link(uid) do
+    "https://arweave.net/#{uid}"
+  end
+
+  defp maybe_add_ipfs_gateway_params_to_url?(url) do
     ipfs_params = Application.get_env(:indexer, :ipfs)
 
     if ipfs_params[:gateway_url_param_location] == :query do
@@ -608,7 +637,7 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   defp fetch_json_from_uri({:ok, [token_uri_string]}, ipfs?, token_id, hex_token_id, from_base_uri?) do
-    fetch_from_ipfs?(token_uri_string, ipfs?, token_id, hex_token_id, from_base_uri?)
+    fetch_from_ipfs_or_ar?(token_uri_string, ipfs?, token_id, hex_token_id, from_base_uri?)
   end
 
   defp fetch_json_from_uri(uri, _ipfs?, _token_id, _hex_token_id, _from_base_uri?) do
@@ -618,7 +647,7 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  defp fetch_from_ipfs?(token_uri_string, ipfs?, token_id, hex_token_id, from_base_uri?) do
+  defp fetch_from_ipfs_or_ar?(token_uri_string, ipfs?, token_id, hex_token_id, from_base_uri?) do
     case URI.parse(token_uri_string) do
       %URI{scheme: "ipfs", host: host, path: path} ->
         resource_id =
@@ -631,6 +660,9 @@ defmodule Explorer.Token.MetadataRetriever do
           end
 
         fetch_from_ipfs(resource_id, hex_token_id)
+
+      %URI{scheme: "ar", host: _host, path: resource_id} ->
+        fetch_from_arweave(resource_id, hex_token_id)
 
       %URI{scheme: _, path: "/ipfs/" <> resource_id} ->
         fetch_from_ipfs(resource_id, hex_token_id)
@@ -685,6 +717,12 @@ defmodule Explorer.Token.MetadataRetriever do
     fetch_metadata_inner(ipfs_url, ipfs?, nil, hex_token_id)
   end
 
+  defp fetch_from_arweave(uid, hex_token_id) do
+    arweave_url = arweave_link(uid)
+    ipfs? = false
+    fetch_metadata_inner(arweave_url, ipfs?, nil, hex_token_id)
+  end
+
   defp fetch_metadata_inner(uri, ipfs?, token_id, hex_token_id, from_base_uri? \\ false)
 
   defp fetch_metadata_inner(uri, ipfs?, token_id, hex_token_id, from_base_uri?) do
@@ -700,6 +738,29 @@ defmodule Explorer.Token.MetadataRetriever do
       {:error, "preparation error"}
   end
 
+  @doc """
+  Fetches metadata from a given URI.
+
+  ## Parameters
+
+    - `uri` (String): The URI from which to fetch metadata.
+    - `ipfs?` (boolean): A flag indicating whether the URI is an IPFS URI.
+    - `hex_token_id` (String, optional): A hexadecimal token ID, defaults to `nil`.
+
+  ## Returns
+
+    - `{:ok, metadata}` on success.
+    - `{:error, reason}` on failure.
+
+  ## Examples
+
+      iex> fetch_metadata_from_uri("http://example.com/metadata", false)
+      {:ok, %{"name" => "Example Token", "description" => "An example token"}}
+
+      iex> fetch_metadata_from_uri("http://localhost/metadata", false)
+      {:error, "ignored host localhost"}
+
+  """
   def fetch_metadata_from_uri(uri, ipfs?, hex_token_id \\ nil) do
     case Mix.env() != :test && URI.parse(uri) do
       %URI{host: host} when host in @ignored_hosts ->

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -1069,4 +1069,98 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                MetadataRetriever.fetch_json({:ok, ["http://localhost:#{bypass.port}#{path}"]})
     end
   end
+
+  describe "ipfs_link/1" do
+    test "returns correct ipfs link for given data" do
+      data = "QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+      expected_link = "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+
+      assert MetadataRetriever.ipfs_link(data) == expected_link
+    end
+
+    test "returns correct ipfs link for given data at public IPFS gateway URL" do
+      original = Application.get_env(:indexer, :ipfs)
+
+      Application.put_env(:indexer, :ipfs,
+        gateway_url: "https://ipfs.io/ipfs/",
+        public_gateway_url: "https://public_ipfs_gateway.io/ipfs/"
+      )
+
+      data = "QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+      expected_link = "https://public_ipfs_gateway.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+
+      assert MetadataRetriever.ipfs_link(data, true) == expected_link
+
+      Application.put_env(:indexer, :ipfs, original)
+    end
+
+    test "returns correct ipfs link for given data with IPFS gateway params" do
+      original = Application.get_env(:indexer, :ipfs)
+
+      Application.put_env(:indexer, :ipfs,
+        gateway_url: "https://ipfs.io/ipfs/",
+        gateway_url_param_key: "user",
+        gateway_url_param_value: "pass",
+        gateway_url_param_location: :query
+      )
+
+      data = "QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"
+      expected_link = "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP?user=pass"
+
+      assert MetadataRetriever.ipfs_link(data) == expected_link
+
+      Application.put_env(:indexer, :ipfs, original)
+    end
+
+    test "returns correct ipfs link for empty data" do
+      data = ""
+      expected_link = "https://ipfs.io/ipfs/"
+
+      assert MetadataRetriever.ipfs_link(data) == expected_link
+    end
+
+    test "returns correct ipfs link for nil data" do
+      data = nil
+      expected_link = "https://ipfs.io/ipfs/"
+
+      assert MetadataRetriever.ipfs_link(data) == expected_link
+    end
+
+    test "returns correct ipfs link for data with special characters" do
+      data = "data_with_special_chars!@#$%^&*()"
+      expected_link = "https://ipfs.io/ipfs/data_with_special_chars!@#$%^&*()"
+
+      assert MetadataRetriever.ipfs_link(data) == expected_link
+    end
+  end
+
+  describe "arweave_link/1" do
+    test "returns correct arweave link for given data" do
+      data = "some_arweave_data"
+      expected_link = "https://arweave.net/some_arweave_data"
+
+      assert MetadataRetriever.arweave_link(data) == expected_link
+    end
+
+    test "returns correct arweave link for empty data" do
+      data = ""
+      expected_link = "https://arweave.net/"
+
+      assert MetadataRetriever.arweave_link(data) == expected_link
+    end
+
+    test "returns correct arweave link for nil data" do
+      data = nil
+      expected_link = "https://arweave.net/"
+
+      assert MetadataRetriever.arweave_link(data) == expected_link
+    end
+
+    test "returns correct arweave link for data with special characters" do
+      data = "data_with_special_chars!@#$%^&*()"
+      expected_link = "https://arweave.net/data_with_special_chars!@#$%^&*()"
+
+      assert MetadataRetriever.arweave_link(data) == expected_link
+    end
+  end
 end

--- a/apps/nft_media_handler/lib/nft_media_handler.ex
+++ b/apps/nft_media_handler/lib/nft_media_handler.ex
@@ -173,6 +173,9 @@ defmodule NFTMediaHandler do
 
         {TokenMetadataRetriever.ipfs_link(resource_id), TokenMetadataRetriever.ipfs_headers()}
 
+      %URI{scheme: "ar", host: _host, path: resource_id} ->
+        {TokenMetadataRetriever.arweave_link(resource_id), []}
+
       %URI{scheme: _, path: "/ipfs/" <> resource_id} ->
         {TokenMetadataRetriever.ipfs_link(resource_id), TokenMetadataRetriever.ipfs_headers()}
 

--- a/apps/nft_media_handler/lib/nft_media_handler.ex
+++ b/apps/nft_media_handler/lib/nft_media_handler.ex
@@ -174,7 +174,7 @@ defmodule NFTMediaHandler do
         {TokenMetadataRetriever.ipfs_link(resource_id), TokenMetadataRetriever.ipfs_headers()}
 
       %URI{scheme: "ar", host: _host, path: resource_id} ->
-        {TokenMetadataRetriever.arweave_link(resource_id), []}
+        {TokenMetadataRetriever.arweave_link(resource_id), TokenMetadataRetriever.ar_headers()}
 
       %URI{scheme: _, path: "/ipfs/" <> resource_id} ->
         {TokenMetadataRetriever.ipfs_link(resource_id), TokenMetadataRetriever.ipfs_headers()}

--- a/cspell.json
+++ b/cspell.json
@@ -43,6 +43,7 @@
         "arbsys",
         "ARGMAX",
         "arounds",
+        "arweave",
         "asda",
         "Asfpp",
         "atoken",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11019

## Motivation

Images from `ar://...` links are not fetched.

## Changelog

This pull request introduces significant updates to how IPFS and Arweave links are handled in the `Explorer.Token.MetadataRetriever` module. The changes include refactoring existing functions, adding new functionality for Arweave links, and updating the corresponding tests.

### Refactoring and new functionality:

* [`apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex`](diffhunk://#diff-b8582a12e31b57b3f95270c8a9e72ddc455b7e20dfd31b8978f113f40bd7dbd0L5-R5): Refactored the `get_media_src` function to use `MetadataRetriever` for generating IPFS and Arweave links, removing the local implementation of `ipfs_link`. [[1]](diffhunk://#diff-b8582a12e31b57b3f95270c8a9e72ddc455b7e20dfd31b8978f113f40bd7dbd0L5-R5) [[2]](diffhunk://#diff-b8582a12e31b57b3f95270c8a9e72ddc455b7e20dfd31b8978f113f40bd7dbd0L71-L94)

* `apps/explorer/lib/explorer/token/metadata_retriever.ex`: 
  - Updated `ipfs_link/2` to include a `public_gateway?` parameter and refactored the function to conditionally use the public IPFS gateway.
  - Added a new function `arweave_link/1` to generate Arweave links.
  - Introduced `fetch_from_arweave/2` to handle fetching metadata from Arweave.
  - Updated `fetch_metadata_from_uri/3` to include documentation and handle Arweave URIs.

### Test updates:

* [`apps/explorer/test/explorer/token/metadata_retriever_test.exs`](diffhunk://#diff-c7064dd8e2c5a0e9b1f03a6eb91c823b6ea0bc8a40ddc498d1e5af86e28b741cR1072-R1165): Added comprehensive tests for the new `ipfs_link/2` and `arweave_link/1` functions, covering various scenarios including empty and special character data.

### Integration with other modules:

* [`apps/nft_media_handler/lib/nft_media_handler.ex`](diffhunk://#diff-408c1f58ca7141a09f5ff183fd6a1abb3a8a37e64d63a1a41c92b90da9dde798R176-R178): Modified to use `arweave_link/1` from `TokenMetadataRetriever` for handling Arweave URIs.

These changes improve the modularity and functionality of the codebase by centralizing link generation and metadata retrieval logic in the `MetadataRetriever` module, and adding support for Arweave links.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Arweave links in NFT metadata retrieval.
	- Enhanced IPFS link generation with an optional public gateway parameter.

- **Documentation**
	- Updated documentation for metadata retrieval functions to include new parameters and examples.

- **Improvements**
	- Centralized metadata link handling for IPFS and Arweave resources.
	- Improved error handling for metadata URI fetching.
	- Expanded test coverage for IPFS and Arweave link generation functions.
	- Added capability to process Arweave URIs in media handling logic.
	- Added "arweave" to the spell check configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->