### PR TITLE
fix: balances export queue to multichain replace do_nothing with replace_all on insertion to the queue

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -219,7 +219,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
         Repo.insert_all(MainExportQueue, Helper.add_timestamps(prepared_main_data), on_conflict: :nothing)
 
-        Repo.insert_all(BalancesExportQueue, Helper.add_timestamps(prepared_balances_data), on_conflict: :nothing)
+        Repo.insert_all(BalancesExportQueue, Helper.add_timestamps(prepared_balances_data), on_conflict: :replace_all)
       end)
 
       :ok


### PR DESCRIPTION
## Motivation

If the balances export queue is processed slower than it is populated, it is possible that balance on the same address of the same token might be added more than once. Currently, we discard adding new item to the queue or update existing one because of `DO NOTHING` clause:
https://github.com/blockscout/blockscout/blob/4d712db9846b18c7e3774c8d4eff877d6e5e3817/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex#L222

## Changelog

Replace `DO NOTHING` with replacing the item.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
