### PR TITLE
fix: new methods submitting Arbitrum batches supported

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -393,4 +393,93 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
         :address
       ]
     }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchFromBlobsDelayProof` function
+  """
+  def add_sequencer_l2_batch_from_blobs_delay_proof_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "addSequencerL2BatchFromBlobsDelayProof",
+      types: [
+        {:uint, 256},
+        {:uint, 256},
+        :address,
+        {:uint, 256},
+        {:uint, 256},
+        {:tuple,
+         [
+           :bytes32,
+           {:tuple,
+            [
+              {:uint, 8},
+              :address,
+              {:uint, 64},
+              {:uint, 64},
+              {:uint, 256},
+              {:uint, 256},
+              :bytes32
+            ]}
+         ]}
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchFromOriginDelayProof` function
+  """
+  def add_sequencer_l2_batch_from_origin_delay_proof_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "addSequencerL2BatchFromOriginDelayProof",
+      types: [
+        {:uint, 256},
+        :bytes,
+        {:uint, 256},
+        :address,
+        {:uint, 256},
+        {:uint, 256},
+        {:tuple,
+         [
+           :bytes32,
+           {:tuple,
+            [
+              {:uint, 8},
+              :address,
+              {:uint, 64},
+              {:uint, 64},
+              {:uint, 256},
+              {:uint, 256},
+              :bytes32
+            ]}
+         ]}
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchDelayProof` function
+  """
+  def add_sequencer_l2_batch_delay_proof_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "addSequencerL2BatchDelayProof",
+      types: [
+        {:uint, 256},
+        :bytes,
+        {:uint, 256},
+        :address,
+        {:uint, 256},
+        {:uint, 256},
+        {:tuple,
+         [
+           :bytes32,
+           {:tuple,
+            [
+              {:uint, 8},
+              :address,
+              {:uint, 64},
+              {:uint, 64},
+              {:uint, 256},
+              {:uint, 256},
+              :bytes32
+            ]}
+         ]}
+      ]
+    }
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -408,7 +408,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
         {:uint, 256},
         {:tuple,
          [
-           :bytes32,
+           {:bytes, 32},
            {:tuple,
             [
               {:uint, 8},
@@ -417,7 +417,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
               {:uint, 64},
               {:uint, 256},
               {:uint, 256},
-              :bytes32
+              {:bytes, 32}
             ]}
          ]}
       ]
@@ -438,7 +438,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
         {:uint, 256},
         {:tuple,
          [
-           :bytes32,
+           {:bytes, 32},
            {:tuple,
             [
               {:uint, 8},
@@ -447,7 +447,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
               {:uint, 64},
               {:uint, 256},
               {:uint, 256},
-              :bytes32
+              {:bytes, 32}
             ]}
          ]}
       ]
