### PR TITLE
fix: Balances export queue: replace `replace_all` with replace only `value` and `updated_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug Fixes
 
+- Balances export queue: replace replace_all with replace only value and updated_at ([#12892](https://github.com/blockscout/blockscout/pull/12892))
 - Fix naming for apikey param in OpenAPI spec ([#12891](https://github.com/blockscout/blockscout/pull/12891))
 - Balances export queue to multichain replace do_nothing with replace_all on insertion to the queue ([#12888](https://github.com/blockscout/blockscout/pull/12888))
 - Allow using temporary token for api/account/v2 by default ([#12869](https://github.com/blockscout/blockscout/pull/12869))

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -215,7 +215,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
         Repo.insert_all(MainExportQueue, Helper.add_timestamps(prepared_main_data), on_conflict: :nothing)
 
         Repo.insert_all(BalancesExportQueue, Helper.add_timestamps(prepared_balances_data),
-          on_conflict: :replace_all,
+          on_conflict: {:replace, [:value, :updated_at]},
           conflict_target:
             {:unsafe_fragment,
              ~s<(address_hash, token_contract_address_hash_or_native, COALESCE(token_id, -1::integer::numeric))>}


### PR DESCRIPTION
## Motivation

`
"time":"2025-07-31T10:14:32.202Z","severity":"error","message":"Task #PID<0.175497.0> started from Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue terminating\n** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 15381 waits for ShareLock on transaction 1837271583; blocked by process 16206.\nProcess 16206 waits for ShareLock on transaction 1837271514; blocked by process 15381.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:1000: Ecto.Repo.Schema.apply/4\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:721: anonymous fn/13 in Ecto.Repo.Schema.do_delete/4\n    (ecto 3.13.2) lib/ecto/multi.ex:905: Ecto.Multi.apply_operation/5\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (ecto 3.13.2) lib/ecto/multi.ex:878: anonymous fn/5 in Ecto.Multi.apply_operations/5\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4\n    (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [], callback_module: Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue, batch: [%{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 0, 198, 247, 179, 165, 133, 221, 19, 127, 207, 16, 5, 73, 137, 183, 226, 57, 18, 164>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 3, 140, 11, 75, 193, 102, 35, 117, 67, 127, 204, 121, 16, 80, 77, 139, 10, 47, 83>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<235, 32, 49, 205, 236, 248, 242, 158, 101, 185, 202, 200, 172, 70, 164, 177, 108, 23, 117, 107>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<3574425979770363095>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<233, 189, 38, 255, 233, 13, 0, 51, 56, 30, 208, 109, 87, 135, 139, 194, 63, 231, 125, 129>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<228, 240, 92, 98, 192, 154, 62, 192, 0, 163, 243, 137, 94, 253, 46, 201, 161, 161, 23, 66>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1140155788735952039>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<227, 74, 215, 108, 68, 129, 140, 64, 48, 239, 209, 164, 87, 159, 62, 250, 23, 51, 192, 82>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<225, 239, 184, 165, 154, 247, 18, 215, 181, 133, 65, 152, 188, 206, 13, 164, 117, 79, 16, 12>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1330000000000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<223, 119, 109, 96, 98, 107, 118, 90, 225, 181, 213, 215, 168, 164, 36, 61, 247, 199, 136, 156>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<452290642927628000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<223, 15, 158, 111, 54, 255, 173, 180, 75, 185, 10, 128, 243, 202, 83, 119, 125, 200, 188, 193>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<121539528033072399>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<221, 91, 26, 41, 99, 153, 20, 62, 62, 22, 118, 252, 74, 160, 162, 62, 119, 151, 224, 155>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 242, 90, 146, 29, 70, 105, 204, 166, 119, 91, 93, 53, 182, 215, 196, 11, 205, 243>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 149, 129, 152, 41, 169, 162, 54, 113, 248, 16, 50, 15, 174, 151, 151, 228, 231, 118>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 143, 105, 63, 247, 166, 75, 81, 148, 137, 30, 253, 39, 191, 226, 182, 119, 209, 77>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 126, 47, 66, 36, 227, 151, 57, 13, 201, 232, 233, 206, 245, 53, 251, 84, 111, 59>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 118, 143, 191, 249, 143, 41, 16, 73, 156, 251, 108, 168, 151, 138, 131, 186, 91, 122>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 4, 103, 124, 35, 141, 97, 223, 21, 214, 203, 171, 71, 90, 45, 243, 37, 149, 249, 150>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<230, 49, 54, 13, 173, 22, 87, 206, 219, 44, 180, 255, 15, 144, 120, 97, 95, 92, 123, 195>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<39, 212, 44, 20, 186, 240, 54, 20, 86, 39, 197, 29, 65, 124, 120, 148, 183, 170, 26, 177>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<4080033004801374>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<171, 117, 81, 43, 52, 84, 44, 85, 243, 247, 208, 97, 148, 56, 89, 0, 102, 22, 59, 192>>}, token_id: nil, token_contract_address_hash_or_native: <<205, 253, 215, 221, 36, 186, 189, 208, 90, 47, 244, 223, 207, 6, 56, 76, 90, 214, 97, 169>>}, %{value: #Explorer.Chain.Wei<362524719>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<197, 118, 149, 135, 94, 141, 122, 254, 159, 76, 2, 12, 85, 23, 151, 60, 163, 44, 43, 4>>}, token_id: nil, token_contract_address_hash_or_native: <<205, 253, 215, 221, 36, 186, 189, 208, 90, 47, 244, 223, 207, 6, 56, 76, 90, 214, 97, 169>>}, %{value: #Explorer.Chain.Wei<1350000000000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<116, 192, 22, 139, 169, 96, 102, 93, 87, 193, 134, 51, 87, 63, 150, 140, 41, 75, 45, 56>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<35237364103189731>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<114, 114, 237, 87, 194, 21, 119, 215, 156, 82, 200, 125, 195, 229, 135, 93, 98, 35, 173, 74>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<742229528150599116>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<103, 208, 74, 117, 207, 244, 58, 202, 137, 99, 184, 50, 133, 12, 147, 224, 211, 46, 7, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<9980897290000000000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<102, 55, 43, 227, 221, 76, 119, 245, 29, 135, 200, 44, 25, 212, 69, 152, 103, 135, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1614561289112457>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<99, 28, 255, 217, 233, 22, 233, 19, 200, 175, 26, 126, 47, 126, 89, 232, 128, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<35659478647231>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<98, 134, 80, 6, 173, 78, 143, 241, 42, 66, 232, 254, 242, 133, 116, 38, ...>>}, token_id: nil, token_contract_address_h (truncated)","metadata":{"error":{"initial_call":null,"reason":"** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 15381 waits for ShareLock on transaction 1837271583; blocked by process 16206.\nProcess 16206 waits for ShareLock on transaction 1837271514; blocked by process 15381.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:1000: Ecto.Repo.Schema.apply/4\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:721: anonymous fn/13 in Ecto.Repo.Schema.do_delete/4\n    (ecto 3.13.2) lib/ecto/multi.ex:905: Ecto.Multi.apply_operation/5\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (ecto 3.13.2) lib/ecto/multi.ex:878: anonymous fn/5 in Ecto.Multi.apply_operations/5\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4\n    (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4\n"}}}
`

## Changelog

Replace `replace_all` with replace only `value` and `updated_at` at insertion to the balances export queue on conflict.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the update process for balances export queue to only modify specific fields when conflicts occur, ensuring more precise data handling.

* **Documentation**
  * Updated the changelog to reflect the latest bug fix related to the balances export queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->