### PR TITLE
refactor: Define pending block operations by set of block hashes query

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1621,10 +1621,7 @@ defmodule Explorer.Chain do
     query =
       case PendingOperationsHelper.pending_operations_type() do
         "blocks" ->
-          from(
-            pbo in PendingBlockOperation,
-            where: pbo.block_hash in ^block_hashes
-          )
+          PendingOperationsHelper.block_hash_in_query(block_hashes)
 
         "transactions" ->
           from(

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
 
   import Ecto.Query
 
-  alias Explorer.Chain.{PendingBlockOperation, PendingTransactionOperation, Transaction}
+  alias Explorer.Chain.{Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Repo
 
   @transactions_batch_size 1000
@@ -117,5 +117,24 @@ defmodule Explorer.Chain.PendingOperationsHelper do
     now = DateTime.utc_now()
 
     Enum.map(params, &Map.merge(&1, %{inserted_at: now, updated_at: now}))
+  end
+
+  @doc """
+  Generates a query to find pending block operations that match any of the given block hashes.
+
+  ## Parameters
+
+    - `block_hashes`: A list of block hashes to filter the pending block operations.
+
+  ## Returns
+
+    - An Ecto query that can be executed to retrieve the matching pending block operations.
+  """
+  @spec block_hash_in_query([Hash.Full.t()]) :: Ecto.Query.t()
+  def block_hash_in_query(block_hashes) do
+    from(
+      pending_ops in PendingBlockOperation,
+      where: pending_ops.block_hash in ^block_hashes
+    )
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
+++ b/apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex
@@ -15,7 +15,7 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
   alias EthereumJSONRPC.Block.ByNumber
   alias EthereumJSONRPC.Blocks
   alias Explorer.Repo
-  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingOperationsHelper, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingOperationsHelper, Transaction}
   alias Explorer.Chain.Cache.BlockNumber
 
   @update_timeout 60_000
@@ -196,8 +196,8 @@ defmodule Indexer.Fetcher.EmptyBlocksSanitizer do
 
     case PendingOperationsHelper.pending_operations_type() do
       "blocks" ->
-        PendingBlockOperation
-        |> where([po], po.block_hash in ^block_hashes)
+        block_hashes
+        |> PendingOperationsHelper.block_hash_in_query()
         |> Repo.delete_all()
 
       "transactions" ->


### PR DESCRIPTION
## Motivation

A query to get pending block operations by a set of block hashes is used in many places. We might define a generic function for that.

## Changelog

Define `PendingOperationsHelper.block_hash_in_query/1` function.

### AI Agent summary

This pull request refactors the handling of queries for pending block operations by introducing a reusable helper function in `PendingOperationsHelper`. The changes aim to improve code readability and reduce duplication across multiple modules.

### Refactoring for query reuse:

* [`apps/explorer/lib/explorer/chain/pending_operations_helper.ex`](diffhunk://#diff-18c8fc0f4efc97351c3c9310120ff34878e8b927eeecd8908c721d1145231253R121-R139): Added a new function, `block_hash_in_query/1`, to encapsulate the logic for generating a query to find pending block operations by block hashes. This function improves code reuse and maintainability.

### Updates to use the new helper function:

* [`apps/explorer/lib/explorer/chain.ex`](diffhunk://#diff-3fce0f082a5cb927aa738ef8f7d582824df91d08957971d36a0873efacd88816L1624-R1624): Replaced inline query logic with a call to `PendingOperationsHelper.block_hash_in_query/1` for handling pending block operations.
* [`apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex`](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211L327-R331): Updated multiple query blocks to use `PendingOperationsHelper.block_hash_in_query/1`, simplifying the code and ensuring consistency. [[1]](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211L327-R331) [[2]](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211L832-R829)
* [`apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex`](diffhunk://#diff-1a7a30b57ddd3723a9e756d126f3e76613bee43004ddaa2b6a2977f66a98e344L199-R200): Refactored the query for deleting pending block operations to use the new helper function.

### Minor cleanup:

* [`apps/indexer/lib/indexer/fetcher/empty_blocks_sanitizer.ex`](diffhunk://#diff-1a7a30b57ddd3723a9e756d126f3e76613bee43004ddaa2b6a2977f66a98e344L18-R18): Removed the unused `PendingBlockOperation` alias to clean up the imports.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and unified how pending block operations are queried by introducing a reusable helper for filtering by block hashes.
  - Improved internal code consistency and maintainability, with no changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->