### PR TITLE
fix: Unify response for single and batch 1155 transfers in RPC API

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -180,10 +180,14 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
     |> Map.put_new(:tokenID, List.first(token_transfer.token_ids))
   end
 
+  # todo: Mark tokenID field as deprecated in release notes, and delete it in the next release
+  # when tokenID will be deleted, merge this, and next `prepare_token_transfer/1` clauses
   defp prepare_token_transfer(%{token_type: "ERC-1155", token_ids: [token_id]} = token_transfer) do
     token_transfer
     |> prepare_common_token_transfer()
     |> Map.put_new(:tokenID, token_id)
+    |> Map.put_new(:tokenIDs, token_transfer.token_ids)
+    |> Map.put_new(:values, token_transfer.amounts)
   end
 
   defp prepare_token_transfer(%{token_type: "ERC-1155"} = token_transfer) do


### PR DESCRIPTION
## Motivation

absence of value for ERC-1155 token transfer:
```
https://creditcoin-testnet.blockscout.com/api?module=account&action=tokentx&address=0x2FabAFfC7F6426C1beEdec22cc150A7dBE6667FB&offset=200&page=0&startblock=2320423&endblock=2320423

{
	"message": "OK",
	"result": [
		{
			"tokenID": "6",
			....
		}
	]
```
## Changelog
- Add `tokenIDs` and `values` fields to single ERC-1155 transfer in  RPC API

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced ERC-1155 token transfers with additional details for token identifiers and corresponding amounts.
  - Deprecated a legacy token field, with plans for its removal in a future update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->