### PR TITLE
fix: Multichain search export: retry only on failed chunks

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -69,9 +69,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
             {:error, data_to_retry} ->
               merged_data_to_retry = %{
-                addresses: data_to_retry.addresses ++ error.data_to_retry.addresses,
-                block_ranges: data_to_retry.block_ranges ++ error.data_to_retry.block_ranges,
-                hashes: data_to_retry.hashes ++ error.data_to_retry.hashes
+                addresses: error.data_to_retry.addresses ++ data_to_retry.addresses,
+                block_ranges: error.data_to_retry.block_ranges ++ data_to_retry.block_ranges,
+                hashes: error.data_to_retry.hashes ++ data_to_retry.hashes
               }
 
               {:error, merged_data_to_retry}

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -15,7 +15,6 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
   @max_concurrency 5
   @post_timeout :timer.minutes(5)
-  @request_error_msg "Error while sending request to Multichain Search DB Service"
   @unspecified "UNSPECIFIED"
 
   @doc """
@@ -35,11 +34,11 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   @spec batch_import(
           %{
             addresses: [Address.t()],
-            blocks: [Block.t()],
-            transactions: [Transaction.t()]
+            blocks: [Block.t() | %{hash: String.t(), hash_type: String.t()}],
+            transactions: [Transaction.t() | %{hash: String.t(), hash_type: String.t()}]
           },
           boolean()
-        ) :: {:error, :disabled | String.t() | Jason.DecodeError.t()} | {:ok, any()}
+        ) :: {:error, map()} | {:ok, any()}
   def batch_import(params, retry? \\ false) do
     if enabled?() do
       params_chunks = extract_batch_import_params_into_chunks(params)
@@ -56,11 +55,29 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
         {:ok, {:ok, _result}}, acc ->
           acc
 
-        {:ok, {:error, error}}, _acc ->
+        {:ok, {:error, error}}, acc ->
           on_error(error, retry?)
-          {:error, @request_error_msg}
 
-        {:exit, {export_body, reason}}, _acc ->
+          case acc do
+            {:ok, {:chunks_processed, _}} ->
+              {:error,
+               %{
+                 addresses: error.data_to_retry.addresses,
+                 block_ranges: error.data_to_retry.block_ranges,
+                 hashes: error.data_to_retry.hashes
+               }}
+
+            {:error, data_to_retry} ->
+              merged_data_to_retry = %{
+                addresses: data_to_retry.addresses ++ error.data_to_retry.addresses,
+                block_ranges: data_to_retry.block_ranges ++ error.data_to_retry.block_ranges,
+                hashes: data_to_retry.hashes ++ error.data_to_retry.hashes
+              }
+
+              {:error, merged_data_to_retry}
+          end
+
+        {:exit, {export_body, reason}}, acc ->
           on_error(
             %{
               url: url,
@@ -70,7 +87,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
             retry?
           )
 
-          {:error, @request_error_msg}
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          case acc do
+            {:ok, {:chunks_processed, _}} ->
+              {:error, export_body}
+
+            {:error, acc} ->
+              {:error, Map.merge(acc, export_body)}
+          end
       end)
     else
       {:ok, :service_disabled}
@@ -222,8 +246,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   """
   @spec extract_batch_import_params_into_chunks(%{
           addresses: [Address.t()],
-          blocks: [Block.t()],
-          transactions: [Transaction.t()]
+          blocks: [Block.t() | %{hash: String.t(), hash_type: String.t()}],
+          transactions: [Transaction.t() | %{hash: String.t(), hash_type: String.t()}]
         }) :: [
           %{
             api_key: String.t(),

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exs
@@ -5,6 +5,7 @@ defmodule Indexer.Fetcher.MultichainSearchDbExport.RetryTest do
   import ExUnit.CaptureLog, only: [capture_log: 1]
   import Mox
 
+  alias Explorer.Chain.MultichainSearchDbExportRetryQueue
   alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.TestHelper
   alias Indexer.Fetcher.MultichainSearchDbExport.Retry, as: MultichainSearchDbExportRetry
@@ -194,9 +195,9 @@ defmodule Indexer.Fetcher.MultichainSearchDbExport.RetryTest do
                   ]} = MultichainSearchDbExportRetry.run(export_data, nil)
         end)
 
