### PR TITLE
fix: Add typeless handler for call_tracer

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -450,6 +450,11 @@ defmodule EthereumJSONRPC.Geth do
     end
   end
 
+  defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?) do
+    unless allow_empty_traces?(), do: log_unknown_type(call)
+    acc
+  end
+
   defp parse_call_tracer_calls(calls, acc, trace_address, _inner) when is_list(calls) do
     calls
     |> Stream.with_index()


### PR DESCRIPTION
## Motivation

Eliminates the following error:

```
{"time":"2025-01-31T10:52:00.163Z","severity":"error","message":"failed to fetch internal transactions for blocks [9219904, 9220501, 9220612]: ** (FunctionClauseError) no function clause matching in EthereumJSONRPC.Geth.parse_call_tracer_calls/4\n    (ethereum_jsonrpc 6.10.1) lib/ethereum_jsonrpc/geth.ex:406: EthereumJSONRPC.Geth.parse_call_tracer_calls({%{\"failed\" => false, \"gas\" => 0, \"returnValue\" => \"\", \"structLogs\" => []}, 0}, [], [], false)\n    (ethereum_jsonrpc 6.10.1) lib/ethereum_jsonrpc/geth.ex:400: EthereumJSONRPC.Geth.prepare_calls/1\n    (ethereum_jsonrpc 6.10.1) lib/ethereum_jsonrpc/geth.ex:351: EthereumJSONRPC.Geth.debug_trace_transaction_response_to_internal_transactions_params/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (ethereum_jsonrpc 6.10.1) lib/ethereum_jsonrpc/geth.ex:302: EthereumJSONRPC.Geth.debug_trace_transaction_responses_to_internal_transactions_params/3\n    (indexer 6.10.1) lib/indexer/fetcher/internal_transaction.ex:246: anonymous fn/3 in Indexer.Fetcher.InternalTransaction.fetch_block_internal_transactions_by_transactions/2\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n","metadata":{"count":3,"fetcher":"internal_transaction","error_count":3}}
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty trace structures in Ethereum JSON-RPC call tracing
	- Added logging for unexpected trace types to enhance error tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->