### PR TITLE
fix: Fix deadlocks in Multichain balances export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix deadlocks in Multichain balances export ([#12898](https://github.com/blockscout/blockscout/pull/12898))
 - Balances export queue: replace replace_all with replace only value and updated_at ([#12892](https://github.com/blockscout/blockscout/pull/12892))
 - Fix naming for apikey param in OpenAPI spec ([#12891](https://github.com/blockscout/blockscout/pull/12891))
 - Balances export queue to multichain replace do_nothing with replace_all on insertion to the queue ([#12888](https://github.com/blockscout/blockscout/pull/12888))

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
@@ -101,51 +101,37 @@ defmodule Explorer.Chain.MultichainSearchDb.BalancesExportQueue do
   # sobelow_skip ["DOS.StringToAtom"]
   @spec delete_elements_from_queue_by_params([map()]) :: list()
   def delete_elements_from_queue_by_params(balances) do
-    q =
-      Enum.reduce(balances, nil, fn balance, acc ->
-        balance_address_hash = balance.address_hash
+    balances
+    |> Enum.with_index()
+    |> Enum.reduce(Multi.new(), fn {balance, ind}, acc ->
+      balance_address_hash = balance.address_hash
 
-        balance_token_contract_address_hash_or_native_binary =
-          if byte_size(balance.token_contract_address_hash_or_native) == 6 do
-            balance.token_contract_address_hash_or_native
-          else
-            "0x" <> hex = balance.token_contract_address_hash_or_native
-            hex |> Base.decode16(case: :lower) |> elem(1)
-          end
-
-        balance_token_id = balance.token_id
-
-        query =
-          from(
-            b in __MODULE__,
-            where: b.address_hash == ^balance_address_hash,
-            where: b.token_contract_address_hash_or_native == ^balance_token_contract_address_hash_or_native_binary,
-            where:
-              fragment(
-                "COALESCE(?, -1::numeric) = COALESCE(?::numeric, -1::numeric)",
-                b.token_id,
-                ^balance_token_id
-              )
-          )
-
-        if is_nil(acc) do
-          query
+      balance_token_contract_address_hash_or_native_binary =
+        if byte_size(balance.token_contract_address_hash_or_native) == 6 do
+          balance.token_contract_address_hash_or_native
         else
-          acc
-          |> union(^query)
+          "0x" <> hex = balance.token_contract_address_hash_or_native
+          hex |> Base.decode16(case: :lower) |> elem(1)
         end
-      end)
 
-    elements = Repo.all(q)
+      balance_token_id = balance.token_id
 
-    delete_elements =
-      elements
-      |> Enum.with_index()
-      |> Enum.reduce(Multi.new(), fn {elem, ind}, acc ->
-        acc
-        |> Multi.delete(String.to_atom("delete_#{ind}"), elem)
-      end)
-
-    Repo.transact(delete_elements)
+      acc
+      |> Multi.delete_all(
+        String.to_atom("delete_#{ind}"),
+        from(
+          b in __MODULE__,
+          where: b.address_hash == ^balance_address_hash,
+          where: b.token_contract_address_hash_or_native == ^balance_token_contract_address_hash_or_native_binary,
+          where:
+            fragment(
+              "COALESCE(?, -1::numeric) = COALESCE(?::numeric, -1::numeric)",
+              b.token_id,
+              ^balance_token_id
+            )
+        ),
+        lock: "FOR NO KEY UPDATE"
+      )
+    end)
   end
 end

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
@@ -129,9 +129,9 @@ defmodule Explorer.Chain.MultichainSearchDb.BalancesExportQueue do
               b.token_id,
               ^balance_token_id
             )
-        ),
-        lock: "FOR NO KEY UPDATE"
+        )
       )
     end)
+    |> Repo.transact()
   end
 end

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -779,12 +779,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
     indexed_addresses_chunks =
       addresses
+      |> Enum.sort_by(& &1.hash)
       |> Enum.uniq()
       |> Enum.chunk_every(addresses_chunk_size())
       |> Enum.with_index()
 
     indexed_address_coin_balances_chunks =
       address_coin_balances
+      |> Enum.sort_by(& &1.address_hash)
       |> Enum.uniq()
       |> Enum.reject(&is_nil(&1.value))
       |> Enum.chunk_every(addresses_chunk_size())

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -368,8 +368,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
       assert {:error,
               %{
                 addresses: [
-                  address_export_data(address_2),
-                  address_export_data(address_1)
+                  address_export_data(address_1),
+                  address_export_data(address_2)
                 ],
                 block_ranges: [
                   %{max_block_number: to_string(block_2.number), min_block_number: to_string(block_1.number)}
@@ -706,8 +706,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
              ]
 
       assert chunk[:address_coin_balances] == [
-               %{value: %Wei{value: Decimal.new("200")}, address_hash: to_string(address_2.hash)},
-               %{value: %Wei{value: Decimal.new("100")}, address_hash: to_string(address_1.hash)}
+               %{value: %Wei{value: Decimal.new("100")}, address_hash: to_string(address_1.hash)},
+               %{value: %Wei{value: Decimal.new("200")}, address_hash: to_string(address_2.hash)}
              ]
 
       assert chunk[:address_token_balances] == [
@@ -791,8 +791,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
       assert second_chunk[:hashes] == []
 
       assert Enum.all?(second_chunk[:addresses], fn item ->
-               item.hash == "0x" <> Base.encode16(Enum.at(addresses, 0).hash.bytes, case: :lower) ||
-                 item.hash == "0x" <> Base.encode16(Enum.at(addresses, 1).hash.bytes, case: :lower)
+               item.hash == "0x" <> Base.encode16(Enum.at(addresses, 7000).hash.bytes, case: :lower) ||
+                 item.hash == "0x" <> Base.encode16(Enum.at(addresses, 7001).hash.bytes, case: :lower)
              end)
     end
 
@@ -852,14 +852,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
       assert chunk[:addresses] == [
                %{
-                 hash: "0x" <> Base.encode16(address_3.hash.bytes, case: :lower),
-                 is_contract: true,
-                 is_verified_contract: true,
-                 contract_name: "SimpleStorage",
-                 token_name: "Main Token",
-                 token_type: "ERC-721",
-                 is_token: true,
-                 ens_name: nil
+                 hash: "0x" <> Base.encode16(address_1.hash.bytes, case: :lower),
+                 is_contract: false,
+                 is_verified_contract: false,
+                 contract_name: nil,
+                 token_name: nil,
+                 token_type: "UNSPECIFIED",
+                 is_token: false,
+                 ens_name: "te.eth"
                },
                %{
                  hash: "0x" <> Base.encode16(address_2.hash.bytes, case: :lower),
@@ -872,14 +872,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                  ens_name: nil
                },
                %{
-                 hash: "0x" <> Base.encode16(address_1.hash.bytes, case: :lower),
-                 is_contract: false,
-                 is_verified_contract: false,
-                 contract_name: nil,
-                 token_name: nil,
-                 token_type: "UNSPECIFIED",
-                 is_token: false,
-                 ens_name: "te.eth"
+                 hash: "0x" <> Base.encode16(address_3.hash.bytes, case: :lower),
+                 is_contract: true,
+                 is_verified_contract: true,
+                 contract_name: "SimpleStorage",
+                 token_name: "Main Token",
+                 token_type: "ERC-721",
+                 is_token: true,
+                 ens_name: nil
                }
              ]
 

--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
@@ -11,12 +11,14 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
   alias Explorer.Chain.Wei
   alias Explorer.Chain.{Hash, MultichainSearchDb.BalancesExportQueue}
   alias Explorer.MicroserviceInterfaces.MultichainSearch
+  alias Explorer.Repo
 
   alias Indexer.BufferedTask
   alias Indexer.Helper, as: IndexerHelper
 
   @behaviour BufferedTask
 
+  @delete_queries_chunk_size 10
   @default_max_batch_size 1000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch balances export retry to the Multichain Search DB failed"
@@ -66,7 +68,14 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
 
         unless Enum.empty?(all_balances) do
           all_balances
-          |> BalancesExportQueue.delete_elements_from_queue_by_params()
+          |> Enum.sort_by(&{&1.address_hash, &1.token_contract_address_hash_or_native, &1.token_id})
+          |> Enum.chunk_every(@delete_queries_chunk_size)
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          |> Enum.each(fn chunk_items ->
+            chunk_items
+            |> BalancesExportQueue.delete_elements_from_queue_by_params()
+            |> Repo.transact()
+          end)
         end
 
         :ok

--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
@@ -11,14 +11,12 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
   alias Explorer.Chain.Wei
   alias Explorer.Chain.{Hash, MultichainSearchDb.BalancesExportQueue}
   alias Explorer.MicroserviceInterfaces.MultichainSearch
-  alias Explorer.Repo
 
   alias Indexer.BufferedTask
   alias Indexer.Helper, as: IndexerHelper
 
   @behaviour BufferedTask
 
-  @delete_queries_chunk_size 10
   @default_max_batch_size 1000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch balances export retry to the Multichain Search DB failed"
@@ -68,14 +66,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
 
         unless Enum.empty?(all_balances) do
           all_balances
-          |> Enum.sort_by(&{&1.address_hash, &1.token_contract_address_hash_or_native, &1.token_id})
-          |> Enum.chunk_every(@delete_queries_chunk_size)
-          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-          |> Enum.each(fn chunk_items ->
-            chunk_items
-            |> BalancesExportQueue.delete_elements_from_queue_by_params()
-            |> Repo.transact()
-          end)
+          |> BalancesExportQueue.delete_elements_from_queue_by_params()
         end
 
         :ok

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -239,7 +239,6 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
       val0 = Decimal.new(100) |> Wei.cast() |> elem(1)
       val1 = Decimal.new(200) |> Wei.cast() |> elem(1)
       val2 = Decimal.new(300) |> Wei.cast() |> elem(1)
-      val3 = Decimal.new(400) |> Wei.cast() |> elem(1)
       val4 = Decimal.new(500) |> Wei.cast() |> elem(1)
 
       log =

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs
@@ -184,6 +184,8 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
       end)
 
       address_1 = insert(:address)
+      address_1_hash = address_1.hash
+      address_1_hash_string = to_string(address_1_hash)
       address_2 = insert(:address)
       address_2_hash = address_2.hash
       address_2_hash_string = to_string(address_2_hash)
@@ -191,8 +193,6 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
       address_3_hash = address_3.hash
       address_3_hash_string = to_string(address_3_hash)
       address_4 = insert(:address)
-      address_4_hash = address_4.hash
-      address_4_hash_string = to_string(address_4_hash)
       address_5 = insert(:address)
       address_5_hash = address_5.hash
       address_5_hash_string = to_string(address_5_hash)
@@ -234,8 +234,9 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      tesla_expectations(address_4_hash_string)
+      tesla_expectations(address_1_hash_string)
 
+      val0 = Decimal.new(100) |> Wei.cast() |> elem(1)
       val1 = Decimal.new(200) |> Wei.cast() |> elem(1)
       val2 = Decimal.new(300) |> Wei.cast() |> elem(1)
       val3 = Decimal.new(400) |> Wei.cast() |> elem(1)
@@ -247,9 +248,9 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
                   %{
                     address_coin_balances: [
                       %{
-                        address_hash: ^address_4_hash_string,
+                        address_hash: ^address_1_hash_string,
                         token_contract_address_hash_or_native: "native",
-                        value: ^val3
+                        value: ^val0
                       }
                     ],
                     address_token_balances: [
@@ -282,7 +283,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      tesla_expectations(address_4_hash_string)
+      tesla_expectations(address_1_hash_string)
 
       MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
 
@@ -294,7 +295,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
 
       TestHelper.get_chain_id_mock()
 
-      tesla_expectations(address_4_hash_string)
+      tesla_expectations(address_1_hash_string)
 
       MultichainSearchDbExportBalancesExportQueue.run(export_data, nil)
 
@@ -316,9 +317,9 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
           token_id: nil
         },
         %{
-          address_hash: address_4.hash,
+          address_hash: address_1.hash,
           token_contract_address_hash_or_native: "native",
-          value: %Wei{value: Decimal.new(400)}
+          value: %Wei{value: Decimal.new(100)}
         },
         %{
           address_hash: address_5.hash,
@@ -346,12 +347,12 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueueTest do
     end
   end
 
-  defp tesla_expectations(address_4_hash_string) do
+  defp tesla_expectations(address_hash_string) do
     Tesla.Test.expect_tesla_call(
       times: 2,
       returns: fn %{url: "http://localhost:1234/api/v1/import:batch", body: body}, _opts ->
         case Jason.decode(body) do
-          {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_4_hash_string}]}} ->
+          {:ok, %{"address_coin_balances" => [%{"address_hash" => ^address_hash_string}]}} ->
             {:ok, %Tesla.Env{status: 500, body: Jason.encode!(%{"code" => 0, "message" => "Error"})}}
 
           _ ->


### PR DESCRIPTION
## Motivation

Deadlocks appear after implementation of balances export to the multichain:

```
{"time":"2025-08-01T15:22:24.576Z","severity":"error","message":"Task #PID<0.6204249.0> started from Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue terminating\n** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 599296 waits for ShareLock on transaction 1844695131; blocked by process 601308.\nProcess 601308 waits for ShareLock on transaction 1844695119; blocked by process 599296.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:996: Ecto.Adapters.SQL.execute/6\n    (ecto 3.13.2) lib/ecto/multi.ex:933: Ecto.Multi.apply_operation/4\n    (ecto 3.13.2) lib/ecto/multi.ex:905: Ecto.Multi.apply_operation/5\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (ecto 3.13.2) lib/ecto/multi.ex:878: anonymous fn/5 in Ecto.Multi.apply_operations/5\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4\n    (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [], callback_module: Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue, batch: [%{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 185, 108, 33, 202, 102, 200, 145, 158, 93, 241, 104, 16, 66, 39, 224, 85, 90, 217>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 181, 76, 30, 235, 30, 88, 110, 7, 37, 118, 237, 46, 103, 66, 136, 167, 39, 254>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 170, 211, 165, 132, 213, 244, 31, 29, 51, 45, 137, 2, 250, 122, 3, 171, 2, 252>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 169, 241, 155, 30, 210, 196, 32, 72, 186, 9, 183, 241, 88, 176, 160, 14, 204, 21>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 166, 7, 220, 212, 89, 148, 222, 46, 175, 72, 193, 54, 159, 236, 89, 183, 218, 145>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 163, 63, 197, 84, 25, 109, 171, 45, 214, 57, 76, 206, 43, 207, 85, 159, 139, 40>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 135, 94, 6, 89, 60, 165, 230, 162, 22, 182, 184, 28, 173, 10, 249, 162, 14, 86>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 126, 146, 203, 182, 104, 165, 198, 99, 184, 120, 58, 40, 71, 40, 177, 180, 120, 29>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 105, 244, 117, 86, 251, 87, 227, 197, 215, 72, 87, 57, 213, 156, 14, 211, 0, 119>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 5, 90, 243, 40, 54, 112, 241, 47, 151, 19, 35, 77, 75, 141, 248, 197, 242, 10, 45>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<236, 103, 239, 178, 39, 33, 140, 204, 60, 112, 50, 166, 80, 115, 57, 231, 180, 214, 35, 173>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1407202392609101112>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<235, 198, 61, 203, 226, 163, 15, 39, 146, 132, 98, 180, 135, 182, 180, 253, 51, 244, 136, 180>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<16559321849005177091>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<235, 37, 186, 6, 217, 214, 113, 185, 86, 26, 146, 82, 138, 254, 51, 1, 108, 93, 16, 97>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1136790446429773465>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<234, 67, 95, 116, 29, 167, 173, 53, 112, 130, 100, 50, 254, 64, 91, 16, 233, 188, 217, 70>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<194066304493439380073893>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<233, 54, 133, 243, 187, 160, 48, 22, 240, 43, 209, 130, 139, 173, 214, 25, 89, 136, 217, 80>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<80186617935323869>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<232, 163, 175, 130, 119, 222, 179, 205, 6, 84, 188, 220, 30, 253, 200, 122, 25, 204, 226, 199>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<232, 90, 6, 194, 56, 67, 159, 152, 28, 144, 178, 201, 19, 147, 178, 243, 196, 110, 39, 252>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<199432563558455000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<231, 104, 173, 99, 187, 212, 245, 174, 219, 155, 102, 84, 135, 143, 82, 188, 163, 73, 143, 247>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<231, 55, 229, 206, 190, 235, 167, 126, 254, 52, 212, 170, 9, 7, 86, 89, 11, 28, 226, 117>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1691333582615483534>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<230, 233, 174, 22, 80, 71, 46, 242, 66, 127, 100, 95, 96, 69, 7, 178, 232, 239, 129, 20>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1871731486774657028>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<225, 208, 14, 95, 148, 71, 131, 37, 94, 182, 149, 95, 59, 159, 50, 89, 166, 181, 194, 12>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<225, 25, 22, 1, 221, 35, 171, 176, 181, 39, 83, 166, 6, 106, 65, 104, 218, 16, 118, 91>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1763794906669342>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<222, 231, 222, 103, 247, 232, 80, 12, 59, 239, 52, 163, 186, 188, 238, 180, 183, 2, 135, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1520153224760627600>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<221, 254, 187, 62, 242, 90, 164, 34, 141, 164, 34, 73, 136, 159, 181, 179, 53, 121, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<503000000000000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<219, 84, 146, 38, 95, 96, 56, 131, 30, 137, 244, 149, 103, 15, 249, 9, 173, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<218, 238, 58, 107, 65, 150, 227, 228, 96, 21, 179, 100, 241, 218, 229, 76, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<36665162367594000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<146, 210, 124, 214, 1, 111, 198, 231, 141, 82, 157, 117, 158, 94, 168, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1650516580319868009>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<146, 176, 77, 196, 164, 229, 25, 166, 19, 135, 211, 160, 169, 143, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<4870780640127637680>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<146, 1, 22, 75, 145, 190, 235, 243, 116, 18, 173, 229, 102, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<210900804194269525>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<145, 139, 154, 30, 238, 237, 250, 167, 196, 192, 39, 72, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<143, 230, 185, 153, 220, 104, 12, 207, 221, 91, 247, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<45979034956438000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<143, 86, 28, 153, 122, 215, 155, 230, 176, 221, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<89728204881765000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<143, 11, 167, 221, 48, 43, 14, 238, 112, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<1137763545347400303>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<142, 68, 178, 143, 171, 175, 160, 160, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<6613236576425910>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<139, 239, 207, 184, 49, 58, 165, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<139, 235, 252, 190, 84, 104, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<3884235261006360>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<139, 150, 16, 0, 49, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<139, 21, 102, 36, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<0>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<139, 7, 190, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<100002808688142104000000000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<137, 187, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<3650607120271854799>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<137, ...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<209238066982385000>, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<...>>}, token_id: nil, token_contract_address_hash_or_native: \"native\"}, %{value: #Explorer.Chain.Wei<27555565492689024>, address_hash: %Explorer.Chain.Hash{byte_count: 20, ...}, token_id: nil, ...}, %{value: #Explorer.Chain.Wei<104358241448533684>, address_hash: %Explorer.Chain.Hash{...}, ...}, %{value: #Explorer.Chain.Wei<118349179270427444>, ...}, %{...}, ...], callback_module_state: []}]","metadata":{"error":{"initial_call":null,"reason":"** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 599296 waits for ShareLock on transaction 1844695131; blocked by process 601308.\nProcess 601308 waits for ShareLock on transaction 1844695119; blocked by process 599296.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:996: Ecto.Adapters.SQL.execute/6\n    (ecto 3.13.2) lib/ecto/multi.ex:933: Ecto.Multi.apply_operation/4\n    (ecto 3.13.2) lib/ecto/multi.ex:905: Ecto.Multi.apply_operation/5\n    (elixir 1.17.3) lib/enum.ex:2531: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (ecto 3.13.2) lib/ecto/multi.ex:878: anonymous fn/5 in Ecto.Multi.apply_operations/5\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1458: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4\n    (db_connection 2.8.0) lib/db_connection.ex:1753: DBConnection.run_transaction/4\n"}}}
```

or 

```
"time":"2025-08-01T15:33:05.345Z","severity":"error","message":"Task #PID<0.8092419.0> started from Indexer.Fetcher.CoinBalance.Realtime terminating\n** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 603989 waits for ShareLock on transaction 1844766124; blocked by process 605188.\nProcess 605188 waits for ShareLock on transaction 1844766127; blocked by process 603989.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:969: Ecto.Adapters.SQL.insert_all/9\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:84: Ecto.Repo.Schema.do_insert_all/7\n    (elixir 1.17.3) lib/enum.ex:987: Enum.\"-each/2-lists^foreach/1-0-\"/2\n    (explorer 9.0.0) lib/explorer/microservice_interfaces/multichain_search.ex:402: Explorer.MicroserviceInterfaces.MultichainSearch.send_data_to_queue/1\n    (explorer 9.0.0) lib/explorer/chain.ex:1165: Explorer.Chain.import/1\n    (indexer 9.0.0) lib/indexer/fetcher/coin_balance/helper.ex:134: Indexer.Fetcher.CoinBalance.Helper.run_fetched_balances/2\n    (indexer 9.0.0) lib/indexer/fetcher/coin_balance/realtime.ex:47: Indexer.Fetcher.CoinBalance.Realtime.run/2\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [fetcher: :coin_balance_realtime], callback_module: Indexer.Fetcher.CoinBalance.Realtime, batch: [{<<66, 88, 48, 103, 101, 128, 113, 36, 126, 200, 206, 10, 81, 106, 88, 246, 130, 0, 45, 7>>, 8890325}, {<<66, 26, 134, 62, 41, 32, 241, 37, 184, 183, 213, 189, 21, 159, 180, 108, 191, 50, 71, 0>>, 8890325}, {<<63, 233, 206, 35, 38, 177, 78, 71, 32, 175, 225, 182, 249, 109, 60, 138, 107, 71, 233, 70>>, 8890325}, {<<63, 177, 202, 161, 100, 119, 112, 75, 214, 121, 197, 168, 131, 217, 219, 177, 146, 79, 78, 224>>, 8890325}, {<<62, 223, 96, 221, 1, 122, 206, 51, 160, 34, 15, 120, 116, 27, 85, 129, 195, 133, 161, 186>>, 8890325}, {<<61, 167, 32, 110, 16, 79, 109, 93, 208, 112, 191, 224, 108, 83, 115, 204, 69, 195, 230, 92>>, 8890325}, {<<61, 109, 201, 15, 72, 64, 197, 149, 213, 135, 57, 195, 142, 136, 252, 194, 63, 206, 55, 74>>, 8890325}, {<<61, 17, 209, 193, 168, 118, 60, 133, 8, 224, 243, 212, 246, 236, 8, 208, 214, 204, 41, 62>>, 8890325}, {<<60, 237, 167, 16, 180, 51, 230, 121, 215, 253, 69, 245, 76, 177, 187, 34, 16, 12, 157, 83>>, 8890325}, {<<60, 15, 104, 120, 94, 171, 25, 14, 139, 130, 65, 89, 179, 225, 154, 70, 67, 216, 13, 3>>, 8890325}, {<<59, 247, 58, 203, 101, 43, 101, 193, 29, 8, 178, 209, 15, 218, 50, 254, 221, 155, 4, 249>>, 8890325}, {<<59, 26, 35, 5, 29, 105, 144, 130, 40, 13, 137, 165, 28, 134, 90, 215, 165, 80, 154, 25>>, 8890325}, {<<58, 55, 165, 131, 84, 95, 79, 24, 5, 184, 115, 183, 166, 159, 11, 28, 113, 34, 226, 1>>, 8890325}, {<<57, 95, 207, 110, 211, 86, 200, 121, 21, 181, 13, 7, 109, 157, 81, 160, 205, 194, 164, 42>>, 8890325}, {<<56, 249, 24, 208, 233, 241, 183, 33, 237, 170, 65, 48, 46, 57, 159, 161, 183, 147, 51, 169>>, 8890325}, {<<56, 38, 83, 156, 189, 141, 104, 220, 241, 25, 232, 11, 153, 69, 87, 180, 39, 140, 236, 159>>, 8890325}, {<<54, 81, 128, 197, 212, 218, 178, 244, 60, 221, 117, 65, 230, 81, 213, 68, 240, 94, 105, 218>>, 8890325}, {<<53, 40, 218, 144, 192, 146, 215, 29, 37, 109, 129, 182, 143, 135, 206, 64, 179, 148, 198, 210>>, 8890325}, {<<53, 11, 48, 244, 38, 188, 250, 97, 57, 48, 226, 40, 5, 31, 60, 39, 74, 150, 203, 33>>, 8890325}, {<<52, 233, 249, 69, 79, 62, 115, 21, 99, 70, 160, 129, 194, 51, 208, 144, 95, 97, 40, 26>>, 8890325}, {<<51, 12, 95, 77, 190, 114, 172, 152, 112, 21, 211, 221, 57, 14, 186, 59, 37, 150, 139, 28>>, 8890325}, {<<50, 68, 84, 24, 107, 183, 40, 163, 234, 85, 117, 14, 6, 24, 255, 27, 24, 206, 108, 248>>, 8890325}, {<<49, 173, 210, 159, 244, 71, 213, 248, 65, 39, 149, 39, 49, 95, 19, 129, 13, 151, 142, 112>>, 8890325}, {<<49, 8, 121, 23, 198, 64, 107, 124, 230, 152, 36, 252, 135, 190, 79, 188, 8, 121, 223, 81>>, 8890325}, {<<48, 164, 167, 119, 240, 157, 187, 85, 87, 152, 70, 129, 64, 145, 202, 202, 138, 166, 137, 112>>, 8890325}, {<<47, 173, 123, 70, 120, 170, 130, 67, 246, 52, 67, 55, 34, 10, 112, 87, 80, 57, 47, ...>>, 8890325}, {<<47, 154, 115, 217, 52, 193, 131, 104, 208, 100, 45, 144, 14, 170, 39, 218, 53, 192, ...>>, 8890325}, {<<46, 176, 15, 106, 173, 73, 127, 102, 87, 77, 206, 19, 35, 232, 223, 227, 167, ...>>, 8890325}, {<<44, 230, 2, 70, 104, 75, 49, 168, 103, 246, 5, 111, 49, 171, 30, 5, ...>>, 8890325}, {<<44, 218, 65, 100, 95, 45, 191, 251, 133, 42, 96, 94, 146, 177, 133, ...>>, 8890325}, {<<44, 209, 240, 163, 9, 70, 200, 219, 47, 127, 208, 211, 151, 63, ...>>, 8890325}, {<<44, 49, 49, 208, 227, 125, 1, 25, 179, 221, 102, 145, 190, ...>>, 8890325}, {<<43, 241, 187, 250, 43, 188, 7, 228, 114, 144, 56, 89, ...>>, 8890325}, {<<43, 39, 59, 215, 22, 187, 23, 152, 119, 121, 231, ...>>, 8890325}, {<<42, 127, 83, 185, 169, 249, 235, 205, 214, 50, ...>>, 8890325}, {<<42, 108, 16, 106, 225, 59, 85, 139, 185, ...>>, 8890325}, {<<42, 68, 150, 187, 195, 68, 65, 78, ...>>, 8890325}, {<<40, 177, 196, 179, 169, 24, 187, ...>>, 8890325}, {<<40, 84, 16, 59, 31, 109, ...>>, 8890325}, {<<40, 82, 236, 53, 71, ...>>, 8890325}, {<<38, 237, 90, 151, ...>>, 8890325}, {<<37, 154, 196, ...>>, 8890325}, {<<35, 241, ...>>, 8890325}, {<<35, ...>>, 8890325}, {<<...>>, ...}, {...}, ...], callback_module_state: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.Tesla, urls: [\"https://rpc-balancer.k8s-dev.blockscout.com/sepolia\"], trace_urls: [\"https://rpc-balancer.k8s-dev.blockscout.com/sepolia\"], eth_call_urls: [\"https://rpc-balancer.k8s-dev.blockscout.com/sepolia\"], fallback_urls: [\"https://eth-sepolia.public.blastapi.io\"], fallback_trace_urls: [\"https://eth-sepolia.public.blastapi.io\"], fallback_eth_call_urls: [\"https://eth-sepolia.public.blastapi.io\"], method_to_url: [eth_call: :eth_call, eth_getBalance: :trace, trace_block: :trace, trace_replayBlockTransactions: :trace, trace_replayTransaction: :trace], http_options: [pool: :ethereum_jsonrpc, recv_timeout: 600000, timeout: 600000]], variant: EthereumJSONRPC.Erigon]}]","metadata":{"error":{"initial_call":null,"reason":"** (Postgrex.Error) ERROR 40P01 (deadlock_detected) deadlock detected\n\n    hint: See server log for query details.\n\nProcess 603989 waits for ShareLock on transaction 1844766124; blocked by process 605188.\nProcess 605188 waits for ShareLock on transaction 1844766127; blocked by process 603989.\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:969: Ecto.Adapters.SQL.insert_all/9\n    (ecto 3.13.2) lib/ecto/repo/schema.ex:84: Ecto.Repo.Schema.do_insert_all/7\n    (elixir 1.17.3) lib/enum.ex:987: Enum.\"-each/2-lists^foreach/1-0-\"/2\n    (explorer 9.0.0) lib/explorer/microservice_interfaces/multichain_search.ex:402: Explorer.MicroserviceInterfaces.MultichainSearch.send_data_to_queue/1\n    (explorer 9.0.0) lib/explorer/chain.ex:1165: Explorer.Chain.import/1\n    (indexer 9.0.0) lib/indexer/fetcher/coin_balance/helper.ex:134: Indexer.Fetcher.CoinBalance.Helper.run_fetched_balances/2\n    (indexer 9.0.0) lib/indexer/fetcher/coin_balance/realtime.ex:47: Indexer.Fetcher.CoinBalance.Realtime.run/2\n"},"count":50,"fetcher":"coin_balance_realtime"}}
```

## Changelog

### AI Agent summary

This pull request introduces several changes to improve the handling of balance export queues, optimize sorting logic, and update test cases for better accuracy and consistency. The most significant updates include refactoring the `delete_elements_from_queue_by_params` function, adding sorting logic to key operations, and updating test data and assertions to reflect these changes.

### Refactoring and Optimization:

* Refactored the `delete_elements_from_queue_by_params` function in `apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex` to use `Ecto.Multi` for batch deletions instead of constructing union queries, improving clarity and efficiency. [[1]](diffhunk://#diff-2bfc4a4a9d74bbec4c7b2021b3ae4b71cc6cf68619354aac86532e1bd6ee2e52L104-R106) [[2]](diffhunk://#diff-2bfc4a4a9d74bbec4c7b2021b3ae4b71cc6cf68619354aac86532e1bd6ee2e52L118-R121) [[3]](diffhunk://#diff-2bfc4a4a9d74bbec4c7b2021b3ae4b71cc6cf68619354aac86532e1bd6ee2e52L130-R135)

* Added sorting logic using `Enum.sort_by` to ensure consistent ordering of `addresses` and `address_coin_balances` in `apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex`.

### Test Case Updates:

* Updated test assertions in `apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs` to reflect the new sorting logic. This includes reordering expected values for addresses, balances, and other test data to match the sorted output. [[1]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L371-R372) [[2]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L709-R710) [[3]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L794-R795) [[4]](diffhunk://#diff-d424a02a71546a98c706a337b4eee9c0ce94f348bf84585d1ae181661aa38368L855-R882)

* Modified test setup and expectations in `apps/indexer/test/indexer/fetcher/multichain_search_db/balances_export_queue_test.exs` to align with new logic, including changes to address hashes, values, and mock expectations. [[1]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7R187-L195) [[2]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L237-L241) [[3]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L250-R252) [[4]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L285-R285) [[5]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L297-R297) [[6]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L319-R321) [[7]](diffhunk://#diff-82d6241cdd8d8694322c0763b5a1fb6e40f17a4f8ef92be5725427513a587ba7L349-R354)

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved deletion logic for balances export queue, making deletions more efficient and transactional.
  * Updated batch import parameter processing to ensure consistent and deterministic ordering before chunking.

* **Tests**
  * Adjusted test assertions to reflect changes in data ordering and attributes.
  * Updated test data and helper functions to focus on different addresses and values, ensuring alignment with new logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->