### PR TITLE
fix: Fix matching in current token balances import filter

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -231,7 +231,7 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
     filtered_ctbs =
       Enum.filter(changes_list, fn ctb ->
         existing_ctb = existing_ctb_map[{ctb[:address_hash], ctb[:token_contract_address_hash], ctb[:token_id]}]
-        should_update?(ctb, existing_ctb)
+        should_update?(Map.put_new(ctb, :value_fetched_at, nil), existing_ctb)
       end)
 
     {:ok, filtered_ctbs}


### PR DESCRIPTION
## Motivation

`should_update?` should return `false` if new ctb has no value. But it checked via `%{value_fetched_at: nil}` matching which means that new ctb params that doesn't have this field won't pass this check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating current token balances by ensuring missing data fields are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->