### PR TITLE
chore: Increase verbosity of error logs in TokenInstanceMetadataRefetch

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
@@ -86,7 +86,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch do
 
       {:fetched_metadata, error} ->
         Logger.error(fn ->
-          "Error while refetching metadata for {#{to_string(token_instance.token_contract_address_hash)}, #{token_id}}: #{inspect(error)}"
+          "Error while refetching metadata for {#{token_instance.token_contract_address_hash}, #{token_id}}: #{inspect(error)}"
         end)
 
         TokenInstanceMetadataRefetchAttempt.insert_retries_number(

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_instance_metadata_refetch.ex
@@ -84,9 +84,9 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch do
       {:empty_result, true} ->
         :ok
 
-      {:fetched_metadata, _error} ->
+      {:fetched_metadata, error} ->
         Logger.error(fn ->
-          "Error while setting address #{inspect(to_string(token_instance.token_contract_address_hash))} metadata"
+          "Error while refetching metadata for {#{to_string(token_instance.token_contract_address_hash)}, #{token_id}}: #{inspect(error)}"
         end)
 
         TokenInstanceMetadataRefetchAttempt.insert_retries_number(


### PR DESCRIPTION
## Motivation
Not detailed logs for failed attempts in TokenInstanceMetadataRefetch
## Changelog
- Log error and token id for failed attempts
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging for the metadata refetching process.
	- Enhanced error message details to provide more context during token metadata retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->