### PR TITLE
fix: Fix increment of `retries_number` in exporting data to Multichain DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix increment of retries_number in exporting data to Multichain DB ([#12847](https://github.com/blockscout/blockscout/pull/12847))
 - Fix various errors on export of balances to Multichain DB ([#12837](https://github.com/blockscout/blockscout/pull/12837))
 - Reject empty token_id and value in export of token balances to the Multichain DB ([#12829](https://github.com/blockscout/blockscout/pull/12829))
 - Fix multichain export queues processing ([#12822](https://github.com/blockscout/blockscout/pull/12822))

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
@@ -75,13 +75,14 @@ defmodule Explorer.Chain.MultichainSearchDb.BalancesExportQueue do
   end
 
   @doc """
-  Returns an Ecto query that defines the default conflict resolution strategy for the
-  `multichain_search_db_export_balances_queue` table. On conflict, it increments the `retries_number`
-  (by using the value from `EXCLUDED.retries_number` or 0 if not present) and updates the
-  `updated_at` field to the greatest value between the current and the new timestamp.
+  Returns an Ecto query that defines the default behavior for handling conflicts
+  when inserting into the `multichain_search_db_export_balances_queue` table.
 
-  This is typically used in upsert operations to ensure retry counts are tracked and
-  timestamps are properly updated.
+  On conflict, this query:
+    - Increments the `retries_number` field by 1 (or sets it to 1 if it was `nil`).
+    - Sets the `updated_at` field to the greatest value between the current and the excluded `updated_at`.
+
+  This is typically used with `on_conflict: default_on_conflict()` in Ecto insert operations.
   """
   @spec default_on_conflict :: Ecto.Query.t()
   def default_on_conflict do

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
@@ -89,7 +89,7 @@ defmodule Explorer.Chain.MultichainSearchDb.BalancesExportQueue do
       multichain_search_db_export_balances_queue in __MODULE__,
       update: [
         set: [
-          retries_number: fragment("COALESCE(EXCLUDED.retries_number, 0) + 1"),
+          retries_number: fragment("COALESCE(?, 0) + 1", multichain_search_db_export_balances_queue.retries_number),
           updated_at:
             fragment("GREATEST(?, EXCLUDED.updated_at)", multichain_search_db_export_balances_queue.updated_at)
         ]

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
@@ -85,13 +85,14 @@ defmodule Explorer.Chain.MultichainSearchDb.MainExportQueue do
   end
 
   @doc """
-  Returns an Ecto query that defines the default conflict resolution strategy for the
-  `multichain_search_db_main_export_queue` table. On conflict, it increments the `retries_number`
-  (by using the value from `EXCLUDED.retries_number` or 0 if not present) and updates the
-  `updated_at` field to the greatest value between the current and the new timestamp.
+  Returns an Ecto query that defines the default behavior for handling conflicts
+  when inserting into the `multichain_search_db_main_export_queue` table.
 
-  This is typically used in upsert operations to ensure retry counts are tracked and
-  timestamps are properly updated.
+  On conflict, this query:
+    - Increments the `retries_number` field by 1 (or sets it to 1 if it was `nil`).
+    - Sets the `updated_at` field to the greatest value between the current and the excluded `updated_at`.
+
+  This is typically used with `on_conflict` options in Ecto insert operations.
   """
   @spec default_on_conflict :: Ecto.Query.t()
   def default_on_conflict do

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
@@ -99,7 +99,7 @@ defmodule Explorer.Chain.MultichainSearchDb.MainExportQueue do
       multichain_search_db_main_export_queue in __MODULE__,
       update: [
         set: [
-          retries_number: fragment("COALESCE(EXCLUDED.retries_number, 0) + 1"),
+          retries_number: fragment("COALESCE(?, 0) + 1", multichain_search_db_main_export_queue.retries_number),
           updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", multichain_search_db_main_export_queue.updated_at)
         ]
       ]

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -234,18 +234,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      Tesla.Test.expect_tesla_call(
-        times: 2,
-        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
-          case Jason.decode(body) do
-            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
-              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-
-            _ ->
-              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
-          end
-        end
-      )
+      tesla_expectations(address_4_hash_string)
 
       val1 = Decimal.new(200) |> Wei.cast() |> elem(1)
       val2 = Decimal.new(300) |> Wei.cast() |> elem(1)
@@ -293,18 +282,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      Tesla.Test.expect_tesla_call(
-        times: 2,
-        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
-          case Jason.decode(body) do
-            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
-              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-
-            _ ->
-              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
-          end
-        end
-      )
+      tesla_expectations(address_4_hash_string)
 
       MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
 
@@ -316,18 +294,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      Tesla.Test.expect_tesla_call(
-        times: 2,
-        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
-          case Jason.decode(body) do
-            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
-              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-
-            _ ->
-              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
-          end
-        end
-      )
+      tesla_expectations(address_4_hash_string)
 
       MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
 
@@ -377,5 +344,20 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       Application.put_env(:explorer, MultichainSearch, service_url: nil, api_key: nil, addresses_chunk_size: 7000)
     end
+  end
+
+  defp tesla_expectations(address_4_hash_string) do
+    Tesla.Test.expect_tesla_call(
+      times: 2,
+      returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
+        case Jason.decode(body) do
+          {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
+            {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+          _ ->
+            {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
+        end
+      end
+    )
   end
 end

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -287,7 +287,53 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
         end)
 
       assert Repo.aggregate(BalancesExportQueue, :count, :id) == 4
+      results = Repo.all(BalancesExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == nil))
       assert log =~ "Batch balances export retry to the Multichain Search DB failed"
+
+      TestHelper.get_chain_id_mock()
+
+      Tesla.Test.expect_tesla_call(
+        times: 2,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
+          case Jason.decode(body) do
+            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+            _ ->
+              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
+          end
+        end
+      )
+
+      MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
+
+      assert Repo.aggregate(BalancesExportQueue, :count, :id) == 4
+      results = Repo.all(BalancesExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == 1))
+
+      # Check, that `retries_number` is incrementing
+
+      TestHelper.get_chain_id_mock()
+
+      Tesla.Test.expect_tesla_call(
+        times: 2,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
+          case Jason.decode(body) do
+            {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+            _ ->
+              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
+          end
+        end
+      )
+
+      MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
+
+      assert Repo.aggregate(BalancesExportQueue, :count, :id) == 4
+      results = Repo.all(BalancesExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == 2))
 
       export_data_2 = [
         %{

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
@@ -227,18 +227,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      Tesla.Test.expect_tesla_call(
-        times: 2,
-        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
-          case Jason.decode(body) do
-            {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
-              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-
-            _ ->
-              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
-          end
-        end
-      )
+      tesla_expectations()
 
       MultichainSearchDbMainExportQueue.run(export_data_2, nil)
 
@@ -250,18 +239,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      Tesla.Test.expect_tesla_call(
-        times: 2,
-        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
-          case Jason.decode(body) do
-            {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
-              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
-
-            _ ->
-              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
-          end
-        end
-      )
+      tesla_expectations()
 
       MultichainSearchDbMainExportQueue.run(export_data_2, nil)
 
@@ -269,5 +247,20 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
       results = Repo.all(MainExportQueue)
       assert Enum.all?(results, &(&1.retries_number == 2))
     end
+  end
+
+  defp tesla_expectations() do
+    Tesla.Test.expect_tesla_call(
+      times: 2,
+      returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
+        case Jason.decode(body) do
+          {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
+            {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+          _ ->
+            {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
+        end
+      end
+    )
   end
 end

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
@@ -209,6 +209,8 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
         end)
 
       assert Repo.aggregate(MainExportQueue, :count, :hash) == 4
+      results = Repo.all(MainExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == nil))
 
       assert log =~ "Batch main export retry to the Multichain Search DB failed"
 
@@ -241,6 +243,31 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
       MultichainSearchDbMainExportQueue.run(export_data_2, nil)
 
       assert Repo.aggregate(MainExportQueue, :count, :hash) == 3
+      results = Repo.all(MainExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == 1))
+
+      # Check, that `retries_number` is incrementing
+
+      TestHelper.get_chain_id_mock()
+
+      Tesla.Test.expect_tesla_call(
+        times: 2,
+        returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
+          case Jason.decode(body) do
+            {:ok, %{"block_ranges" => [%{"max_block_number" => _, "min_block_number" => _}]}} ->
+              {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
+
+            _ ->
+              {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{"status" => "ok"})}}
+          end
+        end
+      )
+
+      MultichainSearchDbMainExportQueue.run(export_data_2, nil)
+
+      assert Repo.aggregate(MainExportQueue, :count, :hash) == 3
+      results = Repo.all(MainExportQueue)
+      assert Enum.all?(results, &(&1.retries_number == 2))
     end
   end
 end


### PR DESCRIPTION
## Motivation

`retries_number` is not properly incrementing for both main and balances export queues to Multichain DB.

## Changelog

Fix `retries_number` increment and cover this case with regression tests.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry count handling for export queue entries, ensuring accurate incrementing on repeated failures.

* **Tests**
  * Enhanced tests to verify proper initialization and incrementation of retry counts during multiple export retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->