### PR TITLE
Correctly use Geth importer for Besu genesis file.

### DIFF
--- a/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
+++ b/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
@@ -100,6 +100,12 @@ defmodule Explorer.ChainSpec.GenesisData do
         chain_spec = fetch_chain_spec(chain_spec_path)
         precompiles_config = fetch_precompiles_config(precompiled_config_path)
 
+        # If the variant is Besu, treat it as Geth for import purposes
+        variant =
+          case variant do
+            EthereumJSONRPC.Besu -> EthereumJSONRPC.Geth
+            _ -> variant
+          end
         extended_chain_spec = extend_chain_spec(chain_spec, precompiles_config, variant)
         import_genesis_accounts(extended_chain_spec, variant)
 


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

This pull request addresses an issue where Blockscout, when configured with the Besu variant and attempting to use the chain spec configuration, was incorrectly defaulting to the POA importer instead of the an appropriate importer for Besu. This resulted in the inability to load the initial accounts and verify the contracts loaded from the genesis file. 

I did some test with my blockscout instance and I verified that forcing to load using the Geth variant solve the importing problem (e.g. blockscout recognize the initial accounts as contract accounts)

## Changelog

### Bug Fixes

- Corrected the importer selection logic for the Besu variant when configuring the chain spec, ensuring the proper Besu genesis file importer is used.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

## Notes

Sadly, I don't have a local toolchain for Elixir and I tried to run the tests using codespaces without no success. Therefore, I not completely confident to add new tests if I can't even run them. Moreover, that part of the code does not seem to be tested at the moment (the importer is tested but not the gluecode that is choosing which importer to use as far as I know). The change is pretty trivial... if somebody can guide me how to test the code base on codespace I'm more than happy to add a test. 
