### PR TITLE
perf: optimize Explorer.Chain.Cache.Blocks

### DIFF
--- a/apps/block_scout_web/benchmarks/block_scout_web/controllers/api/v2/block_controller_benchmark.exs
+++ b/apps/block_scout_web/benchmarks/block_scout_web/controllers/api/v2/block_controller_benchmark.exs
@@ -1,0 +1,68 @@
+defmodule BlockScoutWeb.API.V2.BlockControllerBenchmark do
+  @moduledoc """
+  Benchmark for the Block API V2 controller.
+  Tests the performance of the /api/v2/blocks endpoint with various data volumes.
+
+  To run:
+  ```
+  cd apps/block_scout_web
+  mix run benchmarks/block_scout_web/controllers/api/v2/block_controller_benchmark.exs
+  ```
+  """
+  use BlockScoutWeb.BenchmarkCase
+
+  alias Explorer.Repo
+  alias Explorer.Chain.Block
+
+  @doc """
+  Benchmark the first page of the /api/v2/blocks endpoint. It mainly tests the performance of `Explorer.Chain.Cache.Blocks`.
+  """
+  def list_blocks_first_page do
+    benchmark_setup()
+
+    Benchee.run(
+      %{
+        "GET /api/v2/blocks first page (cached)" => fn %{conn: conn} ->
+          get(conn, "/api/v2/blocks")
+        end
+      },
+      inputs: %{
+        " 0 blocks   0 transactions per block" => %{block_count: 0, transaction_per_block: 0},
+        "51 blocks   0 transactions per block" => %{block_count: 51, transaction_per_block: 0},
+        "51 blocks  10 transactions per block" => %{block_count: 51, transaction_per_block: 10},
+        "51 blocks 100 transactions per block" => %{block_count: 51, transaction_per_block: 100},
+        "51 blocks 500 transactions per block" => %{block_count: 51, transaction_per_block: 500}
+      },
+      before_scenario: fn %{block_count: block_count, transaction_per_block: transaction_per_block} = input ->
+        reset_db()
+
+        Application.put_env(:explorer, Explorer.Chain.Cache.Blocks, ttl_check_interval: false, global_ttl: nil)
+
+        Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
+        Supervisor.restart_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
+
+        0 = Repo.aggregate(Block, :count, :hash)
+
+        block_count
+        |> insert_list(:block)
+        |> Enum.each(fn block ->
+          transaction_per_block
+          |> insert_list(:transaction)
+          |> with_block(block)
+        end)
+
+        Map.put(input, :conn, get_conn())
+      end,
+      formatters: [Benchee.Formatters.Console],
+      load: @path,
+      save: [
+        path: @path
+      ],
+      warmup: 1,
+      time: 10,
+      memory_time: 10
+    )
+  end
+end
+
+BlockScoutWeb.API.V2.BlockControllerBenchmark.list_blocks_first_page()

--- a/apps/block_scout_web/benchmarks/support/benchmark_case.ex
+++ b/apps/block_scout_web/benchmarks/support/benchmark_case.ex
@@ -1,0 +1,64 @@
+defmodule BlockScoutWeb.BenchmarkCase do
+  @moduledoc """
+  This module defines the benchmark case to be used by benchmarks.
+
+  This module provides common setup and utilities for benchmarking,
+  similar to ConnCase but optimized for benchmarking needs, including:
+
+  - Database sandbox management
+  - Connection building
+  - Factory imports
+  - Common helpers
+
+  ## Example
+
+  ```elixir
+  defmodule BlockScoutWeb.MyBenchmark do
+    use BlockScoutWeb.BenchmarkCase
+
+    def run do
+      Benchee.run(...)
+    end
+  end
+
+  # Run the benchmark
+  BlockScoutWeb.MyBenchmark.run()
+  ```
+  """
+
+  defmacro __using__(_opts) do
+    caller_file = __CALLER__.file
+    path = caller_file |> String.replace(Path.extname(caller_file), ".benchee")
+
+    quote do
+      import Explorer.Factory
+      import Phoenix.ConnTest
+
+      @endpoint BlockScoutWeb.Endpoint
+      @path unquote(path)
+
+      @doc """
+      Resets the database for consistent benchmarks
+      """
+      def reset_db do
+        :ok = Ecto.Adapters.SQL.Sandbox.checkout(Explorer.Repo, ownership_timeout: :infinity)
+      end
+
+      @doc """
+      Gets a Phoenix connection for HTTP request benchmarks
+      """
+      def get_conn do
+        Phoenix.ConnTest.build_conn()
+      end
+
+      @doc """
+      Setup common benchmark environment
+      """
+      def benchmark_setup do
+        {:ok, _} = Application.ensure_all_started(:block_scout_web)
+
+        :ok
+      end
+    end
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -30,17 +30,12 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   def prepare_block(block, _conn, single_block? \\ false) do
     block = Block.aggregate_transactions(block)
 
