### PR TITLE
chore: Support Celestia Alt-DA in OP batches indexer and Super Roots in OP withdrawals indexer

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -127,8 +127,8 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
             "index" => g.index,
             "game_type" => g.game_type,
             # todo: It should be removed in favour `contract_address_hash` property with the next release after 8.0.0
-            "contract_address" => g.address,
-            "contract_address_hash" => g.address,
+            "contract_address" => g.address_hash,
+            "contract_address_hash" => g.address_hash,
             "l2_block_number" => l2_block_number,
             "created_at" => g.created_at,
             "status" => status,

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/dispute_games.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/dispute_games.ex
@@ -86,7 +86,7 @@ defmodule Explorer.Chain.Import.Runner.Optimism.DisputeGames do
         set: [
           # don't update `index` as it is a primary key and used for the conflict target
           game_type: fragment("EXCLUDED.game_type"),
-          address: fragment("EXCLUDED.address"),
+          address_hash: fragment("EXCLUDED.address_hash"),
           extra_data: fragment("EXCLUDED.extra_data"),
           created_at: fragment("EXCLUDED.created_at"),
           resolved_at: fragment("EXCLUDED.resolved_at"),
@@ -97,9 +97,9 @@ defmodule Explorer.Chain.Import.Runner.Optimism.DisputeGames do
       ],
       where:
         fragment(
-          "(EXCLUDED.game_type, EXCLUDED.address, EXCLUDED.extra_data, EXCLUDED.created_at, EXCLUDED.resolved_at, EXCLUDED.status) IS DISTINCT FROM (?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.game_type, EXCLUDED.address_hash, EXCLUDED.extra_data, EXCLUDED.created_at, EXCLUDED.resolved_at, EXCLUDED.status) IS DISTINCT FROM (?, ?, ?, ?, ?, ?)",
           game.game_type,
-          game.address,
+          game.address_hash,
           game.extra_data,
           game.created_at,
           game.resolved_at,

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
@@ -90,18 +90,18 @@ defmodule Explorer.Chain.Import.Runner.Optimism.WithdrawalEvents do
           l1_timestamp: fragment("EXCLUDED.l1_timestamp"),
           l1_block_number: fragment("EXCLUDED.l1_block_number"),
           game_index: fragment("EXCLUDED.game_index"),
-          game_address: fragment("EXCLUDED.game_address"),
+          game_address_hash: fragment("EXCLUDED.game_address_hash"),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", we.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", we.updated_at)
         ]
       ],
       where:
         fragment(
-          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_block_number, EXCLUDED.game_index, EXCLUDED.game_address) IS DISTINCT FROM (?, ?, ?, ?)",
+          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_block_number, EXCLUDED.game_index, EXCLUDED.game_address_hash) IS DISTINCT FROM (?, ?, ?, ?)",
           we.l1_timestamp,
           we.l1_block_number,
           we.game_index,
-          we.game_address
+          we.game_address_hash
         )
     )
   end

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/withdrawal_events.ex
@@ -90,16 +90,18 @@ defmodule Explorer.Chain.Import.Runner.Optimism.WithdrawalEvents do
           l1_timestamp: fragment("EXCLUDED.l1_timestamp"),
           l1_block_number: fragment("EXCLUDED.l1_block_number"),
           game_index: fragment("EXCLUDED.game_index"),
+          game_address: fragment("EXCLUDED.game_address"),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", we.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", we.updated_at)
         ]
       ],
       where:
         fragment(
-          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_block_number, EXCLUDED.game_index) IS DISTINCT FROM (?, ?, ?)",
+          "(EXCLUDED.l1_timestamp, EXCLUDED.l1_block_number, EXCLUDED.game_index, EXCLUDED.game_address) IS DISTINCT FROM (?, ?, ?, ?)",
           we.l1_timestamp,
           we.l1_block_number,
-          we.game_index
+          we.game_index,
+          we.game_address
         )
     )
   end

--- a/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
@@ -9,13 +9,13 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
   alias Explorer.Chain.{Data, Hash}
   alias Explorer.{PagingOptions, Repo}
 
