### PR TITLE
fix: interception of an error during DB drop

### DIFF
--- a/.devcontainer/bin/bs
+++ b/.devcontainer/bin/bs
@@ -182,9 +182,15 @@ initialize_project() {
 # Define the initialization subroutine
 initialize_db() {
     echo "Initializing database. Step 1 of 2: Dropping database"
-    mix ecto.drop > /dev/null 2>&1
-    echo "Initializing database. Step 2 of 2: Creating database"
-    mix do ecto.create, ecto.migrate | grep Runn
+    if OUTPUT=$(mix ecto.drop 2>&1); then
+        echo "Initializing database. Step 2 of 2: Creating database"
+        mix do ecto.create, ecto.migrate | grep Runn
+    else
+        echo "Failed to drop database. Initialization aborted."
+        echo "Error output:"
+        echo "$OUTPUT"
+        return 1
+    fi
 }
 
 # Define the recompile subroutine


### PR DESCRIPTION
## Motivation

While using the `bs` script, it was observed that the database is not always dropped if a tab with an active SQL connection (e.g., for running an SQL script) is open in VSCode. This issue occurs silently, meaning the failure to drop the database goes unnoticed, potentially causing unintended behavior in subsequent `bs` commands.

## Changelog

### Bug Fixes

The `initialize_db` action in the `bs` script was updated to display the output of `mix ecto.drop` if the command fails, providing better visibility into the issue.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
