### PR TITLE
feat: add token1155tx api v1 endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -250,16 +250,8 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
   defp prepare_erc1155_transfer(token_transfer, max_block_number) do
     token_transfer
     |> prepare_nft_transfer(max_block_number)
-    |> Map.put_new(:tokenValue, calculate_token_value(token_transfer))
+    |> Map.put_new(:tokenValue, to_string(token_transfer.amount))
   end
-
-  defp calculate_erc1155_token_value(%{amounts: amounts}) when is_list(amounts) do
-    amounts
-    |> Enum.sum()
-    |> to_string()
-  end
-
-  defp calculate_token_value(%{amount: amount}), do: to_string(amount)
 
   defp prepare_block(block) do
     %{

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -49,6 +49,11 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     RPCView.render("show.json", data: data)
   end
 
+  def render("token1155tx.json", %{token_transfers: token_transfers, max_block_number: max_block_number}) do
+    data = Enum.map(token_transfers, &prepare_erc1155_transfer(&1, max_block_number))
+    RPCView.render("show.json", data: data)
+  end
+
   def render("tokenbalance.json", %{token_balance: token_balance}) do
     RPCView.render("show.json", data: to_string(token_balance))
   end
@@ -241,6 +246,20 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "confirmations" => to_string(max_block_number - token_transfer.block_number)
     }
   end
+
+  defp prepare_erc1155_transfer(token_transfer, max_block_number) do
+    token_transfer
+    |> prepare_nft_transfer(max_block_number)
+    |> Map.put_new(:tokenValue, calculate_token_value(token_transfer))
+  end
+
+  defp calculate_erc1155_token_value(%{amounts: amounts}) when is_list(amounts) do
+    amounts
+    |> Enum.sum()
+    |> to_string()
+  end
+
+  defp calculate_token_value(%{amount: amount}), do: to_string(amount)
 
   defp prepare_block(block) do
     %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2749,6 +2749,435 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
     end
   end
 
