### PR TITLE
fix: Add missing preload for logs in /api/v2/transactions/:transactio…

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -8,6 +8,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   alias Explorer.Chain
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Data, InternalTransaction, Log, TokenTransfer, Transaction}
+  alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias HTTPoison.Response
 
   import Explorer.Chain.SmartContract.Proxy.Models.Implementation, only: [proxy_implementations_association: 0]
@@ -233,7 +234,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     full_options =
       [
         necessity_by_association: %{
-          [address: [:names, :smart_contract, proxy_implementations_association()]] => :optional
+          [address: [:names, :smart_contract, Implementation.proxy_implementations_smart_contracts_association()]] =>
+            :optional
         }
       ]
       |> Keyword.merge(@api_true)

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -8,10 +8,11 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   alias Explorer.Chain
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Data, InternalTransaction, Log, TokenTransfer, Transaction}
-  alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias HTTPoison.Response
 
-  import Explorer.Chain.SmartContract.Proxy.Models.Implementation, only: [proxy_implementations_association: 0]
+  import Explorer.Chain.SmartContract.Proxy.Models.Implementation,
+    only: [proxy_implementations_association: 0, proxy_implementations_smart_contracts_association: 0]
+
   import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
   import Explorer.Utility.Microservice, only: [base_url: 2, check_enabled: 2]
   require Logger
@@ -234,8 +235,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     full_options =
       [
         necessity_by_association: %{
-          [address: [:names, :smart_contract, Implementation.proxy_implementations_smart_contracts_association()]] =>
-            :optional
+          [address: [:names, :smart_contract, proxy_implementations_smart_contracts_association()]] => :optional
         }
       ]
       |> Keyword.merge(@api_true)
@@ -257,8 +257,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     log_options =
       [
         necessity_by_association: %{
-          [address: [:names, :smart_contract, Implementation.proxy_implementations_smart_contracts_association()]] =>
-            :optional
+          [address: [:names, :smart_contract, proxy_implementations_smart_contracts_association()]] => :optional
         },
         limit: @items_limit
       ]

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -257,7 +257,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     log_options =
       [
         necessity_by_association: %{
-          [address: [:names, :smart_contract, proxy_implementations_association()]] => :optional
+          [address: [:names, :smart_contract, Implementation.proxy_implementations_smart_contracts_association()]] =>
+            :optional
         },
         limit: @items_limit
       ]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -49,11 +49,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     :ok
   end
 
-  defp topic(topic_hex_string) do
-    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
-    topic
-  end
-
   describe "/addresses/{address_hash}" do
     test "get 200 on non existing address", %{conn: conn} do
       address = build(:address)
@@ -2371,7 +2366,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
           block: transaction.block,
           block_number: transaction.block_number,
           address: address,
-          first_topic: topic(@first_topic_hex_string_1)
+          first_topic: TestHelper.topic(@first_topic_hex_string_1)
         )
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/logs?topic=#{@first_topic_hex_string_1}")
@@ -2417,8 +2412,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       log =
         insert(:log,
           transaction: transaction,
-          first_topic: topic(topic1),
-          second_topic: topic(topic2),
+          first_topic: TestHelper.topic(topic1),
+          second_topic: TestHelper.topic(topic2),
           third_topic: nil,
           fourth_topic: nil,
           data: log_data,
@@ -2497,8 +2492,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       log =
         insert(:log,
           transaction: transaction,
-          first_topic: topic(topic1),
-          second_topic: topic(topic2),
+          first_topic: TestHelper.topic(topic1),
+          second_topic: TestHelper.topic(topic2),
           third_topic: nil,
           fourth_topic: nil,
           data: log_data,

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -297,4 +297,9 @@ defmodule Explorer.TestHelper do
       {:ok, "0x1"}
     end)
   end
+
+  def topic(topic_hex_string) do
+    {:ok, topic} = Explorer.Chain.Hash.Full.cast(topic_hex_string)
+    topic
+  end
 end


### PR DESCRIPTION
…n_hash_param/summary

## Motivation
```
** (Protocol.UndefinedError) protocol Enumerable not implemented for #Ecto.Association.NotLoaded<association :smart_contracts is not loaded> of type Ecto.Association.NotLoaded (a struct). This protocol is implemented for the following type(s): Cldr.Unit.Range, DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, Explorer.BoundQueue, File.Stream, Floki.HTMLTree, Flow, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Postgrex.Stream, Range, Stream, Timex.Interval
    (elixir 1.17.3) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.17.3) lib/enum.ex:166: Enumerable.reduce/3
    (elixir 1.17.3) lib/enum.ex:4423: Enum.flat_map/2
    (block_scout_web 8.1.0) lib/block_scout_web/views/api/v2/transaction_view.ex:268: anonymous fn/2 in BlockScoutWeb.API.V2.TransactionView.decode_logs/2
    (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (block_scout_web 8.1.0) lib/block_scout_web/views/api/v2/transaction_view.ex:266: BlockScoutWeb.API.V2.TransactionView.decode_logs/2
    (block_scout_web 8.1.0) lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex:247: BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation.prepare_logs/2
    (block_scout_web 8.1.0) lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex:191: BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation.prepare_request_body/1
```

## Changelog

- add missing preload
- add regression tests
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive tests for transaction summary endpoint, covering scenarios such as missing transactions, invalid hashes, service disablement, data structure validation, and pagination limits.
  - Updated tests to use a shared helper for topic conversion, improving consistency across test modules.
- **Chores**
  - Refactored internal test helpers to centralize topic conversion logic.
- **Bug Fixes**
  - Improved log decoding by updating proxy implementation associations used in transaction interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->