### PR TITLE
fix: Limit max import concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Bug Fixes
 
+- Limit max import concurrency ([#12261](https://github.com/blockscout/blockscout/pull/12261))
 - CSV export: download items for the given day if from / to period are equal ([#12260](https://github.com/blockscout/blockscout/pull/12260))
 - Upgrade missing balanceOf token condition ([#12254](https://github.com/blockscout/blockscout/pull/12254))
 - Add missing load of health_latest_batch_average_time_from_db ([#12240](https://github.com/blockscout/blockscout/pull/12240))

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -12,6 +12,7 @@ defmodule Explorer.Chain.ImportTest do
     Log,
     Hash,
     Import,
+    InternalTransaction,
     PendingBlockOperation,
     Token,
     TokenTransfer,
@@ -19,6 +20,7 @@ defmodule Explorer.Chain.ImportTest do
   }
 
   alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Utility.MissingBlockRange
 
   @moduletag :capturelog
 
@@ -378,6 +380,18 @@ defmodule Explorer.Chain.ImportTest do
         update_in(@import_data, [:logs, :params], fn params ->
           [params |> Enum.at(0) |> Map.put(:block_hash, not_existing_block_hash)]
         end)
+
+      Ecto.Adapters.SQL.Sandbox.mode(Explorer.Repo, :auto)
+
+      on_exit(fn ->
+        Repo.delete_all(Address)
+        Repo.delete_all(Transaction)
+        Repo.delete_all(InternalTransaction)
+        Repo.delete_all(TokenTransfer)
+        Repo.delete_all(Token)
+        Repo.delete_all(MissingBlockRange)
+        Repo.delete_all(Block)
+      end)
 
       assert_raise(Postgrex.Error, fn -> Import.all(incorrect_data) end)
       assert [] = Repo.all(Log)


### PR DESCRIPTION
## Motivation

In cases when blocks that are about to import have many addresses there may be a huge amount of address multis which run in parallel without any limits. This may cause lack of connections issues.

## Changelog

Added `max_concurrency` to parallel running import tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved system stability by limiting the maximum concurrency for imports.

- **Documentation**
  - Updated the changelog to include the new bug fix regarding import concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->