### PR TITLE
fix: celestia info parsing

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -468,7 +468,8 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     out
     |> Map.merge(%{
       "height" => Map.get(da_info, "height"),
-      "transaction_commitment" => Map.get(da_info, "transaction_commitment")
+      "transaction_commitment" => Map.get(da_info, "transaction_commitment"),
+      "namespace" => get_celestia_namespace()
     })
   end
 
@@ -712,5 +713,11 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     |> Map.put("l1_block_height", Map.get(arbitrum_block, :l1_block_number))
     |> Map.put("send_count", Map.get(arbitrum_block, :send_count))
     |> Map.put("send_root", Map.get(arbitrum_block, :send_root))
+  end
+
+  # Extracts the Celestia namespace from the environment variable.
+  @spec get_celestia_namespace() :: String.t()
+  defp get_celestia_namespace() do
+    System.get_env("INDEXER_ARBITRUM_CELESTIA_NAMESPACE", "")
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -717,7 +717,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
 
   # Extracts the Celestia namespace from the environment variable.
   @spec get_celestia_namespace() :: String.t()
-  defp get_celestia_namespace() do
+  defp get_celestia_namespace do
     System.get_env("INDEXER_ARBITRUM_CELESTIA_NAMESPACE", "")
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -468,8 +468,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     out
     |> Map.merge(%{
       "height" => Map.get(da_info, "height"),
-      "transaction_commitment" => Map.get(da_info, "transaction_commitment"),
-      "namespace" => get_celestia_namespace()
+      "transaction_commitment" => Map.get(da_info, "transaction_commitment")
     })
   end
 
@@ -713,11 +712,5 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     |> Map.put("l1_block_height", Map.get(arbitrum_block, :l1_block_number))
     |> Map.put("send_count", Map.get(arbitrum_block, :send_count))
     |> Map.put("send_root", Map.get(arbitrum_block, :send_root))
-  end
-
-  # Extracts the Celestia namespace from the environment variable.
-  @spec get_celestia_namespace() :: String.t()
-  defp get_celestia_namespace do
-    System.get_env("INDEXER_ARBITRUM_CELESTIA_NAMESPACE", "")
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -388,6 +388,33 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
         uint256 sequenceNumber,
         bytes calldata data,
         uint256 afterDelayedMessagesRead,
+        address gasRefunder,
+        uint256 prevMessageCount,
+        uint256 newMessageCount,
+        bytes quote
+      )
+  """
+  def add_sequencer_l2_batch_from_origin_37501551_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "addSequencerL2BatchFromOrigin",
+      types: [
+        {:uint, 256},
+        :bytes,
+        {:uint, 256},
+        :address,
+        {:uint, 256},
+        {:uint, 256},
+        :bytes
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchFromOrigin(
+        uint256 sequenceNumber,
+        bytes calldata data,
+        uint256 afterDelayedMessagesRead,
         address gasRefunder
       )
   """

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/celestia.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/celestia.ex
@@ -64,16 +64,12 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Celestia do
           height::big-unsigned-integer-size(64),
           _start_index::binary-size(8),
           _shares_length::binary-size(8),
-          _key::big-unsigned-integer-size(64),
-          _num_leaves::big-unsigned-integer-size(64),
-          _tuple_root_nonce::big-unsigned-integer-size(64),
           transaction_commitment::binary-size(32),
           _data_root::binary-size(32),
-          _side_nodes_length::big-unsigned-integer-size(64),
           _rest::binary
         >> = raw
       ) do
-    # https://github.com/celestiaorg/nitro-contracts/blob/celestia/blobstream/src/bridge/SequencerInbox.sol#L334-L360
+    # https://github.com/celestiaorg/nitro-das-celestia/blob/7baf95c5bf1ece467abbbab911db7ed9c7cc6967/das/types.go#L19-L42
     {:ok, :in_celestia,
      %__MODULE__{batch_number: batch_number, height: height, transaction_commitment: transaction_commitment, raw: raw}}
   end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
@@ -122,12 +122,12 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
       0 ->
         {:ok, :in_calldata, nil}
 
-      12 ->
-        Celestia.parse_batch_accompanying_data(batch_number, rest)
-
       32 ->
         log_error("ZERO HEAVY messages are not supported.")
         {:error, nil, nil}
+
+      99 ->
+        Celestia.parse_batch_accompanying_data(batch_number, rest)
 
       128 ->
         Anytrust.parse_batch_accompanying_data(batch_number, rest)

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -675,6 +675,7 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
 
       "0x37501551" <> encoded_params ->
         # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, bytes quote)
+        # https://github.com/EspressoSystems/nitro-contracts/blob/a61b9dbd71ca443f8e7a007851071f5f1d219c19/src/bridge/SequencerInbox.sol#L364-L372
         [
           sequence_number,
           data,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -673,6 +673,24 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
 
         {sequence_number, prev_message_count, new_message_count, data}
 
+      "0x37501551" <> encoded_params ->
+        # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, bytes quote)
+        [
+          sequence_number,
+          data,
+          _after_delayed_messages_read,
+          _gas_refunder,
+          prev_message_count,
+          new_message_count,
+          _quote
+        ] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_origin_37501551_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
+
       "0x3e5aa082" <> encoded_params ->
         # addSequencerL2BatchFromBlobs(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount)
         [sequence_number, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count] =


### PR DESCRIPTION
## Motivation
The Arbitrum-Celestia integration has been updated, so we need to adjust our implementation accordingly to reflect these changes.

## Changelog
1. The `Celestia.parse_batch_accompanying_data` function has been updated to support the latest version of the Arbitrum-Celestia integration.
2. Updated `parse_calldata_of_add_sequencer_l2_batch/1` function to handle [`addSequencerL2BatchFromOrigin`](https://github.com/EspressoSystems/nitro-contracts/blob/a61b9dbd71ca443f8e7a007851071f5f1d219c19/src/bridge/SequencerInbox.sol#L364-L372) with additional `bytes quote` parameter. 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new function for handling an additional parameter in the `addSequencerL2BatchFromOrigin` function.
  - Enhanced parsing capabilities for calldata in the `addSequencerL2BatchFromOrigin` function.
  - Updated control flow for parsing based on header flags.

- **Bug Fixes**
  - Streamlined binary parsing logic by removing unused variables.

- **Documentation**
  - Updated GitHub repository link for Celestia data source reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->