### PR TITLE
fix: Fix latest block/batch timestamp Prometheus metric

### DIFF
--- a/apps/indexer/lib/indexer/block/realtime/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/realtime/fetcher.ex
@@ -294,11 +294,11 @@ defmodule Indexer.Block.Realtime.Fetcher do
       |> put_in([:block_rewards], chain_import_block_rewards)
 
     with {:import, {:ok, imported} = ok} <- {:import, Chain.import(chain_import_options)} do
-      last_batch =
+      last_block =
         chain_import_options[:blocks][:params]
         |> Enum.max_by(& &1.number, fn -> nil end)
 
-      Instrumenter.set_latest_block(last_batch.number, last_batch.timestamp)
+      Instrumenter.set_latest_block(last_block.number, last_block.timestamp)
 
       async_import_remaining_block_data(
         imported,

--- a/apps/indexer/lib/indexer/prometheus/instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/instrumenter.ex
@@ -91,7 +91,7 @@ defmodule Indexer.Prometheus.Instrumenter do
   @spec set_latest_block(number :: integer, timestamp :: DateTime.t()) :: :ok
   def set_latest_block(number, timestamp) do
     latest_block_number(number)
-    latest_block_timestamp(DateTime.to_unix(timestamp))
+    latest_block_timestamp(timestamp)
   end
 
   if @chain_type in @rollups do
@@ -118,7 +118,7 @@ defmodule Indexer.Prometheus.Instrumenter do
     @spec set_latest_batch(number :: integer, timestamp :: DateTime.t()) :: :ok
     def set_latest_batch(number, timestamp) do
       latest_batch_number(number)
-      latest_batch_timestamp(DateTime.to_unix(timestamp))
+      latest_batch_timestamp(timestamp)
     end
   else
     @doc """


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/issues/11888

## Motivation

`latest_block_timestamp` returns 0 value.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved variable naming for clarity in block processing.
  - Updated handling of timestamp values to use DateTime structs directly instead of Unix timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->