### PR TITLE
chore: Migrate from HTTPoison to Tesla.Mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Support multiple interop messages view on transaction page ([#12455](https://github.com/blockscout/blockscout/issues/12455))
 - Remove `is_self_destructed` field in `/api/v2/smart-contracts/{address_hash}` response ([#12239](https://github.com/blockscout/blockscout/issues/12239))
 - Set home directory for blockscout user ([#12337](https://github.com/blockscout/blockscout/issues/12337))
+- Migrate from HTTPoison to Tesla.Mint ([#12699](https://github.com/blockscout/blockscout/pull/12699))
 
 
 | Variable              | Description                                                                                                                                                      | Parameters                                                                                      |

--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -18,7 +18,7 @@ config :block_scout_web,
   session_cookie_ttl: 60 * 60 * 24 * 7,
   invalid_session_key: "invalid_session",
   api_v2_temp_token_key: "api_v2_temp_token",
-  http_adapter: HTTPoison
+  http_client: Explorer.HttpClient.Tesla
 
 config :block_scout_web,
   admin_panel_enabled: ConfigHelper.parse_bool_env_var("ADMIN_PANEL_ENABLED")
@@ -117,6 +117,8 @@ config :ueberauth, Ueberauth,
       [callback_path: "/auth/auth0/callback", callback_params: ["path"]]
     }
   ]
+
+config :tesla, adapter: Tesla.Adapter.Mint
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/block_scout_web/config/test.exs
+++ b/apps/block_scout_web/config/test.exs
@@ -24,6 +24,8 @@ config :block_scout_web, BlockScoutWeb.Counters.BlocksIndexedCounter, enabled: f
 
 config :block_scout_web, BlockScoutWeb.Counters.InternalTransactionsIndexedCounter, enabled: false
 
+config :tesla, adapter: Explorer.Mock.TeslaAdapter
+
 config :ueberauth, Ueberauth,
   providers: [
     auth0: {

--- a/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.CaptchaHelper do
   """
   require Logger
 
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
 
   @type token_scope() :: :token_instance_refetch_metadata
 
@@ -103,13 +103,12 @@ defmodule BlockScoutWeb.CaptchaHelper do
     headers = [{"Content-type", "application/x-www-form-urlencoded"}]
 
     case !Application.get_env(:block_scout_web, :recaptcha)[:is_disabled] &&
-           Application.get_env(:block_scout_web, :http_adapter).post(
+           HttpClient.post(
              "https://www.google.com/recaptcha/api/siteverify",
              body,
-             headers,
-             []
+             headers
            ) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+      {:ok, %{status_code: 200, body: body}} ->
         body |> Jason.decode!() |> success?()
 
       false ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/email_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/email_controller.ex
@@ -7,7 +7,7 @@ defmodule BlockScoutWeb.Account.API.V2.EmailController do
   alias BlockScoutWeb.AccessHelper
   alias BlockScoutWeb.Account.API.V2.AuthenticateController
   alias Explorer.Account.Identity
-  alias Explorer.{Helper, Repo}
+  alias Explorer.{Helper, HttpClient, Repo}
   alias Explorer.ThirdPartyIntegrations.Auth0
 
   require Logger
@@ -36,8 +36,8 @@ defmodule BlockScoutWeb.Account.API.V2.EmailController do
         "user_id" => user.uid
       }
 
-      case HTTPoison.post(url, Jason.encode!(body), headers, []) do
-        {:ok, %HTTPoison.Response{body: _body, status_code: 201}} ->
+      case HttpClient.post(url, Jason.encode!(body), headers) do
+        {:ok, %{body: _body, status_code: 201}} ->
           identity
           |> Identity.changeset(%{verification_email_sent_at: DateTime.utc_now()})
           |> Repo.account_repo().update()

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -5,10 +5,9 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
 
   alias BlockScoutWeb.API.V2.{Helper, InternalTransactionView, TokenTransferView, TokenView, TransactionView}
   alias Ecto.Association.NotLoaded
-  alias Explorer.Chain
+  alias Explorer.{Chain, HttpClient}
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Data, InternalTransaction, Log, TokenTransfer, Transaction}
-  alias HTTPoison.Response
 
   import Explorer.Chain.SmartContract.Proxy.Models.Implementation,
     only: [proxy_implementations_association: 0, proxy_implementations_smart_contracts_association: 0]
@@ -85,8 +84,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   defp http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
+      {:ok, %{body: body, status_code: 200}} ->
         body |> Jason.decode() |> preload_template_variables()
 
       error ->
@@ -106,7 +105,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   end
 
   defp try_get_cached_value(hash) do
-    with {:ok, %Response{body: body, status_code: 200}} <- HTTPoison.get(cache_url(hash)),
+    with {:ok, %{body: body, status_code: 200}} <- HttpClient.get(cache_url(hash)),
          {:ok, json} <- body |> Jason.decode() do
       {:ok, json} |> preload_template_variables()
     else
@@ -115,7 +114,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     end
   end
 
-  defp http_response_code({:ok, %Response{status_code: status_code}}), do: status_code
+  defp http_response_code({:ok, %{status_code: status_code}}), do: status_code
   defp http_response_code(_), do: 500
 
   def enabled?, do: check_enabled(:block_scout_web, __MODULE__) == :ok

--- a/apps/block_scout_web/lib/block_scout_web/utility/rate_limit_config_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/utility/rate_limit_config_helper.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelper do
   """
   require Logger
 
+  alias Explorer.HttpClient
   alias Utils.ConfigHelper
 
   @doc """
@@ -48,16 +49,16 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelper do
 
   defp download_config(url) when is_binary(url) do
     url
-    |> HTTPoison.get([], follow_redirect: true)
+    |> HttpClient.get([], follow_redirect: true)
     |> case do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+      {:ok, %{status_code: 200, body: body}} ->
         decode_config(body)
 
-      {:ok, %HTTPoison.Response{status_code: status}} ->
+      {:ok, %{status_code: status}} ->
         Logger.error("Failed to fetch config from #{url}: #{status}")
         {:error, status}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
+      {:error, reason} ->
         {:error, reason}
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/custom_abi_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/custom_abi_controller_test.exs
@@ -9,10 +9,8 @@ defmodule BlockScoutWeb.Account.CustomABIControllerTest do
   setup %{conn: conn} do
     auth = build(:auth)
 
-    tesla_config = Application.get_env(:tesla, :adapter)
-
     on_exit(fn ->
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/custom_abi_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/custom_abi_controller_test.exs
@@ -9,6 +9,14 @@ defmodule BlockScoutWeb.Account.CustomABIControllerTest do
   setup %{conn: conn} do
     auth = build(:auth)
 
+    tesla_config = Application.get_env(:tesla, :adapter)
+
+    on_exit(fn ->
+      Application.put_env(:tesla, :adapter, tesla_config)
+    end)
+
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     {:ok, user} = Identity.find_or_create(auth)
 
     {:ok, conn: Plug.Test.init_test_session(conn, current_user: user)}

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
@@ -7,11 +7,17 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
   alias Explorer.Market.Token
   alias Explorer.{Factory, TestHelper}
 
+  setup do
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+    on_exit(fn ->
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+    end)
+  end
+
   describe "GET index/3" do
     test "returns not found for nonexistent address", %{conn: conn} do
       nonexistent_address_hash = Hash.to_string(Factory.address_hash())
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       conn =
         get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(nonexistent_address_hash)))
@@ -22,8 +28,6 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found given an invalid address hash ", %{conn: conn} do
       invalid_hash = "invalid_hash"
 
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
-
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, invalid_hash))
 
       assert html_response(conn, 404)
@@ -31,8 +35,6 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
 
     test "returns not found when the address isn't a contract", %{conn: conn} do
       address = insert(:address)
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address)))
 
@@ -54,8 +56,6 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
       )
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address)))
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/address_contract_controller_test.exs
@@ -11,6 +11,8 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found for nonexistent address", %{conn: conn} do
       nonexistent_address_hash = Hash.to_string(Factory.address_hash())
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       conn =
         get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(nonexistent_address_hash)))
 
@@ -20,6 +22,8 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
     test "returns not found given an invalid address hash ", %{conn: conn} do
       invalid_hash = "invalid_hash"
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, invalid_hash))
 
       assert html_response(conn, 404)
@@ -27,6 +31,8 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
 
     test "returns not found when the address isn't a contract", %{conn: conn} do
       address = insert(:address)
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address)))
 
@@ -48,6 +54,8 @@ defmodule BlockScoutWeb.AddressContractControllerTest do
       )
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       conn = get(conn, address_contract_path(BlockScoutWeb.Endpoint, :index, Address.checksum(address)))
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -76,6 +76,15 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
     }
   end
 
+  setup do
+    tesla_config = Application.get_env(:tesla, :adapter)
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+    on_exit(fn ->
+      Application.put_env(:tesla, :adapter, tesla_config)
+    end)
+  end
+
   describe "listcontracts" do
     setup do
       %{params: %{"module" => "contract", "action" => "listcontracts"}}
@@ -336,6 +345,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
       }
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       assert response =
                conn
                |> get("/api", params)
@@ -355,6 +366,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "action" => "getabi",
         "address" => to_string(contract.address_hash)
       }
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -419,6 +432,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         }
       ]
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       assert response =
                conn
                |> get("/api", params)
@@ -464,6 +479,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       ]
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -662,6 +679,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "address" => Address.checksum(proxy_address.hash)
       }
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       assert response =
                conn
                |> get("/api", params)
@@ -729,6 +748,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       ]
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -839,6 +860,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
 
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
+
       assert response =
                conn
                |> get("/api", params)
@@ -858,6 +881,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
   describe "verify" do
     test "verify known on sourcify repo contract", %{conn: conn} do
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
       response = verify(conn)
 
       assert response["message"] == "OK"
@@ -880,6 +904,8 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "action" => "verify_via_sourcify",
         "addressHash" => "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1"
       }
+
+      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       response =
         conn

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -77,11 +77,10 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
   end
 
   setup do
-    tesla_config = Application.get_env(:tesla, :adapter)
     Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
     on_exit(fn ->
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
   end
 
@@ -345,8 +344,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "address" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
       }
 
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
-
       assert response =
                conn
                |> get("/api", params)
@@ -366,8 +363,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "action" => "getabi",
         "address" => to_string(contract.address_hash)
       }
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -432,8 +427,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         }
       ]
 
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
-
       assert response =
                conn
                |> get("/api", params)
@@ -479,8 +472,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       ]
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -679,8 +670,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "address" => Address.checksum(proxy_address.hash)
       }
 
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
-
       assert response =
                conn
                |> get("/api", params)
@@ -748,8 +737,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       ]
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       assert response =
                conn
@@ -860,8 +847,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
       TestHelper.get_all_proxies_implementation_zero_addresses()
 
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
-
       assert response =
                conn
                |> get("/api", params)
@@ -881,7 +866,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
 
   describe "verify" do
     test "verify known on sourcify repo contract", %{conn: conn} do
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
       response = verify(conn)
 
       assert response["message"] == "OK"
@@ -904,8 +888,6 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         "action" => "verify_via_sourcify",
         "addressHash" => "0xf26594F585De4EB0Ae9De865d9053FEe02ac6eF1"
       }
-
-      Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
 
       response =
         conn

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2668,7 +2668,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
@@ -2750,7 +2749,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       Application.put_env(:block_scout_web, :chain_id, old_chain_id)
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       Bypass.down(bypass)
     end
 
@@ -2942,7 +2941,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     test "ignore logs without topics when trying to decode with sig provider", %{conn: conn} do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       old_env_sig_provider = Application.get_env(:explorer, Explorer.SmartContract.SigProviderInterface)
@@ -2954,7 +2952,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.SigProviderInterface, old_env_sig_provider)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       address = insert(:contract_address)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2668,6 +2668,9 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
@@ -2747,6 +2750,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       Application.put_env(:block_scout_web, :chain_id, old_chain_id)
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
+      Application.put_env(:tesla, :adapter, tesla_config)
       Bypass.down(bypass)
     end
 
@@ -2938,6 +2942,9 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     test "ignore logs without topics when trying to decode with sig provider", %{conn: conn} do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       old_env_sig_provider = Application.get_env(:explorer, Explorer.SmartContract.SigProviderInterface)
 
       Application.put_env(:explorer, Explorer.SmartContract.SigProviderInterface,
@@ -2947,6 +2954,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.SigProviderInterface, old_env_sig_provider)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       address = insert(:contract_address)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
@@ -57,10 +57,16 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     } do
       expected_body = "secret=#{recaptcha_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"success" => false})}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"success" => false})
+           }}
+        end
+      )
 
       address = insert(:address)
 
@@ -148,18 +154,20 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     test "exports token transfers to csv", %{conn: conn, v2_secret_key: recaptcha_secret_key} do
       expected_body = "secret=#{recaptcha_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       address = insert(:address)
 
@@ -209,18 +217,20 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     test "download csv file with transactions", %{conn: conn, v2_secret_key: recaptcha_secret_key} do
       expected_body = "secret=#{recaptcha_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       address = insert(:address)
 
@@ -270,18 +280,20 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     test "download csv file with internal transactions", %{conn: conn, v2_secret_key: recaptcha_secret_key} do
       expected_body = "secret=#{recaptcha_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       address = insert(:address)
 
@@ -368,18 +380,20 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     test "download csv file with logs", %{conn: conn, v2_secret_key: recaptcha_secret_key} do
       expected_body = "secret=#{recaptcha_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       address = insert(:address)
 
@@ -489,7 +503,6 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
   defp csv_setup() do
     original_config = :persistent_term.get(:rate_limit_config)
     old_recaptcha_env = Application.get_env(:block_scout_web, :recaptcha)
-    old_http_adapter = Application.get_env(:block_scout_web, :http_adapter)
     original_api_rate_limit = Application.get_env(:block_scout_web, :api_rate_limit)
 
     v2_secret_key = "v2_secret_key"
@@ -500,8 +513,6 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
       v3_secret_key: v3_secret_key,
       is_disabled: false
     )
-
-    Application.put_env(:block_scout_web, :http_adapter, Explorer.Mox.HTTPoison)
 
     Application.put_env(:block_scout_web, :api_rate_limit, Keyword.put(original_api_rate_limit, :disabled, false))
 
@@ -553,7 +564,6 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
     on_exit(fn ->
       :persistent_term.put(:rate_limit_config, original_config)
       Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
-      Application.put_env(:block_scout_web, :http_adapter, old_http_adapter)
       :ets.delete_all_objects(BlockScoutWeb.RateLimit.Hammer.ETS)
       Application.put_env(:block_scout_web, :api_rate_limit, original_api_rate_limit)
     end)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -459,7 +459,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
@@ -472,7 +471,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
         Application.put_env(:block_scout_web, :hide_scam_addresses, old_hide_scam_addresses)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -774,7 +773,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
-      tesla_config = Application.get_env(:tesla, :adapter)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
@@ -784,7 +782,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, metadata_envs)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -1127,7 +1125,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1139,7 +1136,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -1190,7 +1187,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "handles no results from TAC microservice", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1202,7 +1198,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -1235,7 +1231,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1247,7 +1242,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -1305,7 +1300,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with block", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1317,7 +1311,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -1377,7 +1371,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations by sender and paginates", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1389,7 +1382,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       address_hash = Address.checksum(insert(:address).hash)
@@ -1492,7 +1485,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations by TON sender", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1504,7 +1496,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       tac_response = """
@@ -1670,7 +1662,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations with transaction and paginates", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -1682,7 +1673,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
@@ -1902,7 +1893,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
-      tesla_config = Application.get_env(:tesla, :adapter)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
@@ -1912,7 +1902,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, metadata_envs)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -2054,7 +2044,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2066,7 +2055,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -2114,7 +2103,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2126,7 +2114,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -2184,7 +2172,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with block", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2196,7 +2183,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -2256,7 +2243,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a lot of TAC operations with address", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2268,7 +2254,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       address_hash = Address.checksum(insert(:address).hash)
@@ -2341,7 +2327,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with TON address", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2353,7 +2338,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       tac_response = """
@@ -2529,7 +2514,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a lot if TAC operations with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
@@ -2541,7 +2525,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       transaction =

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -459,6 +459,8 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      tesla_config = Application.get_env(:tesla, :adapter)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
       old_hide_scam_addresses = Application.get_env(:block_scout_web, :hide_scam_addresses)
@@ -470,6 +472,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
         Application.put_env(:block_scout_web, :hide_scam_addresses, old_hide_scam_addresses)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -771,14 +774,17 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      tesla_config = Application.get_env(:tesla, :adapter)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, metadata_envs)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -1121,15 +1127,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -1180,15 +1190,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "handles no results from TAC microservice", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -1221,15 +1235,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -1287,15 +1305,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with block", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -1355,15 +1377,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations by sender and paginates", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       address_hash = Address.checksum(insert(:address).hash)
@@ -1466,15 +1492,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations by TON sender", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       tac_response = """
@@ -1640,15 +1670,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds TAC operations with transaction and paginates", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
@@ -1868,14 +1902,17 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       metadata_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      tesla_config = Application.get_env(:tesla, :adapter)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, metadata_envs)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
@@ -2017,15 +2054,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
@@ -2073,15 +2114,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -2139,15 +2184,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with block", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       transaction = insert(:transaction) |> with_block()
@@ -2207,15 +2256,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a lot of TAC operations with address", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       address_hash = Address.checksum(insert(:address).hash)
@@ -2288,15 +2341,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a TAC operation with TON address", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       tac_response = """
@@ -2472,15 +2529,19 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
     test "finds a lot if TAC operations with transaction", %{conn: conn} do
       bypass = Bypass.open()
       tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       transaction =

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -688,8 +688,12 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
 
         old_chain_id = Application.get_env(:block_scout_web, :chain_id)
 
+        tesla_config = Application.get_env(:tesla, :adapter)
+
         {:ok, pid} = Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand.start_link([])
         bypass = Bypass.open()
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
         Application.put_env(:block_scout_web, :chain_id, 5)
 
@@ -709,6 +713,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           Application.put_env(:explorer, Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand, old_fetcher_env)
           Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, old_verifier_env)
           Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+          Application.put_env(:tesla, :adapter, tesla_config)
           Bypass.down(bypass)
         end)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1673,10 +1673,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         times: 1,
         returns: fn %{url: ^url}, _opts ->
           {:ok,
-            %Tesla.Env{
-              status: 200,
-              body: Jason.encode!(metadata)
-            }}
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
         end
       )
 
@@ -1946,10 +1946,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         times: 1,
         returns: fn %{url: ^url}, _opts ->
           {:ok,
-            %Tesla.Env{
-              status: 200,
-              body: Jason.encode!(metadata)
-            }}
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
         end
       )
 
@@ -2023,10 +2023,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         times: 1,
         returns: fn %{url: ^url}, _opts ->
           {:ok,
-            %Tesla.Env{
-              status: 200,
-              body: Jason.encode!(%{"name" => "test"})
-            }}
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"name" => "test"})
+           }}
         end
       )
 
