### PR TITLE
fix: Return compatibility with previous version of health endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 
+- Return compatibility with previous version of health endpoint([#12280](https://github.com/blockscout/blockscout/pull/12280))
 - Unbind import from compile-time chain_type ([#12277](https://github.com/blockscout/blockscout/pull/12277))
 - Read `CHAIN_TYPE` and `MUD_INDEXER_ENABLED` envs in runtime config ([#12270](https://github.com/blockscout/blockscout/issues/12270))
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/health_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/health_controller.ex
@@ -68,9 +68,16 @@ defmodule BlockScoutWeb.API.HealthController do
             else: Map.put(&1, :error, Map.get(blocks_property, :error))
           )).()
 
+    status =
+      if Map.get(health_status, :healthy) do
+        :ok
+      else
+        500
+      end
+
     send_resp(
       conn,
-      :ok,
+      status,
       health_status_with_error
       |> Jason.encode!()
     )

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v1/health_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v1/health_controller_test.exs
@@ -40,7 +40,7 @@ defmodule BlockScoutWeb.API.V1.HealthControllerTest do
     test "returns error when there are no blocks in db", %{conn: conn} do
       request = get(conn, api_health_path(conn, :health))
 
-      assert request.status == 200
+      assert request.status == 500
 
       expected_error =
         %{
@@ -62,7 +62,7 @@ defmodule BlockScoutWeb.API.V1.HealthControllerTest do
 
       request = get(conn, api_health_path(conn, :health))
 
-      assert request.status == 200
+      assert request.status == 500
 
       assert %{
                "latest_block" => %{
@@ -132,7 +132,7 @@ defmodule BlockScoutWeb.API.V1.HealthControllerTest do
 
     request = get(conn, api_health_path(conn, :health))
 
-    assert request.status == 200
+    assert request.status == 500
 
     assert %{
              "latest_block" => %{

--- a/apps/explorer/lib/explorer/chain/health/monitor.ex
+++ b/apps/explorer/lib/explorer/chain/health/monitor.ex
@@ -40,99 +40,96 @@ defmodule Explorer.Chain.Health.Monitor do
   defp perform_work do
     json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
-    with {latest_block_number_from_db, latest_block_timestamp_from_db} <- HealthHelper.last_db_block(),
-         {latest_block_number_from_cache, latest_block_timestamp_from_cache} <-
-           HealthHelper.last_cache_block(),
-         {:ok, latest_block_number_from_node} <-
-           EndpointAvailabilityChecker.fetch_latest_block_number(json_rpc_named_arguments) do
-      now = DateTime.utc_now()
+    now = DateTime.utc_now()
 
-      base_params = [
-        %{
-          counter_type: "health_latest_block_number_from_db",
-          value: latest_block_number_from_db,
-          inserted_at: now,
-          updated_at: now
-        },
-        %{
-          counter_type: "health_latest_block_timestamp_from_db",
-          value: DateTime.to_unix(latest_block_timestamp_from_db),
-          inserted_at: now,
-          updated_at: now
-        },
-        %{
-          counter_type: "health_latest_block_number_from_cache",
-          value: latest_block_number_from_cache,
-          inserted_at: now,
-          updated_at: now
-        },
-        %{
-          counter_type: "health_latest_block_timestamp_from_cache",
-          value: DateTime.to_unix(latest_block_timestamp_from_cache),
-          inserted_at: now,
-          updated_at: now
-        },
-        %{
-          counter_type: "health_latest_block_number_from_node",
-          value: quantity_to_integer(latest_block_number_from_node),
-          inserted_at: now,
-          updated_at: now
-        }
-      ]
+    db_and_cache_params =
+      with {latest_block_number_from_db, latest_block_timestamp_from_db} <- HealthHelper.last_db_block(),
+           {latest_block_number_from_cache, latest_block_timestamp_from_cache} <-
+             HealthHelper.last_cache_block() do
+        [
+          counter("health_latest_block_number_from_db", latest_block_number_from_db, now, now),
+          counter(
+            "health_latest_block_timestamp_from_db",
+            DateTime.to_unix(latest_block_timestamp_from_db),
+            now,
+            now
+          ),
+          counter("health_latest_block_number_from_cache", latest_block_number_from_cache, now, now),
+          counter(
+            "health_latest_block_timestamp_from_cache",
+            DateTime.to_unix(latest_block_timestamp_from_cache),
+            now,
+            now
+          )
+        ]
+      end
 
-      batch_info =
-        case Application.get_env(:explorer, :chain_type) do
-          :arbitrum ->
-            get_latest_batch_info_from_module(ArbitrumReaderCommon)
+    base_params = maybe_add_block_from_node_to_params?(db_and_cache_params, json_rpc_named_arguments, now)
 
-          :zksync ->
-            get_latest_batch_info_from_module(ZkSyncReader)
+    batch_info =
+      case Application.get_env(:explorer, :chain_type) do
+        :arbitrum ->
+          get_latest_batch_info_from_module(ArbitrumReaderCommon)
 
-          :optimism ->
-            get_latest_batch_info_from_module(OptimismReader)
+        :zksync ->
+          get_latest_batch_info_from_module(ZkSyncReader)
 
-          :polygon_zkevm ->
-            get_latest_batch_info_from_module(PolygonZkevmReader)
+        :optimism ->
+          get_latest_batch_info_from_module(OptimismReader)
 
-          :scroll ->
-            get_latest_batch_info_from_module(ScrollReader)
+        :polygon_zkevm ->
+          get_latest_batch_info_from_module(PolygonZkevmReader)
 
-          _ ->
-            nil
-        end
+        :scroll ->
+          get_latest_batch_info_from_module(ScrollReader)
 
-      params =
-        if batch_info do
-          base_params ++
-            [
-              %{
-                counter_type: "health_latest_batch_number_from_db",
-                value: batch_info.number,
-                inserted_at: now,
-                updated_at: now
-              },
-              %{
-                counter_type: "health_latest_batch_timestamp_from_db",
-                value: DateTime.to_unix(batch_info.timestamp),
-                inserted_at: now,
-                updated_at: now
-              },
-              %{
-                counter_type: "health_latest_batch_average_time_from_db",
-                value: batch_info.average_batch_time,
-                inserted_at: now,
-                updated_at: now
-              }
-            ]
-        else
-          base_params
-        end
+        _ ->
+          nil
+      end
 
-      Repo.insert_all(LastFetchedCounter, params,
-        on_conflict: on_conflict(),
-        conflict_target: [:counter_type]
-      )
+    params =
+      if batch_info do
+        base_params ++
+          [
+            counter("health_latest_batch_number_from_db", batch_info.number, now, now),
+            counter("health_latest_batch_timestamp_from_db", DateTime.to_unix(batch_info.timestamp), now, now),
+            counter("health_latest_batch_average_time_from_db", batch_info.average_batch_time, now, now)
+          ]
+      else
+        base_params
+      end
+
+    Repo.insert_all(LastFetchedCounter, params,
+      on_conflict: on_conflict(),
+      conflict_target: [:counter_type]
+    )
+  end
+
+  defp maybe_add_block_from_node_to_params?(params, json_rpc_named_arguments, now) do
+    case EndpointAvailabilityChecker.fetch_latest_block_number(json_rpc_named_arguments) do
+      {:ok, latest_block_number_from_node} ->
+        [
+          counter(
+            "health_latest_block_number_from_node",
+            quantity_to_integer(latest_block_number_from_node),
+            now,
+            now
+          )
+          | params
+        ]
+
+      _ ->
+        params
     end
+  end
+
+  defp counter(counter_type, value, inserted_at, updated_at) do
+    %{
+      counter_type: counter_type,
+      value: value,
+      inserted_at: inserted_at,
+      updated_at: updated_at
+    }
   end
 
   defp on_conflict do


### PR DESCRIPTION
## Motivation

Add compatibility with the previous version of the health endpoint:
- return 500 status code, if the instance is unhealthy
- return latest block data from DB and cache, even if JSON RPC endpoint is unavailable.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored compatibility with previous versions of the health endpoint, ensuring correct HTTP status codes are returned based on system health.
- **Documentation**
  - Updated the changelog to reflect the latest bug fix regarding the health endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->