### PR TITLE
chore: GraphQL introspection plug

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -107,8 +107,7 @@ config :block_scout_web, BlockScoutWeb.CSPHeader,
 config :block_scout_web, Api.GraphQL,
   enabled: ConfigHelper.parse_bool_env_var("API_GRAPHQL_ENABLED", "true"),
   token_limit: ConfigHelper.parse_integer_env_var("API_GRAPHQL_TOKEN_LIMIT", 1000),
-  # Needs to be 215 to support the schema introspection for graphiql
-  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 215)
+  max_complexity: ConfigHelper.parse_integer_env_var("API_GRAPHQL_MAX_COMPLEXITY", 100)
 
 # Configures Ueberauth local settings
 config :ueberauth, Ueberauth,

--- a/apps/block_scout_web/lib/block_scout_web/graphql/schema_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/schema_controller.ex
@@ -1,9 +1,17 @@
 defmodule BlockScoutWeb.GraphQL.SchemaController do
+  @moduledoc """
+  Controller for serving the GraphQL schema in SDL format.
+  """
+
   use BlockScoutWeb, :controller
 
   @graphql_schema BlockScoutWeb.GraphQL.Schema
                   |> Absinthe.Schema.to_sdl()
 
+  @doc """
+  The GraphQL schema in SDL format, pre-built at compile time to avoid runtime
+  overhead.
+  """
   def index(conn, _params) do
     conn
     |> put_resp_content_type("text/plain")

--- a/apps/block_scout_web/lib/block_scout_web/graphql/schema_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/schema_controller.ex
@@ -1,0 +1,12 @@
+defmodule BlockScoutWeb.GraphQL.SchemaController do
+  use BlockScoutWeb, :controller
+
+  @graphql_schema BlockScoutWeb.GraphQL.Schema
+                  |> Absinthe.Schema.to_sdl()
+
+  def index(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, @graphql_schema)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/plug/graphql_schema_introspection.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/graphql_schema_introspection.ex
@@ -1,4 +1,12 @@
 defmodule BlockScoutWeb.Plug.GraphQLSchemaIntrospection do
+  @moduledoc """
+  A plug that handles GraphQL introspection queries by returning a pre-computed
+  schema.
+
+  This plug intercepts GraphQL introspection queries and returns a cached JSON
+  response of the schema, avoiding the need to recompute the introspection
+  result for each request.
+  """
   import Plug.Conn
   alias Absinthe.Schema
 

--- a/apps/block_scout_web/lib/block_scout_web/plug/graphql_schema_introspection.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/graphql_schema_introspection.ex
@@ -1,0 +1,26 @@
+defmodule BlockScoutWeb.Plug.GraphQLSchemaIntrospection do
+  import Plug.Conn
+  alias Absinthe.Schema
+
+  @introspection_json BlockScoutWeb.GraphQL.Schema
+                      |> Schema.introspect()
+                      |> (case do
+                            {:ok, data} -> Jason.encode!(data)
+                            {:error, _} -> raise "Failed to introspect schema"
+                          end)
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    case conn.params["operationName"] do
+      "IntrospectionQuery" ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(200, @introspection_json)
+        |> halt()
+
+      _ ->
+        conn
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -7,7 +7,6 @@ defmodule BlockScoutWeb.Router do
     api_router_reading_enabled: [:block_scout_web, [BlockScoutWeb.Routers.ApiRouter, :reading_enabled]],
     web_router_enabled: [:block_scout_web, [BlockScoutWeb.Routers.WebRouter, :enabled]]
 
-  alias BlockScoutWeb.Plug.{GraphQL, RateLimit}
   alias BlockScoutWeb.Routers.{AccountRouter, ApiRouter}
 
   @max_query_string_length 5_000
@@ -58,7 +57,7 @@ defmodule BlockScoutWeb.Router do
 
     plug(BlockScoutWeb.Plug.Logger, application: :api)
     plug(:accepts, ["json"])
-    plug(RateLimit, graphql?: true)
+    plug(BlockScoutWeb.Plug.RateLimit, graphql?: true)
   end
 
   match(:*, "/auth/*path", AccountRouter, [])
@@ -72,7 +71,7 @@ defmodule BlockScoutWeb.Router do
       forward("/", Absinthe.Plug.GraphiQL,
         schema: BlockScoutWeb.GraphQL.Schema,
         interface: :advanced,
-        default_query: GraphQL.default_query(),
+        default_query: BlockScoutWeb.Plug.GraphQL.default_query(),
         socket: BlockScoutWeb.UserSocket
       )
     end
@@ -90,6 +89,10 @@ defmodule BlockScoutWeb.Router do
     else
       get("/api-docs", PageNotFoundController, :index)
       get("/eth-rpc-api-docs", PageNotFoundController, :index)
+    end
+
+    if @graphql_enabled do
+      get("/schema.graphql", GraphQL.SchemaController, :index)
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -102,6 +102,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     plug(BlockScoutWeb.Plug.Logger, application: :api)
     plug(:accepts, ["json"])
     plug(RateLimit, graphql?: true)
+    plug(BlockScoutWeb.Plug.GraphQLSchemaIntrospection)
   end
 
   alias BlockScoutWeb.API.V2

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/introspection_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/introspection_test.exs
@@ -112,7 +112,12 @@ defmodule BlockScoutWeb.Schema.Query.IntrospectionTest do
     }
     """
 
-    conn = get(conn, "/api/v1/graphql", query: introspection_query)
+    params = %{
+      "operationName" => "IntrospectionQuery",
+      "query" => introspection_query
+    }
+
+    conn = get(conn, "/api/v1/graphql", params)
     response = json_response(conn, 200)
 
     assert %{"data" => %{"__schema" => %{"directives" => _}}} = response


### PR DESCRIPTION
Closes #11845.

## Motivation

This PR lowers the default maximum GraphQL query complexity by handling introspection queries separately. Previously, the maximum complexity needed to be kept high to accommodate introspection queries, which could inadvertently allow other resource-intensive operations. By isolating introspection requests, we can safely reduce the complexity limit for regular queries, enhancing overall API security and performance.

## Changelog

- **Enhanced Introspection Handling**:
  A new plug has been added to better manage introspection queries. This plug intercepts GraphQL introspection queries early in the request lifecycle (relying on `operationName` attribute) and, when a introspection operation is detected, immediately returns a pre-built static introspection result. This ensures that introspection queries do not unnecessarily consume processing resources or bypass our complexity limits.

- **Reduced default value for `API_GRAPHQL_MAX_COMPLEXITY`** :
  The default maximum GraphQL query complexity has been lowered from $215$ to $100$. This change aims to mitigate potential performance issues and reduce the risk of resource exhaustion by limiting overly complex queries.

- **GraphQL Schema Endpoint**:  
  An endpoint `/schema.graphql` has been added, returning a pre-built GraphQL schema generated at compile time using `Absinthe.Schema.to_sdl/1`. This endpoint is particularly useful for importing the schema into API clients (e.g., Postman), which omit the `operationName` in their introspection queries, causing the query to exceed the complexity limit and fail.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables). 
     https://github.com/blockscout/docs/pull/388
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lowered the default maximum GraphQL query complexity, which may influence how queries are processed.
  - Enhanced GraphQL introspection by serving a cached schema response for improved performance.
  - Added a new endpoint that delivers the GraphQL schema in plain text for easier access when enabled.
  - Introduced a new controller for handling GraphQL schema requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->