### PR TITLE
fix: change default ordering in `/api/v2/smart-contracts`

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
@@ -7,10 +7,7 @@ defmodule BlockScoutWeb.VerifiedContractsController do
   import BlockScoutWeb.PagingHelper, only: [current_filter: 1, search_query: 1]
 
   import BlockScoutWeb.API.V2.SmartContractController,
-    only: [
-      smart_contract_addresses_paging_options: 1
-      # smart_contract_addresses_paging_params: 1
-    ]
+    only: [smart_contract_addresses_paging_options: 1]
 
   alias BlockScoutWeb.{Controller, VerifiedContractsView}
   alias Explorer.Chain

--- a/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/verified_contracts_controller.ex
@@ -8,8 +8,8 @@ defmodule BlockScoutWeb.VerifiedContractsController do
 
   import BlockScoutWeb.API.V2.SmartContractController,
     only: [
-      smart_contract_addresses_paging_options: 1,
-      smart_contract_addresses_paging_params: 1
+      smart_contract_addresses_paging_options: 1
+      # smart_contract_addresses_paging_params: 1
     ]
 
   alias BlockScoutWeb.{Controller, VerifiedContractsView}
@@ -18,7 +18,8 @@ defmodule BlockScoutWeb.VerifiedContractsController do
   alias Phoenix.View
 
   @necessity_by_association %{
-    :token => :optional
+    :token => :optional,
+    :smart_contract => :optional
   }
 
   def index(conn, %{"type" => "JSON"} = params) do
@@ -48,7 +49,7 @@ defmodule BlockScoutWeb.VerifiedContractsController do
              next_page,
              verified_contracts,
              params,
-             &smart_contract_addresses_paging_params(&1.address)
+             &%{id: &1.id}
            ) do
         nil -> nil
         next_page_params -> verified_contracts_path(conn, :index, Map.delete(next_page_params, "type"))

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -1617,7 +1617,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           for _ <- 0..50 do
             insert(:smart_contract)
           end
-          |> Enum.sort_by(& &1.address_hash.bytes, :desc)
+          |> Enum.sort_by(& &1.id)
 
         request = get(conn, "/api/v2/smart-contracts")
         assert response = json_response(request, 200)
@@ -1634,7 +1634,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
           for _ <- 0..50 do
             insert(:smart_contract)
           end
-          |> Enum.sort_by(& &1.address_hash.bytes, :desc)
+          |> Enum.sort_by(& &1.id)
 
         ordering_params = %{"sort" => "foo", "order" => "bar"}
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/verified_contracts_controller_test.exs
@@ -55,21 +55,18 @@ defmodule BlockScoutWeb.VerifiedContractsControllerTest do
     end
 
     test "next_page_path exist if not on last page", %{conn: conn} do
-      %SmartContract{address_hash: address_hash} =
+      %SmartContract{id: id} =
         60
         |> insert_list(:smart_contract)
-        |> Enum.reverse()
+        |> Enum.sort_by(& &1.id, :asc)
         |> Enum.fetch!(10)
 
       conn = get(conn, verified_contracts_path(conn, :index), %{"type" => "JSON"})
 
       expected_path =
         verified_contracts_path(conn, :index,
-          coin_balance: nil,
-          hash: address_hash,
-          items_count: "50",
-          transaction_count: nil,
-          transactions_count: nil
+          id: id,
+          items_count: "50"
         )
 
       assert Map.get(json_response(conn, 200), "next_page_path") == expected_path

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -249,8 +249,6 @@ defmodule Explorer.Chain.SmartContract do
     @dead_address_hash_string
   end
 
-  @default_sorting [asc: :hash]
-
   @typedoc """
   The name of a parameter to a function or event.
   """
@@ -1443,7 +1441,20 @@ defmodule Explorer.Chain.SmartContract do
   def verified_contract_addresses(options \\ []) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
-    sorting_options = Keyword.get(options, :sorting, [])
+
+    # If no sorting options are provided, we sort by `:id` descending only. If
+    # there are some sorting options supplied, we sort by `:hash` ascending as a
+    # secondary key.
+    {sorting_options, default_sorting_options} =
+      options
+      |> Keyword.get(:sorting)
+      |> case do
+        nil ->
+          {[], [{:desc, :id, :smart_contract}]}
+
+        options ->
+          {options, [asc: :hash]}
+      end
 
     addresses_query =
       if background_migrations_finished?() do
@@ -1455,8 +1466,8 @@ defmodule Explorer.Chain.SmartContract do
 
     addresses_query
     |> ExplorerHelper.maybe_hide_scam_addresses(:hash, options)
-    |> SortingHelper.apply_sorting(sorting_options, @default_sorting)
-    |> SortingHelper.page_with_sorting(paging_options, sorting_options, @default_sorting)
+    |> SortingHelper.apply_sorting(sorting_options, default_sorting_options)
+    |> SortingHelper.page_with_sorting(paging_options, sorting_options, default_sorting_options)
     |> Chain.join_associations(necessity_by_association)
     |> Chain.select_repo(options).all()
   end
@@ -1500,6 +1511,7 @@ defmodule Explorer.Chain.SmartContract do
       as: :address,
       where: address.verified == true,
       inner_lateral_join: contract in ^smart_contracts_subquery,
+      as: :smart_contract,
       on: true,
       select: address,
       preload: [smart_contract: contract]

--- a/apps/explorer/lib/explorer/chain/smart_contract/legacy_helper.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/legacy_helper.ex
@@ -36,6 +36,7 @@ defmodule Explorer.Chain.SmartContract.LegacyHelper do
       from(
         address in Address,
         join: contract in SmartContract,
+        as: :smart_contract,
         on: address.hash == contract.address_hash,
         preload: [:smart_contract]
       )


### PR DESCRIPTION
Closes #12307.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced pagination and sorting options for the smart contracts list endpoint, including support for pagination by smart contract ID when no sorting is specified.

* **Bug Fixes**
  * Improved robustness in parsing pagination parameters for the smart contracts API.

* **Refactor**
  * Default sorting for verified smart contract addresses now uses smart contract ID when no explicit sorting is provided.
  * Improved clarity in sorting and pagination logic, including more explicit handling of sorting errors and query aliasing.
  * Updated paging parameter extraction to streamline next page URL generation.

* **Tests**
  * Updated test cases to reflect the new default sorting by smart contract ID, ensuring accurate pagination and ordering validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->