### PR TITLE
chore: Add filter for value > 0 to txlistinternal

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -131,35 +131,25 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
       {:error, :error} ->
         txlistinternal(conn, params, :no_param)
 
-      {{:ok, transaction_param}, :error} ->
-        txlistinternal(conn, transaction_param, :transaction)
-
-      {:error, {:ok, address_param}} ->
+      {_, {:ok, address_param}} ->
         txlistinternal(conn, params, address_param, :address)
+
+      {{:ok, transaction_param}, _} ->
+        txlistinternal(conn, params, transaction_param, :transaction)
     end
   end
 
-  def txlistinternal(conn, transaction_param, :transaction) do
-    with {:format, {:ok, transaction_hash}} <- to_transaction_hash(transaction_param),
-         {:ok, internal_transactions} <- list_internal_transactions(transaction_hash) do
-      render(conn, :txlistinternal, %{internal_transactions: internal_transactions})
-    else
-      {:format, :error} ->
-        render(conn, :error, error: "Invalid txhash format")
-
-      {:error, :not_found} ->
-        render(conn, :error, error: "No internal transactions found", data: [])
-    end
-  end
-
-  def txlistinternal(conn, params, :no_param) do
+  def txlistinternal(conn, params, transaction_param, :transaction) do
     options =
       params
       |> optional_params()
 
-    case list_internal_transactions(:all, options) do
-      {:ok, internal_transactions} ->
-        render(conn, :txlistinternal, %{internal_transactions: internal_transactions})
+    with {:format, {:ok, transaction_hash}} <- to_transaction_hash(transaction_param),
+         {:ok, internal_transactions} <- list_internal_transactions(transaction_hash, options) do
+      render(conn, :txlistinternal, %{internal_transactions: internal_transactions})
+    else
+      {:format, :error} ->
+        render(conn, :error, error: "Invalid txhash format")
 
       {:error, :not_found} ->
         render(conn, :error, error: "No internal transactions found", data: [])
@@ -178,6 +168,20 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
         render(conn, :error, error: @invalid_address_message)
 
       {_, :not_found} ->
+        render(conn, :error, error: "No internal transactions found", data: [])
+    end
+  end
+
+  def txlistinternal(conn, params, :no_param) do
+    options =
+      params
+      |> optional_params()
+
+    case list_internal_transactions(:all, options) do
+      {:ok, internal_transactions} ->
+        render(conn, :txlistinternal, %{internal_transactions: internal_transactions})
+
+      {:error, :not_found} ->
         render(conn, :error, error: "No internal transactions found", data: [])
     end
   end
@@ -294,6 +298,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
   @spec optional_params(map()) :: map()
   def optional_params(params) do
     %{}
+    |> put_boolean(params, "include_zero_value", :include_zero_value)
     |> put_order_by_direction(params)
     |> Helper.put_pagination_options(params)
     |> put_block(params, "startblock")
@@ -452,6 +457,14 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     {:format, Chain.string_to_full_hash(transaction_hash_string)}
   end
 
+  defp put_boolean(options, params, params_key, options_key) do
+    case params |> Map.get(params_key, "") |> String.downcase() do
+      "true" -> Map.put(options, options_key, true)
+      "false" -> Map.put(options, options_key, false)
+      _ -> options
+    end
+  end
+
   defp put_order_by_direction(options, params) do
     case params do
       %{"sort" => sort} when sort in ["asc", "desc"] ->
@@ -516,22 +529,8 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     end
   end
 
-  defp list_internal_transactions(transaction_hash) do
-    case Etherscan.list_internal_transactions(transaction_hash) do
-      [] -> {:error, :not_found}
-      internal_transactions -> {:ok, internal_transactions}
-    end
-  end
-
-  defp list_internal_transactions(:all, options) do
-    case Etherscan.list_internal_transactions(:all, options) do
-      [] -> {:error, :not_found}
-      internal_transactions -> {:ok, internal_transactions}
-    end
-  end
-
-  defp list_internal_transactions(address_hash, options) do
-    case Etherscan.list_internal_transactions(address_hash, options) do
+  defp list_internal_transactions(transaction_or_address_hash_param_or_no_param, options) do
+    case Etherscan.list_internal_transactions(transaction_or_address_hash_param_or_no_param, options) do
       [] -> {:error, :not_found}
       internal_transactions -> {:ok, internal_transactions}
     end

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -977,4 +977,26 @@ defmodule Explorer.Chain.InternalTransaction do
     query
     |> where([internal_transaction], internal_transaction.transaction_hash == ^transaction_hash)
   end
+
+  @doc """
+  Conditionally filters internal transactions to include or exclude zero-value transfers.
+
+  When `include_zero` is `true`, the query remains unchanged and will return all
+  internal transactions regardless of their value. When `include_zero` is `false`,
+  the query is modified to exclude internal transactions where the transferred
+  value is zero, returning only transactions with positive Wei values.
+
+  ## Parameters
+  - `query`: An Ecto query for internal transactions
+  - `include_zero`: Whether to include zero-value internal transactions
+
+  ## Returns
+  - Modified Ecto query that either includes or excludes zero-value transfers
+  """
+  @spec include_zero_value(Ecto.Query.t(), boolean()) :: Ecto.Query.t()
+  def include_zero_value(query, true), do: query
+
+  def include_zero_value(query, false) do
+    where(query, [internal_transaction], internal_transaction.value > ^0)
+  end
 end


### PR DESCRIPTION
Close #12665

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an `include_zero_value` option in internal transaction queries to include or exclude zero-value transactions in API responses.
* **Bug Fixes**
  * Improved consistency in filtering internal transactions by value across various API endpoints.
* **Tests**
  * Expanded test coverage to verify filtering behavior of internal transactions with and without the `include_zero_value` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->