### PR TITLE
chore: update Twitter URL to x.com format

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/social_media.ex
+++ b/apps/block_scout_web/lib/block_scout_web/social_media.ex
@@ -6,7 +6,7 @@ defmodule BlockScoutWeb.SocialMedia do
   @services %{
     facebook: "https://www.facebook.com/",
     instagram: "https://www.instagram.com/",
-    twitter: "https://www.twitter.com/",
+    twitter: "https://www.x.com/",
     telegram: "https://t.me/"
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
@@ -24,7 +24,7 @@
           <a href="<%= Application.get_env(:block_scout_web, :footer)[:github_link] %>" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Github") %>'>
             <div class="footer-social-icon-container fontawesome-icon github"></div>
           </a>
-          <a href="https://www.twitter.com/blockscoutcom/" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Twitter") %>'>
+          <a href="https://www.x.com/blockscoutcom/" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Twitter") %>'>
             <div class="footer-social-icon-container fontawesome-icon twitter"></div>
           </a>
           <%= if Application.get_env(:block_scout_web, :footer)[:telegram_link_enabled] && Application.get_env(:block_scout_web, :footer)[:telegram_link] do %>

--- a/apps/block_scout_web/test/block_scout_web/social_media_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/social_media_test.exs
@@ -20,6 +20,6 @@ defmodule BlockScoutWeb.SocialMediaTest do
     Application.put_env(:block_scout_web, BlockScoutWeb.SocialMedia, twitter: "MyTwitterProfile")
 
     links = SocialMedia.links()
-    assert links[:twitter] == "https://www.twitter.com/MyTwitterProfile"
+    assert links[:twitter] == "https://www.x.com/MyTwitterProfile"
   end
 end


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com/) with the updated x.com format (https://x.com/) to align with the platform's rebranding.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Twitter (X) social media links across the application to use the new "x.com" domain

- **Documentation**
  - Reflected platform rebranding from Twitter to X in footer and social media configurations

- **Tests**
  - Updated test cases to validate new Twitter (X) URL format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->