-    # burnt_fees = Block.burnt_fees(block.transactions, block.base_fee_per_gas)
-    # priority_fee = block.base_fee_per_gas && BlockPriorityFeeCount.fetch(block.hash)
-
-    # transaction_fees = Block.transaction_fees(block.transactions)
-
     %{
       "height" => block.number,
       "timestamp" => block.timestamp,
       "transactions_count" => block.transactions_count,
       # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      "transaction_count" => count_transactions(block),
+      "transaction_count" => block.transactions_count,
       "internal_transactions_count" => count_internal_transactions(block),
       "miner" => Helper.address_with_info(nil, block.miner, block.miner_hash, false),
       "size" => block.size,
@@ -97,9 +92,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   end
 
   def burnt_fees_percentage(_, _), do: nil
-
-  defp count_transactions(%Block{transactions: transactions}) when is_list(transactions), do: Enum.count(transactions)
-  defp count_transactions(_), do: nil
 
   defp count_internal_transactions(%Block{internal_transactions: internal_transactions})
        when is_list(internal_transactions),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   alias BlockScoutWeb.BlockView
   alias BlockScoutWeb.API.V2.{ApiView, Helper}
   alias Explorer.Chain.Block
-  alias Explorer.Chain.Cache.Counters.BlockPriorityFeeCount
 
   def render("message.json", assigns) do
     ApiView.render("message.json", assigns)
@@ -29,15 +28,17 @@ defmodule BlockScoutWeb.API.V2.BlockView do
   end
 
   def prepare_block(block, _conn, single_block? \\ false) do
-    burnt_fees = Block.burnt_fees(block.transactions, block.base_fee_per_gas)
-    priority_fee = block.base_fee_per_gas && BlockPriorityFeeCount.fetch(block.hash)
+    block = Block.aggregate_transactions(block)
 
-    transaction_fees = Block.transaction_fees(block.transactions)
+    # burnt_fees = Block.burnt_fees(block.transactions, block.base_fee_per_gas)
+    # priority_fee = block.base_fee_per_gas && BlockPriorityFeeCount.fetch(block.hash)
+
+    # transaction_fees = Block.transaction_fees(block.transactions)
 
     %{
       "height" => block.number,
       "timestamp" => block.timestamp,
-      "transactions_count" => count_transactions(block),
+      "transactions_count" => block.transactions_count,
       # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
       "transaction_count" => count_transactions(block),
       "internal_transactions_count" => count_internal_transactions(block),
@@ -51,17 +52,17 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "gas_limit" => block.gas_limit,
       "nonce" => block.nonce,
       "base_fee_per_gas" => block.base_fee_per_gas,
-      "burnt_fees" => burnt_fees,
-      "priority_fee" => priority_fee,
+      "burnt_fees" => block.burnt_fees,
+      "priority_fee" => block.priority_fees,
       # "extra_data" => "TODO",
       "uncles_hashes" => prepare_uncles(block.uncle_relations),
       # "state_root" => "TODO",
       "rewards" => prepare_rewards(block.rewards, block, single_block?),
       "gas_target_percentage" => Block.gas_target(block),
       "gas_used_percentage" => Block.gas_used_percentage(block),
-      "burnt_fees_percentage" => burnt_fees_percentage(burnt_fees, transaction_fees),
+      "burnt_fees_percentage" => burnt_fees_percentage(block.burnt_fees, block.transactions_fees),
       "type" => block |> BlockView.block_type() |> String.downcase(),
-      "transaction_fees" => transaction_fees,
+      "transaction_fees" => block.transactions_fees,
       "withdrawals_count" => count_withdrawals(block)
     }
     |> chain_type_fields(block, single_block?)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
@@ -1,12 +1,6 @@
 defmodule BlockScoutWeb.API.V2.EthereumView do
   alias Explorer.Chain.{Block, Transaction}
 
-  defp count_blob_transactions(%Block{transactions: transactions}) when is_list(transactions),
-    # EIP-2718 blob transaction type
-    do: Enum.count(transactions, &(&1.type == 3))
-
-  defp count_blob_transactions(_), do: nil
-
   def extend_transaction_json_response(out_json, %Transaction{} = transaction) do
     case Map.get(transaction, :beacon_blob_transaction) do
       nil ->
@@ -29,7 +23,7 @@ defmodule BlockScoutWeb.API.V2.EthereumView do
     blob_gas_used = Map.get(block, :blob_gas_used)
     excess_blob_gas = Map.get(block, :excess_blob_gas)
 
-    blob_transaction_count = count_blob_transactions(block)
+    blob_transaction_count = block.blob_transactions_count
 
     extended_out_json =
       out_json

--- a/apps/block_scout_web/mix.exs
+++ b/apps/block_scout_web/mix.exs
@@ -49,7 +49,8 @@ defmodule BlockScoutWeb.Mixfile do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test, _), do: ["test/support", "test/block_scout_web/features/pages"] ++ elixirc_paths()
+  defp elixirc_paths(:test, _),
+    do: ["test/support", "test/block_scout_web/features/pages", "benchmarks/support"] ++ elixirc_paths()
 
   defp elixirc_paths(_, true),
     do: [
@@ -85,6 +86,7 @@ defmodule BlockScoutWeb.Mixfile do
       {:absinthe_plug, git: "https://github.com/blockscout/absinthe_plug.git", tag: "1.5.8", override: true},
       # Absinthe support for the Relay framework
       {:absinthe_relay, "~> 1.5"},
+      {:benchee, "~> 1.4.0", only: :test},
       {:bypass, "~> 2.1", only: :test},
       # To add (CORS)(https://www.w3.org/TR/cors/)
       {:cors_plug, "~> 3.0"},

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -584,7 +584,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/address/overview.html.eex:277
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:356
+#: lib/block_scout_web/views/address_view.ex:361
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -684,13 +684,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:350
+#: lib/block_scout_web/views/address_view.ex:355
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:42
-#: lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/address_view.ex:360
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -1614,7 +1614,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:347
+#: lib/block_scout_web/views/address_view.ex:352
 #: lib/block_scout_web/views/transaction_view.ex:552
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1774,7 +1774,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/address_view.ex:362
 #: lib/block_scout_web/views/transaction_view.ex:553
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -2285,7 +2285,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:351
+#: lib/block_scout_web/views/address_view.ex:356
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -2293,7 +2293,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:352
+#: lib/block_scout_web/views/address_view.ex:357
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:349
+#: lib/block_scout_web/views/address_view.ex:354
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:74
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:551
@@ -2999,7 +2999,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:84
 #: lib/block_scout_web/templates/tokens/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:346
+#: lib/block_scout_web/views/address_view.ex:351
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -3172,7 +3172,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:80
 #: lib/block_scout_web/templates/chain/show.html.eex:216
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:348
+#: lib/block_scout_web/views/address_view.ex:353
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -3537,14 +3537,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:353
+#: lib/block_scout_web/views/address_view.ex:358
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:354
+#: lib/block_scout_web/views/address_view.ex:359
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""
@@ -3659,7 +3659,7 @@ msgstr ""
 msgid "fallback"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:33
+#: lib/block_scout_web/views/address_contract_view.ex:34
 #, elixir-autogen, elixir-format
 msgid "false"
 msgstr ""
@@ -3725,7 +3725,7 @@ msgstr ""
 msgid "to CSV file"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:32
+#: lib/block_scout_web/views/address_contract_view.ex:33
 #, elixir-autogen, elixir-format
 msgid "true"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -584,7 +584,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address/_tabs.html.eex:56
 #: lib/block_scout_web/templates/address/overview.html.eex:277
 #: lib/block_scout_web/templates/address_validation/index.html.eex:11
-#: lib/block_scout_web/views/address_view.ex:356
+#: lib/block_scout_web/views/address_view.ex:361
 #, elixir-autogen, elixir-format
 msgid "Blocks Validated"
 msgstr ""
@@ -684,13 +684,13 @@ msgstr ""
 #: lib/block_scout_web/templates/api_docs/_action_tile.html.eex:187
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:126
 #: lib/block_scout_web/templates/api_docs/_eth_rpc_item.html.eex:149
-#: lib/block_scout_web/views/address_view.ex:350
+#: lib/block_scout_web/views/address_view.ex:355
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:42
-#: lib/block_scout_web/views/address_view.ex:355
+#: lib/block_scout_web/views/address_view.ex:360
 #, elixir-autogen, elixir-format
 msgid "Coin Balance History"
 msgstr ""
@@ -1614,7 +1614,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_internal_transaction/index.html.eex:17
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:11
 #: lib/block_scout_web/templates/transaction_internal_transaction/index.html.eex:6
-#: lib/block_scout_web/views/address_view.ex:347
+#: lib/block_scout_web/views/address_view.ex:352
 #: lib/block_scout_web/views/transaction_view.ex:552
 #, elixir-autogen, elixir-format
 msgid "Internal Transactions"
@@ -1774,7 +1774,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_logs/index.html.eex:10
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:17
 #: lib/block_scout_web/templates/transaction_log/index.html.eex:8
-#: lib/block_scout_web/views/address_view.ex:357
+#: lib/block_scout_web/views/address_view.ex:362
 #: lib/block_scout_web/views/transaction_view.ex:553
 #, elixir-autogen, elixir-format
 msgid "Logs"
@@ -2285,7 +2285,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:81
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:27
-#: lib/block_scout_web/views/address_view.ex:351
+#: lib/block_scout_web/views/address_view.ex:356
 #: lib/block_scout_web/views/tokens/overview_view.ex:41
 #, elixir-autogen, elixir-format
 msgid "Read Contract"
@@ -2293,7 +2293,7 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:88
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:41
-#: lib/block_scout_web/views/address_view.ex:352
+#: lib/block_scout_web/views/address_view.ex:357
 #, elixir-autogen, elixir-format
 msgid "Read Proxy"
 msgstr ""
@@ -2975,7 +2975,7 @@ msgstr ""
 #: lib/block_scout_web/templates/tokens/transfer/index.html.eex:15
 #: lib/block_scout_web/templates/transaction/_tabs.html.eex:4
 #: lib/block_scout_web/templates/transaction_token_transfer/index.html.eex:7
-#: lib/block_scout_web/views/address_view.ex:349
+#: lib/block_scout_web/views/address_view.ex:354
 #: lib/block_scout_web/views/tokens/instance/overview_view.ex:74
 #: lib/block_scout_web/views/tokens/overview_view.ex:39
 #: lib/block_scout_web/views/transaction_view.ex:551
@@ -2999,7 +2999,7 @@ msgstr ""
 #: lib/block_scout_web/templates/address_token_transfer/index.html.eex:13
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:84
 #: lib/block_scout_web/templates/tokens/index.html.eex:10
-#: lib/block_scout_web/views/address_view.ex:346
+#: lib/block_scout_web/views/address_view.ex:351
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""
@@ -3172,7 +3172,7 @@ msgstr ""
 #: lib/block_scout_web/templates/block/overview.html.eex:80
 #: lib/block_scout_web/templates/chain/show.html.eex:216
 #: lib/block_scout_web/templates/layout/_topnav.html.eex:49
-#: lib/block_scout_web/views/address_view.ex:348
+#: lib/block_scout_web/views/address_view.ex:353
 #, elixir-autogen, elixir-format
 msgid "Transactions"
 msgstr ""
@@ -3537,14 +3537,14 @@ msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:95
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:34
-#: lib/block_scout_web/views/address_view.ex:353
+#: lib/block_scout_web/views/address_view.ex:358
 #, elixir-autogen, elixir-format
 msgid "Write Contract"
 msgstr ""
 
 #: lib/block_scout_web/templates/address/_tabs.html.eex:102
 #: lib/block_scout_web/templates/tokens/overview/_tabs.html.eex:48
-#: lib/block_scout_web/views/address_view.ex:354
+#: lib/block_scout_web/views/address_view.ex:359
 #, elixir-autogen, elixir-format
 msgid "Write Proxy"
 msgstr ""
@@ -3659,7 +3659,7 @@ msgstr ""
 msgid "fallback"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:33
+#: lib/block_scout_web/views/address_contract_view.ex:34
 #, elixir-autogen, elixir-format
 msgid "false"
 msgstr ""
@@ -3725,7 +3725,7 @@ msgstr ""
 msgid "to CSV file"
 msgstr ""
 
-#: lib/block_scout_web/views/address_contract_view.ex:32
+#: lib/block_scout_web/views/address_contract_view.ex:33
 #, elixir-autogen, elixir-format
 msgid "true"
 msgstr ""

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -153,6 +153,12 @@ defmodule Explorer.Chain.Block.Schema do
         field(:refetch_needed, :boolean)
         field(:base_fee_per_gas, Wei)
         field(:is_empty, :boolean)
+        field(:aggregated?, :boolean, virtual: true)
+        field(:transactions_count, :integer, virtual: true)
+        field(:blob_transactions_count, :integer, virtual: true)
+        field(:transactions_fees, :decimal, virtual: true)
+        field(:burnt_fees, :decimal, virtual: true)
+        field(:priority_fees, :decimal, virtual: true)
 
         timestamps()
 
@@ -197,7 +203,7 @@ defmodule Explorer.Chain.Block do
 
   alias Explorer.Chain.{Block, Hash, Transaction, Wei}
   alias Explorer.Chain.Block.{EmissionReward, Reward}
-  alias Explorer.Repo
+  alias Explorer.{Helper, Repo}
   alias Explorer.Utility.MissingRangesManipulator
 
   @optional_attrs ~w(size refetch_needed total_difficulty difficulty base_fee_per_gas)a
@@ -364,7 +370,7 @@ defmodule Explorer.Chain.Block do
       if gas_price do
         gas_used
         |> Decimal.new()
-        |> Decimal.mult(gas_price_to_decimal(gas_price))
+        |> Decimal.mult(Helper.number_to_decimal(gas_price))
         |> Decimal.add(acc)
       else
         acc
@@ -382,14 +388,10 @@ defmodule Explorer.Chain.Block do
       if is_nil(beacon_blob_transaction) do
         nil
       else
-        gas_price_to_decimal(beacon_blob_transaction.blob_gas_price)
+        Helper.number_to_decimal(beacon_blob_transaction.blob_gas_price)
       end
     end)
   end
