### PR TITLE
fix: Expand indexer timeout exception definition

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -239,7 +239,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
   end
 
   defp timeout_exception?(%{message: message}) when is_binary(message) do
-    String.match?(message, ~r/due to a timeout/)
+    String.match?(message, ~r/due to a timeout/) or String.match?(message, ~r/due to user request/)
   end
 
   defp timeout_exception?(_exception), do: false


### PR DESCRIPTION
## Motivation

Postgres exception `canceling statement due to user request` is a timeout exception, but is not considered one when determining whether a block should be added to `MassiveBlocksFetcher`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of timeout-related exceptions to include cases triggered by user requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->