### PR TITLE
feat: Ignore events older than 24 hours in Explorer.Account.Notifier.…

### DIFF
--- a/apps/explorer/lib/explorer/account/notifier/notify.ex
+++ b/apps/explorer/lib/explorer/account/notifier/notify.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Account.Notifier.Notify do
 
   alias Explorer.Account.Notifier.{Email, ForbiddenAddress, Summary}
   alias Explorer.Account.{WatchlistAddress, WatchlistNotification}
-  alias Explorer.Chain.{TokenTransfer, Transaction}
+  alias Explorer.Chain.Transaction
   alias Explorer.{Mailer, Repo}
 
   require Logger
@@ -20,20 +20,16 @@ defmodule Explorer.Account.Notifier.Notify do
     Enum.map(transactions, fn transaction -> process(transaction) end)
   end
 
-  defp process(%TokenTransfer{} = transfer) do
-    Logger.debug(transfer, fetcher: :account)
-
-    transfer
-    |> Summary.process()
-    |> Enum.map(fn summary -> notify_watchlists(summary) end)
-  end
-
   defp process(%Transaction{} = transaction) do
-    Logger.debug(transaction, fetcher: :account)
+    if DateTime.after?(transaction.block_timestamp, DateTime.add(DateTime.utc_now(), -1, :day)) do
+      Logger.debug(transaction, fetcher: :account)
 
-    transaction
-    |> Summary.process()
-    |> Enum.map(fn summary -> notify_watchlists(summary) end)
+      transaction
+      |> Summary.process()
+      |> Enum.map(fn summary -> notify_watchlists(summary) end)
+    else
+      nil
+    end
   end
 
   defp process(_), do: nil

--- a/apps/explorer/lib/explorer/account/notifier/summary.ex
+++ b/apps/explorer/lib/explorer/account/notifier/summary.ex
@@ -45,18 +45,6 @@ defmodule Explorer.Account.Notifier.Summary do
     end)
   end
 
-  def process(%Chain.TokenTransfer{} = transfer) do
-    preloaded_transfer = preload(transfer)
-
-    summary = fetch_summary(preloaded_transfer.transaction, preloaded_transfer)
-
-    if summary != :nothing do
-      [summary]
-    else
-      []
-    end
-  end
-
   def process(_), do: nil
 
   def handle_collection(_transaction, []), do: []
@@ -230,9 +218,5 @@ defmodule Explorer.Account.Notifier.Summary do
 
   defp preload(%Chain.Transaction{} = transaction) do
     Repo.preload(transaction, token_transfers: :token)
-  end
-
-  defp preload(%Chain.TokenTransfer{} = transfer) do
-    Repo.preload(transfer, [:transaction, :token])
   end
 end

--- a/apps/explorer/test/explorer/account/notifier/notify_test.exs
+++ b/apps/explorer/test/explorer/account/notifier/notify_test.exs
@@ -142,5 +142,33 @@ defmodule Explorer.Account.Notifier.NotifyTest do
 
       Application.put_env(:explorer, Explorer.Account, old_envs)
     end
+
+    test "ignore events older than 24 hrs" do
+      wa =
+        %WatchlistAddress{address_hash: address_hash} =
+        build(:account_watchlist_address, watch_coin_input: true)
+        |> Repo.account_repo().insert!()
+
+      _watchlist_address = Repo.preload(wa, watchlist: :identity)
+
+      transaction =
+        %Transaction{
+          from_address: _from_address,
+          to_address: _to_address,
+          block_number: _block_number,
+          hash: _transaction_hash
+        } =
+        with_block(
+          insert(:transaction, to_address: %Chain.Address{hash: address_hash}),
+          insert(:block, timestamp: DateTime.add(DateTime.utc_now(), -25, :hour))
+        )
+
+      notify = Notify.call([transaction])
+
+      assert WatchlistNotification
+             |> Repo.account_repo().all() == []
+
+      assert notify == [nil]
+    end
   end
 end

--- a/apps/explorer/test/explorer/account/notifier/summary_test.exs
+++ b/apps/explorer/test/explorer/account/notifier/summary_test.exs
@@ -86,22 +86,24 @@ defmodule Explorer.Account.Notifier.SummaryTest do
     test "ERC-20 Token transfer" do
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
+
+      transaction_amount = Wei.to(transaction.value, :ether)
 
       transfer =
         %TokenTransfer{
           amount: _amount,
-          block_number: block_number,
+          block_number: _block_number,
           from_address: from_address,
           to_address: to_address,
           token: token
         } =
         :token_transfer
-        |> insert(transaction: transaction)
+        |> insert(transaction: transaction, block: transaction.block, block_number: transaction.block_number)
         |> Repo.preload([
           :token
         ])
@@ -114,7 +116,19 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       amount = Decimal.div(transfer.amount, decimals)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: amount,
                  block_number: block_number,
@@ -135,32 +149,44 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
 
-      transfer =
-        %TokenTransfer{
-          amount: _amount,
-          block_number: block_number,
-          from_address: from_address,
-          to_address: to_address
-        } =
+      transaction_amount = Wei.to(transaction.value, :ether)
+
+      %TokenTransfer{
+        amount: _amount,
+        block_number: _block_number,
+        from_address: from_address,
+        to_address: to_address
+      } =
         :token_transfer
         |> insert(
           transaction: transaction,
           token_ids: [42],
-          token_contract_address: token.contract_address
+          token_contract_address: token.contract_address,
+          block: transaction.block,
+          block_number: transaction.block_number
         )