-
-  defp gas_price_to_decimal(nil), do: nil
-  defp gas_price_to_decimal(%Wei{} = wei), do: wei.value
-  defp gas_price_to_decimal(gas_price), do: Decimal.new(gas_price)
 
   @doc """
   Calculates burnt fees for the list of transactions (from a single block)
@@ -405,7 +407,7 @@ defmodule Explorer.Chain.Block do
         |> Decimal.new()
         |> Decimal.add(acc)
       end)
-      |> Decimal.mult(gas_price_to_decimal(base_fee_per_gas))
+      |> Decimal.mult(Helper.number_to_decimal(base_fee_per_gas))
     end
   end
 
@@ -619,5 +621,81 @@ defmodule Explorer.Chain.Block do
   def by_hashes_query(hashes) do
     __MODULE__
     |> where([block], block.hash in ^hashes)
+  end
+
+  def aggregate_transactions(%__MODULE__{transactions: transactions, aggregated?: aggregated?} = block)
+      when is_list(transactions) and aggregated? in [nil, false] do
+    aggregate_results =
+      Enum.reduce(
+        transactions,
+        %{
+          transactions_count: 0,
+          blob_transactions_count: 0,
+          transactions_fees: Decimal.new(0),
+          burnt_fees: Decimal.new(0),
+          priority_fees: Decimal.new(0)
+        },
+        &transaction_aggregator(&1, &2, block.base_fee_per_gas)
+      )
+
+    block
+    |> Map.merge(aggregate_results)
+    |> Map.put(:aggregated?, true)
+  end
+
+  def aggregate_transactions(block), do: block
+
+  defp transaction_aggregator(transaction, acc, block_base_fee_per_gas) do
+    gas_used = Helper.number_to_decimal(transaction.gas_used)
+
+    transaction_fees =
+      if is_nil(transaction.gas_price) do
+        acc.transactions_fees
+      else
+        gas_used
+        |> Decimal.new()
+        |> Decimal.mult(Helper.number_to_decimal(transaction.gas_price))
+        |> Decimal.add(acc.transactions_fees)
+      end
+
+    burnt_fees =
+      if is_nil(block_base_fee_per_gas) do
+        acc.burnt_fees
+      else
+        transaction.gas_used
+        |> Decimal.new()
+        |> Decimal.mult(Helper.number_to_decimal(block_base_fee_per_gas))
+        |> Decimal.add(acc.burnt_fees)
+      end
+
+    priority_fees =
+      block_base_fee_per_gas
+      |> is_nil()
+      |> if do
+        acc.priority_fees
+      else
+        max_fee = Helper.number_to_decimal(transaction.max_fee_per_gas || transaction.gas_price)
+        priority_fee = Helper.number_to_decimal(transaction.max_priority_fee_per_gas || transaction.gas_price)
+
+        max_fee
+        |> Decimal.eq?(Decimal.new(0))
+        |> if do
+          Decimal.new(0)
+        else
+          max_fee
+          |> Decimal.sub(Helper.number_to_decimal(block_base_fee_per_gas))
+          |> Decimal.min(priority_fee)
+          |> Decimal.mult(gas_used)
+        end
+        |> Decimal.add(acc.priority_fees)
+      end
+
+    %{
+      transactions_count: acc.transactions_count + 1,
+      blob_transactions_count: acc.blob_transactions_count + if(transaction.type == 3, do: 1, else: 0),
+      transactions_fees: transaction_fees,
+      burnt_fees: burnt_fees,
+      priority_fees: priority_fees
+    }
   end
 end

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -623,6 +623,28 @@ defmodule Explorer.Chain.Block do
     |> where([block], block.hash in ^hashes)
   end
 
+  @doc """
+  Calculates and aggregates transaction-related metrics for a block if not already aggregated.
+
+  This function processes all transactions in a block to compute aggregate
+  statistics including transaction counts, fees, burnt fees, and priority fees.
+  The aggregation only occurs if the block has not been previously aggregated
+  (when `aggregated?` is `nil` or `false`) and contains a list of transactions.
+
+  For each transaction, the function calculates:
+  - Total transaction fees (gas_used * gas_price)
+  - Burnt fees (gas_used * base_fee_per_gas)
+  - Priority fees paid to miners (min of priority fee and effective fee)
+  - Blob transaction detection (type 3 transactions)
+
+  ## Parameters
+  - `block`: A Block struct containing transactions to be aggregated
+
+  ## Returns
+  - Block struct with aggregated transaction metrics and `aggregated?` set to `true`
+  - Original block unchanged if already aggregated or transactions is not a list
+  """
+  @spec aggregate_transactions(t()) :: t()
   def aggregate_transactions(%__MODULE__{transactions: transactions, aggregated?: aggregated?} = block)
       when is_list(transactions) and aggregated? in [nil, false] do
     aggregate_results =

--- a/apps/explorer/lib/explorer/chain/cache/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/cache/blocks.ex
@@ -38,4 +38,10 @@ defmodule Explorer.Chain.Cache.Blocks do
   end
 
   def drop_nonconsensus(number) when not is_nil(number), do: drop_nonconsensus([number])
+
+  def sanitize_before_update(block) do
+    block = Block.aggregate_transactions(block)
+
+    %{block | transactions: []}
+  end
 end

--- a/apps/explorer/lib/explorer/chain/cache/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/cache/blocks.ex
@@ -39,6 +39,27 @@ defmodule Explorer.Chain.Cache.Blocks do
 
   def drop_nonconsensus(number) when not is_nil(number), do: drop_nonconsensus([number])
 
+  @doc """
+  Prepares a block for cache update by aggregating transaction metrics and clearing the transactions list.
+
+  This function ensures that all transaction-related statistics are calculated
+  and stored in the block's virtual fields before removing the transactions
+  list. This optimization allows the block to retain computed aggregate data
+  while eliminating the need to store redundant transaction references that
+  are maintained separately in the database.
+
+  The function first triggers transaction aggregation to compute metrics such
+  as transaction counts, total fees, burnt fees, and priority fees. After
+  aggregation is complete, the transactions list is cleared to reduce memory
+  usage.
+
+  ## Parameters
+  - `block`: A Block struct that may contain transactions to be aggregated
+
+  ## Returns
+  - Block struct with aggregated transaction metrics and an empty transactions list
+  """
+  @spec sanitize_before_update(Block.t()) :: Block.t()
   def sanitize_before_update(block) do
     block = Block.aggregate_transactions(block)
 

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -118,6 +118,14 @@ defmodule Explorer.Chain.OrderedCache do
   @callback atomic_take_enough(integer()) :: [element] | nil
 
   @doc """
