### PR TITLE
fix: Use safe field access in CurrentTokenBalances.should_update?/2

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -295,7 +295,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
 
   # new ctb is the same height or older
   defp should_update?(new_ctb, existing_ctb) do
-    existing_ctb.block_number == new_ctb.block_number and not is_nil(new_ctb.value) and
+    existing_ctb.block_number == new_ctb.block_number and not is_nil(Map.get(new_ctb, :value)) and
       (is_nil(existing_ctb.value_fetched_at) or existing_ctb.value_fetched_at < new_ctb.value_fetched_at)
   end
 


### PR DESCRIPTION
## Changelog

Fix current token balance placeholder handling in case when there is an existing one on the same height

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the process for updating token balance data to enhance reliability when handling missing or incomplete information, ensuring smoother and safer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->