### PR TITLE
fix: Fix addresses deadlock

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -13,8 +13,10 @@ defmodule Explorer.Chain.Import do
 
   @stages [
     [
-      Import.Stage.Main,
-      Import.Stage.Tokens
+      Import.Stage.Blocks
+    ],
+    [
+      Import.Stage.Main
     ],
     [
       Import.Stage.BlockTransactionReferencing,

--- a/apps/explorer/lib/explorer/chain/import/stage/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/blocks.ex
@@ -1,6 +1,6 @@
-defmodule Explorer.Chain.Import.Stage.Tokens do
+defmodule Explorer.Chain.Import.Stage.Blocks do
   @moduledoc """
-  Imports tokens.
+  Import blocks.
   """
 
   alias Explorer.Chain.Import.{Runner, Stage}
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Import.Stage.Tokens do
   @behaviour Stage
 
   @runners [
-    Runner.Tokens
+    Runner.Blocks
   ]
 
   @impl Stage

--- a/apps/explorer/lib/explorer/chain/import/stage/main.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/main.ex
@@ -1,6 +1,6 @@
 defmodule Explorer.Chain.Import.Stage.Main do
   @moduledoc """
-  Imports main data (addresses, address_coin_balances, address_coin_balances_daily, tokens, blocks, transactions).
+  Imports main data (addresses, address_coin_balances, address_coin_balances_daily, tokens, transactions).
   """
 
   alias Explorer.Chain.Import.{Runner, Stage}
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.Import.Stage.Main do
   @addresses_runner Runner.Addresses
 
   @rest_runners [
-    Runner.Blocks,
+    Runner.Tokens,
     Runner.Address.CoinBalances,
     Runner.Address.CoinBalancesDaily,
     Runner.Transactions


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/11603

There is the same issue with addresses.

## Changelog

Move blocks runner from the main import stage and bring back tokens runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Reordered import stages in the blockchain explorer.
	- Renamed `Tokens` stage to `Blocks` stage.
	- Updated import stage configurations to reflect changes in data processing sequence. 
	- Adjusted documentation to align with the new focus on blocks instead of tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->