+  Processes the elements before updating the cache.
+  This function is called before the `update/1` function and can be used to
+  modify the elements to be inserted. Can be used to optimize memory usage along
+  with fetching time.
+  """
+  @callback sanitize_before_update(element) :: element
+
+  @doc """
   Adds an element, or a list of elements, to the cache.
   When the cache is full, only the most prevailing elements will be stored, based
   on `c:prevails?/2`.
@@ -168,6 +176,9 @@ defmodule Explorer.Chain.OrderedCache do
 
       @impl OrderedCache
       def element_to_id(element), do: element
+
+      @impl OrderedCache
+      def sanitize_before_update(element), do: element
 
       ### Straightforward fetching functions
 
@@ -250,7 +261,7 @@ defmodule Explorer.Chain.OrderedCache do
             |> Enum.sort_by(&element_to_id(&1), &prevails?(&1, &2))
             |> Enum.take(max_size())
             |> do_preloads()
-            |> Enum.map(&{element_to_id(&1), &1})
+            |> Enum.map(&{element_to_id(&1), sanitize_before_update(&1)})
             |> merge_and_update(ids || [], max_size())
 
           # ids_list is set to never expire
@@ -372,7 +383,8 @@ defmodule Explorer.Chain.OrderedCache do
                      max_size: 0,
                      preloads: 0,
                      prevails?: 2,
