### PR TITLE
fix: Replace unique filecoin addresses indexes with not unique

### DIFF
--- a/apps/explorer/priv/filecoin/migrations/20241220110454_add_filecoin_addresses_indexes.exs
+++ b/apps/explorer/priv/filecoin/migrations/20241220110454_add_filecoin_addresses_indexes.exs
@@ -1,8 +1,0 @@
-defmodule Explorer.Repo.Filecoin.Migrations.AddFilecoinAddressesIndexes do
-  use Ecto.Migration
-
-  def change do
-    create(unique_index(:addresses, [:filecoin_robust]))
-    create(unique_index(:addresses, [:filecoin_id]))
-  end
-end

--- a/apps/explorer/priv/filecoin/migrations/20250220085529_replace_filecoin_addresses_indexes.exs
+++ b/apps/explorer/priv/filecoin/migrations/20250220085529_replace_filecoin_addresses_indexes.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Filecoin.Migrations.ReplaceFilecoinAddressesIndexes do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(unique_index(:addresses, [:filecoin_robust]))
+    drop_if_exists(unique_index(:addresses, [:filecoin_id]))
+
+    create(index(:addresses, [:filecoin_robust]))
+    create(index(:addresses, [:filecoin_id]))
+  end
+end


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the database indexing for address records to provide a more flexible data storage solution. The previous strict uniqueness rules have been replaced with a non-unique approach, streamlining data processing and supporting adaptable data management. These improvements help ensure smoother operations and may optimize query performance while maintaining system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->