### PR TITLE
fix: Fix flaky test for exporting balances to Multichain DB

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -3,6 +3,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   Module to interact with Multichain search microservice
   """
   alias Ecto.Association.NotLoaded
+  alias Explorer.Chain
   alias Explorer.Chain.Cache.ChainId
   alias Explorer.Chain.{Block, Hash, Transaction, Wei}
   alias Explorer.Chain.Block.Range
@@ -293,7 +294,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       address_coin_balances
       |> Enum.map(fn %{address_hash: address_hash, value: value} ->
         %{
-          address_hash: address_hash,
+          address_hash: address_hash |> Chain.string_to_address_hash() |> elem(1),
           token_contract_address_hash_or_native: "native",
           value: value
         }
@@ -308,7 +309,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
                        token_id: token_id
                      } ->
         %{
-          address_hash: address_hash,
+          address_hash: address_hash |> Chain.string_to_address_hash() |> elem(1),
           token_contract_address_hash_or_native: Helper.hash_to_binary(token_address_hash),
           # value is of Wei type in Explorer.Chain.Address.CoinBalance
           # value is of Decimal type in Explorer.Chain.Address.TokenBalance
@@ -398,7 +399,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
         params.address_coin_balances
         |> Enum.map(fn address_coin_balance ->
           %{
-            address_hash: address_coin_balance.address_hash,
+            address_hash: Hash.to_string(address_coin_balance.address_hash),
             token_contract_address_hash_or_native: "native",
             token_id: nil,
             value: address_coin_balance.value
@@ -440,7 +441,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
           params.address_token_balances
           |> Enum.map(fn address_token_balance ->
             %{
-              address_hash: address_token_balance.address_hash,
+              address_hash: Hash.to_string(address_token_balance.address_hash),
               token_address_hash: address_token_balance.token_contract_address_hash,
               token_id: address_token_balance.token_id,
               value: address_token_balance.value
@@ -547,14 +548,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
   defp format_address_coin_balance(address) do
     %{
-      address_hash: address.hash,
+      address_hash: Hash.to_string(address.hash),
       value: address.fetched_coin_balance
     }
   end
 
   defp format_address_token_balance(address_current_token_balance) do
     %{
-      address_hash: address_current_token_balance.address_hash,
+      address_hash: Hash.to_string(address_current_token_balance.address_hash),
       token_address_hash: Hash.to_string(address_current_token_balance.token_contract_address_hash),
       token_id: address_current_token_balance.token_id,
       value: address_current_token_balance.value

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -448,32 +448,32 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
       assert chunk[:hashes] == [
                %{
-                 hash: "0x" <> Base.encode16(block_1.hash.bytes, case: :lower),
+                 hash: to_string(block_1.hash),
                  hash_type: "BLOCK"
                },
                %{
-                 hash: "0x" <> Base.encode16(block_2.hash.bytes, case: :lower),
+                 hash: to_string(block_2.hash),
                  hash_type: "BLOCK"
                },
                %{
-                 hash: "0x" <> Base.encode16(transaction_1.hash.bytes, case: :lower),
+                 hash: to_string(transaction_1.hash),
                  hash_type: "TRANSACTION"
                },
                %{
-                 hash: "0x" <> Base.encode16(transaction_2.hash.bytes, case: :lower),
+                 hash: to_string(transaction_2.hash),
                  hash_type: "TRANSACTION"
                }
              ]
 
       assert chunk[:address_coin_balances] == [
-               %{value: %Wei{value: Decimal.new("200")}, address_hash: address_2.hash},
-               %{value: %Wei{value: Decimal.new("100")}, address_hash: address_1.hash}
+               %{value: %Wei{value: Decimal.new("200")}, address_hash: to_string(address_2.hash)},
+               %{value: %Wei{value: Decimal.new("100")}, address_hash: to_string(address_1.hash)}
              ]
 
       assert chunk[:address_token_balances] == [
                %{
                  value: Decimal.new("30000"),
-                 address_hash: address_1.hash,
+                 address_hash: to_string(address_1.hash),
                  token_id: nil,
                  token_address_hash: to_string(token.contract_address_hash)
                }

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -5,7 +5,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
   import ExUnit.CaptureLog, only: [capture_log: 1]
 
   alias Explorer.Chain
-  alias Explorer.Chain.{Address, Wei}
+  alias Explorer.Chain.Wei
   alias Explorer.Chain.MultichainSearchDb.BalancesExportQueue
   alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.TestHelper
@@ -190,7 +190,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
       address_3_hash = address_3.hash
       address_4 = insert(:address)
       address_4_hash = address_4.hash
-      address_4_hash_string_checksummed = Address.checksum(address_4)
+      address_4_hash_string = to_string(address_4_hash)
       address_5 = insert(:address)
       address_5_hash = address_5.hash
       token_address_1 = insert(:address)
@@ -235,7 +235,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
         times: 2,
         returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
           case Jason.decode(body) do
-            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string_checksummed}]}} ->
+            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
               {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
 
             _ ->

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -186,13 +186,16 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
       address_1 = insert(:address)
       address_2 = insert(:address)
       address_2_hash = address_2.hash
+      address_2_hash_string = to_string(address_2_hash)
       address_3 = insert(:address)
       address_3_hash = address_3.hash
+      address_3_hash_string = to_string(address_3_hash)
       address_4 = insert(:address)
       address_4_hash = address_4.hash
       address_4_hash_string = to_string(address_4_hash)
       address_5 = insert(:address)
       address_5_hash = address_5.hash
+      address_5_hash_string = to_string(address_5_hash)
       token_address_1 = insert(:address)
       token_address_1_hash_string = to_string(token_address_1) |> String.downcase()
       token_address_2 = insert(:address)
@@ -255,26 +258,26 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
                   %{
                     address_coin_balances: [
                       %{
-                        address_hash: ^address_4_hash,
+                        address_hash: ^address_4_hash_string,
                         token_contract_address_hash_or_native: "native",
                         value: ^val3
                       }
                     ],
                     address_token_balances: [
                       %{
-                        address_hash: ^address_5_hash,
+                        address_hash: ^address_5_hash_string,
                         token_address_hash: ^token_address_1_hash_string,
                         value: ^val4,
                         token_id: nil
                       },
                       %{
-                        address_hash: ^address_3_hash,
+                        address_hash: ^address_3_hash_string,
                         token_address_hash: ^token_address_2_hash_string,
                         value: ^val2,
                         token_id: nil
                       },
                       %{
-                        address_hash: ^address_2_hash,
+                        address_hash: ^address_2_hash_string,
                         token_address_hash: ^token_address_1_hash_string,
                         value: ^val1,
                         token_id: nil


### PR DESCRIPTION
## Motivation

Flaky test caused by https://github.com/blockscout/blockscout/pull/12726

```
  1) test run/2 returns {:retry, failed_data} on error where failed_data is only chunks that failed to export (Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest)

Error:      test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs:173

     match (=) failed

     The following variables were pinned:

       val4 = #Explorer.Chain.Wei<500>

       val3 = #Explorer.Chain.Wei<400>

       val2 = #Explorer.Chain.Wei<300>

       val1 = #Explorer.Chain.Wei<200>

       token_address_2_hash_string = "0x0000000000000000000000000000000000000550"

       token_address_1_hash_string = "0x000000000000000000000000000000000000054f"

       address_5_hash = %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 78>>}

       address_4_hash = %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 77>>}

       address_3_hash = %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 76>>}

       address_2_hash = %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 75>>}

     code:  assert {:retry,

             %{

               address_coin_balances: [

                 %{

                   address_hash: ^address_4_hash,

                   token_contract_address_hash_or_native: "native",

                   value: ^val3

                 }

               ],

               address_token_balances: [

                 %{

                   address_hash: ^address_5_hash,

                   token_address_hash: ^token_address_1_hash_string,

                   value: ^val4,

                   token_id: nil

                 },

                 %{

                   address_hash: ^address_3_hash,

                   token_address_hash: ^token_address_2_hash_string,

                   value: ^val2,

                   token_id: nil

                 },

                 %{

                   address_hash: ^address_2_hash,

                   token_address_hash: ^token_address_1_hash_string,

                   value: ^val1,

                   token_id: nil

                 }

               ]

             }} = MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)

     left:  {:retry,

             %{

               address_coin_balances: [

                 %{

                   address_hash: ^address_4_hash,

                   token_contract_address_hash_or_native: "native",

                   value: ^val3

                 }

               ],

               address_token_balances: [

                 %{

                   address_hash: ^address_5_hash,

                   token_address_hash: ^token_address_1_hash_string,

                   value: ^val4,

                   token_id: nil

                 },

                 %{

                   address_hash: ^address_3_hash,

                   token_address_hash: ^token_address_2_hash_string,

                   value: ^val2,

                   token_id: nil

                 },

                 %{

                   address_hash: ^address_2_hash,

                   token_address_hash: ^token_address_1_hash_string,

                   value: ^val1,

                   token_id: nil

                 }

               ]

             }}

     right: :ok

     stacktrace:

       test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs:254: anonymous fn/11 in Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest."test run/2 returns {:retry, failed_data} on error where failed_data is only chunks that failed to export"/1

       (ex_unit 1.17.3) lib/ex_unit/capture_log.ex:113: ExUnit.CaptureLog.with_log/2

       (ex_unit 1.17.3) lib/ex_unit/capture_log.ex:75: ExUnit.CaptureLog.capture_log/2

       test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs:253: (test)
```

## Changelog


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified address hash string handling in tests for balance export retries, improving test clarity without changing test logic.
* **Bug Fixes**
  * Standardized address hash formatting and conversion in balance export and batch import processes for consistent data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->