### PR TITLE
fix: Fix tokens and transactions deadlocks

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -21,6 +21,7 @@ defmodule Explorer.Chain.Import do
     [
       Import.Stage.BlockTransactionReferencing,
       Import.Stage.TokenReferencing,
+      Import.Stage.TokenInstances,
       Import.Stage.InternalTransactions,
       Import.Stage.ChainTypeSpecific
     ]

--- a/apps/explorer/lib/explorer/chain/import/runner/signed_authorizations.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/signed_authorizations.ex
@@ -64,11 +64,12 @@ defmodule Explorer.Chain.Import.Runner.SignedAuthorizations do
   defp insert(repo, changes_list, %{timeout: timeout, timestamps: timestamps} = options) when is_list(changes_list) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
     conflict_target = [:transaction_hash, :index]
+    ordered_changes_list = Enum.sort_by(changes_list, &{&1.transaction_hash, &1.index})
 
     {:ok, _} =
       Import.insert_changes_list(
         repo,
-        changes_list,
+        ordered_changes_list,
         for: SignedAuthorization,
         on_conflict: on_conflict,
         conflict_target: conflict_target,

--- a/apps/explorer/lib/explorer/chain/import/stage/token_instances.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/token_instances.ex
@@ -1,6 +1,6 @@
-defmodule Explorer.Chain.Import.Stage.TokenReferencing do
+defmodule Explorer.Chain.Import.Stage.TokenInstances do
   @moduledoc """
-  Imports any data that is related to tokens.
+  Import token instances.
   """
 
   alias Explorer.Chain.Import.{Runner, Stage}
@@ -8,8 +8,7 @@ defmodule Explorer.Chain.Import.Stage.TokenReferencing do
   @behaviour Stage
 
   @runners [
-    Runner.Address.TokenBalances,
-    Runner.Address.CurrentTokenBalances
+    Runner.TokenInstances
   ]
 
   @impl Stage


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/11616 and https://github.com/blockscout/blockscout/pull/11603

Yet another deadlocks fix.

Fixed issues:

1. Token instances holds a lock against tokens via foreign key and in the same transaction there is tokens update in current token balances runner
2. Signed authorizations insertion holds a non-ordered lock against transactions via foreign key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new stage for processing token instances during data import
  - Enhanced token import capabilities with more granular processing

- **Improvements**
  - Optimized token instance import workflow
  - Improved sorting of changes during import to handle potential conflicts more effectively

- **Changes**
  - Restructured token referencing stage by removing token instances runner
  - Updated import process to support more precise token data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->