### PR TITLE
fix: Async fetch internal transactions from reindex migration

### DIFF
--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -25,7 +25,7 @@ defmodule Explorer.Mixfile do
       ],
       start_permanent: Mix.env() == :prod,
       version: "7.0.2",
-      xref: [exclude: [BlockScoutWeb.Routers.WebRouter.Helpers, Indexer.Helper]]
+      xref: [exclude: [BlockScoutWeb.Routers.WebRouter.Helpers, Indexer.Helper, Indexer.Fetcher.InternalTransaction]]
     ]
   end
 


### PR DESCRIPTION
## Motivation

New pending block operations created from `ReindexInternalTransactionsWithIncompatibleStatus` migration are not added to `InternalTransaction` fetcher queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction processing by integrating asynchronous operations, improving overall efficiency and responsiveness when handling data updates.
	- Introduced a new alias for internal transaction fetching to streamline operations.

- **Bug Fixes**
	- Updated cross-reference exclusions to improve static analysis and reduce false positives during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->