### PR TITLE
fix: Add 'yParity' alias

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/signed_authorization.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.SignedAuthorization do
   * `"chainId"` - specifies the chain for which the authorization was created `t:EthereumJSONRPC.quantity/0`.
   * `"address"` - `t:EthereumJSONRPC.address/0` of the delegate contract.
   * `"nonce"` - signature nonce `t:EthereumJSONRPC.quantity/0`.
-  * `"v"` - v component of the signature `t:EthereumJSONRPC.quantity/0`.
+  * `"v"` or `"yParity"` - v component of the signature `t:EthereumJSONRPC.quantity/0`.
   * `"r"` - r component of the signature `t:EthereumJSONRPC.quantity/0`.
   * `"s"` - s component of the signature `t:EthereumJSONRPC.quantity/0`.
   """
@@ -52,7 +52,7 @@ defmodule EthereumJSONRPC.SignedAuthorization do
       nonce: quantity_to_integer(raw["nonce"]),
       r: quantity_to_integer(raw["r"]),
       s: quantity_to_integer(raw["s"]),
-      v: quantity_to_integer(raw["v"])
+      v: quantity_to_integer(raw["v"] || raw["yParity"])
     }
   end
 end


### PR DESCRIPTION
Resolves #11538

## Motivation
The `v` field of signed authorization was renamed to `yParity` in the Geth implementation, as seen in [this commit](https://github.com/ethereum/go-ethereum/commit/73a4ecf675f6714e1fdf49904ce9426841de2e02). The Reth implementation also uses `yParity` in RPC responses, as shown [here](https://github.com/alloy-rs/eips/blob/ee24cea03bc24febe9189e73c42c01d059ad2396/crates/eip7702/src/auth_list.rs#L113). Therefore, we need to support `yParity` for EIP-7702 signed authorizations.

## Changelog
### Bug Fixes
* Add support for `yParity` as an alias for the `SignedAuthorization.v` field

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated type documentation for signature's v component to support alternative representation
- **Improvements**
	- Enhanced signature parsing to handle multiple formats of v component
	- Added fallback mechanism for retrieving signature v value

<!-- end of auto-generated comment: release notes by coderabbit.ai -->