### PR TITLE
fix: Fix enoent in Indexer.NFTMediaHandler.Queue

### DIFF
--- a/apps/indexer/lib/indexer/nft_media_handler/queue.ex
+++ b/apps/indexer/lib/indexer/nft_media_handler/queue.ex
@@ -62,6 +62,7 @@ defmodule Indexer.NFTMediaHandler.Queue do
   end
 
   def init(_) do
+    File.mkdir("./dets")
     {:ok, queue} = :dets.open_file(@queue_storage, file: ~c"./dets/#{@queue_storage}", type: :bag)
     {:ok, in_progress} = :dets.open_file(@tasks_in_progress, type: :set, file: ~c"./dets/#{@tasks_in_progress}")
 


### PR DESCRIPTION
## Motivation

```
** (Mix) Could not start application indexer: Indexer.Application.start(:normal, []) returned an error: shutdown: failed to start child: Indexer.Supervisor
    ** (EXIT) shutdown: failed to start child: Indexer.NFTMediaHandler.Queue
        ** (EXIT) an exception was raised:
            ** (MatchError) no match of right hand side value: {:error, {:file_error, ~c"./dets/queue_storage", :enoent}}
                (indexer 6.10.0) lib/indexer/nft_media_handler/queue.ex:65: Indexer.NFTMediaHandler.Queue.init/1
                (stdlib 6.1) gen_server.erl:2229: :gen_server.init_it/2
                (stdlib 6.1) gen_server.erl:2184: :gen_server.init_it/6
                (stdlib 6.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

## Changelog
- Ensure `./dets` directory exists
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
