### PR TITLE
chore: Improve logic behind emerging of custom fields in the response of `eth_getTransactionByHash` ETH RPC API endpoint

### DIFF
--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -950,9 +950,7 @@ defmodule Explorer.EthRPC do
     |> Map.put("maxPriorityFeePerGas", max_priority_fee_per_gas |> Wei.to(:wei) |> encode_quantity())
   end
 
-  defp maybe_add_eip_1559_fields(props, _) do
-    props
-  end
+  defp maybe_add_eip_1559_fields(props, _), do: props
 
   # yParity shouldn't be added for legacy (type 0) and is_nil(type) transactions
   defp maybe_add_y_parity(props, %Transaction{type: type, v: v}) when not is_nil(type) and type > 0 do
@@ -960,9 +958,7 @@ defmodule Explorer.EthRPC do
     |> Map.put("yParity", encode_quantity(v))
   end
 
-  defp maybe_add_y_parity(props, %Transaction{type: _type}) do
-    props
-  end
+  defp maybe_add_y_parity(props, %Transaction{type: _type}), do: props
 
   defp maybe_add_signed_authorizations(props, %Transaction{type: 4, signed_authorizations: signed_authorizations}) do
     prepared_signed_authorizations =
@@ -989,7 +985,7 @@ defmodule Explorer.EthRPC do
 
   defp maybe_add_signed_authorizations(props, _transaction), do: props
 
-  defp maybe_add_access_list(props, %Transaction{type: type}) when type > 0 do
+  defp maybe_add_access_list(props, %Transaction{type: type}) when not is_nil(type) and type > 0 do
     props
     |> Map.put("accessList", [])
   end

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -868,8 +868,6 @@ defmodule Explorer.EthRPC do
         "from" => transaction.from_address_hash,
         "gas" => encode_quantity(transaction.gas),
         "gasPrice" => transaction.gas_price |> Wei.to(:wei) |> encode_quantity(),
-        "maxPriorityFeePerGas" => transaction.max_priority_fee_per_gas |> Wei.to(:wei) |> encode_quantity(),
-        "maxFeePerGas" => transaction.max_fee_per_gas |> Wei.to(:wei) |> encode_quantity(),
         "hash" => transaction.hash,
         "input" => transaction.input,
         "nonce" => encode_quantity(transaction.nonce),
@@ -879,10 +877,11 @@ defmodule Explorer.EthRPC do
         "type" => encode_quantity(transaction.type),
         "chainId" => chain_id(),
         "v" => encode_quantity(transaction.v),
-        "yParity" => encode_quantity(transaction.v),
         "r" => encode_quantity(transaction.r),
         "s" => encode_quantity(transaction.s)
       }
+      |> maybe_add_eip_1559_fields(transaction)
+      |> maybe_add_y_parity(transaction)
       |> maybe_add_signed_authorizations(transaction)
       |> maybe_add_chain_type_extra_transaction_info_properties(transaction)
       |> maybe_add_access_list(transaction)
@@ -934,11 +933,35 @@ defmodule Explorer.EthRPC do
         "to" => transaction.to_address_hash,
         "transactionHash" => transaction.hash,
         "transactionIndex" => encode_quantity(transaction.index),
-        "type" => encode_quantity(transaction.type)
+        "type" => encode_quantity(transaction.type) || "0x0"
       }
       |> maybe_add_chain_type_extra_receipt_properties(transaction)
 
     {:ok, props}
+  end
+
+  defp maybe_add_eip_1559_fields(props, %Transaction{
+         max_fee_per_gas: max_fee_per_gas,
+         max_priority_fee_per_gas: max_priority_fee_per_gas
+       })
+       when not is_nil(max_fee_per_gas) and not is_nil(max_priority_fee_per_gas) do
+    props
+    |> Map.put("maxFeePerGas", max_fee_per_gas |> Wei.to(:wei) |> encode_quantity())
+    |> Map.put("maxPriorityFeePerGas", max_priority_fee_per_gas |> Wei.to(:wei) |> encode_quantity())
+  end
+
+  defp maybe_add_eip_1559_fields(props, _) do
+    props
+  end
+
+  # yParity shouldn't be added for legacy (type 0) transactions
+  defp maybe_add_y_parity(props, %Transaction{type: type, v: v}) when type > 0 do
+    props
+    |> Map.put("yParity", encode_quantity(v))
+  end
+
+  defp maybe_add_y_parity(props, %Transaction{type: _type}) do
+    props
   end
 
   defp maybe_add_signed_authorizations(props, %Transaction{type: 4, signed_authorizations: signed_authorizations}) do

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -954,8 +954,8 @@ defmodule Explorer.EthRPC do
     props
   end
 
-  # yParity shouldn't be added for legacy (type 0) transactions
-  defp maybe_add_y_parity(props, %Transaction{type: type, v: v}) when type > 0 do
+  # yParity shouldn't be added for legacy (type 0) and is_nil(type) transactions
+  defp maybe_add_y_parity(props, %Transaction{type: type, v: v}) when not is_nil(type) and type > 0 do
     props
     |> Map.put("yParity", encode_quantity(v))
   end


### PR DESCRIPTION
## Motivation

- The `yParity` field should not be included in the response of eth_getTransactionByHash for legacy (type 0) transactions.
- The fields `maxFeePerGas` and `maxPriorityFeePerGas` should only be returned if both are non-null.

## Changelog

### AI Agent summary

This pull request refactors the `Explorer.EthRPC` module to improve how optional transaction fields are handled. It introduces helper functions to conditionally add EIP-1559 fields and the `yParity` field, ensuring greater flexibility and cleaner code. Additionally, it modifies the default behavior for the `type` field in transaction receipts.

### Refactoring for optional transaction fields:

* Removed direct inclusion of `maxFeePerGas` and `maxPriorityFeePerGas` fields and replaced them with a new helper function `maybe_add_eip_1559_fields`, which conditionally adds these fields based on the presence of relevant data in the transaction. [[1]](diffhunk://#diff-b59057c82bd5148d563936390a818ea98005af9222841773688b868279ae13e6L871-L872) [[2]](diffhunk://#diff-b59057c82bd5148d563936390a818ea98005af9222841773688b868279ae13e6L882-R884) [[3]](diffhunk://#diff-b59057c82bd5148d563936390a818ea98005af9222841773688b868279ae13e6L937-R962)

* Introduced the `maybe_add_y_parity` helper function to conditionally add the `yParity` field for non-legacy transactions (type > 0), ensuring it is not included for legacy transactions. [[1]](diffhunk://#diff-b59057c82bd5148d563936390a818ea98005af9222841773688b868279ae13e6L882-R884) [[2]](diffhunk://#diff-b59057c82bd5148d563936390a818ea98005af9222841773688b868279ae13e6L937-R962)

### Default value adjustment:

* Updated the `type` field in transaction receipts to default to `"0x0"` if it is not explicitly provided, ensuring compatibility with legacy transactions.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how transaction details are displayed by conditionally including fee and parity fields based on transaction type and data availability, ensuring more accurate and relevant information is shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->