### PR TITLE
fix: handle unconfigured coin fetcher ETS access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Bug Fixes
 
+- Handle unconfigured coin fetcher ETS access ([#12228](https://github.com/blockscout/blockscout/pull/12228))
 - Negate condition for language check in solidityscan controller ([#12222](https://github.com/blockscout/blockscout/pull/12222))
 - Look up sources for partially verified smart contracts ([#12221](https://github.com/blockscout/blockscout/pull/12221))
 - BufferedTask-based approach for fetching Arbitrum-specific settlement info ([#12192](https://github.com/blockscout/blockscout/pull/12192))

--- a/apps/explorer/lib/explorer/market/fetcher/coin.ex
+++ b/apps/explorer/lib/explorer/market/fetcher/coin.ex
@@ -165,7 +165,7 @@ defmodule Explorer.Market.Fetcher.Coin do
   end
 
   defp do_get_coin_exchange_rate(secondary_coin?) do
-    if config(:store) == :ets && config(:enabled) do
+    if config(:store) == :ets && config(:enabled) && :ets.whereis(table_name()) != :undefined do
       case :ets.lookup(table_name(), secondary_coin?) do
         [{_, coin} | _] -> coin
         _ -> nil

--- a/cspell.json
+++ b/cspell.json
@@ -655,6 +655,7 @@
         "ufixed",
         "uncatalog",
         "unclosable",
+        "unconfigured",
         "unfetched",
         "unfinalized",
         "Unichain",


### PR DESCRIPTION
## Motivation

```
2025-04-10T11:45:16.120 [error] #PID<0.23890.0> running BlockScoutWeb.Endpoint (connection #PID<0.23889.0>, stream id 1) terminated
Server: 127.0.0.1:80 (http)
Request: GET /api/v2/main-page/transactions
** (exit) an exception was raised:
    ** (ArgumentError) errors were found at the given arguments:

  * 1st argument: the table identifier does not refer to an existing ETS table

        (stdlib 6.1) :ets.lookup(:exchange_rates, false)
        (explorer 8.0.0) lib/explorer/market/fetcher/coin.ex:169: Explorer.Market.Fetcher.Coin.do_get_coin_exchange_rate/1
        (explorer 8.0.0) lib/explorer/market/market.ex:35: Explorer.Market.get_coin_exchange_rate/0
        (block_scout_web 8.0.0) lib/block_scout_web/views/api/v2/transaction_view.ex:475: BlockScoutWeb.API.V2.TransactionView.prepare_transaction/6
        (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
        (phoenix 1.5.14) lib/phoenix/view.ex:472: Phoenix.View.render_to_iodata/3
        (phoenix 1.5.14) lib/phoenix/controller.ex:777: Phoenix.Controller.render_and_send/4
        (block_scout_web 8.0.0) lib/block_scout_web/controllers/api/v2/main_page_controller.ex:1: BlockScoutWeb.API.V2.MainPageController.action/2
        (block_scout_web 8.0.0) lib/block_scout_web/controllers/api/v2/main_page_controller.ex:1: BlockScoutWeb.API.V2.MainPageController.phoenix_controller_pipeline/2
        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (phoenix 1.5.14) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
        (phoenix 1.5.14) lib/phoenix/router.ex:352: Phoenix.Router.__call__/2
        (block_scout_web 8.0.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
        (block_scout_web 8.0.0) /Users/kitt/Developer/Blockscout/blockscout/deps/plug/lib/plug/debugger.ex:155: BlockScoutWeb.Endpoint."call (overridable 3)"/2
        (block_scout_web 8.0.0) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 4)"/2
        (block_scout_web 8.0.0) /Users/kitt/Developer/Blockscout/blockscout/deps/spandex_phoenix/lib/spandex_phoenix.ex:151: BlockScoutWeb.Endpoint.call/2
        (phoenix 1.5.14) lib/phoenix/endpoint/cowboy2_handler.ex:65: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy 2.13.0) /Users/kitt/Developer/Blockscout/blockscout/deps/cowboy/src/cowboy_handler.erl:37: :cowboy_handler.execute/2
        (cowboy 2.13.0) /Users/kitt/Developer/Blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:310: :cowboy_stream_h.execute/3
        (cowboy 2.13.0) /Users/kitt/Developer/Blockscout/blockscout/deps/cowboy/src/cowboy_stream_h.erl:299: :cowboy_stream_h.request_process/3
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of coin exchange rate retrieval by ensuring data is only accessed when available, reducing potential errors and enhancing overall application stability.
  - Addressed issues related to contract creation transaction associations and bytecode twin detection, improving accuracy and reliability.

- **New Features**
  - Added support for handling unconfigured coin fetcher ETS access, enhancing application robustness.
  - Implemented a BufferedTask-based approach for fetching Arbitrum-specific settlement information, improving performance and scalability.
  - Expanded vocabulary for spell checker to recognize the term "unconfigured" without flagging it as an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->