### PR TITLE
fix: Fix race condition for EventNotification

### DIFF
--- a/apps/explorer/lib/explorer/chain/events/listener.ex
+++ b/apps/explorer/lib/explorer/chain/events/listener.ex
@@ -40,7 +40,7 @@ defmodule Explorer.Chain.Events.Listener do
 
   defp expand_payload(payload) do
     case Integer.parse(payload) do
-      {event_notification_id, ""} -> fetch_and_delete_event_notification(event_notification_id)
+      {event_notification_id, ""} -> fetch_event_notification(event_notification_id)
       _ -> payload
     end
   end
@@ -68,18 +68,12 @@ defmodule Explorer.Chain.Events.Listener do
     end)
   end
 
-  defp fetch_and_delete_event_notification(id) do
+  defp fetch_event_notification(id) do
     case Repo.get(EventNotification, id) do
       nil ->
         nil
 
-      %{data: data} = notification ->
-        try do
-          Repo.delete(notification)
-        rescue
-          Ecto.StaleEntryError -> nil
-        end
-
+      %{data: data} ->
         data
     end
   end

--- a/apps/explorer/lib/explorer/utility/event_notification.ex
+++ b/apps/explorer/lib/explorer/utility/event_notification.ex
@@ -7,6 +7,8 @@ defmodule Explorer.Utility.EventNotification do
 
   typed_schema "event_notifications" do
     field(:data, :string)
+
+    timestamps()
   end
 
   @doc false

--- a/apps/explorer/priv/repo/migrations/20250704124014_add_timestamp_to_event_notifications.exs
+++ b/apps/explorer/priv/repo/migrations/20250704124014_add_timestamp_to_event_notifications.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.AddTimestampToEventNotifications do
+  use Ecto.Migration
+
+  def change do
+    alter table(:event_notifications) do
+      timestamps(null: true)
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -62,7 +62,7 @@ defmodule Explorer.Factory do
   alias Explorer.Market.MarketHistory
   alias Explorer.Repo
 
-  alias Explorer.Utility.{MissingBalanceOfToken, MissingBlockRange}
+  alias Explorer.Utility.{EventNotification, MissingBalanceOfToken, MissingBlockRange}
 
   alias Ueberauth.Strategy.Auth0
   alias Ueberauth.Auth.{Extra, Info}
@@ -1397,6 +1397,13 @@ defmodule Explorer.Factory do
       fourth_topic: nil,
       index: sequence("log_index", & &1),
       transaction: transaction
+    }
+  end
+
+  def event_notification_factory do
+    %EventNotification{
+      data: "test_data",
+      inserted_at: DateTime.utc_now()
     }
   end
 end

--- a/apps/indexer/lib/indexer/supervisor.ex
+++ b/apps/indexer/lib/indexer/supervisor.ex
@@ -64,6 +64,8 @@ defmodule Indexer.Supervisor do
     UnclesWithoutIndex
   }
 
+  alias Indexer.Utils.NotificationsCleaner
+
   def child_spec([]) do
     child_spec([[]])
   end
