### PR TITLE
fix: filter scilla transactions by status

### DIFF
--- a/apps/explorer/lib/explorer/chain/zilliqa/reader.ex
+++ b/apps/explorer/lib/explorer/chain/zilliqa/reader.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Chain.Zilliqa.Reader do
         a in Address,
         join: t in Transaction,
         on: a.hash == t.created_contract_address_hash,
-        where: t.v == 0 and not is_nil(a.contract_code) and a.verified == false,
+        where: t.status == :ok and t.v == 0 and not is_nil(a.contract_code) and a.verified == false,
         order_by: [desc: t.block_number],
         select: a
       )

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -273,7 +273,7 @@ defmodule Indexer.Fetcher.ContractCode do
   defp zilliqa_verify_scilla_contracts(entries, addresses) do
     zilliqa_contract_address_hashes =
       entries
-      |> Enum.filter(&ZilliqaHelper.scilla_transaction?(&1.type))
+      |> Enum.filter(&(ZilliqaHelper.scilla_transaction?(&1.type) and &1.status == :ok))
       |> MapSet.new(& &1.created_contract_address_hash)
 
     addresses


### PR DESCRIPTION
We should not create Scilla smart contracts from failed transactions

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of Zilliqa Scilla smart contract transactions to only include those with a successful status, ensuring more accurate results when streaming and verifying unverified contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->