### PR TITLE
fix: support updated zkSync calldata format in batch proof tracking

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/zksync/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/zksync/constants/contracts.ex
@@ -1,0 +1,139 @@
+defmodule EthereumJSONRPC.ZkSync.Constants.Contracts do
+  @moduledoc """
+  Provides constants and ABI definitions for zkSync-specific smart contracts.
+  """
+
+  # /// @notice Rollup batch stored data
+  # /// @param batchNumber Rollup batch number
+  # /// @param batchHash Hash of L2 batch
+  # /// @param indexRepeatedStorageChanges The serial number of the shortcut index that's used as a unique identifier for storage keys that were used twice or more
+  # /// @param numberOfLayer1Txs Number of priority operations to be processed
+  # /// @param priorityOperationsHash Hash of all priority operations from this batch
+  # /// @param l2LogsTreeRoot Root hash of tree that contains L2 -> L1 messages from this batch
+  # /// @param timestamp Rollup batch timestamp, have the same format as Ethereum batch constant
+  # /// @param commitment Verified input for the ZKsync circuit
+  # struct StoredBatchInfo {
+  #     uint64 batchNumber;
+  #     bytes32 batchHash;
+  #     uint64 indexRepeatedStorageChanges;
+  #     uint256 numberOfLayer1Txs;
+  #     bytes32 priorityOperationsHash;
+  #     bytes32 l2LogsTreeRoot;
+  #     uint256 timestamp;
+  #     bytes32 commitment;
+  # }
+  @stored_batch_info_tuple [
+    # batchNumber
+    uint: 64,
+    # batchHash
+    bytes: 32,
+    # indexRepeatedStorageChanges
+    uint: 64,
+    # numberOfLayer1Txs
+    uint: 256,
+    # priorityOperationsHash
+    bytes: 32,
+    # l2LogsTreeRoot
+    bytes: 32,
+    # timestamp
+    uint: 256,
+    # commitment
+    bytes: 32
+  ]
+
+  # /// @notice Recursive proof input data (individual commitments are constructed onchain)
+  # struct ProofInput {
+  #     uint256[] recursiveAggregationInput;
+  #     uint256[] serializedProof;
+  # }
+  @proof_input_tuple [
+    # recursiveAggregationInput
+    array: {:uint, 256},
+    # serializedProof
+    array: {:uint, 256}
+  ]
+
+  @selector_prove_batches "7f61885c"
+  @selector_prove_batches_shared_bridge_c37533bb "c37533bb"
+  @selector_prove_batches_shared_bridge_e12a6137 "e12a6137"
+
+  @doc """
+    Returns selector of the `proveBatches` function
+  """
+  def prove_batches_selector, do: @selector_prove_batches
+
+  @doc """
+    Returns selector of the `proveBatchesSharedBridge` function
+  """
+  def prove_batches_shared_bridge_c37533bb_selector, do: @selector_prove_batches_shared_bridge_c37533bb
+
+  @doc """
+    Returns selector of the `proveBatchesSharedBridge` function with selector e12a6137
+  """
+  def prove_batches_shared_bridge_e12a6137_selector, do: @selector_prove_batches_shared_bridge_e12a6137
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      proveBatches(
+        StoredBatchInfo calldata _prevBatch,
+        StoredBatchInfo[] calldata _committedBatches,
+        ProofInput calldata _proof
+      )
+  """
+  def prove_batches_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "proveBatches",
+      types: [
+        {:tuple, @stored_batch_info_tuple},
+        {:array, {:tuple, @stored_batch_info_tuple}},
+        {:tuple, @proof_input_tuple}
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      proveBatchesSharedBridge(
+        uint256 _chainId,
+        StoredBatchInfo calldata _prevBatch,
+        StoredBatchInfo[] calldata _committedBatches,
+        ProofInput calldata _proof
+      )
+  """
+  def prove_batches_shared_bridge_c37533bb_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "proveBatchesSharedBridge",
+      types: [
+        {:uint, 256},
+        {:tuple, @stored_batch_info_tuple},
+        {:array, {:tuple, @stored_batch_info_tuple}},
+        {:tuple, @proof_input_tuple}
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      proveBatchesSharedBridge(
+        uint256 _chainId,
+        uint256 _processBatchFrom,
+        uint256 _processBatchTo,
+        bytes calldata _proofData
+      )
+  """
+  def prove_batches_shared_bridge_e12a6137_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "proveBatchesSharedBridge",
+      types: [
+        # _chainId
+        {:uint, 256},
+        # _processBatchFrom
+        {:uint, 256},
+        # _processBatchTo
+        {:uint, 256},
+        # _proofData
+        :bytes
+      ]
+    }
+end


### PR DESCRIPTION
## Motivation

After migrating to the new version of zkSync (v26 and above), attempts to update the status of indexed transaction batches to “Proven” fail, resulting in the following error being logged:

```elixir
fetcher=zksync_batches_tracker [info] Checking if the batch 14466 was proven
fetcher=zksync_batches_tracker [info] The batch 14466 looks like proven
fetcher=zksync_batches_tracker [error] Unknown calldata format: 0xe12a613700000000...
fetcher=zksync_batches_tracker [info] Discovered 0 proven batches in the prove transaction
```

## Problem Analysis

### Specification Update in zkSync Code

In the new release of zkSync [V26](https://github.com/matter-labs/era-contracts/tree/release-v26), the set of methods used to submit transaction batch proofs has changed from:

```solidity
/// @notice Batches commitment verification.
/// @dev Only verifies batch commitments without any other processing.
/// @param _prevBatch Stored data of the last committed batch.
/// @param _committedBatches Stored data of the committed batches.
/// @param _proof The zero knowledge proof.
function proveBatches(
    StoredBatchInfo calldata _prevBatch,
    StoredBatchInfo[] calldata _committedBatches,
    ProofInput calldata _proof
) external;

/// @notice same as `proveBatches` but with the chainId so ValidatorTimelock can sort the inputs.
function proveBatchesSharedBridge(
    uint256 _chainId,
    StoredBatchInfo calldata _prevBatch,
    StoredBatchInfo[] calldata _committedBatches,
    ProofInput calldata _proof
) external;
```
to 
```solidity
/// @notice Batches commitment verification.
/// @dev Only verifies batch commitments without any other processing.
/// @param _chainId Chain ID of the chain.
/// @param _processBatchFrom The batch number from which the verification starts.
/// @param _processBatchTo The batch number at which the verification ends.
/// @param _proofData The encoded data of the new batches to be verified.
function proveBatchesSharedBridge(
    uint256 _chainId,
    uint256 _processBatchFrom,
    uint256 _processBatchTo,
    bytes calldata _proofData
) external; 
```
** *The method specifications referenced above are sourced from the `l1-contracts/contracts/state-transition/chain-interfaces/IExecutor.sol` file located at https://github.com/matter-labs/era-contracts.*

The method signature of `proveBatchesSharedBridge` has been updated, introducing new parameters. As a result, the function now starts with the calldata prefix `0xe12a6137`.

### **Handling of Proven Batches in Blockscout**

1. The `BatchesStatusTracker` periodically sends itself the `:check_proven` message which triggers a call to `look_for_batches_and_update`.
2. It retrieves the earliest unproven batch using `get_earliest_unproven_batch_number()`.
3. For the identified batch, it calls `check_if_batch_status_changed` which:
    - Fetches the current batch details from RPC using `zks_getL1BatchDetails`.
    - Compares with the database record to see if the `prove_transaction_hash` has changed.
4. When a batch is found to be newly proven, the system fetches the transaction data via `fetch_transaction_by_hash` to get its calldata.
5. The `get_proven_batches_from_calldata` function then attempts to parse the calldata, supporting two known zkSync function signatures:
    - `0x7f61885c` for `proveBatches`
    - `0xc37533bb` for `proveBatchesSharedBridge`
    
    Proven batches are extracted from the decoded parameters.
    
6. Finally, the process calls `associate_and_import_or_prepare_for_recovery`, which:
    - Associates the batches with the `prove_id` (the parent chain transaction ID).
    - Uses `import_to_db` to update the database.
    - Sets the `prove_id` field in the `zksync_transaction_batches` table.

The following code flow reflects the process described above:

```
Indexer.Fetcher.ZkSync.BatchesStatusTracker.handle_info()
..Indexer.Fetcher.ZkSync.Utils.Db.get_earliest_unproven_batch_number
..Indexer.Fetcher.ZkSync.StatusTracking.CommonUtils.check_if_batch_status_changed
..Indexer.Fetcher.ZkSync.Utils.Rpc.fetch_transaction_by_hash
..Indexer.Fetcher.ZkSync.StatusTracking.Proven.look_for_batches_and_update
....Indexer.Fetcher.ZkSync.StatusTracking.Proven.get_proven_batches_from_calldata
..Indexer.Fetcher.ZkSync.StatusTracking.CommonUtils.associate_and_import_or_prepare_for_recovery
....Indexer.Fetcher.ZkSync.Utils.Db.import_to_db
```

Since the updated signature of `proveBatchesSharedBridge` no longer matches the expected patterns in `get_proven_batches_from_calldata`, parsing fails, resulting in an error log. Consequently, the `prove_id` field is not updated in the database for any affected batches.

## Proposed Solution

1. Extend the `get_proven_batches_from_calldata` function to handle the new calldata prefix (`0xe12a6137`) for the updated `proveBatchesSharedBridge` method. Support for existing prefixes must be preserved to ensure backward compatibility with older transaction formats.
2. With the updated method, the `StoredBatchInfo` array is now encapsulated within the `_proofData` parameter and does not need to be decoded. Instead, batch numbers can be safely and directly extracted from the `_processBatchFrom` and `_processBatchTo` parameters. This approach is consistent with how batch ranges are determined in [the `decodeAndCheckProofData` function](https://github.com/matter-labs/era-contracts/blob/8222265420f362c853da7160769620d9fed7f834/l1-contracts/contracts/state-transition/libraries/BatchDecoder.sol#L113-L152) used by `proveBatchesSharedBridge`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new module with updated constants and definitions to enhance zkSync smart contract integration.
  - Improved extraction of batch details from transaction data for more reliable proven batch processing.

- **Refactor**
  - Streamlined the proven batch processing workflow with consolidated logic and refined error logging to boost performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->