### PR TITLE
chore: Ganache -> Anvil JSON RPC Variant

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/anvil.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/anvil.ex
@@ -1,12 +1,12 @@
-defmodule EthereumJSONRPC.Ganache do
+defmodule EthereumJSONRPC.Anvil do
   @moduledoc """
-  Ethereum JSONRPC methods that are only supported by [Ganache](https://github.com/trufflesuite/ganache-core#implemented-methods).
+  Ethereum JSONRPC methods that are only supported by [Anvil](https://book.getfoundry.sh/anvil/).
   """
 
   @behaviour EthereumJSONRPC.Variant
 
   @doc """
-  Block reward contract beneficiary fetching is not supported currently for Ganache.
+  Block reward contract beneficiary fetching is not supported currently for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """
@@ -14,7 +14,7 @@ defmodule EthereumJSONRPC.Ganache do
   def fetch_beneficiaries(_block_range, _json_rpc_named_arguments), do: :ignore
 
   @doc """
-  Internal transaction fetching is not currently supported for Ganache.
+  Internal transaction fetching is not currently supported for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """
@@ -22,7 +22,7 @@ defmodule EthereumJSONRPC.Ganache do
   def fetch_internal_transactions(_transactions_params, _json_rpc_named_arguments), do: :ignore
 
   @doc """
-  Internal transaction fetching is not currently supported for Ganache.
+  Internal transaction fetching is not currently supported for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """
@@ -30,7 +30,7 @@ defmodule EthereumJSONRPC.Ganache do
   def fetch_block_internal_transactions(_block_range, _json_rpc_named_arguments), do: :ignore
 
   @doc """
-  Pending transaction fetching is not supported currently for Ganache.
+  Pending transaction fetching is not supported currently for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """
@@ -38,7 +38,7 @@ defmodule EthereumJSONRPC.Ganache do
   def fetch_pending_transactions(_json_rpc_named_arguments), do: :ignore
 
   @doc """
-  Traces are not supported currently for Ganache.
+  Traces are not supported currently for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """
@@ -46,7 +46,7 @@ defmodule EthereumJSONRPC.Ganache do
   def fetch_first_trace(_transactions_params, _json_rpc_named_arguments), do: :ignore
 
   @doc """
-  Traces are not supported currently for Ganache.
+  Traces are not supported currently for Anvil.
 
   To signal to the caller that fetching is not supported, `:ignore` is returned.
   """

--- a/apps/explorer/config/dev/anvil.exs
+++ b/apps/explorer/config/dev/anvil.exs
@@ -12,8 +12,8 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      urls: ConfigHelper.parse_urls_list(:http),
-      eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
+      urls: ConfigHelper.parse_urls_list(:http, "http://localhost:7545"),
+      eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:7545"),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),
       fallback_eth_call_urls: ConfigHelper.parse_urls_list(:fallback_eth_call),
       method_to_url: [
@@ -21,7 +21,7 @@ config :explorer,
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ],
   subscribe_named_arguments: [
     transport: EthereumJSONRPC.WebSocket,
@@ -30,5 +30,5 @@ config :explorer,
       url: System.get_env("ETHEREUM_JSONRPC_WS_URL"),
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_WS_URL")
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ]

--- a/apps/explorer/config/prod/anvil.exs
+++ b/apps/explorer/config/prod/anvil.exs
@@ -12,8 +12,8 @@ config :explorer,
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
       http: EthereumJSONRPC.HTTP.HTTPoison,
-      urls: ConfigHelper.parse_urls_list(:http, "http://localhost:7545"),
-      eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:7545"),
+      urls: ConfigHelper.parse_urls_list(:http),
+      eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),
       fallback_eth_call_urls: ConfigHelper.parse_urls_list(:fallback_eth_call),
       method_to_url: [
@@ -21,7 +21,7 @@ config :explorer,
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ],
   subscribe_named_arguments: [
     transport: EthereumJSONRPC.WebSocket,
@@ -30,5 +30,5 @@ config :explorer,
       url: System.get_env("ETHEREUM_JSONRPC_WS_URL"),
       fallback_url: System.get_env("ETHEREUM_JSONRPC_FALLBACK_WS_URL")
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ]

