### PR TITLE
fix: hide market data when fetching disabled

### DIFF
--- a/apps/explorer/benchmarks/explorer/chain/tokens.exs
+++ b/apps/explorer/benchmarks/explorer/chain/tokens.exs
@@ -1,0 +1,64 @@
+defmodule Explorer.Chain.FiatValueBenchmark do
+  @moduledoc """
+  Benchmark for the performance of fetching fiat value type data from the database.
+  """
+
+  use Explorer.BenchmarkCase
+
+  alias Explorer.Repo
+  alias Explorer.Chain.Token
+  alias Explorer.Market.Fetcher.Token, as: TokenFetcher
+
+  def list_tokens do
+    Benchee.run(%{"Fiat value type performance" => fn _ -> Repo.all(Token) end},
+      inputs:
+        for with_market_data <- [false, true],
+            enabled_token_fetcher? when with_market_data or not enabled_token_fetcher? <- [false, true],
+            token_count <- [50, 100, 10000],
+            into: %{} do
+          {"#{token_count} tokens#{if with_market_data, do: " with market data", else: ""}#{if enabled_token_fetcher?, do: " with enabled token fetcher", else: ""}",
+           %{
+             token_count: token_count,
+             with_market_data: with_market_data,
+             enabled_token_fetcher: enabled_token_fetcher?
+           }}
+        end,
+      before_scenario: fn %{
+                            token_count: token_count,
+                            with_market_data: with_market_data,
+                            enabled_token_fetcher: enabled_token_fetcher?
+                          } = input ->
+        :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo, ownership_timeout: :infinity)
+
+        Repo.delete_all(Token)
+
+        market_data = fn i ->
+          if with_market_data do
+            [fiat_value: Decimal.new(i), circulating_market_cap: Decimal.new(i)]
+          else
+            [fiat_value: nil, circulating_market_cap: nil]
+          end
+        end
+
+        1..token_count
+        |> Enum.each(fn i ->
+          insert(:token, market_data.(i))
+        end)
+
+        if enabled_token_fetcher? do
+          Application.put_env(:explorer, Explorer.Market.Source, tokens_source: Explorer.Market.Source.OneCoinSource)
+          TokenFetcher.start_link([])
+        end
+      end,
+      load: @path,
+      save: [
+        path: @path,
+        tag: "fiat-value-no-check"
+      ],
+      time: 5,
+      formatters: [Benchee.Formatters.Console]
+    )
+  end
+end
+
+Explorer.Chain.FiatValueBenchmark.list_tokens()

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -3,6 +3,7 @@ defmodule Explorer.Chain.Token.Schema do
   use Utils.CompileTimeEnvHelper, bridged_tokens_enabled: [:explorer, [Explorer.Chain.BridgedToken, :enabled]]
 
   alias Explorer.Chain.{Address, Hash}
