### PR TITLE
feat: add `creation_status` field to address response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -267,21 +267,21 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         %{
           "deployed_bytecode" => nil,
           "creation_bytecode" => init,
-          "status" => "selfdestructed"
+          "creation_status" => "selfdestructed"
         }
 
       {:failed, creation_code} ->
         %{
           "deployed_bytecode" => "0x",
           "creation_bytecode" => creation_code,
-          "status" => "failed"
+          "creation_status" => "failed"
         }
 
       {:ok, contract_code} ->
         %{
           "deployed_bytecode" => contract_code,
           "creation_bytecode" => AddressContractView.creation_code(address),
-          "status" => "success"
+          "creation_status" => "success"
         }
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -75,7 +75,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "watchlist_address_id" => nil,
         "has_beacon_chain_withdrawals" => false,
         "ens_domain_name" => nil,
-        "metadata" => nil
+        "metadata" => nil,
+        "creation_status" => nil
       }
 
       stub(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
@@ -117,7 +118,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         "watchlist_address_id" => nil,
         "has_beacon_chain_withdrawals" => false,
         "ens_domain_name" => nil,
-        "metadata" => nil
+        "metadata" => nil,
+        "creation_status" => nil
       }
 
       stub(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
@@ -157,6 +159,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
       assert response["is_contract"]
       assert response["creation_transaction_hash"] == to_string(succeeded_transaction.hash)
+      assert response["creation_status"] == "success"
     end
 
     defp check_response(pattern_response, response) do
@@ -273,6 +276,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "watchlist_names" => [],
                "creator_address_hash" => ^from,
                "creation_transaction_hash" => ^transaction_hash,
+               "creation_status" => "success",
                "proxy_type" => "eip1167",
                "implementations" => [
                  %{
@@ -323,6 +327,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "watchlist_names" => [],
                "creator_address_hash" => ^from,
                "creation_transaction_hash" => ^transaction_hash,
+               "creation_status" => "success",
                "proxy_type" => "eip1967",
                "implementations" => [
                  %{
@@ -396,6 +401,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "watchlist_names" => [],
                "creator_address_hash" => ^from,
                "creation_transaction_hash" => ^transaction_hash,
+               "creation_status" => "success",
                "proxy_type" => "resolved_delegate_proxy",
                "implementations" => [
                  %{

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -62,7 +62,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "implementations" => [],
                  "deployed_bytecode" => to_string(address.contract_code),
                  "creation_bytecode" => nil,
-                 "status" => "success"
+                 "creation_status" => "success"
                }
 
       insert(:transaction,
@@ -84,7 +84,34 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "deployed_bytecode" => to_string(address.contract_code),
                  "creation_bytecode" =>
                    "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                 "status" => "success"
+                 "creation_status" => "success"
+               }
+    end
+
+    test "get unverified smart-contract with failed creation status", %{conn: conn} do
+      address = insert(:address, contract_code: "0x")
+
+      creation_bytecode =
+        "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029"
+
+      insert(:transaction,
+        created_contract_address_hash: address.hash,
+        input: creation_bytecode
+      )
+      |> with_block(status: :error)
+
+      TestHelper.get_eip1967_implementation_error_response()
+
+      request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")
+      response = json_response(request, 200)
+
+      assert response ==
+               %{
+                 "proxy_type" => nil,
+                 "implementations" => [],
+                 "deployed_bytecode" => "0x",
+                 "creation_bytecode" => creation_bytecode,
+                 "creation_status" => "failed"
                }
     end
 
@@ -109,7 +136,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       assert implementation.proxy_type == :eip1967
 
       request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(proxy_address.hash)}")
-      response = json_response(request, 200)
+      json_response(request, 200)
     end
 
     test "get smart-contract", %{conn: conn} do
@@ -179,7 +206,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "license_type" => "none",
         "certified" => false,
         "is_blueprint" => false,
-        "status" => "success"
+        "creation_status" => "success"
       }
 
       TestHelper.get_eip1967_implementation_non_zero_address(implementation_address_hash_string)
@@ -547,7 +574,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "license_type" => "none",
         "certified" => false,
         "is_blueprint" => true,
-        "status" => "success"
+        "creation_status" => "success"
       }
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
@@ -728,7 +755,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         TestHelper.get_all_proxies_implementation_zero_addresses()
@@ -813,7 +840,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         TestHelper.get_all_proxies_implementation_zero_addresses()
@@ -945,7 +972,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")
@@ -1032,7 +1059,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         TestHelper.get_all_proxies_implementation_zero_addresses()
@@ -1152,7 +1179,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")
@@ -1289,7 +1316,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")
@@ -1426,7 +1453,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "deployed_bytecode" => to_string(address.contract_code),
                    "creation_bytecode" =>
                      "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
-                   "status" => "success"
+                   "creation_status" => "success"
                  }
 
         request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(address.hash)}")


### PR DESCRIPTION
Related to https://github.com/blockscout/frontend/issues/2658.

We should add `creation_status` field to `/api/v2/address/:hash` response, so the frontend can display the status of contract's creation transaction.

Also this PR renames `status` field to `creation_status` in `/api/v2/smart-contracts/:hash` response, just for naming alignment. 

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "creation_status" field to address API responses, indicating the creation status of smart contract addresses.
  - Updated smart contract API responses to use the "creation_status" field for contract creation status.

- **Tests**
  - Updated tests to validate the presence and correctness of the "creation_status" field in address API responses.
  - Added tests covering failed creation status for unverified smart contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->