### PR TITLE
perf: force index usage in `api/v2/addresses/:hash/transactions`

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -292,8 +292,22 @@ defmodule BlockScoutWeb.PagingHelper do
 
   def address_transactions_sorting(_), do: []
 
-  defp do_address_transaction_sorting("block_number", "asc"), do: [asc: :block_number, asc: :index]
-  defp do_address_transaction_sorting("block_number", "desc"), do: [desc: :block_number, desc: :index]
+  defp do_address_transaction_sorting("block_number", "asc"),
+    do: [
+      asc: :block_number,
+      asc: :index,
+      asc: :inserted_at,
+      desc: :hash
+    ]
+
+  defp do_address_transaction_sorting("block_number", "desc"),
+    do: [
+      desc: :block_number,
+      desc: :index,
+      desc: :inserted_at,
+      asc: :hash
+    ]
+
   defp do_address_transaction_sorting("value", "asc"), do: [asc: :value]
   defp do_address_transaction_sorting("value", "desc"), do: [desc: :value]
   defp do_address_transaction_sorting("fee", "asc"), do: [{:dynamic, :fee, :asc_nulls_first, Transaction.dynamic_fee()}]


### PR DESCRIPTION
Close #12393

## Changelog
- Added `in [hash]` instead of `= hash` along with order by hash, so planner choose the correct index
Plan of problematic request before:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=6.97..197.20 rows=51 width=836) (actual time=320487.813..320508.186 rows=51 loops=1)                                                                                                 |
|  ->  Result  (cost=6.97..3593225.46 rows=963309 width=836) (actual time=320487.812..320508.177 rows=51 loops=1)                                                                                  |
|        ->  Incremental Sort  (cost=6.97..2476819.14 rows=963309 width=835) (actual time=320487.187..320487.271 rows=51 loops=1)                                                                  |
|              Sort Key: t0.block_number DESC, t0.index DESC, t0.inserted_at DESC, t0.hash                                                                                                         |
|              Presorted Key: t0.block_number                                                                                                                                                      |
|              Full-sort Groups: 2  Sort Method: quicksort  Average Memory: 46kB  Peak Memory: 46kB                                                                                                |
|              ->  Index Scan Backward using transactions_block_number_index on transactions t0  (cost=0.44..2442020.88 rows=963309 width=835) (actual time=320171.451..320487.080 rows=54 loops=1)|
|                    Filter: (((error IS NULL) OR ((error)::text <> 'dropped/replaced'::text)) AND (to_address_hash = '\xa45b42a4855ac5cfefc64fd7079da6416511ec22'::bytea))                        |
|                    Rows Removed by Filter: 17108599                                                                                                                                              |
|        SubPlan 1                                                                                                                                                                                 |
|          ->  Limit  (cost=0.56..1.15 rows=1 width=33) (actual time=0.408..0.408 rows=0 loops=51)                                                                                                 |
|                ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.56..8.81 rows=14 width=33) (actual time=0.408..0.408 rows=0 loops=51)      |
|                      Index Cond: (transaction_hash = t0.hash)                                                                                                                                    |
|                      Heap Fetches: 0                                                                                                                                                             |
|Planning Time: 0.366 ms                                                                                                                                                                           |
|Execution Time: 320508.316 ms                                                                                                                                                                     |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```
Plan of problematic request after:
```
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                      |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=0.56..223.05 rows=51 width=836) (actual time=0.128..1.282 rows=51 loops=1)                                                                                                         |
|  ->  Index Scan Backward using transactions_to_address_hash_with_pending_index_asc on transactions t0  (cost=0.56..4202348.59 rows=963292 width=836) (actual time=0.127..1.276 rows=51 loops=1)|
|        Index Cond: (to_address_hash = ANY ('{"\\xa45b42a4855ac5cfefc64fd7079da6416511ec22"}'::bytea[]))                                                                                        |
|        Filter: ((error IS NULL) OR ((error)::text <> 'dropped/replaced'::text))                                                                                                                |
|        SubPlan 1                                                                                                                                                                               |
|          ->  Limit  (cost=0.56..1.15 rows=1 width=33) (actual time=0.021..0.021 rows=0 loops=51)                                                                                               |
|                ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.56..8.81 rows=14 width=33) (actual time=0.020..0.020 rows=0 loops=51)    |
|                      Index Cond: (transaction_hash = t0.hash)                                                                                                                                  |
|                      Heap Fetches: 0                                                                                                                                                           |
|Planning Time: 0.502 ms                                                                                                                                                                         |
|Execution Time: 1.357 ms                                                                                                                                                                        |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```
- Corrected the sort for reversed list of transactions (`?sort=block_number&order=desc`) so it uses index better (when order is the same or the same vice-versa i.e. all columns ordering reverted the query executes much faster)
Plan with sub-optimal oredering:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                                          |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=2080.03..2306.17 rows=51 width=836) (actual time=35945.647..35970.590 rows=51 loops=1)                                                                                                                 |
|  ->  Result  (cost=2080.03..4273930.07 rows=963388 width=836) (actual time=35945.645..35970.580 rows=51 loops=1)                                                                                                   |
|        ->  Incremental Sort  (cost=2080.03..3157432.20 rows=963388 width=835) (actual time=35945.554..35945.575 rows=51 loops=1)                                                                                   |
|              Sort Key: t0.to_address_hash DESC, t0.block_number, t0.index, t0.inserted_at DESC, t0.hash                                                                                                            |
|              Presorted Key: t0.to_address_hash                                                                                                                                                                     |
|              Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 58kB  Peak Memory: 58kB                                                                                                                  |
|              Pre-sorted Groups: 1  Sort Method: top-N heapsort  Average Memory: 70kB  Peak Memory: 70kB                                                                                                            |
|              ->  Index Scan Backward using transactions_to_address_hash_with_pending_index_asc on transactions t0  (cost=0.56..3095944.36 rows=963388 width=835) (actual time=0.951..35005.948 rows=973173 loops=1)|
|                    Index Cond: (to_address_hash = ANY ('{"\\xa45b42a4855ac5cfefc64fd7079da6416511ec22"}'::bytea[]))                                                                                                |
|                    Filter: ((error IS NULL) OR ((error)::text <> 'dropped/replaced'::text))                                                                                                                        |
|        SubPlan 1                                                                                                                                                                                                   |
|          ->  Limit  (cost=0.56..1.15 rows=1 width=33) (actual time=0.488..0.488 rows=0 loops=51)                                                                                                                   |
|                ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.56..8.81 rows=14 width=33) (actual time=0.487..0.487 rows=0 loops=51)                        |
|                      Index Cond: (transaction_hash = t0.hash)                                                                                                                                                      |
|                      Heap Fetches: 0                                                                                                                                                                               |
|Planning Time: 0.305 ms                                                                                                                                                                                             |
|Execution Time: 35970.670 ms                                                                                                                                                                                        |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```
Plan with correct ordering:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                                  |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Limit  (cost=0.56..223.05 rows=51 width=836) (actual time=0.166..2.583 rows=51 loops=1)                                                                                                     |
|  ->  Index Scan using transactions_to_address_hash_with_pending_index_asc on transactions t0  (cost=0.56..4203252.92 rows=963481 width=836) (actual time=0.165..2.564 rows=51 loops=1)     |
|        Index Cond: (to_address_hash = ANY ('{"\\xa45b42a4855ac5cfefc64fd7079da6416511ec22"}'::bytea[]))                                                                                    |
|        Filter: ((error IS NULL) OR ((error)::text <> 'dropped/replaced'::text))                                                                                                            |
|        SubPlan 1                                                                                                                                                                           |
|          ->  Limit  (cost=0.56..1.15 rows=1 width=33) (actual time=0.033..0.033 rows=0 loops=51)                                                                                           |
|                ->  Index Only Scan using token_transfers_transaction_hash_log_index_index on token_transfers  (cost=0.56..8.81 rows=14 width=33) (actual time=0.032..0.032 rows=0 loops=51)|
|                      Index Cond: (transaction_hash = t0.hash)                                                                                                                              |
|                      Heap Fetches: 0                                                                                                                                                       |
|Planning Time: 0.671 ms                                                                                                                                                                     |
|Execution Time: 2.651 ms                                                                                                                                                                    |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved sorting options for address transaction lists, allowing for more precise ordering by block number, index, time, and transaction hash.
- **Refactor**
	- Enhanced the internal sorting logic for address transaction queries to support advanced sorting criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->