### PR TITLE
perf: Use Sig provider microservice batched request

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -477,7 +477,7 @@ defmodule BlockScoutWeb.AddressView do
           | {:error, atom(), list()}
           | {{:error, :contract_not_verified, list()}, any()}
   def decode(log, transaction) do
-    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [], true)
+    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [])
     result
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -477,7 +477,7 @@ defmodule BlockScoutWeb.AddressView do
           | {:error, atom(), list()}
           | {{:error, :contract_not_verified, list()}, any()}
   def decode(log, transaction) do
-    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [])
+    {result, _contracts_acc, _events_acc} = Log.decode(log, transaction, [], true, false)
     result
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -227,13 +227,15 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   """
   @spec decode_logs([Log.t()], boolean) :: [tuple]
   def decode_logs(logs, skip_sig_provider?) do
-    {result, _, _} =
+    {all_logs, _, _} =
       Enum.reduce(logs, {[], %{}, %{}}, fn log, {results, contracts_acc, events_acc} ->
         {result, contracts_acc, events_acc} =
           Log.decode(
             log,
             %Transaction{hash: log.transaction_hash},
             @api_true,
+            skip_sig_provider?,
+            true,
             contracts_acc,
             events_acc
           )
@@ -241,48 +243,35 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         {[result | results], contracts_acc, events_acc}
       end)
 
-    all_logs = Enum.reverse(result)
-
-    already_decoded_logs =
+    %{
+      :already_decoded_logs => already_decoded_logs,
+      :input_for_sig_provider_batched_request => input_for_sig_provider_batched_request
+    } =
       all_logs
-      |> Enum.filter(fn result ->
-        case result do
-          {:error, :try_with_sig_provider, {_log, _transaction_hash}} ->
-            false
+      |> Enum.reduce(
+        %{
+          :already_decoded_logs => [],
+          :input_for_sig_provider_batched_request => []
+        },
+        fn result, acc ->
+          case result do
+            {:error, :try_with_sig_provider, {log, transaction_hash}} ->
+              Map.put(acc, :input_for_sig_provider_batched_request, [
+                %{
+                  :log => log,
+                  :transaction_hash => transaction_hash
+                }
+                | acc.input_for_sig_provider_batched_request
+              ])
 
-          _ ->
-            true
+            _ ->
+              Map.put(acc, :already_decoded_logs, [result | acc.already_decoded_logs])
+          end
         end
-      end)
-
-    logs_for_sig_provider =
-      all_logs
-      |> Enum.filter(fn result ->
-        case result do
-          {:error, :try_with_sig_provider, {_log, _transaction_hash}} ->
-            true
-
-          _ ->
-            false
-        end
-      end)
-
-    tasks =
-      logs_for_sig_provider
-      |> Enum.map(fn {:error, :try_with_sig_provider, {log, transaction_hash}} ->
-        Task.async(fn ->
-          Log.decode_event_via_sig_provider(
-            log,
-            transaction_hash,
-            skip_sig_provider?
-          )
-        end)
-      end)
+      )
 
     decoded_with_sig_provider_logs =
-      tasks
-      |> Task.yield_many(:infinity)
-      |> Enum.map(fn {_task, {:ok, res}} -> res end)
+      Log.decode_events_batch_via_sig_provider(input_for_sig_provider_batched_request, skip_sig_provider?)
 
     full_logs = already_decoded_logs ++ decoded_with_sig_provider_logs
 
@@ -585,8 +574,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   defp format_decoded_log_input({:error, :could_not_decode}), do: nil
   defp format_decoded_log_input({:ok, _method_id, _text, _mapping} = decoded), do: decoded
-
-  # defp format_decoded_log_input({:error, :try_with_sig_provider, candidates}), do: {:try_with_sig_provider, candidates}
   defp format_decoded_log_input({:error, _, candidates}), do: Enum.at(candidates, 0)
 
   def format_confirmations({:ok, confirmations}), do: confirmations

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -167,12 +167,12 @@ defmodule Explorer.Chain.Log do
   @doc """
   Decode transaction log data.
   """
-  @spec decode(Log.t(), Transaction.t(), any(), map(), map()) ::
+  @spec decode(Log.t(), Transaction.t(), any(), boolean(), boolean(), map(), map()) ::
           {{:ok, String.t(), String.t(), map()}
-           | {:error, atom()}
+           | {:error, :could_not_decode}
            | {:error, atom(), list()}
-           | {{:error, :try_with_sig_provider, tuple()}, any()}, map(), map()}
-  def decode(log, transaction, options, contracts_acc \\ %{}, events_acc \\ %{}) do
+           | {{:error, :contract_not_verified | :try_with_sig_provider, [any()]}, any()}, map(), map()}
+  def decode(log, transaction, options, skip_sig_provider?, from_list?, contracts_acc \\ %{}, events_acc \\ %{}) do
     with {full_abi, contracts_acc} <- check_cache(contracts_acc, log.address_hash, options),
          {:no_abi, false} <- {:no_abi, is_nil(full_abi)},
          {:ok, selector, mapping} <- find_and_decode(full_abi, log, transaction.hash),
@@ -181,13 +181,24 @@ defmodule Explorer.Chain.Log do
       {{:ok, identifier, text, mapping}, contracts_acc, events_acc}
     else
       {:error, _} = error ->
-        handle_method_decode_error(error, log, transaction, options, contracts_acc, events_acc)
+        handle_method_decode_error(
+          error,
+          log,
+          transaction,
+          skip_sig_provider?,
+          from_list?,
+          options,
+          contracts_acc,
+          events_acc
+        )
 
       {:no_abi, true} ->
         handle_method_decode_error(
           {:error, :could_not_decode},
           log,
           transaction,
+          skip_sig_provider?,
+          from_list?,
           options,
           contracts_acc,
           events_acc
@@ -195,18 +206,33 @@ defmodule Explorer.Chain.Log do
     end
   end
 
-  defp handle_method_decode_error(error, log, transaction, options, contracts_acc, events_acc) do
+  defp handle_method_decode_error(
+         error,
+         log,
+         transaction,
+         skip_sig_provider?,
+         from_list?,
+         options,
+         contracts_acc,
+         events_acc
+       ) do
     case error do
       {:error, _reason} ->
-        case find_method_candidates(log, transaction, options, events_acc) do
-          {{:error, :contract_not_verified, []}, events_acc} ->
-            {try_decode_event_later_via_sig_provider(log, transaction.hash), contracts_acc, events_acc}
-
-          {{:error, :contract_not_verified, candidates}, events_acc} ->
-            {{:error, :contract_not_verified, candidates}, contracts_acc, events_acc}
-
+        with {{:error, :contract_not_verified, candidates}, events_acc} <-
+               find_method_candidates(log, transaction, options, events_acc),
+             {true, events_acc} <- {is_list(candidates), events_acc},
+             {false, events_acc} <- {Enum.empty?(candidates), events_acc} do
+          {{:error, :contract_not_verified, candidates}, contracts_acc, events_acc}
+        else
           {_, events_acc} ->
-            {try_decode_event_later_via_sig_provider(log, transaction.hash), contracts_acc, events_acc}
+            result =
+              if from_list? do
+                mark_events_to_decode_later_via_sig_provider_in_batch(log, transaction.hash)
+              else
+                decode_event_via_sig_provider(log, transaction.hash, skip_sig_provider?)
+              end
+
+            {result, contracts_acc, events_acc}
         end
     end
   end
@@ -345,13 +371,39 @@ defmodule Explorer.Chain.Log do
 
   defp alter_mapping_names(mapping), do: mapping
 
-  defp try_decode_event_later_via_sig_provider(
+  defp mark_events_to_decode_later_via_sig_provider_in_batch(
          log,
          transaction_hash
        ) do
     {:error, :try_with_sig_provider, {log, transaction_hash}}
   end
 
+  @doc """
+  Decodes an event log using the Sig-provider microservice.
+
+  ## Parameters
+
+    - `log`: The log containing the event data and topics.
+    - `transaction_hash`: The hash of the transaction containing the log.
+    - `skip_sig_provider?`: A boolean indicating whether to skip using the signature provider.
+
+  ## Returns
+
+    - `{:error, :contract_not_verified, [{:ok, identifier, text, mapping}]}` if the event is successfully decoded but the contract is not verified.
+    - `{:error, :could_not_decode}` if the event could not be decoded.
+
+  ## Conditions
+
+    - The signature provider must be enabled.
+    - The `skip_sig_provider?` flag must be `false`.
+    - The result from the signature provider must be a non-empty list.
+  """
+  @spec decode_event_via_sig_provider(
+          __MODULE__.t(),
+          Hash.t(),
+          boolean()
+        ) ::
+          {:error, :could_not_decode} | {:error, :contract_not_verified, list()}
   def decode_event_via_sig_provider(
         log,
         transaction_hash,
@@ -382,12 +434,82 @@ defmodule Explorer.Chain.Log do
     end
   end
 
-  def decode16!(nil), do: nil
+  @doc """
+  Decodes a batch of events using the Sig-provider microservice.
 
