### PR TITLE
fix: spelling for `language` enum field  on `smart_contracts` relation

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -193,7 +193,7 @@ defmodule Explorer.Chain.SmartContract do
     }
   ]
 
-  @default_languages ~w(solidity vyper yul stylys_rust)a
+  @default_languages ~w(solidity vyper yul stylus_rust)a
   @chain_type_languages (case @chain_type do
                            :zilliqa ->
                              ~w(scilla)a


### PR DESCRIPTION
## Motivation

Fix spelling for `language` enum field  on `smart_contracts` relation. (`Stylys` should become `Stylus`)

![image](https://github.com/user-attachments/assets/218aab11-e2d3-47ed-8e92-b69503309076)


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the list of default smart contract languages from "stylys_rust" to "stylus_rust"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->