### PR TITLE
chore: migrate Auth0 to mint as well

### DIFF
--- a/apps/block_scout_web/config/config.exs
+++ b/apps/block_scout_web/config/config.exs
@@ -118,6 +118,8 @@ config :ueberauth, Ueberauth,
     }
   ]
 
+config :oauth2, adapter: Tesla.Adapter.Mint
+
 config :tesla, adapter: Tesla.Adapter.Mint
 
 # Import environment specific config. This must remain at the bottom

--- a/apps/explorer/lib/explorer/third_party_integrations/auth0/internal.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/auth0/internal.ex
@@ -92,7 +92,7 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0.Internal do
     with token when is_binary(token) <- Auth0.get_m2m_jwt(),
          client = OAuth.client(token: token),
          {:ok, %OAuth2.Response{status_code: 200, body: users}} when is_list(users) <-
-           Client.get(client, @users_path, [], params: %{"q" => q}) do
+           Client.get(client, @users_path, [], params: [q: q]) do
       {:ok, users}
     else
       error -> handle_common_errors(error, error_message)

--- a/apps/explorer/lib/explorer/third_party_integrations/auth0/legacy.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/auth0/legacy.ex
@@ -144,7 +144,7 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0.Legacy do
 
   defp maybe_link_email(%{"email" => email, "user_id" => "email|" <> identity_id = user_id} = user) do
     case Internal.find_users(
-           ~s(email:"#{URI.encode(email)}" AND NOT user_id:"#{URI.encode(user_id)}"),
+           ~s(email:"#{email}" AND NOT user_id:"#{user_id}"),
            "Failed to find legacy users by email"
          ) do
       {:ok, []} ->


### PR DESCRIPTION
## Motivation

- Get rid of the following warning
```
[notice] Invalid option {params,#{<<"q">> => <<"email:\"mail@mail.com\" OR user_metadata.email:\"mail@mail\"">>}} ignored 
``` 
- httpc which is used by default considered unsafe https://hexdocs.pm/tesla/3-adapter.html#about-httpc-adapter-and-security-issues

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of HTTP requests to Auth0 by adjusting how query parameters are formatted and removing unnecessary URI encoding in user search queries.

* **Chores**
  * Updated application configuration to explicitly set the HTTP adapter for OAuth2 integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->