### PR TITLE
chore: Change name of the Swagger generation workflow

### DIFF
--- a/.github/workflows/generate-swagger.yml
+++ b/.github/workflows/generate-swagger.yml
@@ -1,4 +1,4 @@
-name: Blockscout
+name: Generate Swagger
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Change name of Swagger generation workflow ([#12840](https://github.com/blockscout/blockscout/pull/12840))
 - migrate Auth0 to mint as well ([#12807](https://github.com/blockscout/blockscout/pull/12807))
 - Migrate from HTTPoison to Tesla.Mint ([#12699](https://github.com/blockscout/blockscout/pull/12699))
 - Merge adjacent missing block ranges ([#12778](https://github.com/blockscout/blockscout/issues/12778))


### PR DESCRIPTION
## Motivation

Equal names for different workflows:

<img width="416" height="329" alt="Screenshot 2025-07-22 at 17 45 35" src="https://github.com/user-attachments/assets/724fda94-1f87-4283-967e-36b399502140" />


## Changelog

Rename workflow responsible for swagger generation to "Generate Swagger".

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the GitHub Actions workflow from "Blockscout" to "Generate Swagger".
  * Updated the changelog to reflect the workflow name change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->