### PR TITLE
Fix Typo in `transaction.ex`

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -559,7 +559,7 @@ defmodule Explorer.Chain.Transaction do
       iex> changeset.valid?
       true
 
-  A collated transaction MUST have an `index` so its position in the `block` is known and the `cumulative_gas_used` ane
+  A collated transaction MUST have an `index` so its position in the `block` is known and the `cumulative_gas_used` and
   `gas_used` to know its fees.
 
   Post-Byzantium, the status must be present when a block is collated.


### PR DESCRIPTION
# Fix Typo in `transaction.ex`

## Description
This pull request corrects a typo in the `transaction.ex` file to enhance readability and maintain consistency in the documentation comments.

**Before**:
- `ane`

**After**:
- `and`

## References (if applicable)
- N/A

## Checklist
- [x] Typo corrected in `transaction.ex`
- [ ] Documentation updated (if applicable)
- [ ] Tests added/updated (if applicable)
