### PR TITLE
fix: Sanitize empty block_ranges payload before sending HTTP request to Multichain service

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
@@ -226,6 +226,16 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueue do
     pre_prepared_export_data
     |> Map.put(:addresses, addresses)
     |> Map.drop([:address_hashes])
+    |> (&if(
+          Map.get(&1, :block_ranges) == [
+            %{
+              max_block_number: nil,
+              min_block_number: nil
+            }
+          ],
+          do: Map.drop(&1, [:block_ranges]),
+          else: &1
+        )).()
   end
 
   defp defaults do


### PR DESCRIPTION
## Motivation

Multichain service API doesn't accept:
```
  "block_ranges": [
    {
      "max_block_number": null,
      "min_block_number": null
    }
  ],
```

It should be removed from payload before sending HTTP request to the Multichain Service API endpoint.


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export data by omitting the block range field when it contains only empty or default values, ensuring cleaner and more relevant data output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->