### PR TITLE
fix: CSV export: download items for the given day if from / to period are equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Bug Fixes
 
+- CSV export: download items for the given day if from / to period are equal ([#12260](https://github.com/blockscout/blockscout/pull/12260))
 - Upgrade missing balanceOf token condition ([#12254](https://github.com/blockscout/blockscout/pull/12254))
 - Add missing load of health_latest_batch_average_time_from_db ([#12240](https://github.com/blockscout/blockscout/pull/12240))
 - Handle unconfigured coin fetcher ETS access ([#12228](https://github.com/blockscout/blockscout/pull/12228))

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -55,6 +55,13 @@ defmodule Explorer.Chain.CsvExport.Helper do
   """
   @spec block_from_period(String.t(), String.t()) :: {Block.block_number(), Block.block_number()}
   def block_from_period(from_period, to_period) do
+    to_period =
+      if from_period == to_period do
+        to_period <> "T23:59:59Z"
+      else
+        to_period
+      end
+
     from_block = convert_date_string_to_block(from_period, :after)
     to_block = convert_date_string_to_block(to_period, :before)
 


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/11862

## Motivation

If the to/from periods are equal during the export, no items will be exported. Desired behaviour would be to download all items for the whole day.

## Changelog

This pull request includes a small but important change to the `block_from_period` function in the `Explorer.Chain.CsvExport.Helper` module. The change ensures that if the `from_period` and `to_period` are the same, the `to_period` is adjusted to include the end of the day.

* [`apps/explorer/lib/explorer/chain/csv_export/helper.ex`](diffhunk://#diff-04f64cd3c9a8a698f11c44811de11f306041d29d51e95f64392bdd6858e104fbR58-R64): Modified the `block_from_period` function to append "T23:59:59Z" to `to_period` if it matches `from_period`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved period handling to ensure the end date includes the full day when exporting data, preventing potential data gaps for single-day selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->