### PR TITLE
fix: Fix for `add_0x_prefix` function

### DIFF
--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -353,7 +353,7 @@ defmodule Explorer.Helper do
   end
 
   def add_0x_prefix(binary_hash) when is_binary(binary_hash) do
-    if String.starts_with?(binary_hash, "0x") do
+    if String.starts_with?(binary_hash, "0x") and String.length(binary_hash) == 42 do
       binary_hash
     else
       "0x" <> Base.encode16(binary_hash, case: :lower)


### PR DESCRIPTION
## Motivation

Explorer.Helper.add_0x_prefix function incorrectly handled addresses starting with "0x" in their binary representation, like `30787849009c24f10a91a327a9f2ed94ebc49ee9` (`3078` is `0x` itself).

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