@@ -255,6 +257,9 @@ defmodule Indexer.Supervisor do
         {EmptyBlocksSanitizer.Supervisor, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
         {PendingTransactionsSanitizer, [[json_rpc_named_arguments: json_rpc_named_arguments]]},
         {TokenTotalSupplyUpdater, [[]]},
+
+        # Notifications cleaner
+        configure(NotificationsCleaner, [[]]),
 
         # Temporary workers
         {UncatalogedTokenTransfers.Supervisor, [[]]},

--- a/apps/indexer/lib/indexer/utils/notifications_cleaner.ex
+++ b/apps/indexer/lib/indexer/utils/notifications_cleaner.ex
@@ -1,0 +1,65 @@
+defmodule Indexer.Utils.NotificationsCleaner do
+  @moduledoc """
+  Module is responsible for cleaning up notifications from the database.
+  """
+
+  alias Explorer.Repo
+  alias Explorer.Utility.EventNotification
+
+  import Ecto.Query
+
+  use GenServer
+
+  require Logger
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(args) do
+    Process.send(self(), :clean_up_legacy_notifications, [])
+    Process.send(self(), :clean_up_notifications, [])
+    {:ok, args}
+  end
+
+  def handle_info(:clean_up_legacy_notifications, state) do
+    clean_up_legacy_notifications()
+    {:noreply, state}
+  end
+
+  def handle_info(:clean_up_notifications, state) do
+    clean_up_notifications()
+    Process.send_after(self(), :clean_up_notifications, interval())
+    {:noreply, state}
+  end
+
+  defp clean_up_notifications do
+    {count, _} =
+      EventNotification
+      |> where([en], en.inserted_at < ago(^max_age(), "millisecond"))
+      |> Repo.delete_all()
+
+    Logger.info("Deleted #{count} event notifications")
+  end
+
+  defp clean_up_legacy_notifications do
+    {count, _} =
+      EventNotification
+      |> where([en], is_nil(en.inserted_at))
+      |> Repo.delete_all()
+
+    Logger.info("Deleted #{count} event notifications with nil inserted_at")
+  end
+
+  defp max_age do
+    config()[:max_age]
+  end
+
+  defp interval do
+    config()[:interval]
+  end
+
+  defp config do
+    Application.get_env(:indexer, __MODULE__)
+  end
+end

--- a/apps/indexer/test/indexer/utils/notifications_cleaner_test.exs
+++ b/apps/indexer/test/indexer/utils/notifications_cleaner_test.exs
@@ -1,0 +1,98 @@
+defmodule Indexer.Utils.NotificationsCleanerTest do
+  use Explorer.DataCase
+
+  alias Explorer.Repo
+  alias Explorer.Utility.EventNotification
+  alias Indexer.Utils.NotificationsCleaner
+
+  import Ecto.Query
+
+  setup do
+    # Store original config
+    original_config = Application.get_env(:indexer, NotificationsCleaner)
+
+    # Restore original config after each test
+    on_exit(fn ->
+      Application.put_env(:indexer, NotificationsCleaner, original_config)
+    end)
+
+    :ok
+  end
+
+  describe "start_link/1" do
+    test "starts the GenServer with the given name" do
+      assert {:ok, pid} = NotificationsCleaner.start_link([])
+      assert Process.alive?(pid)
+      Process.exit(pid, :normal)
+    end
+  end
+
+  describe "clean_up_notifications/0" do
+    test "deletes notifications older than max_age" do
+      # Create notifications with different timestamps
+      old_time = DateTime.utc_now() |> DateTime.add(-2000, :millisecond)
+      new_time = DateTime.utc_now() |> DateTime.add(-500, :millisecond)
+
+      insert(:event_notification, data: "old_data", inserted_at: old_time)
+      insert(:event_notification, data: "new_data", inserted_at: new_time)
+
+      # Verify both notifications exist
+      assert Repo.aggregate(EventNotification, :count) == 2
+
+      # Set configuration for max_age of 1000ms
+      config = Application.get_env(:indexer, NotificationsCleaner)
+      Application.put_env(:indexer, NotificationsCleaner, Keyword.put(config, :max_age, 1000))
+
+      assert {:ok, _pid} = NotificationsCleaner.start_link([])
+      Process.sleep(500)
+
+      # Verify only the old notification was deleted
+      assert Repo.aggregate(EventNotification, :count) == 1
+      remaining = Repo.one(from(n in EventNotification, select: n.data))
+      assert remaining == "new_data"
+    end
+
+    test "deletes multiple old notifications" do
+      old_time = DateTime.utc_now() |> DateTime.add(-2000, :millisecond)
+
+      # Insert multiple old notifications
+      insert_list(3, :event_notification, inserted_at: old_time)
+
+      # Insert one new notification
+      insert(:event_notification, data: "new_data")
+
+      # Verify all notifications exist
+      assert Repo.aggregate(EventNotification, :count) == 4
+
+      # Set configuration
+      config = Application.get_env(:indexer, NotificationsCleaner)
+      Application.put_env(:indexer, NotificationsCleaner, Keyword.put(config, :max_age, 1000))
+
+      assert {:ok, _pid} = NotificationsCleaner.start_link([])
+      Process.sleep(500)
+
+      # Verify only the new notification remains
+      assert Repo.aggregate(EventNotification, :count) == 1
+      remaining = Repo.one(from(n in EventNotification, select: n.data))
+      assert remaining == "new_data"
+    end
+
+    test "does not delete notifications when none are old enough" do
+      # Insert only new notifications
+      insert_list(3, :event_notification)
+
+      # Verify notifications exist
+      assert Repo.aggregate(EventNotification, :count) == 3
+
+      # Set configuration
+      config = Application.get_env(:indexer, NotificationsCleaner)
+      Application.put_env(:indexer, NotificationsCleaner, Keyword.put(config, :max_age, 1000))
+
+      assert {:ok, _pid} = NotificationsCleaner.start_link([])
+      Process.sleep(500)
+
+      # Verify all notifications still exist
+      assert Repo.aggregate(EventNotification, :count) == 3
+    end
+  end
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1411,6 +1411,11 @@ config :indexer, Indexer.Fetcher.Scroll.BridgeL2.Supervisor, disabled?: ConfigHe
 
 config :indexer, Indexer.Fetcher.Scroll.Batch.Supervisor, disabled?: ConfigHelper.chain_type() != :scroll
 
+config :indexer, Indexer.Utils.NotificationsCleaner,
+  interval: ConfigHelper.parse_time_env_var("INDEXER_NOTIFICATIONS_CLEANUP_INTERVAL", "2m"),
+  enabled: ConfigHelper.parse_bool_env_var("INDEXER_NOTIFICATIONS_CLEANUP_ENABLED", "true"),
+  max_age: ConfigHelper.parse_time_env_var("INDEXER_NOTIFICATIONS_CLEANUP_MAX_AGE", "5m")
+
 config :ex_aws,
   json_codec: Jason,
   access_key_id: System.get_env("NFT_MEDIA_HANDLER_AWS_ACCESS_KEY_ID"),


### PR DESCRIPTION
Closes #12724 

## Motivation
Race condition 

## Changelog
- `fetch_and_delete_event_notification`  -> `fetch_event_notification` (`Explorer.Chain.Events.Listener`)
- Added `Indexer.Utils.NotificationsCleaner` which is now responsible for clean up notifications
- `INDEXER_NOTIFICATIONS_CLEANUP_INTERVAL`
- `INDEXER_NOTIFICATIONS_CLEANUP_ENABLED`
- `INDEXER_NOTIFICATIONS_CLEANUP_MAX_AGE`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
