### PR TITLE
chore: Parsing L2 block number of OP Dispute Game on BOB chain

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -5,9 +5,8 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
 
   alias BlockScoutWeb.API.V2.Helper
   alias Explorer.{Chain, Repo}
-  alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Block, Transaction}
-  alias Explorer.Chain.Optimism.{FrameSequence, FrameSequenceBlob, InteropMessage, Withdrawal}
+  alias Explorer.Chain.Optimism.{DisputeGame, FrameSequence, FrameSequenceBlob, InteropMessage, Withdrawal}
 
   @doc """
     Function to render GET requests to `/api/v2/optimism/txn-batches` endpoint.
@@ -121,7 +120,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
               2 -> "Defender wins"
             end
 
-          [l2_block_number] = ExplorerHelper.decode_data(g.extra_data, [{:uint, 256}])
+          l2_block_number = DisputeGame.l2_block_number_from_extra_data(g.extra_data.bytes)
 
           %{
             "index" => g.index,

--- a/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/dispute_game.ex
@@ -6,11 +6,15 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
   import Ecto.Query
   import Explorer.Chain, only: [default_paging_options: 0, select_repo: 1]
 
+  alias Explorer.Chain.Cache.ChainId
   alias Explorer.Chain.{Data, Hash}
   alias Explorer.{PagingOptions, Repo}
 
   @required_attrs ~w(index game_type address_hash created_at)a
   @optional_attrs ~w(extra_data resolved_at status)a
+
+  @chain_id_bob_mainnet 60808
+  @chain_id_bob_sepolia 808_813
 
   @typedoc """
     * `index` - A unique index of the dispute game.
@@ -79,6 +83,35 @@ defmodule Explorer.Chain.Optimism.DisputeGame do
     |> page_dispute_games(paging_options)
     |> limit(^paging_options.page_size)
     |> select_repo(options).all(timeout: :infinity)
+  end
+
+  @doc """
+    Retrieves L2 block number from the `extraData` field of the dispute game. The L2 block number can be encoded in
+    different ways depending on the chain.
+
+    ## Parameters
+    - `extra_data`: The byte sequence of the extra data to retrieve L2 block number from.
+
+    ## Returns
+    - L2 block number of the dispute game.
+  """
+  @spec l2_block_number_from_extra_data(binary()) :: non_neg_integer()
+  def l2_block_number_from_extra_data(extra_data) do
+    current_chain_id =
+      case ChainId.get_id() do
+        nil -> Application.get_env(:block_scout_web, :chain_id)
+        chain_id -> chain_id
+      end
+
+    first_bits =
+      if current_chain_id in [@chain_id_bob_mainnet, @chain_id_bob_sepolia] do
+        64
+      else
+        256
+      end
+
+    <<l2_block_number::size(first_bits), _::binary>> = extra_data
+    l2_block_number
   end
 
   defp page_dispute_games(query, %PagingOptions{key: nil}), do: query

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -257,7 +257,7 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
   defp appropriate_games_found(withdrawal_l2_block_number, respected_games) do
     respected_games
     |> Enum.any?(fn game ->
-      [l2_block_number] = Helper.decode_data(game.extra_data, [{:uint, 256}])
+      l2_block_number = DisputeGame.l2_block_number_from_extra_data(game.extra_data.bytes)
       withdrawal_l2_block_number <= l2_block_number
     end)
   end


### PR DESCRIPTION
## Motivation

BOB chain has another format of keeping L2 block number in the `extraData` field of OP Dispute Game. The block number is stored in the first 8 bytes of the `extraData` instead of 32 bytes (on other OP chains).

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
