### PR TITLE
feat: Enhance txlistinternal API v1: make transaction hash and address hash not mandatory

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1498,7 +1498,7 @@ defmodule BlockScoutWeb.Etherscan do
         placeholder: "transactionHash",
         type: "string",
         description:
-          "Transaction hash. Hash of contents of the transaction. A transaction hash or address hash is required."
+          "Transaction hash. Hash of contents of the transaction. Optional parameter to filter results by a specific transaction hash."
       },
       %{
         key: "address",

--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -1491,16 +1491,15 @@ defmodule BlockScoutWeb.Etherscan do
     name: "txlistinternal",
     description:
       "Get internal transactions by transaction or address hash. Up to a maximum of 10,000 internal transactions. Also available through a GraphQL 'transaction' query.",
-    required_params: [
+    required_params: [],
+    optional_params: [
       %{
         key: "txhash",
         placeholder: "transactionHash",
         type: "string",
         description:
           "Transaction hash. Hash of contents of the transaction. A transaction hash or address hash is required."
-      }
-    ],
-    optional_params: [
+      },
       %{
         key: "address",
         placeholder: "addressHash",

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2483,11 +2483,7 @@ defmodule Explorer.Chain do
   @spec timestamp_to_block_number(DateTime.t(), :before | :after, boolean()) ::
           {:ok, Block.block_number()} | {:error, :not_found}
   def timestamp_to_block_number(given_timestamp, closest, from_api) do
-    consensus_blocks_query =
-      from(
-        block in Block,
-        where: block.consensus == true
-      )
+    consensus_blocks_query = Block.consensus_blocks_query()
 
     gt_timestamp_query =
       from(

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -297,6 +297,13 @@ defmodule Explorer.Chain.Block do
     )
   end
 
+  @doc """
+    Returns a query that filters blocks where consensus is true.
+
+    ## Returns
+    - An `Ecto.Query.t()` that can be used to fetch consensus blocks.
+  """
+  @spec consensus_blocks_query() :: Ecto.Query.t()
   def consensus_blocks_query do
     from(
       block in __MODULE__,

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -283,12 +283,6 @@ defmodule Explorer.Chain.Block do
   end
 
   def blocks_without_reward_query do
-    consensus_blocks_query =
-      from(
-        block in __MODULE__,
-        where: block.consensus == true
-      )
-
     validator_rewards =
       from(
         r in Reward,
@@ -296,10 +290,17 @@ defmodule Explorer.Chain.Block do
       )
 
     from(
-      b in subquery(consensus_blocks_query),
+      b in subquery(consensus_blocks_query()),
       left_join: r in subquery(validator_rewards),
       on: [block_hash: b.hash],
       where: is_nil(r.block_hash)
+    )
+  end
+
+  def consensus_blocks_query do
+    from(
+      block in __MODULE__,
+      where: block.consensus == true
     )
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11070

## Motivation

Allow to request `txlistinternal` API v1 endpoint without address hash or transaction hash.

## Changelog

This pull request includes several updates to the `BlockScoutWeb` and `Explorer` modules, focusing on improving the handling of internal transactions and refactoring query methods for better code reuse and readability.

### Enhancements to Internal Transactions Handling:

* [`apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex`](diffhunk://#diff-1789364de915e3242244c3cb110da84b09a97e789342c715710a7ef083b579daL131-R142): Added a new function `txlistinternal/3` to handle cases where no parameters are provided and refactored existing functions to use more descriptive parameter names. [[1]](diffhunk://#diff-1789364de915e3242244c3cb110da84b09a97e789342c715710a7ef083b579daL131-R142) [[2]](diffhunk://#diff-1789364de915e3242244c3cb110da84b09a97e789342c715710a7ef083b579daR154-R167) [[3]](diffhunk://#diff-1789364de915e3242244c3cb110da84b09a97e789342c715710a7ef083b579daR534-R540)
* [`apps/block_scout_web/lib/block_scout_web/etherscan.ex`](diffhunk://#diff-19c16b67c88dba8ce7240f8dbb5aa7f5e429aa5eb612a23883c0dc05e03e2984L1494-R1502): Updated the `txlistinternal` function to remove required parameters and added a new optional parameter list.
* [`apps/explorer/lib/explorer/etherscan.ex`](diffhunk://#diff-4dda1496a8e2dc344d8e08c1a7eeb38557c66491ee7bfc6636c8d0562902f2acR280-R402): Added a new function `list_internal_transactions/2` to handle fetching all internal transactions with detailed documentation.

### Code Refactoring:

* [`apps/explorer/lib/explorer/chain.ex`](diffhunk://#diff-3fce0f082a5cb927aa738ef8f7d582824df91d08957971d36a0873efacd88816L2486-R2486): Replaced inline query definition with a call to the new `Block.consensus_blocks_query/0` function for better code reuse.
* [`apps/explorer/lib/explorer/chain/block.ex`](diffhunk://#diff-068e2fe344a1d56ad5f54cda1ddcd99e420ee91f31673167307582418f9d3e24L286-R306): Extracted the consensus blocks query into a separate function `consensus_blocks_query/0` to improve readability and reuse.
* [`apps/explorer/lib/explorer/etherscan.ex`](diffhunk://#diff-4dda1496a8e2dc344d8e08c1a7eeb38557c66491ee7bfc6636c8d0562902f2acL179-R179): Updated the consensus blocks query to use the new `Block.consensus_blocks_query/0` function.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs). https://github.com/blockscout/docs/pull/373
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced internal transaction retrieval functionality
	- Added support for listing internal transactions without requiring a specific address or transaction hash

- **Improvements**
	- Improved API flexibility for querying internal transactions
	- Updated parameter handling for internal transaction searches
	- Simplified and modularized internal transaction query logic

- **Bug Fixes**
	- Corrected error messaging for transaction search scenarios

The release introduces more flexible internal transaction retrieval, allowing users to fetch transactions with fewer constraints while maintaining robust query capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->