### PR TITLE
chore: Mention WC Project ID in common-frontend.env

### DIFF
--- a/docker-compose/envs/common-frontend.env
+++ b/docker-compose/envs/common-frontend.env
@@ -15,3 +15,5 @@ NEXT_PUBLIC_VISUALIZE_API_HOST=http://localhost:8081
 NEXT_PUBLIC_IS_TESTNET=true
 NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
 NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
+# Required to enable blockchain interaction
+# NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=


### PR DESCRIPTION
This mentions the required `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` environment variable to enable blockchain interaction via web3 modal in the common env var setup for Docker Compose.

*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

I tried to use Blockchain as a local block explorer to verify the deployed contracts and fiddle with them myself using a UI. 
However, I found it hard to discover why the interaction was disabled and it took a while to find out that there's a separate `frontend` repo, in which the environment variable was buried in the web3 modal init code.

Only now I can see that `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` is documented at https://github.com/blockscout/docs/blob/master/setup/env-variables/frontend-common-envs/envs.md, so I'm sorry I didn't spot that before.

However, since interacting with blockchain via UI seems rather ubiquitous, I'd like to propose to set that to a dummy variable (similarly what we do with "Awesome chain") or at least have it (commented) there for visibility.

Feel free to close it or change it so that we uncomment it or set to a dummy value, instead.

Thanks for working on such a great product, by the way!

## Changelog
N/A
## Upgrading
N/A

## Checklist for your Pull Request (PR)

- [X] None of the below
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined configuration documentation by adding a clarifying comment and ensuring proper formatting. These changes improve maintainability and clarity without affecting current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->