### PR TITLE
fix: Store blocks_validated in DB for Stability Validators

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -330,12 +330,8 @@ defmodule BlockScoutWeb.PagingHelper do
   defp do_validators_stability_sorting("state", "desc"), do: [desc_nulls_last: :state]
   defp do_validators_stability_sorting("address_hash", "asc"), do: [asc_nulls_first: :address_hash]
   defp do_validators_stability_sorting("address_hash", "desc"), do: [desc_nulls_last: :address_hash]
-
-  defp do_validators_stability_sorting("blocks_validated", "asc"),
-    do: [{:dynamic, :blocks_validated, :asc_nulls_first, ValidatorStability.dynamic_validated_blocks()}]
-
-  defp do_validators_stability_sorting("blocks_validated", "desc"),
-    do: [{:dynamic, :blocks_validated, :desc_nulls_last, ValidatorStability.dynamic_validated_blocks()}]
+  defp do_validators_stability_sorting("blocks_validated", "asc"), do: [asc_nulls_first: :blocks_validated]
+  defp do_validators_stability_sorting("blocks_validated", "desc"), do: [desc_nulls_last: :blocks_validated]
 
   defp do_validators_stability_sorting(_, _), do: []
 

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -9,7 +9,6 @@ defmodule BlockScoutWeb.PagingHelper do
 
   alias Explorer.Chain.InternalTransaction.CallType, as: InternalTransactionCallType
   alias Explorer.Chain.InternalTransaction.Type, as: InternalTransactionType
-  alias Explorer.Chain.Stability.Validator, as: ValidatorStability
   alias Explorer.Chain.{SmartContract, Transaction}
   alias Explorer.{Helper, PagingOptions, SortingHelper}
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
@@ -57,14 +57,15 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
     end
 
     defp compare_item({%ValidatorStability{} = validator, count}, json) do
-      assert json["blocks_validated_count"] == count + 1
       assert compare_item(validator, json)
+      assert json["blocks_validated_count"] == count
     end
 
     describe "/validators/stability" do
       test "get paginated list of the validators", %{conn: conn} do
         validators =
-          insert_list(51, :validator_stability)
+          51
+          |> insert_list(:validator_stability)
           |> Enum.sort_by(
             fn validator ->
               {Keyword.fetch!(ValidatorStability.state_enum(), validator.state), validator.address_hash.bytes}
@@ -84,13 +85,8 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
       test "sort by blocks_validated asc", %{conn: conn} do
         validators =
           for _ <- 0..50 do
-            validator = insert(:validator_stability)
             blocks_count = Enum.random(0..50)
-
-            _ =
-              for _ <- 0..blocks_count do
-                insert(:block, miner_hash: validator.address_hash, miner: nil)
-              end
+            validator = insert(:validator_stability, blocks_validated: blocks_count)
 
             {validator, blocks_count}
           end
@@ -111,13 +107,8 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
       test "sort by blocks_validated desc", %{conn: conn} do
         validators =
           for _ <- 0..50 do
-            validator = insert(:validator_stability)
             blocks_count = Enum.random(0..50)
-
-            _ =
-              for _ <- 0..blocks_count do
-                insert(:block, miner_hash: validator.address_hash, miner: nil)
-              end
+            validator = insert(:validator_stability, blocks_validated: blocks_count)
 
             {validator, blocks_count}
           end

--- a/apps/explorer/lib/explorer/chain/import/runner/stability/validators.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/stability/validators.ex
@@ -1,0 +1,117 @@
+defmodule Explorer.Chain.Import.Runner.Stability.Validators do
+  @moduledoc """
+  Bulk updates `t:Explorer.Chain.Stability.Validator.t/0` blocks_validated counters.
+  """
+
+  require Ecto.Query
+
+  alias Ecto.{Multi, Repo}
+  alias Explorer.Chain.{Import, Stability.Validator}
+  alias Explorer.Prometheus.Instrumenter
+
+  import Ecto.Query, only: [from: 2, where: 3]
+
+  require Logger
+
+  @behaviour Import.Runner
+
+  # milliseconds
+  @timeout 60_000
+
+  @type imported :: [Validator.t()]
+
+  @impl Import.Runner
+  def ecto_schema_module, do: Validator
+
+  @impl Import.Runner
+  def option_key, do: :stability_validators
+
+  @impl Import.Runner
+  def imported_table_row do
+    %{
+      value_type: "[#{ecto_schema_module()}.t()]",
+      value_description: "List of `t:#{ecto_schema_module()}.t/0`s with updated counters"
+    }
+  end
+
+  @impl Import.Runner
+  def run(multi, changes_list, %{timestamps: timestamps} = options) do
+    insert_options =
+      options
+      |> Map.get(option_key(), %{})
+      |> Map.take(~w(timeout)a)
+      |> Map.put_new(:timeout, @timeout)
+      |> Map.put(:timestamps, timestamps)
+
+    Multi.run(multi, :stability_validators, fn repo, _ ->
+      Instrumenter.block_import_stage_runner(
+        fn -> update_counters(repo, changes_list, insert_options) end,
+        :block_referencing,
+        :stability_validators,
+        :stability_validators
+      )
+    end)
+  end
+
+  @impl Import.Runner
+  def timeout, do: @timeout
+
+  @spec update_counters(Repo.t(), [map()], %{
+          required(:timeout) => timeout,
+          required(:timestamps) => Import.timestamps()
+        }) ::
+          {:ok, [Validator.t()]}
+  defp update_counters(repo, changes_list, %{timeout: timeout, timestamps: timestamps}) when is_list(changes_list) do
+    if changes_list != [] do
+      # Get all address hashes from the changes
+      address_hashes = Enum.map(changes_list, & &1.address_hash)
+
+      # Get existing validators that match the address hashes
+      existing_validators =
+        Validator
+        |> where([v], v.address_hash in ^address_hashes)
+        |> repo.all(timeout: timeout)
+
+      # Update counters for each existing validator
+      updated_validators =
+        Enum.reduce(changes_list, [], fn change, acc ->
+          case Enum.find(existing_validators, &(&1.address_hash == change.address_hash)) do
+            nil ->
+              # Validator doesn't exist, log error and skip
+              Logger.error("Validator with address hash #{to_string(change.address_hash)} not found")
+              acc
+
+            validator ->
+              # Update the blocks_validated counter
+              # credo:disable-for-next-line
+              case repo.update_all(
+                     from(v in Validator, where: v.address_hash == ^change.address_hash),
+                     [
+                       inc: [blocks_validated: change.blocks_validated],
+                       set: [updated_at: timestamps.updated_at]
+                     ],
+                     timeout: timeout
+                   ) do
+                {1, _} ->
+                  # Successfully updated, add to result
+                  updated_validator = %Validator{
+                    address_hash: change.address_hash,
+                    blocks_validated: validator.blocks_validated + change.blocks_validated
+                  }
+
+                  [updated_validator | acc]
+
+                _ ->
+                  # Update failed, log error and skip
+                  Logger.error("Failed to update validator counter for address hash #{to_string(change.address_hash)}")
+                  acc
+              end
+          end
+        end)
+
+      {:ok, updated_validators}
+    else
+      {:ok, []}
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/stage/chain_type_specific.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/chain_type_specific.ex
@@ -71,6 +71,9 @@ defmodule Explorer.Chain.Import.Stage.ChainTypeSpecific do
       Runner.Zilliqa.AggregateQuorumCertificates,
       Runner.Zilliqa.NestedQuorumCertificates,
       Runner.Zilliqa.QuorumCertificates
+    ],
+    stability: [
+      Runner.Stability.Validators
     ]
   }
 

