### PR TITLE
fix: render token transfers from celo epoch logs

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_transfer_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_transfer_controller.ex
@@ -55,9 +55,11 @@ defmodule BlockScoutWeb.API.V2.TokenTransferController do
 
     transactions =
       token_transfers
-      |> Enum.map(fn token_transfer ->
-        token_transfer.transaction
-      end)
+      |> Enum.map(& &1.transaction)
+      # Celo's Epoch logs does not have an associated transaction and linked to
+      # the block instead, so we discard these token transfers for transaction
+      # decoding
+      |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
     decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -31,7 +31,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
           token_transfers,
           &render("token_transfer.json", %{
             token_transfer: &1,
-            decoded_transaction_input: decoded_transactions_map[&1.transaction.hash],
+            decoded_transaction_input: &1.transaction && decoded_transactions_map[&1.transaction.hash],
             conn: conn
           })
         ),


### PR DESCRIPTION
Closes #11916

## Motivation

Rendering of token transfers fails when they are extracted from Celo Epoch logs. These logs are not linked to a specific transaction but to a particular block instead. This PR adds handling for those cases when `transaction_hash` column in `token_transfers` relation is `nil`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token transfer processing to ensure only valid transactions are displayed by filtering out incomplete data.
  - Enhanced error handling during transaction detail retrieval, reducing issues from missing transaction information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->