### PR TITLE
fix: Update EmptyBlocksSanitizer logic due to refetch_needed field

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -1,7 +1,7 @@
 defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   @moduledoc """
   Periodically checks empty blocks starting from the head of the chain, detects for which blocks transactions should be refetched
-  and lose consensus for block in order to refetch transactions.
+  and set refetch_needed=true for block in order to refetch transactions.
   """
 
   use GenServer
@@ -147,7 +147,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
 
     log_message =
       log_message_base <>
-        ", but those blocks are empty in Blockscout DB. Setting consensus = false for it to re-fetch."
+        ", but those blocks are empty in Blockscout DB. Setting refetch_needed = true for it to re-fetch."
 
     Logger.info(
       log_message,
@@ -210,6 +210,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
       where: is_nil(block.is_empty),
       where: block.number <= ^safe_block_number,
       where: block.consensus == true,
+      where: block.refetch_needed == false,
       order_by: [asc: block.hash],
       limit: ^limit
     )


### PR DESCRIPTION
## Motivation

After https://github.com/blockscout/blockscout/pull/9674 we are using `refetch_needed` field instead of `consensus` to mark blocks that need refetch, but `EmptyBlocksSanitizer` still operates via `consensus` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminology and logging messages related to block refetching
	- Clarified mechanism for marking blocks that need to be refetched

- **Refactor**
	- Modified condition in block query to check for non-refetchable blocks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->