-  @required_attrs ~w(index game_type address created_at)a
+  @required_attrs ~w(index game_type address_hash created_at)a
   @optional_attrs ~w(extra_data resolved_at status)a
 
   @typedoc """
     * `index` - A unique index of the dispute game.
     * `game_type` - A number encoding a type of the dispute game.
-    * `address` - The dispute game contract address.
+    * `address_hash` - The dispute game contract address.
     * `extra_data` - An extra data of the dispute game (contains L2 block number).
       Equals to `nil` when the game is written to database but the rest data is not known yet.
     * `created_at` - UTC timestamp of when the dispute game was created.
@@ -28,7 +28,7 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
   typed_schema "op_dispute_games" do
     field(:index, :integer, primary_key: true)
     field(:game_type, :integer)
-    field(:address, Hash.Address)
+    field(:address_hash, Hash.Address)
     field(:extra_data, Data)
     field(:created_at, :utc_datetime_usec)
     field(:resolved_at, :utc_datetime_usec)

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -378,7 +378,7 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
   # - A list of `{l1_timestamp, game_address, game_index}` tuples where `l1_timestamp` is the L1 block timestamp
   #   when the event appeared, `game_address` is the bound dispute game contract address (can be `nil`),
   #   `game_index` is the bound dispute game index (can be `nil`).
-  @spec proven_events_by_hash(Hash.t()) :: [{DateTime.t(), non_neg_integer()}]
+  @spec proven_events_by_hash(Hash.t()) :: [{DateTime.t(), Hash.t() | nil, non_neg_integer() | nil}]
   defp proven_events_by_hash(withdrawal_hash) do
     Repo.replica().all(
       from(

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -274,6 +274,17 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     withdrawal_l2_block_number <= last_root_l2_block_number
   end
 
+  # Fetches dispute game info from DB by game's contract address or game's unique index.
+  #
+  # ## Parameters
+  # - `game_address`: Game's contract address. Must be `nil` if unknown.
+  # - `game_index`: Game unique index. Must be `nil` if unknown.
+  #
+  # ## Returns
+  # - A map with necessary info about the dispute game.
+  # - `nil` if the dispute game not found in DB or both input parameters are `nil`.
+  @spec game_by_address_or_index(Hash.t() | nil, non_neg_integer() | nil) ::
+          %{:created_at => DateTime.t(), :resolved_at => DateTime.t(), :status => non_neg_integer()} | nil
   defp game_by_address_or_index(nil, nil), do: nil
 
   defp game_by_address_or_index(game_address, nil) do
@@ -295,6 +306,10 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
         where: g.index == ^game_index
       )
     )
+  end
+
+  defp game_by_address_or_index(_game_address, game_index) do
+    game_by_address_or_index(nil, game_index)
   end
 
   # Determines the current withdrawal status by the list of the bound WithdrawalProven events.

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
   alias Explorer.Chain.Hash
 
   @required_attrs ~w(withdrawal_hash l1_event_type l1_timestamp l1_transaction_hash l1_block_number)a
-  @optional_attrs ~w(game_index game_address)a
+  @optional_attrs ~w(game_index game_address_hash)a
 
   @typedoc """
     Descriptor of the withdrawal event:
@@ -17,7 +17,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     * `l1_block_number` - An L1 block number of the L1 transaction.
     * `game_index` - An index of a dispute game (if available in L1 transaction input) when
       the withdrawal is proven. Equals to `nil` if not available.
-    * `game_address` - Contract address of a dispute game (if available in L1 transaction input) when
+    * `game_address_hash` - Contract address of a dispute game (if available in L1 transaction input) when
       the withdrawal is proven. Equals to `nil` if not available.
   """
   @type to_import :: %{
@@ -27,7 +27,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
           l1_transaction_hash: Hash.t(),
           l1_block_number: non_neg_integer(),
           game_index: non_neg_integer(),
-          game_address: Hash.t()
+          game_address_hash: Hash.t()
         }
 
   @typedoc """
@@ -38,7 +38,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     * `l1_block_number` - An L1 block number of the L1 transaction.
     * `game_index` - An index of a dispute game (if available in L1 transaction input) when
       the withdrawal is proven. Equals to `nil` if not available.
-    * `game_address` - Contract address of a dispute game (if available in L1 transaction input) when
+    * `game_address_hash` - Contract address of a dispute game (if available in L1 transaction input) when
       the withdrawal is proven. Equals to `nil` if not available.
   """
   @primary_key false
@@ -49,7 +49,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     field(:l1_transaction_hash, Hash.Full, primary_key: true)
     field(:l1_block_number, :integer)
     field(:game_index, :integer)
-    field(:game_address, Hash.Address)
+    field(:game_address_hash, Hash.Address)
 
     timestamps()
   end

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
@@ -9,6 +9,28 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
   @optional_attrs ~w(game_index game_address)a
 
   @typedoc """
