### PR TITLE
fix: Order address names to return the latest non-primary

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.AddressView do
   require Logger
 
   alias BlockScoutWeb.{AccessHelper, LayoutView}
+  alias BlockScoutWeb.API.V2.Helper, as: APIV2Helper
   alias Explorer.Account.CustomABI
   alias Explorer.{Chain, CustomContractsHelper, Repo}
   alias Explorer.Chain.Address.Counters
@@ -177,15 +178,8 @@ defmodule BlockScoutWeb.AddressView do
   @doc """
   Returns the primary name of an address if available. If there is no names on address function performs preload of names association.
   """
-  def primary_name(%Address{names: [_ | _] = address_names}) do
-    case Enum.find(address_names, &(&1.primary == true)) do
-      nil ->
-        %Address.Name{name: name} = Enum.at(address_names, 0)
-        name
-
-      %Address.Name{name: name} ->
-        name
-    end
+  def primary_name(%Address{names: [_ | _]} = address) do
+    APIV2Helper.address_name(address)
   end
 
   def primary_name(%Address{names: %Ecto.Association.NotLoaded{}} = address) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -146,12 +146,8 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def address_name(%Address{names: [_ | _] = address_names}) do
     case Enum.find(address_names, &(&1.primary == true)) do
       nil ->
-        sorted_address_names =
-          address_names
-          |> Enum.sort_by(& &1.id, :desc)
-
         # take last created address name, if there is no `primary` one.
-        %Address.Name{name: name} = Enum.at(sorted_address_names, 0)
+        %Address.Name{name: name} = Enum.max_by(address_names, & &1.id)
         name
 
       %Address.Name{name: name} ->

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -146,7 +146,12 @@ defmodule BlockScoutWeb.API.V2.Helper do
   def address_name(%Address{names: [_ | _] = address_names}) do
     case Enum.find(address_names, &(&1.primary == true)) do
       nil ->
-        %Address.Name{name: name} = Enum.at(address_names, 0)
+        sorted_address_names =
+          address_names
+          |> Enum.sort_by(& &1.id, :desc)
+
+        # take last created address name, if there is no `primary` one.
+        %Address.Name{name: name} = Enum.at(sorted_address_names, 0)
         name
 
       %Address.Name{name: name} ->


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11611

## Motivation

Processing an unordered list of address names in API v2 leads to ambiguity in UI.

## Changelog

This pull request includes changes to the `BlockScoutWeb.AddressView` module to improve code reuse and functionality. The most important changes involve refactoring the `primary_name` function to use a helper function and modifying the helper function to sort address names before selecting one.

Refactoring and code reuse:

* [`apps/block_scout_web/lib/block_scout_web/views/address_view.ex`](diffhunk://#diff-d11d479c4f4f35d8fb5391019ae69a2495b0e78e5c574ef6f826c2e5f6741f0dL180-R182): Refactored the `primary_name` function to use the `APIV2Helper.address_name` function for determining the primary name of an address.
* [`apps/block_scout_web/lib/block_scout_web/views/address_view.ex`](diffhunk://#diff-d11d479c4f4f35d8fb5391019ae69a2495b0e78e5c574ef6f826c2e5f6741f0dR7): Added an alias for `BlockScoutWeb.API.V2.Helper` as `APIV2Helper` to facilitate the refactoring.

Functionality improvement:

* [`apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex`](diffhunk://#diff-91eed9b237aa2896548071a9a89bd99c6aa321669b08749186aa63027ba23ac6L149-R154): Modified the `address_name` function to sort address names by ID in descending order before selecting the last created name if no primary name is found.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved address name retrieval logic.
	- Enhanced method for selecting primary address names.

- **Refactor**
	- Updated address name selection to prioritize the most recently created names.
	- Simplified address name lookup mechanism across API views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->