### PR TITLE
fix: Fix retrieving max block number in MissingRangesCollector

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -63,7 +63,6 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
 
   alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.{Chain, Helper, Repo}
-  alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Chain.Cache.Counters.LastFetchedCounter
   alias Explorer.Utility.{MissingBlockRange, MissingRangesManipulator}
 
@@ -393,23 +392,17 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   @spec last_block() :: non_neg_integer()
   defp last_block do
     last_block = Application.get_env(:indexer, :last_block)
-    if last_block, do: last_block + 1, else: fetch_max_block_number()
+    if last_block, do: last_block + 1, else: fetch_max_block_number_from_node()
   end
 
-  # Retrieves the highest block number from cache or blockchain.
-  @spec fetch_max_block_number() :: non_neg_integer()
-  defp fetch_max_block_number do
-    case BlockNumber.get_max() do
-      0 ->
-        json_rpc_named_arguments = Application.get_env(:indexer, :json_rpc_named_arguments)
+  # Retrieves the highest block number from blockchain.
+  @spec fetch_max_block_number_from_node() :: non_neg_integer()
+  defp fetch_max_block_number_from_node do
+    json_rpc_named_arguments = Application.get_env(:indexer, :json_rpc_named_arguments)
 
-        case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
-          {:ok, number} -> number
-          _ -> 0
-        end
-
-      number ->
-        number
+    case EthereumJSONRPC.fetch_block_number_by_tag("latest", json_rpc_named_arguments) do
+      {:ok, number} -> number
+      _ -> 0
     end
   end
 

--- a/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/bound_interval_supervisor_test.exs
@@ -434,6 +434,10 @@ defmodule Indexer.Block.Catchup.BoundIntervalSupervisorTest do
       insert(:block, number: 0)
       insert(:block, number: 1)
 
+      stub(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:ok, []}
+      end)
+
       MissingRangesCollector.start_link([])
       start_supervised!({Task.Supervisor, name: Indexer.Block.Catchup.TaskSupervisor})
       CoinBalanceCatchup.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)


### PR DESCRIPTION
## Motivation

In cases when realtime block fetcher for some reason doesn't process any blocks at all, catchup fetcher should be able to handle all the new blocks by itself. However, `MissingRangesCollector` retrieves the max block number via blocks cache which is not updating if realtime fetcher doesn't process blocks. So in that case, catchup fetcher will be stuck along with realtime fetcher.

## Changelog

Update `MissingRangesCollector.fetch_max_block_number/0` logic so the max block number is always fetched from node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved block number retrieval to always fetch the latest data directly from the blockchain, ensuring accuracy.
- **Tests**
  - Enhanced test reliability with mocks simulating blockchain responses.
  - Added stubs to better control test scenarios involving external data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->