+  alias Explorer.Chain.Token.FiatValue
 
   if @bridged_tokens_enabled do
     @bridged_field [
@@ -28,11 +29,11 @@ defmodule Explorer.Chain.Token.Schema do
         field(:skip_metadata, :boolean)
         field(:total_supply_updated_at_block, :integer)
         field(:metadata_updated_at, :utc_datetime_usec)
-        field(:fiat_value, :decimal)
-        field(:circulating_market_cap, :decimal)
+        field(:fiat_value, FiatValue)
+        field(:circulating_market_cap, FiatValue)
         field(:icon_url, :string)
         field(:is_verified_via_admin_panel, :boolean)
-        field(:volume_24h, :decimal)
+        field(:volume_24h, FiatValue)
 
         belongs_to(
           :contract_address,

--- a/apps/explorer/lib/explorer/chain/token/fiat_value.ex
+++ b/apps/explorer/lib/explorer/chain/token/fiat_value.ex
@@ -1,0 +1,57 @@
+defmodule Explorer.Chain.Token.FiatValue do
+  @moduledoc """
+  Represents money values, used to hide the value if there is a chance that the value is not relevant.
+  """
+
+  use Ecto.Type
+
+  alias Explorer.Market.Fetcher.Token
+
+  @impl Ecto.Type
+  def type, do: :decimal
+
+  @impl Ecto.Type
+  def cast(value) when is_binary(value) do
+    case Decimal.parse(value) do
+      {decimal, ""} ->
+        {:ok, decimal}
+
+      _ ->
+        :error
+    end
+  end
+
+  @impl Ecto.Type
+  def cast(value) when is_integer(value) do
+    {:ok, Decimal.new(value)}
+  end
+
+  def cast(value) when is_float(value) do
+    {:ok, Decimal.from_float(value)}
+  end
+
+  @impl Ecto.Type
+  def cast(%Decimal{} = decimal) do
+    {:ok, decimal}
+  end
+
+  @impl Ecto.Type
+  def cast(_), do: :error
+
+  @impl Ecto.Type
+  def dump(%Decimal{} = decimal) do
+    {:ok, decimal}
+  end
+
+  @impl Ecto.Type
+  def dump(_), do: :error
+
+  @impl Ecto.Type
+  def load(%Decimal{} = decimal) do
+    if GenServer.whereis(Token) do
+      {:ok, decimal}
+    else
+      {:ok, nil}
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/market/fetcher/history.ex
+++ b/apps/explorer/lib/explorer/market/fetcher/history.ex
@@ -64,11 +64,16 @@ defmodule Explorer.Market.Fetcher.History do
          }}
       end)
 
-    state = %{types_states: types_states}
+    if Enum.all?(types_states, fn {_type, type_state} -> is_nil(type_state.source) end) do
+      Logger.info("No market history sources are configured")
+      :ignore
+    else
+      state = %{types_states: types_states}
 
-    send(self(), {:fetch_all, config(:first_fetch_day_count)})
+      send(self(), {:fetch_all, config(:first_fetch_day_count)})
 
-    {:ok, state}
+      {:ok, state}
+    end
   end
 
   def handle_info({:fetch_all, day_count}, state) do

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Market do
   Context for data related to the cryptocurrency market.
   """
 
-  alias Explorer.Market.Fetcher.Coin
+  alias Explorer.Market.Fetcher.{Coin, History}
   alias Explorer.Market.{MarketHistory, MarketHistoryCache, Token}
 
   @doc """
@@ -13,18 +13,11 @@ defmodule Explorer.Market do
   """
   @spec fetch_recent_history(boolean()) :: [MarketHistory.t()]
   def fetch_recent_history(secondary_coin? \\ false) do
-    MarketHistoryCache.fetch(secondary_coin?)
-  end
-
-  @doc """
-  Retrieves today's native coin exchange rate from the database.
-  """
-  @spec get_native_coin_exchange_rate_from_db(boolean()) :: Token.t()
-  def get_native_coin_exchange_rate_from_db(secondary_coin? \\ false) do
-    secondary_coin?
-    |> fetch_recent_history()
-    |> List.first()
-    |> MarketHistory.to_token()
+    if GenServer.whereis(History) do
+      MarketHistoryCache.fetch(secondary_coin?)
+    else
+      []
+    end
   end
 
   @doc """
@@ -32,7 +25,7 @@ defmodule Explorer.Market do
   """
   @spec get_coin_exchange_rate() :: Token.t()
   def get_coin_exchange_rate do
-    Coin.get_coin_exchange_rate() || get_native_coin_exchange_rate_from_db()
+    Coin.get_coin_exchange_rate() || Token.null()
   end
 
   @doc """
@@ -40,7 +33,7 @@ defmodule Explorer.Market do
   """
   @spec get_secondary_coin_exchange_rate() :: Token.t()
   def get_secondary_coin_exchange_rate do
-    Coin.get_secondary_coin_exchange_rate() || get_native_coin_exchange_rate_from_db(true)
+    Coin.get_secondary_coin_exchange_rate() || Token.null()
   end
 
   @doc """

