### PR TITLE
chore: eliminate warnings in `epoch_logs.ex`

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/celo/epoch_logs.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/epoch_logs.ex
@@ -3,15 +3,13 @@ defmodule Indexer.Fetcher.Celo.EpochLogs do
   Fetches logs that are not linked to transaction, but to the block.
   """
 
-  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
-
   import Explorer.Chain.Celo.Helper,
     only: [
       epoch_block_number?: 1,
       premigration_block_number?: 1
     ]
 
-  alias EthereumJSONRPC.Logs
+  alias EthereumJSONRPC.{Logs, Transport}
   alias Explorer.Chain.Cache.CeloCoreContracts
   alias Indexer.Helper, as: IndexerHelper
 
@@ -53,6 +51,10 @@ defmodule Indexer.Fetcher.Celo.EpochLogs do
     end
   end
 
+  @spec do_fetch(
+          [Indexer.Transform.Blocks.block()],
+          EthereumJSONRPC.json_rpc_named_arguments()
+        ) :: Logs.t()
   defp do_fetch(blocks, json_rpc_named_arguments) do
     requests =
       blocks
@@ -73,6 +75,10 @@ defmodule Indexer.Fetcher.Celo.EpochLogs do
   # Workaround in order to fix block fetcher tests.
   #
   # If the requests is empty, we still send the requests to the JSON RPC
+  @spec do_requests(
+          [Transport.request()],
+          EthereumJSONRPC.json_rpc_named_arguments()
+        ) :: {:ok, [map()]}
   defp do_requests(requests, json_rpc_named_arguments) do
     if Enum.empty?(requests) do
       {:ok, []}
@@ -86,6 +92,10 @@ defmodule Indexer.Fetcher.Celo.EpochLogs do
     end
   end
 
+  @spec blocks_reducer(
+          Indexer.Transform.Blocks.block(),
+          {[Transport.request()], integer()}
+        ) :: {[Transport.request()], integer()}
   defp blocks_reducer(%{number: number}, {acc, start_request_id}) do
     targets =
       @default_block_targets ++


### PR DESCRIPTION
Just fix some occasional warnings that appeared after https://github.com/blockscout/blockscout/pull/11949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal log retrieval process for improved maintainability and consistent performance, with no noticeable changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->