### PR TITLE
chore: Update blocks consensus in case of import failure

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -343,12 +343,12 @@ defmodule Explorer.Chain.Import do
         {:ok, result}
 
       error ->
-        set_refetch_needed_for_partially_imported_blocks(options)
+        handle_partially_imported_blocks(options)
         error
     end
   rescue
     exception ->
-      set_refetch_needed_for_partially_imported_blocks(options)
+      handle_partially_imported_blocks(options)
       reraise exception, __STACKTRACE__
   end
 
@@ -399,14 +399,15 @@ defmodule Explorer.Chain.Import do
     end)
   end
 
-  defp set_refetch_needed_for_partially_imported_blocks(%{blocks: %{params: blocks_params}}) do
+  defp handle_partially_imported_blocks(%{blocks: %{params: blocks_params}}) do
     block_numbers = Enum.map(blocks_params, & &1.number)
     Block.set_refetch_needed(block_numbers)
+    Import.Runner.Blocks.process_blocks_consensus(blocks_params)
 
     Logger.warning("Set refetch_needed for partially imported block because of error: #{inspect(block_numbers)}")
   end
 
-  defp set_refetch_needed_for_partially_imported_blocks(_options), do: :ok
+  defp handle_partially_imported_blocks(_options), do: :ok
 
   @spec timestamps() :: timestamps
   def timestamps do

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   alias Explorer.Chain.Import.Runner.Address.CurrentTokenBalances
   alias Explorer.Chain.Import.Runner.{Addresses, TokenInstances, Tokens}
   alias Explorer.Prometheus.Instrumenter
+  alias Explorer.Repo, as: ExplorerRepo
   alias Explorer.Utility.MissingRangesManipulator
 
   @behaviour Runner
@@ -68,11 +69,9 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
     hashes = Enum.map(changes_list, & &1.hash)
 
-    consensus_block_numbers = consensus_block_numbers(changes_list)
-
     # Enforce ShareLocks tables order (see docs: sharelocks.md)
     run_func = fn repo ->
-      {:ok, nonconsensus_items} = lose_consensus(repo, hashes, consensus_block_numbers, changes_list, insert_options)
+      {:ok, nonconsensus_items} = lose_consensus(repo, changes_list, insert_options)
 
       {:ok,
        RangesHelper.filter_by_height_range(nonconsensus_items, fn {number, _hash} ->
@@ -399,10 +398,13 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     |> Enum.map(& &1.number)
   end
 
-  def lose_consensus(repo, hashes, consensus_block_numbers, changes_list, %{
+  def lose_consensus(repo, changes_list, %{
         timeout: timeout,
         timestamps: %{updated_at: updated_at}
       }) do
+    hashes = Enum.map(changes_list, & &1.hash)
+    consensus_block_numbers = consensus_block_numbers(changes_list)
+
     acquire_query =
       from(
         block in where_invalid_neighbor(changes_list),
@@ -461,7 +463,30 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     {:ok, removed_consensus_block_hashes}
   rescue
     postgrex_error in Postgrex.Error ->
-      {:error, %{exception: postgrex_error, consensus_block_numbers: consensus_block_numbers}}
+      {:error, %{exception: postgrex_error}}
+  end
+
+  @doc """
+    Processes consensus for blocks that failed to import completely.
+
+    This function handles the consistency updates needed when a block import fails,
+    ensuring that the chain's consensus state remains valid.
+
+    ## Parameters
+    - `blocks_changes`: List of block changes to process
+
+    ## Returns
+    - `{:ok, removed_consensus_block_hashes}`: List of hashes for blocks that lost consensus
+    - `{:error, reason}`: The error encountered during processing
+  """
+  @spec process_blocks_consensus([map()]) :: {:ok, [{non_neg_integer(), binary()}]} | {:error, map()}
+  def process_blocks_consensus(blocks_changes) do
+    opts = %{
+      timeout: @timeout,
+      timestamps: %{updated_at: DateTime.utc_now()}
+    }
+
+    lose_consensus(ExplorerRepo, blocks_changes, opts)
   end
 
   defp new_pending_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -692,7 +692,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
         timestamps: %{updated_at: DateTime.utc_now()}
       }
 
-      assert {:ok, [{0, _}, {1, _}]} = Blocks.lose_consensus(Repo, [new_block1_changes], opts)
+      assert {:ok, [{0, _}, {1, _}]} = Blocks.process_blocks_consensus([new_block1_changes], Repo, opts)
     end
   end
 

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -692,7 +692,7 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
         timestamps: %{updated_at: DateTime.utc_now()}
       }
 
-      assert {:ok, [{0, _}, {1, _}]} = Blocks.lose_consensus(Repo, [], [1], [new_block1_changes], opts)
+      assert {:ok, [{0, _}, {1, _}]} = Blocks.lose_consensus(Repo, [new_block1_changes], opts)
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12129

## Changelog

Update consensus for blocks that would have been imported in case of import failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the block import process with integrated consensus processing for partially imported data, improving overall reliability.

- **Refactor**
  - Streamlined internal logic and error handling to simplify the block import workflow and ensure more consistent processing.
  - Updated function signatures to improve clarity and maintainability.
  - Introduced a new method for handling block consensus processing.

- **Tests**
  - Updated tests to reflect new consensus processing method and simplified function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->