--- a/apps/explorer/lib/explorer/chain/stability/validator.ex
+++ b/apps/explorer/lib/explorer/chain/stability/validator.ex
@@ -239,20 +239,6 @@ defmodule Explorer.Chain.Stability.Validator do
   def state_enum, do: @state_enum
 
   @doc """
-    Returns dynamic query for validated blocks count. Needed for SortingHelper
-  """
-  @spec dynamic_validated_blocks() :: Ecto.Query.dynamic_expr()
-  def dynamic_validated_blocks do
-    dynamic(
-      [vs],
-      fragment(
-        "SELECT count(*) FROM blocks WHERE miner_hash = ?",
-        vs.address_hash
-      )
-    )
-  end
-
-  @doc """
     Returns total count of validators.
   """
   @spec count_validators() :: integer()

--- a/apps/explorer/lib/explorer/chain/stability/validator.ex
+++ b/apps/explorer/lib/explorer/chain/stability/validator.ex
@@ -5,7 +5,8 @@ defmodule Explorer.Chain.Stability.Validator do
 
   use Explorer.Schema
 
-  alias Explorer.Chain.{Address, Import}
+  alias BlockScoutWeb.GraphQL.Resolvers.Block
+  alias Explorer.Chain.{Address, Block, Import}
   alias Explorer.Chain.Hash.Address, as: HashAddress
   alias Explorer.{Chain, Repo, SortingHelper}
   alias Explorer.SmartContract.Reader
@@ -23,13 +24,13 @@ defmodule Explorer.Chain.Stability.Validator do
   typed_schema "validators_stability" do
     field(:address_hash, HashAddress, primary_key: true)
     field(:state, Ecto.Enum, values: @state_enum)
-    field(:blocks_validated, :integer, virtual: true)
+    field(:blocks_validated, :integer)
 
     has_one(:address, Address, foreign_key: :hash, references: :address_hash)
     timestamps()
   end
 
-  @required_attrs ~w(address_hash)a
+  @required_attrs ~w(address_hash blocks_validated)a
   @optional_attrs ~w(state)a
   def changeset(%__MODULE__{} = validator, attrs) do
     validator
@@ -55,13 +56,6 @@ defmodule Explorer.Chain.Stability.Validator do
 
     __MODULE__
     |> apply_filter_by_state(states)
-    |> select_merge([vs], %{
-      blocks_validated:
-        fragment(
-          "SELECT count(*) FROM blocks WHERE miner_hash = ?",
-          vs.address_hash
-        )
-    })
     |> Chain.join_associations(necessity_by_association)
     |> SortingHelper.apply_sorting(sorting, @default_sorting)
     |> SortingHelper.page_with_sorting(paging_options, sorting, @default_sorting)
@@ -218,7 +212,7 @@ defmodule Explorer.Chain.Stability.Validator do
   @spec insert_validators([map()]) :: {non_neg_integer(), nil | []}
   def insert_validators(validators) do
     Repo.insert_all(__MODULE__, validators,
-      on_conflict: {:replace_all_except, [:inserted_at]},
+      on_conflict: {:replace_all_except, [:inserted_at, :blocks_validated]},
       conflict_target: [:address_hash]
     )
   end
@@ -286,4 +280,18 @@ defmodule Explorer.Chain.Stability.Validator do
     |> where([vs], vs.state == :active)
     |> Repo.aggregate(:count, :address_hash)
   end
+
+  @doc """
+    Fetch blocks validated
+  """
+  @spec fetch_blocks_validated(list(binary())) :: list({binary(), integer()})
+  def fetch_blocks_validated([_ | _] = miner_address_hashes) do
+    Block
+    |> where([b], b.miner_hash in ^miner_address_hashes)
+    |> group_by([b], b.miner_hash)
+    |> select([b], {b.miner_hash, count(b.hash)})
+    |> Repo.all()
+  end
+
+  def fetch_blocks_validated(_), do: []
 end

--- a/apps/explorer/lib/explorer/chain/stability/validator.ex
+++ b/apps/explorer/lib/explorer/chain/stability/validator.ex
@@ -5,7 +5,6 @@ defmodule Explorer.Chain.Stability.Validator do
 
   use Explorer.Schema
 
-  alias BlockScoutWeb.GraphQL.Resolvers.Block
   alias Explorer.Chain.{Address, Block, Import}
   alias Explorer.Chain.Hash.Address, as: HashAddress
   alias Explorer.{Chain, Repo, SortingHelper}

