### PR TITLE
doc: Correct the docker compose command for running an external fr…

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -51,7 +51,7 @@ The repo contains built-in configs for different JSON RPC clients without need t
 
 - Running only explorer without DB: `docker-compose -f external-db.yml up -d`. In this case, no db container is created. And it assumes that the DB credentials are provided through `DATABASE_URL` environment variable on the backend container.
 - Running explorer with external backend: `docker-compose -f external-backend.yml up -d`
-- Running explorer with external frontend: `docker-compose -f external-frontend.yml up -d`
+- Running explorer with external frontend: `FRONT_PROXY_PASS=http://host.docker.internal:3000/ docker-compose -f external-frontend.yml up -d`
 - Running all microservices: `docker-compose -f microservices.yml up -d`
 - Running only explorer without microservices: `docker-compose -f no-services.yml up -d`
 


### PR DESCRIPTION
FRONT_PROXY_PASS is necessary for using the external frontend when the backend is set up using docker compose
(https://docs.blockscout.com/setup/deployment/frontend-migration/separate-frontend#id-4-run-docker-compose-with-front_proxy_pass-variable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the command instructions for running the explorer with an external frontend to now include a proxy configuration environment variable. This enhancement ensures that users explicitly set the frontend proxy address when launching the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->