+  describe "token1155tx" do
+    setup do
+      %{params: %{"module" => "account", "action" => "token1155tx"}}
+    end
+
+    test "API endpoint works after `transactions` table denormalization finished", %{conn: conn, params: params} do
+      BackgroundMigrations.set_tt_denormalization_finished(true)
+
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(from_address: address)
+        |> with_block()
+
+      token = insert(:token, name: "NFT", type: "ERC-1155")
+
+      insert(:token_transfer,
+        transaction: transaction,
+        from_address: address,
+        block_number: transaction.block_number,
+        token_contract_address: token.contract_address,
+        token_type: token.type,
+        token_ids: [10, 20, 30],
+        amounts: [100, 200, 300]
+      )
+
+      new_params =
+        params
+        |> Map.put("address", Explorer.Chain.Hash.to_string(address.hash))
+
+      response =
+        conn
+        |> get("/api", new_params)
+
+      assert response.status == 200
+      BackgroundMigrations.set_tt_denormalization_finished(false)
+    end
+
+    test "with missing address and contract address hash", %{conn: conn, params: params} do
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] == "Query parameter address or contractaddress is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "with an invalid address hash", %{conn: conn, params: params} do
+      params = Map.merge(params, %{"address" => "badhash"})
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid address format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "with an address that doesn't exist", %{conn: conn, params: params} do
+      params = Map.merge(params, %{"address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"})
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == []
+      assert response["status"] == "0"
+      assert response["message"] == "No token transfers found"
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "has correct value for single ERC-1155", %{conn: conn, params: params} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      token_address = insert(:contract_address)
+      insert(:token, %{contract_address: token_address, type: "ERC-1155"})
+
+      token_transfer =
+        insert(:token_transfer, %{
+          token_contract_address: token_address,
+          token_ids: [666],
+          amount: 1,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number
+        })
+
+      {:ok, _} = Chain.token_from_address_hash(token_transfer.token_contract_address_hash)
+
+      params = Map.merge(params, %{"address" => to_string(token_transfer.from_address.hash)})
+
+      assert response =
+               %{"result" => results} =
+                 conn
+                 |> get("/api", params)
+                 |> json_response(200)
+
+      assert length(results) == 1
+
+      [result] = results
+
+      assert result["tokenID"] == to_string(List.first(token_transfer.token_ids))
+      assert result["tokenValue"] == to_string(token_transfer.amount)
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "has correct value for multiple ERC-1155", %{conn: conn, params: params} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      token_address = insert(:contract_address)
+      insert(:token, %{contract_address: token_address, type: "ERC-1155"})
+
+      token_transfer =
+        insert(:token_transfer, %{
+          token_contract_address: token_address,
+          token_ids: [669, 999, 1337],
+          amounts: [1, 2, 10],
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number
+        })
+
+      {:ok, _} = Chain.token_from_address_hash(token_transfer.token_contract_address_hash)
+
+      params = Map.merge(params, %{"address" => to_string(token_transfer.from_address.hash)})
+
+      assert response =
+               %{"result" => results} =
+                 conn
+                 |> get("/api", params)
+                 |> json_response(200)
+
+      assert length(results) == 3
+
+      [result1, result2, result3] = results
+      # default sort order is desc, so tokenid and tokenvalue are reversed
+      assert result1["tokenID"] == to_string(Enum.at(token_transfer.token_ids, 2))
+      assert result1["tokenValue"] == to_string(Enum.at(token_transfer.amounts, 2))
+
+      assert result2["tokenID"] == to_string(Enum.at(token_transfer.token_ids, 1))
+      assert result2["tokenValue"] == to_string(Enum.at(token_transfer.amounts, 1))
+
+      assert result3["tokenID"] == to_string(Enum.at(token_transfer.token_ids, 0))
+      assert result3["tokenValue"] == to_string(Enum.at(token_transfer.amounts, 0))
+
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "returns all the required fields", %{conn: conn, params: params} do
+      transaction =
+        %{block: block} =
+          :transaction
+          |> insert()
+          |> with_block()
+
+      token_address = insert(:contract_address)
+      token = insert(:token, contract_address: token_address, type: "ERC-1155")
+
+      token_transfer =
+        insert(:token_transfer,
+          block: transaction.block,
+          transaction: transaction,
+          block_number: block.number,
+          token_ids: [1010],
+          token_contract_address: token_address,
+          amount: 5
+        )
+
+      params = Map.merge(params, %{"address" => to_string(token_transfer.from_address.hash)})
+
+      expected_result = [
+        %{
+          "blockNumber" => to_string(transaction.block_number),
+          "timeStamp" => to_string(DateTime.to_unix(block.timestamp)),
+          "hash" => to_string(token_transfer.transaction_hash),
+          "nonce" => to_string(transaction.nonce),
+          "blockHash" => to_string(block.hash),
+          "from" => to_string(token_transfer.from_address_hash),
+          "contractAddress" => to_string(token_transfer.token_contract_address_hash),
+          "to" => to_string(token_transfer.to_address_hash),
+          "tokenName" => token.name,
+          "tokenSymbol" => token.symbol,
+          "tokenDecimal" => to_string(token.decimals),
+          "transactionIndex" => to_string(transaction.index),
+          "gas" => to_string(transaction.gas),
+          "gasPrice" => to_string(transaction.gas_price.value),
+          "gasUsed" => to_string(transaction.gas_used),
+          "cumulativeGasUsed" => to_string(transaction.cumulative_gas_used),
+          "logIndex" => to_string(token_transfer.log_index),
+          "input" => "deprecated",
+          "confirmations" => "0",
+          "tokenID" => "1010",
+          "tokenValue" => "5"
+        }
+      ]
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "with an invalid contract address", %{conn: conn, params: params} do
+      params =
+        Map.merge(params, %{"address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b", "contractaddress" => "invalid"})
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid contract address format"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "filters results by contract address", %{conn: conn, params: params} do
+      address = insert(:address)
+
+      contract_address = insert(:contract_address)
+
+      insert(:token, contract_address: contract_address, type: "ERC-1155")
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:token_transfer,
+        from_address: address,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number
+      )
+
+      insert(:token_transfer,
+        from_address: address,
+        token_contract_address: contract_address,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        token_ids: [123],
+        amount: 1
+      )
+
+      params =
+        Map.merge(params, %{"address" => to_string(address.hash), "contractaddress" => to_string(contract_address.hash)})
+
+      assert response =
+               %{"result" => [result]} =
+                 conn
+                 |> get("/api", params)
+                 |> json_response(200)
+
+      assert result["contractAddress"] == to_string(contract_address.hash)
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(tokentx_schema(), response)
+    end
+
+    test "Check pagination and ordering (page, offset, sort parameters)", %{conn: conn, params: params} do
+      address = insert(:address)
+
+      erc_1155_token = insert(:token, type: "ERC-1155")
+
+      erc_1155_tt =
+        for x <- 0..50 do
+          transaction = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          insert(:token_transfer,
+            transaction: transaction,
+            block: transaction.block,
+            block_number: transaction.block_number,
+            from_address: address,
+            token_contract_address: erc_1155_token.contract_address,
+            token_ids: [x, x + 100],
+            amounts: [1, 2]
+          )
+        end
+
+      # sort: asc
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 1, "sort" => "asc"})
+
+      assert %{"result" => token_transfers_1} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 2, "sort" => "asc"})
+
+      assert %{"result" => token_transfers_2} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 3, "sort" => "asc"})
+
+      assert %{"result" => token_transfers_3} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert Enum.at(token_transfers_1, 0)["hash"] == to_string(Enum.at(erc_1155_tt, 0).transaction_hash)
+      assert Enum.at(token_transfers_1, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 0).token_ids, 0))
+      assert Enum.at(token_transfers_1, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 0).amounts, 0))
+      assert Enum.at(token_transfers_1, 1)["hash"] == to_string(Enum.at(erc_1155_tt, 0).transaction_hash)
+      assert Enum.at(token_transfers_1, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 0).token_ids, 1))
+      assert Enum.at(token_transfers_1, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 0).amounts, 1))
+
+      assert Enum.at(token_transfers_1, 48)["hash"] == to_string(Enum.at(erc_1155_tt, 24).transaction_hash)
+      assert Enum.at(token_transfers_1, 48)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 24).token_ids, 0))
+      assert Enum.at(token_transfers_1, 48)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 24).amounts, 0))
+      assert Enum.at(token_transfers_1, 49)["hash"] == to_string(Enum.at(erc_1155_tt, 24).transaction_hash)
+      assert Enum.at(token_transfers_1, 49)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 24).token_ids, 1))
+      assert Enum.at(token_transfers_1, 49)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 24).amounts, 1))
+
+      assert Enum.at(token_transfers_2, 0)["hash"] == to_string(Enum.at(erc_1155_tt, 25).transaction_hash)
+      assert Enum.at(token_transfers_2, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 25).token_ids, 0))
+      assert Enum.at(token_transfers_2, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 25).amounts, 0))
+      assert Enum.at(token_transfers_2, 1)["hash"] == to_string(Enum.at(erc_1155_tt, 25).transaction_hash)
+      assert Enum.at(token_transfers_2, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 25).token_ids, 1))
+      assert Enum.at(token_transfers_2, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 25).amounts, 1))
+
+      assert Enum.at(token_transfers_2, 48)["hash"] == to_string(Enum.at(erc_1155_tt, 49).transaction_hash)
+      assert Enum.at(token_transfers_2, 48)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 49).token_ids, 0))
+      assert Enum.at(token_transfers_2, 48)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 49).amounts, 0))
+      assert Enum.at(token_transfers_2, 49)["hash"] == to_string(Enum.at(erc_1155_tt, 49).transaction_hash)
+      assert Enum.at(token_transfers_2, 49)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 49).token_ids, 1))
+      assert Enum.at(token_transfers_2, 49)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 49).amounts, 1))
+
+      assert Enum.at(token_transfers_3, 0)["hash"] == to_string(Enum.at(erc_1155_tt, 50).transaction_hash)
+      assert Enum.at(token_transfers_3, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 50).token_ids, 0))
+      assert Enum.at(token_transfers_3, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 50).amounts, 0))
+      assert Enum.at(token_transfers_3, 1)["hash"] == to_string(Enum.at(erc_1155_tt, 50).transaction_hash)
+      assert Enum.at(token_transfers_3, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt, 50).token_ids, 1))
+      assert Enum.at(token_transfers_3, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt, 50).amounts, 1))
+
+      assert Enum.count(token_transfers_3) == 2
+
+      # sort: desc
+      erc_1155_tt_reversed = Enum.reverse(erc_1155_tt)
+
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 1, "sort" => "desc"})
+
+      assert %{"result" => token_transfers_1} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 2, "sort" => "desc"})
+
+      assert %{"result" => token_transfers_2} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      params = Map.merge(params, %{"address" => to_string(address.hash), "offset" => 50, "page" => 3, "sort" => "desc"})
+
+      assert %{"result" => token_transfers_3} =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert Enum.at(token_transfers_1, 0)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 0).transaction_hash)
+      assert Enum.at(token_transfers_1, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 0).token_ids, 1))
+      assert Enum.at(token_transfers_1, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 0).amounts, 1))
+      assert Enum.at(token_transfers_1, 1)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 0).transaction_hash)
+      assert Enum.at(token_transfers_1, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 0).token_ids, 0))
+      assert Enum.at(token_transfers_1, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 0).amounts, 0))
+
+      assert Enum.at(token_transfers_1, 48)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 24).transaction_hash)
+      assert Enum.at(token_transfers_1, 48)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 24).token_ids, 1))
+      assert Enum.at(token_transfers_1, 48)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 24).amounts, 1))
+      assert Enum.at(token_transfers_1, 49)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 24).transaction_hash)
+      assert Enum.at(token_transfers_1, 49)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 24).token_ids, 0))
+      assert Enum.at(token_transfers_1, 49)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 24).amounts, 0))
+
+      assert Enum.at(token_transfers_2, 0)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 25).transaction_hash)
+      assert Enum.at(token_transfers_2, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 25).token_ids, 1))
+      assert Enum.at(token_transfers_2, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 25).amounts, 1))
+      assert Enum.at(token_transfers_2, 1)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 25).transaction_hash)
+      assert Enum.at(token_transfers_2, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 25).token_ids, 0))
+      assert Enum.at(token_transfers_2, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 25).amounts, 0))
+
+      assert Enum.at(token_transfers_2, 48)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 49).transaction_hash)
+      assert Enum.at(token_transfers_2, 48)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 49).token_ids, 1))
+      assert Enum.at(token_transfers_2, 48)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 49).amounts, 1))
+      assert Enum.at(token_transfers_2, 49)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 49).transaction_hash)
+      assert Enum.at(token_transfers_2, 49)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 49).token_ids, 0))
+      assert Enum.at(token_transfers_2, 49)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 49).amounts, 0))
+
+      assert Enum.at(token_transfers_3, 0)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 50).transaction_hash)
+      assert Enum.at(token_transfers_3, 0)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 50).token_ids, 1))
+      assert Enum.at(token_transfers_3, 0)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 50).amounts, 1))
+      assert Enum.at(token_transfers_3, 1)["hash"] == to_string(Enum.at(erc_1155_tt_reversed, 50).transaction_hash)
+      assert Enum.at(token_transfers_3, 1)["tokenID"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 50).token_ids, 0))
+      assert Enum.at(token_transfers_3, 1)["tokenValue"] == to_string(Enum.at(Enum.at(erc_1155_tt_reversed, 50).amounts, 0))
+
+      assert Enum.count(token_transfers_3) == 2
+    end
+  end
+
   describe "tokenbalance" do
     test "without required params", %{conn: conn} do
       params = %{


### PR DESCRIPTION
## Motivation

This adds the missing functionality for ERC-1155 tokens on v1 api for blockscout to be more compatible and interchangeable with etherscan endpoints

## Changelog

Added token1155tx action to the account module
queries for processing ERC1155 token transfers 
tests

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for processing ERC-1155 token transfers via new API endpoints. Enhanced responses now include detailed transfer data with computed token values and improved pagination.
  - Expanded query capabilities to retrieve and order token transfer details more effectively.

- **Tests**
  - Added comprehensive tests covering various scenarios such as missing or invalid parameters and filtering, ensuring robust handling of ERC-1155 token transfer requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->