### PR TITLE
feature: Enable /api/v2/internal-transactions endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -178,10 +178,9 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/", V2.TokenTransferController, :token_transfers)
     end
 
-    # todo: enable this endpoint when DB index for underlying DB query will be installed.
-    # scope "/internal-transactions" do
-    #   get("/", V2.InternalTransactionController, :internal_transactions)
-    # end
+    scope "/internal-transactions" do
+      get("/", V2.InternalTransactionController, :internal_transactions)
+    end
 
     scope "/blocks" do
       get("/", V2.BlockController, :blocks)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10718

## Motivation

Enabling of `/api/v2/internal-transactions` endpoint.
Swagger update https://github.com/blockscout/blockscout-api-v2-swagger/pull/25.

## Changelog

Enables `/api/v2/internal-transactions` endpoint implemented in https://github.com/blockscout/blockscout/pull/10994 after creation of required DB index in https://github.com/blockscout/blockscout/pull/11604.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activated a new API endpoint (`/v2/internal-transactions`) to fetch internal transaction data.
  - Enhanced the endpoint’s behavior to conditionally return transaction details; if a migration is incomplete, it returns an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->