--- a/apps/explorer/priv/stability/migrations/20250602163043_add_validator_blocks_validated_counter.exs
+++ b/apps/explorer/priv/stability/migrations/20250602163043_add_validator_blocks_validated_counter.exs
@@ -1,0 +1,23 @@
+defmodule Explorer.Repo.Stability.Migrations.AddValidatorBlocksValidatedCounter do
+  use Ecto.Migration
+
+  def change do
+    alter table(:validators_stability) do
+      add(:blocks_validated, :integer, null: true)
+    end
+
+    execute("""
+    UPDATE validators_stability v
+    SET blocks_validated = COALESCE(
+      (SELECT COUNT(*)
+       FROM blocks b
+       WHERE b.miner_hash = v.address_hash),
+      0
+    );
+    """)
+
+    alter table(:validators_stability) do
+      modify(:blocks_validated, :integer, null: false)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/stability/validators_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/stability/validators_test.exs
@@ -1,0 +1,178 @@
+if Application.compile_env(:explorer, :chain_type) == :stability do
+  defmodule Explorer.Chain.Import.Runner.Stability.ValidatorsTest do
+    use Explorer.DataCase
+
+    alias Ecto.Multi
+    alias Explorer.Chain.Stability.Validator
+    alias Explorer.Chain.Import.Runner.Stability.Validators
+
+    describe "run/1" do
+      test "updates blocks_validated counter for existing validators" do
+        # Insert some validators first
+        %Validator{address_hash: validator1_hash} =
+          insert(:validator_stability, blocks_validated: 5)
+
+        %Validator{address_hash: validator2_hash} =
+          insert(:validator_stability, blocks_validated: 3)
+
+        changes = [
+          %{
+            address_hash: validator1_hash,
+            blocks_validated: 2
+          },
+          %{
+            address_hash: validator2_hash,
+            blocks_validated: 1
+          }
+        ]
+
+        assert {:ok, %{stability_validators: updated_validators}} = run_changes(changes)
+
+        assert length(updated_validators) == 2
+
+        # Verify counters were updated in database
+        updated_validator1 = Repo.get(Validator, validator1_hash)
+        updated_validator2 = Repo.get(Validator, validator2_hash)
+
+        # 5 + 2
+        assert updated_validator1.blocks_validated == 7
+        # 3 + 1
+        assert updated_validator2.blocks_validated == 4
+      end
+
+      test "skips non-existent validators" do
+        # Insert one validator
+        %Validator{address_hash: existing_validator_hash} =
+          insert(:validator_stability, blocks_validated: 2)
+
+        # Try to update both existing and non-existing validator
+        non_existing_hash = "0x1111111111111111111111111111111111111111"
+
+        changes = [
+          %{
+            address_hash: existing_validator_hash,
+            blocks_validated: 3
+          },
+          %{
+            address_hash: non_existing_hash,
+            blocks_validated: 5
+          }
+        ]
+
+        assert {:ok, %{stability_validators: updated_validators}} = run_changes(changes)
+
+        # Only the existing validator should be in the result
+        assert length(updated_validators) == 1
+        [updated_validator] = updated_validators
+        assert updated_validator.address_hash == existing_validator_hash
+
+        # Verify the existing validator was updated
+        updated_validator_db = Repo.get(Validator, existing_validator_hash)
+        # 2 + 3
+        assert updated_validator_db.blocks_validated == 5
+
+        # Verify non-existing validator wasn't created
+        assert Repo.get(Validator, non_existing_hash) == nil
+      end
+
+      test "handles empty changes list" do
+        assert {:ok, %{stability_validators: []}} = run_changes([])
+      end
+
+      test "handles multiple increments for the same validator" do
+        %Validator{address_hash: validator_hash} =
+          insert(:validator_stability, blocks_validated: 10)
+
+        changes = [
+          %{
+            address_hash: validator_hash,
+            blocks_validated: 2
+          },
+          %{
+            address_hash: validator_hash,
+            blocks_validated: 3
+          }
+        ]
+
+        assert {:ok, %{stability_validators: updated_validators}} = run_changes(changes)
+
+        # Should have 2 entries in the result (one for each update)
+        assert length(updated_validators) == 2
+
+        # Verify the counter was incremented twice
+        updated_validator = Repo.get(Validator, validator_hash)
+        # 10 + 2 + 3
+        assert updated_validator.blocks_validated == 15
+      end
+
+      test "handles zero increment" do
+        %Validator{address_hash: validator_hash} =
+          insert(:validator_stability, blocks_validated: 7)
+
+        changes = [
+          %{
+            address_hash: validator_hash,
+            blocks_validated: 0
+          }
+        ]
+
+        assert {:ok, %{stability_validators: updated_validators}} = run_changes(changes)
+
+        assert length(updated_validators) == 1
+
+        # Verify the counter remained the same
+        updated_validator = Repo.get(Validator, validator_hash)
+        # 7 + 0
+        assert updated_validator.blocks_validated == 7
+      end
+
+      test "handles large increment values" do
+        %Validator{address_hash: validator_hash} =
+          insert(:validator_stability, blocks_validated: 1000)
+
+        changes = [
+          %{
+            address_hash: validator_hash,
+            blocks_validated: 999_999
+          }
+        ]
+
+        assert {:ok, %{stability_validators: updated_validators}} = run_changes(changes)
+
+        assert length(updated_validators) == 1
+
+        # Verify the counter was updated with large value
+        updated_validator = Repo.get(Validator, validator_hash)
+        # 1000 + 999999
+        assert updated_validator.blocks_validated == 1_000_999
+      end
+
+      test "is atomic - all updates succeed or all fail" do
+        # This test would be more complex to implement as it requires
+        # simulating database errors, but the Multi transaction
+        # ensures atomicity by design
+        %Validator{address_hash: validator_hash} =
+          insert(:validator_stability, blocks_validated: 5)
+
+        changes = [
+          %{
+            address_hash: validator_hash,
+            blocks_validated: 2
+          }
+        ]
+
+        # Normal case - should succeed
+        assert {:ok, %{stability_validators: _}} = run_changes(changes)
+      end
+    end
+
+    defp run_changes(changes) when is_list(changes) do
+      Multi.new()
+      |> Validators.run(changes, %{
+        timeout: :infinity,
+        timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+      })
+      |> Repo.transaction()
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -1319,7 +1319,8 @@ defmodule Explorer.Factory do
 
     %ValidatorStability{
       address_hash: address.hash,
-      state: Enum.random(0..2)
+      state: Enum.random(0..2),
+      blocks_validated: Enum.random(0..100)
     }
   end
 

--- a/apps/indexer/lib/indexer/fetcher/stability/validator.ex
+++ b/apps/indexer/lib/indexer/fetcher/stability/validator.ex
@@ -58,7 +58,11 @@ defmodule Indexer.Fetcher.Stability.Validator do
             |> ValidatorStability.append_timestamps()
           end)
 
-        ValidatorStability.insert_validators(active ++ inactive)
+        ValidatorStability.insert_validators(
+          (active ++ inactive)
+          |> add_blocks_validated(validators_from_db)
+        )
+
         ValidatorStability.delete_validators_by_address_hashes(address_hashes_to_drop_from_db)
 
       _ ->