@@ -468,7 +468,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
         {:uint, 256},
         {:tuple,
          [
-           :bytes32,
+           {:bytes, 32},
            {:tuple,
             [
               {:uint, 8},
@@ -477,7 +477,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
               {:uint, 64},
               {:uint, 256},
               {:uint, 256},
-              :bytes32
+              {:bytes, 32}
             ]}
          ]}
       ]

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -334,7 +334,15 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     ]
 
   @doc """
-    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchFromBlobs(...)` function
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchFromBlobs(
+        uint256 sequenceNumber,
+        uint256 afterDelayedMessagesRead,
+        address gasRefunder,
+        uint256 prevMessageCount,
+        uint256 newMessageCount
+      )
   """
   def add_sequencer_l2_batch_from_blobs_selector_with_abi,
     do: %ABI.FunctionSelector{
@@ -395,7 +403,16 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     }
 
   @doc """
-    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchFromBlobsDelayProof` function
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchFromBlobsDelayProof(
+        uint256 sequenceNumber,
+        uint256 afterDelayedMessagesRead,
+        address gasRefunder,
+        uint256 prevMessageCount,
+        uint256 newMessageCount,
+        DelayProof calldata delayProof
+      )
   """
   def add_sequencer_l2_batch_from_blobs_delay_proof_selector_with_abi,
     do: %ABI.FunctionSelector{
@@ -424,7 +441,17 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     }
 
   @doc """
-    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchFromOriginDelayProof` function
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchFromOriginDelayProof(
+        uint256 sequenceNumber,
+        bytes calldata data,
+        uint256 afterDelayedMessagesRead,
+        address gasRefunder,
+        uint256 prevMessageCount,
+        uint256 newMessageCount,
+        DelayProof calldata delayProof
+      )
   """
   def add_sequencer_l2_batch_from_origin_delay_proof_selector_with_abi,
     do: %ABI.FunctionSelector{
@@ -454,7 +481,17 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     }
 
   @doc """
-    Returns selector with ABI (object of `ABI.FunctionSelector`) of the `addSequencerL2BatchDelayProof` function
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchDelayProof(
+        uint256 sequenceNumber,
+        bytes calldata data,
+        uint256 afterDelayedMessagesRead,
+        address gasRefunder,
+        uint256 prevMessageCount,
+        uint256 newMessageCount,
+        DelayProof calldata delayProof
+      )
   """
   def add_sequencer_l2_batch_delay_proof_selector_with_abi,
     do: %ABI.FunctionSelector{

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -3,6 +3,8 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
     Common functions to simplify RPC routines for Indexer.Fetcher.Arbitrum fetchers
   """
 
+  # TODO: Move the module under EthereumJSONRPC.Arbitrum.
+
   alias ABI.TypeDecoder
 
   import EthereumJSONRPC,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -3,6 +3,8 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
     Common functions to simplify RPC routines for Indexer.Fetcher.Arbitrum fetchers
   """
 
+  alias ABI.TypeDecoder
+
   import EthereumJSONRPC,
     only: [json_rpc: 2, quantity_to_integer: 1, timestamp_to_datetime: 1]
 
@@ -632,5 +634,167 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
   @spec get_resend_attempts() :: non_neg_integer()
   def get_resend_attempts do
     @rpc_resend_attempts
+  end
+
+  @doc """
+    Parses the calldata of various Arbitrum Sequencer batch submission functions to extract batch information.
+
+    Handles calldata for the following functions:
+    - addSequencerL2BatchFromOrigin
+    - addSequencerL2BatchFromBlobs
+    - addSequencerL2BatchFromBlobsDelayProof
+    - addSequencerL2BatchFromOriginDelayProof
+    - addSequencerL2BatchDelayProof
+
+    ## Parameters
+    - `calldata`: The raw calldata from the transaction as a binary string starting with "0x"
+                 followed by the function selector and encoded parameters
+
+    ## Returns
+    A tuple containing:
+    - `sequence_number`: The batch sequence number
+    - `prev_message_count`: The previous L2-to-L1 message count (nil for some functions)
+    - `new_message_count`: The new L2-to-L1 message count (nil for some functions)
+    - `data`: The batch data as binary (nil for blob-based submissions)
+  """
+  @spec parse_calldata_of_add_sequencer_l2_batch(binary()) ::
+          {non_neg_integer(), non_neg_integer() | nil, non_neg_integer() | nil, binary() | nil}
+  def parse_calldata_of_add_sequencer_l2_batch(calldata) do
+    case calldata do
+      "0x8f111f3c" <> encoded_params ->
+        # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount)
+        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_origin_8f111f3c_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
+
+      "0x3e5aa082" <> encoded_params ->
+        # addSequencerL2BatchFromBlobs(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount)
+        [sequence_number, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_blobs_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, nil}
+
+      "0x6f12b0c9" <> encoded_params ->
+        # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder)
+        [sequence_number, data, _after_delayed_messages_read, _gas_refunder] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_origin_6f12b0c9_selector_with_abi()
+          )
+
+        {sequence_number, nil, nil, data}
+
+      "0x917cf8ac" <> encoded_params ->
+        # addSequencerL2BatchFromBlobsDelayProof(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [
+          sequence_number,
+          _after_delayed_messages_read,
+          _gas_refunder,
+          prev_message_count,
+          new_message_count,
+          _delay_proof
+        ] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_blobs_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, nil}
+
+      "0x69cacded" <> encoded_params ->
+        # addSequencerL2BatchFromOriginDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [
+          sequence_number,
+          data,
+          _after_delayed_messages_read,
+          _gas_refunder,
+          prev_message_count,
+          new_message_count,
+          _delay_proof
+        ] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_origin_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
+
+      "0x6e620055" <> encoded_params ->
+        # addSequencerL2BatchDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [
+          sequence_number,
+          data,
+          _after_delayed_messages_read,
+          _gas_refunder,
+          prev_message_count,
+          new_message_count,
+          _delay_proof
+        ] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
+    end
+  end
+
+  @doc """
+    Extracts batch numbers from `SequencerBatchDelivered` event logs.
+
+    Note: This function assumes that all provided logs are SequencerBatchDelivered
+    events. Logs from other events should be filtered out before calling this
+    function.
+
+    ## Parameters
+    - `logs`: A list of event logs, where each log is a map containing event data
+             from the `SequencerBatchDelivered` event.
+
+    ## Returns
+    - A list of non-negative integers representing batch numbers.
+  """
+  @spec extract_batch_numbers_from_logs([%{String.t() => any()}]) :: [non_neg_integer()]
+  def extract_batch_numbers_from_logs(logs) do
+    logs
+    |> Enum.map(fn event ->
+      {batch_num, _, _} = parse_sequencer_batch_delivered_event(event)
+      batch_num
+    end)
+  end
+
+  # Parses SequencerBatchDelivered event to get batch sequence number and associated accumulators
+  @doc """
+    Extracts key information from a `SequencerBatchDelivered` event log.
+
+    The event topics array contains the indexed parameters of the event:
+    - topic[0]: Event signature (not used)
+    - topic[1]: Batch number (indexed parameter)
+    - topic[2]: Before accumulator value (indexed parameter)
+    - topic[3]: After accumulator value (indexed parameter)
+
+    Note: This function does not verify if the event is actually a
+    `SequencerBatchDelivered` event.
+
+    ## Parameters
+    - `event`: A map containing event data with `topics` field.
+
+    ## Returns
+    - A tuple containing:
+      - The batch number as an integer
+      - The before accumulator value as a binary
+      - The after accumulator value as a binary
+  """
+  @spec parse_sequencer_batch_delivered_event(%{String.t() => any()}) :: {non_neg_integer(), binary(), binary()}
+  def parse_sequencer_batch_delivered_event(event) do
+    [_, batch_sequence_number, before_acc, after_acc] = event["topics"]
+
+    {quantity_to_integer(batch_sequence_number), before_acc, after_acc}
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
@@ -1146,8 +1146,9 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
     end)
   end
 