-  def decode16!(value) do
-    value
-    |> String.trim_leading("0x")
-    |> Base.decode16!(case: :lower)
+  This function attempts to decode a batch of events by leveraging the signature provider interface.
+  It first checks if the signature provider is enabled and if it should not be skipped.
+  If these conditions are met, it prepares the input for the signature provider batch request and decodes the events.
+  The decoded results are then processed and mapped to their corresponding logs and transaction hashes.
+
+  ## Parameters
+
+    - `input`: The input data to be decoded, expected to be a list of maps containing `:log` and `:transaction_hash`.
+    - `skip_sig_provider?`: A boolean flag indicating whether to skip the signature provider.
+
+  ## Returns
+
+    - On success: A list of tuples containing the decoded event information.
+    - On failure: `{:error, :could_not_decode}` if the decoding process fails at any step.
+  """
+  @spec decode_events_batch_via_sig_provider(
+          [
+            %{
+              :log => __MODULE__.t(),
+              :transaction_hash => Hash.t()
+            }
+          ],
+          boolean()
+        ) ::
+          {:error, :contract_not_verified, list()} | list()
+  def decode_events_batch_via_sig_provider([], _skip_sig_provider?), do: []
+
+  def decode_events_batch_via_sig_provider(input, skip_sig_provider?) do
+    with true <- SigProviderInterface.enabled?(),
+         false <- skip_sig_provider?,
+         {:ok, result} <-
+           SigProviderInterface.decode_events_in_batch(prepare_input_for_sig_provider_batch_request(input)),
+         true <- is_list(result),
+         false <- Enum.empty?(result) do
+      input
+      |> Enum.zip(result)
+      |> Enum.map(fn {%{
+                        :log => log,
+                        :transaction_hash => transaction_hash
+                      }, %{"abi" => abi}} ->
+        abi = [abi |> List.first() |> Map.put("type", "event")]
+        {:ok, selector, mapping} = find_and_decode(abi, log, transaction_hash)
+
+        identifier = Base.encode16(selector.method_id, case: :lower)
+        text = function_call(selector.function, mapping)
+
+        {:error, :contract_not_verified, [{:ok, identifier, text, mapping}]}
+      end)
+    else
+      _ ->
+        input
+        |> Enum.map(fn _ -> {:error, :could_not_decode} end)
+    end
+  end
+
+  defp prepare_input_for_sig_provider_batch_request(input) do
+    input
+    |> Enum.map(fn %{:log => log, :transaction_hash => _transaction_hash} ->
+      topics = [
+        log.first_topic,
+        log.second_topic,
+        log.third_topic,
+        log.fourth_topic
+      ]
+
+      formatted_topics =
+        topics |> Enum.reject(&is_nil/1) |> Enum.join(",")
+
+      %{
+        :topics => formatted_topics,
+        :data => to_string(log.data)
+      }
+    end)
   end
 
   def fetch_log_by_transaction_hash_and_first_topic(transaction_hash, first_topic, options \\ []) do

--- a/apps/explorer/test/explorer/chain/log_test.exs
+++ b/apps/explorer/test/explorer/chain/log_test.exs
@@ -70,7 +70,7 @@ defmodule Explorer.Chain.LogTest do
 
       log = insert(:log, transaction: transaction)
 
-      assert {{:error, :could_not_decode}, _, _} = Log.decode(log, transaction, [], false)
+      assert {{:error, :could_not_decode}, _, _} = Log.decode(log, transaction, [], false, false)
     end
 
     test "that a contract call transaction that has a verified contract returns the decoded input data" do
@@ -126,7 +126,7 @@ defmodule Explorer.Chain.LogTest do
                      152, 206, 227, 92, 181, 213, 23, 242, 210, 150, 162>>}},
                  {"_number", "uint256", false, 0},
                  {"_belly", "bool", true, true}
-               ]}, _, _} = Log.decode(log, transaction, [], false)
+               ]}, _, _} = Log.decode(log, transaction, [], false, false)
     end
 
     test "replace arg names with argN if it's empty string" do
@@ -182,7 +182,7 @@ defmodule Explorer.Chain.LogTest do
                      152, 206, 227, 92, 181, 213, 23, 242, 210, 150, 162>>}},
                  {"arg1", "uint256", false, 0},
                  {"arg2", "bool", true, true}
-               ]}, _, _} = Log.decode(log, transaction, [], false)
+               ]}, _, _} = Log.decode(log, transaction, [], false, false)
     end
 
     test "finds decoding candidates" do
@@ -237,7 +237,7 @@ defmodule Explorer.Chain.LogTest do
                     {"_number", "uint256", false, 0},
                     {"_belly", "bool", true, true}
                   ]}
-               ]}, _, _} = Log.decode(log, transaction, [], false)
+               ]}, _, _} = Log.decode(log, transaction, [], false, false)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10491

## Motivation

Requests to Sig-provider to decode logs from the list of logs are sent consequently one after another, which notably slows down the response time.

Here is an example of the PR's effect on one of the problematic address's logs page:

https://www.shibariumscan.io/address/0x0000000000000000000000000000000000001001?tab=logs

Before the changes:

![Screenshot 2025-02-26 at 12 56 47](https://github.com/user-attachments/assets/f8a07c14-d51d-41b3-8ac5-16e5d81bbfdc)

After the changes:

![Screenshot 2025-02-26 at 13 22 12](https://github.com/user-attachments/assets/eac28778-0c88-4a43-a631-44656c86a0ad)


## Changelog

Replace per log request to the Sig-provider microservice with usage of [batch logs decoding endpoint](https://github.com/blockscout/swaggers/blob/c5649f57410557de292ac8fe52052410c18c15a7/services/sig-provider/main/swagger.yaml#L41).

### AI Agent summary

This pull request introduces several changes to the log decoding process, focusing on improving the handling of signature providers and batch processing. The key changes include adding new parameters to functions, modifying error handling, and introducing new methods for batch processing of logs.

### Enhancements to Log Decoding:

* [`apps/explorer/lib/explorer/chain/log.ex`](diffhunk://#diff-3d26f98f146ab0da1cbf6667b8eaf78ea17e037af526c4e0c8ae55a38aa8cef0L170-R175): Added a new parameter `from_list?` to the `decode` function and updated the `handle_method_decode_error` function to handle this parameter. Introduced the `mark_events_to_decode_later_via_sig_provider_in_batch` and `decode_events_batch_via_sig_provider` functions for batch processing. [[1]](diffhunk://#diff-3d26f98f146ab0da1cbf6667b8eaf78ea17e037af526c4e0c8ae55a38aa8cef0L170-R175) [[2]](diffhunk://#diff-3d26f98f146ab0da1cbf6667b8eaf78ea17e037af526c4e0c8ae55a38aa8cef0L184-R235) [[3]](diffhunk://#diff-3d26f98f146ab0da1cbf6667b8eaf78ea17e037af526c4e0c8ae55a38aa8cef0L349-R409) [[4]](diffhunk://#diff-3d26f98f146ab0da1cbf6667b8eaf78ea17e037af526c4e0c8ae55a38aa8cef0L370-R513)

### Updates to AddressView and TransactionView:

* [`apps/block_scout_web/lib/block_scout_web/views/address_view.ex`](diffhunk://#diff-d11d479c4f4f35d8fb5391019ae69a2495b0e78e5c574ef6f826c2e5f6741f0dL480-R480): Updated the `decode` function to include the new `from_list?` parameter.
* [`apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex`](diffhunk://#diff-2915eea2f9f0ad5c9194caf62bb34a47f279ea58cc34e221a33a00c0c59ea381L230-R288): Modified the `decode_logs` function to handle the new batch processing and error handling logic.

### SigProviderInterface Improvements:

* [`apps/explorer/lib/explorer/smart_contract/sig_provider_interface.ex`](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edR11-R13): Added new functions `decode_events_in_batch` and `http_post_request` to support batch event decoding. Updated existing functions to improve logging and error handling. [[1]](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edR11-R13) [[2]](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edR26-R28) [[3]](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edL39-R80) [[4]](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edL63-R127) [[5]](diffhunk://#diff-f810059e2b98fedbb50c825593bb573bcfecd471b9da89b11805999d028026edL73-R145)

### Test Adjustments:

* [`apps/explorer/test/explorer/chain/log_test.exs`](diffhunk://#diff-e237a8e4e2f63d8e0e630b4c990a43f0cfa437fd8bde49e4b6ea6b87463c8636L73-R73): Updated tests to include the new `from_list?` parameter in the `decode` function calls. [[1]](diffhunk://#diff-e237a8e4e2f63d8e0e630b4c990a43f0cfa437fd8bde49e4b6ea6b87463c8636L73-R73) [[2]](diffhunk://#diff-e237a8e4e2f63d8e0e630b4c990a43f0cfa437fd8bde49e4b6ea6b87463c8636L129-R129) [[3]](diffhunk://#diff-e237a8e4e2f63d8e0e630b4c990a43f0cfa437fd8bde49e4b6ea6b87463c8636L185-R185) [[4]](diffhunk://#diff-e237a8e4e2f63d8e0e630b4c990a43f0cfa437fd8bde49e4b6ea6b87463c8636L240-R240)

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced batch processing for decoding events, enhancing the handling of transaction logs and smart contract events.
  
- **Refactor**
	- Optimized log processing across the platform for more robust output and improved error handling in address and transaction views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->