--- a/apps/explorer/config/test/anvil.exs
+++ b/apps/explorer/config/test/anvil.exs
@@ -4,10 +4,10 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.Mox,
     transport_options: [],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ],
   subscribe_named_arguments: [
     transport: EthereumJSONRPC.Mox,
     transport_options: [],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ]

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -817,7 +817,7 @@ defmodule Explorer.Chain do
       json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
       variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
 
-      if variant == EthereumJSONRPC.Ganache do
+      if variant == EthereumJSONRPC.Anvil do
         true
       else
         check_left_blocks_to_index_internal_transactions(options)

--- a/apps/indexer/config/dev/anvil.exs
+++ b/apps/indexer/config/dev/anvil.exs
@@ -26,7 +26,7 @@ config :indexer,
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ],
   subscribe_named_arguments: [
     transport:

--- a/apps/indexer/config/prod/anvil.exs
+++ b/apps/indexer/config/prod/anvil.exs
@@ -26,7 +26,7 @@ config :indexer,
       ],
       http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
     ],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ],
   subscribe_named_arguments: [
     transport:

--- a/apps/indexer/config/test/anvil.exs
+++ b/apps/indexer/config/test/anvil.exs
@@ -4,5 +4,5 @@ config :indexer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.Mox,
     transport_options: [],
-    variant: EthereumJSONRPC.Ganache
+    variant: EthereumJSONRPC.Anvil
   ]

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -46,7 +46,7 @@ The repo contains built-in configs for different JSON RPC clients without need t
 | Geth (suitable for Reth as well) | `docker-compose -f geth.yml up -d`     |
 | Geth Clique    | `docker-compose -f geth-clique-consensus.yml up -d`    |
 | Nethermind, OpenEthereum    | `docker-compose -f nethermind.yml up -d`    |
-| Ganache    | `docker-compose -f ganache.yml up -d`    |
+| Anvil    | `docker-compose -f anvil.yml up -d`    |
 | HardHat network    | `docker-compose -f hardhat-network.yml up -d`    |
 
 - Running only explorer without DB: `docker-compose -f external-db.yml up -d`. In this case, no db container is created. And it assumes that the DB credentials are provided through `DATABASE_URL` environment variable on the backend container.

--- a/docker-compose/anvil.yml
+++ b/docker-compose/anvil.yml
@@ -29,7 +29,7 @@ services:
     links:
       - db:database
     environment:
-        ETHEREUM_JSONRPC_VARIANT: 'ganache'
+        ETHEREUM_JSONRPC_VARIANT: 'anvil'
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: 'true'
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'

--- a/docker-compose/external-frontend.yml
+++ b/docker-compose/external-frontend.yml
@@ -29,7 +29,7 @@ services:
     links:
       - db:database
     environment:
-        ETHEREUM_JSONRPC_VARIANT: 'ganache'
+        ETHEREUM_JSONRPC_VARIANT: 'anvil'
         ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
         INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: 'true'
         INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: 'true'


### PR DESCRIPTION
## Motivation

Replace obsolete `Ganache` JSON RPC Variant with `Anvil`.

## Changelog

There are no changes between how Anvil node is treated in comparison to Ganache. Just renaming for now.
Doc update https://github.com/blockscout/docs/pull/390.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Ethereum JSON-RPC integration has been updated to use Anvil across all environments, ensuring a consistent blockchain interaction experience.
  - Configuration settings for development, testing, and production now reflect the new Anvil provider.

- **Documentation**
  - Deployment instructions and Docker Compose setups have been revised to highlight Anvil as the recommended JSON-RPC client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->