### PR TITLE
feat: Adds support for NeonVM linked Solana transactions (#11667)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -64,7 +64,8 @@ jobs:
               "stability",
               "zetachain",
               "zilliqa",
-              "zksync"
+              "zksync",
+              "neon"
             ];
 
             const extraChainTypes = ["suave", "polygon_edge"];

--- a/.github/workflows/pre-release-neon.yml
+++ b/.github/workflows/pre-release-neon.yml
@@ -1,0 +1,80 @@
+name: Pre-release for Neon
+
+on:
+  workflow_dispatch:
+    inputs:
+      number:
+        type: number
+        required: true
+
+env:
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 6.10.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+
+      - name: Build and push Docker image for Neon (indexer + API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon
+
+      - name: Build and push Docker image for Neon (indexer)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon
+
+      - name: Build and push Docker image for Neon (API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}-api
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_INDEXER=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon

--- a/.github/workflows/release-neon.yml
+++ b/.github/workflows/release-neon.yml
@@ -1,0 +1,78 @@
+name: Release for Neon
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 6.10.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+
+      - name: Build and push Docker image for Neon (indexer + API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:latest, blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon
+
+      - name: Build and push Docker image for Neon (indexer)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon
+
+      - name: Build and push Docker image for Neon (API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: blockscout/blockscout-neon:${{ env.RELEASE_VERSION }}-api
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_INDEXER=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=neon

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -257,7 +257,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   end
 
   @doc """
-    Function to handle GET requests to `/api/v2/transactions/:tx_hash/external_transactions` endpoint.
+    Function to handle GET requests to `/api/v2/transactions/:tx_hash/external-transactions` endpoint.
     It renders the list of external transactions that are somehow linked (eg. preceded or initiated by) to the selected one.
     The most common use case is for side-chains and rollups. Currently implemented only for Neon chain but could also be extended for
     similar cases.

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -49,6 +49,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias Explorer.Chain.ZkSync.Reader, as: ZkSyncReader
   alias Explorer.Counters.{FreshPendingTransactionsCounter, Transactions24hStats}
   alias Indexer.Fetcher.OnDemand.FirstTrace, as: FirstTraceOnDemand
+  alias Indexer.Fetcher.OnDemand.NeonSolanaTransactions, as: NeonSolanaTransactions
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -253,6 +254,34 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   @spec arbitrum_batch(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def arbitrum_batch(conn, params) do
     handle_batch_transactions(conn, params, &ArbitrumSettlementReader.batch_transactions/2)
+  end
+
+  @doc """
+    Function to handle GET requests to `/api/v2/transactions/:tx_hash/external_transactions` endpoint.
+    It renders the list of external transactions that are somehow linked (eg. preceded or initiated by) to the selected one.
+    The most common use case is for side-chains and rollups. Currently implemented only for Neon chain but could also be extended for
+    similar cases.
+  """
+  @spec external_transactions(Plug.Conn.t(), %{required(String.t()) => String.t()}) :: Plug.Conn.t()
+  def external_transactions(conn, %{"transaction_hash_param" => transaction_hash} = _params) do
+    with {:format, {:ok, hash}} <- {:format, Chain.string_to_transaction_hash(transaction_hash)} do
+      case NeonSolanaTransactions.maybe_fetch(hash) do
+        {:ok, linked_transactions} ->
+          conn
+          |> put_status(200)
+          |> json(linked_transactions)
+
+        {:error, reason} ->
+          Logger.error("Fetching external linked transactions failed: #{inspect(reason)}")
+
+          conn
+          |> put_status(500)
+          |> json(%{
+            error: "Unable to fetch external linked transactions",
+            reason: "#{inspect(reason)}"
+          })
+      end
+    end
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -170,7 +170,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:transaction_hash_param/summary", V2.TransactionController, :summary)
 
       if @chain_type == :neon do
-        get("/:transaction_hash_param/external_transactions", V2.TransactionController, :external_transactions)
+        get("/:transaction_hash_param/external-transactions", V2.TransactionController, :external_transactions)
       end
 
       if @chain_type == :ethereum do

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -169,6 +169,10 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:transaction_hash_param/state-changes", V2.TransactionController, :state_changes)
       get("/:transaction_hash_param/summary", V2.TransactionController, :summary)
 
+      if @chain_type == :neon do
+        get("/:transaction_hash_param/external_transactions", V2.TransactionController, :external_transactions)
+      end
+
       if @chain_type == :ethereum do
         get("/:transaction_hash_param/blobs", V2.TransactionController, :blobs)
       end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -1633,7 +1633,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         end
       )
 
-      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external_transactions")
+      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external-transactions")
       assert response = json_response(request, 200)
       assert ^response = dummy_response
 
@@ -1651,7 +1651,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       EthereumJSONRPC.Mox
       |> expect(:json_rpc, fn _, _ -> {:error, "must use DB cache"} end)
 
-      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external_transactions")
+      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external-transactions")
       assert response = json_response(request, 200)
 
       assert length(response) == length(dummy_response) and
@@ -1664,7 +1664,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       EthereumJSONRPC.Mox
       |> expect(:json_rpc, fn _, _ -> {:error, "must fail"} end)
 
-      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external_transactions")
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external-transactions")
       assert response = json_response(request, 500)
 
       assert response == %{
@@ -1679,13 +1679,13 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       EthereumJSONRPC.Mox
       |> expect(:json_rpc, fn _, _ -> {:ok, []} end)
 
-      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external_transactions")
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external-transactions")
       assert response = json_response(request, 200)
       assert ^response = []
     end
 
     test "returns 422 for invalid transaction hash", %{conn: conn} do
-      request = get(conn, "/api/v2/transactions/invalid_hash/external_transactions")
+      request = get(conn, "/api/v2/transactions/invalid_hash/external-transactions")
       assert response = json_response(request, 422)
       assert response["message"] == "Invalid parameter(s)"
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -4,9 +4,12 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
   import Explorer.Chain, only: [hash_to_lower_case_string: 1]
   import Mox
 
+  require Logger
   alias Explorer.Account.{Identity, WatchlistAddress}
   alias Explorer.Chain.{Address, InternalTransaction, Log, Token, TokenTransfer, Transaction, Wei}
   alias Explorer.Repo
+  import Ecto.Query, only: [from: 2]
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.TransactionsApiV2.child_id())
@@ -1609,4 +1612,82 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
   end
 
   defp check_total(_, _, _), do: true
+
+  describe "neon linked transactions service" do
+    test "fetches data from the node and caches in the db", %{conn: conn} do
+      transaction = insert(:transaction)
+      transaction_hash = to_string(transaction.hash)
+
+      dummy_response =
+        Enum.map(1..:rand.uniform(10), fn _ ->
+          :crypto.strong_rand_bytes(64) |> Base.encode64()
+        end)
+
+      EthereumJSONRPC.Mox
+      |> expect(
+        :json_rpc,
+        fn
+          %{id: 1, params: [^transaction_hash], method: "neon_getSolanaTransactionByNeonTransaction", jsonrpc: "2.0"},
+          _options ->
+            {:ok, dummy_response}
+        end
+      )
+
+      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external_transactions")
+      assert response = json_response(request, 200)
+      assert ^response = dummy_response
+
+      records =
+        from(
+          solanaTransaction in Explorer.Chain.Neon.LinkedSolanaTransactions,
+          where: solanaTransaction.neon_transaction_hash == ^transaction.hash.bytes,
+          select: solanaTransaction.solana_transaction_hash
+        )
+        |> Repo.all()
+
+      assert length(dummy_response) == length(records) and
+               Enum.all?(dummy_response, fn dummy -> Enum.member?(records, dummy) end)
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn _, _ -> {:error, "must use DB cache"} end)
+
+      request = get(conn, "/api/v2/transactions/#{transaction_hash}/external_transactions")
+      assert response = json_response(request, 200)
+
+      assert length(response) == length(dummy_response) and
+               Enum.all?(dummy_response, fn dummy -> Enum.member?(response, dummy) end)
+    end
+
+    test "returns an error when RPC node request fails", %{conn: conn} do
+      transaction = insert(:transaction)
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn _, _ -> {:error, "must fail"} end)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external_transactions")
+      assert response = json_response(request, 500)
+
+      assert response == %{
+               "error" => "Unable to fetch external linked transactions",
+               "reason" => "\"Unable to fetch data from the node: \\\"must fail\\\"\""
+             }
+    end
+
+    test "returns empty list when RPC returns empty list", %{conn: conn} do
+      transaction = insert(:transaction)
+
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn _, _ -> {:ok, []} end)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/external_transactions")
+      assert response = json_response(request, 200)
+      assert ^response = []
+    end
+
+    test "returns 422 for invalid transaction hash", %{conn: conn} do
+      request = get(conn, "/api/v2/transactions/invalid_hash/external_transactions")
+      assert response = json_response(request, 422)
+      assert response["message"] == "Invalid parameter(s)"
+    end
+  end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -419,6 +419,32 @@ defmodule EthereumJSONRPC do
   end
 
   @doc """
+  Retrieves Solana transactions that are linked to a given Neon transaction.
+
+  ## Parameters
+    - `transaction_hash`: The hash of the Neon transaction
+    - `json_rpc_named_arguments`: Named arguments for JSON RPC call
+
+  ## Returns
+    - `{:ok, list()}`: List of linked Solana transactions
+    - `{:error, reason}`: If the request fails
+  """
+  @spec get_linked_solana_transactions(
+          Explorer.Chain.Hash.t(),
+          EthereumJSONRPC.json_rpc_named_arguments()
+        ) :: {:ok, list()} | {:error, reason :: term}
+  def get_linked_solana_transactions(transaction_hash, json_rpc_named_arguments) do
+    r =
+      request(%{
+        id: 1,
+        method: "neon_getSolanaTransactionByNeonTransaction",
+        params: [to_string(transaction_hash)]
+      })
+
+    EthereumJSONRPC.json_rpc(r, json_rpc_named_arguments)
+  end
+
+  @doc """
   Fetches pending transactions from variant API.
   """
   def fetch_pending_transactions(json_rpc_named_arguments) do

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -30,7 +30,8 @@ for repo <- [
       Explorer.Repo.Stability,
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
-      Explorer.Repo.ZkSync
+      Explorer.Repo.ZkSync,
+      Explorer.Repo.Neon
     ] do
   config :explorer, repo, timeout: :timer.seconds(80)
 end

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -32,7 +32,8 @@ for repo <- [
       Explorer.Repo.Stability,
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
-      Explorer.Repo.ZkSync
+      Explorer.Repo.ZkSync,
+      Explorer.Repo.Neon
     ] do
   config :explorer, repo,
     prepare: :unnamed,

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -71,7 +71,8 @@ for repo <- [
       Explorer.Repo.Stability,
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
-      Explorer.Repo.ZkSync
+      Explorer.Repo.ZkSync,
+      Explorer.Repo.Neon
     ] do
   config :explorer, repo,
     database: database,

--- a/apps/explorer/lib/explorer/chain/neon/linked_solana_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/neon/linked_solana_transactions.ex
@@ -1,0 +1,40 @@
+defmodule Explorer.Chain.Neon.LinkedSolanaTransactions do
+  @moduledoc """
+  A relation table  between a regular EVM transaction and multiple Solana transactions
+  """
+  use Explorer.Schema
+
+  alias Explorer.Chain.{Hash, Transaction}
+
+  @required_attrs ~w(neon_transaction_hash solana_transaction_hash)a
+
+  @primary_key false
+  typed_schema "neon_linked_solana_transactions" do
+    field(:neon_transaction_hash, :binary)
+    field(:solana_transaction_hash, :string)
+
+    belongs_to(:transaction, Transaction,
+      foreign_key: :neon_transaction_hash,
+      primary_key: true,
+      references: :hash,
+      type: Hash.Full,
+      define_field: false
+    )
+
+    timestamps()
+  end
+
+  @doc """
+    Validates that the `attrs` are valid.
+  """
+  @spec changeset(Ecto.Schema.t(), map()) :: Ecto.Schema.t()
+  def changeset(%__MODULE__{} = struct, attrs \\ %{}) do
+    struct
+    |> cast(attrs, @required_attrs)
+    |> validate_required(@required_attrs)
+    |> foreign_key_constraint(:neon_transaction_hash,
+      name: "neon_linked_solana_transactions_neon_transaction_hash_fkey"
+    )
+    |> unique_constraint(:solana_transaction_hash, name: "neon_linked_solana_transactions_hash_index")
+  end
+end

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -151,7 +151,8 @@ defmodule Explorer.Repo do
         Explorer.Repo.Stability,
         Explorer.Repo.Suave,
         Explorer.Repo.Zilliqa,
-        Explorer.Repo.ZkSync
+        Explorer.Repo.ZkSync,
+        Explorer.Repo.Neon
       ] do
     defmodule repo do
       use Ecto.Repo,

--- a/apps/explorer/priv/neon/migrations/20241203161152_create_neon_solana_transactions.exs
+++ b/apps/explorer/priv/neon/migrations/20241203161152_create_neon_solana_transactions.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.CreateNeonSolanaTransactions do
+  use Ecto.Migration
+
+  def change do
+    create table(:neon_linked_solana_transactions) do
+      add(:neon_transaction_hash, references(:transactions, column: :hash, on_delete: :delete_all, type: :bytea),
+        null: false
+      )
+
+      add(:solana_transaction_hash, :string, null: false)
+      timestamps()
+    end
+
+    create(unique_index(:neon_linked_solana_transactions, [:neon_transaction_hash, :solana_transaction_hash]))
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/neon_solana_transactions.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/neon_solana_transactions.ex
@@ -1,0 +1,84 @@
+defmodule Indexer.Fetcher.OnDemand.NeonSolanaTransactions do
+  @moduledoc """
+  A caching proxy service getting linked solana transactions from NeonEVM Node.
+  The corresponding node data is available only via a dedicated endpoint
+  so we don't fetch those unless a user explicitly requests so to minimize requests.
+  ## Caching Behavior
+  Fetched transactions are cached indefinitely in the database. There is no automatic cache invalidation.
+  ## Transaction Hash Format
+  Transaction hashes can be provided with or without "0x" prefix. The prefix will be automatically
+  removed before processing.
+  """
+  require Logger
+
+  import Ecto.Query, only: [from: 2]
+  alias Explorer.Chain.Neon.LinkedSolanaTransactions
+  alias Explorer.Repo
+
+  defp trigger_fetch(transaction_hash) do
+    arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
+
+    case EthereumJSONRPC.get_linked_solana_transactions(transaction_hash, arguments) do
+      {:ok, fetched} when is_list(fetched) ->
+        save_cache(transaction_hash, fetched)
+        {:ok, fetched}
+
+      {:error, reason} ->
+        {:error, "Unable to fetch data from the node: #{inspect(reason)}"}
+    end
+  end
+
+  defp cache(transaction_hash) do
+    Repo.all(
+      from(
+        solanaTransaction in LinkedSolanaTransactions,
+        where: solanaTransaction.neon_transaction_hash == ^transaction_hash.bytes,
+        select: solanaTransaction.solana_transaction_hash
+      )
+    )
+  rescue
+    e in Ecto.QueryError ->
+      Logger.warning("Failed to query cached external transactions: #{inspect(e)}")
+      []
+  end
+
+  defp save_cache(transaction_hash, fetched) do
+    entries =
+      Enum.map(fetched, fn sol_transaction_hash_string ->
+        %{
+          neon_transaction_hash: transaction_hash.bytes,
+          solana_transaction_hash: sol_transaction_hash_string,
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      end)
+
+    case Repo.transaction(fn ->
+           Repo.insert_all(
+             LinkedSolanaTransactions,
+             entries,
+             on_conflict: :nothing,
+             conflict_target: [:neon_transaction_hash, :solana_transaction_hash]
+           )
+         end) do
+      {:ok, _result} ->
+        nil
+
+      {:error, reason} ->
+        Logger.warning(
+          "Failed to save linked Solana transactions: #{inspect(reason)} for transaction hash: #{to_string(transaction_hash)}"
+        )
+    end
+  end
+
+  @spec maybe_fetch(Explorer.Chain.Hash.t()) :: {:ok, list} | {:error, String.t()}
+  def maybe_fetch(transaction_hash) do
+    case cache(transaction_hash) do
+      cached_data when cached_data != [] ->
+        {:ok, cached_data}
+
+      [] ->
+        trigger_fetch(transaction_hash)
+    end
+  end
+end

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -25,7 +25,8 @@ defmodule ConfigHelper do
         stability: Explorer.Repo.Stability,
         suave: Explorer.Repo.Suave,
         zilliqa: Explorer.Repo.Zilliqa,
-        zksync: Explorer.Repo.ZkSync
+        zksync: Explorer.Repo.ZkSync,
+        neon: Explorer.Repo.Neon
       }
       |> Map.get(chain_type())
 
@@ -350,7 +351,8 @@ defmodule ConfigHelper do
     "suave",
     "zetachain",
     "zilliqa",
-    "zksync"
+    "zksync",
+    "neon"
   ]
 
   @spec chain_type() :: atom() | nil

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -130,7 +130,8 @@ for repo <- [
       Explorer.Repo.ZkSync,
       # Feature dependent repos
       Explorer.Repo.BridgedTokens,
-      Explorer.Repo.ShrunkInternalTransactions
+      Explorer.Repo.ShrunkInternalTransactions,
+      Explorer.Repo.Neon
     ] do
   config :explorer, repo,
     database: database,

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -98,7 +98,8 @@ for repo <- [
       Explorer.Repo.Shibarium,
       Explorer.Repo.Stability,
       Explorer.Repo.Zilliqa,
-      Explorer.Repo.ZkSync
+      Explorer.Repo.ZkSync,
+      Explorer.Repo.Neon
     ] do
   config :explorer, repo,
     url: System.get_env("DATABASE_URL"),

--- a/cspell.json
+++ b/cspell.json
@@ -682,7 +682,8 @@
         "zkbob",
         "zkevm",
         "zksolc",
-        "zksync"
+        "zksync",
+        "solana"
     ],
     "enableFiletypes": [
         "dotenv",


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/11667

## Motivation

Allows fetching Solana transactions that are linked to the chosen NeonEVM transaction.

## Changelog

### Enhancements

* New chain_type `neon`
* New schema and a corresponding migration for a relation between EVM and Solana transactions. 
* New on-demand stateless fetcher that retrieves a list of linked Solana transactions and caches it in the database. Subsequent request use cached data. No cache invalidation is introduced at the moment.
* New endpoint `/api/v2/transactions/#{transaction_hash}/external_transactions` in the blockscout_web transaction controller
* New integration test as part of block_scout_web 

### Incompatible Changes

No incompatibilities are expected since the changes are enabled only for `neon` chain_type

## Upgrading

The prior version for NeonVM used `default` chain type, so the application must be recompiled with new value and relevant migration must be run.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for the Neon blockchain in BlockScout.
	- Introduced external transaction lookup for Neon transactions.
	- New API endpoint for retrieving linked Solana transactions.
	- Added a new module for managing linked Solana transactions associated with Neon transactions.

- **Infrastructure**
	- Updated CI/CD workflows to include Neon chain type.
	- Added new GitHub Actions for Neon pre-release and release processes.

- **Technical Improvements**
	- Enhanced database configuration to support Neon repository.
	- Implemented on-demand fetching of Solana transactions for Neon transactions.
	- Introduced a new repository for Neon transactions in the configuration files.
	- Improved spell-checking capabilities by adding "solana" to the recognized terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->