### PR TITLE
refactor: do not create postmigration celo epoch block operations

### DIFF
--- a/apps/explorer/lib/explorer/chain/celo/pending_epoch_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/celo/pending_epoch_block_operation.ex
@@ -68,20 +68,7 @@ defmodule Explorer.Chain.Celo.PendingEpochBlockOperation do
       )
 
     query
-    |> maybe_filter_premigration_epoch_blocks()
     |> add_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
-  end
-
-  @spec maybe_filter_premigration_epoch_blocks(Ecto.Query.t()) :: Ecto.Query.t()
-  defp maybe_filter_premigration_epoch_blocks(query) do
-    l2_migration_block_number = Application.get_env(:explorer, :celo)[:l2_migration_block]
-
-    if l2_migration_block_number do
-      query
-      |> where([op, block], block.number <= ^l2_migration_block_number)
-    else
-      query
-    end
   end
 end

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -1043,7 +1043,11 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp celo_pending_epoch_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
     ordered_epoch_blocks =
       inserted_blocks
-      |> Enum.filter(fn block -> CeloHelper.epoch_block_number?(block.number) && block.consensus end)
+      |> Enum.filter(fn block ->
+        CeloHelper.premigration_block_number?(block.number) &&
+          CeloHelper.epoch_block_number?(block.number) &&
+          block.consensus
+      end)
       |> Enum.map(&%{block_hash: &1.hash})
       |> Enum.sort_by(& &1.block_hash)
       |> Enum.dedup_by(& &1.block_hash)

--- a/apps/explorer/priv/celo/migrations/20250414102702_remove_pending_epoch_block_operations_after_l2_migration_block.exs
+++ b/apps/explorer/priv/celo/migrations/20250414102702_remove_pending_epoch_block_operations_after_l2_migration_block.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Celo.Migrations.RemovePendingEpochBlockOperationsAfterL2MigrationBlock do
+  use Ecto.Migration
+
+  def change do
+    l2_migration_block_number = Application.get_env(:explorer, :celo)[:l2_migration_block]
+
+    execute("""
+    DELETE FROM celo_pending_epoch_block_operations WHERE block_hash IN
+    (SELECT hash FROM blocks WHERE number >= #{l2_migration_block_number})
+    """)
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
@@ -25,12 +25,13 @@ defmodule Indexer.Fetcher.Celo.ValidatorGroupVotes do
 
   @max_request_retries 3
 
+
   @validator_group_vote_activated_topic "0x45aac85f38083b18efe2d441a65b9c1ae177c78307cb5a5d4aec8f7dbcaeabfe"
   @validator_group_active_vote_revoked_topic "0xae7458f8697a680da6be36406ea0b8f40164915ac9cc40c0dad05a2ff6e8c6a8"
 
   @spec fetch(block_number :: EthereumJSONRPC.block_number()) :: :ok
   def fetch(block_number) do
-    GenServer.call(__MODULE__, {:fetch, block_number})
+    GenServer.call(__MODULE__, {:fetch, block_number}, :infinity)
   end
 
   def child_spec(start_link_arguments) do

--- a/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/validator_group_votes.ex
@@ -25,7 +25,6 @@ defmodule Indexer.Fetcher.Celo.ValidatorGroupVotes do
 
   @max_request_retries 3
 
