### PR TITLE
feat: add `/api/v2/config/celo` convenience endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -24,4 +24,12 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
     |> put_status(200)
     |> json(%{update_period_hours: public_metrics_update_period_hours})
   end
+
+  def celo(conn, _params) do
+    config = Application.get_env(:explorer, :celo)
+
+    conn
+    |> put_status(200)
+    |> json(%{l2_migration_block: config[:l2_migration_block]})
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -141,6 +141,10 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/backend-version", V2.ConfigController, :backend_version)
       get("/csv-export", V2.ConfigController, :csv_export)
       get("/public-metrics", V2.ConfigController, :public_metrics)
+
+      chain_scope :celo do
+        get("/celo", V2.ConfigController, :celo)
+      end
     end
 
     scope "/transactions" do


### PR DESCRIPTION


## Motivation

Currently, `CELO_L2_MIGRATION_BLOCK` is present both in frontend's and backend's configs. This enchancement allows to set it once on backend.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint for Celo configuration, allowing users to retrieve specific blockchain configuration details.
  - Expanded the API router to include a dedicated route for the Celo chain, delivering configuration information seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->