### PR TITLE
chore: Support multiple interop messages view on transaction page

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -455,16 +455,10 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
     if interop_messages == [] do
       out_json
     else
-      op_interop =
-        if length(interop_messages) == 1 do
-          # if there is only one message, it should be returned as an item instead of the list of one item
-          # for backward compatibility
-          Enum.at(interop_messages, 0)
-        else
-          interop_messages
-        end
-
-      Map.put(out_json, "op_interop", op_interop)
+      out_json
+      |> Map.put("op_interop_messages", interop_messages)
+      # TODO: remove the deprecated `op_interop` map after frontend switches to the new `op_interop_messages`
+      |> Map.put("op_interop", Enum.at(interop_messages, 0))
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -446,16 +446,25 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
         }
       end)
 
-    interop_message =
+    interop_messages =
       transaction_hash
-      |> InteropMessage.message_by_transaction()
+      |> InteropMessage.messages_by_transaction()
 
     out_json = Map.put(out_json, "op_withdrawals", withdrawals)
 
-    if is_nil(interop_message) do
+    if interop_messages == [] do
       out_json
     else
-      Map.put(out_json, "op_interop", interop_message)
+      op_interop =
+        if length(interop_messages) == 1 do
+          # if there is only one message, it should be returned as an item instead of the list of one item
+          # for backward compatibility
+          Enum.at(interop_messages, 0)
+        else
+          interop_messages
+        end
+
+      Map.put(out_json, "op_interop", op_interop)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/optimism/interop_message.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/interop_message.ex
@@ -557,31 +557,28 @@ defmodule Explorer.Chain.Optimism.InteropMessage do
   end
 
   @doc """
-    Finds a message by transaction hash and prepares to display the message details on transaction page.
+    Finds messages by transaction hash and prepares to display the message details on transaction page.
     Used by `BlockScoutWeb.API.V2.OptimismView.add_optimism_fields` function.
 
     ## Parameters
-    - `transaction_hash`: The transaction hash we need to find the corresponding message for.
+    - `transaction_hash`: The transaction hash we need to find the corresponding messages for.
 
     ## Returns
-    - A map with message details ready to be displayed on transaction page.
-    - `nil` if the message not found.
+    - A list with maps containing message details ready to be displayed on transaction page. The list can be empty.
   """
-  @spec message_by_transaction(Hash.t()) :: map() | nil
-  def message_by_transaction(transaction_hash) do
+  @spec messages_by_transaction(Hash.t()) :: [map()]
+  def messages_by_transaction(transaction_hash) do
     query =
       from(
         m in __MODULE__,
-        where: m.init_transaction_hash == ^transaction_hash or m.relay_transaction_hash == ^transaction_hash,
-        limit: 1
+        where: m.init_transaction_hash == ^transaction_hash or m.relay_transaction_hash == ^transaction_hash
       )
 
-    message =
-      query
-      |> Repo.replica().one()
-      |> extend_with_status()
+    query
+    |> Repo.replica().all()
+    |> Enum.map(fn msg ->
+      message = extend_with_status(msg)
 
-    if not is_nil(message) do
       chain_info =
         if message.init_transaction_hash == transaction_hash do
           %{
@@ -609,7 +606,7 @@ defmodule Explorer.Chain.Optimism.InteropMessage do
         },
         chain_info
       )
-    end
+    end)
   end
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/interop/message_failed.ex
@@ -59,8 +59,7 @@ defmodule Indexer.Fetcher.Optimism.Interop.MessageFailed do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    {:ok, %{}, {:continue, args[:json_rpc_named_arguments]}}
   end
 
   # Initialization function which is used instead of `init` to avoid Supervisor's stop in case of any critical issues

--- a/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/withdrawal.ex
@@ -42,8 +42,7 @@ defmodule Indexer.Fetcher.Optimism.Withdrawal do
 
   @impl GenServer
   def init(args) do
-    json_rpc_named_arguments = args[:json_rpc_named_arguments]
-    {:ok, %{}, {:continue, json_rpc_named_arguments}}
+    {:ok, %{}, {:continue, args[:json_rpc_named_arguments]}}
   end
 
   @impl GenServer