-        |> Repo.preload([
-          :token
-        ])
 
       {_, fee} = Transaction.fee(transaction, :gwei)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: 0,
                  block_number: block_number,
@@ -181,32 +207,44 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
 
-      transfer =
-        %TokenTransfer{
-          amount: _amount,
-          block_number: block_number,
-          from_address: from_address,
-          to_address: to_address
-        } =
+      transaction_amount = Wei.to(transaction.value, :ether)
+
+      %TokenTransfer{
+        amount: _amount,
+        block_number: _block_number,
+        from_address: from_address,
+        to_address: to_address
+      } =
         :token_transfer
         |> insert(
           transaction: transaction,
           token_ids: [42],
-          token_contract_address: token.contract_address
+          token_contract_address: token.contract_address,
+          block: transaction.block,
+          block_number: transaction.block_number
         )
-        |> Repo.preload([
-          :token
-        ])
 
       {_, fee} = Transaction.fee(transaction, :gwei)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: 0,
                  block_number: block_number,
@@ -227,32 +265,44 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
 
-      transfer =
-        %TokenTransfer{
-          amount: _amount,
-          block_number: block_number,
-          from_address: from_address,
-          to_address: to_address
-        } =
+      transaction_amount = Wei.to(transaction.value, :ether)
+
+      %TokenTransfer{
+        amount: _amount,
+        block_number: _block_number,
+        from_address: from_address,
+        to_address: to_address
+      } =
         :token_transfer
         |> insert(
           transaction: transaction,
           token_ids: [23, 42],
-          token_contract_address: token.contract_address
+          token_contract_address: token.contract_address,
+          block: transaction.block,
+          block_number: transaction.block_number
         )
-        |> Repo.preload([
-          :token
-        ])
 
       {_, fee} = Transaction.fee(transaction, :gwei)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: 0,
                  block_number: block_number,
@@ -273,16 +323,18 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
+
+      transaction_amount = Wei.to(transaction.value, :ether)
 
       transfer =
         %TokenTransfer{
           amount: _amount,
-          block_number: block_number,
+          block_number: _block_number,
           from_address: from_address,
           to_address: to_address
         } =
@@ -290,11 +342,10 @@ defmodule Explorer.Account.Notifier.SummaryTest do
         |> insert(
           transaction: transaction,
           token_ids: [42],
-          token_contract_address: token.contract_address
+          token_contract_address: token.contract_address,
+          block: transaction.block,
+          block_number: transaction.block_number
         )
-        |> Repo.preload([
-          :token
-        ])
 
       {_, fee} = Transaction.fee(transaction, :gwei)
 
@@ -304,7 +355,19 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       amount = Decimal.div(transfer.amount, decimals)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: amount,
                  block_number: block_number,
@@ -313,7 +376,7 @@ defmodule Explorer.Account.Notifier.SummaryTest do
                  name: "Infinite Token",
                  subject: "42",
                  to_address_hash: to_address.hash,
-                 transaction_hash: transaction.hash,
+                 transaction_hash: transaction_hash,
                  transaction_fee: fee,
                  type: "ERC-404"
                }
@@ -325,16 +388,18 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       transaction =
         %Transaction{
-          from_address: _from_address,
-          to_address: _to_address,
-          block_number: _block_number,
-          hash: _transaction_hash
+          from_address: transaction_from_address,
+          to_address: transaction_to_address,
+          block_number: block_number,
+          hash: transaction_hash
         } = with_block(insert(:transaction))
+
+      transaction_amount = Wei.to(transaction.value, :ether)
 
       transfer =
         %TokenTransfer{
           amount: _amount,
-          block_number: block_number,
+          block_number: _block_number,
           from_address: from_address,
           to_address: to_address
         } =
@@ -342,11 +407,10 @@ defmodule Explorer.Account.Notifier.SummaryTest do
         |> insert(
           transaction: transaction,
           token_ids: [],
-          token_contract_address: token.contract_address
+          token_contract_address: token.contract_address,
+          block: transaction.block,
+          block_number: transaction.block_number
         )
-        |> Repo.preload([
-          :token
-        ])
 
       {_, fee} = Transaction.fee(transaction, :gwei)
 
@@ -356,7 +420,19 @@ defmodule Explorer.Account.Notifier.SummaryTest do
 
       amount = Decimal.div(transfer.amount, decimals)
 
-      assert Summary.process(transfer) == [
+      assert Summary.process(transaction) == [
+               %Summary{
+                 amount: transaction_amount,
+                 block_number: block_number,
+                 from_address_hash: transaction_from_address.hash,
+                 method: "transfer",
+                 name: "ETH",
+                 subject: "Coin transaction",
+                 to_address_hash: transaction_to_address.hash,
+                 transaction_hash: transaction_hash,
+                 transaction_fee: fee,
+                 type: "COIN"
+               },
                %Summary{
                  amount: amount,
                  block_number: block_number,


### PR DESCRIPTION
…Notify

Closes #11644 

## Changelog
- Add test that transaction is not from block issued earlier than 24 hours ago 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
  - Improved transaction notification filtering to only process transactions from the last 24 hours.
  - Removed legacy token transfer processing logic.

- **Tests**
  - Added test case to verify notification behavior for transactions older than 24 hours.
  - Updated test cases for clarity and consistency in transaction processing.

The update enhances the notification system by implementing a time-based filter for recent transactions, ensuring more relevant and timely alerts for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->