### PR TITLE
feat: ERC-7760 proxy type support

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -16,6 +16,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     EIP1967,
     EIP2535,
     EIP7702,
+    ERC7760,
     MasterCopy,
     ResolvedDelegateProxy
   }
@@ -209,6 +210,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
         :get_implementation_address_hash_string_eip1967,
         :get_implementation_address_hash_string_eip1822,
         :get_implementation_address_hash_string_eip2535,
+        :get_implementation_address_hash_string_erc7760,
         :get_implementation_address_hash_string_resolved_delegate_proxy
       ]
 
@@ -288,6 +290,14 @@ defmodule Explorer.Chain.SmartContract.Proxy do
         }
   def get_implementation_address_hash_string_eip2535(proxy_address_hash) do
     get_implementation_address_hash_string_by_module(EIP2535, :eip2535, proxy_address_hash)
+  end
+
+  @spec get_implementation_address_hash_string_erc7760(Hash.Address.t()) :: %{
+          implementation_address_hash_strings: [String.t() | :error | nil],
+          proxy_type: atom()
+        }
+  def get_implementation_address_hash_string_erc7760(proxy_address_hash) do
+    get_implementation_address_hash_string_by_module(ERC7760, :erc7760, proxy_address_hash)
   end
 
   @spec get_implementation_address_hash_string_resolved_delegate_proxy(Hash.Address.t()) ::

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1967.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/eip_1967.ex
@@ -10,7 +10,9 @@ defmodule Explorer.Chain.SmartContract.Proxy.EIP1967 do
   # 5c60da1b = keccak256(implementation())
   @implementation_signature "5c60da1b"
 
+  # obtained as bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
   @storage_slot_logic_contract_address "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+  # obtained as bytes32(uint256(keccak256('eip1967.proxy.beacon')) - 1)
   @storage_slot_beacon_contract_address "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50"
 
   # to be precise, it is not the part of the EIP-1967 standard, but still uses the same pattern

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/erc_7760.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/erc_7760.ex
@@ -1,0 +1,88 @@
+defmodule Explorer.Chain.SmartContract.Proxy.ERC7760 do
+  @moduledoc """
+  Module for fetching proxy implementation from https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7760.md
+  """
+
+  alias Explorer.Chain
+  alias Explorer.Chain.{Address, Hash}
+  alias Explorer.Chain.SmartContract.Proxy
+  alias Explorer.Chain.SmartContract.Proxy.EIP1967
+
+  @uups_basic_variant "363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3"
+  @uups_l_variant "365814604357363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e603e573d6000fd5b3d6000f35b6020600f3d393d51543d52593df3"
+  @beacon_basic_variant "363d3d373d3d363d602036600436635c60da1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3"
+  @beacon_l_variant "363d3d373d3d363d602036600436635c60da1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50545afa361460525736515af43d600060013e6052573d6001fd5b3d6001f3"
+  @transparent_basic_variant_20_left "3d3d3373"
+  @transparent_basic_variant_20_right "14605757363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d356020355560408036111560525736038060403d373d3d355af43d6000803e6052573d6000fd"
+  @transparent_basic_variant_14_left "3d3d336d"
+  @transparent_basic_variant_14_right "14605157363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e604c573d6000fd5b3d6000f35b3d3560203555604080361115604c5736038060403d373d3d355af43d6000803e604c573d6000fd"
+  @transparent_l_variant_20_left "3658146083573d3d3373"
+  @transparent_l_variant_20_right "14605D57363d3d37363D7f360894a13ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6058573d6000fd5b3d6000f35b3d35602035556040360380156058578060403d373d3d355af43d6000803e6058573d6000fd5b602060293d393d51543d52593df3"
+  @transparent_l_variant_14_left "365814607d573d3d336d"
+  @transparent_l_variant_14_right "14605757363d3D37363d7F360894A13Ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d35602035556040360380156052578060403d373d3d355af43d6000803e6052573d6000fd5b602060233d393d51543d52593df3"
+
+  @doc """
+  Get implementation address hash string following ERC-7760. It returns the value as array of the strings.
+  """
+  @spec get_implementation_address_hash_strings(Hash.Address.t()) :: [binary()]
+  def get_implementation_address_hash_strings(proxy_address_hash, options \\ []) do
+    case get_implementation_address_hash_string(proxy_address_hash, options) do
+      nil -> []
+      implementation_address_hash_string -> [implementation_address_hash_string]
+    end
+  end
+
+  # Get implementation address hash string following ERC-7760
+  @spec get_implementation_address_hash_string(Hash.Address.t(), Keyword.t()) :: binary() | nil
+  defp get_implementation_address_hash_string(proxy_address_hash, options) do
+    case Chain.select_repo(options).get(Address, proxy_address_hash) do
+      nil ->
+        nil
+
+      target_address ->
+        contract_code = target_address.contract_code
+
+        case contract_code do
+          %Chain.Data{bytes: contract_code_bytes} ->
+            contract_bytecode = Base.encode16(contract_code_bytes, case: :lower)
+
+            contract_bytecode |> get_proxy_erc_7760(proxy_address_hash)
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  defp get_proxy_erc_7760(contract_bytecode, proxy_address_hash) do
+    case contract_bytecode do
+      @transparent_basic_variant_20_left <> <<_factory_address::binary-size(40)>> <> @transparent_basic_variant_20_right ->
+        fetch_implementation(proxy_address_hash)
+
+      @transparent_basic_variant_14_left <> <<_factory_address::binary-size(28)>> <> @transparent_basic_variant_14_right ->
+        fetch_implementation(proxy_address_hash)
+
+      @transparent_l_variant_20_left <> <<_factory_address::binary-size(40)>> <> @transparent_l_variant_20_right ->
+        fetch_implementation(proxy_address_hash)
+
+      @transparent_l_variant_14_left <> <<_factory_address::binary-size(28)>> <> @transparent_l_variant_14_right ->
+        fetch_implementation(proxy_address_hash)
+
+      bytecode when bytecode in [@uups_basic_variant, @uups_l_variant, @beacon_basic_variant, @beacon_l_variant] ->
+        fetch_implementation(proxy_address_hash)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp fetch_implementation(proxy_address_hash) do
+    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+    Proxy.get_implementation_from_storage(
+      proxy_address_hash,
+      EIP1967.storage_slot_logic_contract_address(),
+      json_rpc_named_arguments
+    )
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/erc_7760.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/erc_7760.ex
@@ -17,9 +17,9 @@ defmodule Explorer.Chain.SmartContract.Proxy.ERC7760 do
   @transparent_basic_variant_14_left "3d3d336d"
   @transparent_basic_variant_14_right "14605157363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e604c573d6000fd5b3d6000f35b3d3560203555604080361115604c5736038060403d373d3d355af43d6000803e604c573d6000fd"
   @transparent_l_variant_20_left "3658146083573d3d3373"