@@ -67,6 +71,31 @@ defmodule Indexer.Fetcher.Stability.Validator do
 
     {:noreply, state}
   end
+
+  defp add_blocks_validated([_ | _] = validators, validators_from_db) do
+    validators_from_db_map =
+      Enum.reduce(validators_from_db, %{}, fn validator, map -> Map.put(map, validator.address_hash, true) end)
+
+    address_hashes_to_fetch_blocks_validated =
+      Enum.flat_map(validators, fn validator ->
+        if validators_from_db_map[validator.address_hash] do
+          []
+        else
+          [validator.address_hash]
+        end
+      end)
+
+    blocks_validated_map =
+      address_hashes_to_fetch_blocks_validated
+      |> ValidatorStability.fetch_blocks_validated()
+      |> Enum.into(%{})
+
+    Enum.map(validators, fn validator ->
+      Map.put(validator, :blocks_validated, blocks_validated_map[validator.address_hash] || 0)
+    end)
+  end
+
+  defp add_blocks_validated(validators, _), do: validators
 
   @spec trigger_update_validators_list() :: :ok
   def trigger_update_validators_list do

--- a/apps/indexer/lib/indexer/transform/stability/validators.ex
+++ b/apps/indexer/lib/indexer/transform/stability/validators.ex
@@ -1,0 +1,35 @@
+defmodule Indexer.Transform.Stability.Validators do
+  @moduledoc """
+  Helper functions for transforming blocks into stability validator counter updates.
+  """
+
+  require Logger
+
+  @doc """
+  Returns a list of validator counter updates given a list of blocks.
+  Only processes blocks for stability chain type.
+  """
+  def parse(blocks) do
+    chain_type = Application.get_env(:explorer, :chain_type)
+
+    if chain_type == :stability do
+      do_parse(blocks)
+    else
+      []
+    end
+  end
+
+  defp do_parse(blocks) when is_list(blocks) do
+    blocks
+    |> Enum.filter(&(&1[:miner_hash] != nil))
+    |> Enum.group_by(& &1[:miner_hash])
+    |> Enum.map(fn {miner_hash, validator_blocks} ->
+      %{
+        address_hash: miner_hash,
+        blocks_validated: length(validator_blocks)
+      }
+    end)
+  end
+
+  defp do_parse(_), do: []
+end

--- a/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/catchup/fetcher_test.exs
@@ -694,6 +694,167 @@ defmodule Indexer.Block.Catchup.FetcherTest do
 
       assert %{from_number: 1, to_number: 0} = Repo.one(MissingBlockRange)
     end
+
+    if Application.compile_env(:explorer, :chain_type) == :stability do
+      test "update stability validator counter", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        Application.put_env(:indexer, Indexer.Block.Catchup.Fetcher, batch_size: 1, concurrency: 10)
+        Application.put_env(:indexer, :block_ranges, "1..2")
+        start_supervised!({Task.Supervisor, name: Indexer.Block.Catchup.TaskSupervisor})
+        CoinBalanceCatchup.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+        InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+        Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+        TokenBalance.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+        MissingRangesCollector.start_link([])
+        MissingRangesManipulator.start_link([])
+
+        latest_block_number = 3
+        latest_block_quantity = integer_to_quantity(latest_block_number)
+
+        block_number = latest_block_number - 1
+        block_hash = block_hash()
+        block_hash_1 = block_hash()
+        block_quantity = integer_to_quantity(block_number)
+        block_quantity_1 = integer_to_quantity(block_number - 1)
+
+        validator = insert(:validator_stability)
+        miner_hash_data = to_string(validator.address_hash)
+        miner_hash_0 = address_hash()
+        miner_hash_0_data = to_string(miner_hash_0)
+
+        new_block_hash = block_hash()
+
+        refute block_hash == new_block_hash
+
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, 4, fn
+          %{method: "eth_getBlockByNumber", params: ["latest", false]}, _options ->
+            {:ok, %{"number" => latest_block_quantity}}
+
+          [
+            %{
+              id: id,
+              jsonrpc: "2.0",
+              method: "eth_getBlockByNumber",
+              params: [^block_quantity, true]
+            }
+          ],
+          _options ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 jsonrpc: "2.0",
+                 result: %{
+                   "hash" => to_string(block_hash),
+                   "number" => block_quantity,
+                   "difficulty" => "0x0",
+                   "gasLimit" => "0x0",
+                   "gasUsed" => "0x0",
+                   "extraData" => "0x0",
+                   "logsBloom" => "0x0",
+                   "miner" => miner_hash_data,
+                   "parentHash" =>
+                     block_hash()
+                     |> to_string(),
+                   "receiptsRoot" => "0x0",
+                   "size" => "0x0",
+                   "sha3Uncles" => "0x0",
+                   "stateRoot" => "0x0",
+                   "timestamp" => "0x0",
+                   "totalDifficulty" => "0x0",
+                   "transactions" => [],
+                   "transactionsRoot" => "0x0",
+                   "uncles" => []
+                 }
+               }
+             ]}
+
+          [%{id: id, jsonrpc: "2.0", method: "trace_block", params: [^block_quantity]}], _options ->
+            {
+              :ok,
+              [
+                %{
+                  id: id,
+                  jsonrpc: "2.0",
+                  result: []
+                }
+              ]
+            }
+
+          [%{id: id, jsonrpc: "2.0", method: "trace_block", params: [^block_quantity_1]}], _options ->
+            {
+              :ok,
+              [
+                %{
+                  id: id,
+                  jsonrpc: "2.0",
+                  result: []
+                }
+              ]
+            }
+
+          [
+            %{
+              id: id,
+              jsonrpc: "2.0",
+              method: "eth_getBlockByNumber",
+              params: [^block_quantity_1, true]
+            }
+          ],
+          _options ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 jsonrpc: "2.0",
+                 result: %{
+                   "hash" => to_string(block_hash_1),
+                   "number" => block_quantity_1,
+                   "difficulty" => "0x0",
+                   "gasLimit" => "0x0",
+                   "gasUsed" => "0x0",
+                   "extraData" => "0x0",
+                   "logsBloom" => "0x0",
+                   "miner" => miner_hash_data,
+                   "parentHash" =>
+                     block_hash()
+                     |> to_string(),
+                   "receiptsRoot" => "0x0",
+                   "size" => "0x0",
+                   "sha3Uncles" => "0x0",
+                   "stateRoot" => "0x0",
+                   "timestamp" => "0x0",
+                   "totalDifficulty" => "0x0",
+                   "transactions" => [],
+                   "transactionsRoot" => "0x0",
+                   "uncles" => []
+                 }
+               }
+             ]}
+        end)
+
+        assert count(Chain.Block) == 0
+
+        Process.sleep(50)
+
+        assert %{first_block_number: ^block_number, last_block_number: 1, missing_block_count: 2, shrunk: false} =
+                 Fetcher.task(%Fetcher{
+                   block_fetcher: %Block.Fetcher{
+                     callback_module: Fetcher,
+                     json_rpc_named_arguments: json_rpc_named_arguments
+                   }
+                 })
+
+        Process.sleep(3000)
+
+        assert count(Chain.Block) == 2
+
+        validator_from_db = Repo.get!(Explorer.Chain.Stability.Validator, validator.address_hash)
+        assert validator_from_db.blocks_validated == validator.blocks_validated + 2
+      end
+    end
   end
 
   defp count(schema) do

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -288,9 +288,11 @@ defmodule Indexer.Block.FetcherTest do
     } do
       block_number = @first_full_block_number
 
