### PR TITLE
fix: Fix tokens deadlock

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -13,7 +13,8 @@ defmodule Explorer.Chain.Import do
 
   @stages [
     [
-      Import.Stage.Main
+      Import.Stage.Main,
+      Import.Stage.Tokens
     ],
     [
       Import.Stage.BlockTransactionReferencing,

--- a/apps/explorer/lib/explorer/chain/import/stage/main.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/main.ex
@@ -10,7 +10,6 @@ defmodule Explorer.Chain.Import.Stage.Main do
   @addresses_runner Runner.Addresses
 
   @rest_runners [
-    Runner.Tokens,
     Runner.Blocks,
     Runner.Address.CoinBalances,
     Runner.Address.CoinBalancesDaily,

--- a/apps/explorer/lib/explorer/chain/import/stage/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/tokens.ex
@@ -1,0 +1,27 @@
+defmodule Explorer.Chain.Import.Stage.Tokens do
+  @moduledoc """
+  Imports tokens.
+  """
+
+  alias Explorer.Chain.Import.{Runner, Stage}
+
+  @behaviour Stage
+
+  @runners [
+    Runner.Tokens
+  ]
+
+  @impl Stage
+  def runners, do: @runners
+
+  @impl Stage
+  def all_runners, do: runners()
+
+  @impl Stage
+  def multis(runner_to_changes_list, options) do
+    {final_multi, final_remaining_runner_to_changes_list} =
+      Stage.single_multi(runners(), runner_to_changes_list, options)
+
+    {[final_multi], final_remaining_runner_to_changes_list}
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11591

## Motivation

After last [import stages refactoring](https://github.com/blockscout/blockscout/pull/11013), tokens and blocks runners are executed in the same DB transaction. They both trigger the tokens table update. It means that there may be a deadlock error.

For example:

1. (transaction no. 1) Tokens runner inserts tokens `3, 4`
2. (transaction no. 2) Tokens runner want to insert tokens `1, 2, 3, 4`. `1, 2` inserted (and locked), `3, 4` are locked by transaction no. 1.
3. (transaction no. 1) Blocks runner want to update tokens `1, 2` which are locked by transaction no. 2.

To prevent this situation, tokens and blocks runners should run in separate DB transactions.

## Changelog

Move tokens runner to a separate stage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new tokens import stage to the blockchain explorer
	- Added dedicated module for managing token import processes

- **Refactor**
	- Restructured import runners configuration
	- Removed `Runner.Tokens` from the main import stage
	- Consolidated token import logic into a separate stage module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->