### PR TITLE
chore: Upgrade on demand balances fetchers

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_token_balance_controller.ex
@@ -9,9 +9,7 @@ defmodule BlockScoutWeb.AddressTokenBalanceController do
   def index(conn, %{"address_id" => address_hash_string} = params) do
     with true <- ajax?(conn),
          {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string) do
-      Task.start_link(fn ->
-        TokenBalanceOnDemand.trigger_fetch(address_hash)
-      end)
+      TokenBalanceOnDemand.trigger_fetch(address_hash)
 
       case AccessHelper.restricted_access?(address_hash_string, params) do
         {:ok, false} ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -241,9 +241,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
             address_hash
             |> Chain.fetch_last_token_balances(@api_true |> fetch_scam_token_toggle(conn))
 
-          Task.start_link(fn ->
-            TokenBalanceOnDemand.trigger_fetch(address_hash)
-          end)
+          TokenBalanceOnDemand.trigger_fetch(address_hash)
 
           conn
           |> put_status(200)
@@ -690,9 +688,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
               |> fetch_scam_token_toggle(conn)
             )
 
-          Task.start_link(fn ->
-            TokenBalanceOnDemand.trigger_fetch(address_hash)
-          end)
+          TokenBalanceOnDemand.trigger_fetch(address_hash)
 
           {tokens, next_page} = split_list_by_page(results_plus_one)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -22,12 +22,18 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
     start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
     start_supervised!(AverageBlockTime)
-    start_supervised!({CoinBalanceOnDemand, [mocked_json_rpc_named_arguments, [name: CoinBalanceOnDemand]]})
+
+    configuration = Application.get_env(:indexer, CoinBalanceOnDemand.Supervisor)
+    Application.put_env(:indexer, CoinBalanceOnDemand.Supervisor, disabled?: false)
+
+    CoinBalanceOnDemand.Supervisor.Case.start_supervised!(json_rpc_named_arguments: mocked_json_rpc_named_arguments)
+
     start_supervised!(AddressesCount)
 
     Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
 
     on_exit(fn ->
+      Application.put_env(:indexer, CoinBalanceOnDemand.Supervisor, configuration)
       Application.put_env(:explorer, AverageBlockTime, enabled: false, cache_period: 1_800_000)
     end)
 
@@ -159,7 +165,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                                                      %{
                                                        id: id,
                                                        method: "eth_getBalance",
-                                                       params: [^mining_address_hash, "0x66"]
+                                                       params: [^address_hash, "0x66"]
                                                      }
                                                    ],
                                                    _options ->
@@ -183,7 +189,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                                                      %{
                                                        id: id,
                                                        method: "eth_getBalance",
-                                                       params: [^address_hash, "0x66"]
+                                                       params: [^mining_address_hash, "0x66"]
                                                      }
                                                    ],
                                                    _options ->
@@ -205,6 +211,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
         conn
         |> get("/api", params)
         |> json_response(200)
+
+      Process.sleep(100)
 
       schema = listaccounts_schema()
       assert :ok = ExJsonSchema.Validator.validate(schema, response)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -19,7 +19,11 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
     start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
     start_supervised!(AverageBlockTime)
-    start_supervised!({CoinBalanceOnDemand, [mocked_json_rpc_named_arguments, [name: CoinBalanceOnDemand]]})
+
+    Indexer.Fetcher.OnDemand.CoinBalance.Supervisor.Case.start_supervised!(
+      json_rpc_named_arguments: mocked_json_rpc_named_arguments
+    )
+
     start_supervised!(AddressesCount)
 
     Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2425,6 +2425,9 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.BlockNumber.child_id())
       Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.BlockNumber.child_id())
       old_env = Application.get_env(:indexer, Indexer.Fetcher.OnDemand.TokenBalance)
