### PR TITLE
feat: JSON RPC metrics

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -56,13 +56,7 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
   end
 
   defp response_body_has_error?(decoded_body) when is_list(decoded_body) do
-    Enum.reduce_while(decoded_body, false, fn decoded_body_elem, has_error? ->
-      if Map.has_key?(decoded_body_elem, "error") do
-        {:halt, true}
-      else
-        {:cont, has_error?}
-      end
-    end)
+    Enum.any?(decoded_body, &response_body_has_error?/1)
   end
 
   defp response_body_has_error?(_decoded_body), do: false

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -4,6 +4,7 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
   """
 
   alias EthereumJSONRPC.HTTP
+  alias EthereumJSONRPC.Prometheus.Instrumenter
 
   @behaviour HTTP
 
@@ -18,16 +19,56 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
         headers
       end
 
+    method = get_method_from_json_string(json)
+
+    Instrumenter.json_rpc_requests(method)
+
     case HTTPoison.post(url, json, headers, options) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->
+        with {:ok, decoded_body} <- Jason.decode(body) do
+          has_error? = response_body_has_error?(decoded_body)
+
+          if has_error? do
+            Instrumenter.json_rpc_errors(method)
+          end
+        end
+
         {:ok, %{body: try_unzip(gzip_enabled?, body, headers), status_code: status_code}}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
+        Instrumenter.json_rpc_errors(method)
+
         {:error, reason}
     end
   end
 
   def json_rpc(url, _json, _headers, _options) when is_nil(url), do: {:error, "URL is nil"}
+
+  defp get_method_from_json_string(json_string) do
+    with {:ok, decoded_json} <- Jason.decode(json_string) do
+      if is_map(decoded_json) do
+        Map.get(decoded_json, "method")
+      else
+        decoded_json |> Enum.at(0) |> Map.get("method")
+      end
+    end
+  end
+
+  defp response_body_has_error?(decoded_body) when is_map(decoded_body) do
+    Map.has_key?(decoded_body, "error")
+  end
+
+  defp response_body_has_error?(decoded_body) when is_list(decoded_body) do
+    Enum.reduce_while(decoded_body, false, fn decoded_body_elem, has_error? ->
+      if Map.has_key?(decoded_body_elem, "error") do
+        {:halt, true}
+      else
+        {:cont, has_error?}
+      end
+    end)
+  end
+
+  defp response_body_has_error?(_decoded_body), do: false
 
   defp try_unzip(true, body, headers) do
     gzipped =

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -25,12 +25,9 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
 
     case HTTPoison.post(url, json, headers, options) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->
-        with {:ok, decoded_body} <- Jason.decode(body) do
-          has_error? = response_body_has_error?(decoded_body)
-
-          if has_error? do
-            Instrumenter.json_rpc_errors(method)
-          end
+        with {:ok, decoded_body} <- Jason.decode(body),
+             true <- response_body_has_error?(decoded_body) do
+          Instrumenter.json_rpc_errors(method)
         end
 
         {:ok, %{body: try_unzip(gzip_enabled?, body, headers), status_code: status_code}}

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
@@ -1,0 +1,36 @@
+defmodule EthereumJSONRPC.Prometheus.Instrumenter do
+  @moduledoc """
+  JSON RPC metrics for `Prometheus`.
+  """
+
+  use Prometheus.Metric
+
+  @counter [name: :json_rpc_requests_count, labels: [:method], help: "Number of JSON RPC requests"]
+  @counter [name: :json_rpc_requests_errors_count, labels: [:method], help: "Number of JSON RPC requests errors"]
+
+  @doc """
+  Increments the JSON-RPC requests counter for a given method.
+
+  ## Parameters
+
+    - `method` (String): The name of the JSON-RPC method.
+    - `req_count` (integer, optional): The number of requests to increment by. Defaults to 1.
+  """
+  @spec json_rpc_requests(String.t(), non_neg_integer()) :: :ok
+  def json_rpc_requests(method, req_count \\ 1) do
+    Counter.inc([name: :json_rpc_requests_count, labels: [method]], req_count)
+  end
+
+  @doc """
+  Increments the counter for JSON-RPC errors for a given method.
+
+  ## Parameters
+
+    - `method` (string): The name of the JSON-RPC method that encountered an error.
+    - `error_count` (integer, optional): The number of errors to increment the counter by. Defaults to 1.
+  """
+  @spec json_rpc_errors(String.t(), non_neg_integer()) :: :ok
+  def json_rpc_errors(method, error_count \\ 1) do
+    Counter.inc([name: :json_rpc_requests_errors_count, labels: [method]], error_count)
+  end
+end

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -69,6 +69,7 @@ defmodule EthereumJSONRPC.MixProject do
       {:logger_file_backend, "~> 0.0.10"},
       # Mocking `EthereumJSONRPC.Transport` and `EthereumJSONRPC.HTTP` so we avoid hitting real chains for local testing
       {:mox, "~> 1.0", only: [:test]},
+      {:prometheus_ex, git: "https://github.com/lanodan/prometheus.ex", branch: "fix/elixir-1.14", override: true},
       # Tracing
       {:spandex, "~> 3.0"},
       # `:spandex` integration with Datadog


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9369

## Motivation

Collect Prometheus metrics of all / failed JSON RPC requests number per method.

## Changelog

Metrics are exposed to `/metrics` endpoint:
```
# TYPE json_rpc_requests_count counter
# HELP json_rpc_requests_count Number of JSON RPC requests
json_rpc_requests_count{method="txpool_content"} 3
json_rpc_requests_count{method="eth_getCode"} 8
json_rpc_requests_count{method="eth_getBlockByNumber"} 17
json_rpc_requests_count{method="eth_getBalance"} 13
json_rpc_requests_count{method="eth_call"} 17
json_rpc_requests_count{method="debug_traceTransaction"} 935
# TYPE json_rpc_requests_errors_count counter
# HELP json_rpc_requests_errors_count Number of JSON RPC requests errors
json_rpc_requests_errors_count{method="eth_call"} 11
json_rpc_requests_errors_count{method="debug_traceTransaction"} 931
```

### AI Agent summary

This pull request introduces Prometheus metrics to monitor JSON RPC requests and errors in the `ethereum_jsonrpc` application. The most important changes include adding a new module for Prometheus instrumentation, updating the HTTP client to record metrics, and adding the necessary dependency to the project.

### Prometheus Integration:

* [`apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex`](diffhunk://#diff-e8c00698c8710c1f32e5f5f97102c159383d21cdf06dd7094db56640d4702318R1-R18): Added a new module `EthereumJSONRPC.Prometheus.Instrumenter` to define Prometheus metrics for JSON RPC requests and errors.

### HTTP Client Updates:

* [`apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex`](diffhunk://#diff-53cdedc1222e8bea4ff093d2c290b93a8f83071a0b8f85bb0e7ba53b5555c036R7): Updated the `EthereumJSONRPC.HTTP.HTTPoison` module to use the `Instrumenter` for recording JSON RPC requests and errors. Added methods to extract the JSON RPC method and check for errors in the response body. [[1]](diffhunk://#diff-53cdedc1222e8bea4ff093d2c290b93a8f83071a0b8f85bb0e7ba53b5555c036R7) [[2]](diffhunk://#diff-53cdedc1222e8bea4ff093d2c290b93a8f83071a0b8f85bb0e7ba53b5555c036R22-R72)

### Dependency Addition:

* [`apps/ethereum_jsonrpc/mix.exs`](diffhunk://#diff-7163a84ec73e7113bd2cb01d122705183b000d14724660766c5b53195b67577bR72): Added the `prometheus_ex` dependency to the project to enable Prometheus metrics.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON-RPC handling with improved error detection and real-time metrics tracking.
	- Introduced robust monitoring of JSON-RPC requests and responses for better observability.
- **Chores**
	- Integrated a new dependency to support Prometheus-based monitoring enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->