### PR TITLE
fix: Fix MissingBlockRange.fill_ranges_between/3 for empty range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix MissingBlockRange.fill_ranges_between/3 for empty range ([#12319](https://github.com/blockscout/blockscout/pull/12319))
 - Fix CSV export "to" range to include the whole day in all cases ([#12286](https://github.com/blockscout/blockscout/pull/12286))
 - Return compatibility with previous version of health endpoint([#12280](https://github.com/blockscout/blockscout/pull/12280))
 - Unbind import from compile-time chain_type ([#12277](https://github.com/blockscout/blockscout/pull/12277))

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -406,7 +406,7 @@ defmodule Explorer.Utility.MissingBlockRange do
 
   # Fills all missing block ranges that overlap with the interval [from, to]
   @spec fill_ranges_between(Block.block_number(), Block.block_number(), integer() | nil) :: :ok
-  defp fill_ranges_between(from, to, priority) do
+  defp fill_ranges_between(from, to, priority) when from >= to do
     __MODULE__
     |> where([r], r.from_number <= ^from)
     |> where([r], r.to_number >= ^to)
@@ -470,6 +470,8 @@ defmodule Explorer.Utility.MissingBlockRange do
 
     :ok
   end
+
+  defp fill_ranges_between(_from, _to, _priority), do: :ok
 
   defp select_all_ranges_within_the_range(from, to) do
     __MODULE__


### PR DESCRIPTION
## Motivation

In case when `from` < `to` we shouldn't insert any ranges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where certain empty block ranges were not handled correctly, improving reliability when processing missing block ranges.

- **Documentation**
  - Updated the changelog to reflect the latest bug fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->