### PR TITLE
chore: Sanitize ERC-1155 token balances without token ids

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -131,7 +131,8 @@ for migrator <- [
       Explorer.Migrator.SanitizeVerifiedAddresses,
       Explorer.Migrator.SmartContractLanguage,
       Explorer.Migrator.SanitizeEmptyContractCodeAddresses,
-      Explorer.Migrator.BackfillMetadataURL
+      Explorer.Migrator.BackfillMetadataURL,
+      Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds
     ] do
   config :explorer, migrator, enabled: true
 end

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -132,7 +132,7 @@ for migrator <- [
       Explorer.Migrator.SmartContractLanguage,
       Explorer.Migrator.SanitizeEmptyContractCodeAddresses,
       Explorer.Migrator.BackfillMetadataURL,
-      Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds
+      Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds
     ] do
   config :explorer, migrator, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -67,6 +67,7 @@ for migrator <- [
       Explorer.Migrator.SmartContractLanguage,
       Explorer.Migrator.SanitizeEmptyContractCodeAddresses,
       Explorer.Migrator.BackfillMetadataURL,
+      Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds,
 
       # Heavy DB index operations
       Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex,

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -67,7 +67,7 @@ for migrator <- [
       Explorer.Migrator.SmartContractLanguage,
       Explorer.Migrator.SanitizeEmptyContractCodeAddresses,
       Explorer.Migrator.BackfillMetadataURL,
-      Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds,
+      Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds,
 
       # Heavy DB index operations
       Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -154,7 +154,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.RestoreOmittedWETHTransfers),
         configure(Explorer.Migrator.FilecoinPendingAddressOperations),
         configure(Explorer.Migrator.SmartContractLanguage),
-        configure(Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds),
+        configure(Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds),
         Explorer.Migrator.BackfillMultichainSearchDB
         |> configure_mode_dependent_process(:indexer)
         |> configure_multichain_search_microservice(),

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -154,6 +154,7 @@ defmodule Explorer.Application do
         configure(Explorer.Migrator.RestoreOmittedWETHTransfers),
         configure(Explorer.Migrator.FilecoinPendingAddressOperations),
         configure(Explorer.Migrator.SmartContractLanguage),
+        configure(Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds),
         Explorer.Migrator.BackfillMultichainSearchDB
         |> configure_mode_dependent_process(:indexer)
         |> configure_multichain_search_microservice(),

--- a/apps/explorer/lib/explorer/migrator/sanitize_erc_1155_token_balances_without_token_ids.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_erc_1155_token_balances_without_token_ids.ex
@@ -1,4 +1,4 @@
-defmodule Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds do
+defmodule Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds do
   @moduledoc """
   Deletes token balances of ERC-1155 tokens with empty token_id.
   """
@@ -11,7 +11,7 @@ defmodule Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds do
   alias Explorer.Migrator.FillingMigration
   alias Explorer.Repo
 
-  @migration_name "sanitize_token_balances_without_token_ids"
+  @migration_name "sanitize_erc_1155_token_balances_without_token_ids"
 
   @impl FillingMigration
   def migration_name, do: @migration_name

--- a/apps/explorer/lib/explorer/migrator/sanitize_token_balances_without_token_ids.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_token_balances_without_token_ids.ex
@@ -1,0 +1,50 @@
+defmodule Explorer.Migrator.SanitizeTokenBalancesWithoutTokenIds do
+  @moduledoc """
+  Deletes token balances of ERC-1155 tokens with empty token_id.
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "sanitize_token_balances_without_token_ids"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(state) do
+    limit = batch_size() * concurrency()
+
+    ids =
+      unprocessed_data_query()
+      |> select([tb], tb.id)
+      |> limit(^limit)
+      |> Repo.all(timeout: :infinity)
+
+    {ids, state}
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    from(
+      tb in TokenBalance,
+      join: t in assoc(tb, :token),
+      where: tb.token_type == ^"ERC-1155" and t.type == ^"ERC-1155" and is_nil(tb.token_id)
+    )
+  end
+
+  @impl FillingMigration
+  def update_batch(token_balance_ids) do
+    query = from(tb in TokenBalance, where: tb.id in ^token_balance_ids)
+
+    Repo.delete_all(query, timeout: :infinity)
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a background migration to remove ERC-1155 token balances that do not have a token ID.
- **Chores**
  - Updated application configuration to include the new migration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->