### PR TITLE
fix: Fix tests

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
@@ -96,12 +96,12 @@ defmodule BlockScoutWeb.API.V2.FilecoinView do
         |> Enum.map(& &1["address"])
         |> Enum.reject(&is_nil/1)
         |> Chain.hashes_to_addresses(@api_true)
-        |> Enum.group_by(&to_string(&1.hash))
+        |> Enum.into(%{}, &{to_string(&1.hash), &1})
 
       search_results
       |> Enum.map(fn
         %{"address" => address_hash} = result when not is_nil(address_hash) ->
-          address = addresses_map[String.downcase(address_hash)] |> List.first()
+          address = addresses_map[String.downcase(address_hash)]
           put_filecoin_robust_address(result, %{address: address, field_prefix: nil})
 
         other ->

--- a/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
@@ -136,6 +136,7 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
           :instances,
           :token,
           :transaction,
+          :token_instance,
           :__meta__
         ])
       end)


### PR DESCRIPTION
## Motivation
```
  1) test Sanitize duplicated log index logs correctly identifies and updates duplicated log index logs & updates corresponding token transfers and token instances (Explorer.Migrator.SanitizeDuplicatedLogIndexLogsTest)
Error:      test/explorer/migrator/sanitize_duplicated_log_index_logs_test.exs:54
     ** (EXIT from #PID<0.16158.0>) an exception was raised:
         ** (ArgumentError) unknown field `:token_instance` in schema Explorer.Chain.TokenTransfer given to insert_all. Unwritable fields, such as virtual and read only fields are not supported. Associations are also not supported
             (ecto 3.12.5) lib/ecto/repo/schema.ex:190: anonymous fn/6 in Ecto.Repo.Schema.init_mapper/4
```
&
```
  3) test /search check pagination #4 (ens and metadata tags (complex case) added) (BlockScoutWeb.API.V2.SearchControllerTest)
Error:      test/block_scout_web/controllers/api/v2/search_controller_test.exs:769
     ** (FunctionClauseError) no function clause matching in List.first/2

     The following arguments were given to List.first/2:

         # 1
         nil

         # 2
         nil

     Attempted function clauses (showing 2 out of 2):

         def first(-[]-, default)
         def first(-[head | _]-, _default)
```
## Changelog


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the processing of search results by updating the address mapping logic for robust address lookups.
- **Chore**
	- Adjusted the log sanitization process for token transfers to exclude an unnecessary field during data preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->