@@ -2145,10 +2145,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         times: 1,
         returns: fn %{url: ^url}, _opts ->
           {:ok,
-            %Tesla.Env{
-              status: 200,
-              body: Jason.encode!(%{"name" => "test"})
-            }}
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"name" => "test"})
+           }}
         end
       )
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1537,8 +1537,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
       original_config = :persistent_term.get(:rate_limit_config)
       old_recaptcha_env = Application.get_env(:block_scout_web, :recaptcha)
-      old_http_adapter = Application.get_env(:block_scout_web, :http_adapter)
-      old_explorer_http_adapter = Application.get_env(:explorer, :http_adapter)
       original_api_rate_limit = Application.get_env(:block_scout_web, :api_rate_limit)
 
       v2_secret_key = "v2_secret_key"
@@ -1549,8 +1547,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         v3_secret_key: v3_secret_key,
         is_disabled: false
       )
-
-      Application.put_env(:block_scout_web, :http_adapter, Explorer.Mox.HTTPoison)
 
       mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
 
@@ -1587,8 +1583,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       on_exit(fn ->
         :persistent_term.put(:rate_limit_config, original_config)
         Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
-        Application.put_env(:block_scout_web, :http_adapter, old_http_adapter)
-        Application.put_env(:explorer, :http_adapter, old_explorer_http_adapter)
         Application.put_env(:block_scout_web, :api_rate_limit, original_api_rate_limit)
         :ets.delete_all_objects(BlockScoutWeb.RateLimit.Hammer.ETS)
       end)
@@ -1613,12 +1607,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       topic = "token_instances:#{token_contract_address_hash_string}"
 
@@ -1654,25 +1652,33 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       expected_body = "secret=#{v2_secret_key}&response=123"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+            %Tesla.Env{
+              status: 200,
+              body: Jason.encode!(metadata)
+            }}
+        end
+      )
 
       request =
         Phoenix.ConnTest.build_conn()
@@ -1743,12 +1749,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       topic = "token_instances:#{token_contract_address_hash_string}"
 
@@ -1800,12 +1810,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 500, body: "Error"}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 500,
+             body: "Error"
+           }}
+        end
+      )
 
       topic = "token_instances:#{token_contract_address_hash_string}"
 
@@ -1857,11 +1871,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         )
       )
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       on_exit(fn ->
         Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
       end)
 
       token = insert(:token, type: "ERC-721")
@@ -1879,10 +1890,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       topic = "token_instances:#{token_contract_address_hash_string}"
 
@@ -1925,10 +1942,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+            %Tesla.Env{
+              status: 200,
+              body: Jason.encode!(metadata)
+            }}
+        end
+      )
 
       request =
         Phoenix.ConnTest.build_conn()
@@ -1977,11 +2000,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         )
       )
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       on_exit(fn ->
         Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
       end)
 
       token = insert(:token, type: "ERC-721")
@@ -1999,10 +2019,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"name" => "test"})}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+            %Tesla.Env{
+              status: 200,
+              body: Jason.encode!(%{"name" => "test"})
+            }}
+        end
+      )
 
       request =
         patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
@@ -2021,25 +2047,33 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       # Set up normal reCAPTCHA validation for the second request
       expected_body = "secret=#{v2_secret_key}&response=correct_recaptcha_token"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       topic = "token_instances:#{token_contract_address_hash_string}"
 
@@ -2089,11 +2123,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         )
       )
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       on_exit(fn ->
         Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
       end)
 
       token = insert(:token, type: "ERC-721")
@@ -2110,10 +2141,16 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       token_contract_address_hash_string = to_string(token.contract_address_hash)
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"name" => "test"})}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+            %Tesla.Env{
+              status: 200,
+              body: Jason.encode!(%{"name" => "test"})
+            }}
+        end
+      )
 
       request =
         patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
@@ -2148,25 +2185,33 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       # Set up normal reCAPTCHA validation for the second request
       expected_body = "secret=#{v2_secret_key}&response=correct_recaptcha_token"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn _url, ^expected_body, _headers, _options ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 200,
-           body:
-             Jason.encode!(%{
-               "success" => true,
-               "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
-             })
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{body: ^expected_body}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body:
+               Jason.encode!(%{
+                 "success" => true,
+                 "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
+               })
+           }}
+        end
+      )
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       # Second request with correct reCAPTCHA token - should work
       request =

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2019,17 +2019,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Tesla.Test.expect_tesla_call(
-        times: 1,
-        returns: fn %{url: ^url}, _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: Jason.encode!(%{"name" => "test"})
-           }}
-        end
-      )
-
       request =
         patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
 
@@ -2058,6 +2047,17 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
                  "success" => true,
                  "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
                })
+           }}
+        end
+      )
+
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"name" => "test"})
            }}
         end
       )
@@ -2141,17 +2141,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       token_contract_address_hash_string = to_string(token.contract_address_hash)
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Tesla.Test.expect_tesla_call(
-        times: 1,
-        returns: fn %{url: ^url}, _opts ->
-          {:ok,
-           %Tesla.Env{
-             status: 200,
-             body: Jason.encode!(%{"name" => "test"})
-           }}
-        end
-      )
-
       request =
         patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
 
@@ -2196,6 +2185,17 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
                  "success" => true,
                  "hostname" => Application.get_env(:block_scout_web, BlockScoutWeb.Endpoint)[:url][:host]
                })
+           }}
+        end
+      )
+
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"name" => "test"})
            }}
         end
       )

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
@@ -13,9 +13,11 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
   setup do
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
   end
 
@@ -284,8 +286,6 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
 
         old_env = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
 
-        tesla_config = Application.get_env(:tesla, :adapter)
-
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour,
           service_url: "http://localhost:#{bypass.port}",
           enabled: true,
@@ -348,7 +348,7 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
         assert response["is_blueprint"] == true
 
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, old_env)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
         Bypass.down(bypass)
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/verification_controller_test.exs
@@ -284,12 +284,16 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
 
         old_env = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
 
+        tesla_config = Application.get_env(:tesla, :adapter)
+
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour,
           service_url: "http://localhost:#{bypass.port}",
           enabled: true,
           type: "sc_verifier",
           eth_bytecode_db?: true
         )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
         Bypass.expect_once(bypass, "POST", "/api/v2//verifier/vyper/sources%3Averify-multi-part", fn conn ->
           Conn.resp(conn, 200, sc_verifier_response)
@@ -344,6 +348,7 @@ defmodule BlockScoutWeb.API.V2.VerificationControllerTest do
         assert response["is_blueprint"] == true
 
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, old_env)
+        Application.put_env(:tesla, :adapter, tesla_config)
         Bypass.down(bypass)
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
@@ -8,13 +8,18 @@ defmodule BlockScoutWeb.AddressContractVerificationTest do
   setup do
     bypass = Bypass.open()
 
+    tesla_config = Application.get_env(:tesla, :adapter)
+
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
 
     Application.put_env(:explorer, :solc_bin_api_url, "http://localhost:#{bypass.port}")
 
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/features/address_contract_verification_test.exs
@@ -8,8 +8,6 @@ defmodule BlockScoutWeb.AddressContractVerificationTest do
   setup do
     bypass = Bypass.open()
 
-    tesla_config = Application.get_env(:tesla, :adapter)
-
     configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
     Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
 
@@ -19,7 +17,7 @@ defmodule BlockScoutWeb.AddressContractVerificationTest do
 
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
@@ -9,8 +9,11 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
       # Store original config URL
       original_config = Application.get_env(:block_scout_web, :api_rate_limit)
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+
       on_exit(fn ->
         Application.put_env(:block_scout_web, :api_rate_limit, original_config)
+        Application.put_env(:tesla, :adapter, tesla_config)
         :persistent_term.put(:rate_limit_config, original_config_from_persistent_term)
       end)
     end
@@ -24,6 +27,9 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
       }
 
       bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
@@ -48,6 +54,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
     test "falls back to local config when URL fetch fails" do
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 500, "Internal Server Error")
@@ -73,6 +80,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -106,6 +114,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -127,6 +136,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -152,6 +162,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -182,6 +193,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -228,6 +240,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))
@@ -270,6 +283,7 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
 
       bypass = Bypass.open()
       Application.put_env(:block_scout_web, :api_rate_limit, config_url: "http://localhost:#{bypass.port}/config")
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect_once(bypass, "GET", "/config", fn conn ->
         Plug.Conn.resp(conn, 200, Jason.encode!(config))

--- a/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
@@ -9,11 +9,9 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
       # Store original config URL
       original_config = Application.get_env(:block_scout_web, :api_rate_limit)
 
-      tesla_config = Application.get_env(:tesla, :adapter)
-
       on_exit(fn ->
         Application.put_env(:block_scout_web, :api_rate_limit, original_config)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
         :persistent_term.put(:rate_limit_config, original_config_from_persistent_term)
       end)
     end

--- a/apps/block_scout_web/test/test_helper.exs
+++ b/apps/block_scout_web/test/test_helper.exs
@@ -42,4 +42,4 @@ Absinthe.Test.prime(BlockScoutWeb.GraphQL.Schema)
 
 Mox.defmock(EthereumJSONRPC.Mox, for: EthereumJSONRPC.Transport)
 
-Mox.defmock(Explorer.Mox.HTTPoison, for: HTTPoison.Base)
+Mox.defmock(Explorer.Mock.TeslaAdapter, for: Tesla.Adapter)

--- a/apps/ethereum_jsonrpc/README.md
+++ b/apps/ethereum_jsonrpc/README.md
@@ -17,8 +17,8 @@ config :ethereum_jsonrpc,
 Note: the tracing node URL is provided separately from `:url`,
 via `:trace_url`. The trace URL is used for
 `fetch_internal_transactions`, which is only a supported method on
-tracing nodes. The `:http` option is passed directly to the HTTP
-library (`HTTPoison`), which forwards the options down to `:hackney`.
+tracing nodes. The `:http` option is adapted
+to the HTTP library (`HTTPoison` or `Tesla.Mint`).
 
 ## Testing
 

--- a/apps/ethereum_jsonrpc/config/config.exs
+++ b/apps/ethereum_jsonrpc/config/config.exs
@@ -29,6 +29,8 @@ config :logger, :ethereum_jsonrpc,
        block_number step count error_count shrunk import_id transaction_id)a,
   metadata_filter: [application: :ethereum_jsonrpc]
 
+config :tesla, adapter: Tesla.Adapter.Mint
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/apps/ethereum_jsonrpc/config/test.exs
+++ b/apps/ethereum_jsonrpc/config/test.exs
@@ -17,6 +17,8 @@ config :ethereum_jsonrpc, EthereumJSONRPC.RequestCoordinator,
 
 config :ethereum_jsonrpc, EthereumJSONRPC.Tracer, disabled?: false
 
+config :tesla, adapter: Explorer.Mock.TeslaAdapter
+
 config :logger, :ethereum_jsonrpc,
   level: :warn,
   path: Path.absname("logs/test/ethereum_jsonrpc.log")

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -9,12 +9,12 @@ defmodule EthereumJSONRPC do
       config :ethereum_jsonrpc,
         url: "http://localhost:8545",
         trace_url: "http://localhost:8545",
-        http: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+        http: [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc]
 
 
   Note: the tracing node URL is provided separately from `:url`, via `:trace_url`. The trace URL and is used for
-  `fetch_internal_transactions`, which is only a supported method on tracing nodes. The `:http` option is passed
-  directly to the HTTP library (`HTTPoison`), which forwards the options down to `:hackney`.
+  `fetch_internal_transactions`, which is only a supported method on tracing nodes. The `:http` option is adapted
+  to the HTTP library (`HTTPoison` or `Tesla.Mint`).
 
   ## Throttling
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -266,6 +266,15 @@ defmodule EthereumJSONRPC.HTTP do
   end
 
   defp headers do
-    Application.get_env(:ethereum_jsonrpc, __MODULE__)[:headers]
+    gzip_enabled? = Application.get_env(:ethereum_jsonrpc, __MODULE__)[:gzip_enabled?]
+
+    additional_headers =
+      if gzip_enabled? do
+        [{"Accept-Encoding", "gzip"}]
+      else
+        []
+      end
+
+    Application.get_env(:ethereum_jsonrpc, __MODULE__)[:headers] ++ additional_headers
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -1,0 +1,61 @@
+defmodule EthereumJSONRPC.HTTP.Helper do
+  @moduledoc """
+  Helper functions for `EthereumJSONRPC.HTTP` implementations.
+  """
+
+  @spec get_method_from_json_string(binary()) :: binary()
+  def get_method_from_json_string(json_string) do
+    with {:ok, decoded_json} <- Jason.decode(json_string) do
+      if is_map(decoded_json) do
+        Map.get(decoded_json, "method")
+      else
+        decoded_json |> Enum.at(0) |> Map.get("method")
+      end
+    end
+  end
+
+  @spec response_body_has_error?(map() | [map()]) :: boolean()
+  def response_body_has_error?(decoded_body) when is_map(decoded_body) do
+    Map.has_key?(decoded_body, "error")
+  end
+
+  def response_body_has_error?(decoded_body) when is_list(decoded_body) do
+    Enum.any?(decoded_body, &response_body_has_error?/1)
+  end
+
+  def response_body_has_error?(_decoded_body), do: false
+
+  @spec try_unzip(binary(), [{binary(), binary()}]) :: binary()
+  def try_unzip(body, headers) do
+    gzip_enabled? = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.HTTP)[:gzip_enabled?]
+
+    if gzip_enabled? do
+      do_unzip(body, headers)
+    else
+      body
+    end
+  end
+
+  defp do_unzip(body, headers) do
+    gzipped =
+      Enum.any?(
+        headers
+        |> Enum.map(fn {k, v} ->
+          {String.downcase(k), String.downcase(v)}
+        end),
+        fn kv ->
+          case kv do
+            {"content-encoding", "gzip"} -> true
+            {"content-encoding", "x-gzip"} -> true
+            _ -> false
+          end
+        end
+      )
+
+    if gzipped do
+      :zlib.gunzip(body)
+    else
+      body
+    end
+  end
+end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -3,7 +3,18 @@ defmodule EthereumJSONRPC.HTTP.Helper do
   Helper functions for `EthereumJSONRPC.HTTP` implementations.
   """
 
-  @spec get_method_from_json_string(binary()) :: binary()
+  @doc """
+  Extracts the JSON-RPC method from a JSON string payload.
+
+  Supports both single objects and batch requests (arrays).
+
+  ## Parameters
+  - `json_string`: The JSON string to parse
+
+  ## Returns
+  - The method name as a binary, or `{:error, Jason.DecodeError.t()}` if extraction fails
+  """
+  @spec get_method_from_json_string(binary()) :: binary() | {:error, Jason.DecodeError.t()}
   def get_method_from_json_string(json_string) do
     with {:ok, decoded_json} <- Jason.decode(json_string) do
       if is_map(decoded_json) do
@@ -25,6 +36,19 @@ defmodule EthereumJSONRPC.HTTP.Helper do
 
   def response_body_has_error?(_decoded_body), do: false
 
+  @doc """
+  Conditionally decompresses gzip-encoded HTTP response bodies.
+
+  Checks application configuration and HTTP headers to determine if decompression
+  should be attempted.
+
+  ## Parameters
+  - `body`: The response body to potentially decompress
+  - `headers`: List of HTTP response headers as {key, value} tuples
+
+  ## Returns
+  - Decompressed body if gzip-enabled and content is gzipped, otherwise original body
+  """
   @spec try_unzip(binary(), [{binary(), binary()}]) :: binary()
   def try_unzip(body, headers) do
     gzip_enabled? = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.HTTP)[:gzip_enabled?]

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -6,6 +6,7 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
   alias EthereumJSONRPC.HTTP
   alias EthereumJSONRPC.HTTP.Helper
   alias EthereumJSONRPC.Prometheus.Instrumenter
+  alias Utils.HttpClient.HTTPoisonHelper
 
   @behaviour HTTP
 
@@ -15,7 +16,7 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
 
     Instrumenter.json_rpc_requests(method)
 
-    case HTTPoison.post(url, json, headers, options) do
+    case HTTPoison.post(url, json, headers, HTTPoisonHelper.request_opts(options)) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->
         with {:ok, decoded_body} <- Jason.decode(body),
              true <- Helper.response_body_has_error?(decoded_body) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/mint.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/mint.ex
@@ -1,6 +1,6 @@
-defmodule EthereumJSONRPC.HTTP.HTTPoison do
+defmodule EthereumJSONRPC.HTTP.Mint do
   @moduledoc """