-  @transparent_l_variant_20_right "14605D57363d3d37363D7f360894a13ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6058573d6000fd5b3d6000f35b3d35602035556040360380156058578060403d373d3d355af43d6000803e6058573d6000fd5b602060293d393d51543d52593df3"
+  @transparent_l_variant_20_right "14605d57363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6058573d6000fd5b3d6000f35b3d35602035556040360380156058578060403d373d3d355af43d6000803e6058573d6000fd5b602060293d393d51543d52593df3"
   @transparent_l_variant_14_left "365814607d573d3d336d"
-  @transparent_l_variant_14_right "14605757363d3D37363d7F360894A13Ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d35602035556040360380156052578060403d373d3d355af43d6000803e6052573d6000fd5b602060233d393d51543d52593df3"
+  @transparent_l_variant_14_right "14605757363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d35602035556040360380156052578060403d373d3d355af43d6000803e6052573d6000fd5b602060233d393d51543d52593df3"
 
   @doc """
   Get implementation address hash string following ERC-7760. It returns the value as array of the strings.
@@ -54,21 +54,33 @@ defmodule Explorer.Chain.SmartContract.Proxy.ERC7760 do
     end
   end
 
+  # credo:disable-for-next-line /Complexity/
   defp get_proxy_erc_7760(contract_bytecode, proxy_address_hash) do
-    case contract_bytecode do
-      @transparent_basic_variant_20_left <> <<_factory_address::binary-size(40)>> <> @transparent_basic_variant_20_right ->
+    case String.downcase(contract_bytecode) do
+      @transparent_basic_variant_20_left <>
+          <<_factory_address::binary-size(40)>> <> @transparent_basic_variant_20_right <> _ ->
         fetch_implementation(proxy_address_hash)
 
-      @transparent_basic_variant_14_left <> <<_factory_address::binary-size(28)>> <> @transparent_basic_variant_14_right ->
+      @transparent_basic_variant_14_left <>
+          <<_factory_address::binary-size(28)>> <> @transparent_basic_variant_14_right <> _ ->
         fetch_implementation(proxy_address_hash)
 
-      @transparent_l_variant_20_left <> <<_factory_address::binary-size(40)>> <> @transparent_l_variant_20_right ->
+      @transparent_l_variant_20_left <> <<_factory_address::binary-size(40)>> <> @transparent_l_variant_20_right <> _ ->
         fetch_implementation(proxy_address_hash)
 
-      @transparent_l_variant_14_left <> <<_factory_address::binary-size(28)>> <> @transparent_l_variant_14_right ->
+      @transparent_l_variant_14_left <> <<_factory_address::binary-size(28)>> <> @transparent_l_variant_14_right <> _ ->
         fetch_implementation(proxy_address_hash)
 
-      bytecode when bytecode in [@uups_basic_variant, @uups_l_variant, @beacon_basic_variant, @beacon_l_variant] ->
+      @uups_basic_variant <> _ ->
+        fetch_implementation(proxy_address_hash)
+
+      @uups_l_variant <> _ ->
+        fetch_implementation(proxy_address_hash)
+
+      @beacon_basic_variant <> _ ->
+        fetch_implementation(proxy_address_hash)
+
+      @beacon_l_variant <> _ ->
         fetch_implementation(proxy_address_hash)
 
       _ ->

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -52,6 +52,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
         :clone_with_immutable_arguments,
         :eip7702,
         :resolved_delegate_proxy,
+        :erc7760,
         :unknown
       ],
       null: true

--- a/apps/explorer/priv/repo/migrations/20250311090608_add_erc_7760_to_proxy_type.exs
+++ b/apps/explorer/priv/repo/migrations/20250311090608_add_erc_7760_to_proxy_type.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.AddErc7760ToProxyType do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TYPE proxy_type ADD VALUE 'erc7760' BEFORE 'unknown'")
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy/erc_7760_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy/erc_7760_test.exs
@@ -1,0 +1,267 @@
+defmodule Explorer.Chain.SmartContract.Proxy.ERC7760Test do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.SmartContract.Proxy.ERC7760
+  alias Explorer.TestHelper
+
+  @uups_basic_variant "363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3"
+  @uups_l_variant "365814604357363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e603e573d6000fd5b3d6000f35b6020600f3d393d51543d52593df3"
+  @beacon_basic_variant "363d3d373d3d363d602036600436635c60da1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50545afa5036515af43d6000803e604d573d6000fd5b3d6000f3"
+  @beacon_l_variant "363d3d373d3d363d602036600436635c60da1b60e01b36527fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50545afa361460525736515af43d600060013e6052573d6001fd5b3d6001f3"
+  @transparent_basic_variant_20_left "3d3d3373"
+  @transparent_basic_variant_20_right "14605757363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d356020355560408036111560525736038060403d373d3d355af43d6000803e6052573d6000fd"
+  @transparent_basic_variant_14_left "3d3d336d"
+  @transparent_basic_variant_14_right "14605157363d3d37363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e604c573d6000fd5b3d6000f35b3d3560203555604080361115604c5736038060403d373d3d355af43d6000803e604c573d6000fd"
+  @transparent_l_variant_20_left "3658146083573d3d3373"
+  @transparent_l_variant_20_right "14605D57363d3d37363D7f360894a13ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6058573d6000fd5b3d6000f35b3d35602035556040360380156058578060403d373d3d355af43d6000803e6058573d6000fd5b602060293d393d51543d52593df3"
+  @transparent_l_variant_14_left "365814607d573d3d336d"
+  @transparent_l_variant_14_right "14605757363d3D37363d7F360894A13Ba1A3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6052573d6000fd5b3d6000f35b3d35602035556040360380156052578060403d373d3d355af43d6000803e6052573d6000fd5b602060233d393d51543d52593df3"
+
+  describe "get_implementation_address_hash_strings/2" do
+    test "returns implementation address hash string for valid proxy address with uups_basic_variant" do
+      proxy_address = insert(:address, contract_code: "0x" <> @uups_basic_variant)
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with uups_basic_variant and offset" do
+      proxy_address = insert(:address, contract_code: "0x" <> @uups_basic_variant <> "1234")
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_basic_variant_20" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_basic_variant_20_left <>
+              "1234567890123456789012345678901234567890" <> @transparent_basic_variant_20_right
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_basic_variant_20 and offset" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_basic_variant_20_left <>
+              "1234567890123456789012345678901234567890" <> @transparent_basic_variant_20_right <> "1234"
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_basic_variant_14" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_basic_variant_14_left <>
+              "12345678901234567890123456a8" <> @transparent_basic_variant_14_right
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_basic_variant_14 and offset" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_basic_variant_14_left <>
+              "12345678901234567890123456A8" <> @transparent_basic_variant_14_right <> "1234"
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_l_variant_20" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_l_variant_20_left <>
+              "1234567890123456789012345678901234567890" <> @transparent_l_variant_20_right
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_l_variant_20 and offset" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_l_variant_20_left <>
+              "1234567890123456789012345678901234567890" <> @transparent_l_variant_20_right <> "1234"
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_l_variant_14" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <> @transparent_l_variant_14_left <> "1234567890123456789012341234" <> @transparent_l_variant_14_right
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with transparent_l_variant_14 and offset" do
+      proxy_address =
+        insert(:address,
+          contract_code:
+            "0x" <>
+              @transparent_l_variant_14_left <>
+              "1234567890123456789012341234" <> @transparent_l_variant_14_right <> "1234"
+        )
+
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with uups_l_variant" do
+      proxy_address = insert(:address, contract_code: "0x" <> @uups_l_variant)
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with uups_l_variant and offset" do
+      proxy_address = insert(:address, contract_code: "0x" <> @uups_l_variant <> "1234")
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with beacon_basic_variant" do
+      proxy_address = insert(:address, contract_code: "0x" <> @beacon_basic_variant)
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with beacon_basic_variant and offset" do
+      proxy_address = insert(:address, contract_code: "0x" <> @beacon_basic_variant <> "1234")
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with beacon_l_variant" do
+      proxy_address = insert(:address, contract_code: "0x" <> @beacon_l_variant)
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+
+    test "returns implementation address hash string for valid proxy address with beacon_l_variant and offset" do
+      proxy_address = insert(:address, contract_code: "0x" <> @beacon_l_variant <> "1234")
+      implementation_address = insert(:address)
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_logic_storage_pointer_request(false, to_string(implementation_address.hash))
+
+      assert ERC7760.get_implementation_address_hash_strings(proxy_address.hash) == [
+               to_string(implementation_address.hash)
+             ]
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11793

## Motivation

Add [ERC-7760](https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7760.md) proxy pattern support.

> This standard defines minimal [ERC-1967](https://github.com/ethereum/ERCs/blob/master/ERCS/eip-1967.md) proxies for three patterns: (1) transparent, (2) UUPS, (3) beacon. The proxies support optional immutable arguments which are appended to the end of their runtime bytecode. Additional variants which support onchain implementation querying are provided.

## Changelog

### AI Agent summary

This pull request introduces support for the ERC-7760 standard in the `Explorer.Chain.SmartContract.Proxy` module. The most important changes include adding the ERC-7760 module, updating the proxy type, and adding tests for the new functionality.

Support for ERC-7760:

* [`apps/explorer/lib/explorer/chain/smart_contract/proxy.ex`](diffhunk://#diff-1f59e8cd3d2661e7dc7c31e3c00441f38b2d071e6d4a771393ccf901c870b57aR19): Added ERC-7760 to the list of supported proxy types and implemented the `get_implementation_address_hash_string_erc7760` function. [[1]](diffhunk://#diff-1f59e8cd3d2661e7dc7c31e3c00441f38b2d071e6d4a771393ccf901c870b57aR19) [[2]](diffhunk://#diff-1f59e8cd3d2661e7dc7c31e3c00441f38b2d071e6d4a771393ccf901c870b57aR213) [[3]](diffhunk://#diff-1f59e8cd3d2661e7dc7c31e3c00441f38b2d071e6d4a771393ccf901c870b57aR295-R302)
* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/erc_7760.ex`](diffhunk://#diff-ee045b8e0135812bdae69718bb1db372866409e42fc464fb69b011fdeba089dcR1-R100): Created a new module for handling ERC-7760 proxy implementations, including functions to fetch implementation address hash strings.

Proxy type update:

* [`apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex`](diffhunk://#diff-4368a4709c365fca0fdd56b5bea73e8b9ca4e8e8c8b5fc475d69fc14db028791R55): Added `erc7760` to the list of proxy types.
* [`apps/explorer/priv/repo/migrations/20250311090608_add_erc_7760_to_proxy_type.exs`](diffhunk://#diff-60a04786f4c014d3d8dbac2edaa2aeb5acfb4ca28f32646d2dcfa8ca8965cf8dR1-R7): Created a migration to add `erc7760` to the `proxy_type` enum in the database.

Testing:

* [`apps/explorer/test/explorer/chain/smart_contract/proxy/erc_7760_test.exs`](diffhunk://#diff-8bd27daf6d806561b288ee507c047a663427600ae0bf8ac6661bbc88eff92b67R1-R265): Added tests for the ERC-7760 module to verify correct implementation address hash string retrieval.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for the ERC-7760 proxy type with enhanced address hash retrieval and broadened contract code recognition.
  - Added new methods for fetching implementation addresses specific to the ERC-7760 standard.

- **Documentation**
  - Enhanced inline commentary explaining how key address derivations are computed for the EIP-1967 storage slots.

- **Tests**
  - Added comprehensive tests to validate the new ERC-7760 proxy functionality across various contract code scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->