### PR TITLE
fix: update docker cache references to use ghcr.io

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -34,8 +34,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:master, ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
@@ -56,8 +56,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}-indexer
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -34,8 +34,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:master, ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
@@ -77,7 +77,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
           tags: ghcr.io/blockscout/blockscout:frontend-main
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |

--- a/.github/workflows/publish-docker-image-staging-on-demand.yml
+++ b/.github/workflows/publish-docker-image-staging-on-demand.yml
@@ -35,8 +35,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout-staging:latest, ghcr.io/blockscout/blockscout-staging:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |

--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -28,8 +28,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}.commit.${{ env.SHORT_SHA }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:latest, ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
@@ -54,8 +54,8 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}-indexer
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
@@ -78,8 +78,8 @@ jobs:
           context: .
           file: ./docker/oldUI.Dockerfile
           push: true
-          cache-from: type=registry,ref=blockscout/blockscout:buildcache
-          cache-to: type=registry,ref=blockscout/blockscout:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache
+          cache-to: type=registry,ref=ghcr.io/blockscout/blockscout:buildcache,mode=max
           tags: ghcr.io/blockscout/blockscout:${{ env.RELEASE_VERSION }}-with-old-ui
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |


### PR DESCRIPTION
Fix of https://github.com/blockscout/blockscout/pull/12128

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced deployment processes by updating our build automation settings for improved consistency and reliability in image releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->