### PR TITLE
chore: update docker compose to use ghcr.io images

### DIFF
--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   backend:
-    image: blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-latest}
+    image: ghcr.io/blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-latest}
     pull_policy: always
     restart: always
     stop_grace_period: 5m

--- a/docker-compose/services/nft_media_handler.yml
+++ b/docker-compose/services/nft_media_handler.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   nft_media_handler:
-    image: blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-latest}
+    image: ghcr.io/blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-latest}
     pull_policy: always
     restart: always
     stop_grace_period: 5m


### PR DESCRIPTION
First, we should merge https://github.com/blockscout/blockscout/pull/12128. And then, we must merge this PR right after v8.0 is released.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated container image references to pull from the GitHub Container Registry for enhanced consistency.
	- Made minor configuration formatting adjustments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->