-  Uses `HTTPoison` for `EthereumJSONRPC.HTTP`
+  Uses `Tesla.Mint` for `EthereumJSONRPC.HTTP`
   """
 
   alias EthereumJSONRPC.HTTP
@@ -15,8 +15,8 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
 
     Instrumenter.json_rpc_requests(method)
 
-    case HTTPoison.post(url, json, headers, options) do
-      {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->
+    case Tesla.post(client(options), url, json, headers: headers, opts: request_opts(options)) do
+      {:ok, %Tesla.Env{body: body, status: status_code, headers: headers}} ->
         with {:ok, decoded_body} <- Jason.decode(body),
              true <- Helper.response_body_has_error?(decoded_body) do
           Instrumenter.json_rpc_errors(method)
@@ -24,12 +24,20 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
 
         {:ok, %{body: Helper.try_unzip(body, headers), status_code: status_code}}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
+      {:error, error} ->
         Instrumenter.json_rpc_errors(method)
 
-        {:error, reason}
+        {:error, error}
     end
   end
 
   def json_rpc(url, _json, _headers, _options) when is_nil(url), do: {:error, "URL is nil"}
+
+  defp client(options) do
+    Tesla.client([{Tesla.Middleware.Timeout, timeout: options[:recv_timeout]}], Tesla.Adapter.Mint)
+  end
+
+  defp request_opts(options) do
+    [adapter: [protocols: [:http1], timeout: options[:recv_timeout], transport_opts: [timeout: options[:timeout]]]]
+  end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -1,4 +1,4 @@
-defmodule EthereumJSONRPC.HTTP.Mint do
+defmodule EthereumJSONRPC.HTTP.Tesla do
   @moduledoc """
   Uses `Tesla.Mint` for `EthereumJSONRPC.HTTP`
   """

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -74,6 +74,7 @@ defmodule EthereumJSONRPC.MixProject do
       {:spandex, "~> 3.0"},
       # `:spandex` integration with Datadog
       {:spandex_datadog, "~> 1.0"},
+      {:tesla, "~> 1.14.1"},
       # Convert unix timestamps in JSONRPC to DateTimes
       {:timex, "~> 3.7.1"},
       # Encode/decode function names and arguments

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -31,7 +31,7 @@ defmodule EthereumJSONRPC.MixProject do
   def application do
     [
       mod: {EthereumJSONRPC.Application, []},
-      extra_applications: [:logger]
+      extra_applications: [:logger, :tesla]
     ]
   end
 

--- a/apps/ethereum_jsonrpc/mix.exs
+++ b/apps/ethereum_jsonrpc/mix.exs
@@ -74,7 +74,7 @@ defmodule EthereumJSONRPC.MixProject do
       {:spandex, "~> 3.0"},
       # `:spandex` integration with Datadog
       {:spandex_datadog, "~> 1.0"},
-      {:tesla, "~> 1.14.1"},
+      {:tesla, "~> 1.14.2"},
       # Convert unix timestamps in JSONRPC to DateTimes
       {:timex, "~> 3.7.1"},
       # Encode/decode function names and arguments

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case.ex
@@ -15,7 +15,8 @@ defmodule EthereumJSONRPC.Case do
   environment variable to determine `:json_rpc_named_arguments` `:transport_options` `:url`.  Failure to set
   `ETHEREUM_JSONRPC_HTTP_URL` in this case will raise an `ArgumentError`.
 
-  * `EthereumJSONRPC.HTTP.HTTPoison` - HTTP responses from calls to real chain URLs
+  * `EthereumJSONRPC.HTTP.HTTPoison` - HTTP responses from calls to real chain URLs (using HTTPoison client)
+  * `EthereumJSONRPC.HTTP.Mint` - HTTP responses from calls to real chain URLs (using Tesla.Mint client)
   * `EthereumJSONRPC.HTTP.Mox` - mock HTTP responses, so can be used for HTTP-only behavior like status codes.
 
   ## `subscribe_named_arguments`

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case.ex
@@ -16,7 +16,7 @@ defmodule EthereumJSONRPC.Case do
   `ETHEREUM_JSONRPC_HTTP_URL` in this case will raise an `ArgumentError`.
 
   * `EthereumJSONRPC.HTTP.HTTPoison` - HTTP responses from calls to real chain URLs (using HTTPoison client)
-  * `EthereumJSONRPC.HTTP.Mint` - HTTP responses from calls to real chain URLs (using Tesla.Mint client)
+  * `EthereumJSONRPC.HTTP.Tesla` - HTTP responses from calls to real chain URLs (using Tesla.Mint client)
   * `EthereumJSONRPC.HTTP.Mox` - mock HTTP responses, so can be used for HTTP-only behavior like status codes.
 
   ## `subscribe_named_arguments`

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
@@ -11,7 +11,7 @@ defmodule EthereumJSONRPC.Case.Geth.HTTPWebSocket do
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
         http: EthereumJSONRPC.HTTP.Mint,
-        http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
+        http_options: [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc],
         urls: ["https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY"]
       ],
       variant: EthereumJSONRPC.Geth

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.Case.Geth.HTTPWebSocket do
       :json_rpc_named_arguments,
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         http_options: [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc],
         urls: ["https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY"]
       ],

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/geth/http_websocket.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.Case.Geth.HTTPWebSocket do
       :json_rpc_named_arguments,
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
         urls: ["https://mainnet.infura.io/8lTvJTKmHPCHazkneJsY"]
       ],

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
@@ -11,7 +11,7 @@ defmodule EthereumJSONRPC.Case.Nethermind.HTTPWebSocket do
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
         http: EthereumJSONRPC.HTTP.Mint,
-        http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
+        http_options: [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc],
         urls: ["http://3.85.253.242:8545"]
       ],
       variant: EthereumJSONRPC.Nethermind

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.Case.Nethermind.HTTPWebSocket do
       :json_rpc_named_arguments,
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         http_options: [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]],
         urls: ["http://3.85.253.242:8545"]
       ],

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/case/nethermind/http_websocket.ex
@@ -10,7 +10,7 @@ defmodule EthereumJSONRPC.Case.Nethermind.HTTPWebSocket do
       :json_rpc_named_arguments,
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         http_options: [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc],
         urls: ["http://3.85.253.242:8545"]
       ],

--- a/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/http/case.ex
+++ b/apps/ethereum_jsonrpc/test/support/ethereum_jsonrpc/http/case.ex
@@ -21,7 +21,7 @@ defmodule EthereumJSONRPC.HTTP.Case do
   end
 
   def http_options do
-    [recv_timeout: 60_000, timeout: 60_000, hackney: [pool: :ethereum_jsonrpc]]
+    [recv_timeout: 60_000, timeout: 60_000, pool: :ethereum_jsonrpc]
   end
 
   def url do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -197,7 +197,7 @@ config :explorer, Explorer.Tracer,
 config :explorer,
   solc_bin_api_url: "https://solc-bin.ethereum.org"
 
-config :explorer, :http_adapter, HTTPoison
+config :explorer, :http_client, Explorer.HttpClient.Tesla
 
 config :explorer, Explorer.Chain.BridgedToken, enabled: ConfigHelper.parse_bool_env_var("BRIDGED_TOKENS_ENABLED")
 
@@ -213,6 +213,8 @@ config :spandex_ecto, SpandexEcto.EctoLogger,
   service: :ecto,
   tracer: Explorer.Tracer,
   otp_app: :explorer
+
+config :tesla, adapter: Tesla.Adapter.Mint
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/explorer/config/dev/anvil.exs
+++ b/apps/explorer/config/dev/anvil.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/explorer/config/dev/anvil.exs
+++ b/apps/explorer/config/dev/anvil.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -19,7 +16,7 @@ config :explorer,
       method_to_url: [
         eth_call: :eth_call
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Anvil
   ],

--- a/apps/explorer/config/dev/anvil.exs
+++ b/apps/explorer/config/dev/anvil.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/besu.exs
+++ b/apps/explorer/config/dev/besu.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/erigon.exs
+++ b/apps/explorer/config/dev/erigon.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/explorer/config/dev/filecoin.exs
+++ b/apps/explorer/config/dev/filecoin.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http, "http://localhost:1234/rpc/v1"),
       trace_urls: ConfigHelper.parse_urls_list(:trace, "http://localhost:1234/rpc/v1"),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:1234/rpc/v1"),

--- a/apps/explorer/config/dev/filecoin.exs
+++ b/apps/explorer/config/dev/filecoin.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http, "http://localhost:1234/rpc/v1"),
       trace_urls: ConfigHelper.parse_urls_list(:trace, "http://localhost:1234/rpc/v1"),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:1234/rpc/v1"),

--- a/apps/explorer/config/dev/filecoin.exs
+++ b/apps/explorer/config/dev/filecoin.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -22,7 +19,7 @@ config :explorer,
         eth_call: :eth_call,
         trace_block: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Filecoin
   ],

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/geth.exs
+++ b/apps/explorer/config/dev/geth.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         debug_traceTransaction: :trace,
         debug_traceBlockByNumber: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/explorer/config/dev/nethermind.exs
+++ b/apps/explorer/config/dev/nethermind.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/dev/rsk.exs
+++ b/apps/explorer/config/dev/rsk.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/explorer/config/prod/anvil.exs
+++ b/apps/explorer/config/prod/anvil.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/explorer/config/prod/anvil.exs
+++ b/apps/explorer/config/prod/anvil.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -19,7 +16,7 @@ config :explorer,
       method_to_url: [
         eth_call: :eth_call
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Anvil
   ],

--- a/apps/explorer/config/prod/anvil.exs
+++ b/apps/explorer/config/prod/anvil.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/besu.exs
+++ b/apps/explorer/config/prod/besu.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/erigon.exs
+++ b/apps/explorer/config/prod/erigon.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/explorer/config/prod/filecoin.exs
+++ b/apps/explorer/config/prod/filecoin.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/filecoin.exs
+++ b/apps/explorer/config/prod/filecoin.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/filecoin.exs
+++ b/apps/explorer/config/prod/filecoin.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -22,7 +19,7 @@ config :explorer,
         eth_call: :eth_call,
         trace_block: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Filecoin
   ],

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/geth.exs
+++ b/apps/explorer/config/prod/geth.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         debug_traceTransaction: :trace,
         debug_traceBlockByNumber: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/explorer/config/prod/nethermind.exs
+++ b/apps/explorer/config/prod/nethermind.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -11,7 +11,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -8,7 +8,7 @@ config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/explorer/config/prod/rsk.exs
+++ b/apps/explorer/config/prod/rsk.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :explorer,
   json_rpc_named_arguments: [
     transport: EthereumJSONRPC.HTTP,
@@ -23,7 +20,7 @@ config :explorer,
         eth_getBalance: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/explorer/lib/explorer/chain/blackfort/validator.ex
+++ b/apps/explorer/lib/explorer/chain/blackfort/validator.ex
@@ -7,7 +7,7 @@ defmodule Explorer.Chain.Blackfort.Validator do
 
   alias Explorer.Chain.{Address, Import}
   alias Explorer.Chain.Hash.Address, as: HashAddress
-  alias Explorer.{Chain, Helper, Repo, SortingHelper}
+  alias Explorer.{Chain, Helper, HttpClient, Repo, SortingHelper}
 
   require Logger
 
@@ -148,8 +148,7 @@ defmodule Explorer.Chain.Blackfort.Validator do
     url = validator_url()
 
     with {:url, true} <- {:url, Helper.valid_url?(url)},
-         {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
-           HTTPoison.get(validator_url(), [], follow_redirect: true) do
+         {:ok, %{status_code: 200, body: body}} <- HttpClient.get(validator_url(), [], follow_redirect: true) do
       body |> Jason.decode() |> parse_validators_info()
     else
       {:url, false} ->

--- a/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
+++ b/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
@@ -46,7 +46,7 @@ defmodule Explorer.Chain.Cache.OptimismFinalizationPeriod do
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),
-          hackney: [pool: :ethereum_jsonrpc]
+          pool: :ethereum_jsonrpc
         ]
       ]
     ]

--- a/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
+++ b/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
@@ -41,7 +41,7 @@ defmodule Explorer.Chain.Cache.OptimismFinalizationPeriod do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         urls: [optimism_l1_rpc],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
+++ b/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
@@ -41,7 +41,7 @@ defmodule Explorer.Chain.Cache.OptimismFinalizationPeriod do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         urls: [optimism_l1_rpc],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/explorer/lib/explorer/chain/fetcher/addresses_blacklist/blockaid.ex
+++ b/apps/explorer/lib/explorer/chain/fetcher/addresses_blacklist/blockaid.ex
@@ -2,7 +2,7 @@ defmodule Explorer.Chain.Fetcher.AddressesBlacklist.Blockaid do
   @moduledoc """
   Fetcher for addresses blacklist from blockaid provider
   """
-  alias Explorer.Chain
+  alias Explorer.{Chain, HttpClient}
   alias Explorer.Chain.Fetcher.AddressesBlacklist
 
   @behaviour AddressesBlacklist
@@ -12,8 +12,8 @@ defmodule Explorer.Chain.Fetcher.AddressesBlacklist.Blockaid do
 
   @impl AddressesBlacklist
   def fetch_addresses_blacklist do
-    case HTTPoison.get(AddressesBlacklist.url(), [], recv_timeout: @timeout, timeout: @timeout) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+    case HttpClient.get(AddressesBlacklist.url(), [], recv_timeout: @timeout, timeout: @timeout) do
+      {:ok, %{status_code: 200, body: body}} ->
         body
         |> Jason.decode()
         |> parse_blacklist()

--- a/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
+++ b/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
@@ -14,8 +14,7 @@ defmodule Explorer.ChainSpec.GenesisData do
   alias Explorer.Chain.SmartContract
   alias Explorer.ChainSpec.Geth.Importer, as: GethImporter
   alias Explorer.ChainSpec.Parity.Importer
-  alias Explorer.Helper
-  alias HTTPoison.Response
+  alias Explorer.{Helper, HttpClient}
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -172,10 +171,10 @@ defmodule Explorer.ChainSpec.GenesisData do
   end
 
   # Fetches JSON data from a provided URL.
-  @spec fetch_from_url(binary()) :: {:ok, list() | map()} | {:error, Jason.DecodeError.t() | HTTPoison.Error.t()}
+  @spec fetch_from_url(binary()) :: {:ok, list() | map()} | {:error, Jason.DecodeError.t() | any()}
   defp fetch_from_url(url) do
-    case HTTPoison.get(url) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url) do
+      {:ok, %{body: body, status_code: 200}} ->
         {:ok, Jason.decode!(body)}
 
       reason ->

--- a/apps/explorer/lib/explorer/http_client.ex
+++ b/apps/explorer/lib/explorer/http_client.ex
@@ -17,6 +17,10 @@ defmodule Explorer.HttpClient do
     adapter().head(url, headers, options)
   end
 
+  def request(method, url, headers, body, options \\ []) do
+    adapter().request(method, url, headers, body, options)
+  end
+
   defp adapter do
     Application.get_env(:explorer, :http_client)
   end

--- a/apps/explorer/lib/explorer/http_client.ex
+++ b/apps/explorer/lib/explorer/http_client.ex
@@ -1,0 +1,23 @@
+defmodule Explorer.HttpClient do
+  @moduledoc false
+
+  def get(url, headers \\ [], options \\ []) do
+    adapter().get(url, headers, options)
+  end
+
+  def get!(url, headers \\ [], options \\ []) do
+    adapter().get!(url, headers, options)
+  end
+
+  def post(url, body, headers \\ [], options \\ []) do
+    adapter().post(url, body, headers, options)
+  end
+
+  def head(url, headers \\ [], options \\ []) do
+    adapter().head(url, headers, options)
+  end
+
+  defp adapter do
+    Application.get_env(:explorer, :http_client)
+  end
+end

--- a/apps/explorer/lib/explorer/http_client/httpoison.ex
+++ b/apps/explorer/lib/explorer/http_client/httpoison.ex
@@ -1,0 +1,38 @@
+defmodule Explorer.HttpClient.HTTPoison do
+  @moduledoc false
+
+  def get(url, headers, options) do
+    url
+    |> HTTPoison.get(headers, options)
+    |> parse_response()
+  end
+
+  def get!(url, headers, options) do
+    url
+    |> HTTPoison.get!(headers, options)
+    |> parse_response()
+  end
+
+  def post(url, body, headers, options) do
+    url
+    |> HTTPoison.post(body, headers, options)
+    |> parse_response()
+  end
+
+  def head(url, headers, options) do
+    url
+    |> HTTPoison.head(headers, options)
+    |> parse_response()
+  end
+
+  defp parse_response({:ok, %{body: body, status_code: status_code, headers: response_headers}}) do
+    {:ok, %{body: body, status_code: status_code, headers: response_headers}}
+  end
+
+  defp parse_response(%{body: body, status_code: status_code, headers: response_headers}) do
+    %{body: body, status_code: status_code, headers: response_headers}
+  end
+
+  defp parse_response({:error, %{reason: reason}}), do: {:error, reason}
+  defp parse_response(error), do: error
+end

--- a/apps/explorer/lib/explorer/http_client/httpoison.ex
+++ b/apps/explorer/lib/explorer/http_client/httpoison.ex
@@ -27,6 +27,12 @@ defmodule Explorer.HttpClient.HTTPoison do
     |> parse_response()
   end
 
+  def request(method, url, headers, body, options) do
+    method
+    |> HTTPoison.request(url, body, headers, HTTPoisonHelper.request_opts(options))
+    |> parse_response()
+  end
+
   defp parse_response({:ok, %{body: body, status_code: status_code, headers: response_headers}}) do
     {:ok, %{body: body, status_code: status_code, headers: response_headers}}
   end

--- a/apps/explorer/lib/explorer/http_client/httpoison.ex
+++ b/apps/explorer/lib/explorer/http_client/httpoison.ex
@@ -1,27 +1,29 @@
 defmodule Explorer.HttpClient.HTTPoison do
   @moduledoc false
 
+  alias Utils.HttpClient.HTTPoisonHelper
+
   def get(url, headers, options) do
     url
-    |> HTTPoison.get(headers, options)
+    |> HTTPoison.get(headers, HTTPoisonHelper.request_opts(options))
     |> parse_response()
   end
 
   def get!(url, headers, options) do
     url
-    |> HTTPoison.get!(headers, options)
+    |> HTTPoison.get!(headers, HTTPoisonHelper.request_opts(options))
     |> parse_response()
   end
 
   def post(url, body, headers, options) do
     url
-    |> HTTPoison.post(body, headers, options)
+    |> HTTPoison.post(body, headers, HTTPoisonHelper.request_opts(options))
     |> parse_response()
   end
 
   def head(url, headers, options) do
     url
-    |> HTTPoison.head(headers, options)
+    |> HTTPoison.head(headers, HTTPoisonHelper.request_opts(options))
     |> parse_response()
   end
 

--- a/apps/explorer/lib/explorer/http_client/tesla.ex
+++ b/apps/explorer/lib/explorer/http_client/tesla.ex
@@ -1,0 +1,83 @@
+defmodule Explorer.HttpClient.Tesla do
+  @moduledoc false
+
+  def get(url, headers, options) do
+    options
+    |> client()
+    |> Tesla.get(url, headers: headers, opts: request_opts(options))
+    |> parse_response()
+  end
+
+  def get!(url, headers, options) do
+    options
+    |> client()
+    |> Tesla.get!(url, headers: headers, opts: request_opts(options))
+    |> parse_response()
+  end
+
+  def post(url, body, headers, options) do
+    options
+    |> client()
+    |> Tesla.post(url, body, headers: headers, opts: request_opts(options))
+    |> parse_response()
+  end
+
+  def head(url, headers, options) do
+    options
+    |> client()
+    |> Tesla.head(url, headers: headers, opts: request_opts(options))
+    |> parse_response()
+  end
+
+  defp parse_response({:ok, %{body: body, status: status_code, headers: response_headers}}) do
+    {:ok, %{body: body, status_code: status_code, headers: response_headers}}
+  end
+
+  defp parse_response(%{body: body, status: status_code, headers: response_headers}) do
+    %{body: body, status_code: status_code, headers: response_headers}
+  end
+
+  defp parse_response(error), do: error
+
+  defp client(options) do
+    options[:recv_timeout]
+    |> add_timeout_middleware()
+    |> add_follow_redirect_middleware(options[:follow_redirect])
+    |> Tesla.client()
+  end
+
+  defp add_timeout_middleware(middleware \\ [], timeout)
+
+  defp add_timeout_middleware(middleware, nil), do: middleware
+
+  defp add_timeout_middleware(middleware, timeout) do
+    [{Tesla.Middleware.Timeout, timeout: timeout} | middleware]
+  end
+
+  defp add_follow_redirect_middleware(middleware, true) do
+    [Tesla.Middleware.FollowRedirects | middleware]
+  end
+
+  defp add_follow_redirect_middleware(middleware, _follow_redirect?), do: middleware
+
+  defp request_opts(options) do
+    adapter_options =
+      [protocols: [:http1]]
+      |> add_recv_timeout_option(options[:recv_timeout])
+      |> add_timeout_option(options[:timeout])
+
+    [adapter: adapter_options]
+  end
+
+  defp add_recv_timeout_option(options, nil), do: options
+
+  defp add_recv_timeout_option(options, timeout) do
+    Keyword.put(options, :timeout, timeout)
+  end
+
+  defp add_timeout_option(options, nil), do: options
+
+  defp add_timeout_option(options, timeout) do
+    Keyword.put(options, :transport_opts, timeout: timeout)
+  end
+end

--- a/apps/explorer/lib/explorer/http_client/tesla.ex
+++ b/apps/explorer/lib/explorer/http_client/tesla.ex
@@ -31,6 +31,13 @@ defmodule Explorer.HttpClient.Tesla do
     |> parse_response()
   end
 
+  def request(method, url, headers, body, options) do
+    options
+    |> TeslaHelper.client()
+    |> Tesla.request(method: method, url: url, headers: headers, body: body, opts: TeslaHelper.request_opts(options))
+    |> parse_response()
+  end
+
   defp parse_response({:ok, %{body: body, status: status_code, headers: response_headers}}) do
     {:ok, %{body: body, status_code: status_code, headers: response_headers}}
   end

--- a/apps/explorer/lib/explorer/http_client/tesla.ex
+++ b/apps/explorer/lib/explorer/http_client/tesla.ex
@@ -1,31 +1,33 @@
 defmodule Explorer.HttpClient.Tesla do
   @moduledoc false
 
+  alias Utils.HttpClient.TeslaHelper
+
   def get(url, headers, options) do
     options
-    |> client()
-    |> Tesla.get(url, headers: headers, query: options[:params] || [], opts: request_opts(options))
+    |> TeslaHelper.client()
+    |> Tesla.get(url, headers: headers, query: options[:params] || [], opts: TeslaHelper.request_opts(options))
     |> parse_response()
   end
 
   def get!(url, headers, options) do
     options
-    |> client()
-    |> Tesla.get!(url, headers: headers, query: options[:params] || [], opts: request_opts(options))
+    |> TeslaHelper.client()
+    |> Tesla.get!(url, headers: headers, query: options[:params] || [], opts: TeslaHelper.request_opts(options))
     |> parse_response()
   end
 
   def post(url, body, headers, options) do
     options
-    |> client()
-    |> Tesla.post(url, body, headers: headers, opts: request_opts(options))
+    |> TeslaHelper.client()
+    |> Tesla.post(url, body, headers: headers, opts: TeslaHelper.request_opts(options))
     |> parse_response()
   end
 
   def head(url, headers, options) do
     options
-    |> client()
-    |> Tesla.head(url, headers: headers, opts: request_opts(options))
+    |> TeslaHelper.client()
+    |> Tesla.head(url, headers: headers, opts: TeslaHelper.request_opts(options))
     |> parse_response()
   end
 
@@ -38,46 +40,4 @@ defmodule Explorer.HttpClient.Tesla do
   end
 
   defp parse_response(error), do: error
-
-  defp client(options) do
-    options[:recv_timeout]
-    |> add_timeout_middleware()
-    |> add_follow_redirect_middleware(options[:follow_redirect])
-    |> Tesla.client()
-  end
-
-  defp add_timeout_middleware(middleware \\ [], timeout)
-
-  defp add_timeout_middleware(middleware, nil), do: middleware
-
-  defp add_timeout_middleware(middleware, timeout) do
-    [{Tesla.Middleware.Timeout, timeout: timeout} | middleware]
-  end
-
-  defp add_follow_redirect_middleware(middleware, true) do
-    [Tesla.Middleware.FollowRedirects | middleware]
-  end
-
-  defp add_follow_redirect_middleware(middleware, _follow_redirect?), do: middleware
-
-  defp request_opts(options) do
-    adapter_options =
-      [protocols: [:http1]]
-      |> add_recv_timeout_option(options[:recv_timeout])
-      |> add_timeout_option(options[:timeout])
-
-    [adapter: adapter_options]
-  end
-
-  defp add_recv_timeout_option(options, nil), do: options
-
-  defp add_recv_timeout_option(options, timeout) do
-    Keyword.put(options, :timeout, timeout)
-  end
-
-  defp add_timeout_option(options, nil), do: options
-
-  defp add_timeout_option(options, timeout) do
-    Keyword.put(options, :transport_opts, timeout: timeout)
-  end
 end

--- a/apps/explorer/lib/explorer/http_client/tesla.ex
+++ b/apps/explorer/lib/explorer/http_client/tesla.ex
@@ -4,14 +4,14 @@ defmodule Explorer.HttpClient.Tesla do
   def get(url, headers, options) do
     options
     |> client()
-    |> Tesla.get(url, headers: headers, opts: request_opts(options))
+    |> Tesla.get(url, headers: headers, query: options[:params] || [], opts: request_opts(options))
     |> parse_response()
   end
 
   def get!(url, headers, options) do
     options
     |> client()
-    |> Tesla.get!(url, headers: headers, opts: request_opts(options))
+    |> Tesla.get!(url, headers: headers, query: options[:params] || [], opts: request_opts(options))
     |> parse_response()
   end
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/account_abstraction.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/account_abstraction.ex
@@ -3,8 +3,8 @@ defmodule Explorer.MicroserviceInterfaces.AccountAbstraction do
     Interface to interact with Blockscout Account Abstraction (EIP-4337) microservice
   """
 
