### PR TITLE
feat: runtime config option to disable file logging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,35 +13,6 @@ end
 
 config :phoenix, :json_library, Jason
 
-config :logger,
-  backends: [
-    # all applications and all levels
-    :console,
-    # all applications, but only errors
-    {LoggerFileBackend, :error},
-    # only :ecto, but all levels
-    {LoggerFileBackend, :ecto},
-    # only :block_scout_web, but all levels
-    {LoggerFileBackend, :block_scout_web},
-    # only :ethereum_jsonrpc, but all levels
-    {LoggerFileBackend, :ethereum_jsonrpc},
-    # only :explorer, but all levels
-    {LoggerFileBackend, :explorer},
-    # only :indexer, but all levels
-    {LoggerFileBackend, :indexer},
-    {LoggerFileBackend, :indexer_token_balances},
-    {LoggerFileBackend, :token_instances},
-    {LoggerFileBackend, :reading_token_functions},
-    {LoggerFileBackend, :pending_transactions_to_refetch},
-    {LoggerFileBackend, :empty_blocks_to_refetch},
-    {LoggerFileBackend, :withdrawal},
-    {LoggerFileBackend, :api},
-    {LoggerFileBackend, :block_import_timings},
-    {LoggerFileBackend, :account},
-    {LoggerFileBackend, :api_v2},
-    LoggerJSON
-  ]
-
 config :logger_json, :backend,
   metadata:
     ~w(application fetcher request_id first_block_number last_block_number missing_block_range_count missing_block_count

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -45,7 +45,11 @@ defmodule ConfigHelper do
   end
 
   @doc """
-  TODO
+  Returns the list of logger backends to be used by the application.
+
+  If the DISABLE_FILE_LOGGING environment variable is set to true, only base
+  logger backends (:console and LoggerJSON) are returned. Otherwise, returns
+  both base and file logger backends.
   """
   @spec logger_backends() :: list()
   def logger_backends do

--- a/config/config_helper.exs
+++ b/config/config_helper.exs
@@ -44,6 +44,43 @@ defmodule ConfigHelper do
     base_repos ++ chain_type_repos ++ ext_repos
   end
 
+  @doc """
+  TODO
+  """
+  @spec logger_backends() :: list()
+  def logger_backends do
+    base_logger_backends = [
+      :console,
+      LoggerJSON
+    ]
+
+    file_logger_backends =
+      [
+        {LoggerFileBackend, :error},
+        {LoggerFileBackend, :ecto},
+        {LoggerFileBackend, :block_scout_web},
+        {LoggerFileBackend, :ethereum_jsonrpc},
+        {LoggerFileBackend, :explorer},
+        {LoggerFileBackend, :indexer},
+        {LoggerFileBackend, :indexer_token_balances},
+        {LoggerFileBackend, :token_instances},
+        {LoggerFileBackend, :reading_token_functions},
+        {LoggerFileBackend, :pending_transactions_to_refetch},
+        {LoggerFileBackend, :empty_blocks_to_refetch},
+        {LoggerFileBackend, :withdrawal},
+        {LoggerFileBackend, :api},
+        {LoggerFileBackend, :block_import_timings},
+        {LoggerFileBackend, :account},
+        {LoggerFileBackend, :api_v2}
+      ]
+
+    if parse_bool_env_var("DISABLE_FILE_LOGGING") do
+      base_logger_backends
+    else
+      base_logger_backends ++ file_logger_backends
+    end
+  end
+
   @spec http_options(non_neg_integer()) :: list()
   def http_options(default_timeout \\ 1) do
     http_timeout = timeout(default_timeout)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,6 +4,9 @@ import Config
 |> Path.join()
 |> Code.eval_file()
 
+config :logger,
+  backends: ConfigHelper.logger_backends()
+
 ######################
 ### BlockScout Web ###
 ######################

--- a/docker-compose/envs/common-blockscout.env
+++ b/docker-compose/envs/common-blockscout.env
@@ -1,5 +1,6 @@
 ETHEREUM_JSONRPC_VARIANT=geth
 ETHEREUM_JSONRPC_HTTP_URL=http://host.docker.internal:8545/
+DISABLE_FILE_LOGGING=false
 DATABASE_URL=postgresql://blockscout:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
 
 # DATABASE_EVENT_URL=


### PR DESCRIPTION
One of our clients struggled with disabling logging into files. Thus, I suggest we introduce a `DISABLE_FILE_LOGGING` config option.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
https://github.com/blockscout/docs/pull/45
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new environment variable to enable or disable file-based logging.
* **Chores**
  * Updated logger configuration to dynamically set logger backends based on environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->