-      Indexer.Fetcher.Filecoin.AddressInfo.Supervisor.Case.start_supervised!(
-        json_rpc_named_arguments: json_rpc_named_arguments
-      )
+      if Application.get_env(:explorer, :chain_type) == :filecoin do
+        Indexer.Fetcher.Filecoin.AddressInfo.Supervisor.Case.start_supervised!(
+          json_rpc_named_arguments: json_rpc_named_arguments
+        )
+      end
 
       if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
         case Keyword.fetch!(json_rpc_named_arguments, :variant) do

--- a/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/realtime/fetcher_test.exs
@@ -847,6 +847,297 @@ defmodule Indexer.Block.Realtime.FetcherTest do
 
       Application.put_env(:indexer, :fetch_rewards_way, nil)
     end
+
+    if Application.compile_env(:explorer, :chain_type) == :stability do
+      @tag :no_geth
+      test "update stability validator counter", %{
+        block_fetcher: %Indexer.Block.Fetcher{} = block_fetcher,
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        Token.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+        ContractCode.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+        InternalTransaction.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+        UncleBlock.Supervisor.Case.start_supervised!(
+          block_fetcher: %Indexer.Block.Fetcher{json_rpc_named_arguments: json_rpc_named_arguments}
+        )
+
+        ReplacedTransaction.Supervisor.Case.start_supervised!()
+
+        Indexer.Fetcher.Filecoin.AddressInfo.Supervisor.Case.start_supervised!(
+          json_rpc_named_arguments: json_rpc_named_arguments
+        )
+
+        # In CELO network, there is a token duality feature where CELO can be used
+        # as both a native chain currency and as an ERC-20 token (GoldToken).
+        # Transactions that transfer CELO are also counted as token transfers, and
+        # the TokenInstance fetcher is called. However, for simplicity, we disable
+        # it in this test.
+        Application.put_env(:indexer, Indexer.Fetcher.TokenInstance.Realtime.Supervisor, disabled?: true)
+
+        on_exit(fn ->
+          Application.put_env(:indexer, Indexer.Fetcher.TokenInstance.Realtime.Supervisor, disabled?: false)
+        end)
+
+        validator_1 = insert(:validator_stability)
+        validator_2 = insert(:validator_stability)
+
+        if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+          EthereumJSONRPC.Mox
+          |> expect(:json_rpc, fn [
+                                    %{
+                                      id: 0,
+                                      jsonrpc: "2.0",
+                                      method: "eth_getBlockByNumber",
+                                      params: ["0x3C365F", true]
+                                    },
+                                    %{
+                                      id: 1,
+                                      jsonrpc: "2.0",
+                                      method: "eth_getBlockByNumber",
+                                      params: ["0x3C3660", true]
+                                    }
+                                  ],
+                                  _ ->
+            {:ok,
+             [
+               %{
+                 id: 0,
+                 jsonrpc: "2.0",
+                 result: %{
+                   "author" => "0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2",
+                   "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+                   "extraData" => "0xd583010b088650617269747986312e32372e32826c69",
+                   "gasLimit" => "0x7a1200",
+                   "gasUsed" => "0x2886e",
+                   "hash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+                   "logsBloom" =>
+                     "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                   "miner" => to_string(validator_1.address_hash),
+                   "number" => "0x3c365f",
+                   "parentHash" => "0x57f6d66e07488defccd5216c4d2968dd6afd3bd32415e284de3b02af6535e8dc",
+                   "receiptsRoot" => "0x111be72e682cea9c93e02f1ef503fb64aa821b2ef510fd9177c49b37d0af98b5",
+                   "sealFields" => [
+                     "0x841246c63f",
+                     "0xb841ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700"
+                   ],
+                   "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                   "signature" =>
+                     "ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700",
+                   "size" => "0x33e",
+                   "stateRoot" => "0x7f73f5fb9f891213b671356126c31e9795d038844392c7aa8800ed4f52307209",
+                   "step" => "306628159",
+                   "timestamp" => "0x5b61df3b",
+                   "totalDifficulty" => "0x3c365effffffffffffffffffffffffed7f0362",
+                   "transactions" => [],
+                   "transactionsRoot" => "0xd7c39a93eafe0bdcbd1324c13dcd674bed8c9fa8adbf8f95bf6a59788985da6f",
+                   "uncles" => ["0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cd"]
+                 }
+               },
+               %{
+                 id: 1,
+                 jsonrpc: "2.0",
+                 result: %{
+                   "author" => "0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3",
+                   "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+                   "extraData" => "0xd583010a068650617269747986312e32362e32826c69",
+                   "gasLimit" => "0x7a1200",
+                   "gasUsed" => "0x0",
+                   "hash" => "0xfb483e511d316fa4072694da3f7abc94b06286406af45061e5e681395bdc6815",
+                   "logsBloom" =>
+                     "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                   "miner" => to_string(validator_2.address_hash),
+                   "number" => "0x3c3660",
+                   "parentHash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+                   "receiptsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                   "sealFields" => [
+                     "0x841246c640",
+                     "0xb84114db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800"
+                   ],
+                   "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                   "signature" =>
+                     "14db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800",
+                   "size" => "0x243",
+                   "stateRoot" => "0x3174c461989e9f99e08fa9b4ffb8bce8d9a281c8fc9f80694bb9d3acd4f15559",
+                   "step" => "306628160",
+                   "timestamp" => "0x5b61df40",
+                   "totalDifficulty" => "0x3c365fffffffffffffffffffffffffed7f0360",
+                   "transactions" => [],
+                   "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                   "uncles" => []
+                 }
+               }
+             ]}
+          end)
+          |> expect(:json_rpc, 1, fn
+            [
+              %{id: 0, jsonrpc: "2.0", method: "trace_block", params: ["0x3C365F"]},
+              %{id: 1, jsonrpc: "2.0", method: "trace_block", params: ["0x3C3660"]}
+            ],
+            _ ->
+              {:ok,
+               [
+                 %{id: 0, jsonrpc: "2.0", result: []},
+                 %{id: 1, jsonrpc: "2.0", result: []}
+               ]}
+
+            [
+              %{
+                id: 0,
+                jsonrpc: "2.0",
+                method: "eth_getBlockByNumber",
+                params: ["0x3C365F", true]
+              }
+            ],
+            _ ->
+              {:ok,
+               [
+                 %{
+                   id: 0,
+                   jsonrpc: "2.0",
+                   result: %{
+                     "author" => "0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2",
+                     "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+                     "extraData" => "0xd583010b088650617269747986312e32372e32826c69",
+                     "gasLimit" => "0x7a1200",
+                     "gasUsed" => "0x2886e",
+                     "hash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+                     "logsBloom" =>
+                       "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                     "miner" => "0x5ee341ac44d344ade1ca3a771c59b98eb2a77df2",
+                     "number" => "0x3c365f",
+                     "parentHash" => "0x57f6d66e07488defccd5216c4d2968dd6afd3bd32415e284de3b02af6535e8dc",
+                     "receiptsRoot" => "0x111be72e682cea9c93e02f1ef503fb64aa821b2ef510fd9177c49b37d0af98b5",
+                     "sealFields" => [
+                       "0x841246c63f",
+                       "0xb841ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700"
+                     ],
+                     "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                     "signature" =>
+                       "ba3d11db672fd7893d1b7906275fa7c4c7f4fbcc8fa29eab0331480332361516545ef10a36d800ad2be2b449dde8d5703125156a9cf8a035f5a8623463e051b700",
+                     "size" => "0x33e",
+                     "stateRoot" => "0x7f73f5fb9f891213b671356126c31e9795d038844392c7aa8800ed4f52307209",
+                     "step" => "306628159",
+                     "timestamp" => "0x5b61df3b",
+                     "totalDifficulty" => "0x3c365effffffffffffffffffffffffed7f0362",
+                     "transactions" => [],
+                     "transactionsRoot" => "0xd7c39a93eafe0bdcbd1324c13dcd674bed8c9fa8adbf8f95bf6a59788985da6f",
+                     "uncles" => ["0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cd"]
+                   }
+                 }
+               ]}
+
+            [
+              %{
+                id: 0,
+                jsonrpc: "2.0",
+                method: "eth_getBlockByNumber",
+                params: ["0x3C3660", true]
+              }
+            ],
+            _ ->
+              {:ok,
+               [
+                 %{
+                   id: 0,
+                   jsonrpc: "2.0",
+                   result: %{
+                     "author" => "0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3",
+                     "difficulty" => "0xfffffffffffffffffffffffffffffffe",
+                     "extraData" => "0xd583010a068650617269747986312e32362e32826c69",
+                     "gasLimit" => "0x7a1200",
+                     "gasUsed" => "0x0",
+                     "hash" => "0xfb483e511d316fa4072694da3f7abc94b06286406af45061e5e681395bdc6815",
+                     "logsBloom" =>
+                       "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                     "miner" => "0x66c9343c7e8ca673a1fedf9dbf2cd7936dbbf7e3",
+                     "number" => "0x3c3660",
+                     "parentHash" => "0xa4ec735cabe1510b5ae081b30f17222580b4588dbec52830529753a688b046cc",
+                     "receiptsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                     "sealFields" => [
+                       "0x841246c640",
+                       "0xb84114db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800"
+                     ],
+                     "sha3Uncles" => "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                     "signature" =>
+                       "14db3fd7526b7ea3635f5c85c30dd8a645453aa2f8afe5fd33fe0ec663c9c7b653b0fb5d8dc7d0b809674fa9dca9887d1636a586bf62191da22255eb068bf20800",
+                     "size" => "0x243",
+                     "stateRoot" => "0x3174c461989e9f99e08fa9b4ffb8bce8d9a281c8fc9f80694bb9d3acd4f15559",
+                     "step" => "306628160",
+                     "timestamp" => "0x5b61df40",
+                     "totalDifficulty" => "0x3c365fffffffffffffffffffffffffed7f0360",
+                     "transactions" => [],
+                     "transactionsRoot" => "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                     "uncles" => []
+                   }
+                 }
+               ]}
+
+            [
+              %{
+                id: 0,
+                jsonrpc: "2.0",
+                method: "trace_replayBlockTransactions",
+                params: [
+                  "0x3C3660",
+                  ["trace"]
+                ]
+              },
+              %{
+                id: 1,
+                jsonrpc: "2.0",
+                method: "trace_replayBlockTransactions",
+                params: [
+                  "0x3C365F",
+                  ["trace"]
+                ]
+              }
+            ],
+            _ ->
+              {:ok,
+               [
+                 %{id: 0, jsonrpc: "2.0", result: []},
+                 %{
+                   id: 1,
+                   jsonrpc: "2.0",
+                   result: []
+                 }
+               ]}
+          end)
+        end
+
+        validator_1_address_hash = validator_1.address_hash
+        validator_2_address_hash = validator_2.address_hash
+
+        assert {:ok,
+                %{
+                  inserted: %{
+                    blocks: [%Chain.Block{number: 3_946_079}, %Chain.Block{number: 3_946_080}],
+                    stability_validators: [
+                      %Explorer.Chain.Stability.Validator{
+                        address_hash: ^validator_1_address_hash,
+                        blocks_validated: blocks_validated_1
+                      },
+                      %Explorer.Chain.Stability.Validator{
+                        address_hash: ^validator_2_address_hash,
+                        blocks_validated: blocks_validated_2
+                      }
+                    ]
+                  },
+                  errors: []
+                }} = Indexer.Block.Fetcher.fetch_and_import_range(block_fetcher, 3_946_079..3_946_080)
+
+        validator_from_db = Repo.get!(Explorer.Chain.Stability.Validator, validator_1.address_hash)
+        assert validator_from_db.blocks_validated == blocks_validated_1
+        assert validator_from_db.blocks_validated == validator_1.blocks_validated + 1
+
+        validator_from_db = Repo.get!(Explorer.Chain.Stability.Validator, validator_2.address_hash)
+        assert validator_from_db.blocks_validated == blocks_validated_2
+        assert validator_from_db.blocks_validated == validator_2.blocks_validated + 1
+      end
+    end
   end
 
   describe "start_fetch_and_import" do

