### PR TITLE
fix: Temporary disable PendingTransactionOperation

### DIFF
--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -10,10 +10,17 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   @blocks_batch_size 10
 
   def pending_operations_type do
-    if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.Geth and
-         not Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)[:block_traceable?],
-       do: "transactions",
-       else: "blocks"
+    # TODO: bring back this condition after the migration of internal transactions PK to [:block_hash, :transaction_index, :index]
+    # if Application.get_env(:explorer, :json_rpc_named_arguments)[:variant] == EthereumJSONRPC.Geth and
+    #      not Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)[:block_traceable?],
+    #    do: "transactions",
+    #    else: "blocks"
+
+    if Application.get_env(:explorer, :non_existing_variable, false) do
+      "transactions"
+    else
+      "blocks"
+    end
   end
 
   def actual_entity do

--- a/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
+++ b/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
@@ -16,6 +16,8 @@ defmodule Explorer.Migrator.SwitchPendingOperationsTest do
       end)
     end
 
+    # TODO: remove tag after the migration of internal transactions PK to [:block_hash, :transaction_index, :index]
+    @tag :skip
     test "from pbo to pto" do
       first_block = insert(:block)
       second_block = insert(:block)


### PR DESCRIPTION
Temporary partial fix, related to: https://github.com/blockscout/blockscout/issues/12311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for determining pending operation types, now defaulting to "blocks".
  - Enhanced internal transaction fetching with improved handling for variants without block-level tracing.
- **Tests**
  - Temporarily skipped a migration-related test pending primary key update.
  - Updated internal transaction tests to align with new block-based processing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->