+  alias Explorer.HttpClient
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
   require Logger
 
   @doc """
@@ -138,13 +138,13 @@ defmodule Explorer.MicroserviceInterfaces.AccountAbstraction do
   end
 
   defp http_get_request(url, query_params) do
-    case HTTPoison.get(url, [], params: query_params) do
-      {:ok, %Response{body: body, status_code: status_code}}
+    case HttpClient.get(url, [], params: query_params) do
+      {:ok, %{body: body, status_code: status_code}}
       when status_code in [200, 404] ->
         {:ok, response_json} = Jason.decode(body)
         {status_code, response_json}
 
-      {_, %Response{body: body, status_code: status_code} = error} ->
+      {_, %{body: body, status_code: status_code} = error} ->
         old_truncate = Application.get_env(:logger, :truncate)
         Logger.configure(truncate: :infinity)
 
@@ -159,7 +159,7 @@ defmodule Explorer.MicroserviceInterfaces.AccountAbstraction do
         {:ok, response_json} = Jason.decode(body)
         {status_code, response_json}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
+      {:error, reason} ->
         {500, %{error: reason}}
     end
   end

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -3,13 +3,12 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
     Interface to interact with Blockscout ENS microservice
   """
 
-  alias Explorer.Chain
+  alias Explorer.{Chain, HttpClient}
   alias Explorer.Chain.Address.MetadataPreloader
 
   alias Explorer.Chain.{Address, Transaction}
 
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
 
   require Logger
 
@@ -92,8 +91,8 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   defp http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
+      {:ok, %{body: body, status_code: 200}} ->
         Jason.decode(body)
 
       {_, error} ->
@@ -113,8 +112,8 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   end
 
   defp http_get_request(url, query_params) do
-    case HTTPoison.get(url, [], params: query_params) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url, [], params: query_params) do
+      {:ok, %{body: body, status_code: 200}} ->
         Jason.decode(body)
 
       {_, error} ->

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -7,9 +7,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   alias Explorer.Chain.{Block, Hash, Transaction}
   alias Explorer.Chain.Block.Range
   alias Explorer.Chain.MultichainSearchDb.MainExportQueue
-  alias Explorer.{Helper, Repo}
+  alias Explorer.{Helper, HttpClient, Repo}
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
 
   require Logger
 
