### PR TITLE
fix: prevent constant refetching of celo epoch blocks

### DIFF
--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -135,6 +135,7 @@ defmodule Explorer.Chain.TokenTransfer do
 
   use Explorer.Schema
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+  use Utils.RuntimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   require Explorer.Chain.TokenTransfer.Schema
 
@@ -633,29 +634,45 @@ defmodule Explorer.Chain.TokenTransfer do
           l.first_topic == ^@constant or
             l.first_topic == ^@erc1155_single_transfer_signature or
             l.first_topic == ^@erc1155_batch_transfer_signature,
-        where:
-          not exists(
-            from(tt in TokenTransfer,
-              # For Celo epoch blocks, `transaction_hash` can be `nil` in both
-              # `Log` and `TokenTransfer`. A direct SQL comparison `NULL = NULL`
-              # evaluates to `UNKNOWN` (effectively false in this context).
-              # Therefore, we need a NULL-safe comparison for
-              # `transaction_hash`. Additionally, `block_hash` is included in
-              # the join condition to uniquely identify the token transfer, as
-              # `transaction_hash` (when nil) and `log_index` alone are
-              # insufficient.
-              where:
-                tt.transaction_hash == parent_as(:log).transaction_hash or
-                  (is_nil(parent_as(:log).transaction_hash) and is_nil(tt.transaction_hash)),
-              where: tt.block_hash == parent_as(:log).block_hash,
-              where: tt.log_index == parent_as(:log).index
-            )
-          ),
+        where: not exists(token_transfer_exists_query()),
         select: l.block_number,
         distinct: l.block_number
       )
 
     Repo.stream_reduce(query, [], &[&1 | &2])
+  end
+
+  # Builds a query to check if a token transfer exists for a given log. Handles
+  # chain-specific logic for transaction_hash comparison.
+  #
+  # For Celo epoch blocks, `transaction_hash` can be `nil` in both `Log` and
+  # `TokenTransfer`. A direct SQL comparison `NULL = NULL` evaluates to
+  # `UNKNOWN` (effectively false in this context). Therefore, we need a
+  # NULL-safe comparison for `transaction_hash`. Additionally, `block_hash` is
+  # included in the join condition to uniquely identify the token transfer, as
+  # `transaction_hash` (when nil) and `log_index` alone are insufficient.
+  @spec token_transfer_exists_query() :: Ecto.Query.t()
+  defp token_transfer_exists_query do
+    query =
+      from(tt in TokenTransfer,
+        where: tt.block_hash == parent_as(:log).block_hash,
+        where: tt.log_index == parent_as(:log).index
+      )
+
+    chain_type()
+    |> case do
+      :celo ->
+        query
+        |> where(
+          [tt],
+          tt.transaction_hash == parent_as(:log).transaction_hash or
+            (is_nil(parent_as(:log).transaction_hash) and is_nil(tt.transaction_hash))
+        )
+
+      _ ->
+        query
+        |> where([tt], tt.transaction_hash == parent_as(:log).transaction_hash)
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -635,7 +635,7 @@ defmodule Explorer.Chain.TokenTransfer do
             l.first_topic == ^@erc1155_batch_transfer_signature,
         where:
           not exists(
-            from(tf in TokenTransfer,
+            from(tt in TokenTransfer,
               # For Celo epoch blocks, `transaction_hash` can be `nil` in both
               # `Log` and `TokenTransfer`. A direct SQL comparison `NULL = NULL`
               # evaluates to `UNKNOWN` (effectively false in this context).
@@ -645,10 +645,10 @@ defmodule Explorer.Chain.TokenTransfer do
               # `transaction_hash` (when nil) and `log_index` alone are
               # insufficient.
               where:
-                tf.transaction_hash == parent_as(:log).transaction_hash or
-                  (is_nil(parent_as(:log).transaction_hash) and is_nil(tf.transaction_hash)),
-              where: tf.block_hash == parent_as(:log).block_hash,
-              where: tf.log_index == parent_as(:log).index
+                tt.transaction_hash == parent_as(:log).transaction_hash or
+                  (is_nil(parent_as(:log).transaction_hash) and is_nil(tt.transaction_hash)),
+              where: tt.block_hash == parent_as(:log).block_hash,
+              where: tt.log_index == parent_as(:log).index
             )
           ),
         select: l.block_number,


### PR DESCRIPTION
## Motivation

The `uncataloged_token_transfer_block_numbers/0` was incorrectly identifying token transfers in Celo epoch blocks (where `transaction_hash` is `nil`) as uncataloged. This led to these blocks being continuously sent for refetching.

This PR addresses the issue by:
- Implementing a NULL-safe comparison for `transaction_hash` in the subquery. This ensures that if both the log's and the token  transfer's `transaction_hash` are `nil`, they are correctly matched.
- Adding `block_hash` to the join conditions in the subquery. This is necessary because `transaction_hash` (when `nil`) and `log_index` alone are not sufficient to uniquely identify a token transfer.
- Including an explanatory comment detailing the rationale for these changes.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of token transfers with missing transaction hashes, ensuring more accurate identification and display of token transfer records, especially for Celo epoch blocks.  
- **Tests**
  - Added tests to verify token transfer handling for Celo epoch blocks with missing transaction hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->