--- a/apps/explorer/test/explorer/market/market_history_test.exs
+++ b/apps/explorer/test/explorer/market/market_history_test.exs
@@ -1,0 +1,81 @@
+defmodule Explorer.Market.MarketHistoryTest do
+  use Explorer.DataCase
+
+  alias Explorer.Repo
+  alias Explorer.Market.MarketHistory
+
+  describe "bulk_insert/1" do
+    test "inserts records" do
+      comparable_values = %{
+        ~D[2018-04-01] => %{
+          date: ~D[2018-04-01],
+          closing_price: Decimal.new(1),
+          opening_price: Decimal.new(1)
+        },
+        ~D[2018-04-02] => %{
+          date: ~D[2018-04-02],
+          closing_price: Decimal.new(1),
+          opening_price: Decimal.new(1)
+        },
+        ~D[2018-04-03] => %{
+          date: ~D[2018-04-03],
+          closing_price: Decimal.new(1),
+          opening_price: Decimal.new(1)
+        }
+      }
+
+      insertable_records = Map.values(comparable_values)
+      MarketHistory.bulk_insert(insertable_records)
+      history = Repo.all(MarketHistory)
+
+      missing_records =
+        Enum.reduce(history, comparable_values, fn record, acc ->
+          initial_record = Map.get(acc, record.date)
+          assert record.date == initial_record.date
+          assert record.closing_price == initial_record.closing_price
+          assert record.opening_price == initial_record.opening_price
+          Map.delete(acc, record.date)
+        end)
+
+      assert missing_records == %{}
+    end
+
+    test "doesn't replace existing records with zeros" do
+      date = ~D[2018-04-01]
+
+      {:ok, old_record} =
+        Repo.insert(%MarketHistory{date: date, closing_price: Decimal.new(1), opening_price: Decimal.new(1)})
+
+      new_record = %{
+        date: date,
+        closing_price: Decimal.new(0),
+        opening_price: Decimal.new(0)
+      }
+
+      MarketHistory.bulk_insert([new_record])
+
+      fetched_record = Repo.get_by(MarketHistory, date: date)
+      assert fetched_record.closing_price == old_record.closing_price
+      assert fetched_record.opening_price == old_record.opening_price
+    end
+
+    test "does not override existing records on date conflict" do
+      date = ~D[2018-04-01]
+
+      {:ok, old_record} =
+        Repo.insert(%MarketHistory{date: date, closing_price: Decimal.new(2), opening_price: Decimal.new(2)})
+
+      new_record = %{
+        date: date,
+        closing_price: Decimal.new(1),
+        opening_price: Decimal.new(1)
+      }
+
+      MarketHistory.bulk_insert([new_record])
+
+      fetched_record = Repo.get_by(MarketHistory, date: date)
+      assert fetched_record.closing_price == old_record.closing_price
+      assert fetched_record.opening_price == old_record.opening_price
+    end
+  end
+end

--- a/apps/explorer/test/explorer/market/market_test.exs
+++ b/apps/explorer/test/explorer/market/market_test.exs
@@ -3,7 +3,6 @@ defmodule Explorer.MarketTest do
 
   alias Explorer.Market
   alias Explorer.Market.MarketHistory
-  alias Explorer.Repo
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
@@ -17,99 +16,121 @@ defmodule Explorer.MarketTest do
     :ok
   end
 
-  test "fetch_recent_history/1" do
-    ConCache.delete(:market_history, :last_update)
+  describe "fetch_recent_history/1" do
+    test "with enabled history fetcher" do
+      ConCache.delete(:market_history, :last_update)
 
-    today = Date.utc_today()
+      start_supervised!(Explorer.Market.Fetcher.History)
 
-    records =
-      for i <- 0..29 do
-        %{
-          date: Timex.shift(today, days: i * -1),
-          closing_price: Decimal.new(1),
-          opening_price: Decimal.new(1)
-        }
-      end
+      today = Date.utc_today()
 
-    MarketHistory.bulk_insert(records)
+      records =
+        for i <- 0..29 do
+          %{
+            date: Timex.shift(today, days: i * -1),
+            closing_price: Decimal.new(1),
+            opening_price: Decimal.new(1)
+          }
+        end
 
