### PR TITLE
fix: Add traceable blocks filtering to contract code fetcher

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -6,6 +6,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
 
   @default_trace_block_ranges "0..latest"
 
+  @doc """
+  Checks if block number is traceable
+  """
   @spec traceable_block_number?(integer() | nil) :: boolean()
   def traceable_block_number?(block_number) do
     if trace_ranges_present?() do
@@ -15,6 +18,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     end
   end
 
+  @doc """
+  Filters out non-traceable records from `data` by its block number
+  """
   @spec filter_traceable_block_numbers([integer() | map()]) :: [integer() | map()]
   def filter_traceable_block_numbers(data) do
     if trace_ranges_present?() do
@@ -25,11 +31,17 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     end
   end
 
+  @doc """
+  Checks if trace ranges are defined via env variables
+  """
   @spec trace_ranges_present? :: boolean()
   def trace_ranges_present? do
     Application.get_env(:indexer, :trace_block_ranges) != @default_trace_block_ranges
   end
 
+  @doc """
+  Retrieves trace ranges from application variable in string format and parses them into Range/integer
+  """
   @spec get_trace_block_ranges :: [Range.t() | integer()]
   def get_trace_block_ranges do
     :indexer
@@ -37,6 +49,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     |> parse_block_ranges()
   end
 
+  @doc """
+  Parse ranges from string format into Range/integer
+  """
   @spec parse_block_ranges(binary()) :: [Range.t() | integer()]
   def parse_block_ranges(block_ranges_string) do
     block_ranges_string
@@ -56,6 +71,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     |> sanitize_ranges()
   end
 
+  @doc """
+  Checks if `number` is present in `ranges`
+  """
   @spec number_in_ranges?(integer(), [Range.t()]) :: boolean()
   def number_in_ranges?(number, ranges) do
     Enum.reduce_while(ranges, false, fn
@@ -73,6 +91,9 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
     end
   end
 
+  @doc """
+  Rejects empty ranges and merges adjacent ranges
+  """
   @spec sanitize_ranges([Range.t() | integer()]) :: [Range.t() | integer()]
   def sanitize_ranges(ranges) do
     ranges

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -76,21 +76,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   @impl BufferedTask
   def init(initial, reducer, _json_rpc_named_arguments) do
-    stream_reducer =
-      if RangesHelper.trace_ranges_present?() do
-        trace_block_ranges = RangesHelper.get_trace_block_ranges()
-
-        fn block_number, acc ->
-          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-          if RangesHelper.number_in_ranges?(block_number, trace_block_ranges),
-            do: reducer.(block_number, acc),
-            else: acc
-        end
-      else
-        fn block_number, acc ->
-          reducer.(block_number, acc)
-        end
-      end
+    stream_reducer = RangesHelper.stream_reducer_traceable(reducer)
 
     {:ok, final} = Chain.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11687

## Changelog

- Moved traceable stream reducer definition to `EthereumJSONRPC.Utility.RangesHelper`
- Added traceable stream reducer usage for `Indexer.Fetcher.ContractCode`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced block number filtering functionality in Ethereum JSON RPC utility.
  - Introduced new stream reducer for processing traceable block numbers.

- **Improvements**
  - Simplified stream reducer logic in contract code and internal transaction fetchers.
  - Improved flexibility in handling complex data structures for block number processing.
  
- **Documentation**
  - Added detailed documentation comments for various functions to enhance readability and maintainability. 

- **Technical Updates**
  - Updated method signatures in RangesHelper module.
  - Added new utility functions for more robust data filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->