### PR TITLE
perf: Remove custom paging option from main page controller

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -31,7 +31,6 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
         [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional
       }
       |> Map.merge(@chain_type_transaction_necessity_by_association),
-    paging_options: %PagingOptions{page_size: 6},
     api?: true
   ]
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
@@ -41,14 +41,14 @@ defmodule BlockScoutWeb.API.V2.MainPageControllerTest do
       assert [] = json_response(request, 200)
     end
 
-    test "get last 6 transactions", %{conn: conn} do
-      transactions = insert_list(10, :transaction) |> with_block() |> Enum.take(-6) |> Enum.reverse()
+    test "get last 50 transactions", %{conn: conn} do
+      transactions = insert_list(60, :transaction) |> with_block() |> Enum.take(-50) |> Enum.reverse()
 
       request = get(conn, "/api/v2/main-page/transactions")
       assert response = json_response(request, 200)
-      assert Enum.count(response) == 6
+      assert Enum.count(response) == 50
 
-      for i <- 0..5 do
+      for i <- 0..49 do
         compare_item(Enum.at(transactions, i), Enum.at(response, i))
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/main_page_controller_test.exs
@@ -60,9 +60,7 @@ defmodule BlockScoutWeb.API.V2.MainPageControllerTest do
       assert %{"message" => "Unauthorized"} = json_response(request, 401)
     end
 
-    test "get last 6 transactions", %{conn: conn} do
-      insert_list(10, :transaction) |> with_block()
-
+    test "get last 50 transactions", %{conn: conn} do
       auth = build(:auth)
       {:ok, user} = Identity.find_or_create(auth)
 
@@ -106,16 +104,16 @@ defmodule BlockScoutWeb.API.V2.MainPageControllerTest do
           notify_email: true
         })
 
-      transactions_1 = insert_list(2, :transaction, from_address: address_1) |> with_block()
-      transactions_2 = insert_list(1, :transaction, from_address: address_2, to_address: address_1) |> with_block()
-      transactions_3 = insert_list(3, :transaction, to_address: address_2) |> with_block()
+      transactions_1 = insert_list(20, :transaction, from_address: address_1) |> with_block()
+      transactions_2 = insert_list(10, :transaction, from_address: address_2, to_address: address_1) |> with_block()
+      transactions_3 = insert_list(30, :transaction, to_address: address_2) |> with_block()
       transactions = (transactions_1 ++ transactions_2 ++ transactions_3) |> Enum.reverse()
 
       request = get(conn, "/api/v2/main-page/transactions/watchlist")
       assert response = json_response(request, 200)
-      assert Enum.count(response) == 6
+      assert Enum.count(response) == 50
 
-      for i <- 0..5 do
+      for i <- 0..49 do
         compare_item(Enum.at(transactions, i), Enum.at(response, i), %{
           address_1.hash => watchlist_address_1.name,
           address_2.hash => watchlist_address_2.name


### PR DESCRIPTION
## Motivation

Slow query execution at https://eth-sepolia.k8s-dev.blockscout.com/api/v2/main-page/transactions/watchlist

## Changelog

```
SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL, b1.* 
FROM transactions AS t0 
INNER JOIN blocks AS b1 ON b1.hash = t0.block_hash 
WHERE (NOT (t0.block_number IS NULL)) 
    AND (t0.to_address_hash = ANY (ARRAY['\x91be515287a961a8d09fd4ca3dfb5e76ed01575e'::BYTEA, '\x993a0f3653887078215914badcf039263293add9'::BYTEA, '\x13cb6ae34a13a0977f4d7101ebc24b87bb23f0d5'::BYTEA])) 
ORDER BY t0.block_number DESC, t0.index DESC 
LIMIT 6;
```

never finishes.

At the same time,

```
EXPLAIN ANALYZE SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL
FROM transactions AS t0 
WHERE (NOT (t0.block_number IS NULL)) 
    AND (t0.to_address_hash = ANY (ARRAY['\x91be515287a961a8d09fd4ca3dfb5e76ed01575e'::BYTEA, '\x993a0f3653887078215914badcf039263293add9'::BYTEA, '\x13cb6ae34a13a0977f4
d7101ebc24b87bb23f0d5'::BYTEA])) 
ORDER BY t0.block_number DESC, t0.index DESC 
LIMIT 51;
                                                                                                                       QUERY PLAN                                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=287164.10..287213.96 rows=51 width=606) (actual time=139.101..160.310 rows=51 loops=1)
   ->  Result  (cost=287164.10..356475.21 rows=70907 width=606) (actual time=128.803..150.000 rows=51 loops=1)
         ->  Sort  (cost=287164.10..287341.37 rows=70907 width=605) (actual time=128.195..128.230 rows=51 loops=1)
               Sort Key: t0.block_number DESC, t0.index DESC
               Sort Method: top-N heapsort  Memory: 70kB
               ->  Bitmap Heap Scan on transactions t0  (cost=8060.90..284798.50 rows=70907 width=605) (actual time=3.800..127.272 rows=659 loops=1)
                     Recheck Cond: ((to_address_hash = ANY ('{"\\x91be515287a961a8d09fd4ca3dfb5e76ed01575e","\\x993a0f3653887078215914badcf039263293add9","\\x13cb6ae34a13a0977f4d7101ebc24b87bb23f0d5"}'::bytea[])) AND (block_number IS NOT NULL))
                     Heap Blocks: exact=658
                     ->  Bitmap Index Scan on transactions_to_address_hash_with_pending_index_asc  (cost=0.00..8043.17 rows=70907 width=0) (actual time=3.507..3.507 rows=660 loops=1)
                           Index Cond: ((to_address_hash = ANY ('{"\\x91be515287a961a8d09fd4ca3dfb5e76ed01575e","\\x993a0f3653887078215914badcf039263293add9","\\x13cb6ae34a13a0977f4d7101ebc24b87bb23f0d5"}'::bytea[])) AND (block_number IS NOT NULL))
         SubPlan 1
           ->  Limit  (cost=0.70..0.96 rows=1 width=33) (actual time=0.424..0.424 rows=0 loops=51)
                 ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.70..3889.47 rows=14675 width=33) (actual time=0.423..0.423 rows=0 loops=51)
                       Index Cond: (transaction_hash = t0.hash)
                       Heap Fetches: 0
 Planning Time: 0.229 ms
 JIT:
   Functions: 13
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 1.013 ms, Inlining 0.000 ms, Optimization 0.831 ms, Emission 9.507 ms, Total 11.351 ms
 Execution Time: 161.547 ms
(21 rows)
```

executes almost immediately.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed fixed page size limit for transactions on the main page API.
- **Tests**
  - Expanded recent transactions tested from 6 to 50+ to better match real data volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->