### PR TITLE
fix: resolve timeouts on Celo epoch reward contract reads

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
@@ -25,12 +25,13 @@ defmodule Indexer.Fetcher.Celo.ValidatorGroupVotes do
 
   @max_request_retries 3
 
+
   @validator_group_vote_activated_topic "0x45aac85f38083b18efe2d441a65b9c1ae177c78307cb5a5d4aec8f7dbcaeabfe"
   @validator_group_active_vote_revoked_topic "0xae7458f8697a680da6be36406ea0b8f40164915ac9cc40c0dad05a2ff6e8c6a8"
 
   @spec fetch(block_number :: EthereumJSONRPC.block_number()) :: :ok
   def fetch(block_number) do
-    GenServer.call(__MODULE__, {:fetch, block_number})
+    GenServer.call(__MODULE__, {:fetch, block_number}, :infinity)
   end
 
   def child_spec(start_link_arguments) do

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -365,6 +365,52 @@ defmodule Indexer.Helper do
   end
 
   @doc """
+  Processes a large batch of contract calls by splitting them into smaller
+  chunks for efficiency and resiliency.
+
+  This function takes a potentially large list of contract call requests,
+  divides them into manageable chunks, applies the provided reader function to
+  each chunk, and then consolidates the results.
+
+  The chunking approach helps prevent timeouts that can occur when making too
+  many simultaneous RPC calls.
+
+  ## Parameters
+  - `requests`: A list of `EthereumJSONRPC.Contract.call()` instances
+    representing contract calls to execute.
+  - `chunk_size`: The maximum number of contract calls to include in each chunk.
+  - `reader`: A function that takes a chunk of contract call requests and
+           returns `{responses, errors}` tuple.
+
+  ## Returns
+  - A tuple `{responses, errors}` where:
+  - `responses`: A concatenated list of all response tuples `{:ok, result}` or
+                `{:error, reason}` from all chunks, maintaining the original
+                order.
+  - `errors`: A deduplicated list of all error messages encountered across all
+    chunks.
+  """
+  @spec read_contracts_with_retries_by_chunks(
+          [EthereumJSONRPC.Contract.call()],
+          integer(),
+          ([EthereumJSONRPC.Contract.call()] ->
+             {[{:ok | :error, any()}], list()})
+        ) ::
+          {[{:ok | :error, any()}], list()}
+  def read_contracts_with_retries_by_chunks(requests, chunk_size, reader) do
+    {responses_lists, errors_lists} =
+      requests
+      |> Enum.chunk_every(chunk_size)
+      |> Enum.map(reader)
+      |> Enum.unzip()
+
+    {
+      Enum.concat(responses_lists),
+      errors_lists |> Enum.concat() |> Enum.uniq()
+    }
+  end
+
+  @doc """
     Retrieves decoded results of `eth_call` requests to contracts, with retry
     logic for handling errors.
 
@@ -399,7 +445,8 @@ defmodule Indexer.Helper do
           [EthereumJSONRPC.Contract.call()],
           [map()],
           EthereumJSONRPC.json_rpc_named_arguments(),
-          integer()
+          integer(),
+          boolean()
         ) :: {[{:ok | :error, any()}], list()}
   def read_contracts_with_retries(requests, abi, json_rpc_named_arguments, retries_left, log_error? \\ true)
       when is_list(requests) and is_list(abi) and is_integer(retries_left) do

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -29,6 +29,7 @@ defmodule Indexer.Transform.TokenTransfers do
         (log.first_topic == TokenTransfer.weth_deposit_signature() ||
            log.first_topic == TokenTransfer.weth_withdrawal_signature()) &&
           TokenTransfer.whitelisted_weth_contract?(log.address_hash)
+          && !is_nil(log.second_topic)
       end)
       |> Enum.reduce(initial_acc, &do_parse/2)
       |> drop_repeated_token_transfers(erc20_and_erc721_token_transfers.token_transfers)


### PR DESCRIPTION
Introduce a function that does repeated contract reads, but separates those requests into chunks first. 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
