### PR TITLE
Fix: Reject empty token_id and value in export of token balances to the Multichain DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix: Reject empty token_id and value in export of token balances to the Multichain DB ([#12829](https://github.com/blockscout/blockscout/pull/12829))
 - Fix multichain export queues processing ([#12822](https://github.com/blockscout/blockscout/pull/12822))
 - Remove token_id parameter from coin balance payload to Multichain service API endpoint ([#12817](https://github.com/blockscout/blockscout/pull/12817))
 - Sanitize empty block_ranges payload before sending HTTP request to Multichain service([#12816](https://github.com/blockscout/blockscout/pull/12816))

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -446,11 +446,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
               value: address_token_balance.value
             }
           end)
-          |> Enum.reject(&(is_nil(&1.value) && is_nil(&1.token_id)))
 
         true ->
           []
       end
+
+    sanitized_address_token_balances =
+      address_token_balances
+      |> Enum.reject(&(is_nil(&1.value) && is_nil(&1.token_id)))
 
     api_key = api_key()
     chain_id = ChainId.get_id()
@@ -469,7 +472,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     prepare_chunk(indexed_addresses_chunks, indexed_address_coin_balances_chunks, base_data_chunk, %{
       block_transaction_hashes: block_transaction_hashes,
       block_ranges: block_ranges,
-      address_token_balances: address_token_balances
+      address_token_balances: sanitized_address_token_balances
     })
   end
 


### PR DESCRIPTION
## Motivation

Token balances with the empty pair: token_id and value) still appear in the queue for export to Multichain DB.


## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of token balance exports to the Multichain database by ensuring entries with empty token IDs or values are excluded.

* **Documentation**
  * Updated the changelog to document the bug fix related to token balance exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->