### PR TITLE
fix: error on too big block numbers in APIv1 `txlist` method

### DIFF
--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -133,7 +133,7 @@ defmodule Explorer.Helper do
         iex> safe_parse_non_negative_integer("27606393966689717254124294199939478533331961967491413693980084341759630764504")
         {:error, :too_big_integer}
   """
-  @spec safe_parse_non_negative_integer(String.t()) ::
+  @spec safe_parse_non_negative_integer(String.t(), integer()) ::
           {:ok, integer()} | {:error, :negative_integer | :too_big_integer | :invalid_integer}
   def safe_parse_non_negative_integer(string, max_safe_integer \\ @max_safe_integer) do
     case Integer.parse(string) do

--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -133,11 +133,13 @@ defmodule Explorer.Helper do
         iex> safe_parse_non_negative_integer("27606393966689717254124294199939478533331961967491413693980084341759630764504")
         {:error, :too_big_integer}
   """
-  def safe_parse_non_negative_integer(string) do
+  @spec safe_parse_non_negative_integer(String.t()) ::
+          {:ok, integer()} | {:error, :negative_integer | :too_big_integer | :invalid_integer}
+  def safe_parse_non_negative_integer(string, max_safe_integer \\ @max_safe_integer) do
     case Integer.parse(string) do
       {num, ""} ->
         case num do
-          _ when num > @max_safe_integer -> {:error, :too_big_integer}
+          _ when num > max_safe_integer -> {:error, :too_big_integer}
           _ when num < 0 -> {:error, :negative_integer}
           _ -> {:ok, num}
         end


### PR DESCRIPTION
I initially started resolving #12666, but it turned out that there's actually no issue. However, I accidentally found another bug.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for block number parameters to ensure excessively large values are safely handled and ignored when necessary.

* **Tests**
  * Added a test to confirm that overly large block numbers in API requests are ignored, ensuring correct transaction results are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->