### PR TITLE
feat: initial support of indexing EigenDA-grounded Arbitrum batches

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/arbitrum_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/arbitrum_controller.ex
@@ -138,23 +138,23 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   end
 
   @doc """
-    Function to handle GET requests to `/api/v2/arbitrum/batches/da/:data_hash` or
-    `/api/v2/arbitrum/batches/da/:transaction_commitment/:height` endpoints.
+    Function to handle GET requests to `/api/v2/arbitrum/batches/da/.../:data_hash` or
+    `/api/v2/arbitrum/batches/da/celestia/:transaction_commitment/:height` endpoints.
 
-    For AnyTrust data hash, the function can be called in two ways:
+    For AnyTrust and EigenDA data hash, the function can be called in two ways:
     1. Without type parameter - returns the most recent batch for the data hash
     2. With type=all parameter - returns all batches for the data hash
 
     ## Parameters
     - `conn`: The connection struct
     - `params`: A map that may contain:
-      * `data_hash` - The AnyTrust data hash
+      * `data_hash` - The AnyTrust or EigenDA data hash
       * `transaction_commitment` and `height` - For Celestia data
       * `type` - Optional parameter to specify return type ("all" for all batches)
   """
   @spec batch_by_data_availability_info(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def batch_by_data_availability_info(conn, %{"data_hash" => data_hash} = params) do
-    # In case of AnyTrust, `data_key` is the hash of the data itself
+    # In case of AnyTrust or EigenDA, `data_key` is the hash of the data itself
     case Map.get(params, "type") do
       "all" -> all_batches_by_data_availability_info(conn, data_hash, params)
       _ -> one_batch_by_data_availability_info(conn, data_hash, params)
@@ -185,7 +185,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   #
   # ## Parameters
   # - `conn`: The connection struct
-  # - `data_hash`: The AnyTrust data hash
+  # - `data_hash`: The AnyTrust or EigenDA data hash
   # - `params`: The original request parameters
   #
   # ## Returns
@@ -205,7 +205,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumController do
   #
   # ## Parameters
   # - `conn`: The connection struct
-  # - `data_hash`: The AnyTrust data hash
+  # - `data_hash`: The AnyTrust or EigenDA data hash
   # - `params`: The original request parameters (for pagination)
   #
   # ## Returns

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -495,6 +495,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/batches/count", V2.ArbitrumController, :batches_count)
         get("/batches/:batch_number", V2.ArbitrumController, :batch)
         get("/batches/da/anytrust/:data_hash", V2.ArbitrumController, :batch_by_data_availability_info)
+        get("/batches/da/eigenda/:data_hash", V2.ArbitrumController, :batch_by_data_availability_info)
 
         get(
           "/batches/da/celestia/:height/:transaction_commitment",

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -41,7 +41,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       batch_data_container: %Schema{
         type: :string,
         nullable: true,
-        enum: ["in_blob4844", "in_calldata", "in_celestia", "in_anytrust"]
+        enum: ["in_blob4844", "in_calldata", "in_celestia", "in_anytrust", "in_eigenda"]
       },
       status: %Schema{
         type: :string,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -400,7 +400,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   # - An updated JSON map containing the data availability information.
   @spec add_da_info(map(), %{
           :__struct__ => L1Batch,
-          :batch_container => :in_anytrust | :in_celestia | atom() | nil,
+          :batch_container => :in_anytrust | :in_celestia | :in_eigenda | atom() | nil,
           :number => non_neg_integer(),
           optional(any()) => any()
         }) :: map()
@@ -410,6 +410,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
         nil -> %{"batch_data_container" => nil}
         :in_anytrust -> generate_anytrust_certificate(batch.number)
         :in_celestia -> generate_celestia_da_info(batch.number)
+        :in_eigenda -> generate_eigen_da_info(batch.number)
         value -> %{"batch_data_container" => to_string(value)}
       end
 
@@ -484,6 +485,20 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     |> Map.merge(%{
       "height" => Map.get(da_info, "height"),
       "transaction_commitment" => Map.get(da_info, "transaction_commitment")
+    })
+  end
+
+  # Generates EigenDA information for the given batch number.
+  @spec generate_eigen_da_info(non_neg_integer()) :: map()
+  defp generate_eigen_da_info(batch_number) do
+    out = %{"batch_data_container" => "in_eigenda"}
+
+    da_info = SettlementReader.get_da_info_by_batch_number(batch_number)
+
+    out
+    |> Map.merge(%{
+      "blob_header" => Map.get(da_info, "blob_header"),
+      "blob_verification_proof" => Map.get(da_info, "blob_verification_proof")
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -389,8 +389,9 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   # Adds data availability (DA) information to the given output JSON based on the batch container type.
   #
   # This function enriches the output JSON with data availability information based on
-  # the type of batch container. It handles different DA types, including AnyTrust and
-  # Celestia, and generates the appropriate DA data for inclusion in the output.
+  # the type of batch container. It handles different DA types, including AnyTrust,
+  # Celestia, and EigenDA, and generates the appropriate DA data for inclusion in the
+  # output.
   #
   # ## Parameters
   # - `out_json`: The initial JSON map to be enriched with DA information.

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -715,6 +715,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     The BlobVerificationProof contains batchId, blobIndex, BatchMetadata, inclusionProof, and quorumIndices.
   """
   def eigen_da_blob_verification_proof_abi,
+    # https://github.com/Layr-Labs/eigenda/blob/6c1deb51fced68efb1aaa585dd5ddb6a27f88637/contracts/src/core/libraries/v1/EigenDATypesV1.sol#L36-L55
     do: %ABI.FunctionSelector{
       function: nil,
       types: [
@@ -759,6 +760,7 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
     The BlobHeader contains BN254.G1Point commitment, dataLength, and quorumBlobParams array.
   """
   def eigen_da_blob_header_abi,
+    # https://github.com/Layr-Labs/eigenda/blob/6c1deb51fced68efb1aaa585dd5ddb6a27f88637/contracts/src/core/libraries/v1/EigenDATypesV1.sol#L18-L29
     do: %ABI.FunctionSelector{
       function: nil,
       types: [

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -564,11 +564,231 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
       function: "addSequencerL2BatchFromEigenDA",
       types: [
         {:uint, 256},
-        :bytes,
+        # EigenDACert structure
+        {:tuple,
+         [
+           # BlobVerificationProof
+           {:tuple,
+            [
+              # batchId
+              {:uint, 32},
+              # blobIndex
+              {:uint, 32},
+              # BatchMetadata
+              {:tuple,
+               [
+                 # BatchHeader
+                 {:tuple,
+                  [
+                    # blobHeadersRoot
+                    {:bytes, 32},
+                    # quorumNumbers
+                    :bytes,
+                    # signedStakeForQuorums
+                    :bytes,
+                    # referenceBlockNumber
+                    {:uint, 32}
+                  ]},
+                 # signatoryRecordHash
+                 {:bytes, 32},
+                 # confirmationBlockNumber
+                 {:uint, 32}
+               ]},
+              # inclusionProof
+              :bytes,
+              # quorumIndices
+              :bytes
+            ]},
+           # BlobHeader
+           {:tuple,
+            [
+              # BN254.G1Point commitment
+              {:tuple,
+               [
+                 # X
+                 {:uint, 256},
+                 # Y
+                 {:uint, 256}
+               ]},
+              # dataLength
+              {:uint, 32},
+              # QuorumBlobParam[] quorumBlobParams
+              {:array,
+               {:tuple,
+                [
+                  # quorumNumber
+                  {:uint, 8},
+                  # adversaryThresholdPercentage
+                  {:uint, 8},
+                  # confirmationThresholdPercentage
+                  {:uint, 8},
+                  # chunkLength
+                  {:uint, 32}
+                ]}}
+            ]}
+         ]},
         :address,
         {:uint, 256},
         {:uint, 256},
         {:uint, 256}
+      ]
+    }
+
+  @doc """
+    Returns ABI definition for EigenDACert structure for encoding purposes.
+
+    The EigenDACert contains BlobVerificationProof and BlobHeader with full nested structures.
+  """
+  def eigen_da_cert_abi,
+    do: %ABI.FunctionSelector{
+      function: nil,
+      types: [
+        # EigenDACert structure
+        {:tuple,
+         [
+           # BlobVerificationProof
+           {:tuple,
+            [
+              # batchId
+              {:uint, 32},
+              # blobIndex
+              {:uint, 32},
+              # BatchMetadata
+              {:tuple,
+               [
+                 # BatchHeader
+                 {:tuple,
+                  [
+                    # blobHeadersRoot
+                    {:bytes, 32},
+                    # quorumNumbers
+                    :bytes,
+                    # signedStakeForQuorums
+                    :bytes,
+                    # referenceBlockNumber
+                    {:uint, 32}
+                  ]},
+                 # signatoryRecordHash
+                 {:bytes, 32},
+                 # confirmationBlockNumber
+                 {:uint, 32}
+               ]},
+              # inclusionProof
+              :bytes,
+              # quorumIndices
+              :bytes
+            ]},
+           # BlobHeader
+           {:tuple,
+            [
+              # BN254.G1Point commitment
+              {:tuple,
+               [
+                 # X
+                 {:uint, 256},
+                 # Y
+                 {:uint, 256}
+               ]},
+              # dataLength
+              {:uint, 32},
+              # QuorumBlobParam[] quorumBlobParams
+              {:array,
+               {:tuple,
+                [
+                  # quorumNumber
+                  {:uint, 8},
+                  # adversaryThresholdPercentage
+                  {:uint, 8},
+                  # confirmationThresholdPercentage
+                  {:uint, 8},
+                  # chunkLength
+                  {:uint, 32}
+                ]}}
+            ]}
+         ]}
+      ]
+    }
+
+  @doc """
+    Returns ABI definition for BlobVerificationProof structure for encoding purposes.
+
+    The BlobVerificationProof contains batchId, blobIndex, BatchMetadata, inclusionProof, and quorumIndices.
+  """
+  def eigen_da_blob_verification_proof_abi,
+    do: %ABI.FunctionSelector{
+      function: nil,
+      types: [
+        # BlobVerificationProof
+        {:tuple,
+         [
+           # batchId
+           {:uint, 32},
+           # blobIndex
+           {:uint, 32},
+           # BatchMetadata
+           {:tuple,
+            [
+              # BatchHeader
+              {:tuple,
+               [
+                 # blobHeadersRoot
+                 {:bytes, 32},
+                 # quorumNumbers
+                 :bytes,
+                 # signedStakeForQuorums
+                 :bytes,
+                 # referenceBlockNumber
+                 {:uint, 32}
+               ]},
+              # signatoryRecordHash
+              {:bytes, 32},
+              # confirmationBlockNumber
+              {:uint, 32}
+            ]},
+           # inclusionProof
+           :bytes,
+           # quorumIndices
+           :bytes
+         ]}
+      ]
+    }
+
+  @doc """
+    Returns ABI definition for BlobHeader structure for encoding purposes.
+
+    The BlobHeader contains BN254.G1Point commitment, dataLength, and quorumBlobParams array.
+  """
+  def eigen_da_blob_header_abi,
+    do: %ABI.FunctionSelector{
+      function: nil,
+      types: [
+        # BlobHeader
+        {:tuple,
+         [
+           # BN254.G1Point commitment
+           {:tuple,
+            [
+              # X
+              {:uint, 256},
+              # Y
+              {:uint, 256}
+            ]},
+           # dataLength
+           {:uint, 32},
+           # QuorumBlobParam[] quorumBlobParams
+           {:array,
+            {:tuple,
+             [
+               # quorumNumber
+               {:uint, 8},
+               # adversaryThresholdPercentage
+               {:uint, 8},
+               # confirmationThresholdPercentage
+               {:uint, 8},
+               # chunkLength
+               {:uint, 32}
+             ]}}
+         ]}
       ]
     }
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex
@@ -546,4 +546,29 @@ defmodule EthereumJSONRPC.Arbitrum.Constants.Contracts do
          ]}
       ]
     }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      addSequencerL2BatchFromEigenDA(
+        uint256 sequenceNumber,
+        EigenDACert calldata cert,
+        IGasRefunder gasRefunder,
+        uint256 afterDelayedMessagesRead,
+        uint256 prevMessageCount,
+        uint256 newMessageCount
+      )
+  """
+  def add_sequencer_l2_batch_from_eigen_da_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "addSequencerL2BatchFromEigenDA",
+      types: [
+        {:uint, 256},
+        :bytes,
+        :address,
+        {:uint, 256},
+        {:uint, 256},
+        {:uint, 256}
+      ]
+    }
 end

--- a/apps/explorer/lib/explorer/chain/arbitrum/da_multi_purpose_record.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/da_multi_purpose_record.ex
@@ -103,4 +103,19 @@ defmodule Explorer.Chain.Arbitrum.DaMultiPurposeRecord.Helper do
       when is_integer(height) and is_binary(transaction_commitment) do
     :crypto.hash(:sha256, :binary.encode_unsigned(height) <> transaction_commitment)
   end
+
+  @doc """
+    Calculates the data key for `Explorer.Chain.Arbitrum.DaMultiPurposeRecord` that contains EigenDA blob data.
+
+    ## Parameters
+    - `blob_header`: The binary blob header from EigenDA.
+
+    ## Returns
+    - A binary representing the calculated data key for the record containing
+      EigenDA blob data.
+  """
+  @spec calculate_eigenda_data_key(binary()) :: binary()
+  def calculate_eigenda_data_key(blob_header) when is_binary(blob_header) do
+    ExKeccak.hash_256(blob_header)
+  end
 end

--- a/apps/explorer/lib/explorer/chain/arbitrum/l1_batch.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/l1_batch.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Chain.Arbitrum.L1Batch do
     Migrations:
     - Explorer.Repo.Arbitrum.Migrations.CreateArbitrumTables
     - Explorer.Repo.Arbitrum.Migrations.AddDaInfo
+    - Explorer.Repo.Arbitrum.Migrations.AddEigendaBatches
   """
 
   use Explorer.Schema
@@ -31,7 +32,7 @@ defmodule Explorer.Chain.Arbitrum.L1Batch do
     * `before_acc` - The hash of the state before the batch.
     * `after_acc` - The hash of the state after the batch.
     * `commitment_id` - The ID of the commitment L1 transaction from Explorer.Chain.Arbitrum.LifecycleTransaction.
-    * `batch_container` - The tag meaning the container of the batch data: `:in_blob4844`, `:in_calldata`, `:in_celestia`, `:in_anytrust`
+    * `batch_container` - The tag meaning the container of the batch data: `:in_blob4844`, `:in_calldata`, `:in_celestia`, `:in_anytrust`, `:in_eigenda`
   """
   @type to_import :: %{
           number: non_neg_integer(),
@@ -41,7 +42,7 @@ defmodule Explorer.Chain.Arbitrum.L1Batch do
           before_acc: binary(),
           after_acc: binary(),
           commitment_id: non_neg_integer(),
-          batch_container: :in_blob4844 | :in_calldata | :in_celestia | :in_anytrust
+          batch_container: :in_blob4844 | :in_calldata | :in_celestia | :in_anytrust | :in_eigenda
         }
 
   @typedoc """
@@ -53,7 +54,7 @@ defmodule Explorer.Chain.Arbitrum.L1Batch do
     * `after_acc` - The hash of the state after the batch.
     * `commitment_id` - The ID of the commitment L1 transaction from `Explorer.Chain.Arbitrum.LifecycleTransaction`.
     * `commitment_transaction` - An instance of `Explorer.Chain.Arbitrum.LifecycleTransaction` referenced by `commitment_id`.
-    * `batch_container` - The tag meaning the container of the batch data: `:in_blob4844`, `:in_calldata`, `:in_celestia`, `:in_anytrust`
+    * `batch_container` - The tag meaning the container of the batch data: `:in_blob4844`, `:in_calldata`, `:in_celestia`, `:in_anytrust`, `:in_eigenda`
   """
   @primary_key {:number, :integer, autogenerate: false}
   typed_schema "arbitrum_l1_batches" do
@@ -69,7 +70,7 @@ defmodule Explorer.Chain.Arbitrum.L1Batch do
       type: :integer
     )
 
-    field(:batch_container, Ecto.Enum, values: [:in_blob4844, :in_calldata, :in_celestia, :in_anytrust])
+    field(:batch_container, Ecto.Enum, values: [:in_blob4844, :in_calldata, :in_celestia, :in_anytrust, :in_eigenda])
 
     timestamps()
   end

--- a/apps/explorer/priv/arbitrum/migrations/20250731001757_add_eigenda_batches.exs
+++ b/apps/explorer/priv/arbitrum/migrations/20250731001757_add_eigenda_batches.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Arbitrum.Migrations.AddEigendaBatches do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TYPE arbitrum_da_containers_types ADD VALUE 'in_eigenda'")
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
@@ -6,7 +6,7 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
 
   import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_error: 1]
 
-  alias Indexer.Fetcher.Arbitrum.DA.{Anytrust, Celestia}
+  alias Indexer.Fetcher.Arbitrum.DA.{Anytrust, Celestia, Eigenda}
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Settlement, as: Db
 
   alias Explorer.Chain.Arbitrum
@@ -25,14 +25,14 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
     - `{status, da_type, da_info}` where `da_type` is one of `:in_blob4844`,
       `:in_calldata`, `:in_celestia`, `:in_anytrust`, `:in_eigenda`, or `nil` if
       the accompanying data cannot be parsed or is of an unsupported type.
-      `da_info` contains the DA info descriptor for Celestia or Anytrust.
+      `da_info` contains the DA info descriptor for Celestia, Anytrust, or EigenDA.
   """
   @spec examine_batch_accompanying_data(non_neg_integer(), binary()) ::
           {:ok, :in_blob4844, nil}
           | {:ok, :in_calldata, nil}
           | {:ok, :in_celestia, Celestia.t()}
           | {:ok, :in_anytrust, Anytrust.t()}
-          | {:ok, :in_eigenda, nil}
+          | {:ok, :in_eigenda, Eigenda.t()}
           | {:error, nil, nil}
   def examine_batch_accompanying_data(batch_number, batch_accompanying_data) do
     case batch_accompanying_data do
@@ -206,7 +206,7 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
           {:ok, :in_calldata, nil}
           | {:ok, :in_celestia, Celestia.t()}
           | {:ok, :in_anytrust, Anytrust.t()}
-          | {:ok, :in_eigenda, nil}
+          | {:ok, :in_eigenda, Eigenda.t()}
           | {:error, nil, nil}
   defp parse_data_availability_info(batch_number, <<
          header_flag::size(8),
@@ -231,7 +231,7 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
         Anytrust.parse_batch_accompanying_data(batch_number, rest)
 
       237 ->
-        {:ok, :in_eigenda, nil}
+        Eigenda.parse_batch_accompanying_data(batch_number, rest)
 
       _ ->
         log_error("Unknown header flag found during an attempt to parse DA data: #{header_flag}")

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/common.ex
@@ -44,9 +44,9 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
   @doc """
     Prepares data availability (DA) information for import.
 
-    This function processes a list of DA information, either from Celestia or Anytrust,
-    preparing it for database import. It handles deduplication of records within the same
-    processing chunk and against existing database records.
+    This function processes a list of DA information, either from Celestia, Anytrust, or
+    EigenDA, preparing it for database import. It handles deduplication of records
+    within the same processing chunk and against existing database records.
 
     ## Parameters
     - `da_info`: A list of DA information structs.
@@ -59,7 +59,7 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
         the current batch and against existing database records.
       - A list of batch-to-blob associations (`BatchToDaBlob`) ready for import.
   """
-  @spec prepare_for_import([Celestia.t() | Anytrust.t() | map()], %{
+  @spec prepare_for_import([Celestia.t() | Anytrust.t() | Eigenda.t() | map()], %{
           :sequencer_inbox_address => String.t(),
           :json_rpc_named_arguments => EthereumJSONRPC.json_rpc_named_arguments()
         }) :: {[Arbitrum.DaMultiPurposeRecord.to_import()], [Arbitrum.BatchToDaBlob.to_import()]}
@@ -205,8 +205,8 @@ defmodule Indexer.Fetcher.Arbitrum.DA.Common do
       `:in_celestia`, `:in_anytrust`, `:in_eigenda`, or `nil`.
 
     ## Returns
-    - `true` if the DA type is `:in_celestia`, `:in_anytrust`, or `:in_eigenda`, indicating that the data
-      requires import.
+    - `true` if the DA type is `:in_celestia`, `:in_anytrust`, or `:in_eigenda`, indicating
+      that the data requires import.
     - `false` for all other DA types, indicating that the data does not require import.
   """
   @spec required_import?(:in_blob4844 | :in_calldata | :in_celestia | :in_anytrust | :in_eigenda | nil) :: boolean()

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/da/eigenda.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/da/eigenda.ex
@@ -1,0 +1,89 @@
+defmodule Indexer.Fetcher.Arbitrum.DA.Eigenda do
+  @moduledoc """
+    Provides functionality for parsing EigenDA data availability information
+    associated with Arbitrum rollup batches.
+  """
+
+  import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_error: 1]
+
+  alias ABI.{TypeDecoder, TypeEncoder}
+  alias EthereumJSONRPC.Arbitrum.Constants.Contracts, as: ArbitrumContracts
+
+  @enforce_keys [:batch_number, :blob_verification_proof, :blob_header]
+  defstruct @enforce_keys
+
+  @typedoc """
+  EigenDA certificate struct:
+    * `batch_number` - The batch number in the Arbitrum rollup associated with the
+                       EigenDA certificate.
+    * `blob_verification_proof` - The encoded binary data of the blob verification proof
+                                  containing batchId, blobIndex, BatchMetadata, inclusionProof, and quorumIndices.
+    * `blob_header` - The encoded binary data of the blob header containing commitment (BN254.G1Point),
+                      dataLength, and quorumBlobParams array.
+  """
+  @type t :: %__MODULE__{
+          batch_number: non_neg_integer(),
+          blob_verification_proof: binary(),
+          blob_header: binary()
+        }
+
+  @doc """
+    Parses the batch accompanying data for EigenDA.
+
+    This function extracts EigenDA certificate information from the binary input
+    associated with a given batch number by decoding the full EigenDACert structure,
+    then encoding the BlobVerificationProof and BlobHeader components back to binary
+    format for storage. The complex nested structures (BatchMetadata, BN254.G1Point,
+    QuorumBlobParams, etc.) are preserved in their encoded binary form.
+
+    ## Parameters
+    - `batch_number`: The batch number in the Arbitrum rollup associated with the EigenDA data.
+    - `binary_data`: The binary data containing the encoded EigenDA certificate.
+
+    ## Returns
+    - `{:ok, :in_eigenda, da_info}` if the data is successfully parsed.
+    - `{:error, nil, nil}` if the data cannot be parsed.
+  """
+  @spec parse_batch_accompanying_data(non_neg_integer(), binary()) ::
+          {:ok, :in_eigenda, __MODULE__.t()} | {:error, nil, nil}
+  def parse_batch_accompanying_data(batch_number, binary_data) do
+    # This function implements a decode->encode pattern that may seem redundant but is
+    # architecturally necessary for the following reasons:
+    #
+    # 1. Data Validation: Decoding first ensures the EigenDA certificate is well-formed
+    #    and contains valid data before storing it in the database.
+    # 2. Interface Compatibility: The DA pipeline requires individual BlobVerificationProof
+    #    and BlobHeader components as separate binary fields, not as a single combined structure.
+    # 3. Library Reliability: Using TypeDecoder/TypeEncoder leverages battle-tested ABI
+    #    handling instead of manual binary parsing, reducing the risk of encoding bugs.
+    #
+    # Alternative approaches (direct binary extraction) would require reimplementing
+    # complex ABI parsing logic and handling dynamic arrays/nested structures manually,
+    # introducing significant complexity and maintenance burden for minimal performance gain.
+
+    # Decode the complex EigenDACert structure to get the tuple components
+    [{blob_verification_proof_tuple, blob_header_tuple}] =
+      TypeDecoder.decode(
+        binary_data,
+        ArbitrumContracts.eigen_da_cert_abi()
+      )
+
+    # Encode each component back to bytes for storage
+    blob_verification_proof_bytes =
+      TypeEncoder.encode([blob_verification_proof_tuple], ArbitrumContracts.eigen_da_blob_verification_proof_abi())
+
+    blob_header_bytes =
+      TypeEncoder.encode([blob_header_tuple], ArbitrumContracts.eigen_da_blob_header_abi())
+
+    {:ok, :in_eigenda,
+     %__MODULE__{
+       batch_number: batch_number,
+       blob_verification_proof: blob_verification_proof_bytes,
+       blob_header: blob_header_bytes
+     }}
+  rescue
+    exception ->
+      log_error("Can not parse EigenDA certificate: #{inspect(exception)}")
+      {:error, nil, nil}
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -770,7 +770,7 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
         # addSequencerL2BatchFromEigenDA(uint256 sequenceNumber, EigenDACert calldata cert, IGasRefunder gasRefunder, uint256 afterDelayedMessagesRead, uint256 prevMessageCount, uint256 newMessageCount)
         [
           sequence_number,
-          _cert,
+          cert,
           _gas_refunder,
           _after_delayed_messages_read,
           prev_message_count,
@@ -781,7 +781,7 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
             ArbitrumContracts.add_sequencer_l2_batch_from_eigen_da_selector_with_abi()
           )
 
-        {sequence_number, prev_message_count, new_message_count, nil}
+        {sequence_number, prev_message_count, new_message_count, <<237>> <> cert}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -768,6 +768,7 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
 
       "0x283d8225" <> encoded_params ->
         # addSequencerL2BatchFromEigenDA(uint256 sequenceNumber, EigenDACert calldata cert, IGasRefunder gasRefunder, uint256 afterDelayedMessagesRead, uint256 prevMessageCount, uint256 newMessageCount)
+        # https://github.com/Layr-Labs/nitro-contracts/blob/278fdbc39089fa86330f0c23f0a05aee61972c84/src/bridge/SequencerInbox.sol#L505-L512
         [
           sequence_number,
           cert,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex
@@ -647,6 +647,7 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
     - addSequencerL2BatchFromBlobsDelayProof
     - addSequencerL2BatchFromOriginDelayProof
     - addSequencerL2BatchDelayProof
+    - addSequencerL2BatchFromEigenDA
 
     ## Parameters
     - `calldata`: The raw calldata from the transaction as a binary string starting with "0x"
@@ -764,6 +765,23 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Rpc do
           )
 
         {sequence_number, prev_message_count, new_message_count, data}
+
+      "0x283d8225" <> encoded_params ->
+        # addSequencerL2BatchFromEigenDA(uint256 sequenceNumber, EigenDACert calldata cert, IGasRefunder gasRefunder, uint256 afterDelayedMessagesRead, uint256 prevMessageCount, uint256 newMessageCount)
+        [
+          sequence_number,
+          _cert,
+          _gas_refunder,
+          _after_delayed_messages_read,
+          prev_message_count,
+          new_message_count
+        ] =
+          TypeDecoder.decode(
+            Base.decode16!(encoded_params, case: :lower),
+            ArbitrumContracts.add_sequencer_l2_batch_from_eigen_da_selector_with_abi()
+          )
+
+        {sequence_number, prev_message_count, new_message_count, nil}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/README.md
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/README.md
@@ -17,6 +17,7 @@ The indexer supports multiple data storage mechanisms for batch data:
 - Data Availability (DA) blobs (EIP-4844)
 - AnyTrust solution
 - Celestia DA layer
+- Eigen DA layer
 
 For each batch, the indexer:
 1. Processes the `SequencerBatchDelivered` event

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/discovery.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/discovery.ex
@@ -5,7 +5,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery do
   The module's primary responsibilities include:
     * Processing `SequencerBatchDelivered` event logs to extract batch information
     * Building comprehensive data structures for batches and associated entities
-    * Handling Data Availability information for AnyTrust and Celestia solutions
+    * Handling Data Availability information for AnyTrust, Celestia, and EigenDA
+      solutions
     * Managing L2-to-L1 message status updates for committed messages
     * Importing discovered data into the database
     * Broadcasting new batch notifications for websocket clients
@@ -22,7 +23,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery do
   alias Explorer.Chain.Events.Publisher
 
   alias Indexer.Fetcher.Arbitrum.DA.Common, as: DataAvailabilityInfo
-  alias Indexer.Fetcher.Arbitrum.DA.{Anytrust, Celestia}
+  alias Indexer.Fetcher.Arbitrum.DA.{Anytrust, Celestia, Eigenda}
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Messages, as: DbMessages
   alias Indexer.Fetcher.Arbitrum.Utils.Db.ParentChainTransactions, as: DbParentChainTransactions
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Settlement, as: DbSettlement
@@ -466,8 +467,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery do
   # and decodes the calldata from the transactions to obtain batch details. It updates
   # the provided batch map with block ranges for new batches and constructs a map of
   # lifecycle transactions with their timestamps and finalization status. Additionally,
-  # it examines the data availability (DA) information for Anytrust or Celestia and
-  # constructs a list of DA info structs.
+  # it examines the data availability (DA) information for Anytrust, Celestia, or EigenDA
+  # and constructs a list of DA info structs.
   #
   # ## Parameters
   # - `transactions_requests`: The list of RPC requests to fetch transaction data.
@@ -487,7 +488,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery do
   #     database import and require further processing.
   #   - An updated map of batch descriptions with block ranges and data availability
   #     information.
-  #   - A list of data availability information structs for Anytrust or Celestia.
+  #   - A list of data availability information structs for Anytrust, Celestia, or EigenDA.
   @spec execute_transaction_requests_parse_transactions_calldata(
           [EthereumJSONRPC.Transport.request()],
           non_neg_integer(),
@@ -520,7 +521,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery do
                :data_available => atom() | nil,
                optional(any()) => any()
              }
-           }, [Anytrust.t() | Celestia.t()]}
+           }, [Anytrust.t() | Celestia.t() | Eigenda.t()]}
   defp execute_transaction_requests_parse_transactions_calldata(
          transactions_requests,
          msg_to_block_shift,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/tasks.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/tasks.ex
@@ -10,10 +10,10 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.Tasks do
     The module processes logs from the `SequencerBatchDelivered` events emitted by
     the Arbitrum `SequencerInbox` contract to extract batch details. It maintains
     linkages between batches and their corresponding rollup blocks and transactions.
-    For batches stored in Data Availability solutions like AnyTrust or Celestia,
-    it retrieves DA information to locate the batch data. The module also tracks
-    cross-chain messages initiated in rollup blocks associated with new batches,
-    updating their status to committed (`:sent`).
+    For batches stored in Data Availability solutions like AnyTrust, Celestia, or
+    EigenDA, it retrieves DA information to locate the batch data. The module also
+    tracks cross-chain messages initiated in rollup blocks associated with new
+    batches, updating their status to committed (`:sent`).
 
     For any blocks or transactions missing in the database, data is requested in
     chunks from the rollup RPC endpoint by `eth_getBlockByNumber`. Additionally,

--- a/cspell.json
+++ b/cspell.json
@@ -214,6 +214,8 @@
         "EDCSA",
         "edhygl",
         "efkuga",
+        "Eigen",
+        "EigenDA",
         "einval",
         "Encryptor",
         "endregion",


### PR DESCRIPTION
## Motivation

The issue on new Orbit chains that use EigenDA as the data availability layer. 

New batches are not being indexed. The following issue appear in the logs:

```plaintext
2025-07-30T21:28:23.857 application=indexer fetcher=arbitrum_batches_tracker [info] Block range for historical batches discovery: 4254350..4254409
2025-07-30T21:28:24.218 application=indexer fetcher=arbitrum_batches_tracker [info] New batch 3735 found in 0xe0a4188b0baa2ed6dee32e418eca9342af112167527f9ea5ff309acf855564a9
2025-07-30T21:28:24.695 fetcher=arbitrum_batches_tracker [error] Task #PID<0.430143.0> started from Indexer.Fetcher.Arbitrum.TrackingBatchesStatuses terminating
** (CaseClauseError) no case clause matching: "0x283d82250000000000000000000000000000000000000000000000000000000000000e9700000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000010d1f7000000000000000000000000000000000000000000000000000000000010d204000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000003a0000000000000000000000000000000000000000000000000000000000003fd4e000000000000000000000000000000000000000000000000000000000000007700000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003200000000000000000000000000000000000000000000000000000000000000060ba517ef16177259600f274a2a04661f59f7d88ff09814ced5f8761aa4b3a66e9000000000000000000000000000000000000000000000000000000000040eab88b2cde422d914346f4ac7cf1873cf1b4e8fb8fdf153c976b9e8a5ed0696f076e000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000040ea6100000000000000000000000000000000000000000000000000000000000000020001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000262640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100588dba2825a87bbd3a0c8cfb99df031e38669df760e0c541367cf1752cd20a4656c054d1a54266858f6f178af3ef98f175636cffe90de89b01fa7b915ac526f34e3490a611d522e9169f42cccef8b6447163fdc5612b103b9cafe777cb487ebc139995b7e2a3394941be0ff0a5400cb6684cfa85f5c7b2b24e6b71c84af9f521a1a41e87bd72e66e62fdb31b1058f695095d669e7a4c20b0b5d8d061070940a906de4de7c739b17f58a40ecb76ed181f34ee6f03bdb7af2e26ac694d095073e133f675bc21e79217c325fee9a56eac5ae04014723a5251f9b6be7b61573f5f72e56970a1a3207b087a6254b868e6e622ef0298b3e9358c116fbb43ae796566c3000000000000000000000000000000000000000000000000000000000000000200010000000000000000000000000000000000000000000000000000000000001790eecb08dcc2f94d30323e003458486a96fedf3c7fc638648700517863e2a10cf684efa344decc800c4708821e4ede506900a3f33cf632c592d9ab70f1252600000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000021000000000000000000000000000000000000000000000000000000000000003700000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002100000000000000000000000000000000000000000000000000000000000000370000000000000000000000000000000000000000000000000000000000000008"
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/utils/rpc.ex:665: Indexer.Fetcher.Arbitrum.Utils.Rpc.parse_calldata_of_add_sequencer_l2_batch/1
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/workers/batches/discovery.ex:551: anonymous fn/6 in Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.execute_transaction_requests_parse_transactions_calldata/6
    (elixir 1.17.3) lib/enum.ex:2531: Enum."-reduce/3-lists^foldl/2-0-"/3
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/workers/batches/discovery.ex:240: Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.handle_batches_from_logs/6
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/workers/batches/discovery.ex:115: anonymous fn/7 in Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.perform/8
    (elixir 1.17.3) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/workers/batches/tasks.ex:243: Indexer.Fetcher.Arbitrum.Workers.Batches.Tasks.check_historical/1
    (indexer 9.0.0) lib/indexer/fetcher/arbitrum/tracking_batches_statuses.ex:624: Indexer.Fetcher.Arbitrum.TrackingBatchesStatuses.run_worker_with_conditional_rescheduling/6
    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4
Function: &Indexer.BufferedTask.log_run/1
    Args: [%{metadata: [fetcher: :arbitrum_batches_tracker], batch: [{1753910885226, :historical_batches}], callback_module: Indexer.Fetcher.Arbitrum.TrackingBatchesStatuses, callback_module_state: %{config: %{recheck_interval: 15000, l1_rpc: %{chunk_size: 50, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.Tesla, urls: [". . ."], http_options: [recv_timeout: 600000, timeout: 600000, pool: :ethereum_jsonrpc]]], finalized_confirmations: false, logs_block_range: 60, track_finalization: true}, l1_rollup_address: "0x798CA465048fa8ec711FFc8cE0F03409f6985a04", l1_rollup_init_block: 3325914, l1_start_block: 4254590, messages_to_blocks_shift: 0, new_batches_limit: 2, missing_batches_range: 1000, failure_interval_threshold: 600000, rollup_rpc: %{chunk_size: 50, json_rpc_named_arguments: [transport: EthereumJSONRPC.HTTP, transport_options: [http: EthereumJSONRPC.HTTP.Tesla, urls: [". . ."], trace_urls: [". . ."], eth_call_urls: [". . ."], fallback_urls: [". . ."], fallback_trace_urls: [". . ."], fallback_eth_call_urls: [". . ."], method_to_url: [eth_call: :eth_call, debug_traceTransaction: :trace, debug_traceBlockByNumber: :trace], http_options: [pool: :ethereum_jsonrpc, recv_timeout: 60000, timeout: 60000]], variant: EthereumJSONRPC.Geth]}, confirmation_batches_depth: nil, node_interface_address: "0x00000000000000000000000000000000000000C8", rollup_first_block: 0, l1_outbox_address: "0x5e3fbac4e9635d8d87dc839e353a63c20c786b3b", l1_sequencer_inbox_address: "0x47c3dec256db25c527d92aacee1269c17805ce9d", lowest_batch: nil}, completed_tasks: %{historical_batches: false, historical_confirmations: false, historical_executions: false, missing_batches: true}, intervals: %{historical_batches: 2000, historical_confirmations: 2000, historical_executions: 2000, missing_batches: 2000, new_batches: 15000, new_confirmations: 15000, new_executions: 15000, settlement_transactions_finalization: 15000}, task_data: %{historical_batches: %{end_block: 4254409}, historical_confirmations: %{start_block: nil, end_block: 4254589}, historical_executions: %{end_block: 4253989}, missing_batches: %{end_batch: nil}, new_batches: %{start_block: 4254639}, new_confirmations: %{start_block: 4254640}, new_executions: %{start_block: 4254640}}}}]
```

## Problem Analysis

The main issue is that `parse_calldata_of_add_sequencer_l2_batch` of `apps/indexer/lib/indexer/fetcher/arbitrum/utils/rpc.ex` does not support the new method selector `0x283d8225` which corresponds to `addSequencerL2BatchFromEigenDA`.

## Background Information

### New Method to Deliver Batches

The implementation of the new method of the SequencerInbox contract is defined here: https://github.com/Layr-Labs/nitro-contracts/blob/eigenda-v2.1.3/src/bridge/SequencerInbox.sol:

```solidity
function addSequencerL2BatchFromEigenDA(
    uint256 sequenceNumber,
    EigenDACert calldata cert,
    IGasRefunder gasRefunder,
    uint256 afterDelayedMessagesRead,
    uint256 prevMessageCount,
    uint256 newMessageCount
) external refundsGas(gasRefunder, IReader4844(address(0)))
```

Where `EigenDACert` is defined in https://github.com/Layr-Labs/nitro-contracts/blob/eigenda-v2.1.3/src/bridge/ISequencerInbox.sol:

```solidity
struct EigenDACert {
    BlobVerificationProof blobVerificationProof;
    BlobHeader blobHeader;
}
```

`BlobVerificationProof` and `BlobHeader` are defined in https://github.com/Layr-Labs/eigenda/blob/v2.1.0/contracts/src/core/libraries/v1/EigenDATypesV1.sol:

```solidity
struct QuorumBlobParam {
    uint8 quorumNumber;
    uint8 adversaryThresholdPercentage;
    uint8 confirmationThresholdPercentage;
    uint32 chunkLength;
}

struct BlobHeader {
    BN254.G1Point commitment;
    uint32 dataLength;
    QuorumBlobParam[] quorumBlobParams;
}

struct BatchHeader {
    bytes32 blobHeadersRoot;
    bytes quorumNumbers;
    bytes signedStakeForQuorums;
    uint32 referenceBlockNumber;
}

struct BatchMetadata {
    BatchHeader batchHeader;
    bytes32 signatoryRecordHash;
    uint32 confirmationBlockNumber;
}

struct BlobVerificationProof {
    uint32 batchId;
    uint32 blobIndex;
    BatchMetadata batchMetadata;
    bytes inclusionProof;
    bytes quorumIndices;
}
```

`BN254.G1Point` is defined in https://github.com/Layr-Labs/eigenlayer-middleware/blob/master/src/libraries/BN254.sol:

```solidity
struct G1Point {
    uint256 X;
    uint256 Y;
}
```

### Blockscout Indexer Code Flows

`Indexer.Fetcher.Arbitrum.Utils.Rpc.parse_calldata_of_add_sequencer_l2_batch` is invoked in the scenario of a new batch discovery:

```plaintext
Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.perform
..Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.handle_batches_from_logs
....Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.execute_transaction_requests_parse_transactions_calldata
......Indexer.Fetcher.Arbitrum.Utils.Rpc.parse_calldata_of_add_sequencer_l2_batch
```

One of important results of `parse_calldata_of_add_sequencer_l2_batch` wrt Data Availability solutions is the last element in the returned tuple: `data`. 

In order to get this information from the method call arguments `parse_calldata_of_add_sequencer_l2_batch` decodes the transaction calldata by using ABI that corresponds to the given contract method. These ABIs are returned by `add_sequencer_l2_batch_*` functions of apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex.

The accompanying data is used by `execute_transaction_requests_parse_transactions_calldata` to be passed to `Indexer.Fetcher.Arbitrum.DA.Common.examine_batch_accompanying_data`. This function determine the type of the data committed together with the batch information and parses it depending on the determined type. If there is no accompanying data - it is assumed that the batch data is in EIP4844 blobs, otherwise the first byte of data is used to understand which handler is responsible for the accompanying data parsing. 

```plaintext
Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.execute_transaction_requests_parse_transactions_calldata
..Indexer.Fetcher.Arbitrum.DA.Common.examine_batch_accompanying_data
....Indexer.Fetcher.Arbitrum.DA.Common.parse_data_availability_info
```

The handlers parsing the accompanying data has the same name `parse_batch_accompanying_data` and locates in apps/indexer/lib/indexer/fetcher/arbitrum/da/anytrust.ex and apps/indexer/lib/indexer/fetcher/arbitrum/da/celestia.ex. They decode bytes set by knowing encoding scheme/ABI that corresponds to the specific DA solution. Extracted information is used to compose `Indexer.Fetcher.Arbitrum.DA.Celestia` or `Indexer.Fetcher.Arbitrum.DA.Anytrust` structure returned by handlers.

Batch accompanying data for Celestia and AnyTrust must be stored in the database while there is no such need for batches which data are in EIP4844 blobs or calldata. The decision is made `Indexer.Fetcher.Arbitrum.DA.Common.required_import?`. It allows to collect data for import and return the list of `Indexer.Fetcher.Arbitrum.DA.Celestia` and `Indexer.Fetcher.Arbitrum.DA.Anytrust` from `execute_transaction_requests_parse_transactions_calldata`. Then, every entity in the list is handled in `Indexer.Fetcher.Arbitrum.DA.Common.prepare_for_import`, where depending on the entity type, the functions `prepare_for_import` from apps/indexer/lib/indexer/fetcher/arbitrum/da/anytrust.ex or apps/indexer/lib/indexer/fetcher/arbitrum/da/celestia.ex are called.

```plaintext
Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.handle_batches_from_logs
..Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.execute_transaction_requests_parse_transactions_calldata
....Indexer.Fetcher.Arbitrum.Utils.Rpc.parse_calldata_of_add_sequencer_l2_batch
....Indexer.Fetcher.Arbitrum.DA.Common.examine_batch_accompanying_data
....Indexer.Fetcher.Arbitrum.DA.Common.required_import?
..Indexer.Fetcher.Arbitrum.DA.Common.prepare_for_import
....Indexer.Fetcher.Arbitrum.DA.{Celestia,Anytrust}.prepare_for_import
....Indexer.Fetcher.Arbitrum.DA.Common.eliminate_conflicts
......Indexer.Fetcher.Arbitrum.DA.Common.process_records
........Indexer.Fetcher.Arbitrum.DA.{Celestia,Anytrust}.resolve_conflict
```

The goal of `Indexer.Fetcher.Arbitrum.DA.{Celestia,Anytrust}.prepare_for_import` is to compose structures which will be imported in the database later: the DA-related batch accompanying data structure `Explorer.Chain.Arbitrum.DaMultiPurposeRecord.to_import()` and `Explorer.Chain.Arbitrum.BatchToDaBlob.to_import()` - an update for the table keeping a link between the rollup batch and the corresponding DA-related data.

As soon as the sets of structures for import are ready, they are inspected to not have conflicts with existing entities already existing in the data base. This is done by calling `Indexer.Fetcher.Arbitrum.DA.Common.eliminate_conflicts` which for all records related to Celestia calls `Indexer.Fetcher.Arbitrum.DA.Celestia.resolve_conflict` and for all records related to AnyTrust calls `Indexer.Fetcher.Arbitrum.DA.Anytrust.resolve_conflict`.

Final lists of the DA-related batch accompanying data structures and links between the rollup batches and the corresponding DA-related data are returned from `Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.handle_batches_from_logs` and then imported to the database in `Indexer.Fetcher.Arbitrum.Workers.Batches.Discovery.perform`.

### API DA Information Rendering Flow

```plaintext
BlockScoutWeb.API.V2.ArbitrumController.batch
..Explorer.Chain.Arbitrum.Reader.API.Settlement.batch
..BlockScoutWeb.API.V2.ArbitrumView.render("arbitrum_batch.json", %{batch: batch})
....BlockScoutWeb.API.V2.ArbitrumView.add_da_info
......BlockScoutWeb.API.V2.ArbitrumView.{generate_celestia_da_info,generate_anytrust_certificate}
........Explorer.Chain.Arbitrum.Reader.API.Settlement.get_da_info_by_batch_number
```

The main part of work related to extending the batch data with DA-related information specific for a particular DA protocol is done in `add_da_info` of apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex.

Depending on `batch_container` field of the batch, it is chosen the way how to render the DA-related information:
- `generate_celestia_da_info` for Celesita-grounded batches
- `generate_anytrust_certificate` for AnyTrust-grounded batches

These function prepare the content of the map `data_availability` which is then merged with the general batch data.

### AnyTrust Data Hash API Flow

```plaintext
BlockScoutWeb.API.V2.ArbitrumController.batch_by_data_availability_info
..BlockScoutWeb.API.V2.ArbitrumController.one_batch_by_data_availability_info
....Explorer.Chain.Arbitrum.Reader.API.Settlement.get_da_record_by_data_key
....BlockScoutWeb.API.V2.ArbitrumController.batch
```

The endpoint `/batches/da/anytrust/:data_hash` performs a reverse lookup from AnyTrust data hash to batch. The `batch_by_data_availability_info` function is responsible for handling requests to this endpoint. When it is called to get only one batch (default behavior), `get_da_record_by_data_key` is used to get the most recent batch for the provided data hash and then the standard batch rendering pipeline is engaged.

### Data Base Entities

The type `arbitrum_da_containers_types` created by migration apps/explorer/priv/arbitrum/migrations/20240527212653_add_da_info.exs defines possible batch data container types. These types are being used in the table `arbitrum_l1_batches` to extend the batch information with a mark specifying where the batch data are stored.

The possible types of the data container type also defined in the schema of `arbitrum_l1_batches` defined apps/explorer/lib/explorer/chain/arbitrum/l1_batch.ex.

## Solution

### Phase I - No Exception For New Method

On this phase the support of the method selector `0x283d8225` is added to `parse_calldata_of_add_sequencer_l2_batch`.

To extract the batch specific information the new function `add_sequencer_l2_batch_from_eigen_da_selector_with_abi` is added to apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex. 

Since the main purpose of this phase is to recover batch indexing mechanism, `parse_calldata_of_add_sequencer_l2_batch` will return `nil` as the batch accompanying data instead of EiegenDA's `cert`.

### Phase II - Proper Batch Data Container Type

The new item `in_eigenda` is added to the type `arbitrum_da_containers_types`. It is done in the new migration script.
The migration module mentioned in the file defining the `arbitrum_l1_batches` schema. The new batch container type is explicitely used in the schema as well.

Since the structure `EigenDACert` does not specify any flag that can be used to distinguish batch accompanying data which is required by `parse_data_availability_info`, `parse_calldata_of_add_sequencer_l2_batch` returns `0xed` conctatenated with the `cert` data.

`0xed` (237) will be used by `parse_data_availability_info` to determine that the accompanying data is specific for batches stored in EigenDA and returns `{:ok, :in_eigenda, nil}`. It means that the `cert` data is not parsed on this phase.

The spec and doc comment of `Indexer.Fetcher.Arbitrum.DA.Common.examine_batch_accompanying_data` must be adjusted to reflect the new batch data container type. The same with the spec of `Indexer.Fetcher.Arbitrum.DA.Common.required_import?`.

### Phase III - Parsing EigenDA certificate

The function `add_sequencer_l2_batch_from_eigen_da_selector_with_abi` is refactored to return proper ABI for `EigenDACert` that consists of `BlobVerificationProof` and `BlobHeader` which are a complex structures in their turn.

`parse_calldata_of_add_sequencer_l2_batch` is refactored to accept from `add_sequencer_l2_batch_from_eigen_da_selector_with_abi` a complex structure as `cert`. Then `cert` is encoded to bytes by `TypeEncoder.encode` to be properly concatenated with a byte `237`. To properly encode the structure to bytes, a new function `eigen_da_cert_abi` is created in apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex.

The module apps/indexer/lib/indexer/fetcher/arbitrum/da/eigenda.ex is created. The main purpose of this module on this phase is to provide the structure of parsed certificate and the handler `parse_batch_accompanying_data`.

The handler `parse_batch_accompanying_data` uses `TypeDecoder.decode` to extract from the certificate `BlobVerificationProof` and `BlobHeader`. ABI of `EigenDACert` is defined in apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/arbitrum/constants/contracts.ex. `BlobVerificationProof` and `BlobHeader` are returned as set of bytes from the handler among with the batch number, for this both structures are encoded back to bytes with `TypeEncoder.encode` before to be used to compose the output structure. 

The new handler is called in `Indexer.Fetcher.Arbitrum.DA.Common.parse_data_availability_info` so for the header flag 237 the tuple `{:ok, :in_eigenda, Indexer.Fetcher.Arbitrum.DA.Eigenda.t()}` is returned.

### Phase IV - Preparation EigenDA certificate for import

Functionality of `required_import?` is extended to announce that EigenDA certificates must be imported to the data base.

Functionality of `Indexer.Fetcher.Arbitrum.DA.Common.prepare_for_import` is extended to handle `Indexer.Fetcher.Arbitrum.DA.Eigenda.t()` structures.

The new function `prepare_for_import` is added to apps/indexer/lib/indexer/fetcher/arbitrum/da/eigenda.ex. It builds the blob key as `ExKeccak.hash_256` of the blob header. The key is used to build a link between the DA record and the batch. The logic to build the hash must be located in the helper module defined in apps/explorer/lib/explorer/chain/arbitrum/da_multi_purpose_record.ex. The DA record to be used for import must consists of hex representation of the blob header and the blob verification proof. The overal logic is very close to how `Indexer.Fetcher.Arbitrum.DA.Celestia.prepare_for_import` is implemented.

The function `eliminate_conflicts` is updated to be able to handle EigenDA-related records.

The doc comment and specification of the function `process_records` are updated to reflect the fact that the function is able to work with EigenDA-related records.

The new function `resolve_conflict` is added to apps/indexer/lib/indexer/fetcher/arbitrum/da/eigenda.ex. It logic is similar to how `Indexer.Fetcher.Arbitrum.DA.Celestia.resolve_conflict` is implemented.

### Phase V - Extending batch view with EigenDA related data

The new function `generate_eigen_da_info` is added to apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex. This function in the similar way to `generate_celestia_da_info` generates a map with the field of EigenDA certificate.

The function `add_da_info` is extended to call `generate_eigen_da_info` to prepare the content for the `data_availability` field of the batch data.

### Phase VI - Getting the batch info by the EigenDA blob key

The scope "arbitrum" in apps/block_scout_web/lib/block_scout_web/routers/api_router.ex is extended with a new endpoint "/batches/da/eigenda/:data_hash" to use `batch_by_data_availability_info` of `BlockScoutWeb.API.V2.ArbitrumController` as a handler.

No changes in `batch_by_data_availability_info` or below in the code flow are required - it is assumed that the data hash corresponds to an EigenDA blob key so the corresponding batch will be found by `get_da_record_by_data_key`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
