### PR TITLE
chore: Move addresses to a separate import stage

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -17,6 +17,7 @@ defmodule Explorer.Chain.Import do
       Import.Stage.Blocks
     ],
     [
+      Import.Stage.Addresses,
       Import.Stage.Main
     ],
     [

--- a/apps/explorer/lib/explorer/chain/import/stage/addresses.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/addresses.ex
@@ -1,0 +1,26 @@
+defmodule Explorer.Chain.Import.Stage.Addresses do
+  @moduledoc """
+  Import addresses.
+  """
+
+  alias Explorer.Chain.Import.{Runner, Stage}
+
+  @behaviour Stage
+
+  @runners [
+    Runner.Addresses
+  ]
+
+  @impl Stage
+  def runners, do: @runners
+
+  @impl Stage
+  def all_runners, do: runners()
+
+  @addresses_chunk_size 50
+
+  @impl Stage
+  def multis(runner_to_changes_list, options) do
+    Stage.chunk_every(runner_to_changes_list, Runner.Addresses, @addresses_chunk_size, options)
+  end
+end

--- a/apps/explorer/lib/explorer/chain/import/stage/main.ex
+++ b/apps/explorer/lib/explorer/chain/import/stage/main.ex
@@ -1,15 +1,13 @@
 defmodule Explorer.Chain.Import.Stage.Main do
   @moduledoc """
-  Imports main data (addresses, address_coin_balances, address_coin_balances_daily, tokens, transactions).
+  Imports main data (address_coin_balances, address_coin_balances_daily, tokens, transactions).
   """
 
   alias Explorer.Chain.Import.{Runner, Stage}
 
   @behaviour Stage
 
-  @addresses_runner Runner.Addresses
-
-  @rest_runners [
+  @runners [
     Runner.Tokens,
     Runner.Address.CoinBalances,
     Runner.Address.CoinBalancesDaily,
@@ -17,21 +15,16 @@ defmodule Explorer.Chain.Import.Stage.Main do
   ]
 
   @impl Stage
-  def runners, do: [@addresses_runner | @rest_runners]
+  def runners, do: @runners
 
   @impl Stage
   def all_runners, do: runners()
 
-  @addresses_chunk_size 50
-
   @impl Stage
   def multis(runner_to_changes_list, options) do
-    {addresses_multis, remaining_runner_to_changes_list} =
-      Stage.chunk_every(runner_to_changes_list, Runner.Addresses, @addresses_chunk_size, options)
-
     {final_multi, final_remaining_runner_to_changes_list} =
-      Stage.single_multi(@rest_runners, remaining_runner_to_changes_list, options)
+      Stage.single_multi(@runners, runner_to_changes_list, options)
 
-    {[final_multi | addresses_multis], final_remaining_runner_to_changes_list}
+    {[final_multi], final_remaining_runner_to_changes_list}
   end
 end


### PR DESCRIPTION
## Motivation

Addresses are inserted in the main import stage which means that they are inserted in the same DB transaction as all of the other main data. Since there are no references to address table, they may be imported in a parallel transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new stage to the import process for handling address data in batches, improving the import pipeline.

* **Documentation**
  * Updated documentation to reflect that address data is now processed separately from the main import stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->