### PR TITLE
fix: Increase DB pool size to take into account Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch

### DIFF
--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -39,9 +39,10 @@ defmodule Indexer.Application do
           Indexer.Fetcher.TokenInstance.Refetch.Supervisor
         ) +
         token_instance_fetcher_pool_size(Indexer.Fetcher.TokenInstance.SanitizeERC1155, nil) +
-        token_instance_fetcher_pool_size(Indexer.Fetcher.TokenInstance.SanitizeERC721, nil) + 1
+        token_instance_fetcher_pool_size(Indexer.Fetcher.TokenInstance.SanitizeERC721, nil) + 1 + 1
 
     # + 1 (above in pool_size calculation) for the Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch
+    # + 1 (above in pool_size calculation) for the Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch
 
     base_children = [
       :hackney_pool.child_spec(:token_instance_fetcher, max_connections: pool_size),


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10263

## Motivation

```
GenServer Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch terminating\n** (DBConnection.ConnectionError) ssl recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)\n    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1096: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:994: Ecto.Adapters.SQL.execute/6\n    (indexer 7.0.0) lib/indexer/fetcher/on_demand/nft_collection_metadata_refetch.ex:34: Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch.handle_cast/2\n    (stdlib 6.1) gen_server.erl:2371: :gen_server.try_handle_cast/3\n    (stdlib 6.1) gen_server.erl:2433: :gen_server.handle_msg/6\n    (stdlib 6.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3\nLast message: {:\"$gen_cast\", {:refetch, %Explorer.Chain.Token{__meta__: #Ecto.Schema.Metadata<:loaded, \"tokens\">, name: \"Azuki\", symbol: \"AZUKI\", total_supply: Decimal.new(\"14812\"), decimals: nil, type: \"ERC-721\", cataloged: true, holder_count: 5874, skip_metadata: nil, total_supply_updated_at_block: 7690918, metadata_updated_at: ~U[2025-02-08 21:27:39.426274Z], fiat_value: nil, circulating_market_cap: nil, icon_url: nil, is_verified_via_admin_panel: false, volume_24h: nil, contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<172, 54, 250, 135, 122, 223, 181, 107, 18, 226, 162, 216, 237, 167, 228, 164, 2, 42, 230, 255>>}, contract_address: %Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, \"addresses\">, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<172, 54, 250, 135, 122, 223, 181, 107, 18, 226, 162, 216, 237, 167, 228, 164, 2, 42, 230, 255>>}, fetched_coin_balance: #Explorer.Chain.Wei<0>, fetched_coin_balance_block_number: 7674434, contract_code: %Explorer.Chain.Data{bytes: <<96, 128, 96, 64, 82, 52, 128, 21, 97, 0, 16, 87, 96, 0, 128, 253, 91, 80, 96, 4, 54, 16, ...>>}, nonce: nil, decompiled: false, verified: false, has_decompiled_code?: nil, stale?: nil, transactions_count: nil, token_transfers_count: nil, gas_used: nil, ens_domain_name: nil, metadata: nil,...
```

## Changelog

Extend token_instance_fetcher pool size to take into account connection from Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch fetcher.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved background processing reliability by increasing the number of operational instances for metadata tasks, which supports enhanced performance in handling metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->