-                     element_to_id: 1
+                     element_to_id: 1,
+                     sanitize_before_update: 1
     end
   end
 end

--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Helper do
 
   alias ABI.TypeDecoder
   alias Explorer.Chain
-  alias Explorer.Chain.{Data, Hash}
+  alias Explorer.Chain.{Data, Hash, Wei}
 
   import Ecto.Query, only: [where: 3]
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
@@ -487,6 +487,7 @@ defmodule Explorer.Helper do
   end
 
   @doc """
+  <<<<<<< HEAD
   Extracts the method ID from an ABI specification.
 
   ## Parameters
@@ -532,4 +533,28 @@ defmodule Explorer.Helper do
 
     Enum.map(params, &Map.merge(&1, %{inserted_at: now, updated_at: now}))
   end
+
+  @doc """
+  Converts various value types to a Decimal type.
+
+  This function handles multiple input types and ensures they are properly
+  converted to a Decimal representation.
+
+  ## Parameters
+  - `value`: The value to convert, which can be:
+    - `nil`: Converted to Decimal 0
+    - `%Wei{}`: The Decimal value is extracted from the struct
+    - `float`: Converted using Decimal.from_float/1
+    - `String.t()` or `integer()`: Converted using Decimal.new/1
+    - `Decimal.t()`: Returned unchanged
+
+  ## Returns
+  - A Decimal representation of the input value
+  """
+  @spec number_to_decimal(nil | Wei.t() | integer() | float() | String.t() | Decimal.t()) :: Decimal.t()
+  def number_to_decimal(nil), do: Decimal.new(0)
+  def number_to_decimal(%Wei{value: value}), do: value
+  def number_to_decimal(value) when is_float(value), do: Decimal.from_float(value)
+  def number_to_decimal(value) when is_binary(value) or is_integer(value), do: Decimal.new(value)
+  def number_to_decimal(%Decimal{} = value), do: value
 end

--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -487,7 +487,6 @@ defmodule Explorer.Helper do
   end
 
   @doc """
