### PR TITLE
fix: deletion in chunks for the balances and main data export queues to the multichain DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 🐛 Bug Fixes
 
 - Ignore rate limit for api/v2/import/token-info and api/v2/import/smart-contracts/:param ([#12917](https://github.com/blockscout/blockscout/pull/12917))
-- Fix deadlocks in Multichain balances export ([#12898](https://github.com/blockscout/blockscout/pull/12898), [#12928](https://github.com/blockscout/blockscout/pull/12928))
+- Mitigate deadlocks while exporting balances and the main queue to the Multichain DB ([#12898](https://github.com/blockscout/blockscout/pull/12898), [#12928](https://github.com/blockscout/blockscout/pull/12928))
 - Balances export queue: replace replace_all with replace only value and updated_at ([#12892](https://github.com/blockscout/blockscout/pull/12892))
 - Fix naming for apikey param in OpenAPI spec ([#12891](https://github.com/blockscout/blockscout/pull/12891))
 - Don't send coin balances with zero delta via ws ([#12890](https://github.com/blockscout/blockscout/pull/12890))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 🐛 Bug Fixes
 
 - Ignore rate limit for api/v2/import/token-info and api/v2/import/smart-contracts/:param ([#12917](https://github.com/blockscout/blockscout/pull/12917))
-- Fix deadlocks in Multichain balances export ([#12898](https://github.com/blockscout/blockscout/pull/12898))
+- Fix deadlocks in Multichain balances export ([#12898](https://github.com/blockscout/blockscout/pull/12898), [#12928](https://github.com/blockscout/blockscout/pull/12928))
 - Balances export queue: replace replace_all with replace only value and updated_at ([#12892](https://github.com/blockscout/blockscout/pull/12892))
 - Fix naming for apikey param in OpenAPI spec ([#12891](https://github.com/blockscout/blockscout/pull/12891))
 - Don't send coin balances with zero delta via ws ([#12890](https://github.com/blockscout/blockscout/pull/12890))

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/balances_export_queue.ex
@@ -132,6 +132,5 @@ defmodule Explorer.Chain.MultichainSearchDb.BalancesExportQueue do
         )
       )
     end)
-    |> Repo.transact()
   end
 end

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/main_export_queue.ex
@@ -80,6 +80,9 @@ defmodule Explorer.Chain.MultichainSearchDb.MainExportQueue do
   """
   @spec by_hashes_query([binary()]) :: Ecto.Query.t()
   def by_hashes_query(hashes) do
+    # todo: In order to prevent deadlocks consider ordering by `hash`
+    # and rewrite logic to acquire items first with locking
+    # then deleting them.
     __MODULE__
     |> where([export], export.hash in ^hashes)
   end

--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
@@ -11,12 +11,14 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
   alias Explorer.Chain.Wei
   alias Explorer.Chain.{Hash, MultichainSearchDb.BalancesExportQueue}
   alias Explorer.MicroserviceInterfaces.MultichainSearch
+  alias Explorer.Repo
 
   alias Indexer.BufferedTask
   alias Indexer.Helper, as: IndexerHelper
 
   @behaviour BufferedTask
 
+  @delete_queries_chunk_size 10
   @default_max_batch_size 1000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch balances export retry to the Multichain Search DB failed"
@@ -66,7 +68,14 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
 
         unless Enum.empty?(all_balances) do
           all_balances
-          |> BalancesExportQueue.delete_elements_from_queue_by_params()
+          |> Enum.sort_by(&{&1.address_hash, &1.token_contract_address_hash_or_native, &1.token_id})
+          |> Enum.chunk_every(@delete_queries_chunk_size)
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          |> Enum.each(fn chunk_items ->
+            chunk_items
+            |> BalancesExportQueue.delete_elements_from_queue_by_params()
+            |> Repo.transact()
+          end)
         end
 
         :ok

--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
@@ -17,6 +17,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueue do
 
   @behaviour BufferedTask
 
+  @delete_queries_chunk_size 100
   @default_max_batch_size 1000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch main export retry to the Multichain Search DB failed"
@@ -78,8 +79,12 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueue do
           end)
 
         all_hashes
-        |> MainExportQueue.by_hashes_query()
-        |> Repo.delete_all()
+        |> Enum.chunk_every(@delete_queries_chunk_size)
+        |> Enum.each(fn chunk_items ->
+          chunk_items
+          |> MainExportQueue.by_hashes_query()
+          |> Repo.delete_all()
+        end)
 
         :ok
 


### PR DESCRIPTION
## Motivation

The number of deadlocks on the process of deletion of multichain export balances per unit of time decreased but still happens after https://github.com/blockscout/blockscout/pull/12898.

## Changelog

Reintroduce chunking for the deletion of processed multichain balance exports to help mitigate deadlock issues.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Multichain balances export by processing deletions of balances and hashes in smaller chunks, reducing the risk of deadlocks during export operations.
* **Documentation**
  * Updated changelog to reference all relevant pull requests for the Multichain balances export deadlock fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->