### PR DESCRIPTION
## Motivation

The current `/api/v2/transactions/:transaction_hash_param` endpoint outputs only one OP interop message related to the transaction even when there are more than one such interop messages.

This PR extends the API endpoint to output a list of the messages.

## Changelog

Example of the modified output for https://optimism-interop-alpha-0.blockscout.com/api/v2/transactions/0x8e85b50ed266611cf1b978a35997442ff2d19ce1674a5adb8f8a4cdd5f2e674b:

```
  ...
  "op_interop_messages": [
    {
      "nonce": 2798,
      "payload": "0x7cfd6dbc000000000000000000000000bcaf2507a2ba54b5b9c43b09c0ceab5434bd681800000000000000000000000053e4f005029c106be2e34aa7cf4c01cff832ce6f000000000000000000000000e59ad7fa6f4d5a90c54a42a0b8cb4de9950684fd000000000000000000000000000000000000000000000001ec831809a5931931",
      "relay_chain": null,
      "relay_transaction_hash": null,
      "sender": "0x4200000000000000000000000000000000000028",
      "sender_address_hash": "0x4200000000000000000000000000000000000028",
      "status": "Sent",
      "target": "0x4200000000000000000000000000000000000028",
      "target_address_hash": "0x4200000000000000000000000000000000000028"
    },
    {
      "nonce": 2799,
      "payload": "0x7cfd6dbc000000000000000000000000bcaf2507a2ba54b5b9c43b09c0ceab5434bd681800000000000000000000000053e4f005029c106be2e34aa7cf4c01cff832ce6f000000000000000000000000e59ad7fa6f4d5a90c54a42a0b8cb4de9950684fd000000000000000000000000000000000000000000000001f4cb74f9fbc16c8b",
      "relay_chain": null,
      "relay_transaction_hash": null,
      "sender": "0x4200000000000000000000000000000000000028",
      "sender_address_hash": "0x4200000000000000000000000000000000000028",
      "status": "Sent",
      "target": "0x4200000000000000000000000000000000000028",
      "target_address_hash": "0x4200000000000000000000000000000000000028"
    },
    {
      "nonce": 2800,
      "payload": "0x7cfd6dbc000000000000000000000000ce63460925afe0fc517b4ff5aa8dd79e09a83ec800000000000000000000000053e4f005029c106be2e34aa7cf4c01cff832ce6f00000000000000000000000053e4f005029c106be2e34aa7cf4c01cff832ce6f0000000000000000000000000000000000000000000000000379483b827693f8",
      "relay_chain": null,
      "relay_transaction_hash": null,
      "sender": "0x4200000000000000000000000000000000000028",
      "sender_address_hash": "0x4200000000000000000000000000000000000028",
      "status": "Sent",
      "target": "0x4200000000000000000000000000000000000028",
      "target_address_hash": "0x4200000000000000000000000000000000000028"
    },
    ...
  ],
  "op_interop": {
    "nonce": 2798,
    "payload": "0x7cfd6dbc000000000000000000000000bcaf2507a2ba54b5b9c43b09c0ceab5434bd681800000000000000000000000053e4f005029c106be2e34aa7cf4c01cff832ce6f000000000000000000000000e59ad7fa6f4d5a90c54a42a0b8cb4de9950684fd000000000000000000000000000000000000000000000001ec831809a5931931",
    "relay_chain": null,
    "relay_transaction_hash": null,
    "sender": "0x4200000000000000000000000000000000000028",
    "sender_address_hash": "0x4200000000000000000000000000000000000028",
    "status": "Sent",
    "target": "0x4200000000000000000000000000000000000028",
    "target_address_hash": "0x4200000000000000000000000000000000000028"
  },
  ...
```

Please note that the `op_interop` map is kept for backward compatibility returning only one interop message related to the transaction. If `op_interop_messages` contains more than one item, the `op_interop` will contain the first item from the list.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for transactions with multiple interop messages, allowing users to view all related messages when applicable.
- **Bug Fixes**
  - Improved consistency in how interop messages are displayed for transactions, maintaining compatibility for single-message cases.
- **Refactor**
  - Streamlined internal processes for handling and displaying interop messages, resulting in cleaner and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->