-
   @validator_group_vote_activated_topic "0x45aac85f38083b18efe2d441a65b9c1ae177c78307cb5a5d4aec8f7dbcaeabfe"
   @validator_group_active_vote_revoked_topic "0xae7458f8697a680da6be36406ea0b8f40164915ac9cc40c0dad05a2ff6e8c6a8"
 

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -365,6 +365,52 @@ defmodule Indexer.Helper do
   end
 
   @doc """
+  Processes a large batch of contract calls by splitting them into smaller
+  chunks for efficiency and resiliency.
+
+  This function takes a potentially large list of contract call requests,
+  divides them into manageable chunks, applies the provided reader function to
+  each chunk, and then consolidates the results.
+
+  The chunking approach helps prevent timeouts that can occur when making too
+  many simultaneous RPC calls.
+
+  ## Parameters
+  - `requests`: A list of `EthereumJSONRPC.Contract.call()` instances
+    representing contract calls to execute.
+  - `chunk_size`: The maximum number of contract calls to include in each chunk.
+  - `reader`: A function that takes a chunk of contract call requests and
+           returns `{responses, errors}` tuple.
+
+  ## Returns
+  - A tuple `{responses, errors}` where:
+  - `responses`: A concatenated list of all response tuples `{:ok, result}` or
+                `{:error, reason}` from all chunks, maintaining the original
+                order.
+  - `errors`: A deduplicated list of all error messages encountered across all
+    chunks.
+  """
+  @spec read_contracts_with_retries_by_chunks(
+          [EthereumJSONRPC.Contract.call()],
+          integer(),
+          ([EthereumJSONRPC.Contract.call()] ->
+             {[{:ok | :error, any()}], list()})
+        ) ::
+          {[{:ok | :error, any()}], list()}
+  def read_contracts_with_retries_by_chunks(requests, chunk_size, reader) do
+    {responses_lists, errors_lists} =
+      requests
+      |> Enum.chunk_every(chunk_size)
+      |> Enum.map(reader)
+      |> Enum.unzip()
+
+    {
+      Enum.concat(responses_lists),
+      errors_lists |> Enum.concat() |> Enum.uniq()
+    }
+  end
+
+  @doc """
     Retrieves decoded results of `eth_call` requests to contracts, with retry
     logic for handling errors.
 
@@ -399,7 +445,8 @@ defmodule Indexer.Helper do
           [EthereumJSONRPC.Contract.call()],
           [map()],
           EthereumJSONRPC.json_rpc_named_arguments(),
-          integer()
+          integer(),
+          boolean()
         ) :: {[{:ok | :error, any()}], list()}
   def read_contracts_with_retries(requests, abi, json_rpc_named_arguments, retries_left, log_error? \\ true)
       when is_list(requests) and is_list(abi) and is_integer(retries_left) do

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -29,6 +29,7 @@ defmodule Indexer.Transform.TokenTransfers do
         (log.first_topic == TokenTransfer.weth_deposit_signature() ||
            log.first_topic == TokenTransfer.weth_withdrawal_signature()) &&
           TokenTransfer.whitelisted_weth_contract?(log.address_hash)
+          && !is_nil(log.second_topic)
       end)
       |> Enum.reduce(initial_acc, &do_parse/2)
       |> drop_repeated_token_transfers(erc20_and_erc721_token_transfers.token_transfers)

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -28,8 +28,8 @@ defmodule Indexer.Transform.TokenTransfers do
       |> Enum.filter(fn log ->
         (log.first_topic == TokenTransfer.weth_deposit_signature() ||
            log.first_topic == TokenTransfer.weth_withdrawal_signature()) &&
-          TokenTransfer.whitelisted_weth_contract?(log.address_hash)
-          && !is_nil(log.second_topic)
+          TokenTransfer.whitelisted_weth_contract?(log.address_hash) &&
+          !is_nil(log.second_topic)
       end)
       |> Enum.reduce(initial_acc, &do_parse/2)
       |> drop_repeated_token_transfers(erc20_and_erc721_token_transfers.token_transfers)

--- a/apps/indexer/test/indexer/fetcher/celo/epoch_block_operations_test.exs
+++ b/apps/indexer/test/indexer/fetcher/celo/epoch_block_operations_test.exs
@@ -36,29 +36,5 @@ defmodule Indexer.Fetcher.Celo.EpochBlockOperationsTest do
                  )
       end
     end
-
-    test "correctly buffers blocks when :l2_migration_block is set", %{
-      json_rpc_named_arguments: json_rpc_named_arguments
-    } do
-      last_l1_epoch_block_number = 1 * blocks_per_epoch()
-      l1_block = insert(:block, number: last_l1_epoch_block_number)
-      l2_block = insert(:block, number: 2 * blocks_per_epoch())
-      insert(:celo_pending_epoch_block_operation, block: l1_block)
-      insert(:celo_pending_epoch_block_operation, block: l2_block)
-
-      Application.put_env(:explorer, :celo, l2_migration_block: last_l1_epoch_block_number)
-
-      assert [
-               %{
-                 block_number: l1_block.number,
-                 block_hash: l1_block.hash
-               }
-             ] ==
-               EpochBlockOperations.init(
-                 [],
-                 fn block_number, acc -> [block_number | acc] end,
-                 json_rpc_named_arguments
-               )
-    end
   end
 end


### PR DESCRIPTION
Should be merged after #12229.

## Motivation

Do not store celo epoch block operations after L2 migration has happened.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a database migration to remove pending epoch block operations after a specified L2 migration block number.
	- Introduced a chunking mechanism for contract calls to improve efficiency and reduce RPC timeouts.
- **Improvements**
	- Enhanced handling of contract read requests by batching them in smaller chunks.
	- Increased reliability of validator group vote fetching by allowing unlimited wait time.
	- Improved filtering of WETH token transfer logs to exclude incomplete entries.
- **Bug Fixes**
	- Adjusted filtering logic for epoch block operations to better align with premigration block criteria.
- **Tests**
	- Removed a test related to L2 migration block buffering to reflect updated logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->