-  <<<<<<< HEAD
   Extracts the method ID from an ABI specification.
 
   ## Parameters

--- a/apps/explorer/test/explorer/chain/cache/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/blocks_test.exs
@@ -1,6 +1,7 @@
 defmodule Explorer.Chain.Cache.BlocksTest do
   use Explorer.DataCase
 
+  alias Explorer.Chain.Block
   alias Explorer.Chain.Cache.Blocks
   alias Explorer.Repo
 
@@ -16,7 +17,7 @@ defmodule Explorer.Chain.Cache.BlocksTest do
 
       Blocks.update(block)
 
-      assert Blocks.all() == [block]
+      assert Blocks.all() == [block |> Block.aggregate_transactions() |> Map.put(:transactions, [])]
     end
 
     test "adds a new elements removing the oldest one" do


### PR DESCRIPTION
Closes #12382 

## Changelog
- Now blocks are aggregated before storing in cache, so cache takes less memory and responds faster
- Along with this ^ another performance problem was observed and fixed, `priority_fee` was calculated for each block separately and not using preloaded transactions:
```elixir
priority_fee = block.base_fee_per_gas && BlockPriorityFeeCount.fetch(block.hash)
```
This most of the times issued a separate database request, so loading the list of blocks could result in up to 50 additional database requests
- Added benchmark for `api/v2/blocks`, to run: 
```bash
cd apps/block_scout_web
mix run benchmarks/block_scout_web/controllers/api/v2/block_controller_benchmark.exs
```
requires the same envs as tests

