### PR TITLE
fix: Set timeout: :infinity for PendingTransactionsSanitizer delete

### DIFF
--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -127,7 +127,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
 
     case transaction
          |> Changeset.change()
-         |> Repo.delete() do
+         |> Repo.delete(timeout: :infinity) do
       {:ok, _transaction} ->
         Logger.debug(
           "Transaction with hash #{pending_transaction_hash_string} successfully deleted from Blockscout DB because it doesn't exist in the archive node anymore",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced database transaction deletion process by removing potential timeout limitations
	- Improved error handling for pending transaction deletions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->