### PR TITLE
chore: catchup fetcher various improvements

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -308,7 +308,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
   # new ctb is the same height or older
   defp should_update?(new_ctb, existing_ctb) do
     existing_ctb.block_number == new_ctb.block_number and not is_nil(Map.get(new_ctb, :value)) and
-      (is_nil(existing_ctb.value_fetched_at) or existing_ctb.value_fetched_at < new_ctb.value_fetched_at)
+      (is_nil(existing_ctb.value_fetched_at) or Timex.before?(existing_ctb.value_fetched_at, new_ctb.value_fetched_at))
   end
 
   @spec insert(Repo.t(), [map()], %{

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -68,7 +68,7 @@ defmodule Explorer.Utility.MissingBlockRange do
     - A list of `Range` structs, where each range represents a contiguous block range of missing blocks.
 
   """
-  @spec get_latest_batch(integer()) :: [__MODULE__.t()]
+  @spec get_latest_batch(integer()) :: [Range.t()]
   def get_latest_batch(size \\ @default_returning_batch_size) do
     size
     |> get_latest_ranges_query()

--- a/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/address/current_token_balances_test.exs
@@ -339,6 +339,45 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalancesTest do
       assert current_token_balance.value == Decimal.new(200)
     end
 
+    test "ignores when the new value_fetched_at is lower (values compared correctly)", %{
+      address: %Address{hash: address_hash} = address,
+      token: %Token{contract_address_hash: token_contract_address_hash},
+      options: options
+    } do
+      time_before = ~U[2024-12-31 00:00:00.000000Z]
+      time_after = ~U[2025-01-01 00:00:00.000000Z]
+
+      assert time_before > time_after
+
+      insert(
+        :address_current_token_balance,
+        address: address,
+        block_number: 1,
+        token_contract_address_hash: token_contract_address_hash,
+        value: 200,
+        value_fetched_at: time_after
+      )
+
+      update_holder_count!(token_contract_address_hash, 1)
+
+      assert {:ok, %{address_current_token_balances: [], address_current_token_balances_update_token_holder_counts: []}} =
+               run_changes(
+                 %{
+                   address_hash: address_hash,
+                   token_contract_address_hash: token_contract_address_hash,
+                   block_number: 1,
+                   value: Decimal.new(100),
+                   value_fetched_at: time_before
+                 },
+                 options
+               )
+
+      current_token_balance = Repo.get_by(CurrentTokenBalance, address_hash: address_hash)
+
+      assert Decimal.eq?(current_token_balance.value, 200)
+      assert Timex.equal?(current_token_balance.value_fetched_at, time_after)
+    end
+
     test "a non-holder updating to a holder increases the holder_count", %{
       address: %Address{hash: address_hash} = address,
       token: %Token{contract_address_hash: token_contract_address_hash},

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -29,7 +29,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
   alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain
   alias Explorer.Chain.NullRoundHeight
-  alias Explorer.Utility.{MassiveBlock, MissingRangesManipulator}
+  alias Explorer.Utility.{MassiveBlock, MissingBlockRange, MissingRangesManipulator}
   alias Indexer.{Block, Tracer}
   alias Indexer.Block.Catchup.TaskSupervisor
   alias Indexer.Fetcher.OnDemand.ContractCreator, as: ContractCreatorOnDemand
@@ -50,7 +50,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
     Logger.metadata(fetcher: :block_catchup)
     Process.flag(:trap_exit, true)
 
-    case MissingRangesManipulator.get_latest_batch(blocks_batch_size() * blocks_concurrency()) do
+    case MissingBlockRange.get_latest_batch(blocks_batch_size() * blocks_concurrency()) do
       [] ->
         %{
           first_block_number: nil,


### PR DESCRIPTION
## Motivation

- `value_fetched_at` field of a `CurrentTokenBalance` struct doesn't compared correctly on insert since it has `DateTime` type
- Importing all current token balances in one query may cause `statement_too_complex` errors
- Missing ranges request from catchup fetcher shouldn't use `MissingRangesManipulator` since it runs in a single instance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved accuracy when selecting the most recent token balance when timestamps are equal.
  * Reorganized token-balance processing to handle batches more predictably.
  * Updated handling of missing block ranges used during background data fetching.

* **Tests**
  * Added tests verifying timestamp comparison and balance-update behavior.

No user-facing changes or interface updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->