### PR TITLE
fix: Unbind import from compile-time chain_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 
+- Unbind import from compile-time chain_type ([#12277](https://github.com/blockscout/blockscout/pull/12277))
 - Read `CHAIN_TYPE` and `MUD_INDEXER_ENABLED` envs in runtime config ([#12270](https://github.com/blockscout/blockscout/issues/12270))
 
 ### ⚙️ Miscellaneous Tasks

--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -28,10 +28,6 @@ defmodule Explorer.Chain.Import do
     ]
   ]
 
-  # in order so that foreign keys are inserted before being referenced
-  @configured_runners Enum.flat_map(@stages, fn stage_batch ->
-                        Enum.flat_map(stage_batch, fn stage -> stage.runners() end)
-                      end)
   @all_runners Enum.flat_map(@stages, fn stage_batch ->
                  Enum.flat_map(stage_batch, fn stage -> stage.all_runners() end)
                end)
@@ -151,6 +147,13 @@ defmodule Explorer.Chain.Import do
     end
   end
 
+  defp configured_runners do
+    # in order so that foreign keys are inserted before being referenced
+    Enum.flat_map(@stages, fn stage_batch ->
+      Enum.flat_map(stage_batch, fn stage -> stage.runners() end)
+    end)
+  end
+
   defp runner_to_changes_list(runner_options_pairs) when is_list(runner_options_pairs) do
     runner_options_pairs
     |> Stream.map(fn {runner, options} -> runner_changes_list(runner, options) end)
@@ -204,8 +207,8 @@ defmodule Explorer.Chain.Import do
     local_options = Map.drop(options, @global_options)
 
     {reverse_runner_options_pairs, unknown_options} =
-      Enum.reduce(@configured_runners, {[], local_options}, fn runner,
-                                                               {acc_runner_options_pairs, unknown_options} = acc ->
+      Enum.reduce(configured_runners(), {[], local_options}, fn runner,
+                                                                {acc_runner_options_pairs, unknown_options} = acc ->
         option_key = runner.option_key()
 
         case local_options do


### PR DESCRIPTION
## Motivation

`Explorer.Chain.Import` is unable to operate with runtime-only chain type since `runners/0` depends on it and is called from module body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog for version 8.0.1 to include a new bug fix entry referencing pull request #12277.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->