-    history = Market.fetch_recent_history()
-    assert length(history) == 30
-    assert Enum.at(history, 0).date == Enum.at(records, 0).date
+      MarketHistory.bulk_insert(records)
+
+      history = Market.fetch_recent_history()
+      assert length(history) == 30
+      assert Enum.at(history, 0).date == Enum.at(records, 0).date
+    end
+
+    test "with disabled history fetcher" do
+      ConCache.delete(:market_history, :last_update)
+
+      old_env = Application.get_env(:explorer, Explorer.Market.Fetcher.History)
+      Application.put_env(:explorer, Explorer.Market.Fetcher.History, Keyword.merge(old_env, enabled: false))
+
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.Market.Fetcher.History, old_env)
+      end)
+
+      today = Date.utc_today()
+
+      records =
+        for i <- 0..29 do
+          %{
+            date: Timex.shift(today, days: i * -1),
+            closing_price: Decimal.new(1),
+            opening_price: Decimal.new(1)
+          }
+        end
+
+      MarketHistory.bulk_insert(records)
+
+      history = Market.fetch_recent_history()
+      assert length(history) == 0
+    end
   end
 
-  describe "bulk_insert_history/1" do
-    test "inserts records" do
-      comparable_values = %{
-        ~D[2018-04-01] => %{
-          date: ~D[2018-04-01],
-          closing_price: Decimal.new(1),
-          opening_price: Decimal.new(1)
-        },
-        ~D[2018-04-02] => %{
-          date: ~D[2018-04-02],
-          closing_price: Decimal.new(1),
-          opening_price: Decimal.new(1)
-        },
-        ~D[2018-04-03] => %{
-          date: ~D[2018-04-03],
-          closing_price: Decimal.new(1),
-          opening_price: Decimal.new(1)
-        }
-      }
+  describe "get_coin_exchange_rate/0" do
+    test "with enabled coin fetcher" do
+      old_source_env = Application.get_env(:explorer, Explorer.Market.Source)
+      old_fetcher_env = Application.get_env(:explorer, Explorer.Market.Fetcher.Coin)
 
-      insertable_records = Map.values(comparable_values)
-      MarketHistory.bulk_insert(insertable_records)
-      history = Repo.all(MarketHistory)
+      Application.put_env(
+        :explorer,
+        Explorer.Market.Source,
+        Keyword.merge(old_source_env, native_coin_source: Explorer.Market.Source.OneCoinSource)
+      )
 
-      missing_records =
-        Enum.reduce(history, comparable_values, fn record, acc ->
-          initial_record = Map.get(acc, record.date)
-          assert record.date == initial_record.date
-          assert record.closing_price == initial_record.closing_price
-          assert record.opening_price == initial_record.opening_price
-          Map.delete(acc, record.date)
-        end)
+      Application.put_env(:explorer, Explorer.Market.Fetcher.Coin, Keyword.merge(old_fetcher_env, enabled: true))
 
-      assert missing_records == %{}
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.Market.Source, old_source_env)
+        Application.put_env(:explorer, Explorer.Market.Fetcher.Coin, old_fetcher_env)
+      end)
+
+      start_supervised!(Explorer.Market.Fetcher.Coin)
+
+      :timer.sleep(100)
+
+      exchange_rate = Market.get_coin_exchange_rate()
+
+      assert exchange_rate.fiat_value == Decimal.new(1)
     end
 
-    test "doesn't replace existing records with zeros" do
-      date = ~D[2018-04-01]
+    test "with disabled coin fetcher" do
+      exchange_rate = Market.get_coin_exchange_rate()
+      assert exchange_rate.fiat_value == nil
+    end
+  end
 
-      {:ok, old_record} =
-        Repo.insert(%MarketHistory{date: date, closing_price: Decimal.new(1), opening_price: Decimal.new(1)})
+  describe "get_secondary_coin_exchange_rate/0" do
+    test "with enabled coin fetcher" do
+      old_source_env = Application.get_env(:explorer, Explorer.Market.Source)
+      old_fetcher_env = Application.get_env(:explorer, Explorer.Market.Fetcher.Coin)
 
-      new_record = %{
-        date: date,
-        closing_price: Decimal.new(0),
-        opening_price: Decimal.new(0)
-      }
+      Application.put_env(
+        :explorer,
+        Explorer.Market.Source,
+        Keyword.merge(old_source_env, secondary_coin_source: Explorer.Market.Source.OneCoinSource)
+      )
 
