### PR TITLE
chore: Decrease PendingOperationsHelper blocks_batch_size

### DIFF
--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   alias Explorer.Repo
 
   @transactions_batch_size 1000
-  @blocks_batch_size 100
+  @blocks_batch_size 30
 
   def pending_operations_type do
     if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.Geth and


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/11157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reduced the batch size for processing blocks from 100 to 30, affecting how many records are handled at once during data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->