### PR TITLE
chore: set home directory for blockscout user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,7 @@ ARG BLOCKSCOUT_GID=10001
 
 RUN apk --no-cache --update add jq curl && \
     addgroup --system --gid ${BLOCKSCOUT_GID} ${BLOCKSCOUT_GROUP} && \
-    adduser --system --uid ${BLOCKSCOUT_UID} --ingroup ${BLOCKSCOUT_GROUP} --disabled-password ${BLOCKSCOUT_USER}
+    adduser --system --uid ${BLOCKSCOUT_UID} --ingroup ${BLOCKSCOUT_GROUP} --disabled-password --home /app ${BLOCKSCOUT_USER}
 
 ENV DISABLE_WEBAPP=true
 ENV ADMIN_PANEL_ENABLED=false


### PR DESCRIPTION
**## Motivation**

The `blockscout` user was missing a home directory in the Dockerfile, which could lead to minor issues with processes not having a defined home path.

**## Changelog**

### Enhancements
- None.

### Bug Fixes
- Added `--home /app` to the Dockerfile to ensure the `blockscout` user has a home directory, preventing potential minor issues.

### Incompatible Changes
- None.

**## Checklist for your Pull Request (PR)**

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [[docs repository](https://github.com/blockscout/docs)](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [[docs repository](https://github.com/blockscout/docs)](https://github.com/blockscout/docs) to update the list of [[env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md)](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [[Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md)](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [[pages](https://docs.blockscout.com/setup/env-variables)](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated container configuration to set the home directory for the system user to `/app`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->