### PR TITLE
fix: Handle mismatched `0x` prefixed bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug Fixes
 
+- Handle mismatched 0x prefixed bytes ([#12453](https://github.com/blockscout/blockscout/pull/12453))
 - Fix logs decoding issue for proxies ([#12414](https://github.com/blockscout/blockscout/issues/12414))
 - Refactor TokenInstanceMetadataRefetch on demand fetcher ([#12419](https://github.com/blockscout/blockscout/issues/12419))
 - Fix for type output in ETH RPC API transaction by hash endpoint

--- a/apps/explorer/lib/explorer/chain/decoding_helper.ex
+++ b/apps/explorer/lib/explorer/chain/decoding_helper.ex
@@ -3,7 +3,6 @@ defmodule Explorer.Chain.DecodingHelper do
   Data decoding functions
   """
   alias ABI.FunctionSelector
-  alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Address, Hash}
 
   require Logger
@@ -55,7 +54,7 @@ defmodule Explorer.Chain.DecodingHelper do
   end
 
   defp base_value_json(_, {:dynamic, value}) do
-    ExplorerHelper.add_0x_prefix(value)
+    "0x" <> Base.encode16(value, case: :lower)
   end
 
   defp base_value_json(:address, value) do
@@ -66,7 +65,7 @@ defmodule Explorer.Chain.DecodingHelper do
   end
 
   defp base_value_json(:bytes, value) do
-    ExplorerHelper.add_0x_prefix(value)
+    "0x" <> Base.encode16(value, case: :lower)
   end
 
   defp base_value_json(_, value), do: to_string(value)


### PR DESCRIPTION
## Motivation
https://shapescan.xyz/api/v2/transactions/0xd6d7c981990d97f944559bc77d325a9b3559da13b0bd882fe44a8d689d3fb472

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to ensure transactions with input data starting with "0x" are correctly handled and returned by the API.

- **Bug Fixes**
  - Improved handling of byte data with "0x" prefixes to prevent mismatches.

- **Refactor**
  - Updated internal logic to directly prepend "0x" to hexadecimal-encoded binary values, removing reliance on an external helper. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->