@@ -247,14 +246,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   defp http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case Application.get_env(:explorer, :http_adapter).post(url, Jason.encode!(body), headers,
+    case HttpClient.post(url, Jason.encode!(body), headers,
            recv_timeout: @post_timeout,
            hackney: [pool: false]
          ) do
-      {:ok, %Response{body: response_body, status_code: 200}} ->
+      {:ok, %{body: response_body, status_code: 200}} ->
         response_body |> Jason.decode()
 
-      {:ok, %Response{body: response_body, status_code: status_code}} ->
+      {:ok, %{body: response_body, status_code: status_code}} ->
         {:error,
          %{
            url: url,
@@ -263,7 +262,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
            response_body: response_body
          }}
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
+      {:error, reason} ->
         {:error,
          %{
            url: url,

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -248,7 +248,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
     case HttpClient.post(url, Jason.encode!(body), headers,
            recv_timeout: @post_timeout,
-           hackney: [pool: false]
+           pool: false
          ) do
       {:ok, %{body: response_body, status_code: 200}} ->
         response_body |> Jason.decode()

--- a/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
@@ -3,8 +3,8 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
     Interface to interact with Tac Operation Lifecycle Service (https://github.com/blockscout/blockscout-rs/tree/main/tac-operation-lifecycle)
   """
 
+  alias Explorer.HttpClient
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
   require Logger
 
   @request_error_msg "Error while sending request to Tac Operation Lifecycle Service"
@@ -33,8 +33,8 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
   end
 
   defp http_get_request(url, query_params) do
-    case HTTPoison.get(url, [], params: query_params) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url, [], params: query_params) do
+      {:ok, %{body: body, status_code: 200}} ->
         case Jason.decode(body) do
           {:ok, decoded_body} ->
             {:ok, decoded_body}
@@ -44,7 +44,7 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
             {:error, error}
         end
 
-      {:ok, %Response{body: _body, status_code: 404}} ->
+      {:ok, %{body: _body, status_code: 404}} ->
         {:error, :not_found}
 
       {_, error} ->

--- a/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
+++ b/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
@@ -76,7 +76,6 @@ defmodule Explorer.SmartContract.CompilerVersion do
     else
       headers = [{"Content-Type", "application/json"}]
 
-      # credo:disable-for-next-line
       case HttpClient.get(source_url(compiler_type), headers) do
         {:ok, %{status_code: 200, body: body}} ->
           {:ok, format_data(body, compiler_type)}

--- a/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
+++ b/apps/explorer/lib/explorer/smart_contract/compiler_version.ex
@@ -3,7 +3,7 @@ defmodule Explorer.SmartContract.CompilerVersion do
   Adapter for fetching compiler versions from https://solc-bin.ethereum.org/bin/list.json.
   """
 
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
   alias Explorer.SmartContract.{RustVerifierInterface, StylusVerifierInterface}
 
   @unsupported_solc_versions ~w(0.1.1 0.1.2)
@@ -77,14 +77,14 @@ defmodule Explorer.SmartContract.CompilerVersion do
       headers = [{"Content-Type", "application/json"}]
 
       # credo:disable-for-next-line
-      case HTTPoison.get(source_url(compiler_type), headers) do
+      case HttpClient.get(source_url(compiler_type), headers) do
         {:ok, %{status_code: 200, body: body}} ->
           {:ok, format_data(body, compiler_type)}
 
         {:ok, %{status_code: _status_code, body: body}} ->
           {:error, Helper.decode_json(body)["error"]}
 
-        {:error, %{reason: reason}} ->
+        {:error, reason} ->
           {:error, reason}
       end
     end

--- a/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface_behaviour.ex
+++ b/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface_behaviour.ex
@@ -5,8 +5,8 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
   defmacro __using__(_) do
     # credo:disable-for-next-line
     quote([]) do
+      alias Explorer.HttpClient
       alias Explorer.Utility.Microservice
-      alias HTTPoison.Response
       require Logger
 
       @post_timeout :timer.minutes(5)
@@ -78,10 +78,10 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
       def http_post_request(url, body, is_verification_request?, options \\ []) do
         headers = [{"Content-Type", "application/json"}]
 
-        case HTTPoison.post(url, Jason.encode!(body), maybe_put_api_key_header(headers, is_verification_request?),
+        case HttpClient.post(url, Jason.encode!(body), maybe_put_api_key_header(headers, is_verification_request?),
                recv_timeout: @post_timeout
              ) do
-          {:ok, %Response{body: body, status_code: _}} ->
+          {:ok, %{body: body, status_code: _}} ->
             process_verifier_response(body, options)
 
           {:error, error} ->
@@ -113,11 +113,11 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
       end
 
       def http_get_request(url) do
-        case HTTPoison.get(url) do
-          {:ok, %Response{body: body, status_code: 200}} ->
+        case HttpClient.get(url) do
+          {:ok, %{body: body, status_code: 200}} ->
             process_verifier_response(body, [])
 
-          {:ok, %Response{body: body, status_code: _}} ->
+          {:ok, %{body: body, status_code: _}} ->
             {:error, body}
 
           {:error, error} ->

--- a/apps/explorer/lib/explorer/smart_contract/sig_provider_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/sig_provider_interface.ex
@@ -3,8 +3,8 @@ defmodule Explorer.SmartContract.SigProviderInterface do
     Adapter for decoding events and function calls with https://github.com/blockscout/blockscout-rs/tree/main/sig-provider
   """
 
+  alias Explorer.HttpClient
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
   require Logger
 
   @request_error_msg "Error while sending request to sig-provider"
@@ -78,11 +78,11 @@ defmodule Explorer.SmartContract.SigProviderInterface do
   end
 
   defp http_get_request(url) do
-    case HTTPoison.get(url) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url) do
+      {:ok, %{body: body, status_code: 200}} ->
         process_sig_provider_response(body)
 
-      {:ok, %Response{body: body, status_code: _}} ->
+      {:ok, %{body: body, status_code: _}} ->
         {:error, body}
 
       {:error, error} ->
@@ -104,8 +104,8 @@ defmodule Explorer.SmartContract.SigProviderInterface do
   defp http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
+      {:ok, %{body: body, status_code: 200}} ->
         body |> Jason.decode()
 
       error ->

--- a/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solc_downloader.ex
@@ -5,6 +5,7 @@ defmodule Explorer.SmartContract.SolcDownloader do
   """
   use GenServer
 
+  alias Explorer.HttpClient
   alias Explorer.SmartContract.CompilerVersion
 
   @latest_compiler_refetch_time :timer.minutes(30)
@@ -93,7 +94,7 @@ defmodule Explorer.SmartContract.SolcDownloader do
     download_path = "https://solc-bin.ethereum.org/bin/soljson-#{version}.js"
 
     download_path
-    |> HTTPoison.get!([], timeout: 60_000, recv_timeout: 60_000)
+    |> HttpClient.get!([], timeout: 60_000, recv_timeout: 60_000)
     |> Map.get(:body)
   end
 end

--- a/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
@@ -20,6 +20,7 @@ defmodule Explorer.SmartContract.Solidity.CodeCompiler do
 
   ## Examples
 
+      iex(1)> Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
       iex(1)> Explorer.SmartContract.Solidity.CodeCompiler.run([
       ...>      name: "SimpleStorage",
       ...>      compiler_version: "v0.4.24+commit.e67f0147",

--- a/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/code_compiler.ex
@@ -20,7 +20,7 @@ defmodule Explorer.SmartContract.Solidity.CodeCompiler do
 
   ## Examples
 
-      iex(1)> Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+      iex(1)> Tesla.Test.expect_tesla_call(times: 1, returns: %Tesla.Env{status: 200, body: ""})
       iex(1)> Explorer.SmartContract.Solidity.CodeCompiler.run([
       ...>      name: "SimpleStorage",
       ...>      compiler_version: "v0.4.24+commit.e67f0147",

--- a/apps/explorer/lib/explorer/smart_contract/stylus_verifier_interface.ex
+++ b/apps/explorer/lib/explorer/smart_contract/stylus_verifier_interface.ex
@@ -6,7 +6,7 @@ defmodule Explorer.SmartContract.StylusVerifierInterface do
     Handles verification requests for Stylus contracts deployed from GitHub repositories by
     communicating with an external verification service.
   """
-  alias HTTPoison.Response
+  alias Explorer.HttpClient
   require Logger
 
   @post_timeout :timer.minutes(5)
@@ -55,8 +55,8 @@ defmodule Explorer.SmartContract.StylusVerifierInterface do
   defp http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
-      {:ok, %Response{body: body, status_code: _}} ->
+    case HttpClient.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
+      {:ok, %{body: body, status_code: _}} ->
         process_verifier_response(body)
 
       {:error, error} ->
@@ -73,11 +73,11 @@ defmodule Explorer.SmartContract.StylusVerifierInterface do
 
   @spec http_get_request(String.t()) :: {:ok, [String.t()]} | {:error, any()}
   defp http_get_request(url) do
-    case HTTPoison.get(url) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url) do
+      {:ok, %{body: body, status_code: 200}} ->
         process_verifier_response(body)
 
-      {:ok, %Response{body: body, status_code: _}} ->
+      {:ok, %{body: body, status_code: _}} ->
         {:error, body}
 
       {:error, error} ->

--- a/apps/explorer/lib/explorer/smart_contract/vyper_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper_downloader.ex
@@ -125,8 +125,7 @@ defmodule Explorer.SmartContract.VyperDownloader do
     |> HttpClient.get!([],
       timeout: 60_000,
       recv_timeout: 60_000,
-      follow_redirect: true,
-      hackney: [force_redirect: true]
+      follow_redirect: true
     )
     |> Map.get(:body)
   end

--- a/apps/explorer/lib/explorer/smart_contract/vyper_downloader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/vyper_downloader.ex
@@ -5,6 +5,7 @@ defmodule Explorer.SmartContract.VyperDownloader do
   """
   use GenServer
 
+  alias Explorer.HttpClient
   alias Explorer.SmartContract.CompilerVersion
 
   @latest_compiler_refetch_time :timer.minutes(30)
@@ -97,7 +98,7 @@ defmodule Explorer.SmartContract.VyperDownloader do
 
     releases_body =
       releases_path
-      |> HTTPoison.get!([], timeout: 60_000, recv_timeout: 60_000)
+      |> HttpClient.get!([], timeout: 60_000, recv_timeout: 60_000)
       |> Map.get(:body)
       |> Jason.decode!()
 
@@ -121,7 +122,12 @@ defmodule Explorer.SmartContract.VyperDownloader do
       end)
 
     download_path
-    |> HTTPoison.get!([], timeout: 60_000, recv_timeout: 60_000, follow_redirect: true, hackney: [force_redirect: true])
+    |> HttpClient.get!([],
+      timeout: 60_000,
+      recv_timeout: 60_000,
+      follow_redirect: true,
+      hackney: [force_redirect: true]
+    )
     |> Map.get(:body)
   end
 end

--- a/apps/explorer/lib/explorer/third_party_integrations/airtable.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/airtable.ex
@@ -7,8 +7,7 @@ defmodule Explorer.ThirdPartyIntegrations.AirTable do
   alias Ecto.Changeset
   alias Explorer.Account.PublicTagsRequest
   alias Explorer.Chain.SmartContract.AuditReport
-  alias Explorer.Repo
-  alias HTTPoison.Response
+  alias Explorer.{HttpClient, Repo}
 
   @doc """
     Submits a public tags request or audit report to AirTable
@@ -76,10 +75,10 @@ defmodule Explorer.ThirdPartyIntegrations.AirTable do
       "records" => [%{"fields" => map}]
     }
 
-    request = HTTPoison.post(url, Jason.encode!(body), headers, [])
+    request = HttpClient.post(url, Jason.encode!(body), headers)
 
     case request do
-      {:ok, %Response{body: body, status_code: 200}} ->
+      {:ok, %{body: body, status_code: 200}} ->
         request_id = Enum.at(Jason.decode!(body)["records"], 0)["fields"]["request_id"]
 
         success_callback.(request_id)

--- a/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
@@ -5,7 +5,7 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
   require Logger
 
   alias Explorer.Account.Identity
-  alias Explorer.{Account, Helper}
+  alias Explorer.{Account, Helper, HttpClient}
   alias Explorer.ThirdPartyIntegrations.Auth0.Internal
   alias Ueberauth.Auth
   alias Ueberauth.Strategy.Auth0.OAuth
@@ -42,8 +42,8 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
       "grant_type" => "client_credentials"
     }
 
-    case HTTPoison.post("https://#{config[:domain]}/oauth/token", Jason.encode!(body), @json_content_type, []) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+    case HttpClient.post("https://#{config[:domain]}/oauth/token", Jason.encode!(body), @json_content_type) do
+      {:ok, %{status_code: 200, body: body}} ->
         case Jason.decode!(body) do
           %{"access_token" => token, "expires_in" => ttl} ->
             cache_token(token, ttl - 1)

--- a/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/noves_fi.ex
@@ -5,7 +5,7 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
 
   require Logger
 
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
   alias Explorer.Utility.Microservice
 
   @recv_timeout 60_000
@@ -31,8 +31,8 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
       conn.query_params
       |> Map.drop(["hashes"])
 
-    case HTTPoison.post(url, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout, params: prepared_params) do
-      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+    case HttpClient.post(url, Jason.encode!(hashes), headers, recv_timeout: @recv_timeout, params: prepared_params) do
+      {:ok, %{status_code: status, body: body}} ->
         {Helper.decode_json(body), status}
 
       {:error, reason} ->
@@ -49,8 +49,8 @@ defmodule Explorer.ThirdPartyIntegrations.NovesFi do
 
     url_with_params = url <> "?" <> conn.query_string
 
-    case HTTPoison.get(url_with_params, headers, recv_timeout: @recv_timeout) do
-      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+    case HttpClient.get(url_with_params, headers, recv_timeout: @recv_timeout) do
+      {:ok, %{status_code: status, body: body}} ->
         {Helper.decode_json(body), status}
 
       {:error, reason} ->

--- a/apps/explorer/lib/explorer/third_party_integrations/solidityscan.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/solidityscan.ex
@@ -4,7 +4,7 @@ defmodule Explorer.ThirdPartyIntegrations.SolidityScan do
   """
 
   require Logger
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
 
   @recv_timeout 60_000
 
@@ -18,8 +18,8 @@ defmodule Explorer.ThirdPartyIntegrations.SolidityScan do
     url = base_url(address_hash_string)
 
     if url do
-      case HTTPoison.get(url, headers, recv_timeout: @recv_timeout) do
-        {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+      case HttpClient.get(url, headers, recv_timeout: @recv_timeout) do
+        {:ok, %{status_code: 200, body: body}} ->
           Helper.decode_json(body)
 
         _ ->

--- a/apps/explorer/lib/explorer/third_party_integrations/universal_proxy.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/universal_proxy.ex
@@ -2,7 +2,6 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
   @moduledoc """
   Module for universal proxying 3rd party API endpoints
   """
-  use Tesla
 
   alias Explorer.Helper
 

--- a/apps/explorer/lib/explorer/third_party_integrations/universal_proxy.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/universal_proxy.ex
@@ -3,7 +3,7 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
   Module for universal proxying 3rd party API endpoints
   """
 
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
 
   @recv_timeout 60_000
 
@@ -53,7 +53,7 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
   1. Retrieves the platform-specific configuration based on the `platform_id` key in `proxy_params`.
   2. Constructs the request URL using the `base_url` and `base` endpoint path.
   3. Parses and applies any API key and endpoint parameters.
-  4. Sends the HTTP request using the Tesla library with the specified method, URL, headers, and body.
+  4. Sends the HTTP request using `Explorer.HttpClient` with the specified method, URL, headers, and body.
 
   ## Returns
 
@@ -73,7 +73,7 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
 
   ## Notes
 
-    - The function uses the `Tesla` library with the `Tesla.Adapter.Mint` adapter.
+    - The function uses the `Explorer.HttpClient` with pre-configured adapter.
     - A timeout is applied to the request using the `@recv_timeout` module attribute.
   """
   @spec api_request(map()) :: {any(), integer()}
@@ -104,14 +104,8 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
 
     with {:invalid_config, false} <- {:invalid_config, is_nil(url)},
          {:invalid_config, false} <- {:invalid_config, is_nil(method)},
-         {:ok, %Tesla.Env{status: status, body: body}} <-
-           Tesla.request(
-             method: method,
-             url: url,
-             headers: headers,
-             body: body,
-             opts: [timeout: @recv_timeout, adapter: [protocols: [:http1]]]
-           ) do
+         {:ok, %{status_code: status, body: body}} <-
+           HttpClient.request(method, url, headers, body, timeout: @recv_timeout) do
       {Helper.decode_json(body), status}
     else
       {:invalid_config, true} ->
@@ -332,8 +326,8 @@ defmodule Explorer.ThirdPartyIntegrations.UniversalProxy do
         safe_parse_config_string(config_string)
 
       nil ->
-        case Tesla.get(config_url()) do
-          {:ok, %Tesla.Env{status: 200, body: config_string}} ->
+        case HttpClient.get(config_url()) do
+          {:ok, %{status_code: 200, body: config_string}} ->
             safe_parse_config_string(config_string, true)
 
           _ ->

--- a/apps/explorer/lib/explorer/third_party_integrations/xname.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/xname.ex
@@ -5,7 +5,7 @@ defmodule Explorer.ThirdPartyIntegrations.Xname do
 
   require Logger
 
-  alias Explorer.Helper
+  alias Explorer.{Helper, HttpClient}
   alias Explorer.Utility.Microservice
 
   @recv_timeout 60_000
@@ -19,8 +19,8 @@ defmodule Explorer.ThirdPartyIntegrations.Xname do
   def api_request(url, _conn, :get) do
     headers = [{"x-api-key", api_key()}]
 
-    case HTTPoison.get(url, headers, recv_timeout: @recv_timeout) do
-      {:ok, %HTTPoison.Response{status_code: status, body: body}} ->
+    case HttpClient.get(url, headers, recv_timeout: @recv_timeout) do
+      {:ok, %{status_code: status, body: body}} ->
         {Helper.decode_json(body), status}
 
       {:error, reason} ->

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -5,11 +5,10 @@ defmodule Explorer.Token.MetadataRetriever do
 
   require Logger
 
-  alias Explorer.{MetadataURIValidator, Repo}
+  alias Explorer.{HttpClient, MetadataURIValidator, Repo}
   alias Explorer.Chain.{Hash, Token}
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.SmartContract.Reader
-  alias HTTPoison.{Error, Response}
 
   @no_uri_error "no uri"
   @vm_execution_error "VM execution error"
@@ -848,12 +847,12 @@ defmodule Explorer.Token.MetadataRetriever do
   defp fetch_metadata_from_uri_request(uri, hex_token_id, ipfs_params) do
     headers = if ipfs?(ipfs_params), do: ipfs_headers(), else: @default_headers
 
-    case Application.get_env(:explorer, :http_adapter).get(uri, headers,
+    case HttpClient.get(uri, headers,
            recv_timeout: 30_000,
            follow_redirect: true,
            hackney: [pool: :token_instance_fetcher]
          ) do
-      {:ok, %Response{body: body, status_code: 200, headers: response_headers}} ->
+      {:ok, %{body: body, status_code: 200, headers: response_headers}} ->
         content_type = get_content_type_from_headers(response_headers)
 
         case check_content_type(content_type, uri, hex_token_id, body, ipfs_params) do
@@ -864,7 +863,7 @@ defmodule Explorer.Token.MetadataRetriever do
             {:error, reason}
         end
 
-      {:ok, %Response{body: body, status_code: code}} ->
+      {:ok, %{body: body, status_code: code}} ->
         Logger.debug(
           ["Request to token uri: #{inspect(uri)} failed with code #{code}. Body:", inspect(body)],
           fetcher: :token_instances
@@ -872,7 +871,7 @@ defmodule Explorer.Token.MetadataRetriever do
 
         {:error_code, code}
 
-      {:error, %Error{reason: reason}} ->
+      {:error, reason} ->
         Logger.warning(
           ["Request to token uri failed: #{inspect(uri)}.", inspect(reason)],
           fetcher: :token_instances

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -850,7 +850,7 @@ defmodule Explorer.Token.MetadataRetriever do
     case HttpClient.get(uri, headers,
            recv_timeout: 30_000,
            follow_redirect: true,
-           hackney: [pool: :token_instance_fetcher]
+           pool: :token_instance_fetcher
          ) do
       {:ok, %{body: body, status_code: 200, headers: response_headers}} ->
         content_type = get_content_type_from_headers(response_headers)

--- a/apps/explorer/lib/explorer/visualize/sol2uml.ex
+++ b/apps/explorer/lib/explorer/visualize/sol2uml.ex
@@ -2,8 +2,8 @@ defmodule Explorer.Visualize.Sol2uml do
   @moduledoc """
     Adapter for sol2uml visualizer with https://github.com/blockscout/blockscout-rs/blob/main/visualizer
   """
+  alias Explorer.HttpClient
   alias Explorer.Utility.Microservice
-  alias HTTPoison.Response
   require Logger
 
   @post_timeout 60_000
@@ -16,11 +16,11 @@ defmodule Explorer.Visualize.Sol2uml do
   def http_post_request(url, body) do
     headers = [{"Content-Type", "application/json"}]
 
-    case HTTPoison.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.post(url, Jason.encode!(body), headers, recv_timeout: @post_timeout) do
+      {:ok, %{body: body, status_code: 200}} ->
         process_visualizer_response(body)
 
-      {:ok, %Response{body: body, status_code: status_code}} ->
+      {:ok, %{body: body, status_code: status_code}} ->
         Logger.error(fn -> ["Invalid status code from visualizer: #{status_code}. body: ", inspect(body)] end)
         {:error, "failed to visualize contract"}
 

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -115,7 +115,7 @@ defmodule Explorer.Mixfile do
       # `Timex.Duration` for `Explorer.Chain.Cache.Counters.AverageBlockTime.average_block_time/0`
       {:timex, "~> 3.7.1"},
       {:con_cache, "~> 1.0"},
-      {:tesla, "~> 1.14.1"},
+      {:tesla, "~> 1.14.2"},
       {:cbor, "~> 1.0"},
       {:cloak_ecto, "~> 1.3.0"},
       {:redix, "~> 1.1"},

--- a/apps/explorer/mix.exs
+++ b/apps/explorer/mix.exs
@@ -134,7 +134,8 @@ defmodule Explorer.Mixfile do
       {:dns, "~> 2.4.0"},
       {:inet_cidr, "~> 1.0.0"},
       {:hammer, "~> 7.0"},
-      {:ton, "~> 0.5.0"}
+      {:ton, "~> 0.5.0"},
+      {:mint, "~> 1.0"}
     ]
   end
 

--- a/apps/explorer/test/explorer/market/fetcher/history_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/history_test.exs
@@ -52,15 +52,18 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
   test "handle_info with native_coin_price_history" do
     source_configuration = Application.get_env(:explorer, Source)
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     bypass = Bypass.open()
 
     Application.put_env(:explorer, Source, native_coin_history_source: CryptoCompare)
     Application.put_env(:explorer, CryptoCompare, base_url: "http://localhost:#{bypass.port}", coin_symbol: "TEST")
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
     on_exit(fn ->
       Application.put_env(:explorer, Source, source_configuration)
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     resp =
@@ -187,13 +190,16 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
     bypass = Bypass.open()
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
     source_configuration = Application.get_env(:explorer, Source)
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Source, native_coin_history_source: CryptoCompare)
     Application.put_env(:explorer, CryptoCompare, base_url: "http://localhost:#{bypass.port}", coin_symbol: "TEST")
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
     on_exit(fn ->
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
       Application.put_env(:explorer, Source, source_configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     resp =

--- a/apps/explorer/test/explorer/market/fetcher/history_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/history_test.exs
@@ -52,7 +52,6 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
   test "handle_info with native_coin_price_history" do
     source_configuration = Application.get_env(:explorer, Source)
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     bypass = Bypass.open()
 
@@ -63,7 +62,7 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
     on_exit(fn ->
       Application.put_env(:explorer, Source, source_configuration)
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     resp =
@@ -190,7 +189,6 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
     bypass = Bypass.open()
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
     source_configuration = Application.get_env(:explorer, Source)
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Source, native_coin_history_source: CryptoCompare)
     Application.put_env(:explorer, CryptoCompare, base_url: "http://localhost:#{bypass.port}", coin_symbol: "TEST")
@@ -199,7 +197,7 @@ defmodule Explorer.Market.Fetcher.HistoryTest do
     on_exit(fn ->
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
       Application.put_env(:explorer, Source, source_configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     resp =

--- a/apps/explorer/test/explorer/market/fetcher/token_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/token_test.exs
@@ -18,7 +18,6 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
       fetcher_configuration = Application.get_env(:explorer, Explorer.Market.Fetcher.Token)
       coin_gecko_configuration = Application.get_env(:explorer, Explorer.Market.Source.CoinGecko)
-      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.Market.Source, tokens_source: Explorer.Market.Source.CoinGecko)
 
@@ -41,7 +40,7 @@ defmodule Explorer.Market.Fetcher.TokenTest do
         Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
         Application.put_env(:explorer, Explorer.Market.Fetcher.Token, fetcher_configuration)
         Application.put_env(:explorer, Explorer.Market.Source.CoinGecko, coin_gecko_configuration)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       [_token_with_no_exchange_rate | tokens] =

--- a/apps/explorer/test/explorer/market/fetcher/token_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/token_test.exs
@@ -18,6 +18,7 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
       fetcher_configuration = Application.get_env(:explorer, Explorer.Market.Fetcher.Token)
       coin_gecko_configuration = Application.get_env(:explorer, Explorer.Market.Source.CoinGecko)
+      tesla_config = Application.get_env(:tesla, :adapter)
 
       Application.put_env(:explorer, Explorer.Market.Source, tokens_source: Explorer.Market.Source.CoinGecko)
 
@@ -34,10 +35,13 @@ defmodule Explorer.Market.Fetcher.TokenTest do
         base_url: "http://localhost:#{bypass.port}"
       )
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
         Application.put_env(:explorer, Explorer.Market.Fetcher.Token, fetcher_configuration)
         Application.put_env(:explorer, Explorer.Market.Source.CoinGecko, coin_gecko_configuration)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       [_token_with_no_exchange_rate | tokens] =

--- a/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
+++ b/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
@@ -11,6 +11,7 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
 
     coin_gecko_configuration = Application.get_env(:explorer, CoinGecko)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Explorer.Market.Source,
       native_coin_source: CoinGecko,
@@ -30,9 +31,12 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
       platform: "test"
     )
 
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CoinGecko, coin_gecko_configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
+++ b/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
@@ -11,7 +11,6 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
 
     coin_gecko_configuration = Application.get_env(:explorer, CoinGecko)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Explorer.Market.Source,
       native_coin_source: CoinGecko,
@@ -36,7 +35,7 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CoinGecko, coin_gecko_configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/coin_market_cap_test.exs
+++ b/apps/explorer/test/explorer/market/source/coin_market_cap_test.exs
@@ -10,6 +10,7 @@ defmodule Explorer.Market.Source.CoinMarketCapTest do
 
     coin_market_cap_configuration = Application.get_env(:explorer, CoinMarketCap)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Explorer.Market.Source,
       native_coin_source: CoinMarketCap,
@@ -28,9 +29,12 @@ defmodule Explorer.Market.Source.CoinMarketCapTest do
       currency_id: "2781"
     )
 
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CoinMarketCap, coin_market_cap_configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/coin_market_cap_test.exs
+++ b/apps/explorer/test/explorer/market/source/coin_market_cap_test.exs
@@ -10,7 +10,6 @@ defmodule Explorer.Market.Source.CoinMarketCapTest do
 
     coin_market_cap_configuration = Application.get_env(:explorer, CoinMarketCap)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, Explorer.Market.Source,
       native_coin_source: CoinMarketCap,
@@ -34,7 +33,7 @@ defmodule Explorer.Market.Source.CoinMarketCapTest do
     on_exit(fn ->
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CoinMarketCap, coin_market_cap_configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/crypto_compare_test.exs
+++ b/apps/explorer/test/explorer/market/source/crypto_compare_test.exs
@@ -10,7 +10,6 @@ defmodule Explorer.Market.Source.CryptoCompareTest do
     coin = Application.get_env(:explorer, :coin)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, :coin, "TEST")
 
@@ -37,7 +36,7 @@ defmodule Explorer.Market.Source.CryptoCompareTest do
       Application.put_env(:explorer, :coin, coin)
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/crypto_compare_test.exs
+++ b/apps/explorer/test/explorer/market/source/crypto_compare_test.exs
@@ -10,6 +10,7 @@ defmodule Explorer.Market.Source.CryptoCompareTest do
     coin = Application.get_env(:explorer, :coin)
     source_configuration = Application.get_env(:explorer, Explorer.Market.Source)
     crypto_compare_configuration = Application.get_env(:explorer, CryptoCompare)
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(:explorer, :coin, "TEST")
 
@@ -30,10 +31,13 @@ defmodule Explorer.Market.Source.CryptoCompareTest do
       currency: "AED"
     )
 
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     on_exit(fn ->
       Application.put_env(:explorer, :coin, coin)
       Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
       Application.put_env(:explorer, CryptoCompare, crypto_compare_configuration)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/crypto_rank_test.exs
+++ b/apps/explorer/test/explorer/market/source/crypto_rank_test.exs
@@ -7,7 +7,6 @@ defmodule Explorer.Market.Source.CryptoRankTest do
   setup do
     bypass = Bypass.open()
     old_env = Application.get_env(:explorer, CryptoRank, [])
-    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(
       :explorer,
@@ -26,7 +25,7 @@ defmodule Explorer.Market.Source.CryptoRankTest do
 
     on_exit(fn ->
       Application.put_env(:explorer, CryptoRank, old_env)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, old_env: old_env, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source/crypto_rank_test.exs
+++ b/apps/explorer/test/explorer/market/source/crypto_rank_test.exs
@@ -7,6 +7,7 @@ defmodule Explorer.Market.Source.CryptoRankTest do
   setup do
     bypass = Bypass.open()
     old_env = Application.get_env(:explorer, CryptoRank, [])
+    tesla_config = Application.get_env(:tesla, :adapter)
 
     Application.put_env(
       :explorer,
@@ -21,8 +22,11 @@ defmodule Explorer.Market.Source.CryptoRankTest do
       )
     )
 
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
     on_exit(fn ->
       Application.put_env(:explorer, CryptoRank, old_env)
+      Application.put_env(:tesla, :adapter, tesla_config)
     end)
 
     {:ok, old_env: old_env, bypass: bypass}

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -16,10 +16,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
       Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
       Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())
 
-      tesla_config = Application.get_env(:tesla, :adapter)
-
       on_exit(fn ->
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       :ok

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -16,6 +16,12 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
       Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
       Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+
+      on_exit(fn ->
+        Application.put_env(:tesla, :adapter, tesla_config)
+      end)
+
       :ok
     end
 
@@ -31,6 +37,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
     test "processes chunks and returns {:ok, result} when the service is enabled" do
       bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",
@@ -76,6 +84,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
     test "returns {:error, data_to_retry} when an error occurs during processing and 'multichain_search_db_main_export_queue' table is populated" do
       bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",
@@ -150,11 +160,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
         addresses_chunk_size: 7000
       )
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       on_exit(fn ->
         Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
       end)
 
       TestHelper.get_chain_id_mock()
@@ -173,18 +180,28 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
           insert(:address)
         end
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn "http://localhost:1234/api/v1/import:batch", _expected_body, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"status" => "ok"})}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(%{"status" => "ok"})
+           }}
+        end
+      )
 
-      Explorer.Mox.HTTPoison
-      |> expect(:post, fn "http://localhost:1234/api/v1/import:batch",
-                          _expected_body,
-                          [{"Content-Type", "application/json"}],
-                          _options ->
-        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", headers: [{"Content-Type", "application/json"}]},
+                    _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 500,
+             body: Jason.encode!(%{"code" => 0, "message" => "Error"})
+           }}
+        end
+      )
 
       params = %{
         addresses: addresses,
@@ -202,6 +219,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
     test "returns {:error, data_to_retry} when an error occurs in all chunks during processing and 'multichain_search_db_main_export_queue' table is populated with all the input data" do
       bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",
@@ -244,6 +263,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
     test "returns {:error, data_to_retry} when an error occurs in all chunks (and number of chunks more than @max_concurrency) during processing and 'multichain_search_db_main_export_queue' table is populated with all the input data" do
       bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",

--- a/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
@@ -19,6 +19,13 @@ defmodule Explorer.SmartContract.CompilerVersionTest do
     setup do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+
+      on_exit(fn ->
+        Application.put_env(:tesla, :adapter, tesla_config)
+      end)
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
       Application.put_env(:explorer, :solc_bin_api_url, "http://localhost:#{bypass.port}")
 
       {:ok, bypass: bypass}
@@ -59,7 +66,7 @@ defmodule Explorer.SmartContract.CompilerVersionTest do
     test "returns error when there is server error", %{bypass: bypass} do
       Bypass.down(bypass)
 
-      assert {:error, :econnrefused} = CompilerVersion.fetch_versions(:solc)
+      assert {:error, %{reason: :econnrefused}} = CompilerVersion.fetch_versions(:solc)
     end
   end
 

--- a/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/compiler_version_test.exs
@@ -19,10 +19,8 @@ defmodule Explorer.SmartContract.CompilerVersionTest do
     setup do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
-
       on_exit(fn ->
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)

--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -15,10 +15,13 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
   describe "run/2" do
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
 
       {:ok,

--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -15,13 +15,12 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
   describe "run/2" do
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       {:ok,

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -14,13 +14,12 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
     end
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -14,10 +14,13 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
     end
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -66,10 +66,13 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
     end
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -66,13 +66,12 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
     end
 

--- a/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
@@ -14,13 +14,12 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
     end
 

--- a/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/vyper/publisher_test.exs
@@ -14,10 +14,13 @@ if Application.compile_env(:explorer, :chain_type) !== :zksync do
 
     setup do
       configuration = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)
+      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, enabled: false)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour, configuration)
+        Application.put_env(:tesla, :adapter, tesla_config)
       end)
     end
 

--- a/apps/explorer/test/explorer/third_party_integrations/universal_proxy_test.exs
+++ b/apps/explorer/test/explorer/third_party_integrations/universal_proxy_test.exs
@@ -1,5 +1,5 @@
 defmodule Explorer.ThirdPartyIntegrations.UniversalProxyTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   import Mox
 

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -1008,8 +1008,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         Conn.resp(conn, 200, json)
       end)
 
-      # Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
       assert {:ok_store_uri,
               %{
                 metadata: Jason.decode!(json)

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -587,10 +587,8 @@ defmodule Explorer.Token.MetadataRetrieverTest do
     setup do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
-
       on_exit(fn ->
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       end)
 
       {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -587,6 +587,12 @@ defmodule Explorer.Token.MetadataRetrieverTest do
     setup do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+
+      on_exit(fn ->
+        Application.put_env(:tesla, :adapter, tesla_config)
+      end)
+
       {:ok, bypass: bypass}
     end
 
@@ -673,14 +679,17 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "collectionId" => "1871_1665123820823"
       }
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP?x-apikey=mykey",
-                         _headers,
-                         _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP?x-apikey=mykey"},
+                    _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(result)
+           }}
+        end
+      )
 
       assert {:ok,
               %{
@@ -693,7 +702,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                 }
               }} == MetadataRetriever.fetch_json({:ok, [data]})
 
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
       Application.put_env(:indexer, :ipfs, configuration)
     end
 
