### PR TITLE
feat: Add ENS and metadata preload to /api/v2/tokens/{hash}/instances

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -161,7 +161,11 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       |> put_status(200)
       |> put_view(AddressView)
       |> render(:nft_list, %{
-        token_instances: token_instances |> put_owner(holder_address_with_proxy_implementations),
+        token_instances:
+          token_instances
+          |> put_owner(holder_address_with_proxy_implementations, holder_address_hash)
+          |> maybe_preload_ens()
+          |> maybe_preload_metadata(),
         next_page_params: next_page_params,
         token: token
       })
@@ -186,7 +190,11 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
       conn
       |> put_status(200)
-      |> render(:token_instances, %{token_instances: token_instances, next_page_params: next_page_params, token: token})
+      |> render(:token_instances, %{
+        token_instances: token_instances |> maybe_preload_ens() |> maybe_preload_metadata(),
+        next_page_params: next_page_params,
+        token: token
+      })
     end
   end
 
@@ -362,8 +370,11 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     end
   end
 
-  defp put_owner(token_instances, holder_address),
-    do: Enum.map(token_instances, fn token_instance -> %Instance{token_instance | owner: holder_address} end)
+  defp put_owner(token_instances, holder_address, holder_address_hash),
+    do:
+      Enum.map(token_instances, fn token_instance ->
+        %Instance{token_instance | owner: holder_address, owner_address_hash: holder_address_hash}
+      end)
 
   @spec put_token_to_instance(Instance.t(), Token.t()) :: Instance.t()
   defp put_token_to_instance(

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -223,13 +223,19 @@ defmodule BlockScoutWeb.API.V2.AddressView do
            ) do
         # `%{hash: address_hash}` will match with `address_with_info(_, address_hash)` clause in `BlockScoutWeb.API.V2.Helper`
         {:ok, token_instance} ->
-          %Instance{token_instance | owner: %{hash: address_hash}, current_token_balance: token_balance}
+          %Instance{
+            token_instance
+            | owner: %{hash: address_hash},
+              owner_address_hash: address_hash,
+              current_token_balance: token_balance
+          }
 
         {:error, :not_found} ->
           %Instance{
             token_id: token_id,
             metadata: nil,
             owner: %Address{hash: address_hash},
+            owner_address_hash: address_hash,
             current_token_balance: token_balance,
             token_contract_address_hash: token.contract_address_hash
           }

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -4476,7 +4476,7 @@ defmodule Explorer.Chain do
         )
       )
 
-    %{token_instance | owner: owner}
+    %{token_instance | owner: owner, owner_address_hash: owner_address_hash}
   end
 
   def put_owner_to_token_instance(%Instance{} = token_instance, _token, _options), do: token_instance

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -11,6 +11,7 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     Block,
     InternalTransaction,
     Log,
+    Token.Instance,
     TokenTransfer,
     Transaction,
     Withdrawal
@@ -68,6 +69,7 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
       |> Enum.reduce([], fn item, acc ->
         item_to_address_hash_strings(item) ++ acc
       end)
+      |> Enum.filter(&(&1 != ""))
       |> Enum.uniq()
 
     case BENS.ens_names_batch_request(address_hash_strings) do
@@ -186,6 +188,10 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     [to_string(hash)]
   end
 
+  defp item_to_address_hash_strings(%Instance{owner_address_hash: owner_address_hash}) do
+    [to_string(owner_address_hash)]
+  end
+
   defp put_ens_names(names, items) do
     Enum.map(items, &put_meta_to_item(&1, names, :ens_domain_name))
   end
@@ -284,6 +290,10 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
 
   defp put_meta_to_item(%Address{} = address, names, field_to_put_info) do
     alter_address(address, address.hash, names, field_to_put_info)
+  end
+
+  defp put_meta_to_item(%Instance{owner: owner_address, owner_address_hash: owner_address_hash} = instance, names, field_to_put_info) do
+    %Instance{instance | owner: alter_address(owner_address, owner_address_hash, names, field_to_put_info)}
   end
 
   defp alter_address(address, nil, _names, _field), do: address

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -292,7 +292,11 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     alter_address(address, address.hash, names, field_to_put_info)
   end
 
-  defp put_meta_to_item(%Instance{owner: owner_address, owner_address_hash: owner_address_hash} = instance, names, field_to_put_info) do
+  defp put_meta_to_item(
+         %Instance{owner: owner_address, owner_address_hash: owner_address_hash} = instance,
+         names,
+         field_to_put_info
+       ) do
     %Instance{instance | owner: alter_address(owner_address, owner_address_hash, names, field_to_put_info)}
   end
 


### PR DESCRIPTION
Closes #11495 

## Changelog
- Add ENS and metadata preload to `/api/v2/tokens/{hash}/instances`
 
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced token instance data retrieval with additional owner address hash information
	- Improved metadata preloading for token instances, including ENS support

- **Improvements**
	- Updated API responses to include more contextual information about token instances, transfers, and balances
	- Added more detailed address and ownership metadata for token-related entities

- **Technical Enhancements**
	- Refined data processing for token-related API endpoints
	- Expanded metadata preloading capabilities across multiple modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->