### PR TITLE
chore: Add disconnect_on_error_codes param to repo config

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -187,7 +187,9 @@ config :explorer, Explorer.Utility.RateLimiter, enabled: true
 config :explorer, Explorer.Utility.Hammer.Redis, enabled: true
 config :explorer, Explorer.Utility.Hammer.ETS, enabled: true
 
-config :explorer, Explorer.Repo, migration_timestamps: [type: :utc_datetime_usec]
+config :explorer, Explorer.Repo,
+  migration_timestamps: [type: :utc_datetime_usec],
+  disconnect_on_error_codes: [:query_canceled]
 
 config :explorer, Explorer.Tracer,
   service: :explorer,


### PR DESCRIPTION
## Motivation

Long running queries may hang in the DB even when they are already canceled by timeout. Setting the `client_connection_check_interval` may be not enough since connection may be just returned to the pool and still be alive.

## Changelog

Added `disconnect_on_error_codes` repo option so in case of timeouts the connection will be explicitly closed and `client_connection_check_interval` will take the effect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection settings to improve handling of certain error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->