### PR TITLE
feat: Decode OP interop message payload and store cross-chain transfer data

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -492,6 +492,11 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
   # - Resulting map with the `op_interop_messages` table's fields.
   @spec interop_prepare_import(map()) :: map()
   defp interop_prepare_import(%{"init_transaction_hash" => init_transaction_hash} = params) do
+    payload = hash_to_binary(params["payload"])
+
+    [transfer_token_address_hash, transfer_from_address_hash, transfer_to_address_hash, transfer_amount] =
+      InteropMessage.decode_payload(payload)
+
     %{
       sender_address_hash: params["sender_address_hash"],
       target_address_hash: params["target_address_hash"],
@@ -500,7 +505,11 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
       init_transaction_hash: init_transaction_hash,
       timestamp: DateTime.from_unix!(params["timestamp"]),
       relay_chain_id: params["relay_chain_id"],
-      payload: hash_to_binary(params["payload"])
+      payload: payload,
+      transfer_token_address_hash: transfer_token_address_hash,
+      transfer_from_address_hash: transfer_from_address_hash,
+      transfer_to_address_hash: transfer_to_address_hash,
+      transfer_amount: transfer_amount
     }
   end
 

--- a/apps/explorer/lib/explorer/chain/import/runner/optimism/interop_messages.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/optimism/interop_messages.ex
@@ -96,13 +96,20 @@ defmodule Explorer.Chain.Import.Runner.Optimism.InteropMessages do
             fragment("COALESCE(EXCLUDED.relay_transaction_hash, ?)", message.relay_transaction_hash),
           payload: fragment("COALESCE(EXCLUDED.payload, ?)", message.payload),
           failed: fragment("COALESCE(EXCLUDED.failed, ?)", message.failed),
+          transfer_token_address_hash:
+            fragment("COALESCE(EXCLUDED.transfer_token_address_hash, ?)", message.transfer_token_address_hash),
+          transfer_from_address_hash:
+            fragment("COALESCE(EXCLUDED.transfer_from_address_hash, ?)", message.transfer_from_address_hash),
+          transfer_to_address_hash:
+            fragment("COALESCE(EXCLUDED.transfer_to_address_hash, ?)", message.transfer_to_address_hash),
+          transfer_amount: fragment("COALESCE(EXCLUDED.transfer_amount, ?)", message.transfer_amount),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", message.inserted_at),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", message.updated_at)
         ]
       ],
       where:
         fragment(
-          "(EXCLUDED.sender_address_hash, EXCLUDED.target_address_hash, EXCLUDED.init_transaction_hash, EXCLUDED.block_number, EXCLUDED.timestamp, EXCLUDED.relay_chain_id, EXCLUDED.relay_transaction_hash, EXCLUDED.payload, EXCLUDED.failed) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.sender_address_hash, EXCLUDED.target_address_hash, EXCLUDED.init_transaction_hash, EXCLUDED.block_number, EXCLUDED.timestamp, EXCLUDED.relay_chain_id, EXCLUDED.relay_transaction_hash, EXCLUDED.payload, EXCLUDED.failed, EXCLUDED.transfer_token_address_hash, EXCLUDED.transfer_from_address_hash, EXCLUDED.transfer_to_address_hash, EXCLUDED.transfer_amount) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           message.sender_address_hash,
           message.target_address_hash,
           message.init_transaction_hash,
@@ -111,7 +118,11 @@ defmodule Explorer.Chain.Import.Runner.Optimism.InteropMessages do
           message.relay_chain_id,
           message.relay_transaction_hash,
           message.payload,
-          message.failed
+          message.failed,
+          message.transfer_token_address_hash,
+          message.transfer_from_address_hash,
+          message.transfer_to_address_hash,
+          message.transfer_amount
         )
     )
   end

--- a/apps/explorer/priv/optimism/migrations/20250501120524_op_interop_transfer_fields.exs
+++ b/apps/explorer/priv/optimism/migrations/20250501120524_op_interop_transfer_fields.exs
@@ -2,6 +2,8 @@ defmodule Explorer.Repo.Optimism.Migrations.OPInteropTransferFields do
   use Ecto.Migration
 
   def change do
+    execute("TRUNCATE TABLE op_interop_messages;")
+
     alter table(:op_interop_messages) do
       add(:transfer_token_address_hash, :bytea, null: true, default: nil)
       add(:transfer_from_address_hash, :bytea, null: true, default: nil)

--- a/apps/explorer/priv/optimism/migrations/20250501120524_op_interop_transfer_fields.exs
+++ b/apps/explorer/priv/optimism/migrations/20250501120524_op_interop_transfer_fields.exs
@@ -1,0 +1,12 @@
+defmodule Explorer.Repo.Optimism.Migrations.OPInteropTransferFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:op_interop_messages) do
+      add(:transfer_token_address_hash, :bytea, null: true, default: nil)
+      add(:transfer_from_address_hash, :bytea, null: true, default: nil)
+      add(:transfer_to_address_hash, :bytea, null: true, default: nil)
+      add(:transfer_amount, :decimal, null: true, default: nil)
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message.ex
@@ -320,6 +320,9 @@ defmodule Indexer.Fetcher.Optimism.Interop.Message do
         if Enum.at(event["topics"], 0) == @sent_message_event do
           [sender_address_hash, payload] = decode_data(event["data"], [:address, :bytes])
 
