### PR TITLE
docs: typo fix Update README.md

### DIFF
--- a/apps/block_scout_web/README.md
+++ b/apps/block_scout_web/README.md
@@ -33,7 +33,7 @@ You can also run IEx (Interactive Elixir): `$ iex -S mix phx.server` (This can b
 * Lint the Elixir code: `mix credo --strict`
 * Run the dialyzer: `mix dialyzer --halt-exit-status`
 * Check the Elixir code for vulnerabilities: `mix sobelow --config`
-* Update translations templates and translations and check there are no uncommitted changes: `mix gettext.extract --merge`
+* Update translation templates and translations and check there are no uncommitted changes: `mix gettext.extract --merge`
 * Lint the JavaScript code: `cd assets && npm run eslint`
 
 ## Internationalization


### PR DESCRIPTION
## Motivation

The phrase "translations templates" is grammatically incorrect. The correct form is "translation templates", where "translation" is used as an adjective to modify "templates."

Corrected.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a minor grammatical error in the BlockScout Web project README, correcting "translations templates" to "translation templates"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->