--- a/apps/indexer/test/indexer/fetcher/stability/validator_test.exs
+++ b/apps/indexer/test/indexer/fetcher/stability/validator_test.exs
@@ -265,6 +265,206 @@ defmodule Indexer.Fetcher.Stability.ValidatorTest do
         assert %ValidatorStability{state: :probation} = map[validator_inactive1.address_hash.bytes]
         assert %ValidatorStability{state: :active} = map[validator_probation1.address_hash.bytes]
       end
+
+      test "handles blocks_validated for new and existing validators" do
+        # Create existing validators with known blocks_validated values
+        existing_validator_1 = insert(:validator_stability, state: :active, blocks_validated: 100)
+        existing_validator_2 = insert(:validator_stability, state: :inactive, blocks_validated: 50)
+
+        # Create some blocks for the new validators that will be added
+        new_validator_address_1 = insert(:address)
+        new_validator_address_2 = insert(:address)
+
+        # Insert blocks to test blocks_validated functionality
+        insert(:block, miner: new_validator_address_1)
+        insert(:block, miner: new_validator_address_1)
+        insert(:block, miner: new_validator_address_1)
+        insert(:block, miner: new_validator_address_2)
+        insert(:block, miner: new_validator_address_2)
+
+        start_supervised!({Indexer.Fetcher.Stability.Validator, name: Indexer.Fetcher.Stability.Validator})
+
+        # Mock the first call to get validator lists (existing + new validators in the network)
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn
+          [
+            %{
+              id: id_1,
+              jsonrpc: "2.0",
+              method: "eth_call",
+              params: [%{data: "0xa5aa7380", to: "0x0000000000000000000000000000000000000805"}, "latest"]
+            },
+            %{
+              id: id_2,
+              jsonrpc: "2.0",
+              method: "eth_call",
+              params: [%{data: "0xe35c0f7d", to: "0x0000000000000000000000000000000000000805"}, "latest"]
+            }
+          ],
+          _ ->
+            # Return all validators (existing + new)
+            <<"0x", _method_id::binary-size(8), result_all::binary>> =
+              [@accepts_list_of_addresses]
+              |> ABI.parse_specification()
+              |> Enum.at(0)
+              |> Encoder.encode_function_call([
+                [
+                  existing_validator_1.address_hash.bytes,
+                  existing_validator_2.address_hash.bytes,
+                  new_validator_address_1.hash.bytes,
+                  new_validator_address_2.hash.bytes
+                ]
+              ])
+
+            # Return active validators (subset of all)
+            <<"0x", _method_id::binary-size(8), result_active::binary>> =
+              [@accepts_list_of_addresses]
+              |> ABI.parse_specification()
+              |> Enum.at(0)
+              |> Encoder.encode_function_call([
+                [
+                  existing_validator_1.address_hash.bytes,
+                  new_validator_address_1.hash.bytes,
+                  new_validator_address_2.hash.bytes
+                ]
+              ])
+
+            {:ok,
+             [
+               %{
+                 id: id_1,
+                 jsonrpc: "2.0",
+                 result: "0x" <> result_active
+               },
+               %{
+                 id: id_2,
+                 jsonrpc: "2.0",
+                 result: "0x" <> result_all
+               }
+             ]}
+        end)
+
+        # Mock the second call to get missing blocks for active validators
+        "0x" <> existing_address_1 = to_string(existing_validator_1.address_hash)
+        "0x" <> new_address_1 = to_string(new_validator_address_1.hash)
+        "0x" <> new_address_2 = to_string(new_validator_address_2.hash)
+
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn
+          [
+            %{
+              id: id_1,
+              jsonrpc: "2.0",
+              method: "eth_call",
+              params: [
+                %{
+                  data: "0x41ee9a53000000000000000000000000" <> ^existing_address_1,
+                  to: "0x0000000000000000000000000000000000000805"
+                },
+                "latest"
+              ]
+            },
+            %{
+              id: id_2,
+              jsonrpc: "2.0",
+              method: "eth_call",
+              params: [
+                %{
+                  data: "0x41ee9a53000000000000000000000000" <> ^new_address_1,
+                  to: "0x0000000000000000000000000000000000000805"
+                },
+                "latest"
+              ]
+            },
+            %{
+              id: id_3,
+              jsonrpc: "2.0",
+              method: "eth_call",
+              params: [
+                %{
+                  data: "0x41ee9a53000000000000000000000000" <> ^new_address_2,
+                  to: "0x0000000000000000000000000000000000000805"
+                },
+                "latest"
+              ]
+            }
+          ],
+          _ ->
+            # Return missing blocks for each validator
+            <<"0x", _method_id::binary-size(8), result_1::binary>> =
+              [@accepts_integer]
+              |> ABI.parse_specification()
+              |> Enum.at(0)
+              # existing validator - still active
+              |> Encoder.encode_function_call([0])
+
+            <<"0x", _method_id::binary-size(8), result_2::binary>> =
+              [@accepts_integer]
+              |> ABI.parse_specification()
+              |> Enum.at(0)
+              # new validator 1 - active
+              |> Encoder.encode_function_call([0])
+
+            <<"0x", _method_id::binary-size(8), result_3::binary>> =
+              [@accepts_integer]
+              |> ABI.parse_specification()
+              |> Enum.at(0)
+              # new validator 2 - active
+              |> Encoder.encode_function_call([0])
+
+            {:ok,
+             [
+               %{
+                 id: id_1,
+                 jsonrpc: "2.0",
+                 result: "0x" <> result_1
+               },
+               %{
+                 id: id_2,
+                 jsonrpc: "2.0",
+                 result: "0x" <> result_2
+               },
+               %{
+                 id: id_3,
+                 jsonrpc: "2.0",
+                 result: "0x" <> result_3
+               }
+             ]}
+        end)
+
+        # Wait for async processing
+        :timer.sleep(100)
+
+        validators = ValidatorStability.get_all_validators()
+        assert Enum.count(validators) == 4
+
+        validator_map =
+          Enum.reduce(validators, %{}, fn validator, map ->
+            Map.put(map, validator.address_hash.bytes, validator)
+          end)
+
+        # Verify existing validators keep their original blocks_validated values
+        existing_val_1 = validator_map[existing_validator_1.address_hash.bytes]
+        existing_val_2 = validator_map[existing_validator_2.address_hash.bytes]
+
+        # Original value preserved
+        assert existing_val_1.blocks_validated == 100
+        # Original value preserved
+        assert existing_val_2.blocks_validated == 50
+        assert existing_val_1.state == :active
+        assert existing_val_2.state == :inactive
+
+        # Verify new validators get blocks_validated populated from database
+        new_val_1 = validator_map[new_validator_address_1.hash.bytes]
+        new_val_2 = validator_map[new_validator_address_2.hash.bytes]
+
+        # Should match actual blocks count
+        assert new_val_1.blocks_validated == 3
+        # Should match actual blocks count
+        assert new_val_2.blocks_validated == 2
+        assert new_val_1.state == :active
+        assert new_val_2.state == :active
+      end
     end
   end
 end