+          [transfer_token_address_hash, transfer_from_address_hash, transfer_to_address_hash, transfer_amount] =
+            InteropMessage.decode_payload(payload)
+
           %{
             sender_address_hash: sender_address_hash,
             target_address_hash: truncate_address_hash(Enum.at(event["topics"], 2)),
@@ -329,7 +332,11 @@ defmodule Indexer.Fetcher.Optimism.Interop.Message do
             block_number: block_number,
             timestamp: Map.get(timestamps, block_number),
             relay_chain_id: quantity_to_integer(Enum.at(event["topics"], 1)),
-            payload: payload
+            payload: payload,
+            transfer_token_address_hash: transfer_token_address_hash,
+            transfer_from_address_hash: transfer_from_address_hash,
+            transfer_to_address_hash: transfer_to_address_hash,
+            transfer_amount: transfer_amount
           }
         else
           %{

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
@@ -59,9 +59,8 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageFailed do
 
   @impl GenServer
   def init(args) do
-    :ignore
-    # json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    # {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    json_rpc_named_arguments = args[:json_rpc_named_arguments]
+    {:ok, %{}, {:continue, json_rpc_named_arguments}}
   end
 
   # Initialization function which is used instead of `init` to avoid Supervisor's stop in case of any critical issues

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
@@ -59,8 +59,9 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageFailed do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    :ignore
+    # json_rpc_named_arguments = args[:json_rpc_named_arguments]
+    # {:ok, %{}, {:continue, json_rpc_named_arguments}}
   end
 
   # Initialization function which is used instead of `init` to avoid Supervisor's stop in case of any critical issues

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
@@ -59,8 +59,7 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageFailed do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    {:ok, %{}, {:continue, args[:json_rpc_named_arguments]}}
   end
 
   # Initialization function which is used instead of `init` to avoid Supervisor's stop in case of any critical issues

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message_queue.ex
@@ -343,6 +343,9 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageQueue do
           pl -> hash_to_binary(pl)
         end
 
+      [transfer_token_address_hash, transfer_from_address_hash, transfer_to_address_hash, transfer_amount] =
+        InteropMessage.decode_payload(payload)
+
       %{
         sender_address_hash: Map.get(response, "sender_address_hash"),
         target_address_hash: Map.get(response, "target_address_hash"),
@@ -351,7 +354,11 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageQueue do
         init_transaction_hash: Map.get(response, "init_transaction_hash"),
         relay_chain_id: message.relay_chain_id,
         timestamp: timestamp,
-        payload: payload
+        payload: payload,
+        transfer_token_address_hash: transfer_token_address_hash,
+        transfer_from_address_hash: transfer_from_address_hash,
+        transfer_to_address_hash: transfer_to_address_hash,
+        transfer_amount: transfer_amount
       }
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -42,8 +42,7 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    {:ok, %{}, {:continue, args[:json_rpc_named_arguments]}}
   end
 
   @impl GenServer

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -42,8 +42,9 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    :ignore
+    # json_rpc_named_arguments = args[:json_rpc_named_arguments]
+    # {:ok, %{}, {:continue, json_rpc_named_arguments}}
   end
 
   @impl GenServer

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -42,9 +42,8 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
 
   @impl GenServer
   def init(args) do
-    :ignore
-    # json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    # {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    json_rpc_named_arguments = args[:json_rpc_named_arguments]
+    {:ok, %{}, {:continue, json_rpc_named_arguments}}
   end
 
   @impl GenServer

--- a/cspell.json
+++ b/cspell.json
@@ -606,6 +606,7 @@
         "subtraces",
         "successa",
         "successb",
+        "Superchain",
         "supermajority",
         "supernet",
         "sushiswap",


### PR DESCRIPTION
This PR adds decoding of OP interop message payload to get info about cross-chain operation when transferring SuperchainERC20 token or native coin.

The `op_interop_messages` database table is extended by the following fields:

- `transfer_token_address_hash`: stores SuperchainERC20 token address if the message relates to SuperchainERC20 cross-chain transfer. Otherwise, this field is `nil` (including the case with native coin cross-chain transfer).
- `transfer_from_address_hash`: stores `From` address of the cross-chain transfer. Equals to `nil` if the message doesn't relate to cross-chain transfer.
- `transfer_to_address_hash`: stores `To` address of the cross-chain transfer. Equals to `nil` if the message doesn't relate to cross-chain transfer.
- `transfer_amount`: stores `value` of the cross-chain transfer. Equals to `nil` if the message doesn't relate to cross-chain transfer.

OP interop message can currently have one of three types:
1. SuperchainERC20 cross-chain token transfer.
2. Native coin cross-chain transfer.
3. Arbitrary calldata.

There is no `operation_type` field in the `op_interop_messages` table because the operation type can be defined by the following conditions based on the above fields:

- If `transfer_amount` is `nil`, the message doesn't relate to cross-chain transfer and only has arbitrary calldata.

- If `transfer_amount` is not `nil` and `transfer_token_address_hash` is `nil`, this is native coin cross-chain transfer.

- If `transfer_amount` is not `nil` and `transfer_token_address_hash` is not `nil`, this is SuperchainERC20 cross-chain token transfer.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
