### PR TITLE
fix: Fix naming for apikey param in OpenAPI spec

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -432,7 +432,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       schema: %Schema{type: :string},
       required: false,
       description: "API key for rate limiting",
-      name: :api_key
+      name: :apikey
     }
   end
 


### PR DESCRIPTION
## Motivation

```
{"errors":[{"title":"Invalid value","source":{"pointer":"/apikey"},"detail":"Unexpected field: apikey"}]}
```

## Changelog
- `api_key` -> `apikey`
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
