### PR TITLE
chore: Drop transactions index duplicates

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -154,7 +154,10 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersFromAddressHashTransactionHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersToAddressHashTransactionHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersTokenContractAddressHashTransactionHashIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsCreatedContractAddressHashWithPendingIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsFromAddressHashWithPendingIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsToAddressHashWithPendingIndex
     ] do
   config :explorer, index_operation, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -81,7 +81,10 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersFromAddressHashTransactionHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersToAddressHashTransactionHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersTokenContractAddressHashTransactionHashIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.DropTokenTransfersBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsCreatedContractAddressHashWithPendingIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsFromAddressHashWithPendingIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsToAddressHashWithPendingIndex
     ] do
   config :explorer, migrator, enabled: false
 end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -232,6 +232,18 @@ defmodule Explorer.Application do
           Explorer.Migrator.HeavyDbIndexOperation.CreateArbitrumBatchL2BlocksUnconfirmedBlocksIndex,
           :indexer
         ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsCreatedContractAddressHashWithPendingIndex,
+          :indexer
+        ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsFromAddressHashWithPendingIndex,
+          :indexer
+        ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsToAddressHashWithPendingIndex,
+          :indexer
+        ),
         Explorer.Migrator.RefetchContractCodes |> configure() |> configure_chain_type_dependent_process(:zksync),
         configure(Explorer.Chain.Fetcher.AddressesBlacklist),
         Explorer.Migrator.SwitchPendingOperations

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -44,7 +44,10 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_drop_token_transfers_block_number_index_finished,
     key: :heavy_indexes_drop_internal_transactions_from_address_hash_index_finished,
     key: :heavy_indexes_create_internal_transactions_block_number_desc_transaction_index_desc_index_desc_index_finished,
-    key: :heavy_indexes_create_arbitrum_batch_l2_blocks_unconfirmed_blocks_index_finished
+    key: :heavy_indexes_create_arbitrum_batch_l2_blocks_unconfirmed_blocks_index_finished,
+    key: :heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_finished,
+    key: :heavy_indexes_drop_transactions_from_address_hash_with_pending_index_finished,
+    key: :heavy_indexes_drop_transactions_to_address_hash_with_pending_index_finished
 
   @dialyzer :no_match
 
@@ -74,7 +77,10 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     DropTokenTransfersBlockNumberIndex,
     DropTokenTransfersFromAddressHashTransactionHashIndex,
     DropTokenTransfersToAddressHashTransactionHashIndex,
-    DropTokenTransfersTokenContractAddressHashTransactionHashIndex
+    DropTokenTransfersTokenContractAddressHashTransactionHashIndex,
+    DropTransactionsCreatedContractAddressHashWithPendingIndex,
+    DropTransactionsFromAddressHashWithPendingIndex,
+    DropTransactionsToAddressHashWithPendingIndex
   }
 
   defp handle_fallback(:transactions_denormalization_finished) do
@@ -216,6 +222,27 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     start_migration_status_task(
       CreateInternalTransactionsBlockNumberDescTransactionIndexDescIndexDescIndex,
       &set_heavy_indexes_create_internal_transactions_block_number_desc_transaction_index_desc_index_desc_index_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index) do
