### PR TITLE
fix: Fix finding of first block to index

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -72,6 +72,36 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
   end
 
   @doc """
+  Extracts the minimum block number from a given block ranges string.
+
+  ## Parameters
+
+    - block_ranges_string: A string representing block ranges.
+
+  ## Returns
+
+    - The minimum block number as an integer.
+
+  ## Examples
+
+      iex> get_min_block_number_from_range_string("100..200,300..400")
+      100
+
+  """
+  @spec get_min_block_number_from_range_string(binary()) :: integer()
+  def get_min_block_number_from_range_string(block_ranges_string) do
+    min_block_number =
+      case block_ranges_string
+           |> parse_block_ranges()
+           |> Enum.at(0) do
+        block_number.._//_ -> block_number
+        block_number -> block_number
+      end
+
+    min_block_number
+  end
+
+  @doc """
   Checks if `number` is present in `ranges`
   """
   @spec number_in_ranges?(integer(), [Range.t()]) :: boolean()

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1482,7 +1482,8 @@ defmodule Explorer.Chain do
     if indexer_running?() do
       %{min: min_saved_block_number, max: max_saved_block_number} = BlockNumber.get_all()
 
-      min_blockchain_block_number = Application.get_env(:indexer, :first_block)
+      min_blockchain_block_number =
+        RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
       case {min_saved_block_number, max_saved_block_number} do
         {0, 0} ->

--- a/apps/explorer/lib/explorer/chain/block_number_helper.ex
+++ b/apps/explorer/lib/explorer/chain/block_number_helper.ex
@@ -13,6 +13,8 @@ defmodule Explorer.Chain.BlockNumberHelper do
 
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
+  alias EthereumJSONRPC.Utility.RangesHelper
+
   @doc """
     Returns the previous block number in the blockchain sequence.
 
@@ -83,7 +85,7 @@ defmodule Explorer.Chain.BlockNumberHelper do
     Moves block number by one in the specified direction.
 
     When moving backward from the configured minimum possible blockchain block number
-    (set in :indexer, :first_block), returns that minimum block number to maintain
+    (set in :indexer, :block_ranges), returns that minimum block number to maintain
     the lower boundary. Callers implementing block traversal loops must explicitly check
     for the minimum block number to prevent infinite loops, as moving backward from the
     minimum block will continuously return the same number.
@@ -111,7 +113,7 @@ defmodule Explorer.Chain.BlockNumberHelper do
   """
   @spec move_by_one(non_neg_integer(), :previous | :next) :: non_neg_integer()
   def move_by_one(number, direction) do
-    min_block = Application.get_env(:indexer, :first_block)
+    min_block = RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
     case {number, direction} do
       {n, :previous} when n <= min_block -> min_block

--- a/apps/explorer/lib/explorer/chain/cache/helper.ex
+++ b/apps/explorer/lib/explorer/chain/cache/helper.ex
@@ -2,6 +2,7 @@ defmodule Explorer.Chain.Cache.Helper do
   @moduledoc """
   Common helper functions for cache modules
   """
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain
 
   @block_number_threshold_1 10_000