--- a/apps/indexer/test/indexer/transform/stability/validators_test.exs
+++ b/apps/indexer/test/indexer/transform/stability/validators_test.exs
@@ -1,0 +1,162 @@
+if Application.compile_env(:explorer, :chain_type) == :stability do
+  defmodule Indexer.Transform.Stability.ValidatorsTest do
+    use ExUnit.Case, async: true
+
+    alias Indexer.Transform.Stability.Validators
+
+    describe "parse/1" do
+      setup do
+        # Save original chain type and restore after each test
+        original_chain_type = Application.get_env(:explorer, :chain_type)
+
+        on_exit(fn ->
+          Application.put_env(:explorer, :chain_type, original_chain_type)
+        end)
+
+        :ok
+      end
+
+      test "parses blocks for stability chain type and returns validator counter updates" do
+        Application.put_env(:explorer, :chain_type, :stability)
+
+        blocks = [
+          %{
+            number: 100,
+            hash: "0xabc123",
+            miner_hash: "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          %{
+            number: 101,
+            hash: "0xdef456",
+            miner_hash: "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          %{
+            number: 102,
+            hash: "0x789012",
+            miner_hash: "0xabcdef1234567890abcdef1234567890abcdef12"
+          }
+        ]
+
+        result = Validators.parse(blocks)
+
+        expected = [
+          %{
+            address_hash: "0x1234567890abcdef1234567890abcdef12345678",
+            blocks_validated: 2
+          },
+          %{
+            address_hash: "0xabcdef1234567890abcdef1234567890abcdef12",
+            blocks_validated: 1
+          }
+        ]
+
+        # Sort both lists by address_hash for comparison
+        sorted_result = Enum.sort_by(result, & &1.address_hash)
+        sorted_expected = Enum.sort_by(expected, & &1.address_hash)
+
+        assert sorted_result == sorted_expected
+      end
+
+      test "filters out blocks with nil miner_hash" do
+        Application.put_env(:explorer, :chain_type, :stability)
+
+        blocks = [
+          %{
+            number: 100,
+            hash: "0xabc123",
+            miner_hash: "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          %{
+            number: 101,
+            hash: "0xdef456",
+            miner_hash: nil
+          },
+          %{
+            number: 102,
+            hash: "0x789012"
+            # no miner_hash field
+          }
+        ]
+
+        result = Validators.parse(blocks)
+
+        expected = [
+          %{
+            address_hash: "0x1234567890abcdef1234567890abcdef12345678",
+            blocks_validated: 1
+          }
+        ]
+
+        assert result == expected
+      end
+
+      test "returns empty list for non-stability chain type" do
+        Application.put_env(:explorer, :chain_type, :ethereum)
+
+        blocks = [
+          %{
+            number: 100,
+            hash: "0xabc123",
+            miner_hash: "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          %{
+            number: 101,
+            hash: "0xdef456",
+            miner_hash: "0xabcdef1234567890abcdef1234567890abcdef12"
+          }
+        ]
+
+        result = Validators.parse(blocks)
+
+        assert result == []
+      end
+
+      test "returns empty list for empty blocks list" do
+        Application.put_env(:explorer, :chain_type, :stability)
+
+        result = Validators.parse([])
+
+        assert result == []
+      end
+
+      test "returns empty list for nil input" do
+        Application.put_env(:explorer, :chain_type, :stability)
+
+        result = Validators.parse(nil)
+
+        assert result == []
+      end
+
+      test "groups multiple blocks by same validator correctly" do
+        Application.put_env(:explorer, :chain_type, :stability)
+
+        blocks = [
+          %{number: 100, hash: "0x1", miner_hash: "0x1111"},
+          %{number: 101, hash: "0x2", miner_hash: "0x1111"},
+          %{number: 102, hash: "0x3", miner_hash: "0x1111"},
+          %{number: 103, hash: "0x4", miner_hash: "0x2222"},
+          %{number: 104, hash: "0x5", miner_hash: "0x1111"}
+        ]
+
+        result = Validators.parse(blocks)
+
+        expected = [
+          %{
+            address_hash: "0x1111",
+            blocks_validated: 4
+          },
+          %{
+            address_hash: "0x2222",
+            blocks_validated: 1
+          }
+        ]
+
+        # Sort both lists by address_hash for comparison
+        sorted_result = Enum.sort_by(result, & &1.address_hash)
+        sorted_expected = Enum.sort_by(expected, & &1.address_hash)
+
+        assert sorted_result == sorted_expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #12281 

## Changelog
- Store `blocks_validated` in DB for Stability Validators

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a persistent counter for the number of blocks validated by each stability validator.
  - Stability validators' block counts are updated automatically during block import and reflected in the database.
  - Added parsing and importing support for stability validators in the block fetching process.
- **Bug Fixes**
  - Ensured accurate, atomic updates to validator counters, including handling multiple and zero increments.
- **Tests**
  - Added comprehensive tests covering validator counter updates during import and block processing, including edge cases.
- **Chores**
  - Database migration adds and initializes the new validator counter field.
  - Updated factory and test setups to support the new validator counter feature.
- **Refactor**
  - Simplified sorting logic for stability validators by using direct field sorting instead of dynamic queries.
  - Improved API test clarity by directly setting validator block counts instead of simulating via associated records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->