### PR TITLE
fix: Fix Indexer.Fetcher.ContractCode unhandled error

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -183,6 +183,9 @@ defmodule Indexer.Fetcher.ContractCode do
             zilliqa_verify_scilla_contracts(entries, addresses)
             :ok
 
+          {:ok, %{}} ->
+            {:retry, entries}
+
           {:error, step, reason, _changes_so_far} ->
             Logger.error(
               fn ->

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -169,6 +169,9 @@ defmodule Indexer.Fetcher.ContractCode do
     )
     |> EthereumJSONRPC.fetch_balances(json_rpc_named_arguments, BlockNumber.get_max())
     |> case do
+      {:ok, %{params_list: []}} ->
+        {:retry, entries}
+
       {:ok, fetched_balances} ->
         balance_addresses_params = CoinBalanceHelper.balances_params_to_address_params(fetched_balances.params_list)
 
@@ -182,9 +185,6 @@ defmodule Indexer.Fetcher.ContractCode do
             Accounts.drop(addresses)
             zilliqa_verify_scilla_contracts(entries, addresses)
             :ok
-
-          {:ok, %{}} ->
-            {:retry, entries}
 
           {:error, step, reason, _changes_so_far} ->
             Logger.error(


### PR DESCRIPTION
## Motivation

An error was discovered during local testing in `Indexer.Fetcher.ContractCode` module when the node is down:
```
{"time":"2025-02-16T14:27:04.477Z","severity":"error","message":"Task #PID<0.1566033.0> started from Indexer.Fetcher.ContractCode terminating\n** (CaseClauseError) no case clause matching: {:ok, %{}}\n    (indexer 7.0.0) lib/indexer/fetcher/contract_code.ex:177: Indexer.Fetcher.ContractCode.import_with_balances/3\n    (indexer 7.0.0) lib/indexer/fetcher/contract_code.ex:142: Indexer.Fetcher.ContractCode.run/2\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [fetcher: :code], callback_module: Indexer.Fetcher.ContractCode, batch: [%Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<153, 35, 211, 204, 9, 65, 35, 188, 99, 193, 98, 104, 145, 54, 13, 77, 57, 199, 158, 33, 172, 159, 42, 133, 55, 93, 70, 12, 116, 127, 238, 231>>}, block_number: 4341979, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: nil, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_internal_transactions: nil, has_token_transfers: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, internal_transactions: #Ecto.Association.NotLoaded<association :internal_transactions is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, transaction_actions: #Ecto.Association.NotLoaded<association :transaction_actions is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, created_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, ...}, created_contract_address: #Ecto.Association.NotLoaded<association :created_contract_address is not loaded>, ...}, %Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<69, 249, 197, 84, 180, 253, 192, 104, 96, 14, 223, 206, 26, 89, 6, 168, 187, 145, 61, 80, 168, 212, 39, 75, 192, 232, 142, 252, 82, 241, 140, 57>>}, block_number: 6074731, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: nil, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_internal_transactions: nil, has_token_transfers: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, internal_transactions: #Ecto.Association.NotLoaded<association :internal_transactions is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, transaction_actions: #Ecto.Association.NotLoaded<association :transaction_actions is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, created_contract_address_hash: %Explorer.Chain.Hash{...}, ...}, %Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<203, 155, 132, 202, 237, 193, 189, 124, 189, 46, 120, 92, 215, 11, 14, 157, 27, 36, 241, 148, 254, 85, 150, 134, 43, 214, 8, 171, 249, 153, 54, 241>>}, block_number: 5240493, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: nil, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_internal_transactions: nil, has_token_transfers: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, internal_transactions: #Ecto.Association.NotLoaded<association :internal_transactions is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, transaction_actions: #Ecto.Association.NotLoaded<association :transaction_actions is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, ...}, %Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<38, 119, 231, 170, 238, 177, 208, 44, 111, 184, 168, 198, 86, 10, 51, 165, 157, 117, 246, 21, 53, 248, 255, 206, 129, 228, 24, 64, 22, 32, 71, 192>>}, block_number: 5383707, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: nil, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_internal_transactions: nil, has_token_transfers: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, internal_transactions: #Ecto.Association.NotLoaded<association :internal_transactions is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, transaction_actions: #Ecto.Association.NotLoaded<association :transaction_actions is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, ...}, %Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<204, 62, 17, 8, 27, 101, 74, 128, 121, 130, 35, 200, 83, 103, 12, 189, 55, 64, 210, 165, 15, 102, 209, 169, 235, 182, 128, 226, 131, 29, 230, 69>>}, block_number: 7199332, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: nil, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_interna (truncated)","metadata":{"error":{"initial_call":null,"reason":"** (CaseClauseError) no case clause matching: {:ok, %{}}\n    (indexer 7.0.0) lib/indexer/fetcher/contract_code.ex:177: Indexer.Fetcher.ContractCode.import_with_balances/3\n    (indexer 7.0.0) lib/indexer/fetcher/contract_code.ex:142: Indexer.Fetcher.ContractCode.run/2\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\n"},"fetcher":"code"}}
```

## AI Agent summary

This pull request includes a small but important change to the `apps/indexer/lib/indexer/fetcher/contract_code.ex` file. The change adds a new clause to handle an `{:ok, %{}}` response by retrying the entries.

* [`apps/indexer/lib/indexer/fetcher/contract_code.ex`](diffhunk://#diff-5773a0a471c8dce6a22d64c00382f78f9db293911b4393184974736fd7c4897eR186-R188): Added a new clause to handle `{:ok, %{}}` responses by returning `{:retry, entries}`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the data import process to automatically retry when no balance parameters are available, enhancing the system's overall stability and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->