### PR TITLE
fix: Cleanup token instance metadata on nft collection metadata refetch

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -1044,7 +1044,19 @@ defmodule Explorer.Chain.Token.Instance do
       from(instance in __MODULE__,
         where: instance.token_contract_address_hash == ^token_contract_address_hash
       ),
-      [set: [metadata: nil, error: @marked_to_refetch, updated_at: now]],
+      [
+        set: [
+          metadata: nil,
+          error: @marked_to_refetch,
+          thumbnails: nil,
+          media_type: nil,
+          cdn_upload_error: nil,
+          is_banned: false,
+          retries_count: 0,
+          refetch_after: nil,
+          updated_at: now
+        ]
+      ],
       timeout: @timeout
     )
   end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/10263

## Motivation

Cleanup token instance metadata on nft collection metadata refetch

## AI Agent Changelog summary

This pull request includes changes to the `apps/explorer/lib/explorer/chain/token/instance.ex` file to update the attributes set when a token instance is marked for refetching. The most important changes include adding new attributes to the `set` list and initializing their values.

Updates to attributes:

* [`apps/explorer/lib/explorer/chain/token/instance.ex`](diffhunk://#diff-05c6d0bbb8f8224b1201c221d7d5d5cb24bbcbc1b78ae5d728e6ca879d4fa65cL1047-R1059): Added `thumbnails`, `media_type`, `cdn_upload_error`, `is_banned`, `retries_count`, and `refetch_after` to the `set` list and initialized their values when a token instance is marked for refetching.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
