### PR TITLE
fix: Fix scam addresses ban in quick search

### DIFF
--- a/.dialyzer-ignore
+++ b/.dialyzer-ignore
@@ -8,4 +8,4 @@ lib/explorer/smart_contract/stylus/publisher_worker.ex:8
 lib/phoenix/router.ex:402
 lib/explorer/chain/search.ex:81
 lib/explorer/chain/search.ex:228
-lib/explorer/chain/search.ex:319
+lib/explorer/chain/search.ex:324

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -312,7 +312,12 @@ defmodule Explorer.Chain.Search do
           [
             address_hash
             |> search_token_by_address_hash_query()
-            |> union_all(^search_address_by_address_hash_query(address_hash))
+            |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+            |> union_all(
+              ^(address_hash
+                |> search_address_by_address_hash_query()
+                |> ExplorerHelper.maybe_hide_scam_addresses(:hash, options))
+            )
             |> select_repo(options).all()
           ]
 


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved search result filtering to ensure that scam addresses are hidden from view, enhancing the overall reliability of search outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->