### PR TITLE
fix: Disable `Indexer.Fetcher.Optimism.Interop.MultichainExport` for non-OP chains

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1169,6 +1169,9 @@ config :indexer, Indexer.Fetcher.Optimism.Interop.MessageFailed.Supervisor,
 config :indexer, Indexer.Fetcher.Optimism.Interop.MessageQueue.Supervisor,
   disabled?: ConfigHelper.chain_type() != :optimism
 
+config :indexer, Indexer.Fetcher.Optimism.Interop.MultichainExport.Supervisor,
+  disabled?: ConfigHelper.chain_type() != :optimism
+
 config :indexer, Indexer.Fetcher.Optimism,
   optimism_l1_rpc: System.get_env("INDEXER_OPTIMISM_L1_RPC"),
   optimism_l1_system_config: System.get_env("INDEXER_OPTIMISM_L1_SYSTEM_CONFIG_CONTRACT"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to conditionally enable or disable a specific supervisor based on the current chain type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->