-  # Parses calldata of `addSequencerL2BatchFromOrigin` or `addSequencerL2BatchFromBlobs`
-  # functions to extract batch information.
+  # Parses calldata of `addSequencerL2BatchFromOrigin`, `addSequencerL2BatchFromBlobs`,
+  # `addSequencerL2BatchFromBlobsDelayProof`, `addSequencerL2BatchFromOriginDelayProof`,
+  # or `addSequencerL2BatchDelayProof` functions to extract batch information.
   @spec add_sequencer_l2_batch_from_origin_calldata_parse(binary()) ::
           {non_neg_integer(), non_neg_integer() | nil, non_neg_integer() | nil, binary() | nil}
   defp add_sequencer_l2_batch_from_origin_calldata_parse(calldata) do
@@ -1181,6 +1182,36 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
           )
 
         {sequence_number, nil, nil, data}
+
+      "0x917cf8ac" <> encoded_params ->
+        # addSequencerL2BatchFromBlobsDelayProof(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [sequence_number, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_blobs_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, nil}
+
+      "0x69cacded" <> encoded_params ->
+        # addSequencerL2BatchFromOriginDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_origin_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
+
+      "0x6e620055" <> encoded_params ->
+        # addSequencerL2BatchDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
+        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_delay_proof_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, data}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex
@@ -22,10 +22,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
     for the necessary information not available in the logs.
   """
 
-  alias ABI.TypeDecoder
-
   import EthereumJSONRPC, only: [quantity_to_integer: 1]
-  alias EthereumJSONRPC.Arbitrum.Constants.Contracts, as: ArbitrumContracts
   alias EthereumJSONRPC.Arbitrum.Constants.Events, as: ArbitrumEvents
 
   import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_info: 1, log_debug: 1]
@@ -750,7 +747,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
        ) do
     existing_batches =
       logs
-      |> parse_logs_to_get_batch_numbers()
+      |> Rpc.extract_batch_numbers_from_logs()
       |> DbSettlement.batches_exist()
 
     {batches, transactions_requests, blocks_requests, existing_commitment_transactions} =
@@ -827,16 +824,6 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
      rollup_transactions_to_import, committed_messages, da_records, batch_to_data_blobs}
   end
 
-  # Extracts batch numbers from logs of SequencerBatchDelivered events.
-  @spec parse_logs_to_get_batch_numbers([%{String.t() => any()}]) :: [non_neg_integer()]
-  defp parse_logs_to_get_batch_numbers(logs) do
-    logs
-    |> Enum.map(fn event ->
-      {batch_num, _, _} = sequencer_batch_delivered_event_parse(event)
-      batch_num
-    end)
-  end
-
   # Parses logs representing SequencerBatchDelivered events to identify new batches.
   #
   # This function sifts through logs of SequencerBatchDelivered events, extracts the
@@ -887,21 +874,13 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
         blk_num = quantity_to_integer(event["blockNumber"])
 
         handle_new_batch_data(
-          {sequencer_batch_delivered_event_parse(event), transaction_hash_raw, blk_num},
+          {Rpc.parse_sequencer_batch_delivered_event(event), transaction_hash_raw, blk_num},
           existing_batches,
           acc
         )
       end)
 
     {batches, transactions_requests, Map.values(blocks_requests), existing_commitment_transactions}
-  end
-
-  # Parses SequencerBatchDelivered event to get batch sequence number and associated accumulators
-  @spec sequencer_batch_delivered_event_parse(%{String.t() => any()}) :: {non_neg_integer(), binary(), binary()}
-  defp sequencer_batch_delivered_event_parse(event) do
-    [_, batch_sequence_number, before_acc, after_acc] = event["topics"]
-
-    {quantity_to_integer(batch_sequence_number), before_acc, after_acc}
   end
 
   # Handles the new batch data to assemble a map of new batch descriptions.
@@ -1088,7 +1067,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
         # Although they are called messages in the functions' ABI, in fact they are
         # rollup blocks
         {batch_num, prev_message_count, new_message_count, extra_data} =
-          add_sequencer_l2_batch_from_origin_calldata_parse(resp["input"])
+          Rpc.parse_calldata_of_add_sequencer_l2_batch(resp["input"])
 
         # For the case when the rollup blocks range is not discovered on the previous
         # step due to handling of legacy events, it is required to make more
@@ -1144,75 +1123,6 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewBatches do
         {updated_transactions_map, updated_batches_map, updated_da_info_list}
       end)
     end)
-  end
-
-  # Parses calldata of `addSequencerL2BatchFromOrigin`, `addSequencerL2BatchFromBlobs`,
-  # `addSequencerL2BatchFromBlobsDelayProof`, `addSequencerL2BatchFromOriginDelayProof`,
-  # or `addSequencerL2BatchDelayProof` functions to extract batch information.
-  @spec add_sequencer_l2_batch_from_origin_calldata_parse(binary()) ::
-          {non_neg_integer(), non_neg_integer() | nil, non_neg_integer() | nil, binary() | nil}
-  defp add_sequencer_l2_batch_from_origin_calldata_parse(calldata) do
-    case calldata do
-      "0x8f111f3c" <> encoded_params ->
-        # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount)
-        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_from_origin_8f111f3c_selector_with_abi()
-          )
-
-        {sequence_number, prev_message_count, new_message_count, data}
-
-      "0x3e5aa082" <> encoded_params ->
-        # addSequencerL2BatchFromBlobs(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount)
-        [sequence_number, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_from_blobs_selector_with_abi()
-          )
-
-        {sequence_number, prev_message_count, new_message_count, nil}
-
-      "0x6f12b0c9" <> encoded_params ->
-        # addSequencerL2BatchFromOrigin(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder)
-        [sequence_number, data, _after_delayed_messages_read, _gas_refunder] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_from_origin_6f12b0c9_selector_with_abi()
-          )
-
-        {sequence_number, nil, nil, data}
-
-      "0x917cf8ac" <> encoded_params ->
-        # addSequencerL2BatchFromBlobsDelayProof(uint256 sequenceNumber, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
-        [sequence_number, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_from_blobs_delay_proof_selector_with_abi()
-          )
-
-        {sequence_number, prev_message_count, new_message_count, nil}
-
-      "0x69cacded" <> encoded_params ->
-        # addSequencerL2BatchFromOriginDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
-        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_from_origin_delay_proof_selector_with_abi()
-          )
-
-        {sequence_number, prev_message_count, new_message_count, data}
-
-      "0x6e620055" <> encoded_params ->
-        # addSequencerL2BatchDelayProof(uint256 sequenceNumber, bytes calldata data, uint256 afterDelayedMessagesRead, address gasRefunder, uint256 prevMessageCount, uint256 newMessageCount, DelayProof calldata delayProof)
-        [sequence_number, data, _after_delayed_messages_read, _gas_refunder, prev_message_count, new_message_count, _delay_proof] =
-          TypeDecoder.decode(
-            Base.decode16!(encoded_params, case: :lower),
-            ArbitrumContracts.add_sequencer_l2_batch_delay_proof_selector_with_abi()
-          )
-
-        {sequence_number, prev_message_count, new_message_count, data}
-    end
   end
 
   # Determines the block range for a batch based on provided message counts and


### PR DESCRIPTION
## Motivation

Closes #11729

## Analysis

Starting from last week, some batches of Arbitrum Sepolia have been submitted to the `SequencerInbox` contract using the method `addSequencerL2BatchFromBlobsDelayProof`.

In fact, there are a family of calls, including [`addSequencerL2BatchFromBlobsDelayProof`](https://github.com/OffchainLabs/nitro-contracts/blob/94999b3e2d3b4b7f8e771cc458b9eb229620dd8f/src/bridge/ISequencerInbox.sol#L239-L248), [`addSequencerL2BatchFromOriginDelayProof`](https://github.com/OffchainLabs/nitro-contracts/blob/94999b3e2d3b4b7f8e771cc458b9eb229620dd8f/src/bridge/ISequencerInbox.sol#L250-L261), and [`addSequencerL2BatchDelayProof`](https://github.com/OffchainLabs/nitro-contracts/blob/94999b3e2d3b4b7f8e771cc458b9eb229620dd8f/src/bridge/ISequencerInbox.sol#L263-L273), that were introduced by the `SequencerInbox` contract. However, their support was not added to the Blockscout backend responsible for indexing new batches.

## Changelog

1. The ABIs of new functions of the `SequencerInbox` contract are added to the module `EthereumJSONRPC.Arbitrum.Constants.Contracts` (in `apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex`). The ABI of new functions refers to the structure `` which is defined in [DelayBufferTypes.sol](https://github.com/OffchainLabs/nitro-contracts/blob/94999b3e2d3b4b7f8e771cc458b9eb229620dd8f/src/bridge/DelayBufferTypes.sol). In its turn, it uses the  `Message` struct defined in [Messages.sol](https://github.com/OffchainLabs/nitro-contracts/blob/94999b3e2d3b4b7f8e771cc458b9eb229620dd8f/src/bridge/Messages.sol).

2. Parsing input parameters of the new functions is introduced in the function `add_sequencer_l2_batch_from_origin_calldata_parse` initially located in the module `Indexer.Fetcher.Arbitrum.Workers.NewBatches` (`apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex`). The selectors of the functions are double-checked on [the `SequencerInbox` contract page](https://eth-sepolia.blockscout.com/address/0x6c97864CE4bEf387dE0b3310A44230f7E3F1be0D?tab=read_write_proxy&source_address=0xBBb2EF6dD70759F6c335c116895c6749ec7427da#0x6e620055).

3. In order to reduce the size of the module `apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_batches.ex`, the functions strictly related to the parsing events and call data were moved to `apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex`:

    - `add_sequencer_l2_batch_from_origin_calldata_parse` -> `parse_calldata_of_add_sequencer_l2_batch`
    - `parse_logs_to_get_batch_numbers` -> `extract_batch_numbers_from_logs`
    - `sequencer_batch_delivered_event_parse` -> `parse_sequencer_batch_delivered_event`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for handling sequencer batch processing in Arbitrum.
	- Enhanced RPC utility functions for parsing Arbitrum batch-related data.
	- Improved capabilities for extracting batch numbers and parsing event logs.

- **Refactor**
	- Streamlined code structure for Arbitrum batch processing.
	- Centralized parsing logic for sequencer batch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->