### PR TITLE
perf: optimize query for user token transfers list filtered by token

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -333,69 +333,10 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           | {:not_found, {:error, :not_found}}
           | {:restricted_access, true}
           | Plug.Conn.t()
-  def token_transfers(
-        conn,
-        %{"address_hash_param" => address_hash_string, "token" => token_address_hash_string} = params
-      ) do
-    with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
-         {:ok, token_address_hash} <- validate_address_hash(token_address_hash_string, params),
-         {:not_found, {:ok, _address}} <- {:not_found, Chain.hash_to_address(token_address_hash, @api_true, false)} do
-      case Chain.hash_to_address(address_hash, @address_options, false) do
-        {:ok, _address} ->
-          paging_options = paging_options(params)
-
-          options =
-            [
-              necessity_by_association: %{
-                [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-                [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] =>
-                  :optional,
-                :block => :optional,
-                :token => :optional,
-                :transaction => :optional
-              }
-            ]
-            |> Keyword.merge(paging_options)
-            |> Keyword.merge(@api_true)
-
-          results =
-            address_hash
-            |> Chain.address_hash_to_token_transfers_by_token_address_hash(
-              token_address_hash,
-              options
-            )
-            |> Chain.flat_1155_batch_token_transfers()
-            |> Chain.paginate_1155_batch_token_transfers(paging_options)
-
-          {token_transfers, next_page} = split_list_by_page(results)
-
-          next_page_params =
-            next_page
-            |> token_transfers_next_page_params(token_transfers, delete_parameters_from_next_page_params(params))
-
-          conn
-          |> put_status(200)
-          |> put_view(TransactionView)
-          |> render(:token_transfers, %{
-            token_transfers:
-              token_transfers |> Instance.preload_nft(@api_true) |> maybe_preload_ens() |> maybe_preload_metadata(),
-            next_page_params: next_page_params
-          })
-
-        _ ->
-          conn
-          |> put_status(200)
-          |> put_view(TransactionView)
-          |> render(:token_transfers, %{
-            token_transfers: [],
-            next_page_params: nil
-          })
-      end
-    end
-  end
-
   def token_transfers(conn, %{"address_hash_param" => address_hash_string} = params) do
-    with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
+    with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
+         {:ok, token_address_hash} <- validate_optional_address_hash(params["token"], params),
+         :ok <- (token_address_hash && Address.check_address_exists(token_address_hash)) || :ok do
       case Chain.hash_to_address(address_hash, @address_options, false) do
         {:ok, _address} ->
           paging_options = paging_options(params)
@@ -405,6 +346,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
             |> Keyword.merge(paging_options)
             |> Keyword.merge(current_filter(params))
             |> Keyword.merge(token_transfers_types_options(params))
+            |> Keyword.merge(token_address_hash: token_address_hash)
 
           results =
             address_hash
@@ -1064,7 +1006,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     end
   end
 
-  # Checks if this valid address hash string, and this address is not prohibited address.
+  # Checks if this address hash string is valid, and this address is not prohibited.
   # Returns the `{:ok, address_hash}` if address hash passed all the checks.
   # Returns {:ok, _} response even if the address is not present in the database.
   @spec validate_address_hash(String.t(), any()) ::
@@ -1075,6 +1017,24 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params) do
       {:ok, address_hash}
+    end
+  end
+
+  # Checks if this address hash string is valid, and this address is not prohibited.
+  # Returns the `{:ok, nil}` if first argument is `nil`.
+  # Returns the `{:ok, address_hash}` if address hash passed all the checks.
+  # Returns {:ok, _} response even if the address is not present in the database.
+  @spec validate_optional_address_hash(nil | String.t(), any()) ::
+          {:format, :error}
+          | {:restricted_access, true}
+          | {:ok, nil | Hash.t()}
+  defp validate_optional_address_hash(address_hash_string, params) do
+    case address_hash_string do
+      nil ->
+        {:ok, nil}
+
+      _ ->
+        validate_address_hash(address_hash_string, params)
     end
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/graphql/resolvers/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/resolvers/token_transfer.ex
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.GraphQL.Resolvers.TokenTransfer do
     connection_args = Map.take(args, [:after, :before, :first, :last])
 
     address_hash
-    |> TokenTransfer.token_transfers_by_address_hash(nil, [], nil)
+    |> TokenTransfer.token_transfers_by_address_hash(nil, nil, [], nil)
     |> Connection.from_query(&Repo.replica().all/1, connection_args, options(args))
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -317,36 +317,14 @@ defmodule Explorer.Chain do
   def address_hash_to_token_transfers_new(address_hash, options \\ []) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
     direction = Keyword.get(options, :direction)
+    token_address_hash = Keyword.get(options, :token_address_hash)
     filters = Keyword.get(options, :token_type)
     necessity_by_association = Keyword.get(options, :necessity_by_association)
 
     address_hash
-    |> TokenTransfer.token_transfers_by_address_hash(direction, filters, paging_options)
+    |> TokenTransfer.token_transfers_by_address_hash(direction, token_address_hash, filters, paging_options)
     |> join_associations(necessity_by_association)
     |> select_repo(options).all()
-  end
-
-  @spec address_hash_to_token_transfers_by_token_address_hash(
-          Hash.Address.t() | String.t(),
-          Hash.Address.t() | String.t(),
-          Keyword.t()
-        ) :: [TokenTransfer.t()]
-  def address_hash_to_token_transfers_by_token_address_hash(address_hash, token_address_hash, options \\ []) do
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-
-    case paging_options do
-      %PagingOptions{key: {0, 0}} ->
-        []
-
-      _ ->
-        necessity_by_association = Keyword.get(options, :necessity_by_association)
-
-        address_hash
-        |> TokenTransfer.token_transfers_by_address_hash_and_token_address_hash(token_address_hash)
-        |> join_associations(necessity_by_association)
-        |> TokenTransfer.handle_paging_options(paging_options)
-        |> select_repo(options).all()
-    end
   end
 
   @spec address_hash_to_withdrawals(


### PR DESCRIPTION
Reuse query from #9576 for the following view:
* https://eth.blockscout.com/address/0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE?tab=token_transfers&token=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48

We don't have indices on both token address and from/to addresses, so in some cases it'll still be slow, but in general it should still work much better.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
