### PR TITLE
fix: Handle pending operations for empty blocks as well

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -500,10 +500,10 @@ defmodule Indexer.Block.Fetcher do
 
   def async_import_created_contract_codes(_, _), do: :ok
 
-  def async_import_internal_transactions(%{blocks: blocks, transactions: transactions}, realtime?) do
+  def async_import_internal_transactions(%{blocks: blocks} = imported, realtime?) do
     blocks
     |> Enum.map(fn %Block{number: block_number} -> block_number end)
-    |> InternalTransaction.async_fetch(transactions, realtime?, 10_000)
+    |> InternalTransaction.async_fetch(Map.get(imported, :transactions, []), realtime?, 10_000)
   end
 
   def async_import_internal_transactions(_, _), do: :ok


### PR DESCRIPTION
## Motivation

If block has no transactions, the result of import won't have `:transactions` field. In that case `async_import_internal_transactions` won't match on `%{blocks: blocks, transactions: transactions}` and therefore `PendingBlockOperation` record won't be processed.

## Changelog
Process internal transactions for empty blocks as well so the related `PendingBlockOperation` record will be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal handling of transaction data to enhance reliability and maintainability. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->