### PR TITLE
feat: Berachain support

### DIFF
--- a/.github/workflows/pre-release-berachain.yml
+++ b/.github/workflows/pre-release-berachain.yml
@@ -1,0 +1,62 @@
+name: Pre-release for Berachain
+
+on:
+  workflow_dispatch:
+    inputs:
+      number:
+        type: number
+        required: true
+
+env:
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 8.1.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+
+      - name: Build and push Docker image for Ethereum (indexer + API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/blockscout/blockscout-berachain:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain
+
+      - name: Build and push Docker image for Ethereum (indexer)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/blockscout/blockscout-berachain:${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-alpha.${{ inputs.number }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain

--- a/.github/workflows/publish-docker-image-for-berachain.yml
+++ b/.github/workflows/publish-docker-image-for-berachain.yml
@@ -1,0 +1,57 @@
+name: Berachain Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - production-berachain
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 8.1.1
+      DOCKER_CHAIN_NAME: berachain
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+      
+      - name: Build and push Docker image (indexer + API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags:  ghcr.io/blockscout/blockscout-${{ env.DOCKER_CHAIN_NAME }}:${{ env.RELEASE_VERSION }}-postrelease-${{ env.SHORT_SHA }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain
+
+      - name: Build and push Docker image (indexer)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/blockscout/blockscout-${{ env.DOCKER_CHAIN_NAME }}:${{ env.RELEASE_VERSION }}-postrelease-${{ env.SHORT_SHA }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain

--- a/.github/workflows/release-berachain.yml
+++ b/.github/workflows/release-berachain.yml
@@ -1,0 +1,60 @@
+name: Release for Berachain
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+env:
+  OTP_VERSION: ${{ vars.OTP_VERSION }}
+  ELIXIR_VERSION: ${{ vars.ELIXIR_VERSION }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 8.1.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          docker-remote-multi-platform: true
+          docker-arm-host: ${{ secrets.ARM_RUNNER_HOSTNAME }}
+          docker-arm-host-key: ${{ secrets.ARM_RUNNER_KEY }}
+
+      - name: Build and push Docker image for Ethereum (indexer + API)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/blockscout/blockscout-berachain:latest, ghcr.io/blockscout/blockscout-berachain:${{ env.RELEASE_VERSION }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain
+
+      - name: Build and push Docker image for Ethereum (indexer)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ghcr.io/blockscout/blockscout-berachain:${{ env.RELEASE_VERSION }}-indexer
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          build-args: |
+            DISABLE_API=true
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            CHAIN_TYPE=berachain

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_withdrawal_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_withdrawal_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule BlockScoutWeb.AddressWithdrawalControllerTest do
   use BlockScoutWeb.ConnCase, async: true
   use ExUnit.Case, async: false
+  require Decimal
 
   import BlockScoutWeb.Routers.WebRouter.Helpers, only: [address_withdrawal_path: 3, address_withdrawal_path: 4]
   import BlockScoutWeb.WeiHelper, only: [format_wei_value: 2]
@@ -70,7 +71,16 @@ defmodule BlockScoutWeb.AddressWithdrawalControllerTest do
 
       conn =
         get(conn, address_withdrawal_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address.hash)), %{
-          "index" => first_page |> List.last() |> (& &1.index).() |> Integer.to_string(),
+          "index" =>
+            first_page
+            |> List.last()
+            |> (& &1.index).()
+            |> case do
+              index when is_integer(index) -> Integer.to_string(index)
+              # `index` field is of decimal type for `berachain` chain type
+              index when Decimal.is_decimal(index) -> Decimal.to_string(index)
+              index -> index
+            end,
           "type" => "JSON"
         })
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   use BlockScoutWeb.ConnCase
   use EthereumJSONRPC.Case, async: false
   use BlockScoutWeb.ChannelCase
+  require Decimal
 
   alias ABI.{TypeDecoder, TypeEncoder}
   alias Explorer.{Chain, Repo, TestHelper}
@@ -3934,7 +3935,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   end
 
   defp compare_item(%Withdrawal{} = withdrawal, json) do
-    assert withdrawal.index == json["index"]
+    # `index` field is of decimal type for `berachain` chain type
+    if Decimal.is_decimal(withdrawal.index) do
+      assert withdrawal.index == Decimal.new(json["index"])
+    else
+      assert withdrawal.index == json["index"]
+    end
   end
 
   defp compare_item(%Instance{token: %Token{} = token} = instance, json) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule BlockScoutWeb.API.V2.BlockControllerTest do
   use BlockScoutWeb.ConnCase
+  require Decimal
 
   alias Explorer.Chain.{Address, Block, InternalTransaction, Transaction, Withdrawal}
 
@@ -500,7 +501,12 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
   end
 
   defp compare_item(%Withdrawal{} = withdrawal, json) do
-    assert withdrawal.index == json["index"]
+    # `index` field is of decimal type for `berachain` chain type
+    if Decimal.is_decimal(withdrawal.index) do
+      assert withdrawal.index == Decimal.new(json["index"])
+    else
+      assert withdrawal.index == json["index"]
+    end
   end
 
   defp compare_item(%InternalTransaction{} = internal_transaction, json) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/withdrawal_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/withdrawal_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule BlockScoutWeb.API.V2.WithdrawalControllerTest do
   use BlockScoutWeb.ConnCase
+  require Decimal
 
   alias Explorer.Chain.Withdrawal
 
@@ -50,7 +51,12 @@ defmodule BlockScoutWeb.API.V2.WithdrawalControllerTest do
   end
 
   defp compare_item(%Withdrawal{} = withdrawal, json) do
-    assert withdrawal.index == json["index"]
+    # `index` field is of decimal type for `berachain` chain type
+    if Decimal.is_decimal(withdrawal.index) do
+      assert withdrawal.index == Decimal.new(json["index"])
+    else
+      assert withdrawal.index == json["index"]
+    end
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, list) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/withdrawal_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/withdrawal_controller_test.exs
@@ -24,7 +24,7 @@ defmodule BlockScoutWeb.WithdrawalControllerTest do
       conn =
         get(conn, withdrawal_path(conn, :index), %{
           "type" => "JSON",
-          "index" => Integer.to_string(withdrawal.index)
+          "index" => withdrawal.index
         })
 
       items = Map.get(json_response(conn, 200), "items")

--- a/apps/explorer/config/dev.exs
+++ b/apps/explorer/config/dev.exs
@@ -31,7 +31,8 @@ for repo <- [
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
       Explorer.Repo.ZkSync,
-      Explorer.Repo.Neon
+      Explorer.Repo.Neon,
+      Explorer.Repo.Berachain
     ] do
   config :explorer, repo, timeout: :timer.seconds(80)
 end

--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -33,7 +33,8 @@ for repo <- [
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
       Explorer.Repo.ZkSync,
-      Explorer.Repo.Neon
+      Explorer.Repo.Neon,
+      Explorer.Repo.Berachain
     ] do
   config :explorer, repo,
     prepare: :unnamed,

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -72,7 +72,8 @@ for repo <- [
       Explorer.Repo.Suave,
       Explorer.Repo.Zilliqa,
       Explorer.Repo.ZkSync,
-      Explorer.Repo.Neon
+      Explorer.Repo.Neon,
+      Explorer.Repo.Berachain
     ] do
   config :explorer, repo,
     database: database,

--- a/apps/explorer/lib/explorer/chain/import/runner/withdrawals.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/withdrawals.ex
@@ -72,7 +72,7 @@ defmodule Explorer.Chain.Import.Runner.Withdrawals do
         repo,
         ordered_changes_list,
         conflict_target: [:index],
-        on_conflict: on_conflict,
+        on_conflict: if(Application.get_env(:explorer, :chain_type) == :berachain, do: :nothing, else: on_conflict),
         for: Withdrawal,
         returning: true,
         timeout: timeout,

--- a/apps/explorer/lib/explorer/chain/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/withdrawal.ex
@@ -4,6 +4,7 @@ defmodule Explorer.Chain.Withdrawal do
   """
 
   use Explorer.Schema
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Explorer.Chain.{Address, Block, Hash, Wei}
   alias Explorer.PagingOptions
@@ -12,8 +13,13 @@ defmodule Explorer.Chain.Withdrawal do
 
   @primary_key false
   typed_schema "withdrawals" do
-    field(:index, :integer, primary_key: true, null: false)
-    field(:validator_index, :integer, null: false)
+    field(:index, if(@chain_type == :berachain, do: :decimal, else: :integer),
+      primary_key: true,
+      null: false
+    )
+
+    field(:validator_index, if(@chain_type == :berachain, do: :decimal, else: :integer), null: false)
+
     field(:amount, Wei, null: false)
 
     belongs_to(:address, Address,

--- a/apps/explorer/lib/explorer/repo.ex
+++ b/apps/explorer/lib/explorer/repo.ex
@@ -152,7 +152,8 @@ defmodule Explorer.Repo do
         Explorer.Repo.Suave,
         Explorer.Repo.Zilliqa,
         Explorer.Repo.ZkSync,
-        Explorer.Repo.Neon
+        Explorer.Repo.Neon,
+        Explorer.Repo.Berachain
       ] do
     defmodule repo do
       use Ecto.Repo,

--- a/apps/explorer/priv/berachain/migrations/20250304153107_alter_withdrawals_validator_index_type.exs
+++ b/apps/explorer/priv/berachain/migrations/20250304153107_alter_withdrawals_validator_index_type.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Berachain.Migrations.AlterWithdrawalsValidatorIndexType do
+  use Ecto.Migration
+
+  def change do
+    alter table("withdrawals") do
+      modify(:validator_index, :numeric, precision: 20)
+    end
+  end
+end

--- a/apps/explorer/priv/berachain/migrations/20250304181359_alter_withdrawals_index_type.exs
+++ b/apps/explorer/priv/berachain/migrations/20250304181359_alter_withdrawals_index_type.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Berachain.Migrations.AlterWithdrawalsIndexType do
+  use Ecto.Migration
+
+  def change do
+    alter table("withdrawals") do
+      modify(:index, :numeric, precision: 20)
+    end
+  end
+end

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -25,7 +25,8 @@ defmodule ConfigHelper do
         suave: Explorer.Repo.Suave,
         zilliqa: Explorer.Repo.Zilliqa,
         zksync: Explorer.Repo.ZkSync,
-        neon: Explorer.Repo.Neon
+        neon: Explorer.Repo.Neon,
+        berachain: Explorer.Repo.Berachain
       }
       |> Map.get(chain_type())
 
@@ -307,6 +308,7 @@ defmodule ConfigHelper do
   @supported_chain_types [
     "default",
     "arbitrum",
+    "berachain",
     "blackfort",
     "celo",
     "ethereum",

--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -131,7 +131,8 @@ for repo <- [
       # Feature dependent repos
       Explorer.Repo.BridgedTokens,
       Explorer.Repo.ShrunkInternalTransactions,
-      Explorer.Repo.Neon
+      Explorer.Repo.Neon,
+      Explorer.Repo.Berachain
     ] do
   config :explorer, repo,
     database: database,

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -99,7 +99,8 @@ for repo <- [
       Explorer.Repo.Stability,
       Explorer.Repo.Zilliqa,
       Explorer.Repo.ZkSync,
-      Explorer.Repo.Neon
+      Explorer.Repo.Neon,
+      Explorer.Repo.Berachain
     ] do
   config :explorer, repo,
     url: System.get_env("DATABASE_URL"),

--- a/cspell.json
+++ b/cspell.json
@@ -71,6 +71,7 @@
         "bafybeihxuj",
         "balancemulti",
         "benchee",
+        "berachain",
         "beryx",
         "besu",
         "bignumber",


### PR DESCRIPTION
## Motivation

Add Berachain support through a new chain type.

## Changelog

`CHAIN_TYPE=berachain` (both, in compile-time and runtime) is introduced.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the "berachain" chain type across configuration and database modules.
  - Introduced a dedicated repository for Berachain, enabling chain-specific data handling.
- **Database**
  - Updated withdrawal-related fields and migrations to support decimal types for Berachain.
- **Bug Fixes**
  - Improved test logic to correctly handle decimal and integer types for withdrawal indices.
- **Chores**
  - Added "berachain" to the spell checker dictionary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->