-      assert log =~ "Batch export retry to the Multichain Search DB failed"
+      assert Repo.aggregate(MultichainSearchDbExportRetryQueue, :count, :hash) == 3
 
-      Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
+      assert log =~ "Batch export retry to the Multichain Search DB failed"
     end
   end
 end

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exs
@@ -3,6 +3,7 @@ defmodule Indexer.Fetcher.MultichainSearchDbExport.RetryTest do
   use Explorer.DataCase
 
   import ExUnit.CaptureLog, only: [capture_log: 1]
+  import Mox
 
   alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.TestHelper
@@ -112,33 +113,90 @@ defmodule Indexer.Fetcher.MultichainSearchDbExport.RetryTest do
       assert :ok = MultichainSearchDbExportRetry.run(export_data, nil)
     end
 
-    test "returns {:retry, export_data} on error", %{bypass: bypass} do
-      address = insert(:address)
+    test "returns {:retry, failed_data} on error where failed_data is only chunks that failed to export", %{
+      bypass: _bypass
+    } do
+      Application.put_env(:explorer, MultichainSearch,
+        service_url: "http://localhost:1234",
+        api_key: "12345",
+        addresses_chunk_size: 1
+      )
+
+      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
+        Application.put_env(:explorer, :http_adapter, HTTPoison)
+      end)
+
+      address_1 = insert(:address)
+      address_2 = insert(:address)
+      address_3 = insert(:address)
+      address_3_hash_string = to_string(address_3) |> String.downcase()
       block = insert(:block)
+      block_hash_string = to_string(block.hash)
+      block_number = to_string(block.number)
       transaction = insert(:transaction) |> with_block(block)
+      transaction_hash_string = to_string(transaction.hash)
 
       export_data = [
-        %{hash: address.hash.bytes, hash_type: :address},
+        %{hash: address_1.hash.bytes, hash_type: :address},
+        %{hash: address_2.hash.bytes, hash_type: :address},
+        %{hash: address_3.hash.bytes, hash_type: :address},
         %{hash: block.hash.bytes, hash_type: :block},
         %{hash: transaction.hash.bytes, hash_type: :transaction}
       ]
 
       TestHelper.get_chain_id_mock()
 
-      Bypass.expect_once(bypass, "POST", "/api/v1/import:batch", fn conn ->
-        Conn.resp(
-          conn,
-          500,
-          Jason.encode!(%{"status" => "ok"})
-        )
-      end)
+      for _ <- 0..2 do
+        Explorer.Mox.HTTPoison
+        |> expect(:post, fn "http://localhost:1234/api/v1/import:batch",
+                            body,
+                            [{"Content-Type", "application/json"}],
+                            _options ->
+          case Jason.decode(body) do
+            {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
+              {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+            _ ->
+              {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"status" => "ok"})}}
+          end
+        end)
+      end
 
       log =
         capture_log(fn ->
-          assert {:retry, ^export_data} = MultichainSearchDbExportRetry.run(export_data, nil)
+          assert {:retry,
+                  [
+                    %{
+                      addresses: [
+                        %{
+                          hash: ^address_3_hash_string,
+                          token_type: "UNSPECIFIED",
+                          is_contract: false,
+                          token_name: nil,
+                          contract_name: nil,
+                          ens_name: nil,
+                          is_token: false,
+                          is_verified_contract: false
+                        }
+                      ],
+                      block_ranges: [%{max_block_number: ^block_number, min_block_number: ^block_number}],
+                      hashes: [
+                        %{hash: ^block_hash_string, hash_type: "BLOCK"},
+                        %{
+                          hash: ^transaction_hash_string,
+                          hash_type: "TRANSACTION"
+                        }
+                      ]
+                    }
+                  ]} = MultichainSearchDbExportRetry.run(export_data, nil)
         end)
 
       assert log =~ "Batch export retry to the Multichain Search DB failed"
+
+      Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12422

## Motivation

Retry only failed chunks in the Multichain search export retry fetcher.

## Changelog

### AI Agent summary

