### PR TITLE
fix: add missing fields to Celo Epochs-related endpoints

### DIFF
--- a/apps/explorer/lib/explorer/chain/celo/helper.ex
+++ b/apps/explorer/lib/explorer/chain/celo/helper.ex
@@ -126,12 +126,13 @@ defmodule Explorer.Chain.Celo.Helper do
   @doc """
   Checks if an epoch number is prior to Celo L2 migration.
   """
-  @spec premigration_epoch_number?(non_neg_integer()) :: boolean()
-  def premigration_epoch_number?(epoch_number) do
+  @spec pre_migration_epoch_number?(non_neg_integer()) :: boolean()
+  def pre_migration_epoch_number?(epoch_number) do
     l2_migration_block_number = Application.get_env(:explorer, :celo)[:l2_migration_block]
 
     if l2_migration_block_number do
-      epoch_number < block_number_to_epoch_number(l2_migration_block_number)
+      l2_migration_epoch_number = l2_migration_block_number |> block_number_to_epoch_number()
+      epoch_number < l2_migration_epoch_number
     else
       true
     end


### PR DESCRIPTION
Add missing fields in the Celo epochs API after adjustments in the Figma layout. 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
