### PR TITLE
fix: Add flat value to BoundInterval increase/decrease

### DIFF
--- a/apps/indexer/lib/indexer/bound_interval.ex
+++ b/apps/indexer/lib/indexer/bound_interval.ex
@@ -17,6 +17,7 @@ defmodule Indexer.BoundInterval do
     new_current =
       current
       |> div(2)
+      |> Kernel.-(:timer.seconds(1))
       |> max(minimum)
 
     %__MODULE__{bound_interval | current: new_current}
@@ -24,7 +25,7 @@ defmodule Indexer.BoundInterval do
 
   def increase(%__MODULE__{current: current, maximum: maximum} = bound_interval)
       when is_integer(current) and is_integer(maximum) do
-    new_current = min(current * 2, maximum)
+    new_current = min(current * 2 + :timer.seconds(1), maximum)
 
     %__MODULE__{bound_interval | current: new_current}
   end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/11626

## Changelog

Added flat value to increasing/decreasing of bound interval so it can go up from `0` and back down to `0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined interval calculation logic to improve precision in boundary adjustments
  - Added subtle time-based adjustments to interval decrease and increase mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->