+      configuration = Application.get_env(:indexer, Indexer.Fetcher.OnDemand.TokenBalance.Supervisor)
+      Application.put_env(:indexer, Indexer.Fetcher.OnDemand.TokenBalance.Supervisor, disabled?: false)
+      Indexer.Fetcher.OnDemand.TokenBalance.Supervisor.Case.start_supervised!()
 
       Application.put_env(
         :indexer,
@@ -2433,6 +2436,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       )
 
       on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.OnDemand.TokenBalance.Supervisor, configuration)
         Application.put_env(:indexer, Indexer.Fetcher.OnDemand.TokenBalance, old_env)
       end)
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2497,70 +2497,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                                                     method: "eth_call",
                                                     params: [
                                                       %{
-                                                        data: "0x00fdd58e" <> request_1,
-                                                        to: contract_address_1
-                                                      },
-                                                      ^block_number_hex
-                                                    ]
-                                                  },
-                                                  %{
-                                                    id: id_2,
-                                                    jsonrpc: "2.0",
-                                                    method: "eth_call",
-                                                    params: [
-                                                      %{
-                                                        data: "0x00fdd58e" <> request_2,
-                                                        to: contract_address_2
-                                                      },
-                                                      ^block_number_hex
-                                                    ]
-                                                  }
-                                                ],
-                                                _options ->
-        types_list = [:address, {:uint, 256}]
-
-        [address_1, token_id_1] = request_1 |> Base.decode16!(case: :lower) |> TypeDecoder.decode_raw(types_list)
-
-        assert address_1 == address.hash.bytes
-
-        result_1 =
-          balances_erc_1155[{contract_address_1 |> String.downcase(), to_string(token_id_1)}]
-          |> List.wrap()
-          |> TypeEncoder.encode_raw([{:uint, 256}], :standard)
-          |> Base.encode16(case: :lower)
-
-        [address_2, token_id_2] = request_2 |> Base.decode16!(case: :lower) |> TypeDecoder.decode_raw(types_list)
-
-        assert address_2 == address.hash.bytes
-
-        result_2 =
-          balances_erc_1155[{contract_address_2 |> String.downcase(), to_string(token_id_2)}]
-          |> List.wrap()
-          |> TypeEncoder.encode_raw([{:uint, 256}], :standard)
-          |> Base.encode16(case: :lower)
-
-        {:ok,
-         [
-           %{
-             id: id_1,
-             jsonrpc: "2.0",
-             result: "0x" <> result_1
-           },
-           %{
-             id: id_2,
-             jsonrpc: "2.0",
-             result: "0x" <> result_2
-           }
-         ]}
-      end)
-
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [
-                                                  %{
-                                                    id: id_1,
-                                                    jsonrpc: "2.0",
-                                                    method: "eth_call",
-                                                    params: [
-                                                      %{
                                                         data: "0x70a08231" <> request_1,
                                                         to: contract_address_1
                                                       },
@@ -2602,6 +2538,30 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                                                       },
                                                       ^block_number_hex
                                                     ]
+                                                  },
+                                                  %{
+                                                    id: id_5,
+                                                    jsonrpc: "2.0",
+                                                    method: "eth_call",
+                                                    params: [
+                                                      %{
+                                                        data: "0x00fdd58e" <> request_5,
+                                                        to: contract_address_5
+                                                      },
+                                                      ^block_number_hex
+                                                    ]
+                                                  },
+                                                  %{
+                                                    id: id_6,
+                                                    jsonrpc: "2.0",
+                                                    method: "eth_call",
+                                                    params: [
+                                                      %{
+                                                        data: "0x00fdd58e" <> request_6,
+                                                        to: contract_address_6
+                                                      },
+                                                      ^block_number_hex
+                                                    ]
                                                   }
                                                 ],
                                                 _options ->
@@ -2639,6 +2599,28 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
           |> TypeEncoder.encode_raw([{:uint, 256}], :standard)
           |> Base.encode16(case: :lower)
 
+        types_list = [:address, {:uint, 256}]
+
+        [address_5, token_id_5] = request_5 |> Base.decode16!(case: :lower) |> TypeDecoder.decode_raw(types_list)
+
+        assert address_5 == address.hash.bytes
+
+        result_5 =
+          balances_erc_1155[{contract_address_5 |> String.downcase(), to_string(token_id_5)}]
+          |> List.wrap()
+          |> TypeEncoder.encode_raw([{:uint, 256}], :standard)
+          |> Base.encode16(case: :lower)
+
+        [address_6, token_id_6] = request_6 |> Base.decode16!(case: :lower) |> TypeDecoder.decode_raw(types_list)
+
+        assert address_6 == address.hash.bytes
+
+        result_6 =
+          balances_erc_1155[{contract_address_6 |> String.downcase(), to_string(token_id_6)}]
+          |> List.wrap()
+          |> TypeEncoder.encode_raw([{:uint, 256}], :standard)
+          |> Base.encode16(case: :lower)
+
         {:ok,
          [
            %{
@@ -2660,6 +2642,16 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
              id: id_4,
              jsonrpc: "2.0",
              result: "0x" <> result_4
+           },
+           %{
+             id: id_5,
+             jsonrpc: "2.0",
+             result: "0x" <> result_5
+           },
+           %{
+             id: id_6,
+             jsonrpc: "2.0",
+             result: "0x" <> result_6
            }
          ]}
       end)

--- a/apps/block_scout_web/test/block_scout_web/controllers/transaction_state_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/transaction_state_controller_test.exs
@@ -24,11 +24,18 @@ defmodule BlockScoutWeb.TransactionStateControllerTest do
     start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
     start_supervised!(AverageBlockTime)
     start_supervised!(AddressesCount)
-    start_supervised!({CoinBalanceOnDemand, [mocked_json_rpc_named_arguments, [name: CoinBalanceOnDemand]]})
+
+    configuration = Application.get_env(:indexer, Indexer.Fetcher.OnDemand.CoinBalance.Supervisor)
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.CoinBalance.Supervisor, disabled?: false)
 
     Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
 
+    Indexer.Fetcher.OnDemand.CoinBalance.Supervisor.Case.start_supervised!(
+      json_rpc_named_arguments: mocked_json_rpc_named_arguments
+    )
+
     on_exit(fn ->
+      Application.put_env(:indexer, Indexer.Fetcher.OnDemand.CoinBalance.Supervisor, configuration)
       Application.put_env(:explorer, AverageBlockTime, enabled: false, cache_period: 1_800_000)
     end)
   end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3488,9 +3488,9 @@ defmodule Explorer.Chain do
     end
   end
 
