### PR TITLE
fix: Fix typo in API key creation message Update default.pot

### DIFF
--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -986,7 +986,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/account/api_key/index.html.eex:12
 #, elixir-autogen, elixir-format
-msgid "Create an API key to use with your RPC и EthRPC API requests."
+msgid "Create an API key to use with your RPC and EthRPC API requests."
 msgstr ""
 
 #: lib/block_scout_web/views/internal_transaction_view.ex:26


### PR DESCRIPTION
## Motivation

I noticed a small typo in the API key creation message where the word "and" was mistakenly written with a Cyrillic "и" instead of the Latin "i". This has been corrected to ensure consistency and proper readability.  

The corrected line now reads:  
```plaintext  
msgid "Create an API key to use with your RPC and EthRPC API requests."  
```  

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typographical error in the API key creation message, replacing the Cyrillic "и" with the English word "and" for improved readability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->