### PR TITLE
fix: Ease SQL query for EIP1559ConfigUpdate fetcher

### DIFF
--- a/apps/explorer/lib/explorer/chain/optimism/eip1559_config_update.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/eip1559_config_update.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Chain.Optimism.EIP1559ConfigUpdate do
 
   import Explorer.Chain, only: [get_last_fetched_counter: 1, upsert_last_fetched_counter: 1]
 
-  alias Explorer.Chain.{Block, Hash}
+  alias Explorer.Chain.Hash
   alias Explorer.Repo
 
   @counter_type "optimism_eip1559_config_updates_fetcher_last_l2_block_hash"
@@ -147,32 +147,5 @@ defmodule Explorer.Chain.Optimism.EIP1559ConfigUpdate do
       counter_type: @counter_type,
       value: block_hash_integer
     })
-  end
-
-  @doc """
-    Finds the closest block number which timestamp is greater or equal to the given timestamp.
-
-    ## Parameters
-    - `timestamp`: The given timestamp.
-
-    ## Returns
-    - The number of the found block.
-    - `nil` in case the block is not found.
-  """
-  @spec nearest_block_number_to_timestamp(DateTime.t()) :: non_neg_integer() | nil
-  def nearest_block_number_to_timestamp(timestamp) do
-    # here we limit the time range to 30 minutes to avoid creating [:timestamp, :number] index
-    # 30 minutes is a reasonable time to exceed block time on any chain
-    timestamp_plus_30_minutes = DateTime.add(timestamp, 30, :minute)
-
-    query =
-      from(b in Block,
-        select: b.number,
-        where: b.timestamp >= ^timestamp and b.timestamp < ^timestamp_plus_30_minutes and b.consensus == true,
-        order_by: [asc: b.number],
-        limit: 1
-      )
-
-    Repo.one(query)
   end
 end

--- a/apps/explorer/lib/explorer/chain/optimism/eip1559_config_update.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/eip1559_config_update.ex
@@ -161,10 +161,14 @@ defmodule Explorer.Chain.Optimism.EIP1559ConfigUpdate do
   """
   @spec nearest_block_number_to_timestamp(DateTime.t()) :: non_neg_integer() | nil
   def nearest_block_number_to_timestamp(timestamp) do
+    # here we limit the time range to 30 minutes to avoid creating [:timestamp, :number] index
+    # 30 minutes is a reasonable time to exceed block time on any chain
+    timestamp_plus_30_minutes = DateTime.add(timestamp, 30, :minute)
+
     query =
       from(b in Block,
         select: b.number,
-        where: b.timestamp >= ^timestamp and b.consensus == true,
+        where: b.timestamp >= ^timestamp and b.timestamp < ^timestamp_plus_30_minutes and b.consensus == true,
         order_by: [asc: b.number],
         limit: 1
       )

--- a/apps/indexer/lib/indexer/fetcher/optimism/eip1559_config_update.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/eip1559_config_update.ex
@@ -459,17 +459,17 @@ defmodule Indexer.Fetcher.Optimism.EIP1559ConfigUpdate do
 
     Logger.info("Trying to detect Holocene block number by its timestamp using indexed L2 blocks...")
 
-    block_number = EIP1559ConfigUpdate.nearest_block_number_to_timestamp(timestamp_dt)
+    case Chain.timestamp_to_block_number(timestamp_dt, :after, false) do
+      {:ok, block_number} ->
+        Logger.info("Holocene block number is detected using indexed L2 blocks. The block number is #{block_number}")
+        block_number
 
-    if is_nil(block_number) do
-      Logger.info(
-        "Cannot detect Holocene block number using indexed L2 blocks. Trying to calculate the number using RPC requests..."
-      )
+      _ ->
+        Logger.info(
+          "Cannot detect Holocene block number using indexed L2 blocks. Trying to calculate the number using RPC requests..."
+        )
 
-      block_number_by_timestamp_from_rpc(timestamp, block_duration, json_rpc_named_arguments)
-    else
-      Logger.info("Holocene block number is detected using indexed L2 blocks. The block number is #{block_number}")
-      block_number
+        block_number_by_timestamp_from_rpc(timestamp, block_duration, json_rpc_named_arguments)
     end
   end
 


### PR DESCRIPTION
## Motivation

The query https://github.com/blockscout/blockscout/blob/913f2d5d2719278a57427d45549f32924fd041f2/apps/explorer/lib/explorer/chain/optimism/eip1559_config_update.ex#L164-L170 takes a lot of time since there is no `[:timestamp, :number]` index for `blocks` table. This PR speeds up the query by using the existing `Chain.timestamp_to_block_number` function which doesn't require additional index.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
	- Enhanced block timestamp query efficiency by introducing a 30-minute time range limitation.
	- Optimized block selection process to prevent unnecessary indexing.
	- Improved error handling and control flow in the block number retrieval process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->