### PR TITLE
fix: `/verified-contracts` in old UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix /verified-contracts in old UI ([#11854](https://github.com/blockscout/blockscout/pull/11854))
 - Cleanup token instance metadata on nft collection metadata refetch ([#11848](https://github.com/blockscout/blockscout/pull/11848))
 - Allow skip fiat_value in /api/v2/addresses/{hash}/tokens endpoint ([#11837](https://github.com/blockscout/blockscout/pull/11837))
 - Handle invalid BLACKFORT_VALIDATOR_API_URL ([#11812](https://github.com/blockscout/blockscout/issues/11812))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
@@ -11,7 +11,10 @@ defmodule BlockScoutWeb.VerifiedContractsController do
   alias Explorer.Chain.SmartContract
   alias Phoenix.View
 
-  @necessity_by_association %{[address: :token] => :optional}
+  @necessity_by_association %{
+    [address: :token] => :optional,
+    address: :required
+  }
 
   def index(conn, %{"type" => "JSON"} = params) do
     full_options =

--- a/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/address/_responsive_hash.html.eex
@@ -32,7 +32,7 @@
       <%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %>
     <% else %>
       <span class="d-none d-md-none d-xl-inline"><%= @address %></span>
-      <span class="d-md-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address.hash) %></span>
+      <span class="d-md-inline-block d-xl-none"><%= BlockScoutWeb.AddressView.trimmed_hash(@address && @address.hash) %></span>
     <% end %>
   <% end %>
 </span>

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -178,6 +178,8 @@ defmodule BlockScoutWeb.AddressView do
   @doc """
   Returns the primary name of an address if available. If there is no names on address function performs preload of names association.
   """
+  def primary_name(nil), do: nil
+
   def primary_name(%Address{names: [_ | _]} = address) do
     APIV2Helper.address_name(address)
   end


### PR DESCRIPTION
Closes #11853.

Fix for the following problem in old ui: 

```
2025-02-13T14:13:14.991 [error] #PID<0.2705.0> running BlockScoutWeb.Endpoint (connection #PID<0.2686.0>, stream id 5) terminated
Server: localhost:4000 (http)
Request: GET /verified-contracts?type=JSON
** (exit) an exception was raised:
    ** (Ecto.QueryError) invalid query has specified more bindings than bindings available in `where` (look for `unknown_binding!` in the printed query below) in query:

from s0 in Explorer.Chain.SmartContract,
  where: unknown_binding_1!.verified == true,
  order_by: [desc: s0.id],
  limit: ^51,
  select: s0,
  preload: [address: :token]

        (elixir 1.17.3) lib/enum.ex:1829: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
        (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
        (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
        (ecto 3.12.5) lib/ecto/repo/queryable.ex:214: Ecto.Repo.Queryable.execute/4
        (ecto 3.12.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
        (block_scout_web 7.0.0) lib/block_scout_web/controllers/verified_contracts_controller.ex:23: BlockScoutWeb.VerifiedContractsController.index/2
        (block_scout_web 7.0.0) lib/block_scout_web/controllers/verified_contracts_controller.ex:1: BlockScoutWeb.VerifiedContractsController.action/2
        (block_scout_web 7.0.0) lib/block_scout_web/controllers/verified_contracts_controller.ex:1: BlockScoutWeb.VerifiedContractsController.phoenix_controller_pipeline/2
        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
```

- Add `:address` as `:required` preload.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for Arbitrum, including indexing of L1-L2 messages and batch transactions.
  - Integrated with Sourcify for partially verified contracts.
  - Introduced new API endpoints for user operations and additional Ethereum client variants.
  - Enhanced user interface with a new dark theme and network selector.

- **Bug Fixes**
  - Improved error handling for address hash retrieval to prevent runtime errors.
  - Enhanced robustness of primary name handling for nil inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->