### PR TITLE
fix: Correctly use Geth importer for Besu genesis file. (#12466)

### DIFF
--- a/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
+++ b/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
@@ -205,7 +205,7 @@ defmodule Explorer.ChainSpec.GenesisData do
 
   # Resulting spec will be handled by Explorer.ChainSpec.Geth.Importer
   defp extend_chain_spec(chain_spec, precompiles_config, variant)
-       when is_list(chain_spec) and variant == EthereumJSONRPC.Geth do
+       when is_list(chain_spec) and variant in [EthereumJSONRPC.Geth, EthereumJSONRPC.Besu] do
     precompiles_as_map =
       precompiles_config
       |> Enum.reduce(%{}, fn contract, acc ->
@@ -227,7 +227,7 @@ defmodule Explorer.ChainSpec.GenesisData do
 
   # Resulting spec will be handled by Explorer.ChainSpec.Geth.Importer
   defp extend_chain_spec(%{"genesis" => sub_entity} = chain_spec, precompiles_config, variant)
-       when variant == EthereumJSONRPC.Geth do
+       when variant in [EthereumJSONRPC.Geth, EthereumJSONRPC.Besu] do
     updated_sub_entity = extend_chain_spec(sub_entity, precompiles_config, variant)
 
     Map.put(chain_spec, "genesis", updated_sub_entity)
@@ -235,7 +235,7 @@ defmodule Explorer.ChainSpec.GenesisData do
 
   # Resulting spec will be handled by Explorer.ChainSpec.Geth.Importer
   defp extend_chain_spec(chain_spec, precompiles_config, variant)
-       when is_map(chain_spec) and variant == EthereumJSONRPC.Geth do
+       when is_map(chain_spec) and variant in [EthereumJSONRPC.Geth, EthereumJSONRPC.Besu] do
     accounts =
       case chain_spec["alloc"] do
         nil -> %{}
@@ -275,7 +275,7 @@ defmodule Explorer.ChainSpec.GenesisData do
   defp import_genesis_accounts(chain_spec, variant) do
     if not Enum.empty?(chain_spec) do
       case variant do
-        EthereumJSONRPC.Geth ->
+        variant when variant in [EthereumJSONRPC.Geth, EthereumJSONRPC.Besu] ->
           {:ok, _} = GethImporter.import_genesis_accounts(chain_spec)
 
         _ ->

--- a/apps/explorer/test/explorer/chain_spec/genesis_data_test.exs
+++ b/apps/explorer/test/explorer/chain_spec/genesis_data_test.exs
@@ -1,0 +1,53 @@
+# apps/explorer/test/explorer/chain_spec/geth/genesis_data.exs
+defmodule Explorer.ChainSpec.GenesisDataTest do
+  use ExUnit.Case, async: false
+
+  @besu_genesis "#{File.cwd!()}/test/support/fixture/chain_spec/qdai_genesis.json"
+                |> File.read!()
+                |> Jason.decode!()
+  setup do
+    # Patch application env
+    old_genesis_data = Application.get_env(:explorer, Explorer.ChainSpec.GenesisData)
+
+    old_json_rpc_named_arguments =
+      Application.get_env(:indexer, :json_rpc_named_arguments)
+
+    Application.put_env(
+      :explorer,
+      Explorer.ChainSpec.GenesisData,
+      Keyword.merge(old_genesis_data,
+        chain_spec_path: "#{File.cwd!()}/test/support/fixture/chain_spec/qdai_genesis.json",
+        precompiled_config_path: nil
+      )
+    )
+
+    Application.put_env(
+      :indexer,
+      :json_rpc_named_arguments,
+      Keyword.merge(old_json_rpc_named_arguments, variant: EthereumJSONRPC.Besu)
+    )
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.ChainSpec.GenesisData, old_genesis_data)
+      Application.put_env(:indexer, :json_rpc_named_arguments, old_json_rpc_named_arguments)
+      :meck.unload()
+    end)
+
+    :ok
+  end
+
+  test "remaps Besu variant to Geth and calls GethImporter.import_genesis_accounts/1" do
+    test_pid = self()
+
+    :meck.new(Explorer.ChainSpec.Geth.Importer, [:passthrough])
+
+    :meck.expect(Explorer.ChainSpec.Geth.Importer, :import_genesis_accounts, fn args ->
+      send(test_pid, {:import_called, args})
+      {:ok, []}
+    end)
+
+    Explorer.ChainSpec.GenesisData.fetch_genesis_data()
+
+    assert_receive {:import_called, @besu_genesis}, 1000
+  end
+end


### PR DESCRIPTION
Resolves #12569
This PR is created to check CI passing. The original PR #12466.

## Motivation

This pull request addresses an issue where Blockscout, when configured with the Besu variant and attempting to use the chain spec configuration, was incorrectly defaulting to the POA importer instead of the an appropriate importer for Besu. This resulted in the inability to load the initial accounts and verify the contracts loaded from the genesis file. 

I did some test with my blockscout instance and I verified that forcing to load using the Geth variant solve the importing problem (e.g. blockscout recognize the initial accounts as contract accounts)

## Changelog

### Bug Fixes

- Corrected the importer selection logic for the Besu variant when configuring the chain spec, ensuring the proper Besu genesis file importer is used.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by ensuring that both Geth and Besu variants follow the same processing path for chain specification and genesis account import.

* **Tests**
  * Added tests to verify correct handling of the Besu variant and ensure proper import logic is triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->