### PR TITLE
fix: Add consensus filter to reindex internal transactions migration

### DIFF
--- a/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
@@ -57,6 +57,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
       t in Transaction,
       as: :transaction,
       where: t.status == ^:error,
+      where: t.block_consensus == true,
       where: not is_nil(t.block_number),
       where: not exists(pbo_query),
       where: exists(it_query),
@@ -71,6 +72,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
     params =
       Block
       |> where([b], b.number in ^block_numbers)
+      |> where([b], b.consensus == true)
       |> select([b], %{block_hash: b.hash, block_number: b.number})
       |> Repo.all()
       |> Enum.uniq_by(& &1.block_number)


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/11709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction and block indexing by adding consensus validation checks
	- Enhanced filtering of internal transactions to ensure only valid, consensus-based transactions are processed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->