### PR TITLE
chore: Limit number of implementations proxy before insertion into the DB

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -420,7 +420,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
   # Cut off implementations per proxy up to @max_implementations_number_per_proxy number
   # before insert into the DB to prevent DoS via the verification endpoint of Diamond smart contracts.
   defp sanitize_implementation_address_hash_strings(implementation_address_hash_strings) do
-    Enum.slice(implementation_address_hash_strings, 0, @max_implementations_number_per_proxy)
+    Enum.take(implementation_address_hash_strings, @max_implementations_number_per_proxy)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -22,6 +22,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
 
   @burn_address_hash_string "0x0000000000000000000000000000000000000000"
   @burn_address_hash_string_32 "0x0000000000000000000000000000000000000000000000000000000000000000"
+  @max_implementations_number_per_proxy 100
 
   defguard is_burn_signature(term) when term in ["0x", "0x0", @burn_address_hash_string, @burn_address_hash_string_32]
 
@@ -313,7 +314,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
   def save_implementation_data(implementation_address_hash_strings, proxy_address_hash, proxy_type, options)
       when is_nil(implementation_address_hash_strings) or
              implementation_address_hash_strings == [] do
-    upsert_implementation(proxy_address_hash, proxy_type, [], [], options)
+    upsert_implementations(proxy_address_hash, proxy_type, [], [], options)
 
     :empty
   end
@@ -325,7 +326,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
         options
       )
       when is_burn_signature(empty_implementation_address_hash_string) do
-    upsert_implementation(proxy_address_hash, proxy_type, [], [], options)
+    upsert_implementations(proxy_address_hash, proxy_type, [], [], options)
 
     :empty
   end
@@ -359,7 +360,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     if Enum.empty?(implementation_addresses) do
       :empty
     else
-      case upsert_implementation(
+      case upsert_implementations(
              proxy_address_hash,
              proxy_type,
              implementation_addresses,
@@ -376,22 +377,25 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     end
   end
 
-  defp upsert_implementation(proxy_address_hash, proxy_type, implementation_address_hash_strings, names, options) do
+  defp upsert_implementations(proxy_address_hash, proxy_type, implementation_address_hash_strings, names, options) do
     proxy = get_proxy_implementations(proxy_address_hash, options)
 
     if proxy do
-      update_implementation(proxy, proxy_type, implementation_address_hash_strings, names)
+      update_implementations(proxy, proxy_type, implementation_address_hash_strings, names)
     else
-      insert_implementation(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
+      insert_implementations(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
     end
   end
 
-  defp insert_implementation(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
+  defp insert_implementations(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
        when not is_nil(proxy_address_hash) do
+    sanitized_implementation_address_hash_strings =
+      sanitize_implementation_address_hash_strings(implementation_address_hash_strings)
+
     changeset = %{
       proxy_address_hash: proxy_address_hash,
       proxy_type: proxy_type,
-      address_hashes: implementation_address_hash_strings,
+      address_hashes: sanitized_implementation_address_hash_strings,
       names: names
     }
 
@@ -400,14 +404,23 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     |> Repo.insert()
   end
 
-  defp update_implementation(proxy, proxy_type, implementation_address_hash_strings, names) do
+  defp update_implementations(proxy, proxy_type, implementation_address_hash_strings, names) do
+    sanitized_implementation_address_hash_strings =
+      sanitize_implementation_address_hash_strings(implementation_address_hash_strings)
+
     proxy
     |> changeset(%{
       proxy_type: proxy_type,
-      address_hashes: implementation_address_hash_strings,
+      address_hashes: sanitized_implementation_address_hash_strings,
       names: names
     })
     |> Repo.update()
+  end
+
+  # Cut off implementations per proxy up to @max_implementations_number_per_proxy number
+  # before insert into the DB to prevent DoS via the verification endpoint of Diamond smart contracts.
+  defp sanitize_implementation_address_hash_strings(implementation_address_hash_strings) do
+    Enum.slice(implementation_address_hash_strings, 0, @max_implementations_number_per_proxy)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -387,7 +387,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     end
   end
 
-  @spec insert_implementations(Hash.Address.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  @spec insert_implementations(Hash.Address.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) ::
+          {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   defp insert_implementations(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
        when not is_nil(proxy_address_hash) do
     sanitized_implementation_address_hash_strings =
@@ -405,7 +406,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     |> Repo.insert()
   end
 
-  @spec update_implementations(__MODULE__.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
+  @spec update_implementations(__MODULE__.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) ::
+          {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   defp update_implementations(proxy, proxy_type, implementation_address_hash_strings, names) do
     sanitized_implementation_address_hash_strings =
       sanitize_implementation_address_hash_strings(implementation_address_hash_strings)

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -387,6 +387,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     end
   end
 
+  @spec insert_implementations(Hash.Address.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   defp insert_implementations(proxy_address_hash, proxy_type, implementation_address_hash_strings, names)
        when not is_nil(proxy_address_hash) do
     sanitized_implementation_address_hash_strings =
@@ -404,6 +405,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     |> Repo.insert()
   end
 
+  @spec update_implementations(__MODULE__.t(), atom() | nil, [EthereumJSONRPC.hash()], [String.t()]) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   defp update_implementations(proxy, proxy_type, implementation_address_hash_strings, names) do
     sanitized_implementation_address_hash_strings =
       sanitize_implementation_address_hash_strings(implementation_address_hash_strings)
@@ -419,6 +421,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
 
   # Cut off implementations per proxy up to @max_implementations_number_per_proxy number
   # before insert into the DB to prevent DoS via the verification endpoint of Diamond smart contracts.
+  @spec sanitize_implementation_address_hash_strings([EthereumJSONRPC.hash()]) :: [EthereumJSONRPC.hash()]
   defp sanitize_implementation_address_hash_strings(implementation_address_hash_strings) do
     Enum.take(implementation_address_hash_strings, @max_implementations_number_per_proxy)
   end


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/10753

## Changelog

### AI agent summary

This pull request includes several changes to the `Explorer.Chain.SmartContract.Proxy.Models.Implementation` module in the `implementation.ex` file. The primary focus is on renaming functions and adding a new constant to limit the number of implementations per proxy.

Key changes include:

### Introduction of a new constant:
* Added `@max_implementations_number_per_proxy` to limit the number of implementations per proxy to 100.

### Function renaming:
* Renamed the `upsert_implementation` function to `upsert_implementations` and updated all its references. [[1]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L316-R317) [[2]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L328-R329) [[3]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L362-R363) [[4]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L379-R398)
* Renamed the `insert_implementation` function to `insert_implementations` and updated all its references.
* Renamed the `update_implementation` function to `update_implementations` and updated all its references.

### Data sanitization:
* Added a new private function `sanilize_implementation_address_hash_strings` to limit the number of implementation address hash strings before inserting them into the database. This is to prevent potential DoS attacks via the verification endpoint of Diamond smart contracts. [[1]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L379-R398) [[2]](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791L403-R424)

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a limit on the number of addresses processed per proxy to ensure optimal performance and stability.
- **Refactor**
	- Streamlined data sanitization and handling processes for multiple records, enhancing overall error handling and system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->