### PR TITLE
fix: Fix error in old UI

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/address_view.ex
@@ -333,6 +333,17 @@ defmodule BlockScoutWeb.AddressView do
     ]
   end
 
+  defp matching_address_check(current_address, nil, contract?, truncate) do
+    [
+      view_module: __MODULE__,
+      partial: "_responsive_hash.html",
+      address: current_address,
+      contract: contract?,
+      truncate: truncate,
+      use_custom_tooltip: false
+    ]
+  end
+
   @doc """
   Get the current tab name/title from the request path and possible tab names.
 


### PR DESCRIPTION
## Motivation

Fix errors

```
2025-03-20T16:27:17.256 [error] #PID<0.4729.0> running BlockScoutWeb.Endpoint (connection #PID<0.4655.0>, stream id 6) terminated
Server: localhost:4000 (http)
Request: GET /address/0xE44E299c7012956F3981745D4F635697337d5894/tokens/0x186cca6904490818AB0DC409ca59D932A2366031/token-transfers?type=JSON
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in BlockScoutWeb.AddressView.matching_address_check/4
        (block_scout_web 7.0.2) lib/block_scout_web/views/address_view.ex:314: BlockScoutWeb.AddressView.matching_address_check(%Explorer.Chain.Address{__meta__: #Ecto.Schema.Metadata<:loaded, "addresses">, hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<228, 78, 41, 156, 112, 18, 149, 111, 57, 129, 116, 93, 79, 99, 86, 151, 51, 125, 88, 148>>}, fetched_coin_balance: #Explorer.Chain.Wei<49420894993067627>, fetched_coin_balance_block_number: 7942371, contract_code: nil, nonce: 27, decompiled: false, verified: false, has_decompiled_code?: nil, stale?: nil, transactions_count: 1, token_transfers_count: 3, gas_used: 158784, ens_domain_name: nil, metadata: nil, smart_contract: nil, token: nil, proxy_implementations: #Ecto.Association.NotLoaded<association :proxy_implementations is not loaded>, contracts_creation_internal_transaction: nil, contracts_creation_transaction: nil, names: [], scam_badge: #Ecto.Association.NotLoaded<association :scam_badge is not loaded>, decompiled_smart_contracts: #Ecto.Association.NotLoaded<association :decompiled_smart_contracts is not loaded>, withdrawals: #Ecto.Association.NotLoaded<association :withdrawals is not loaded>, signed_authorization: #Ecto.Association.NotLoaded<association :signed_authorization is not loaded>, inserted_at: ~U[2025-03-20 09:08:02.410822Z], updated_at: ~U[2025-03-20 12:51:16.004058Z]}, nil, false, false)
        (block_scout_web 7.0.2) lib/block_scout_web/templates/transaction/_tile.html.eex:43: BlockScoutWeb.TransactionView."_tile.html"/1
        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.14) lib/phoenix/view.ex:479: Phoenix.View.render_to_string/3
        (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
        (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
        (block_scout_web 7.0.2) lib/block_scout_web/controllers/address_token_transfer_controller.ex:74: BlockScoutWeb.AddressTokenTransferController.index/2
        (block_scout_web 7.0.2) lib/block_scout_web/controllers/address_token_transfer_controller.ex:1: BlockScoutWeb.AddressTokenTransferController.action/2
        (block_scout_web 7.0.2) lib/block_scout_web/controllers/address_token_transfer_controller.ex:1: BlockScoutWeb.AddressTokenTransferController.phoenix_controller_pipeline/2
        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.14) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 7.0.2) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 7.0.2) /Users/viktor/Documents/code/blockscout/deps/plug/lib/plug/debugger.ex:155: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 7.0.2) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 7.0.2) /Users/viktor/Documents/code/blockscout/deps/spandex_phoenix/lib/spandex_phoenix.ex:151: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.14) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.13.0) /Users/viktor/Documents/code/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.13.0) /Users/viktor/Documents/code/blockscout/deps/cowboy/src/cowboy_stream_h.erl:310: :cowboy_stream_h.execute/3
        (cowboy 2.13.0) /Users/viktor/Documents/code/blockscout/deps/cowboy/src/cowboy_stream_h.erl:299: :cowboy_stream_h.request_process/3
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved address display handling for cases with incomplete data, ensuring more consistent and visually appealing presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->