-  @spec fetch_last_token_balances_include_unfetched(Hash.Address.t(), [api?]) :: []
-  def fetch_last_token_balances_include_unfetched(address_hash, options \\ []) do
-    address_hash
+  @spec fetch_last_token_balances_include_unfetched([Hash.Address.t()], [api?]) :: []
+  def fetch_last_token_balances_include_unfetched(address_hashes, options \\ []) do
+    address_hashes
     |> CurrentTokenBalance.last_token_balances_include_unfetched()
     |> select_repo(options).all()
   end

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -171,14 +171,14 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   end
 
   @doc """
-  Builds an `t:Ecto.Query.t/0` to fetch the current token balances of the given address (include unfetched).
+  Builds an `t:Ecto.Query.t/0` to fetch the current token balances of the given addresses (include unfetched).
   """
-  def last_token_balances_include_unfetched(address_hash) do
+  def last_token_balances_include_unfetched(address_hashes) do
     fiat_balance = fiat_value_query()
 
     from(
       ctb in __MODULE__,
-      where: ctb.address_hash == ^address_hash,
+      where: ctb.address_hash in ^address_hashes,
       left_join: t in assoc(ctb, :token),
       on: ctb.token_contract_address_hash == t.contract_address_hash,
       preload: [token: t],

--- a/apps/indexer/config/runtime/test.exs
+++ b/apps/indexer/config/runtime/test.exs
@@ -4,6 +4,8 @@ alias EthereumJSONRPC.Variant
 
 config :indexer, Indexer.Fetcher.Beacon.Blob.Supervisor, disabled?: true
 config :indexer, Indexer.Fetcher.Beacon.Blob, start_block: 0
+config :indexer, Indexer.Fetcher.OnDemand.CoinBalance.Supervisor, disabled?: true
+config :indexer, Indexer.Fetcher.OnDemand.TokenBalance.Supervisor, disabled?: true
 
 variant = Variant.get()
 

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -9,6 +9,7 @@ defmodule Indexer.Application do
   alias Indexer.Fetcher.OnDemand.ContractCode, as: ContractCodeOnDemand
   alias Indexer.Fetcher.OnDemand.FirstTrace, as: FirstTraceOnDemand
   alias Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch, as: NFTCollectionMetadataRefetchOnDemand
+  alias Indexer.Fetcher.OnDemand.TokenBalance, as: TokenBalanceOnDemand
   alias Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch, as: TokenInstanceMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.TokenTotalSupply, as: TokenTotalSupplyOnDemand
   alias Indexer.Fetcher.TokenInstance.Refetch, as: TokenInstanceRefetch
@@ -46,7 +47,8 @@ defmodule Indexer.Application do
     base_children = [
       :hackney_pool.child_spec(:token_instance_fetcher, max_connections: pool_size),
       {Memory.Monitor, [%{}, [name: memory_monitor_name]]},
-      {CoinBalanceOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {CoinBalanceOnDemand.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
+      {TokenBalanceOnDemand.Supervisor, []},
       {ContractCodeOnDemand.Supervisor, [json_rpc_named_arguments]},
       {NFTCollectionMetadataRefetchOnDemand.Supervisor, [json_rpc_named_arguments]},
       {TokenInstanceMetadataRefetchOnDemand.Supervisor, [json_rpc_named_arguments]},

--- a/apps/indexer/lib/indexer/fetcher/coin_balance/helper.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance/helper.ex
@@ -93,7 +93,7 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     end)
   end
 
-  def import_fetched_balances(%FetchedBalances{params_list: params_list}, broadcast_type \\ false) do
+  def import_fetched_balances(params_list, broadcast_type \\ false) do
     value_fetched_at = DateTime.utc_now()
 
     importable_balances_params = Enum.map(params_list, &Map.put(&1, :value_fetched_at, value_fetched_at))
@@ -112,7 +112,7 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     })
   end
 
-  def import_fetched_daily_balances(%FetchedBalances{params_list: params_list}, broadcast_type \\ false) do
+  def import_fetched_daily_balances(params_list, broadcast_type \\ false) do
     value_fetched_at = DateTime.utc_now()
 
     importable_balances_params = Enum.map(params_list, &Map.put(&1, :value_fetched_at, value_fetched_at))
@@ -130,8 +130,8 @@ defmodule Indexer.Fetcher.CoinBalance.Helper do
     })
   end
 
-  defp run_fetched_balances(%FetchedBalances{errors: errors} = fetched_balances, fetcher_type) do
-    with {:ok, imported} <- import_fetched_balances(fetched_balances, fetcher_type) do
+  defp run_fetched_balances(%FetchedBalances{errors: errors, params_list: params_list}, fetcher_type) do
+    with {:ok, imported} <- import_fetched_balances(params_list, fetcher_type) do
       Accounts.drop(imported[:addresses])
     end
 