@@ -48,7 +49,9 @@ defmodule Explorer.Chain.Cache.Helper do
   """
   @spec ttl(atom, String.t()) :: non_neg_integer()
   def ttl(module, management_variable) do
-    min_blockchain_block_number = Application.get_env(:indexer, :first_block)
+    min_blockchain_block_number =
+      RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
+
     max_block_number = Chain.fetch_max_block_number()
     blocks_amount = max_block_number - min_blockchain_block_number
     global_ttl_from_var = Application.get_env(:explorer, module)[:global_ttl]

--- a/apps/explorer/lib/explorer/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/counters/average_block_time.ex
@@ -6,6 +6,7 @@ defmodule Explorer.Counters.AverageBlockTime do
 
   import Ecto.Query, only: [from: 2, where: 2]
 
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain.Block
   alias Explorer.Repo
   alias Timex.Duration
@@ -69,7 +70,8 @@ defmodule Explorer.Counters.AverageBlockTime do
   end
 
   defp refresh_timestamps do
-    first_block_from_config = Application.get_env(:indexer, :first_block)
+    first_block_from_config =
+      RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
     base_query =
       from(block in Block,

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -966,7 +966,7 @@ defmodule Explorer.ChainTest do
     end
 
     test "returns 1.0 if fully indexed blocks starting from given FIRST_BLOCK" do
-      Application.put_env(:indexer, :first_block, 5)
+      Application.put_env(:indexer, :block_ranges, "5..latest")
 
       for index <- 5..9 do
         insert(:block, number: index, consensus: true)

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -173,7 +173,8 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   end
 
   defp first_block do
-    first_block_from_config = Application.get_env(:indexer, :first_block)
+    first_block_from_config =
+      RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
     min_missing_block_number =
       "min_missing_block_number"

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/data_backfill.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/data_backfill.ex
@@ -37,6 +37,7 @@ defmodule Indexer.Fetcher.Arbitrum.DataBackfill do
 
   require Logger
 
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Common, as: ArbitrumDbUtils
   alias Indexer.Fetcher.Arbitrum.Workers.Backfill
@@ -63,7 +64,9 @@ defmodule Indexer.Fetcher.Arbitrum.DataBackfill do
               "to allow for json_rpc calls when running."
     end
 
-    indexer_first_block = Application.get_all_env(:indexer)[:first_block]
+    indexer_first_block =
+      RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
+
     rollup_chunk_size = Application.get_all_env(:indexer)[Indexer.Fetcher.Arbitrum][:rollup_chunk_size]
     backfill_blocks_depth = Application.get_all_env(:indexer)[__MODULE__][:backfill_blocks_depth]
     recheck_interval = Application.get_all_env(:indexer)[__MODULE__][:recheck_interval]

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/rollup_messages_catchup.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/rollup_messages_catchup.ex
@@ -61,6 +61,7 @@ defmodule Indexer.Fetcher.Arbitrum.RollupMessagesCatchup do
 
   import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_warning: 1]
 
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Common, as: DbCommon
   alias Indexer.Fetcher.Arbitrum.Workers.HistoricalMessagesOnL2
 
@@ -88,7 +89,8 @@ defmodule Indexer.Fetcher.Arbitrum.RollupMessagesCatchup do
   def init(args) do
     Logger.metadata(fetcher: :arbitrum_bridge_l2_catchup)
 
-    indexer_first_block = Application.get_all_env(:indexer)[:first_block]
+    indexer_first_block =
+      RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
     config_common = Application.get_all_env(:indexer)[Indexer.Fetcher.Arbitrum]
     rollup_chunk_size = config_common[:rollup_chunk_size]

--- a/apps/indexer/lib/indexer/fetcher/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/withdrawal.ex
@@ -9,6 +9,7 @@ defmodule Indexer.Fetcher.Withdrawal do
   require Logger
 
   alias EthereumJSONRPC.Blocks
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Withdrawal
   alias Explorer.Helper
@@ -44,7 +45,7 @@ defmodule Indexer.Fetcher.Withdrawal do
   @impl GenServer
   def init(opts) when is_list(opts) do
     Logger.metadata(fetcher: :withdrawal)
-    first_block = Application.get_env(:indexer, __MODULE__)[:first_block]
+    first_block = RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
 
     if first_block |> Helper.parse_integer() |> is_integer() do
       # withdrawals from all other blocks will be imported by realtime and catchup indexers

--- a/apps/indexer/lib/indexer/fetcher/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/withdrawal.ex
@@ -9,7 +9,6 @@ defmodule Indexer.Fetcher.Withdrawal do
   require Logger
 
   alias EthereumJSONRPC.Blocks
-  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Withdrawal
   alias Explorer.Helper
@@ -45,7 +44,7 @@ defmodule Indexer.Fetcher.Withdrawal do
   @impl GenServer
   def init(opts) when is_list(opts) do
     Logger.metadata(fetcher: :withdrawal)
-    first_block = RangesHelper.get_min_block_number_from_range_string(Application.get_env(:indexer, :block_ranges))
+    first_block = Application.get_env(:indexer, __MODULE__)[:first_block]
 
     if first_block |> Helper.parse_integer() |> is_integer() do
       # withdrawals from all other blocks will be imported by realtime and catchup indexers

--- a/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/missing_ranges_collector_test.exs
@@ -14,7 +14,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollectorTest do
       insert(:block, number: 1_000_000)
       insert(:block, number: 500_123)
       MissingRangesCollector.start_link([])
-      Process.sleep(1000)
+      Process.sleep(1500)
 
       assert [999_999..999_900//-1] = batch = MissingBlockRange.get_latest_batch(100)
       MissingBlockRange.clear_batch(batch)
@@ -31,21 +31,6 @@ defmodule Indexer.Block.Catchup.MissingRangesCollectorTest do
       assert [1_000_099..1_000_001//-1, 999_699..999_699//-1] = batch = MissingBlockRange.get_latest_batch(100)
       MissingBlockRange.clear_batch(batch)
       assert [999_698..999_599//-1] = MissingBlockRange.get_latest_batch(100)
-    end
-
-    test "FIRST_BLOCK and LAST_BLOCK envs" do
-      Application.put_env(:indexer, :first_block, 100)
-      Application.put_env(:indexer, :last_block, 200)
-
-      insert(:missing_block_range, from_number: 250, to_number: 220)
-      insert(:missing_block_range, from_number: 219, to_number: 190)
-      insert(:missing_block_range, from_number: 120, to_number: 90)
-      insert(:missing_block_range, from_number: 89, to_number: 80)
-
-      MissingRangesCollector.start_link([])
-      Process.sleep(500)
-
-      assert [%{from_number: 120, to_number: 100}, %{from_number: 200, to_number: 190}] = Repo.all(MissingBlockRange)
     end
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -722,6 +722,13 @@ config :explorer, Explorer.Chain.Fetcher.AddressesBlacklist,
 ###############
 
 first_block = ConfigHelper.parse_integer_env_var("FIRST_BLOCK", 0)
+last_block = ConfigHelper.parse_integer_or_nil_env_var("LAST_BLOCK")
+
+block_ranges =
+  case ConfigHelper.safe_get_env("BLOCK_RANGES", nil) do
+    "" -> "#{first_block}..#{last_block || "latest"}"
+    ranges -> ranges
+  end
 
 trace_first_block = ConfigHelper.parse_integer_env_var("TRACE_FIRST_BLOCK", 0)
 trace_last_block = ConfigHelper.parse_integer_or_nil_env_var("TRACE_LAST_BLOCK")
@@ -735,9 +742,9 @@ trace_block_ranges =
 config :indexer,
   block_transformer: ConfigHelper.block_transformer(),
   metadata_updater_milliseconds_interval: ConfigHelper.parse_time_env_var("TOKEN_METADATA_UPDATE_INTERVAL", "48h"),
-  block_ranges: System.get_env("BLOCK_RANGES"),
+  block_ranges: block_ranges,
   first_block: first_block,
-  last_block: ConfigHelper.parse_integer_or_nil_env_var("LAST_BLOCK"),
+  last_block: last_block,
   trace_block_ranges: trace_block_ranges,
   trace_first_block: trace_first_block,
   trace_last_block: trace_last_block,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -724,11 +724,7 @@ config :explorer, Explorer.Chain.Fetcher.AddressesBlacklist,
 first_block = ConfigHelper.parse_integer_env_var("FIRST_BLOCK", 0)
 last_block = ConfigHelper.parse_integer_or_nil_env_var("LAST_BLOCK")
 
-block_ranges =
-  case ConfigHelper.safe_get_env("BLOCK_RANGES", nil) do
-    "" -> "#{first_block}..#{last_block || "latest"}"
-    ranges -> ranges
-  end
+block_ranges =  ConfigHelper.safe_get_env("BLOCK_RANGES", "#{first_block}..#{last_block || "latest"}")
 
 trace_first_block = ConfigHelper.parse_integer_env_var("TRACE_FIRST_BLOCK", 0)
 trace_last_block = ConfigHelper.parse_integer_or_nil_env_var("TRACE_LAST_BLOCK")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -724,7 +724,7 @@ config :explorer, Explorer.Chain.Fetcher.AddressesBlacklist,
 first_block = ConfigHelper.parse_integer_env_var("FIRST_BLOCK", 0)
 last_block = ConfigHelper.parse_integer_or_nil_env_var("LAST_BLOCK")
 
-block_ranges =  ConfigHelper.safe_get_env("BLOCK_RANGES", "#{first_block}..#{last_block || "latest"}")
+block_ranges = ConfigHelper.safe_get_env("BLOCK_RANGES", "#{first_block}..#{last_block || "latest"}")
 
 trace_first_block = ConfigHelper.parse_integer_env_var("TRACE_FIRST_BLOCK", 0)
 trace_last_block = ConfigHelper.parse_integer_or_nil_env_var("TRACE_LAST_BLOCK")


### PR DESCRIPTION
## Motivation

If `BLOCK_RANGES` is defined, the minimum block number, represented there, is ignored in the codebase where the logic depends on it for indexing.

## Changelog

### AI Agent summary

This pull request introduces a significant refactor to the handling of block ranges within the Ethereum JSON RPC and Explorer applications. The changes focus on replacing the use of the `:first_block` and `:last_block` configuration parameters with a new `:block_ranges` parameter, and includes the addition of a helper function to extract the minimum block number from the block ranges string.

Key changes include:

### Utility Enhancements:
* Added `get_min_block_number_from_range_string/1` function to `EthereumJSONRPC.Utility.RangesHelper` to extract the minimum block number from a block ranges string.

### Configuration Updates:
* Updated `config/runtime.exs` to parse and use the new `:block_ranges` environment variable, defaulting to a range derived from `FIRST_BLOCK` and `LAST_BLOCK` if not specified. [[1]](diffhunk://#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092R725-R731) [[2]](diffhunk://#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092L738-R747)

### Refactoring for Consistency:
* Replaced occurrences of `Application.get_env(:indexer, :first_block)` with the new helper function `RangesHelper.get_min_block_number_from_range_string/1` in various modules, including `Explorer.Chain`, `Explorer.Chain.BlockNumberHelper`, and `Explorer.Chain.Cache.Helper`. [[1]](diffhunk://#diff-3fce0f082a5cb927aa738ef8f7d582824df91d08957971d36a0873efacd88816L1485-R1486) [[2]](diffhunk://#diff-ef3837b0b90b8e19cb893bf91311422a794f871588ee0f6db66ed74d1c750610L114-R116) [[3]](diffhunk://#diff-3b6de2fb3744bd1383e51b9d4381625007f1ca78eb03fe4b0d10a7db78557175L51-R54) [[4]](diffhunk://#diff-d4e2610f5c4f4ddbb373c81106b12c9065fd169b22a829bbfec5efcfaf695defL72-R74) [[5]](diffhunk://#diff-8a5cf50fb12ec1e653949b8f8621120a9fdea418da1ca2bc71e1e04e742e32faL176-R177) [[6]](diffhunk://#diff-425903a3fde299b100d50d7304f85a7ba0100907be7464bc431470921346b358L66-R69) [[7]](diffhunk://#diff-d6f07f32c65ea771e0bc075968a3468305bb66723e65348a8792e8dd890e0079L91-R93)

### Test Adjustments:
* Updated tests to reflect the new `:block_ranges` configuration parameter, including removing tests that were specific to the old `:first_block` and `:last_block` parameters. [[1]](diffhunk://#diff-b5537bec41cd3aeeafc1fc4d1045904cdfb63fd87228df177d24c2251f226899L969-R969) [[2]](diffhunk://#diff-0934375cca5eca9e197524c8d2823eeb1487b25ce9fac828eecf5cee39bb4cd5L35-L49)

These changes aim to improve the flexibility and clarity of block range configurations within the system.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced dynamic block range configuration that automatically determines the starting block for indexing and related calculations.
- **Refactor**
	- Updated core components to use the new range-based logic for block computations, caching, and backfill processes.
	- Added new aliases for improved module referencing.
- **Bug Fixes**
	- Enhanced logic for managing block ranges, refining conditions for insertion and deletion of ranges.
- **Tests**
	- Adjusted test configurations to support and validate the enhanced dynamic block range setup.
	- Removed outdated test cases related to specific block range environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->