### PR TITLE
chore: Use DB replica, if it's enabled, for proxy-related queries

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -305,7 +305,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
          proxy_type,
          proxy_address_hash
        ) do
-    implementation_address_hash_strings = module.get_implementation_address_hash_strings(proxy_address_hash)
+    implementation_address_hash_strings = module.get_implementation_address_hash_strings(proxy_address_hash, api?: true)
 
     if implementation_address_hash_strings == [] ||
          implementation_address_hash_strings == [burn_address_hash_string()] ||

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.CloneWithImmutableArguments do
   @doc """
   Get implementation address hash string following "Clone with immutable arguments" proxy pattern. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()]
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), list()) :: [binary()]
   def get_implementation_address_hash_strings(proxy_address_hash, options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash, options) do
       nil -> []

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.CloneWithImmutableArguments do
   @doc """
   Get implementation address hash string following "Clone with immutable arguments" proxy pattern. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t(), list()) :: [binary()]
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()]
   def get_implementation_address_hash_strings(proxy_address_hash, options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash, options) do
       nil -> []

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex
@@ -10,7 +10,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1167 do
   @doc """
   Get implementation address hash string following EIP-1167. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()]
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()]
   def get_implementation_address_hash_strings(proxy_address_hash, options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash, options) do
       nil -> []

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1822.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1822.ex
@@ -2,6 +2,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1822 do
   @moduledoc """
   Module for fetching proxy implementation from https://eips.ethereum.org/EIPS/eip-1822 Universal Upgradeable Proxy Standard (UUPS)
   """
+  alias Explorer.Chain
   alias Explorer.Chain.Hash
   alias Explorer.Chain.SmartContract.Proxy
 
@@ -11,8 +12,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1822 do
   @doc """
   Get implementation address hash string following EIP-1822. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()] | :error
-  def get_implementation_address_hash_strings(proxy_address_hash) do
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()] | :error
+  def get_implementation_address_hash_strings(proxy_address_hash, _options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash) do
       nil -> []
       :error -> :error

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1967.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1967.ex
@@ -2,6 +2,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1967 do
   @moduledoc """
   Module for fetching proxy implementation from https://eips.ethereum.org/EIPS/eip-1967 (Proxy Storage Slots)
   """
+  alias Explorer.Chain
   alias Explorer.Chain.Hash
   alias Explorer.Chain.SmartContract.Proxy
   alias Explorer.SmartContract.Helper, as: SmartContractHelper
@@ -31,8 +32,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1967 do
   @doc """
   Get implementation address hash string following EIP-1967. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()] | :error
-  def get_implementation_address_hash_strings(proxy_address_hash) do
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()] | :error
+  def get_implementation_address_hash_strings(proxy_address_hash, _options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash) do
       nil -> []
       :error -> :error

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex
@@ -6,6 +6,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
   # 52ef6b2c = keccak256(facetAddresses())
   @facet_addresses_signature "52ef6b2c"
 
+  alias Explorer.Chain
   alias Explorer.Chain.Hash
   alias Explorer.SmartContract.Helper, as: SmartContractHelper
 
@@ -19,8 +20,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP2535 do
     }
   ]
 
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()]
-  def get_implementation_address_hash_strings(proxy_address_hash) do
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()]
+  def get_implementation_address_hash_strings(proxy_address_hash, _options \\ []) do
     case @facet_addresses_signature
          |> SmartContractHelper.get_binary_string_from_contract_getter(
            to_string(proxy_address_hash),

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
@@ -11,9 +11,9 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
   @doc """
   Get implementation address hash string following EIP-7702. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()]
-  def get_implementation_address_hash_strings(address_hash) do
-    case get_implementation_address_hash_string(address_hash) do
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), list()) :: [binary()]
+  def get_implementation_address_hash_strings(address_hash, options \\ []) do
+    case get_implementation_address_hash_string(address_hash, options) do
       nil -> []
       implementation_address_hash_string -> [implementation_address_hash_string]
     end
@@ -32,8 +32,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
   # - The delegate address in the hex string format if found and successfully decoded.
   # - `nil` if the address doesn't exist, has no contract code, or the delegate address
   #   couldn't be extracted or decoded.
-  @spec get_implementation_address_hash_string(Hash.Address.t()) :: binary() | nil
-  defp get_implementation_address_hash_string(address_hash, options \\ []) do
+  @spec get_implementation_address_hash_string(Hash.Address.t(), [Chain.api?()]) :: binary() | nil
+  defp get_implementation_address_hash_string(address_hash, options) do
     case Chain.select_repo(options).get(Address, address_hash) do
       nil ->
         nil

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex
@@ -11,7 +11,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP7702 do
   @doc """
   Get implementation address hash string following EIP-7702. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t(), list()) :: [binary()]
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()]
   def get_implementation_address_hash_strings(address_hash, options \\ []) do
     case get_implementation_address_hash_string(address_hash, options) do
       nil -> []

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/resolved_delegate_proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/resolved_delegate_proxy.ex
@@ -74,8 +74,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.ResolvedDelegateProxy do
   Get implementation address hash string following ResolvedDelegateProxy proxy pattern. It returns the value as array of the strings.
   """
   @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()] | :error
