### PR TITLE
fix: Start PubSub before Endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -14,6 +14,12 @@ defmodule BlockScoutWeb.Application do
     if Application.get_env(:nft_media_handler, :standalone_media_worker?) do
       Supervisor.start_link([Supervisor.child_spec(HealthEndpoint, [])], opts)
     else
+      # Endpoint must be the last child in the supervision tree
+      # since it must be started after all of the other processes
+      # (to be sure that application is ready to handle traffic)
+      # and stopped before them for the same reason.
+      # However, some processes may depend on Endpoint
+      # so they need to be started after.
       base_children = [Supervisor.child_spec(Endpoint, [])]
       {first_api_children, last_api_children} = setup_and_define_children()
       all_children = first_api_children ++ base_children ++ last_api_children

--- a/apps/block_scout_web/lib/block_scout_web/application.ex
+++ b/apps/block_scout_web/lib/block_scout_web/application.ex
@@ -15,8 +15,8 @@ defmodule BlockScoutWeb.Application do
       Supervisor.start_link([Supervisor.child_spec(HealthEndpoint, [])], opts)
     else
       base_children = [Supervisor.child_spec(Endpoint, [])]
-      api_children = setup_and_define_children()
-      all_children = base_children ++ api_children
+      {first_api_children, last_api_children} = setup_and_define_children()
+      all_children = first_api_children ++ base_children ++ last_api_children
 
       Supervisor.start_link(all_children, opts)
     end
@@ -32,7 +32,7 @@ defmodule BlockScoutWeb.Application do
   if @disable_api? do
     defp setup_and_define_children do
       BlockScoutWeb.Prometheus.Exporter.setup()
-      []
+      {[], []}
     end
   else
     defp setup_and_define_children do
@@ -60,18 +60,21 @@ defmodule BlockScoutWeb.Application do
       )
 
       # Define workers and child supervisors to be supervised
-      [
-        # Start the endpoint when the application starts
-        {Phoenix.PubSub, name: BlockScoutWeb.PubSub},
-        {Absinthe.Subscription, Endpoint},
-        {MainPageRealtimeEventHandler, name: MainPageRealtimeEventHandler},
-        {RealtimeEventHandler, name: RealtimeEventHandler},
-        {SmartContractRealtimeEventHandler, name: SmartContractRealtimeEventHandler},
-        {BlocksIndexedCounter, name: BlocksIndexedCounter},
-        {InternalTransactionsIndexedCounter, name: InternalTransactionsIndexedCounter},
-        {EventHandlersMetrics, []},
-        {ChainMetrics, []}
-      ]
+      {
+        [
+          {Phoenix.PubSub, name: BlockScoutWeb.PubSub},
+          {MainPageRealtimeEventHandler, name: MainPageRealtimeEventHandler},
+          {RealtimeEventHandler, name: RealtimeEventHandler},
+          {SmartContractRealtimeEventHandler, name: SmartContractRealtimeEventHandler},
+          {BlocksIndexedCounter, name: BlocksIndexedCounter},
+          {InternalTransactionsIndexedCounter, name: InternalTransactionsIndexedCounter},
+          {EventHandlersMetrics, []},
+          {ChainMetrics, []}
+        ],
+        [
+          {Absinthe.Subscription, Endpoint}
+        ]
+      }
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11119

## Motivation

Since `Phoenix.PubSub` is started after the `BlockScoutWeb.Endpoint`, on the application shutdown the `Phoenix.PubSub` is stopped before the `BlockScoutWeb.Endpoint`. It may lead to `unknown registry` errors because there is a time range when `PubSub` is already stopped but `Endpoint` isn't. Best practice is to start endpoint after all the other application processes.

## Changelog

Move `BlockScoutWeb.Endpoint` to the end of application supervision tree (but before `Absinthe.Subscription` since it depends on `BlockScoutWeb.Endpoint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved application startup and shutdown sequence to enhance reliability and stability. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->