### PR TITLE
chore: Upsert token instances by batches

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -933,4 +933,89 @@ defmodule Explorer.Chain.Token.Instance do
   end
 
   def preload_nft(other, _options), do: other
+
+  @doc """
+  Prepares params list for batch upsert
+  (filters out params for instances that shouldn't be updated
+  and adjusts `refetch_after` and `is_banned` fields based on existing instances).
+  """
+  @spec adjust_insert_params([map()]) :: [map()]
+  def adjust_insert_params(params_list) do
+    now = Timex.now()
+
+    adjusted_params_list =
+      Enum.map(params_list, fn params ->
+        {:ok, token_contract_address_hash} = Hash.Address.cast(params.token_contract_address_hash)
+
+        Map.merge(params, %{
+          token_id: Decimal.new(params.token_id),
+          token_contract_address_hash: token_contract_address_hash,
+          inserted_at: now,
+          updated_at: now
+        })
+      end)
+
+    token_instance_ids =
+      Enum.map(adjusted_params_list, fn params ->
+        {params.token_id, params.token_contract_address_hash.bytes}
+      end)
+
+    existing_token_instances_query =
+      from(token_instance in Instance,
+        where:
+          fragment(
+            "(?, ?) = ANY(?::token_instance_id[])",
+            token_instance.token_id,
+            token_instance.token_contract_address_hash,
+            ^token_instance_ids
+          )
+      )
+
+    existing_token_instances_map =
+      existing_token_instances_query
+      |> Repo.all()
+      |> Map.new(&{{&1.token_id, &1.token_contract_address_hash}, &1})
+
+    Enum.reduce(adjusted_params_list, [], fn params, acc ->
+      existing_token_instance =
+        existing_token_instances_map[{params.token_id, params.token_contract_address_hash}]
+
+      cond do
+        is_nil(existing_token_instance) ->
+          [params | acc]
+
+        is_nil(existing_token_instance.metadata) ->
+          {refetch_after, is_banned} = determine_refetch_after_and_is_banned(params, existing_token_instance)
+          full_params = Map.merge(params, %{refetch_after: refetch_after, is_banned: is_banned})
+          [full_params | acc]
+
+        true ->
+          acc
+      end
+    end)
+  end
+
+  defp determine_refetch_after_and_is_banned(params, existing_token_instance) do
+    config = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Retry)
+
+    coef = config[:exp_timeout_coeff]
+    base = config[:exp_timeout_base]
+    max_refetch_interval = config[:max_refetch_interval]
+    max_retry_count = :math.log(max_refetch_interval / 1000 / coef) / :math.log(base)
+    new_retries_count = existing_token_instance.retries_count + 1
+    max_retries_count_before_ban = error_to_max_retries_count_before_ban(params[:error])
+
+    cond do
+      new_retries_count > max_retries_count_before_ban ->
+        {nil, true}
+
+      is_nil(params[:metadata]) ->
+        value = floor(coef * :math.pow(base, min(new_retries_count, max_retry_count)))
+
+        {Timex.shift(Timex.now(), seconds: value), false}
+
+      true ->
+        {nil, false}
+    end
+  end
 end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -169,7 +169,7 @@ defmodule Explorer.ChainTest do
     end
   end
 
-  describe "upsert_token_instance/1" do
+  describe "batch_upsert_token_instances/1" do
     test "insert a new token instance with valid params" do
       token = insert(:token)
 
@@ -179,26 +179,11 @@ defmodule Explorer.ChainTest do
         metadata: %{uri: "http://example.com"}
       }
 
-      {:ok, result} = Chain.upsert_token_instance(params)
+      [result] = Chain.batch_upsert_token_instances([params])
 
       assert result.token_id == Decimal.new(1)
-      assert result.metadata == params.metadata
+      assert result.metadata == %{"uri" => "http://example.com"}
       assert result.token_contract_address_hash == token.contract_address_hash
-    end
-
-    test "fails to import with invalid params" do
-      params = %{
-        token_id: 1,
-        metadata: %{uri: "http://example.com"}
-      }
-
-      {:error,
-       %{
-         errors: [
-           token_contract_address_hash: {"can't be blank", [validation: :required]}
-         ],
-         valid?: false
-       }} = Chain.upsert_token_instance(params)
     end
 
     test "inserts just an error without metadata" do
@@ -211,7 +196,7 @@ defmodule Explorer.ChainTest do
         error: error
       }
 
-      {:ok, result} = Chain.upsert_token_instance(params)
+      [result] = Chain.batch_upsert_token_instances([params])
 
       assert result.error == error
     end
@@ -232,10 +217,10 @@ defmodule Explorer.ChainTest do
         metadata: %{uri: "http://example1.com"}
       }
 
-      {:ok, result} = Chain.upsert_token_instance(params)
+      [result] = Chain.batch_upsert_token_instances([params])
 
       assert is_nil(result.error)
-      assert result.metadata == params.metadata
+      assert result.metadata == %{"uri" => "http://example1.com"}
     end
   end
 


### PR DESCRIPTION
## Motivation

`Indexer.Fetcher.TokenInstance.Helper.batch_fetch_instances/1` currently upserts token instances by one element. It can be done in batches to reduce the number of DB queries.

## Changelog

- Added batch inserting to `Indexer.Fetcher.TokenInstance.Helper.batch_fetch_instances/1`
- Updated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced batch processing for token records, enabling simultaneous data insertions for improved efficiency.
  - Added enhanced validation and automatic timestamping during data preparation.

- **Refactor**
  - Replaced single-record operations with a streamlined batch approach for more reliable processing.
  - Simplified conflict resolution and improved error logging for enhanced system stability.

- **Tests**
  - Updated test cases to verify the new batch processing workflow and ensure expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->