### PR TITLE
chore: Decrease catchup interval

### DIFF
--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/filecoin.exs
+++ b/apps/indexer/config/dev/filecoin.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(1)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/ganache.exs
+++ b/apps/indexer/config/dev/ganache.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(1)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(1)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   blocks_concurrency: 1,
   receipts_concurrency: 1,
   json_rpc_named_arguments: [

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/filecoin.exs
+++ b/apps/indexer/config/prod/filecoin.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/ganache.exs
+++ b/apps/indexer/config/prod/ganache.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(1)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout()
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
     transport:
       if(System.get_env("ETHEREUM_JSONRPC_TRANSPORT", "http") == "http",

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -8,7 +8,7 @@ hackney_opts = ConfigHelper.hackney_options()
 timeout = ConfigHelper.timeout(10)
 
 config :indexer,
-  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "5s"),
+  block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   blocks_concurrency: 1,
   receipts_concurrency: 1,
   json_rpc_named_arguments: [

--- a/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
+++ b/apps/indexer/lib/indexer/block/catchup/bound_interval_supervisor.ex
@@ -68,7 +68,8 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisor do
 
     block_interval = Map.get(named_arguments, :block_interval, @block_interval)
     minimum_interval = div(block_interval, 2)
-    bound_interval = BoundInterval.within(minimum_interval..(minimum_interval * 10))
+    maximum_interval = (minimum_interval + :timer.seconds(1)) * 10
+    bound_interval = BoundInterval.within(minimum_interval..maximum_interval)
 
     %__MODULE__{
       fetcher: %Catchup.Fetcher{block_fetcher: block_fetcher, memory_monitor: Map.get(named_arguments, :memory_monitor)},


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10548

Docs update: https://github.com/blockscout/docs/pull/372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated block interval settings from "5s" to "0s" across multiple blockchain configurations (dev and prod environments)
	- Modifications include configurations for Besu, Erigon, Filecoin, Ganache, Geth, Nethermind, and RSK

- **Code Changes**
	- Adjusted bound interval calculation in `BoundIntervalSupervisor` to modify maximum interval range

<!-- end of auto-generated comment: release notes by coderabbit.ai -->