@@ -717,12 +725,16 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "collectionId" => "1871_1665123820823"
       }
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP", _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(result)
+           }}
+        end
+      )
 
       assert {:ok,
               %{
@@ -735,7 +747,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                 }
               }} == MetadataRetriever.fetch_json({:ok, [data]})
 
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
       Application.put_env(:indexer, :ipfs, configuration)
     end
 
@@ -759,14 +770,20 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "collectionId" => "1871_1665123820823"
       }
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP",
-                         [{"x-apikey", "mykey"}, {"User-Agent", _}],
-                         _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{
+                      url: "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP",
+                      headers: [{"x-apikey", "mykey"}, {"User-Agent", _}]
+                    },
+                    _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(result)
+           }}
+        end
+      )
 
       assert {:ok,
               %{
@@ -779,7 +796,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                 }
               }} == MetadataRetriever.fetch_json({:ok, [data]})
 
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
       Application.put_env(:indexer, :ipfs, configuration)
     end
 
@@ -791,6 +807,8 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "name": "Sérgio Mendonça"
       }
       """
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(bypass, "GET", path, fn conn ->
         Conn.resp(conn, 200, json)
@@ -821,6 +839,8 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "attributes": #{attributes}
       }
       """
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(bypass, "GET", path, fn conn ->
         Conn.resp(conn, 200, json)
@@ -898,14 +918,16 @@ defmodule Explorer.Token.MetadataRetrieverTest do
       }
       """
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu",
-                         _headers,
-                         _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: json}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: json
+           }}
+        end
+      )
 
       data =
         {:ok,
@@ -919,8 +941,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                   "image" => "https://ipfs.io/ipfs/bafybeig6nlmyzui7llhauc52j2xo5hoy4lzp6442lkve5wysdvjkizxonu"
                 }
               }} == MetadataRetriever.fetch_json(data)
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "Fetches metadata from ipfs" do
@@ -932,14 +952,17 @@ defmodule Explorer.Token.MetadataRetrieverTest do
       }
       """
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/bafybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json",
-                         _headers,
-                         _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: json}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/bafybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json"},
+                    _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: json
+           }}
+        end
+      )
 
       data =
         {:ok,
@@ -953,7 +976,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
        }} = MetadataRetriever.fetch_json(data)
 
       assert "ipfs://bafybeihxuj3gxk7x5p36amzootyukbugmx3pw7dyntsrohg3se64efkuga/51.png" == Map.get(metadata, "image")
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "Fetches metadata from '${url}'", %{bypass: bypass} do
@@ -980,9 +1002,13 @@ defmodule Explorer.Token.MetadataRetrieverTest do
       }
       """
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       Bypass.expect(bypass, "GET", path, fn conn ->
         Conn.resp(conn, 200, json)
       end)
+
+      # Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       assert {:ok_store_uri,
               %{
@@ -1009,12 +1035,16 @@ defmodule Explorer.Token.MetadataRetrieverTest do
         "collectionId" => "1871_1665123820823"
       }
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP", _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(result)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/QmT1Yz43R1PLn2RVovAnEM5dHQEvpTcnwgX8zftvY1FcjP"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(result)
+           }}
+        end
+      )
 
       assert {:ok,
               %{
@@ -1026,8 +1056,6 @@ defmodule Explorer.Token.MetadataRetrieverTest do
                   "salePrice" => 34
                 }
               }} == MetadataRetriever.fetch_json({:ok, [data]})
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "Process URI directly from link", %{bypass: bypass} do
@@ -1062,6 +1090,8 @@ defmodule Explorer.Token.MetadataRetrieverTest do
           ]
       }
       """
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(bypass, "GET", path, fn conn ->
         Conn.resp(conn, 200, json)

--- a/apps/explorer/test/test_helper.exs
+++ b/apps/explorer/test/test_helper.exs
@@ -29,6 +29,5 @@ Mox.defmock(Explorer.Market.Source.TestSource, for: Explorer.Market.Source)
 Mox.defmock(Explorer.History.TestHistorian, for: Explorer.History.Historian)
 
 Mox.defmock(EthereumJSONRPC.Mox, for: EthereumJSONRPC.Transport)
-Mox.defmock(Explorer.Mox.HTTPoison, for: HTTPoison.Base)
 
 Mox.defmock(Explorer.Mock.TeslaAdapter, for: Tesla.Adapter)

--- a/apps/indexer/config/dev/anvil.exs
+++ b/apps/indexer/config/dev/anvil.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -24,7 +21,7 @@ config :indexer,
       method_to_url: [
         eth_call: :eth_call
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Anvil
   ],

--- a/apps/indexer/config/dev/anvil.exs
+++ b/apps/indexer/config/dev/anvil.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/indexer/config/dev/anvil.exs
+++ b/apps/indexer/config/dev/anvil.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -31,7 +28,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -14,7 +14,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/besu.exs
+++ b/apps/indexer/config/dev/besu.exs
@@ -17,7 +17,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -14,7 +14,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -17,7 +17,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/erigon.exs
+++ b/apps/indexer/config/dev/erigon.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -31,7 +28,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/indexer/config/dev/filecoin.exs
+++ b/apps/indexer/config/dev/filecoin.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -27,7 +24,7 @@ config :indexer,
         eth_call: :eth_call,
         trace_block: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Filecoin
   ],

--- a/apps/indexer/config/dev/filecoin.exs
+++ b/apps/indexer/config/dev/filecoin.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http, "http://localhost:1234/rpc/v1"),
       trace_urls: ConfigHelper.parse_urls_list(:trace, "http://localhost:1234/rpc/v1"),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:1234/rpc/v1"),

--- a/apps/indexer/config/dev/filecoin.exs
+++ b/apps/indexer/config/dev/filecoin.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http, "http://localhost:1234/rpc/v1"),
       trace_urls: ConfigHelper.parse_urls_list(:trace, "http://localhost:1234/rpc/v1"),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call, "http://localhost:1234/rpc/v1"),

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -28,7 +25,7 @@ config :indexer,
         debug_traceTransaction: :trace,
         debug_traceBlockByNumber: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/geth.exs
+++ b/apps/indexer/config/dev/geth.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -14,7 +14,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -17,7 +17,7 @@ config :indexer,
       ),
     else: EthereumJSONRPC.IPC,
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/nethermind.exs
+++ b/apps/indexer/config/dev/nethermind.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -31,7 +28,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -18,7 +18,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -15,7 +15,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/dev/rsk.exs
+++ b/apps/indexer/config/dev/rsk.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   blocks_concurrency: 1,
@@ -32,7 +29,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/indexer/config/prod/anvil.exs
+++ b/apps/indexer/config/prod/anvil.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(1)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -24,7 +21,7 @@ config :indexer,
       method_to_url: [
         eth_call: :eth_call
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(1)
     ],
     variant: EthereumJSONRPC.Anvil
   ],

--- a/apps/indexer/config/prod/anvil.exs
+++ b/apps/indexer/config/prod/anvil.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/indexer/config/prod/anvil.exs
+++ b/apps/indexer/config/prod/anvil.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),
       fallback_urls: ConfigHelper.parse_urls_list(:fallback_http),

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -30,7 +27,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Besu
   ],

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/besu.exs
+++ b/apps/indexer/config/prod/besu.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/erigon.exs
+++ b/apps/indexer/config/prod/erigon.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -30,7 +27,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Erigon
   ],

--- a/apps/indexer/config/prod/filecoin.exs
+++ b/apps/indexer/config/prod/filecoin.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/filecoin.exs
+++ b/apps/indexer/config/prod/filecoin.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/filecoin.exs
+++ b/apps/indexer/config/prod/filecoin.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -27,7 +24,7 @@ config :indexer,
         eth_call: :eth_call,
         trace_block: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Filecoin
   ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -28,7 +25,7 @@ config :indexer,
         debug_traceTransaction: :trace,
         debug_traceBlockByNumber: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.Geth
   ],