-      MarketHistory.bulk_insert([new_record])
+      Application.put_env(:explorer, Explorer.Market.Fetcher.Coin, Keyword.merge(old_fetcher_env, enabled: true))
 
-      fetched_record = Repo.get_by(MarketHistory, date: date)
-      assert fetched_record.closing_price == old_record.closing_price
-      assert fetched_record.opening_price == old_record.opening_price
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.Market.Source, old_source_env)
+        Application.put_env(:explorer, Explorer.Market.Fetcher.Coin, old_fetcher_env)
+      end)
+
+      start_supervised!(Explorer.Market.Fetcher.Coin)
+
+      :timer.sleep(100)
+
+      exchange_rate = Market.get_secondary_coin_exchange_rate()
+
+      assert exchange_rate.fiat_value == Decimal.new(1)
     end
 
-    test "does not override existing records on date conflict" do
-      date = ~D[2018-04-01]
-
-      {:ok, old_record} =
-        Repo.insert(%MarketHistory{date: date, closing_price: Decimal.new(2), opening_price: Decimal.new(2)})
-
-      new_record = %{
-        date: date,
-        closing_price: Decimal.new(1),
-        opening_price: Decimal.new(1)
-      }
-
-      MarketHistory.bulk_insert([new_record])
-
-      fetched_record = Repo.get_by(MarketHistory, date: date)
-      assert fetched_record.closing_price == old_record.closing_price
-      assert fetched_record.opening_price == old_record.opening_price
+    test "with disabled coin fetcher" do
+      exchange_rate = Market.get_secondary_coin_exchange_rate()
+      assert exchange_rate.fiat_value == nil
     end
   end
 end

--- a/apps/explorer/test/support/benchmark_case.ex
+++ b/apps/explorer/test/support/benchmark_case.ex
@@ -1,0 +1,54 @@
+defmodule Explorer.BenchmarkCase do
+  @moduledoc """
+  This module defines the benchmark case to be used by benchmarks.
+
+  This module provides common setup and utilities for benchmarking,
+  similar to DataCase but optimized for benchmarking needs, including:
+
+  - Database sandbox management
+  - Factory imports
+  - Common helpers
+
+  ## Example
+
+  ```elixir
+  defmodule Explorer.MyBenchmark do
+    use Explorer.BenchmarkCase
+
+    def run do
+      Benchee.run(...)
+    end
+  end
+
+  # Run the benchmark
+  Explorer.MyBenchmark.run()
+  ```
+  """
+
+  defmacro __using__(_opts) do
+    caller_file = __CALLER__.file
+    path = caller_file |> String.replace(Path.extname(caller_file), ".benchee")
+
+    quote do
+      import Explorer.Factory
+
+      @path unquote(path)
+
+      @doc """
+      Resets the database for consistent benchmarks
+      """
+      def reset_db do
+        :ok = Ecto.Adapters.SQL.Sandbox.checkout(Explorer.Repo, ownership_timeout: :infinity)
+      end
+
+      @doc """
+      Setup common benchmark environment
+      """
+      def benchmark_setup do
+        {:ok, _} = Application.ensure_all_started(:explorer)
+
+        :ok
+      end
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -361,7 +361,7 @@ config :explorer, Explorer.Chain.Cache.Counters.AverageBlockTime,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_AVERAGE_BLOCK_PERIOD", "30m")
 
 config :explorer, Explorer.Market.MarketHistoryCache,
-  cache_period: ConfigHelper.parse_time_env_var("CACHE_MARKET_HISTORY_PERIOD", "6h")
+  cache_period: ConfigHelper.parse_time_env_var("CACHE_MARKET_HISTORY_PERIOD", "1h")
 
 config :explorer, Explorer.Chain.Cache.Counters.AddressTransactionsCount,
   cache_period: ConfigHelper.parse_time_env_var("CACHE_ADDRESS_TRANSACTIONS_COUNTER_PERIOD", "1h")


### PR DESCRIPTION
Close #11540 

## Changelog
Do not reuturn market-related data if a corresponding fetcher is disabled since 


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