<details>
<summary>Benchmark results</summary>

```
##### With input  0 blocks   0 transactions per block #####
Name                                                      ips        average  deviation         median         99th %
GET /api/v2/blocks first page (cached) (master)        1.87 K      535.62 μs    ±71.46%      479.71 μs     2719.54 μs
GET /api/v2/blocks first page (cached)                 1.83 K      546.79 μs    ±75.85%      457.85 μs     2899.30 μs

Comparison: 
GET /api/v2/blocks first page (cached) (master)        1.87 K
GET /api/v2/blocks first page (cached)                 1.83 K - 1.02x slower +11.18 μs

Memory usage statistics:

Name                                                    average  deviation         median         99th %
GET /api/v2/blocks first page (cached) (master)        79.70 KB     ±0.67%       79.88 KB       79.88 KB
GET /api/v2/blocks first page (cached)                 79.73 KB     ±0.69%       79.91 KB       79.91 KB

Comparison: 
GET /api/v2/blocks first page (cached) (master)        79.88 KB
GET /api/v2/blocks first page (cached)                 79.73 KB - 1.00x memory usage +0.0308 KB

##### With input 51 blocks   0 transactions per block #####
Name                                                      ips        average  deviation         median         99th %
GET /api/v2/blocks first page (cached) (master)        277.58        3.60 ms    ±27.60%        3.40 ms        7.99 ms
GET /api/v2/blocks first page (cached)                 262.76        3.81 ms    ±23.17%        3.64 ms        6.21 ms

Comparison: 
GET /api/v2/blocks first page (cached) (master)        277.58
GET /api/v2/blocks first page (cached)                 262.76 - 1.06x slower +0.20 ms

Memory usage statistics:

Name                                                    average  deviation         median         99th %
GET /api/v2/blocks first page (cached) (master)         4.09 MB     ±0.02%        4.09 MB        4.10 MB
GET /api/v2/blocks first page (cached)                  4.10 MB     ±0.00%        4.10 MB        4.10 MB

Comparison: 
GET /api/v2/blocks first page (cached) (master)         4.09 MB
GET /api/v2/blocks first page (cached)                  4.10 MB - 1.00x memory usage +0.00801 MB

##### With input 51 blocks  10 transactions per block #####
Name                                                      ips        average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                 271.09        3.69 ms    ±94.28%        3.47 ms        6.03 ms
GET /api/v2/blocks first page (cached) (master)        241.99        4.13 ms    ±65.58%        4.02 ms        6.47 ms

Comparison: 
GET /api/v2/blocks first page (cached)                 271.09
GET /api/v2/blocks first page (cached) (master)        241.99 - 1.12x slower +0.44 ms

Memory usage statistics:

Name                                                    average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                  4.15 MB     ±0.00%        4.15 MB        4.15 MB
GET /api/v2/blocks first page (cached) (master)         4.60 MB     ±0.01%        4.60 MB        4.60 MB

Comparison: 
GET /api/v2/blocks first page (cached)                  4.15 MB
GET /api/v2/blocks first page (cached) (master)         4.60 MB - 1.11x memory usage +0.45 MB

##### With input 51 blocks 100 transactions per block #####
Name                                                      ips        average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                 295.99        3.38 ms    ±18.31%        3.29 ms        5.08 ms
GET /api/v2/blocks first page (cached) (master)         64.96       15.39 ms    ±27.60%       17.06 ms       24.50 ms

Comparison: 
GET /api/v2/blocks first page (cached)                 295.99
GET /api/v2/blocks first page (cached) (master)         64.96 - 4.56x slower +12.01 ms

Memory usage statistics:

Name                                                    average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                  4.16 MB     ±0.00%        4.16 MB        4.16 MB
GET /api/v2/blocks first page (cached) (master)         8.61 MB     ±0.01%        8.61 MB        8.61 MB

Comparison: 
GET /api/v2/blocks first page (cached)                  4.16 MB
GET /api/v2/blocks first page (cached) (master)         8.61 MB - 2.07x memory usage +4.45 MB

##### With input 51 blocks 500 transactions per block #####
Name                                                      ips        average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                 312.34        3.20 ms    ±16.99%        3.13 ms        4.76 ms
GET /api/v2/blocks first page (cached) (master)         12.38       80.77 ms    ±32.57%       86.77 ms      135.85 ms

Comparison: 
GET /api/v2/blocks first page (cached)                 312.34
GET /api/v2/blocks first page (cached) (master)         12.38 - 25.23x slower +77.56 ms

Memory usage statistics:

Name                                                    average  deviation         median         99th %
GET /api/v2/blocks first page (cached)                  4.15 MB     ±0.00%        4.15 MB        4.15 MB
GET /api/v2/blocks first page (cached) (master)        26.59 MB     ±0.00%       26.59 MB       26.59 MB

Comparison: 
GET /api/v2/blocks first page (cached)                  4.15 MB
GET /api/v2/blocks first page (cached) (master)        26.59 MB - 6.40x memory usage +22.43 MB
```
</details>
tldr: with quite heavy blocks (that have a lot of transactions) old cache can take up to 80.77 ms to respond while optimized version takes 3.20 ms


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced benchmarking tools for measuring API endpoint performance.
  - Added support for aggregating transaction metrics within blocks, including fees and transaction counts.
- **Refactor**
  - Centralized transaction aggregation logic, simplifying how transaction metrics are accessed and rendered.
  - Improved cache update process by sanitizing data before storage to optimize memory and performance.
  - Enhanced caching behaviour to allow element sanitization before update.
  - Added helper function for consistent numeric to decimal conversions.
- **Bug Fixes**
  - Ensured precomputed transaction metrics are used throughout the application for consistency.
- **Chores**
  - Added benchmarking dependencies and support files for improved testing and performance analysis.
  - Updated translation source references to reflect codebase changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->