--- a/apps/indexer/config/prod/geth.exs
+++ b/apps/indexer/config/prod/geth.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -13,7 +13,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -16,7 +16,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/nethermind.exs
+++ b/apps/indexer/config/prod/nethermind.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout()
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   json_rpc_named_arguments: [
@@ -30,7 +27,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options()
     ],
     variant: EthereumJSONRPC.Nethermind
   ],

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -18,7 +18,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.HTTPoison,
+      http: EthereumJSONRPC.HTTP.Mint,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -15,7 +15,7 @@ config :indexer,
         else: EthereumJSONRPC.IPC
       ),
     transport_options: [
-      http: EthereumJSONRPC.HTTP.Mint,
+      http: EthereumJSONRPC.HTTP.Tesla,
       urls: ConfigHelper.parse_urls_list(:http),
       trace_urls: ConfigHelper.parse_urls_list(:trace),
       eth_call_urls: ConfigHelper.parse_urls_list(:eth_call),

--- a/apps/indexer/config/prod/rsk.exs
+++ b/apps/indexer/config/prod/rsk.exs
@@ -4,9 +4,6 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
-hackney_opts = ConfigHelper.hackney_options()
-timeout = ConfigHelper.timeout(10)
-
 config :indexer,
   block_interval: ConfigHelper.parse_time_env_var("INDEXER_CATCHUP_BLOCK_INTERVAL", "0s"),
   blocks_concurrency: 1,
@@ -32,7 +29,7 @@ config :indexer,
         trace_replayBlockTransactions: :trace,
         trace_replayTransaction: :trace
       ],
-      http_options: [recv_timeout: timeout, timeout: timeout, hackney: hackney_opts]
+      http_options: ConfigHelper.http_options(10)
     ],
     variant: EthereumJSONRPC.RSK
   ],

--- a/apps/indexer/lib/indexer/fetcher/beacon/client.ex
+++ b/apps/indexer/lib/indexer/fetcher/beacon/client.ex
@@ -2,17 +2,18 @@ defmodule Indexer.Fetcher.Beacon.Client do
   @moduledoc """
     HTTP Client for Beacon Chain RPC
   """
-  alias HTTPoison.Response
   require Logger
+
+  alias Explorer.HttpClient
 
   @request_error_msg "Error while sending request to beacon rpc"
 
   def http_get_request(url) do
-    case Application.get_env(:explorer, :http_adapter).get(url) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url) do
+      {:ok, %{body: body, status_code: 200}} ->
         Jason.decode(body)
 
-      {:ok, %Response{body: body, status_code: _}} ->
+      {:ok, %{body: body, status_code: _}} ->
         {:error, body}
 
       {:error, error} ->

--- a/apps/indexer/lib/indexer/fetcher/filecoin/beryx_api.ex
+++ b/apps/indexer/lib/indexer/fetcher/filecoin/beryx_api.ex
@@ -4,8 +4,7 @@ defmodule Indexer.Fetcher.Filecoin.BeryxAPI do
   address hash
   """
 
-  alias Explorer.Helper
-  alias HTTPoison.Response
+  alias Explorer.{Helper, HttpClient}
 
   @doc """
   Fetches account information for a given Ethereum address hash from the Beryx API.
@@ -16,12 +15,12 @@ defmodule Indexer.Fetcher.Filecoin.BeryxAPI do
   ## Returns
   - `{:ok, map()}`: On success, returns the account information as a map.
   - `{:error, integer(), map()}`: On failure, returns the HTTP status code and the error message as a map.
-  - `{:error, HTTPoison.Error.t()}`: On network or other HTTP errors, returns the error structure.
+  - `{:error, any()}`: On network or other HTTP errors, returns the error reason.
   """
   @spec fetch_address_info(EthereumJSONRPC.address()) ::
           {:ok, map()}
           | {:error, integer(), map()}
-          | {:error, HTTPoison.Error.t()}
+          | {:error, any()}
   def fetch_address_info(eth_address_hash) do
     config = Application.get_env(:indexer, __MODULE__)
     base_url = config |> Keyword.get(:base_url) |> String.trim_trailing("/")
@@ -34,16 +33,16 @@ defmodule Indexer.Fetcher.Filecoin.BeryxAPI do
       {"Content-Type", "application/json"}
     ]
 
-    case HTTPoison.get(url, headers) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url, headers) do
+      {:ok, %{body: body, status_code: 200}} ->
         json = Helper.decode_json(body)
         {:ok, json}
 
-      {:ok, %Response{body: body, status_code: status_code}} ->
+      {:ok, %{body: body, status_code: status_code}} ->
         json = Helper.decode_json(body)
         {:error, status_code, json}
 
-      {:error, %HTTPoison.Error{}} = error ->
+      error ->
         error
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/filecoin/filfox_api.ex
+++ b/apps/indexer/lib/indexer/fetcher/filecoin/filfox_api.ex
@@ -4,8 +4,7 @@ defmodule Indexer.Fetcher.Filecoin.FilfoxAPI do
   address hash
   """
 
-  alias Explorer.Helper
-  alias HTTPoison.Response
+  alias Explorer.{Helper, HttpClient}
 
   @doc """
   Fetches account information for a given Ethereum address hash from the Filfox API.
@@ -16,12 +15,12 @@ defmodule Indexer.Fetcher.Filecoin.FilfoxAPI do
   ## Returns
   - `{:ok, map()}`: On success, returns the account information as a map.
   - `{:error, integer(), map()}`: On failure, returns the HTTP status code and the error message as a map.
-  - `{:error, HTTPoison.Error.t()}`: On network or other HTTP errors, returns the error structure.
+  - `{:error, any()}`: On network or other HTTP errors, returns the error reason.
   """
   @spec fetch_address_info(EthereumJSONRPC.address()) ::
           {:ok, map()}
           | {:error, integer(), map()}
-          | {:error, HTTPoison.Error.t()}
+          | {:error, any()}
   def fetch_address_info(eth_address_hash) do
     config = Application.get_env(:indexer, __MODULE__)
     base_url = config |> Keyword.get(:base_url) |> String.trim_trailing("/")
@@ -32,16 +31,16 @@ defmodule Indexer.Fetcher.Filecoin.FilfoxAPI do
       {"Content-Type", "application/json"}
     ]
 
-    case HTTPoison.get(url, headers) do
-      {:ok, %Response{body: body, status_code: 200}} ->
+    case HttpClient.get(url, headers) do
+      {:ok, %{body: body, status_code: 200}} ->
         json = Helper.decode_json(body)
         {:ok, json}
 
-      {:ok, %Response{body: body, status_code: status_code}} ->
+      {:ok, %{body: body, status_code: status_code}} ->
         json = Helper.decode_json(body)
         {:error, status_code, json}
 
-      {:error, %HTTPoison.Error{}} = error ->
+      error ->
         error
     end
   end

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -572,7 +572,7 @@ defmodule Indexer.Fetcher.PolygonEdge do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         urls: [polygon_edge_l1_rpc],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -572,7 +572,7 @@ defmodule Indexer.Fetcher.PolygonEdge do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         urls: [polygon_edge_l1_rpc],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
+++ b/apps/indexer/lib/indexer/fetcher/polygon_edge.ex
@@ -577,7 +577,7 @@ defmodule Indexer.Fetcher.PolygonEdge do
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),
-          hackney: [pool: :ethereum_jsonrpc]
+          pool: :ethereum_jsonrpc
         ]
       ]
     ]

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
@@ -563,7 +563,7 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         urls: [rpc_url],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
@@ -563,7 +563,7 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         urls: [rpc_url],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
@@ -568,7 +568,7 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),
-          hackney: [pool: :ethereum_jsonrpc]
+          pool: :ethereum_jsonrpc
         ]
       ]
     ]

--- a/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
@@ -87,7 +87,7 @@ defmodule Indexer.Fetcher.ZkSync.BatchesStatusTracker do
          json_l1_rpc_named_arguments: [
            transport: EthereumJSONRPC.HTTP,
            transport_options: [
-             http: EthereumJSONRPC.HTTP.HTTPoison,
+             http: EthereumJSONRPC.HTTP.Mint,
              urls: [l1_rpc],
              http_options: [
                recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
@@ -92,7 +92,7 @@ defmodule Indexer.Fetcher.ZkSync.BatchesStatusTracker do
              http_options: [
                recv_timeout: :timer.minutes(10),
                timeout: :timer.minutes(10),
-               hackney: [pool: :ethereum_jsonrpc]
+               pool: :ethereum_jsonrpc
              ]
            ]
          ],

--- a/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/batches_status_tracker.ex
@@ -87,7 +87,7 @@ defmodule Indexer.Fetcher.ZkSync.BatchesStatusTracker do
          json_l1_rpc_named_arguments: [
            transport: EthereumJSONRPC.HTTP,
            transport_options: [
-             http: EthereumJSONRPC.HTTP.Mint,
+             http: EthereumJSONRPC.HTTP.Tesla,
              urls: [l1_rpc],
              http_options: [
                recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -223,7 +223,7 @@ defmodule Indexer.Helper do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.HTTPoison,
+        http: EthereumJSONRPC.HTTP.Mint,
         urls: [rpc_url],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -228,7 +228,7 @@ defmodule Indexer.Helper do
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),
-          hackney: [pool: :ethereum_jsonrpc]
+          pool: :ethereum_jsonrpc
         ]
       ]
     ]

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -223,7 +223,7 @@ defmodule Indexer.Helper do
     [
       transport: EthereumJSONRPC.HTTP,
       transport_options: [
-        http: EthereumJSONRPC.HTTP.Mint,
+        http: EthereumJSONRPC.HTTP.Tesla,
         urls: [rpc_url],
         http_options: [
           recv_timeout: :timer.minutes(10),

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
@@ -73,6 +73,8 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
     setup do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",
         api_key: "12345",
@@ -81,6 +83,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       on_exit(fn ->
         Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
+        Application.put_env(:tesla, :adapter, tesla_config)
         Bypass.down(bypass)
       end)
 
@@ -104,6 +107,8 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       Bypass.expect_once(bypass, "POST", "/api/v1/import:batch", fn conn ->
         Conn.resp(
           conn,
@@ -124,11 +129,8 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
         addresses_chunk_size: 1
       )
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       on_exit(fn ->
         Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
       end)
 
       address_1 = insert(:address)
@@ -156,24 +158,21 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      for _ <- 0..2 do
-        Explorer.Mox.HTTPoison
-        |> expect(:post, fn "http://localhost:1234/api/v1/import:batch",
-                            body,
-                            [{"Content-Type", "application/json"}],
-                            _options ->
+      Tesla.Test.expect_tesla_call(
+        times: 3,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
           case Jason.decode(body) do
             {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
-              {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
 
             {:ok, %{"addresses" => [%{"hash" => ^address_2_hash_string}]}} ->
-              {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
 
             _ ->
-              {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"status" => "ok"})}}
+              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
           end
-        end)
-      end
+        end
+      )
 
       log =
         capture_log(fn ->
@@ -229,21 +228,18 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      for _ <- 0..1 do
-        Explorer.Mox.HTTPoison
-        |> expect(:post, fn "http://localhost:1234/api/v1/import:batch",
-                            body,
-                            [{"Content-Type", "application/json"}],
-                            _options ->
+      Tesla.Test.expect_tesla_call(
+        times: 2,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
           case Jason.decode(body) do
             {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
-              {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
 
             _ ->
-              {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(%{"status" => "ok"})}}
+              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
           end
-        end)
-      end
+        end
+      )
 
       MultichainSearchDbMainExportQueue.run(export_data_2, nil)
 

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
@@ -73,8 +73,6 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
     setup do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
-
       Application.put_env(:explorer, MultichainSearch,
         service_url: "http://localhost:#{bypass.port}",
         api_key: "12345",
@@ -83,7 +81,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       on_exit(fn ->
         Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
-        Application.put_env(:tesla, :adapter, tesla_config)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
         Bypass.down(bypass)
       end)
 

--- a/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/token_instance_metadata_refetch_test.exs
@@ -34,12 +34,6 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
       Subscriber.to(:fetched_token_instance_metadata, :on_demand)
       Subscriber.to(:not_fetched_token_instance_metadata, :on_demand)
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      on_exit(fn ->
-        Application.put_env(:explorer, :http_adapter, HTTPoison)
-      end)
-
       :ok
     end
 
@@ -61,10 +55,16 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       assert TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance) == :ok
 
@@ -108,10 +108,16 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(metadata)}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: Jason.encode!(metadata)
+           }}
+        end
+      )
 
       assert TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance) == :ok
 
@@ -154,10 +160,16 @@ defmodule Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetchTest do
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn ^url, _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: nil}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: nil
+           }}
+        end
+      )
 
       assert TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance) == :ok
 

--- a/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
@@ -15,22 +15,31 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
   setup do
     bypass = Bypass.open()
 
-    on_exit(fn -> Bypass.down(bypass) end)
+    tesla_config = Application.get_env(:tesla, :adapter)
+
+    on_exit(fn ->
+      Bypass.down(bypass)
+      Application.put_env(:tesla, :adapter, tesla_config)
+    end)
 
     {:ok, bypass: bypass}
   end
 
   describe "fetch instance tests" do
     test "fetches json metadata for kitties" do
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
       result =
         "{\"id\":100500,\"name\":\"KittyBlue_2_Lemonade\",\"generation\":20,\"genes\":\"623509754227292470437941473598751240781530569131665917719736997423495595\",\"created_at\":\"2017-12-06T01:56:27.000Z\",\"birthday\":\"2017-12-06T00:00:00.000Z\",\"image_url\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/100500.svg\",\"image_url_cdn\":\"https://img.cn.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/100500.svg\",\"color\":\"strawberry\",\"background_color\":\"#ffe0e5\",\"bio\":\"Shalom! I'm KittyBlue_2_Lemonade. I'm a professional Foreign Film Director and I love cantaloupe. I'm convinced that the world is flat. One day I'll prove it. It's pawesome to meet you!\",\"kitty_type\":null,\"is_fancy\":false,\"is_exclusive\":false,\"is_special_edition\":false,\"fancy_type\":null,\"language\":\"en\",\"is_prestige\":false,\"prestige_type\":null,\"prestige_ranking\":null,\"prestige_time_limit\":null,\"status\":{\"is_ready\":true,\"is_gestating\":false,\"cooldown\":1410310201506,\"dynamic_cooldown\":1475064986478,\"cooldown_index\":10,\"cooldown_end_block\":0,\"pending_transaction_type\":null,\"pending_tx_since\":null},\"purrs\":{\"count\":1,\"is_purred\":false},\"watchlist\":{\"count\":0,\"is_watchlisted\":false},\"hatcher\":{\"address\":\"0x7b9ea9ac69b8fde875554321472c732eeff06ca0\",\"image\":\"14\",\"nickname\":\"KittyBlu\",\"hasDapper\":false,\"twitter_id\":null,\"twitter_image_url\":null,\"twitter_handle\":null},\"auction\":{},\"offer\":{},\"owner\":{\"address\":\"0x7b9ea9ac69b8fde875554321472c732eeff06ca0\",\"hasDapper\":false,\"twitter_id\":null,\"twitter_image_url\":null,\"twitter_handle\":null,\"image\":\"14\",\"nickname\":\"KittyBlu\"},\"matron\":{\"id\":46234,\"name\":\"KittyBlue_1_Limegreen\",\"generation\":10,\"enhanced_cattributes\":[{\"type\":\"body\",\"kittyId\":19631,\"position\":105,\"description\":\"cymric\"},{\"type\":\"coloreyes\",\"kittyId\":40356,\"position\":263,\"description\":\"limegreen\"},{\"type\":\"eyes\",\"kittyId\":3185,\"position\":16,\"description\":\"raisedbrow\"},{\"type\":\"pattern\",\"kittyId\":46234,\"position\":-1,\"description\":\"totesbasic\"},{\"type\":\"mouth\",\"kittyId\":46234,\"position\":-1,\"description\":\"happygokitty\"},{\"type\":\"colorprimary\",\"kittyId\":46234,\"position\":-1,\"description\":\"greymatter\"},{\"type\":\"colorsecondary\",\"kittyId\":46234,\"position\":-1,\"description\":\"lemonade\"},{\"type\":\"colortertiary\",\"kittyId\":46234,\"position\":-1,\"description\":\"granitegrey\"}],\"owner_wallet_address\":\"0x7b9ea9ac69b8fde875554321472c732eeff06ca0\",\"owner\":{\"address\":\"0x7b9ea9ac69b8fde875554321472c732eeff06ca0\"},\"created_at\":\"2017-12-03T21:29:17.000Z\",\"image_url\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/46234.svg\",\"image_url_cdn\":\"https://img.cn.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/46234.svg\",\"color\":\"limegreen\",\"is_fancy\":false,\"kitty_type\":null,\"is_exclusive\":false,\"is_special_edition\":false,\"fancy_type\":null,\"status\":{\"is_ready\":true,\"is_gestating\":false,\"cooldown\":1486487069384},\"hatched\":true,\"wrapped\":false,\"image_url_png\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/46234.png\"},\"sire\":{\"id\":82090,\"name\":null,\"generation\":19,\"enhanced_cattributes\":[{\"type\":\"body\",\"kittyId\":82090,\"position\":-1,\"description\":\"himalayan\"},{\"type\":\"coloreyes\",\"kittyId\":82090,\"position\":-1,\"description\":\"strawberry\"},{\"type\":\"eyes\",\"kittyId\":82090,\"position\":-1,\"description\":\"thicccbrowz\"},{\"type\":\"pattern\",\"kittyId\":82090,\"position\":-1,\"description\":\"totesbasic\"},{\"type\":\"mouth\",\"kittyId\":82090,\"position\":-1,\"description\":\"pouty\"},{\"type\":\"colorprimary\",\"kittyId\":82090,\"position\":-1,\"description\":\"aquamarine\"},{\"type\":\"colorsecondary\",\"kittyId\":82090,\"position\":-1,\"description\":\"chocolate\"},{\"type\":\"colortertiary\",\"kittyId\":82090,\"position\":-1,\"description\":\"granitegrey\"}],\"owner_wallet_address\":\"0x798fdad0cedc4b298fc7d53a982fa0c5f447eaa5\",\"owner\":{\"address\":\"0x798fdad0cedc4b298fc7d53a982fa0c5f447eaa5\"},\"created_at\":\"2017-12-05T06:30:05.000Z\",\"image_url\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/82090.svg\",\"image_url_cdn\":\"https://img.cn.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/82090.svg\",\"color\":\"strawberry\",\"is_fancy\":false,\"is_exclusive\":false,\"is_special_edition\":false,\"fancy_type\":null,\"status\":{\"is_ready\":true,\"is_gestating\":false,\"cooldown\":1486619010030},\"kitty_type\":null,\"hatched\":true,\"wrapped\":false,\"image_url_png\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/82090.png\"},\"children\":[],\"hatched\":true,\"wrapped\":false,\"enhanced_cattributes\":[{\"type\":\"colorprimary\",\"description\":\"greymatter\",\"position\":null,\"kittyId\":100500},{\"type\":\"coloreyes\",\"description\":\"strawberry\",\"position\":null,\"kittyId\":100500},{\"type\":\"body\",\"description\":\"himalayan\",\"position\":null,\"kittyId\":100500},{\"type\":\"colorsecondary\",\"description\":\"lemonade\",\"position\":null,\"kittyId\":100500},{\"type\":\"mouth\",\"description\":\"pouty\",\"position\":null,\"kittyId\":100500},{\"type\":\"pattern\",\"description\":\"totesbasic\",\"position\":null,\"kittyId\":100500},{\"type\":\"eyes\",\"description\":\"thicccbrowz\",\"position\":null,\"kittyId\":100500},{\"type\":\"colortertiary\",\"description\":\"kittencream\",\"position\":null,\"kittyId\":100500},{\"type\":\"secret\",\"description\":\"se5\",\"position\":-1,\"kittyId\":100500},{\"type\":\"purrstige\",\"description\":\"pu20\",\"position\":-1,\"kittyId\":100500}],\"variation\":null,\"variation_ranking\":null,\"image_url_png\":\"https://img.cryptokitties.co/0x06012c8cf97bead5deae237070f9587f8e7a266d/100500.png\",\"items\":[]}"
 
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://api.cryptokitties.co/kitties/100500", _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: result}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://api.cryptokitties.co/kitties/100500"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: result
+           }}
+        end
+      )
 
       token =
         insert(:token,
@@ -42,8 +51,6 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
         Helper.batch_fetch_instances([{token.contract_address_hash, 100_500}])
 
       assert Map.get(metadata, "name") == "KittyBlue_2_Lemonade"
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "replace {id} with actual token_id", %{bypass: bypass} do
@@ -89,6 +96,8 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
            }
          ]}
       end)
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(
         bypass,
@@ -145,12 +154,17 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
          ]}
       end)
 