+    Descriptor of the withdrawal event:
+    * `withdrawal_hash` - A withdrawal hash.
+    * `l1_event_type` - A type of withdrawal event: `WithdrawalProven` or `WithdrawalFinalized`.
+    * `l1_timestamp` - A timestamp of when the withdrawal event appeared.
+    * `l1_transaction_hash` - An hash of L1 transaction that contains the event.
+    * `l1_block_number` - An L1 block number of the L1 transaction.
+    * `game_index` - An index of a dispute game (if available in L1 transaction input) when
+      the withdrawal is proven. Equals to `nil` if not available.
+    * `game_address` - Contract address of a dispute game (if available in L1 transaction input) when
+      the withdrawal is proven. Equals to `nil` if not available.
+  """
+  @type to_import :: %{
+          withdrawal_hash: Hash.t(),
+          l1_event_type: String.t(),
+          l1_timestamp: DateTime.t(),
+          l1_transaction_hash: Hash.t(),
+          l1_block_number: non_neg_integer(),
+          game_index: non_neg_integer(),
+          game_address: Hash.t()
+        }
+
+  @typedoc """
     * `withdrawal_hash` - A withdrawal hash.
     * `l1_event_type` - A type of withdrawal event: `WithdrawalProven` or `WithdrawalFinalized`.
     * `l1_timestamp` - A timestamp of when the withdrawal event appeared.

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal_event.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
   alias Explorer.Chain.Hash
 
   @required_attrs ~w(withdrawal_hash l1_event_type l1_timestamp l1_transaction_hash l1_block_number)a
-  @optional_attrs ~w(game_index)a
+  @optional_attrs ~w(game_index game_address)a
 
   @typedoc """
     * `withdrawal_hash` - A withdrawal hash.
@@ -15,6 +15,8 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     * `l1_transaction_hash` - An hash of L1 transaction that contains the event.
     * `l1_block_number` - An L1 block number of the L1 transaction.
     * `game_index` - An index of a dispute game (if available in L1 transaction input) when
+      the withdrawal is proven. Equals to `nil` if not available.
+    * `game_address` - Contract address of a dispute game (if available in L1 transaction input) when
       the withdrawal is proven. Equals to `nil` if not available.
   """
   @primary_key false
@@ -25,6 +27,7 @@ defmodule Explorer.Chain.Optimism.WithdrawalEvent do
     field(:l1_transaction_hash, Hash.Full, primary_key: true)
     field(:l1_block_number, :integer)
     field(:game_index, :integer)
+    field(:game_address, Hash.Address)
 
     timestamps()
   end

--- a/apps/explorer/priv/optimism/migrations/20250428080401_game_address_field_in_withdrawals.exs
+++ b/apps/explorer/priv/optimism/migrations/20250428080401_game_address_field_in_withdrawals.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Optimism.Migrations.GameAddressFieldInWithdrawals do
+  use Ecto.Migration
+
+  def change do
+    alter table(:op_withdrawal_events) do
+      add(:game_address, :bytea, null: true)
+    end
+
+    create(index(:op_dispute_games, :address))
+  end
+end

--- a/apps/explorer/priv/optimism/migrations/20250428080401_game_address_field_in_withdrawals.exs
+++ b/apps/explorer/priv/optimism/migrations/20250428080401_game_address_field_in_withdrawals.exs
@@ -3,9 +3,10 @@ defmodule Explorer.Repo.Optimism.Migrations.GameAddressFieldInWithdrawals do
 
   def change do
     alter table(:op_withdrawal_events) do
-      add(:game_address, :bytea, null: true)
+      add(:game_address_hash, :bytea, null: true)
     end
 
-    create(index(:op_dispute_games, :address))
+    rename(table(:op_dispute_games), :address, to: :address_hash)
+    create(index(:op_dispute_games, :address_hash))
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -308,6 +308,7 @@ defmodule Indexer.Fetcher.Optimism do
     Updates the last handled block hash by a fetcher.
     The new block hash is written to the `last_fetched_counters` table.
     This function accepts the block number for which the block hash must be determined.
