### PR TITLE
fix: Add missing load of health_latest_batch_average_time_from_db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Bug Fixes
 
+- Add missing load of health_latest_batch_average_time_from_db ([#12240](https://github.com/blockscout/blockscout/pull/12240))
 - Handle unconfigured coin fetcher ETS access ([#12228](https://github.com/blockscout/blockscout/pull/12228))
 - Negate condition for language check in solidityscan controller ([#12222](https://github.com/blockscout/blockscout/pull/12222))
 - Look up sources for partially verified smart contracts ([#12221](https://github.com/blockscout/blockscout/pull/12221))
@@ -63,6 +64,7 @@
 
 ### ⚡ Performance
 
+- Add index for slow `/api/v2/addresses?sort=transactions_count&order=asc` ([#12230](https://github.com/blockscout/blockscout/pull/12230))
 - `/api/v2/smart-contracts` endpoint ([#12060](https://github.com/blockscout/blockscout/issues/12060))
 - Optimize query for user token transfers list filtered by token ([#12039](https://github.com/blockscout/blockscout/issues/12039))
 - Improve watchlist rendering performance ([#11999](https://github.com/blockscout/blockscout/issues/11999))

--- a/apps/explorer/lib/explorer/chain/health/helper.ex
+++ b/apps/explorer/lib/explorer/chain/health/helper.ex
@@ -129,6 +129,7 @@ defmodule Explorer.Chain.Health.Helper do
     - "health_latest_block_number_from_node"
     - "health_latest_batch_number_from_db",
     - "health_latest_batch_timestamp_from_db"
+    - "health_latest_batch_average_time_from_db"
 
   The retrieved values are then reduced into a map with the following keys:
     - `:health_latest_block_number_from_db`
@@ -138,6 +139,7 @@ defmodule Explorer.Chain.Health.Helper do
     - `:health_latest_block_number_from_node`
     - `:health_latest_batch_number_from_db`
     - `:health_latest_batch_timestamp_from_db`
+    - `:health_latest_batch_average_time_from_db`
 
   Each key in the map is assigned the corresponding value fetched from the `LastFetchedCounter`.
 
@@ -154,7 +156,8 @@ defmodule Explorer.Chain.Health.Helper do
         "health_latest_block_timestamp_from_db",
         "health_latest_block_number_from_node",
         "health_latest_batch_number_from_db",
-        "health_latest_batch_timestamp_from_db"
+        "health_latest_batch_timestamp_from_db",
+        "health_latest_batch_average_time_from_db"
       ])
 
     values
@@ -166,7 +169,8 @@ defmodule Explorer.Chain.Health.Helper do
         health_latest_block_timestamp_from_cache: nil,
         health_latest_block_number_from_node: nil,
         health_latest_batch_number_from_db: nil,
-        health_latest_batch_timestamp_from_db: nil
+        health_latest_batch_timestamp_from_db: nil,
+        health_latest_batch_average_time_from_db: nil
       },
       fn {key, value}, acc ->
         Map.put(acc, String.to_existing_atom(key), value)


### PR DESCRIPTION
## Motivation

https://optimism-sepolia.k8s-dev.blockscout.com/api/health
`average_batch_time` is ""

## Changelog
- Add missing load of `health_latest_batch_average_time_from_db`
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced system health monitoring by introducing a new performance metric that tracks the average retrieval time of recent batch data from the database. This adjustment provides improved visibility into system performance trends, allowing users to better gauge operational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->