### PR TITLE
chore: Duplicate block countdown endpoint in API v2

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -579,6 +579,7 @@ defmodule BlockScoutWeb.Chain do
     %PagingOptions{options | page_number: new_page_number, page_size: new_page_size}
   end
 
+  @spec param_to_block_number(binary()) :: {:ok, integer()} | {:error, :invalid}
   def param_to_block_number(formatted_number) when is_binary(formatted_number) do
     case Integer.parse(formatted_number) do
       {number, ""} -> {:ok, number}

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -7,6 +7,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       next_page_params: 3,
       next_page_params: 4,
       paging_options: 1,
+      param_to_block_number: 1,
       put_key_value_to_paging_options: 3,
       split_list_by_page: 1,
       parse_block_hash_or_number_param: 1
@@ -31,9 +32,11 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
   alias Explorer.Chain
   alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
+  alias Explorer.Chain.Cache.{BlockNumber, Counters.AverageBlockTime}
   alias Explorer.Chain.InternalTransaction
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
+  alias Timex.Duration
 
   case @chain_type do
     :ethereum ->
@@ -366,6 +369,25 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         withdrawals: withdrawals |> maybe_preload_ens() |> maybe_preload_metadata(),
         next_page_params: next_page_params
       })
+    end
+  end
+
+  def block_countdown(conn, %{"block_number" => block_number}) do
+    with {:format, {:ok, target_block_number}} <- {:format, param_to_block_number(block_number)},
+         {:max_block, current_block_number} when not is_nil(current_block_number) <-
+           {:max_block, BlockNumber.get_max()},
+         {:average_block_time, average_block_time} when is_struct(average_block_time) <-
+           {:average_block_time, AverageBlockTime.average_block_time()},
+         {:remaining_blocks, remaining_blocks} when remaining_blocks > 0 <-
+           {:remaining_blocks, target_block_number - current_block_number} do
+      estimated_time_in_sec = Float.round(remaining_blocks * Duration.to_seconds(average_block_time), 1)
+
+      render(conn, :block_countdown,
+        current_block: current_block_number,
+        countdown_block: target_block_number,
+        remaining_blocks: remaining_blocks,
+        estimated_time_in_sec: estimated_time_in_sec
+      )
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -372,6 +372,25 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     end
   end
 
+  @doc """
+  Function to handle GET requests to `/api/v2/blocks/:block_number/countdown` endpoint.
+  Calculates the estimated time remaining until a specified block number is reached
+  based on the current block number and average block time.
+
+  ## Parameters
+  - `conn`: The connection struct
+  - `params`: Map containing the target block number
+
+  ## Returns
+  - Renders countdown data with current block, target block, remaining blocks, and estimated time
+  - Returns appropriate error responses via fallback controller for various failure cases
+  """
+  @spec block_countdown(Plug.Conn.t(), map()) ::
+          Plug.Conn.t()
+          | {:format, {:error, :invalid}}
+          | {:max_block, nil}
+          | {:average_block_time, {:error, :disabled}}
+          | {:remaining_blocks, 0}
   def block_countdown(conn, %{"block_number" => block_number}) do
     with {:format, {:ok, target_block_number}} <- {:format, param_to_block_number(block_number)},
          {:max_block, current_block_number} when not is_nil(current_block_number) <-

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -318,6 +318,27 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> render(:message, %{message: @not_a_smart_contract})
   end
 
+  def call(conn, {:average_block_time, {:error, :disabled}}) do
+    conn
+    |> put_status(501)
+    |> put_view(ApiView)
+    |> render(:message, %{message: "Average block time calculating is disabled, so getblockcountdown is not available"})
+  end
+
+  def call(conn, {stage, _}) when stage in ~w(max_block average_block_time)a do
+    conn
+    |> put_status(200)
+    |> put_view(ApiView)
+    |> render(:message, %{message: "Chain is indexing now, try again later"})
+  end
+
+  def call(conn, {:remaining_blocks, _}) do
+    conn
+    |> put_status(200)
+    |> put_view(ApiView)
+    |> render(:message, %{message: "Error! Block number already pass"})
+  end
+
   def call(conn, {code, response}) when is_integer(code) do
     conn
     |> put_status(code)

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -207,6 +207,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:block_hash_or_number/transactions", V2.BlockController, :transactions)
       get("/:block_hash_or_number/internal-transactions", V2.BlockController, :internal_transactions)
       get("/:block_hash_or_number/withdrawals", V2.BlockController, :withdrawals)
+      get("/:block_number/countdown", V2.BlockController, :block_countdown)
 
       if @chain_type == :arbitrum do
         get("/arbitrum-batch/:batch_number", V2.BlockController, :arbitrum_batch)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -35,9 +35,9 @@ defmodule BlockScoutWeb.API.V2.BlockView do
         estimated_time_in_sec: estimated_time_in_sec
       }) do
     %{
-      current_block_number: to_string(current_block),
-      countdown_block_number: to_string(countdown_block),
-      remaining_blocks_count: to_string(remaining_blocks),
+      current_block_number: current_block,
+      countdown_block_number: countdown_block,
+      remaining_blocks_count: remaining_blocks,
       estimated_time_in_seconds: to_string(estimated_time_in_sec)
     }
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -28,6 +28,20 @@ defmodule BlockScoutWeb.API.V2.BlockView do
     prepare_block(block, nil, false)
   end
 
+  def render("block_countdown.json", %{
+        current_block: current_block,
+        countdown_block: countdown_block,
+        remaining_blocks: remaining_blocks,
+        estimated_time_in_sec: estimated_time_in_sec
+      }) do
+    %{
+      current_block: to_string(current_block),
+      countdown_block: to_string(countdown_block),
+      remaining_blocks: to_string(remaining_blocks),
+      estimated_time_in_sec: to_string(estimated_time_in_sec)
+    }
+  end
+
   def prepare_block(block, _conn, single_block? \\ false) do
     burnt_fees = Block.burnt_fees(block.transactions, block.base_fee_per_gas)
     priority_fee = block.base_fee_per_gas && BlockPriorityFeeCount.fetch(block.hash)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -35,10 +35,10 @@ defmodule BlockScoutWeb.API.V2.BlockView do
         estimated_time_in_sec: estimated_time_in_sec
       }) do
     %{
-      current_block: to_string(current_block),
-      countdown_block: to_string(countdown_block),
-      remaining_blocks: to_string(remaining_blocks),
-      estimated_time_in_sec: to_string(estimated_time_in_sec)
+      current_block_number: to_string(current_block),
+      countdown_block_number: to_string(countdown_block),
+      remaining_blocks_count: to_string(remaining_blocks),
+      estimated_time_in_seconds: to_string(estimated_time_in_sec)
     }
   end
 


### PR DESCRIPTION
Closes #12392 

## Changelog
- add `api/v2/blocks/:block_number/countdown`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to estimate the countdown and time remaining until a specified block number.
  * The response includes the current block, target block, remaining blocks, and estimated time in seconds.

* **Bug Fixes**
  * Improved error handling for scenarios such as disabled average block time calculation, ongoing chain indexing, and cases where the target block has already passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->