### PR TITLE
chore: Remove duplicate endpoints for 3d party proxies

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -357,20 +357,6 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         end
       end
 
-      # todo: this endpoint should be removed in 7.1.0 release
-      scope "/noves-fi" do
-        get("/transactions/:transaction_hash_param", V2.Proxy.NovesFiController, :transaction)
-
-        get("/addresses/:address_hash_param/transactions", V2.Proxy.NovesFiController, :address_transactions)
-
-        get("/transaction-descriptions", V2.Proxy.NovesFiController, :describe_transactions)
-      end
-
-      # todo: this endpoint should be removed in 7.1.0 release
-      scope "/xname" do
-        get("/addresses/:address_hash_param", V2.Proxy.XnameController, :address)
-      end
-
       scope "/account-abstraction" do
         get("/operations/:operation_hash_param", V2.Proxy.AccountAbstractionController, :operation)
         get("/operations/:operation_hash_param/summary", V2.Proxy.AccountAbstractionController, :summary)

--- a/apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex
@@ -55,8 +55,6 @@ defmodule BlockScoutWeb.Routers.SmartContractsApiV2Router do
     get("/:address_hash/methods-write", V2.SmartContractController, :methods_write)
     get("/:address_hash/methods-read-proxy", V2.SmartContractController, :methods_read_proxy)
     get("/:address_hash/methods-write-proxy", V2.SmartContractController, :methods_write_proxy)
-    # todo: this endpoint should be removed in 7.1.0 release
-    get("/:address_hash/solidityscan-report", V2.SmartContractController, :solidityscan_report)
     get("/:address_hash/audit-reports", V2.SmartContractController, :audit_reports_list)
 
     get("/verification/config", V2.VerificationController, :config)


### PR DESCRIPTION
## Motivation

PR https://github.com/blockscout/blockscout/pull/11808 introduced a new root path for 3d party proxies in the release 7.0.0. We can now remove old paths.

## Changelog

This pull request includes changes to the `BlockScoutWeb` routers to remove deprecated endpoints. The changes focus on cleaning up the codebase by removing endpoints that were marked for removal in the 7.1.0 release.

Removed deprecated endpoints:

* [`apps/block_scout_web/lib/block_scout_web/routers/api_router.ex`](diffhunk://#diff-7b31aa9ca8af99c00b6548ddcef75c78c1824715a3cd6d5e10dbcc6ace229780L360-L373): Removed the `/noves-fi` and `/xname` endpoint scopes and their associated routes. These endpoints were marked for removal in the 7.1.0 release.
* [`apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex`](diffhunk://#diff-22c8c5e494892676457d8ec73b559af98322dcdabba2803060495affab9177edL58-L59): Removed the `/solidityscan-report` endpoint, which was also marked for removal in the 7.1.0 release.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