-  def get_implementation_address_hash_strings(proxy_address_hash, _options \\ []) do
-    case get_implementation_address_hash_string(proxy_address_hash) do
+  def get_implementation_address_hash_strings(proxy_address_hash, options \\ []) do
+    case get_implementation_address_hash_string(proxy_address_hash, options) do
       nil -> []
       :error -> :error
       implementation_address_hash_string -> [implementation_address_hash_string]
@@ -91,11 +91,11 @@ defmodule Explorer.Chain.SmartContract.Proxy.ResolvedDelegateProxy do
   end
 
   # Get implementation address hash string following ResolvedDelegateProxy proxy pattern
-  @spec get_implementation_address_hash_string(Hash.Address.t()) :: binary() | nil | :error
-  defp get_implementation_address_hash_string(proxy_address_hash) do
+  @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: binary() | nil | :error
+  defp get_implementation_address_hash_string(proxy_address_hash, options) do
     proxy_smart_contract =
       proxy_address_hash
-      |> SmartContract.address_hash_to_smart_contract()
+      |> SmartContract.address_hash_to_smart_contract(options)
 
     if proxy_smart_contract && proxy_smart_contract.abi == @resolved_delegate_proxy_abi do
       case SmartContract.format_constructor_arguments(

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/resolved_delegate_proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/resolved_delegate_proxy.ex
@@ -2,6 +2,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.ResolvedDelegateProxy do
   @moduledoc """
   Module for fetching proxy implementation from ResolvedDelegateProxy https://github.com/ethereum-optimism/optimism/blob/9580179013a04b15e6213ae8aa8d43c3f559ed9a/packages/contracts-bedrock/src/legacy/ResolvedDelegateProxy.sol
   """
+  alias Explorer.Chain
   alias Explorer.Chain.{Hash, SmartContract}
   alias Explorer.SmartContract.Helper, as: SmartContractHelper
 
@@ -72,8 +73,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.ResolvedDelegateProxy do
   @doc """
   Get implementation address hash string following ResolvedDelegateProxy proxy pattern. It returns the value as array of the strings.
   """
-  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()] | :error
-  def get_implementation_address_hash_strings(proxy_address_hash) do
+  @spec get_implementation_address_hash_strings(Hash.Address.t(), [Chain.api?()]) :: [binary()] | :error
+  def get_implementation_address_hash_strings(proxy_address_hash, _options \\ []) do
     case get_implementation_address_hash_string(proxy_address_hash) do
       nil -> []
       :error -> :error


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8930

## Motivation

Use DB replica, if it's enabled, for proxy-related queries

## Changelog

### AI Agent summary

This pull request introduces changes to the `Explorer.Chain.SmartContract.Proxy` module and its submodules to update the `get_implementation_address_hash_strings` function signatures. The updates involve adding an optional `options` parameter to these functions. This change ensures consistency across different proxy pattern implementations and allows for additional options to be passed in the future.

Key changes include:

*General changes to function signatures:*
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy.ex`](diffhunk://#diff-1f59e8cd3d2661e7dc7c31e3c00441f38b2d071e6d4a771393ccf901c870b57aL308-R308): Updated `get_implementation_address_hash_strings` to include an `api?: true` option.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/clone_with_immutable_arguments.ex`](diffhunk://#diff-c0511c599cc738cc4484218a28d079e937ef428a10ec083d8667b7e72aad5dc6L13-R13): Added an `options` parameter to the `get_implementation_address_hash_strings` function.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1167.ex`](diffhunk://#diff-c97e9a682623142ee20bd907d9f6bde26a57eacef890cf7d0bbf31d4ae082813L13-R13): Added an `options` parameter to the `get_implementation_address_hash_strings` function.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1822.ex`](diffhunk://#diff-f8f5d19a30fe5ef6c091634b33d096ad876c8f094f6b257e8eb71099070f976aL14-R15): Added an `options` parameter to the `get_implementation_address_hash_strings` function.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1967.ex`](diffhunk://#diff-6fdedce27255a007e91c366f086d398559ecb0a391ff768169d62f5a10aa2d19L34-R35): Added an `options` parameter to the `get_implementation_address_hash_strings` function.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_2535.ex`](diffhunk://#diff-706af09b170f490d3354b16f8da50aaf6cfe13dc49e84fac06c03167ecbd0eaaL22-R23): Added an `options` parameter to the `get_implementation_address_hash_strings` function.
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_7702.ex`](diffhunk://#diff-db49c6a50687871b4a2d75b4acd587c2132b74ff818e3a2f07d0faf797e1ab82L14-R16): Added an `options` parameter to the `get_implementation_address_hash_strings` function and updated the private `get_implementation_address_hash_string` function accordingly. [[1]](diffhunk://#diff-db49c6a50687871b4a2d75b4acd587c2132b74ff818e3a2f07d0faf797e1ab82L14-R16) [[2]](diffhunk://#diff-db49c6a50687871b4a2d75b4acd587c2132b74ff818e3a2f07d0faf797e1ab82L35-R36)
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/resolved_delegate_proxy.ex`](diffhunk://#diff-93df1e63bb9c563d161b8487fa412425a6a723873b05e4af229cb482f3bee597L75-R76): Added an `options` parameter to the `get_implementation_address_hash_strings` function.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved the smart contract proxy interactions by standardizing how implementation details are retrieved.
	- Added support for optional configuration parameters, enhancing flexibility and paving the way for future customizations while maintaining consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->