### PR TITLE
feat: Add `internal_transactions_count` prop in api/v2/blocks/:block endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -127,7 +127,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         :nephews => :optional,
         :rewards => :optional,
         :transactions => :optional,
-        :withdrawals => :optional
+        :withdrawals => :optional,
+        :internal_transactions => :optional
       }
       |> Map.merge(@chain_type_block_necessity_by_association),
     api?: true

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -40,6 +40,7 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "transactions_count" => count_transactions(block),
       # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
       "transaction_count" => count_transactions(block),
+      "internal_transactions_count" => count_internal_transactions(block),
       "miner" => Helper.address_with_info(nil, block.miner, block.miner_hash, false),
       "size" => block.size,
       "hash" => block.hash,
@@ -96,11 +97,17 @@ defmodule BlockScoutWeb.API.V2.BlockView do
 
   def burnt_fees_percentage(_, _), do: nil
 
-  def count_transactions(%Block{transactions: transactions}) when is_list(transactions), do: Enum.count(transactions)
-  def count_transactions(_), do: nil
+  defp count_transactions(%Block{transactions: transactions}) when is_list(transactions), do: Enum.count(transactions)
+  defp count_transactions(_), do: nil
 
-  def count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
-  def count_withdrawals(_), do: nil
+  defp count_internal_transactions(%Block{internal_transactions: internal_transactions})
+       when is_list(internal_transactions),
+       do: Enum.count(internal_transactions)
+
+  defp count_internal_transactions(_), do: nil
+
+  defp count_withdrawals(%Block{withdrawals: withdrawals}) when is_list(withdrawals), do: Enum.count(withdrawals)
+  defp count_withdrawals(_), do: nil
 
   case @chain_type do
     :rsk ->

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -11,6 +11,7 @@ defmodule Explorer.Chain.Block.Schema do
     Address,
     Block,
     Hash,
+    InternalTransaction,
     PendingBlockOperation,
     Transaction,
     Wei,
@@ -164,6 +165,8 @@ defmodule Explorer.Chain.Block.Schema do
 
         has_many(:transactions, Transaction, references: :hash)
         has_many(:transaction_forks, Transaction.Fork, foreign_key: :uncle_hash, references: :hash)
+
+        has_many(:internal_transactions, InternalTransaction, foreign_key: :block_hash, references: :hash)
 
         has_many(:rewards, Reward, foreign_key: :block_hash, references: :hash)
 


### PR DESCRIPTION
Related to https://github.com/blockscout/frontend/issues/2698

## Motivation

To determine whether to display the internal transactions tab on a block, this PR adds a counter for internal transactions to the api/v2/blocks/:block endpoint.

## Changelog

Add `internal_transactions_count` in the response of api/v2/blocks/:block endpoint.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying the count of internal transactions within each block in the API response.

- **Enhancements**
  - Improved block data to optionally include details about internal transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->