+    If RPC node returns `nil` as the successful result, this function doesn't do anything.
 
     ## Parameters
     - `block_number`: The number of the block.
@@ -319,11 +320,16 @@ defmodule Indexer.Fetcher.Optimism do
   """
   @spec set_last_block_hash_by_number(non_neg_integer(), binary(), EthereumJSONRPC.json_rpc_named_arguments()) :: any()
   def set_last_block_hash_by_number(block_number, counter_type, json_rpc_named_arguments) do
-    [block_number]
-    |> get_blocks_by_numbers(json_rpc_named_arguments, Helper.infinite_retries_number())
-    |> List.first()
-    |> Map.get("hash")
-    |> set_last_block_hash(counter_type)
+    block =
+      [block_number]
+      |> get_blocks_by_numbers(json_rpc_named_arguments, Helper.infinite_retries_number())
+      |> List.first()
+
+    if not is_nil(block) do
+      block
+      |> Map.get("hash")
+      |> set_last_block_hash(counter_type)
+    end
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
@@ -649,24 +649,22 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
     end
   end
 
-  defp celestia_blob_to_input("0x" <> transaction_input, transaction_hash, blobs_api_url) do
+  defp celestia_blob_to_input("0x" <> transaction_input, transaction_hash, blobs_api_url, offset) do
     transaction_input
     |> Base.decode16!(case: :mixed)
-    |> celestia_blob_to_input(transaction_hash, blobs_api_url)
+    |> celestia_blob_to_input(transaction_hash, blobs_api_url, offset)
   end
 
-  defp celestia_blob_to_input(transaction_input, _transaction_hash, blobs_api_url)
-       when byte_size(transaction_input) == 1 + 8 + 32 and blobs_api_url != "" do
-    # the first byte encodes Celestia sign 0xCE
-
-    # the next 8 bytes encode little-endian Celestia blob height
+  defp celestia_blob_to_input(transaction_input, _transaction_hash, blobs_api_url, offset)
+       when byte_size(transaction_input) == offset + 8 + 32 and blobs_api_url != "" do
+    # 8 bytes after alt-da signature encode little-endian Celestia blob height
     height =
       transaction_input
-      |> binary_part(1, 8)
+      |> binary_part(offset, 8)
       |> :binary.decode_unsigned(:little)
 
     # the next 32 bytes contain the commitment
-    commitment = binary_part(transaction_input, 1 + 8, 32)
+    commitment = binary_part(transaction_input, offset + 8, 32)
     commitment_string = Base.encode16(commitment, case: :lower)
 
     url = blobs_api_url <> "?height=#{height}&commitment=" <> commitment_string
@@ -699,13 +697,13 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
     end
   end
 
-  defp celestia_blob_to_input(_transaction_input, transaction_hash, blobs_api_url) when blobs_api_url != "" do
+  defp celestia_blob_to_input(_transaction_input, transaction_hash, blobs_api_url, _offset) when blobs_api_url != "" do
     Logger.error("L1 transaction with Celestia commitment has incorrect input length. Tx hash: #{transaction_hash}")
 
     []
   end
 
-  defp celestia_blob_to_input(_transaction_input, _transaction_hash, "") do
+  defp celestia_blob_to_input(_transaction_input, _transaction_hash, "", _offset) do
     Logger.error(
       "Cannot read Celestia blobs from the server as the API URL is not defined. Please, check INDEXER_OPTIMISM_L1_BATCH_CELESTIA_BLOBS_API_URL env variable."
     )
@@ -739,9 +737,13 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
               chain_id_l1
             )
 
-          first_byte(transaction.input) == 0xCE ->
+          commitment_alt_da_signature(transaction.input) == 0x01010C ->
             # this is Celestia DA transaction, so we get the data from Celestia blob
-            celestia_blob_to_input(transaction.input, transaction.hash, celestia_blobs_api_url)
+            celestia_blob_to_input(transaction.input, transaction.hash, celestia_blobs_api_url, 3)
+
+          first_byte(transaction.input) == 0xCE ->
+            # backward compatibility with OP Celestia Raspberry
+            celestia_blob_to_input(transaction.input, transaction.hash, celestia_blobs_api_url, 1)
 
           true ->
             # this is calldata transaction, so the data is in the transaction input
@@ -1422,14 +1424,29 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
     end
   end
 
+  @spec commitment_alt_da_signature(binary()) :: non_neg_integer() | nil
+  defp commitment_alt_da_signature("0x" <> transaction_input) do
+    transaction_input
+    |> Base.decode16!(case: :mixed)
+    |> commitment_alt_da_signature()
+  end
+
+  defp commitment_alt_da_signature(<<0, _rest::binary>>), do: 0x00
+  defp commitment_alt_da_signature(<<1, 0, _rest::binary>>), do: 0x0100
+
+  defp commitment_alt_da_signature(<<1, 1, da_layer_byte::size(8), _rest::binary>>),
+    do: :binary.decode_unsigned(<<0x01, 0x01, da_layer_byte>>)
+
+  defp commitment_alt_da_signature(_), do: nil
+
   defp first_byte("0x" <> transaction_input) do
     transaction_input
     |> Base.decode16!(case: :mixed)
     |> first_byte()
   end
 
-  defp first_byte(<<version_byte::size(8), _rest::binary>>) do
-    version_byte
+  defp first_byte(<<first_byte::size(8), _rest::binary>>) do
+    first_byte
   end
 
   defp first_byte(_transaction_input) do

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -191,6 +191,15 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
     end)
   end
 
+  # Prepares withdrawal events from `eth_getLogs` response to be imported to DB.
+  #
+  # ## Parameters
+  # - `events`: The list of L1 withdrawal events from `eth_getLogs` response.
+  # - `json_rpc_named_arguments`: JSON-RPC configuration containing transport options for L1.
+  #
+  # ## Returns
+  # - A list of `WithdrawalEvent` maps.
+  @spec prepare_events([map()], EthereumJSONRPC.json_rpc_named_arguments()) :: [WithdrawalEvent.to_import()]
   defp prepare_events(events, json_rpc_named_arguments) do
     blocks =
       events
@@ -313,6 +322,16 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
     end
   end
 
+  # Parses input of the prove L1 transaction and retrieves dispute game index or contract address
+  # (depending on whether Super Roots are active) from that.
+  #
+  # ## Parameters
+  # - `input`: The L1 transaction input in form of `0x` string.
+  #
+  # ## Returns
+  # - `{game_index, game_address}` tuple where one of the elements is not `nil`, but another one is `nil` (and vice versa).
+  #   Both elements can be `nil` if the input cannot be parsed (or has unsupported format).
+  @spec input_to_game_index_or_address(String.t()) :: {non_neg_integer() | nil, String.t() | nil}
   defp input_to_game_index_or_address(input) do
     method_signature = String.slice(input, 0..9)
 

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal_event.ex
@@ -236,9 +236,9 @@ defmodule Indexer.Fetcher.Optimism.WithdrawalEvent do
             |> Map.get(transaction_hash)
             |> input_to_game_index_or_address()
 
-          {"WithdrawalProven", game_index, game_address}
+          {:WithdrawalProven, game_index, game_address}
         else
-          {"WithdrawalFinalized", nil, nil}
+          {:WithdrawalFinalized, nil, nil}
         end
 
       l1_block_number = quantity_to_integer(event["blockNumber"])


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12052

## Motivation

Partially relates to https://github.com/blockscout/blockscout/issues/9947 in part of Celestia DA service (see https://github.com/ethereum-optimism/specs/blob/main/specs/experimental/alt-da.md#input-commitment-submission): adds proper handling of Celestia DA service signature in the batch L1 transaction input.

Previously, the signature for Celestia DA consisted of 1-byte `0xCE` (when used with `OP Celestia Raspberry`). Now the signature handler corresponds to the format described by Optimism.

Also, this PR adds handling of Super Roots version of the `proveWithdrawalTransaction` function of `OptimismPortal2` contract.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for extracting and displaying both dispute game index and dispute game address from withdrawal events.
  - Database schema updated to store dispute game addresses for withdrawals.
- **Bug Fixes**
  - Improved handling of missing block data to prevent errors when no block is returned by the RPC node.
- **Refactor**
  - Enhanced event processing to support multiple method signatures and improved flexibility for future updates.
  - Parameterized Celestia blob extraction logic to support Alt-DA signatures and offsets.
  - Renamed dispute game address fields from `address` to `address_hash` across modules for consistency.
  - Updated conflict resolution logic to consider `game_address_hash` in addition to other fields.
- **Documentation**
  - Updated documentation to reflect new fields and data structures related to dispute game addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->