This pull request introduces significant changes to the `MultichainSearch` module and its related components to improve error handling, enhance data processing, and expand test coverage. The most notable updates include modifying the `batch_import` function to handle partial failures more robustly, adding utility functions for data transformation, and updating tests to reflect the new behavior.

### Updates to `MultichainSearch` module:

* Enhanced the `batch_import` function to return detailed error information (`{:error, map()}`) instead of a generic error message, allowing for more granular error handling and retry logic. This includes merging retry data when multiple chunks fail. (`apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex`, [[1]](diffhunk://#diff-4df7b4dbbb83cc7019726f6f9832ba5b00d4e8c02cd006a4ce0fab194b6175c9L38-R51) [[2]](diffhunk://#diff-4df7b4dbbb83cc7019726f6f9832ba5b00d4e8c02cd006a4ce0fab194b6175c9L59-R82) [[3]](diffhunk://#diff-4df7b4dbbb83cc7019726f6f9832ba5b00d4e8c02cd006a4ce0fab194b6175c9L73-R99)

* Updated the type specifications for `blocks` and `transactions` in `batch_import` and `extract_batch_import_params_into_chunks` to support both structs and enriched maps containing `hash` and `hash_type`. (`apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex`, [[1]](diffhunk://#diff-4df7b4dbbb83cc7019726f6f9832ba5b00d4e8c02cd006a4ce0fab194b6175c9L38-R51) [[2]](diffhunk://#diff-4df7b4dbbb83cc7019726f6f9832ba5b00d4e8c02cd006a4ce0fab194b6175c9L225-R252)

### Test enhancements:

* Refactored tests to validate the new error structure (`{:error, data_to_retry}`) and ensure retry logic handles partial failures correctly. This includes verifying the retry data for failed chunks and adding assertions for enriched error details. (`apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs`, [[1]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L79-R79) [[2]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L118-R131) [[3]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L133-R146) [[4]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L182-R203) [[5]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L221-R245) [[6]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L260-R282)

* Added utility functions (`transaction_export_data`, `block_export_data`, and `address_export_data`) to transform data into the required export format, ensuring consistency across tests. (`apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs`, [apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exsR581-R607](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368R581-R607))

### Changes to `MultichainSearchDbExport.Retry`:

* Introduced a `prepare_export_data` function to categorize and enrich input hashes for addresses, blocks, and transactions, improving data preparation for batch imports. (`apps/indexer/lib/indexer/fetcher/multichain_search_db_export/retry.ex`, [[1]](diffhunk://#diff-9119f16311dffd2a7fd667e222807521548d6d5fd946ba8593063b7598977ae0L41-R113) [[2]](diffhunk://#diff-9119f16311dffd2a7fd667e222807521548d6d5fd946ba8593063b7598977ae0L92-L116)

* Updated the `run` function to handle partial failures by retrying only the failed chunks, leveraging the new error structure returned by `batch_import`. (`apps/indexer/lib/indexer/fetcher/multichain_search_db_export/retry.ex`, [apps/indexer/lib/indexer/fetcher/multichain_search_db_export/retry.exL41-R113](diffhunk://#diff-9119f16311dffd2a7fd667e222807521548d6d5fd946ba8593063b7598977ae0L41-R113))

### Test updates for `MultichainSearchDbExport.Retry`:

* Added a new test to verify that the retry logic processes only failed chunks and logs the appropriate error messages. Mocked HTTP responses to simulate partial failures. (`apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exs`, [apps/indexer/test/indexer/fetcher/multichain_search_db_export/retry_test.exsL115-R198](diffhunk://#diff-fd2472fb00ecf2b06ab6adc819099645743aa3fea43e879c9bd02e36f00990faL115-R198))

These changes collectively improve the robustness and maintainability of the `MultichainSearch` module and its associated components.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling during batch imports to accumulate detailed retry data for failed exports, enabling more precise identification and resolution of issues.
  - Improved retry logic to selectively retry only failed export chunks, reducing unnecessary retries.

- **Tests**
  - Updated and expanded tests to verify error scenarios return structured retry data with detailed export information.
  - Added helper functions in tests for consistent formatting and validation of retry data.
  - Introduced mocks to simulate partial failures and verify retry behavior more precisely.

- **Refactor**
  - Modularized data preparation and retry logic for improved clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->