+    start_migration_status_task(
+      DropTransactionsCreatedContractAddressHashWithPendingIndex,
+      &set_heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_drop_transactions_from_address_hash_with_pending_index) do
+    start_migration_status_task(
+      DropTransactionsFromAddressHashWithPendingIndex,
+      &set_heavy_indexes_drop_transactions_from_address_hash_with_pending_index_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_drop_transactions_to_address_hash_with_pending_index) do
+    start_migration_status_task(
+      DropTransactionsToAddressHashWithPendingIndex,
+      &set_heavy_indexes_drop_transactions_to_address_hash_with_pending_index_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
@@ -22,7 +22,8 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
 
   If you need to add a new table, extend this type specification with the new table name.
   """
-  @callback table_name :: :logs | :internal_transactions | :token_transfers | :addresses | :arbitrum_batch_l2_blocks
+  @callback table_name ::
+              :transactions | :logs | :internal_transactions | :token_transfers | :addresses | :arbitrum_batch_l2_blocks
 
   @doc """
   Specifies the type of operation to be performed on the database index.

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_created_contract_address_hash_with_pending_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_created_contract_address_hash_with_pending_index.ex
@@ -1,0 +1,60 @@
+defmodule Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsCreatedContractAddressHashWithPendingIndex do
+  @moduledoc """
+  Drops index "transactions_created_contract_address_hash_with_pending_index" btree (created_contract_address_hash, block_number DESC, index DESC, inserted_at DESC, hash).
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
+
+  @table_name :transactions
+  @index_name "transactions_created_contract_address_hash_with_pending_index"
+  @operation_type :drop
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations, do: []
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    operation = HeavyDbIndexOperationHelper.drop_index_query_string(@index_name)
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation)
+  end
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation_status do
+    HeavyDbIndexOperationHelper.db_index_dropping_status(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def restart_db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache do
+    BackgroundMigrations.set_heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_finished(
+      true
+    )
+  end
+end

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_from_address_hash_with_pending_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_from_address_hash_with_pending_index.ex
@@ -1,0 +1,63 @@
+defmodule Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsFromAddressHashWithPendingIndex do
+  @moduledoc """
+  Drops index "transactions_from_address_hash_with_pending_index" btree (from_address_hash, block_number DESC, index DESC, inserted_at DESC, hash).
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
+
+  alias Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsCreatedContractAddressHashWithPendingIndex
+
+  @table_name :transactions
+  @index_name "transactions_from_address_hash_with_pending_index"
+  @operation_type :drop
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations,
+    do: [
+      DropTransactionsCreatedContractAddressHashWithPendingIndex.migration_name()
+    ]
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    operation = HeavyDbIndexOperationHelper.drop_index_query_string(@index_name)
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation)
+  end
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation_status do
+    HeavyDbIndexOperationHelper.db_index_dropping_status(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def restart_db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache do
+    BackgroundMigrations.set_heavy_indexes_drop_transactions_from_address_hash_with_pending_index_finished(true)
+  end
+end

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_to_address_hash_with_pending_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_to_address_hash_with_pending_index.ex
@@ -1,0 +1,67 @@
+defmodule Explorer.Migrator.HeavyDbIndexOperation.DropTransactionsToAddressHashWithPendingIndex do
+  @moduledoc """
+  Drops index "transactions_to_address_hash_with_pending_index" btree (to_address_hash, block_number DESC, index DESC, inserted_at DESC, hash).
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
+
+  alias Explorer.Migrator.HeavyDbIndexOperation.{
+    DropTransactionsCreatedContractAddressHashWithPendingIndex,
+    DropTransactionsFromAddressHashWithPendingIndex
+  }
+
+  @table_name :transactions
+  @index_name "transactions_to_address_hash_with_pending_index"
+  @operation_type :drop
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations,
+    do: [
+      DropTransactionsCreatedContractAddressHashWithPendingIndex.migration_name(),
+      DropTransactionsFromAddressHashWithPendingIndex.migration_name()
+    ]
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    operation = HeavyDbIndexOperationHelper.drop_index_query_string(@index_name)
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation)
+  end
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation_status do
+    HeavyDbIndexOperationHelper.db_index_dropping_status(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def restart_db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache do
+    BackgroundMigrations.set_heavy_indexes_drop_transactions_to_address_hash_with_pending_index_finished(true)
+  end
+end


### PR DESCRIPTION
A part of https://github.com/blockscout/blockscout/issues/9457

## Motivation

Drop `transactions` table index duplicates sorted in reverse direction.

> Drop transactions_created_contract_address_hash_with_pending_index, transactions_created_from_address_hash_with_pending_index, transactions_created_to_address_hash_with_pending_index as unused (as reported by pganalyze). All 3 indices have a similar index in ASC order, that's being used for list queries.

## Changelog

### AI Agent summary

This pull request introduces several changes to the `Explorer` application, primarily focusing on adding new operations for dropping various transaction-related indexes. These changes involve updates to configuration files, application modules, and the addition of new modules for handling these index operations.

### New Index Drop Operations:

* Added new modules for dropping transaction-related indexes:
  - `DropTransactionsCreatedContractAddressHashWithPendingIndex` (`apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_created_contract_address_hash_with_pending_index.ex`)
  - `DropTransactionsFromAddressHashWithPendingIndex` (`apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_from_address_hash_with_pending_index.ex`)
  - `DropTransactionsToAddressHashWithPendingIndex` (`apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_transactions_to_address_hash_with_pending_index.ex`)

### Configuration Updates:

* Updated `config.exs` and `test.exs` to include new index drop operations in the list of migrators:
  - `apps/explorer/config/config.exs`
  - `apps/explorer/config/runtime/test.exs`

### Application Module Changes:

* Modified `Explorer.Application` to configure the new index drop operations:
  - `apps/explorer/lib/explorer/application.ex`

### Background Migrations:

* Updated `BackgroundMigrations` to handle new index drop operations:
  - Added keys for new indexes in `background_migrations.ex`
  - Included new operations in the list of handled migrations
  - Added fallback handlers for new index drop operations

### Type Specification:

* Extended the `table_name` type specification to include `:transactions`:
  - `apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced database indexing operations to streamline transaction index management by safely dropping outdated indexes.
  - Updated runtime and test configurations to integrate the new index management tasks.
  - Improved background migration handling with better monitoring and status updates.

- **Refactor**
  - Extended index operation support to include transaction records, broadening overall database maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->