### PR TITLE
chore: Drop address_coin_balances value_fetched_at index

### DIFF
--- a/apps/explorer/priv/repo/migrations/20250613144606_drop_address_coin_balances_value_fetched_at_index.exs
+++ b/apps/explorer/priv/repo/migrations/20250613144606_drop_address_coin_balances_value_fetched_at_index.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.DropAddressCoinBalancesValueFetchedAtIndex do
+  use Ecto.Migration
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def change do
+    drop_if_exists(index(:address_coin_balances, [:value_fetched_at], concurrently: true))
+  end
+end


### PR DESCRIPTION
## Motivation

In case when `address_coin_balances` table has `null_frac = 0`, the `CoinBalance.latest_coin_balance_query/2` uses the `value_fetched_at` index instead of `unfetched_balances` which is much less efficient. On the other hand, the `value_fetched_at` is used only for `Explorer.Chain.stream_unfetched_balances/3` query. And since the `unfetched_balances` index is also suitable for this query, there is no reason to keep the `value_fetched_at` one.

## Changelog

Deleted the `address_coin_balances` `value_fetched_at` index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an existing database index to improve system performance during concurrent operations. No impact to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->