-      Application.put_env(:explorer, :http_adapter, Explorer.Mox.HTTPoison)
-
-      Explorer.Mox.HTTPoison
-      |> expect(:get, fn "https://ipfs.io/ipfs/Qmd9pvThEwgjTBbEkNmmGFbcpJKw17fnRBAT4Td4rcog22", _headers, _options ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: "123", headers: [{"Content-Type", "image/jpg"}]}}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: "https://ipfs.io/ipfs/Qmd9pvThEwgjTBbEkNmmGFbcpJKw17fnRBAT4Td4rcog22"}, _opts ->
+          {:ok,
+           %Tesla.Env{
+             status: 200,
+             body: "123",
+             headers: [{"Content-Type", "image/jpg"}]
+           }}
+        end
+      )
 
       token =
         insert(:token,
@@ -165,8 +179,6 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
                  }
                }
              ] = Helper.batch_fetch_instances([{token.contract_address_hash, 0}])
-
-      Application.put_env(:explorer, :http_adapter, HTTPoison)
     end
 
     test "re-fetch metadata from baseURI", %{bypass: bypass} do
@@ -238,6 +250,8 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
            }
          ]}
       end)
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(
         bypass,
@@ -362,6 +376,8 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
          ]}
       end)
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       Bypass.expect(
         bypass,
         "GET",
@@ -440,6 +456,8 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
            }
          ]}
       end)
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(
         bypass,
@@ -811,6 +829,8 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
            }
          ]}
       end)
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       Bypass.expect(
         bypass,

--- a/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/helper_test.exs
@@ -15,11 +15,9 @@ defmodule Indexer.Fetcher.TokenInstance.HelperTest do
   setup do
     bypass = Bypass.open()
 
-    tesla_config = Application.get_env(:tesla, :adapter)
-
     on_exit(fn ->
       Bypass.down(bypass)
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
     end)
 
     {:ok, bypass: bypass}

--- a/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
@@ -29,6 +29,9 @@ defmodule Indexer.Fetcher.TokenInstance.RealtimeTest do
     test "retry once after timeout" do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       []
       |> TokenInstanceRealtime.Supervisor.child_spec()
       |> ExUnit.Callbacks.start_supervised!()
@@ -117,6 +120,7 @@ defmodule Indexer.Fetcher.TokenInstance.RealtimeTest do
 
       assert is_nil(instance.error)
       assert instance.metadata == %{"name" => "name"}
+      Application.put_env(:tesla, :adapter, tesla_config)
       Bypass.down(bypass)
     end
   end

--- a/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
@@ -29,7 +29,6 @@ defmodule Indexer.Fetcher.TokenInstance.RealtimeTest do
     test "retry once after timeout" do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       []
@@ -120,7 +119,7 @@ defmodule Indexer.Fetcher.TokenInstance.RealtimeTest do
 
       assert is_nil(instance.error)
       assert instance.metadata == %{"name" => "name"}
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       Bypass.down(bypass)
     end
   end

--- a/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
@@ -76,6 +76,8 @@ defmodule Indexer.Fetcher.TokenInstance.RefetchTest do
     test "filters and fetches token instances marked to refetch" do
       bypass = Bypass.open()
 
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
       json = """
       {
         "name": "nice nft"

--- a/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
@@ -76,7 +76,6 @@ defmodule Indexer.Fetcher.TokenInstance.RefetchTest do
     test "filters and fetches token instances marked to refetch" do
       bypass = Bypass.open()
 
-      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       json = """
@@ -208,7 +207,7 @@ defmodule Indexer.Fetcher.TokenInstance.RefetchTest do
         assert updated_token_instance.error == nil
       end
 
-      Application.put_env(:tesla, :adapter, tesla_config)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
       Bypass.down(bypass)
     end
   end

--- a/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/refetch_test.exs
@@ -76,6 +76,7 @@ defmodule Indexer.Fetcher.TokenInstance.RefetchTest do
     test "filters and fetches token instances marked to refetch" do
       bypass = Bypass.open()
 
+      tesla_config = Application.get_env(:tesla, :adapter)
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
       json = """
@@ -207,6 +208,7 @@ defmodule Indexer.Fetcher.TokenInstance.RefetchTest do
         assert updated_token_instance.error == nil
       end
 
+      Application.put_env(:tesla, :adapter, tesla_config)
       Bypass.down(bypass)
     end
   end

--- a/apps/indexer/test/test_helper.exs
+++ b/apps/indexer/test/test_helper.exs
@@ -17,7 +17,7 @@ end
 Mox.defmock(EthereumJSONRPC.Mox, for: EthereumJSONRPC.Transport)
 Mox.defmock(Indexer.BufferedTaskTest.RetryableTask, for: Indexer.BufferedTask)
 Mox.defmock(Indexer.BufferedTaskTest.ShrinkableTask, for: Indexer.BufferedTask)
-Mox.defmock(Explorer.Mox.HTTPoison, for: HTTPoison.Base)
+Mox.defmock(Explorer.Mock.TeslaAdapter, for: Tesla.Adapter)
 
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()

--- a/apps/utils/lib/utils/http_client/httpoison_helper.ex
+++ b/apps/utils/lib/utils/http_client/httpoison_helper.ex
@@ -1,5 +1,11 @@
 defmodule Utils.HttpClient.HTTPoisonHelper do
-  @moduledoc false
+  @moduledoc """
+  Helper module for building HTTPoison request options.
+
+  This module provides utilities to construct keyword lists of options
+  for HTTPoison HTTP client requests, including timeouts, authentication,
+  redirects, and connection pooling.
+  """
 
   def request_opts(options) do
     []

--- a/apps/utils/lib/utils/http_client/httpoison_helper.ex
+++ b/apps/utils/lib/utils/http_client/httpoison_helper.ex
@@ -1,0 +1,55 @@
+defmodule Utils.HttpClient.HTTPoisonHelper do
+  @moduledoc false
+
+  def request_opts(options) do
+    []
+    |> add_recv_timeout_option(options[:recv_timeout])
+    |> add_timeout_option(options[:timeout])
+    |> add_basic_auth_option(options[:basic_auth])
+    |> add_pool_option(options[:pool])
+    |> add_follow_redirect_option(options[:follow_redirect])
+    |> add_params_option(options[:params])
+  end
+
+  defp add_recv_timeout_option(options, nil), do: options
+
+  defp add_recv_timeout_option(options, timeout) do
+    Keyword.put(options, :recv_timeout, timeout)
+  end
+
+  defp add_params_option(options, nil), do: options
+
+  defp add_params_option(options, params) do
+    Keyword.put(options, :params, params)
+  end
+
+  defp add_timeout_option(options, nil), do: options
+
+  defp add_timeout_option(options, timeout) do
+    Keyword.put(options, :timeout, timeout)
+  end
+
+  defp add_follow_redirect_option(options, nil), do: options
+
+  defp add_follow_redirect_option(options, follow_redirect) do
+    Keyword.put(options, :follow_redirect, follow_redirect)
+  end
+
+  defp add_insecure_option(options, true) do
+    Keyword.put(options, :hackney, [:insecure | options[:hackney] || []])
+  end
+
+  defp add_insecure_option(options, _insecure), do: options
+
+  defp add_basic_auth_option(options, {username, password}) do
+    Keyword.put(options, :hackney, [{:basic_auth, {username, password}} | options[:hackney] || []])
+  end
+
+  defp add_basic_auth_option(options, _basic_auth), do: options
+
+  defp add_pool_option(options, nil), do: options
+
+  defp add_pool_option(options, pool) do
+    Keyword.put(options, :hackney, [{:pool, pool} | options[:hackney] || []])
+  end
+end

--- a/apps/utils/lib/utils/http_client/httpoison_helper.ex
+++ b/apps/utils/lib/utils/http_client/httpoison_helper.ex
@@ -8,6 +8,7 @@ defmodule Utils.HttpClient.HTTPoisonHelper do
     |> add_basic_auth_option(options[:basic_auth])
     |> add_pool_option(options[:pool])
     |> add_follow_redirect_option(options[:follow_redirect])
+    |> add_insecure_option(options[:insecure])
     |> add_params_option(options[:params])
   end
 

--- a/apps/utils/lib/utils/http_client/tesla_helper.ex
+++ b/apps/utils/lib/utils/http_client/tesla_helper.ex
@@ -1,6 +1,22 @@
 defmodule Utils.HttpClient.TeslaHelper do
-  @moduledoc false
+  @moduledoc """
+  Helper module for building Tesla HTTP clients and adapter options.
 
+  This module provides utilities to construct Tesla clients with appropriate
+  middleware and adapter options, including timeouts, authentication, redirects,
+  and TLS settings.
+  """
+
+  @doc """
+  Builds a Tesla client with configured middleware based on the provided options.
+
+  ## Parameters
+  - `options`: A keyword list or map containing HTTP client options
+
+  ## Returns
+  - A Tesla client struct with configured middleware
+  """
+  @spec client(keyword() | map()) :: Tesla.Client.t()
   def client(options) do
     options[:recv_timeout]
     |> add_timeout_middleware()
@@ -9,6 +25,16 @@ defmodule Utils.HttpClient.TeslaHelper do
     |> Tesla.client()
   end
 
+  @doc """
+  Builds adapter options for Tesla HTTP client requests from the provided options map.
+
+  ## Parameters
+  - `options`: A keyword list or map containing HTTP client options
+
+  ## Returns
+  - A keyword list containing adapter options for Tesla
+  """
+  @spec request_opts(keyword() | map()) :: keyword()
   def request_opts(options) do
     adapter_options =
       [protocols: [:http1]]

--- a/apps/utils/lib/utils/http_client/tesla_helper.ex
+++ b/apps/utils/lib/utils/http_client/tesla_helper.ex
@@ -1,0 +1,59 @@
+defmodule Utils.HttpClient.TeslaHelper do
+  @moduledoc false
+
+  def client(options) do
+    options[:recv_timeout]
+    |> add_timeout_middleware()
+    |> add_follow_redirect_middleware(options[:follow_redirect])
+    |> add_basic_auth_middleware(options[:basic_auth])
+    |> Tesla.client()
+  end
+
+  def request_opts(options) do
+    adapter_options =
+      [protocols: [:http1]]
+      |> add_recv_timeout_option(options[:recv_timeout])
+      |> add_timeout_option(options[:timeout])
+      |> add_insecure_option(options[:insecure])
+
+    [adapter: adapter_options]
+  end
+
+  defp add_timeout_middleware(middleware \\ [], timeout)
+
+  defp add_timeout_middleware(middleware, nil), do: middleware
+
+  defp add_timeout_middleware(middleware, timeout) do
+    [{Tesla.Middleware.Timeout, timeout: timeout} | middleware]
+  end
+
+  defp add_follow_redirect_middleware(middleware, true) do
+    [Tesla.Middleware.FollowRedirects | middleware]
+  end
+
+  defp add_follow_redirect_middleware(middleware, _follow_redirect?), do: middleware
+
+  defp add_basic_auth_middleware(middleware, {username, password}) do
+    [{Tesla.Middleware.BasicAuth, %{username: username, password: password}} | middleware]
+  end
+
+  defp add_basic_auth_middleware(middleware, _basic_auth), do: middleware
+
+  defp add_recv_timeout_option(options, nil), do: options
+
+  defp add_recv_timeout_option(options, timeout) do
+    Keyword.put(options, :timeout, timeout)
+  end
+
+  defp add_timeout_option(options, nil), do: options
+
+  defp add_timeout_option(options, timeout) do
+    Keyword.put(options, :transport_opts, [{:timeout, timeout} | options[:transport_opts] || []])
+  end
+
+  defp add_insecure_option(options, true) do
+    Keyword.put(options, :transport_opts, [{:verify, :verify_none} | options[:transport_opts] || []])
+  end
+
+  defp add_insecure_option(options, _insecure), do: options
+end

--- a/apps/utils/mix.exs
+++ b/apps/utils/mix.exs
@@ -23,7 +23,7 @@ defmodule Utils.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :tesla]
     ]
   end
 

--- a/apps/utils/mix.exs
+++ b/apps/utils/mix.exs
@@ -32,7 +32,8 @@ defmodule Utils.MixProject do
     [
       {:credo, "~> 1.5", only: [:test, :dev], runtime: false},
       {:httpoison, "~> 2.0"},
-      {:mime, "~> 2.0"}
+      {:mime, "~> 2.0"},
+      {:tesla, "~> 1.14.2"}
     ]
   end
 

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -50,7 +50,21 @@ defmodule ConfigHelper do
     basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
 
     [pool: :ethereum_jsonrpc]
-    |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [:insecure] ++ &1, else: &1)).()
+    |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [insecure: true] ++ &1, else: &1)).()
+    |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
+          do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
+          else: &1
+        )).()
+  end
+
+  @spec http_options(non_neg_integer()) :: list()
+  def http_options(default_timeout \\ 1) do
+    http_timeout = timeout(default_timeout)
+    basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
+    basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
+
+    [pool: :ethereum_jsonrpc, recv_timeout: http_timeout, timeout: http_timeout]
+    |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [insecure: true] ++ &1, else: &1)).()
     |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
           do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
           else: &1

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -44,19 +44,6 @@ defmodule ConfigHelper do
     base_repos ++ chain_type_repos ++ ext_repos
   end
 
-  @spec hackney_options() :: any()
-  def hackney_options() do
-    basic_auth_user = System.get_env("ETHEREUM_JSONRPC_USER", "")
-    basic_auth_pass = System.get_env("ETHEREUM_JSONRPC_PASSWORD", nil)
-
-    [pool: :ethereum_jsonrpc]
-    |> (&if(System.get_env("ETHEREUM_JSONRPC_HTTP_INSECURE", "") == "true", do: [insecure: true] ++ &1, else: &1)).()
-    |> (&if(basic_auth_user != "" && !is_nil(basic_auth_pass),
-          do: [basic_auth: {basic_auth_user, basic_auth_pass}] ++ &1,
-          else: &1
-        )).()
-  end
-
   @spec http_options(non_neg_integer()) :: list()
   def http_options(default_timeout \\ 1) do
     http_timeout = timeout(default_timeout)

--- a/mix.exs
+++ b/mix.exs
@@ -96,7 +96,7 @@ defmodule BlockScout.Mixfile do
     [
       {:prometheus_ex, git: "https://github.com/lanodan/prometheus.ex", branch: "fix/elixir-1.14", override: true},
       {:absinthe_plug, git: "https://github.com/blockscout/absinthe_plug.git", tag: "1.5.8", override: true},
-      {:tesla, "~> 1.14.1"},
+      {:tesla, "~> 1.14.2"},
       {:mint, "~> 1.7.1"},
       # Documentation
       {:ex_doc, "~> 0.38.1", only: :dev, runtime: false},


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified HTTP client abstraction with implementations for HTTPoison and Tesla.
  * Added utility modules for HTTP client configuration and request option handling.
  * Enhanced Ethereum JSON-RPC with JSON method extraction, error detection, and gzip decompression.

* **Refactor**
  * Replaced direct HTTPoison calls with the generic HTTP client across applications.
  * Updated configurations to use Tesla as the default HTTP client and simplified HTTP options.
  * Centralized HTTP client logic and normalized response handling.

* **Bug Fixes**
  * Improved error handling and response pattern matching for HTTP requests.

* **Documentation**
  * Clarified configuration examples and updated documentation to reflect new HTTP client usage.

* **Tests**
  * Migrated mocks from HTTPoison to Tesla’s native test helpers.
  * Added setup and teardown hooks to explicitly set and reset Tesla adapters for consistent test environments.

* **Chores**
  * Updated Tesla and related dependencies versions in multiple projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->