### PR TITLE
fix: signed_authorizations table migrate nonce to numeric(20,0)

### DIFF
--- a/apps/explorer/lib/explorer/chain/signed_authorization.ex
+++ b/apps/explorer/lib/explorer/chain/signed_authorization.ex
@@ -51,7 +51,7 @@ defmodule Explorer.Chain.SignedAuthorization do
     field(:index, :integer, primary_key: true, null: false)
     field(:chain_id, :integer, null: false)
     field(:address, Hash.Address, null: false)
-    field(:nonce, :integer, null: false)
+    field(:nonce, :decimal, null: false)
     field(:r, :decimal, null: false)
     field(:s, :decimal, null: false)
     field(:v, :integer, null: false)

--- a/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_bigint.exs
+++ b/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_bigint.exs
@@ -1,0 +1,15 @@
+defmodule :"Elixir.Explorer.Repo.Migrations.Signed-authorizations-nonce-change-type-to-bigint" do
+  use Ecto.Migration
+
+  def up do
+    alter table(:signed_authorizations) do
+      modify(:nonce, :numeric, precision: 20, scale: 0)
+    end
+  end
+
+  def down do
+    alter table(:signed_authorizations) do
+      modify(:nonce, :integer)
+    end
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_bigint.exs
+++ b/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_bigint.exs
@@ -1,4 +1,4 @@
-defmodule :"Elixir.Explorer.Repo.Migrations.Signed-authorizations-nonce-change-type-to-bigint" do
+defmodule :"Elixir.Explorer.Repo.Migrations.SignedAuthorizationsNonceChangeTypeToBigint" do
   use Ecto.Migration
 
   def up do

--- a/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_numeric.exs
+++ b/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_numeric.exs
@@ -1,4 +1,4 @@
-defmodule :"Elixir.Explorer.Repo.Migrations.SignedAuthorizationsNonceChangeTypeToBigint" do
+defmodule :"Elixir.Explorer.Repo.Migrations.SignedAuthorizationsNonceChangeTypeToNumeric" do
   use Ecto.Migration
 
   def up do

--- a/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_numeric.exs
+++ b/apps/explorer/priv/repo/migrations/20250328104924_signed_authorizations_nonce_change_type_to_numeric.exs
@@ -1,4 +1,4 @@
-defmodule :"Elixir.Explorer.Repo.Migrations.SignedAuthorizationsNonceChangeTypeToNumeric" do
+defmodule Explorer.Repo.Migrations.SignedAuthorizationsNonceChangeTypeToNumeric do
   use Ecto.Migration
 
   def up do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11120

## Motivation

Error on insertion of sighed authorizations because of nonce interger type overflow:

> Postgrex expected an integer in -2147483648..2147483647, got 9223372036854775807

## Changelog

Change `nonce` column in `signed_authorizations` table from `integer` to `numeric(20,0)`.

Based on [EIP-7702 spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7702.md#:~:text=Verify%20the%20nonce%20is%20less%20than%202**64%20%2D%201.):

> Verify the nonce is less than 2**64 - 1.

2^64 = 18446744073709551616 (20 decimal digits). `numeric(20,0)` should be enough.


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated numeric handling to now support fractional values, ensuring improved precision for authorization-related processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->