--- a/apps/indexer/lib/indexer/fetcher/on_demand/coin_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/coin_balance.ex
@@ -7,7 +7,6 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
   If we have a fetched coin balance, but it is over 100 blocks old, we will fetch and create a fetched coin balance.
   """
 
-  use GenServer
   use Indexer.Fetcher, restart: :permanent
 
   import EthereumJSONRPC, only: [integer_to_quantity: 1]
@@ -18,8 +17,21 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
   alias Explorer.Chain.Address.{CoinBalance, CoinBalanceDaily}
   alias Explorer.Chain.Cache.{Accounts, BlockNumber}
   alias Explorer.Chain.Cache.Counters.AverageBlockTime
+  alias Indexer.BufferedTask
   alias Indexer.Fetcher.CoinBalance.Helper, as: CoinBalanceHelper
   alias Timex.Duration
+
+  @behaviour BufferedTask
+
+  @max_batch_size 500
+  @max_concurrency 4
+  @defaults [
+    flush_interval: :timer.seconds(3),
+    max_concurrency: @max_concurrency,
+    max_batch_size: @max_batch_size,
+    task_supervisor: Indexer.Fetcher.OnDemand.CoinBalance.TaskSupervisor,
+    metadata: [fetcher: :coin_balance_on_demand]
+  ]
 
   @type block_number :: integer
 
@@ -34,84 +46,112 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
           | {:stale, block_number}
           | {:pending, block_number}
 
-  ## Interface
-
   @spec trigger_fetch(Address.t()) :: balance_status
   def trigger_fetch(address) do
-    latest_block_number = latest_block_number()
+    if __MODULE__.Supervisor.disabled?() do
+      :current
+    else
+      latest_block_number = latest_block_number()
 
-    case stale_balance_window(latest_block_number) do
-      {:error, _} ->
-        :current
+      case stale_balance_window(latest_block_number) do
+        {:error, _} ->
+          :current
 
-      stale_balance_window ->
-        do_trigger_fetch(address, latest_block_number, stale_balance_window)
+        stale_balance_window ->
+          do_trigger_fetch(address, latest_block_number, stale_balance_window)
+      end
     end
   end
 
   @spec trigger_historic_fetch(Hash.Address.t(), non_neg_integer()) :: balance_status
   def trigger_historic_fetch(address_hash, block_number) do
-    do_trigger_historic_fetch(address_hash, block_number)
+    if __MODULE__.Supervisor.disabled?() do
+      :current
+    else
+      do_trigger_historic_fetch(address_hash, block_number)
+    end
   end
 
-  ## Callbacks
+  @doc false
+  def child_spec([init_options, gen_server_options]) do
+    {state, mergeable_init_options} = Keyword.pop(init_options, :json_rpc_named_arguments)
 
-  def child_spec([json_rpc_named_arguments, server_opts]) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [json_rpc_named_arguments, server_opts]},
-      type: :worker
-    }
-  end
-
-  def start_link(json_rpc_named_arguments, server_opts) do
-    GenServer.start_link(__MODULE__, json_rpc_named_arguments, server_opts)
-  end
-
-  @impl true
-  def init(json_rpc_named_arguments) do
-    {:ok, %{json_rpc_named_arguments: json_rpc_named_arguments}}
-  end
-
-  @impl true
-  def handle_cast({:fetch_and_update, block_number, address}, state) do
-    result = fetch_and_update(block_number, address, state.json_rpc_named_arguments)
-
-    with {:ok, %{addresses: addresses}} <- result do
-      Accounts.drop(addresses)
+    unless state do
+      raise ArgumentError,
+            ":json_rpc_named_arguments must be provided to `#{__MODULE__}.child_spec " <>
+              "to allow for json_rpc calls when running."
     end
 
-    {:noreply, state}
+    merged_init_opts =
+      @defaults
+      |> Keyword.merge(mergeable_init_options)
+      |> Keyword.put(:state, state)
+
+    Supervisor.child_spec({BufferedTask, [{__MODULE__, merged_init_opts}, gen_server_options]}, id: __MODULE__)
   end
 
-  @impl true
-  def handle_cast({:fetch_and_import, block_number, address}, state) do
-    fetch_and_import(block_number, address, state.json_rpc_named_arguments)
-
-    {:noreply, state}
+  @impl BufferedTask
+  def init(initial, _, _) do
+    initial
   end
 
-  @impl true
-  def handle_cast({:fetch_and_import_daily_balances, block_number, address}, state) do
-    fetch_and_import_daily_balances(block_number, address, state.json_rpc_named_arguments)
+  @impl BufferedTask
+  def run(entries, json_rpc_named_arguments) do
+    {fetch_and_update_params, fetch_and_import_params, daily_params} =
+      Enum.reduce(entries, {[], [], []}, fn
+        {:fetch_and_update, block_number, address}, {acc, other_1, other_2} ->
+          {[{block_number, address} | acc], other_1, other_2}
 
-    {:noreply, state}
+        {:fetch_and_import, block_number, address}, {other_1, acc, other_2} ->
+          {other_1, [{block_number, address} | acc], other_2}
+
+        {:fetch_and_import_daily_balances, block_number, address}, {other_1, other_2, acc} ->
+          {other_1, other_2, [{block_number, address} | acc]}
+      end)
+
+    fetch_and_update(fetch_and_update_params, json_rpc_named_arguments)
+    fetch_and_import(fetch_and_import_params, json_rpc_named_arguments)
+    fetch_and_import_daily_balances(daily_params, json_rpc_named_arguments)
+
+    :ok
   end
 
-  @impl true
-  def handle_info({:DOWN, _, :process, _, _}, state) do
-    {:noreply, state}
+  defp fetch_and_update([], _json_rpc_named_arguments), do: :ok
+
+  defp fetch_and_update(params, json_rpc_named_arguments) do
+    with {:ok, %{params_list: params_list}} when params_list != [] <- fetch_balances(params, json_rpc_named_arguments),
+         address_params = CoinBalanceHelper.balances_params_to_address_params(params_list),
+         {:ok, %{addresses: addresses}} <-
+           Chain.import(%{
+             addresses: %{params: address_params, with: :balance_changeset},
+             broadcast: :on_demand
+           }) do
+      Accounts.drop(addresses)
+    else
+      _ -> :ok
+    end
   end
 
-  @impl true
-  def handle_info({_ref, _}, state) do
-    {:noreply, state}
+  defp fetch_and_import([], _json_rpc_named_arguments), do: :ok
+
+  defp fetch_and_import(params, json_rpc_named_arguments) do
+    case fetch_balances(params, json_rpc_named_arguments) do
+      {:ok, fetched_balances} -> do_import(fetched_balances)
+      _ -> :ok
+    end
   end
 
-  ## Implementation
+  defp fetch_and_import_daily_balances([], _json_rpc_named_arguments), do: :ok
+
+  defp fetch_and_import_daily_balances(params, json_rpc_named_arguments) do
+    case fetch_balances(params, json_rpc_named_arguments) do
+      {:ok, fetched_balances} -> do_import_daily_balances(fetched_balances)
+      _ -> :ok
+    end
+  end
 
   defp do_trigger_fetch(%Address{fetched_coin_balance_block_number: nil} = address, latest_block_number, _) do
-    GenServer.cast(__MODULE__, {:fetch_and_update, latest_block_number, address})
+    BufferedTask.buffer(__MODULE__, [{:fetch_and_update, latest_block_number, address}], false)
 
     {:stale, 0}
   end
@@ -125,7 +165,7 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
   end
 
   defp do_trigger_historic_fetch(address_hash, block_number) do
-    GenServer.cast(__MODULE__, {:fetch_and_import, block_number, %{hash: address_hash}})
+    BufferedTask.buffer(__MODULE__, [{:fetch_and_import, block_number, %{hash: address_hash}}], false)
 
     {:stale, 0}
   end
@@ -139,7 +179,7 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
        ) do
     if address.fetched_coin_balance_block_number < stale_balance_window do
       do_trigger_balance_daily_fetch_query(address, latest_block_number, query_balances_daily)
-      GenServer.cast(__MODULE__, {:fetch_and_update, latest_block_number, address})
+      BufferedTask.buffer(__MODULE__, [{:fetch_and_update, latest_block_number, address}], false)
 
       {:stale, latest_block_number}
     else
@@ -152,7 +192,7 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
           :current
 
         %CoinBalance{value_fetched_at: nil, block_number: block_number} ->
-          GenServer.cast(__MODULE__, {:fetch_and_import, block_number, address})
+          BufferedTask.buffer(__MODULE__, [{:fetch_and_import, block_number, address}], false)
 
           {:pending, block_number}
 
@@ -166,46 +206,16 @@ defmodule Indexer.Fetcher.OnDemand.CoinBalance do
 
   defp do_trigger_balance_daily_fetch_query(address, latest_block_number, query) do
     if Repo.one(query) == nil do
-      GenServer.cast(__MODULE__, {:fetch_and_import_daily_balances, latest_block_number, address})
+      BufferedTask.buffer(__MODULE__, [{:fetch_and_import_daily_balances, latest_block_number, address}], false)
     end
   end
 
-  defp fetch_and_import(block_number, address, json_rpc_named_arguments) do
-    case fetch_balances(block_number, address, json_rpc_named_arguments) do
-      {:ok, fetched_balances} -> do_import(fetched_balances)
-      _ -> :ok
-    end
-  end
-
-  defp fetch_and_import_daily_balances(block_number, address, json_rpc_named_arguments) do
-    case fetch_balances(block_number, address, json_rpc_named_arguments) do
-      {:ok, fetched_balances} -> do_import_daily_balances(fetched_balances)
-      _ -> :ok
-    end
-  end
-
-  defp fetch_and_update(block_number, address, json_rpc_named_arguments) do
-    case fetch_balances(block_number, address, json_rpc_named_arguments) do
-      {:ok, %{params_list: []}} ->
-        :ok
-
-      {:ok, %{params_list: params_list}} ->
-        address_params = CoinBalanceHelper.balances_params_to_address_params(params_list)
-
-        Chain.import(%{
-          addresses: %{params: address_params, with: :balance_changeset},
-          broadcast: :on_demand
-        })
-
-      _ ->
-        :ok
-    end
-  end
-
-  defp fetch_balances(block_number, address, json_rpc_named_arguments) do
-    params = %{block_quantity: integer_to_quantity(block_number), hash_data: to_string(address.hash)}
-
-    EthereumJSONRPC.fetch_balances([params], json_rpc_named_arguments, latest_block_number())
+  defp fetch_balances(params, json_rpc_named_arguments) do
+    params
+    |> Enum.map(fn {block_number, address} ->
+      %{block_quantity: integer_to_quantity(block_number), hash_data: to_string(address.hash)}
+    end)
+    |> EthereumJSONRPC.fetch_balances(json_rpc_named_arguments, latest_block_number())
   end
 
   defp do_import(%FetchedBalances{} = fetched_balances) do

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -114,6 +114,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
 
       stale_balance_window ->
         address_hashes
+        |> Enum.uniq()
         |> Chain.fetch_last_token_balances_include_unfetched()
         |> delete_invalid_balances()
         |> Enum.filter(fn current_token_balance -> current_token_balance.block_number < stale_balance_window end)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -72,120 +72,120 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
 
   @impl BufferedTask
   def run(entries, _) do
-    {fetch_params, historic_fetch_params} =
-      Enum.reduce(entries, {[], []}, fn
-        {:fetch, address_hash}, {fetch_acc, historic_acc} ->
-          {[address_hash | fetch_acc], historic_acc}
+    entries_by_type = Enum.group_by(entries, &elem(&1, 0), &elem(&1, 1))
 
-        {:historic_fetch, params}, {fetch_acc, historic_acc} ->
-          {fetch_acc, [params | historic_acc]}
-      end)
+    latest_block_number = latest_block_number()
 
-    do_trigger_fetch(fetch_params)
-    do_trigger_historic_fetch(historic_fetch_params)
+    fetch_data = prepare_fetch_requests(entries_by_type[:fetch], latest_block_number)
+
+    {historic_fetch_ft_requests, historic_fetch_nft_requests} =
+      prepare_historic_fetch_requests(entries_by_type[:historic_fetch])
+
+    all_responses =
+      BalanceReader.get_balances_of_all(
+        fetch_data.ft_balances ++ historic_fetch_ft_requests,
+        fetch_data.nft_balances ++ historic_fetch_nft_requests
+      )
+
+    {fetch_ft_responses, other_responses} = Enum.split(all_responses, Enum.count(fetch_data.ft_balances))
+    {historic_fetch_ft_responses, nft_responses} = Enum.split(other_responses, Enum.count(historic_fetch_ft_requests))
+    {fetch_nft_responses, historic_fetch_nft_responses} = Enum.split(nft_responses, Enum.count(fetch_data.nft_balances))
+
+    (fetch_ft_responses ++ fetch_nft_responses)
+    |> Enum.zip(fetch_data.ft_balances ++ fetch_data.nft_balances)
+    |> process_fetch_responses(fetch_data.tokens, fetch_data.balances_map, latest_block_number)
+
+    (historic_fetch_ft_responses ++ historic_fetch_nft_responses)
+    |> Enum.zip(historic_fetch_ft_requests ++ historic_fetch_nft_requests)
+    |> process_historic_fetch_responses()
 
     :ok
   end
 
-  defp do_trigger_fetch([]), do: :ok
+  defp prepare_fetch_requests(nil, _latest_block_number),
+    do: %{nft_balances: [], ft_balances: [], tokens: %{}, balances_map: %{}}
 
-  defp do_trigger_fetch(address_hashes) do
-    latest_block_number = latest_block_number()
+  defp prepare_fetch_requests(address_hashes, latest_block_number) do
+    initial_acc = %{nft_balances: [], ft_balances: [], tokens: %{}, balances_map: %{}}
 
     case stale_balance_window(latest_block_number) do
       {:error, _} ->
-        :current
+        initial_acc
 
       stale_balance_window ->
-        stale_current_token_balances =
-          address_hashes
-          |> Chain.fetch_last_token_balances_include_unfetched()
-          |> delete_invalid_balances()
-          |> Enum.filter(fn current_token_balance -> current_token_balance.block_number < stale_balance_window end)
-
-        if Enum.empty?(stale_current_token_balances) do
-          :current
-        else
-          fetch_and_update(latest_block_number, stale_current_token_balances)
-        end
+        address_hashes
+        |> Chain.fetch_last_token_balances_include_unfetched()
+        |> delete_invalid_balances()
+        |> Enum.filter(fn current_token_balance -> current_token_balance.block_number < stale_balance_window end)
+        |> prepare_ctb_params(initial_acc, latest_block_number)
     end
   end
 
-  defp delete_invalid_balances(current_token_balances) do
-    {invalid_balances, valid_balances} = Enum.split_with(current_token_balances, &is_nil(&1.token_type))
-    Enum.each(invalid_balances, &Repo.delete/1)
-    valid_balances
+  defp prepare_ctb_params(current_token_balances, initial_acc, block_number) do
+    Enum.reduce(current_token_balances, initial_acc, fn %{token_id: token_id} = stale_current_token_balance, acc ->
+      prepared_ctb = %{
+        token_contract_address_hash:
+          ExplorerHelper.add_0x_prefix(stale_current_token_balance.token.contract_address_hash),
+        address_hash: ExplorerHelper.add_0x_prefix(stale_current_token_balance.address_hash),
+        block_number: block_number,
+        token_id: token_id && Decimal.to_integer(token_id),
+        token_type: stale_current_token_balance.token_type
+      }
+
+      updated_tokens =
+        Map.put_new(
+          acc[:tokens],
+          stale_current_token_balance.token.contract_address_hash.bytes,
+          stale_current_token_balance.token
+        )
+
+      result =
+        if stale_current_token_balance.token_type == "ERC-1155" do
+          Map.put(acc, :nft_balances, [prepared_ctb | acc[:nft_balances]])
+        else
+          Map.put(acc, :ft_balances, [prepared_ctb | acc[:ft_balances]])
+        end
+
+      updated_balances_map =
+        Map.put(
+          acc[:balances_map],
+          ctb_to_key(stale_current_token_balance),
+          stale_current_token_balance.value
+        )
+
+      result
+      |> Map.put(:tokens, updated_tokens)
+      |> Map.put(:balances_map, updated_balances_map)
+    end)
   end
 
-  defp fetch_and_update(block_number, stale_current_token_balances) do
-    %{
-      erc_1155: erc_1155_ctbs,
-      other: other_ctbs,
-      tokens: tokens,
-      balances_map: balances_map
-    } =
-      stale_current_token_balances
-      |> Enum.reduce(%{erc_1155: [], other: [], tokens: %{}, balances_map: %{}}, fn %{
-                                                                                      token_id: token_id
-                                                                                    } = stale_current_token_balance,
-                                                                                    acc ->
-        prepared_ctb = %{
-          token_contract_address_hash:
-            ExplorerHelper.add_0x_prefix(stale_current_token_balance.token.contract_address_hash),
-          address_hash: ExplorerHelper.add_0x_prefix(stale_current_token_balance.address_hash),
-          block_number: block_number,
-          token_id: token_id && Decimal.to_integer(token_id),
-          token_type: stale_current_token_balance.token_type
-        }
+  defp prepare_historic_fetch_requests(nil), do: {[], []}
 
-        updated_tokens =
-          Map.put_new(
-            acc[:tokens],
-            stale_current_token_balance.token.contract_address_hash.bytes,
-            stale_current_token_balance.token
-          )
+  defp prepare_historic_fetch_requests(params) do
+    Enum.reduce(params, {[], []}, fn {address_hash, contract_address_hash, token_type, token_id, block_number},
+                                     {regular_acc, erc_1155_acc} ->
+      request = %{
+        token_contract_address_hash: to_string(contract_address_hash),
+        address_hash: to_string(address_hash),
+        block_number: block_number,
+        token_type: token_type,
+        token_id: token_id && Decimal.to_integer(token_id)
+      }
 
-        result =
-          if stale_current_token_balance.token_type == "ERC-1155" do
-            Map.put(acc, :erc_1155, [prepared_ctb | acc[:erc_1155]])
-          else
-            Map.put(acc, :other, [prepared_ctb | acc[:other]])
-          end
-
-        updated_balances_map =
-          Map.put(
-            acc[:balances_map],
-            ctb_to_key(stale_current_token_balance),
-            stale_current_token_balance.value
-          )
-
-        result
-        |> Map.put(:tokens, updated_tokens)
-        |> Map.put(:balances_map, updated_balances_map)
-      end)
-
-    updated_erc_1155_ctbs =
-      if Enum.empty?(erc_1155_ctbs) do
-        []
-      else
-        erc_1155_ctbs
-        |> BalanceReader.get_balances_of_erc_1155()
-        |> Enum.zip(erc_1155_ctbs)
-        |> Enum.map(&prepare_updated_balance(&1, block_number))
+      case {token_type, token_id} do
+        {"ERC-404", nil} -> {[request | regular_acc], erc_1155_acc}
+        {"ERC-404", _token_id} -> {regular_acc, [request | erc_1155_acc]}
+        {"ERC-1155", _token_id} -> {regular_acc, [request | erc_1155_acc]}
+        {_type, _token_id} -> {[request | regular_acc], erc_1155_acc}
       end
+    end)
+  end
 
-    updated_other_ctbs =
-      if Enum.empty?(other_ctbs) do
-        []
-      else
-        other_ctbs
-        |> BalanceReader.get_balances_of()
-        |> Enum.zip(other_ctbs)
-        |> Enum.map(&prepare_updated_balance(&1, block_number))
-      end
-
+  defp process_fetch_responses(responses, tokens, balances_map, block_number) do
     filtered_current_token_balances_update_params =
-      (updated_erc_1155_ctbs ++ updated_other_ctbs) |> Enum.filter(&(!is_nil(&1)))
+      responses
+      |> Enum.map(&prepare_updated_balance(&1, block_number))
+      |> Enum.reject(&is_nil/1)
 
     if not Enum.empty?(filtered_current_token_balances_update_params) do
       {:ok,
@@ -217,6 +217,38 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
         )
       end)
     end
+  end
+
+  defp process_historic_fetch_responses([]), do: :ok
+
+  defp process_historic_fetch_responses(responses) do
+    import_params =
+      Enum.reduce(responses, [], fn
+        {{:ok, balance}, request}, acc ->
+          params = %{
+            address_hash: request.address_hash,
+            token_contract_address_hash: request.contract_address_hash,
+            token_type: request.token_type,
+            token_id: request.token_id,
+            block_number: request.block_number,
+            value: Decimal.new(balance),
+            value_fetched_at: DateTime.utc_now()
+          }
+
+          [params | acc]
+
+        {{:error, error}, request}, acc ->
+          Logger.error("Error while fetching token balances: #{inspect(error)}, request: #{inspect(request)}")
+          acc
+      end)
+
+    Chain.import(%{address_token_balances: %{params: import_params}, broadcast: :on_demand})
+  end
+
+  defp delete_invalid_balances(current_token_balances) do
+    {invalid_balances, valid_balances} = Enum.split_with(current_token_balances, &is_nil(&1.token_type))
+    Enum.each(invalid_balances, &Repo.delete/1)
+    valid_balances
   end
 
   defp filter_imported_ctbs(imported_ctbs, balances_map) do
@@ -261,61 +293,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
     end)
 
     nil
-  end
-
-  defp do_trigger_historic_fetch([]), do: :ok
-
-  defp do_trigger_historic_fetch(params) do
-    {regular_requests, erc_1155_requests} =
-      Enum.reduce(params, {[], []}, fn {address_hash, contract_address_hash, token_type, token_id, block_number},
-                                       {regular_acc, erc_1155_acc} ->
-        request = %{
-          token_contract_address_hash: to_string(contract_address_hash),
-          address_hash: to_string(address_hash),
-          block_number: block_number,
-          token_type: token_type,
-          token_id: token_id && Decimal.to_integer(token_id)
-        }
-
-        case {token_type, token_id} do
-          {"ERC-404", nil} -> {[request | regular_acc], erc_1155_acc}
-          {"ERC-404", _token_id} -> {regular_acc, [request | erc_1155_acc]}
-          {"ERC-1155", _token_id} -> {regular_acc, [request | erc_1155_acc]}
-          {_type, _token_id} -> {[request | regular_acc], erc_1155_acc}
-        end
-      end)
-
-    regular_balances_response =
-      regular_requests
-      |> BalanceReader.get_balances_of()
-      |> Enum.zip(regular_requests)
-
-    erc_1155_balances_response =
-      erc_1155_requests
-      |> BalanceReader.get_balances_of_erc_1155()
-      |> Enum.zip(erc_1155_requests)
-
-    import_params =
-      Enum.reduce(regular_balances_response ++ erc_1155_balances_response, [], fn
-        {{:ok, balance}, request}, acc ->
-          params = %{
-            address_hash: request.address_hash,
-            token_contract_address_hash: request.contract_address_hash,
-            token_type: request.token_type,
-            token_id: request.token_id,
-            block_number: request.block_number,
-            value: Decimal.new(balance),
-            value_fetched_at: DateTime.utc_now()
-          }
-
-          [params | acc]
-
-        {{:error, error}, request}, acc ->
-          Logger.error("Error while fetching token balances: #{inspect(error)}, request: #{inspect(request)}")
-          acc
-      end)
-
-    Chain.import(%{address_token_balances: %{params: import_params}, broadcast: :on_demand})
   end
 
   defp latest_block_number do

--- a/apps/indexer/test/support/indexer/fetcher/on_demand/coin_balance_supervisor_case.ex
+++ b/apps/indexer/test/support/indexer/fetcher/on_demand/coin_balance_supervisor_case.ex
@@ -1,0 +1,20 @@
+defmodule Indexer.Fetcher.OnDemand.CoinBalance.Supervisor.Case do
+  alias Indexer.Fetcher.OnDemand.CoinBalance
+
+  def start_supervised!(fetcher_arguments \\ []) when is_list(fetcher_arguments) do
+    merged_fetcher_arguments =
+      Keyword.merge(
+        [
+          flush_interval: 50,
+          max_batch_size: 1,
+          max_concurrency: 1,
+          poll: false
+        ],
+        fetcher_arguments
+      )
+
+    [merged_fetcher_arguments]
+    |> CoinBalance.Supervisor.child_spec()
+    |> ExUnit.Callbacks.start_supervised!()
+  end
+end

--- a/apps/indexer/test/support/indexer/fetcher/on_demand/token_balance_supervisor_case.ex
+++ b/apps/indexer/test/support/indexer/fetcher/on_demand/token_balance_supervisor_case.ex
@@ -1,0 +1,20 @@
+defmodule Indexer.Fetcher.OnDemand.TokenBalance.Supervisor.Case do
+  alias Indexer.Fetcher.OnDemand.TokenBalance
+
+  def start_supervised!(fetcher_arguments \\ []) when is_list(fetcher_arguments) do
+    merged_fetcher_arguments =
+      Keyword.merge(
+        [
+          flush_interval: 50,
+          max_batch_size: 1,
+          max_concurrency: 1,
+          poll: false
+        ],
+        fetcher_arguments
+      )
+
+    [merged_fetcher_arguments]
+    |> TokenBalance.Supervisor.child_spec()
+    |> ExUnit.Callbacks.start_supervised!()
+  end
+end


### PR DESCRIPTION
## Motivation

- Coin balance on demand fetcher process entries one by one. It's more efficient to group requests in batches.
- Token balance on demand fetcher doesn't work in a separate process so it's hard to monitor its memory consumption, etc.

## Changelog

Moved coin balance and token balance on demand fetchers to `BufferedTask` behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined token and coin balance retrieval by switching from asynchronous calls to direct, synchronous execution.
  - Enhanced balance fetching to support processing of multiple addresses in a single operation for improved efficiency.
  - Transitioned task management to utilize buffered tasks for better concurrency and organization.
  - Introduced a new function to retrieve balances for multiple token requests simultaneously.

- **Tests**
  - Updated supervisor initialization and test setups for more reliable and flexible component management.
  - Revised test mocks to allow smoother simulation of external interactions.
  - Enhanced tests to validate new functionality for ERC-1155 tokens.
  
- **Chores**
  - Introduced configuration adjustments to control component activation during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->