### PR TITLE
chore: Remove obsolete API response props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Remove obsolete API response props ([#12931](https://github.com/blockscout/blockscout/pull/12931))
 - Balances Multichain export: Refactor rows acquisition for deletion query ([#12839](https://github.com/blockscout/blockscout/pull/12839))
 - Change name of Swagger generation workflow ([#12840](https://github.com/blockscout/blockscout/pull/12840))
 - migrate Auth0 to mint as well ([#12807](https://github.com/blockscout/blockscout/pull/12807))

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -223,21 +223,19 @@ defmodule BlockScoutWeb.Chain do
   def paging_options(
         %{
           "market_cap" => market_cap_string,
-          "holders_count" => holder_count_string,
-          # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-          "holder_count" => holder_count_string,
+          "holders_count" => holders_count_string,
           "name" => name_string,
           "contract_address_hash" => contract_address_hash_string,
           "is_name_null" => is_name_null_string
         } = params
       )
-      when is_binary(market_cap_string) and is_binary(holder_count_string) and is_binary(name_string) and
+      when is_binary(market_cap_string) and is_binary(holders_count_string) and is_binary(name_string) and
              is_binary(contract_address_hash_string) and is_binary(is_name_null_string) do
     market_cap_decimal = decimal_parse(market_cap_string)
 
     fiat_value_decimal = decimal_parse(params["fiat_value"])
 
-    holder_count = parse_integer(holder_count_string)
+    holders_count = parse_integer(holders_count_string)
     token_name = if is_name_null_string == "true", do: nil, else: name_string
 
     case Hash.Address.cast(contract_address_hash_string) do
@@ -248,7 +246,7 @@ defmodule BlockScoutWeb.Chain do
             | key: %{
                 fiat_value: fiat_value_decimal,
                 circulating_market_cap: market_cap_decimal,
-                holder_count: holder_count,
+                holder_count: holders_count,
                 name: token_name,
                 contract_address_hash: contract_address_hash
               }
@@ -759,15 +757,13 @@ defmodule BlockScoutWeb.Chain do
   defp paging_params(%Token{
          contract_address_hash: contract_address_hash,
          circulating_market_cap: circulating_market_cap,
-         holder_count: holder_count,
+         holder_count: holders_count,
          name: token_name,
          fiat_value: fiat_value
        }) do
     %{
       "market_cap" => circulating_market_cap,
-      "holders_count" => holder_count,
-      # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-      "holder_count" => holder_count,
+      "holders_count" => holders_count,
       "contract_address_hash" => contract_address_hash,
       "name" => token_name,
       "is_name_null" => is_nil(token_name),
@@ -862,8 +858,6 @@ defmodule BlockScoutWeb.Chain do
     %{
       "smart_contract_id" => smart_contract.id,
       "transactions_count" => smart_contract.address.transactions_count,
-      # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      "transaction_count" => smart_contract.address.transactions_count,
       "coin_balance" =>
         smart_contract.address.fetched_coin_balance && Wei.to(smart_contract.address.fetched_coin_balance, :wei)
     }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -100,7 +100,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
             end
 
           # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
-          transaction_count =
+          transactions_count =
             case l2_block_range do
               nil -> 0
               range -> Transaction.transaction_count_for_block_range(range)
@@ -110,9 +110,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
 
           fs
           |> Map.put(:l2_block_range, l2_block_range)
-          |> Map.put(:transactions_count, transaction_count)
-          # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-          |> Map.put(:transaction_count, transaction_count)
+          |> Map.put(:transactions_count, transactions_count)
           |> Map.put(:batch_data_container, batch_data_container)
         end)
       end)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -161,13 +161,13 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   parameters.
 
   ## Returns
-  If 'hash', 'transaction_count', and 'coin_balance' parameters are provided,
+  If 'hash', 'transactions_count', and 'coin_balance' parameters are provided,
   uses them as pagination keys for address-based sorting. If 'smart_contract_id'
   parameter is provided, uses it as pagination key for smart contract ID-based
   sorting. Otherwise, returns default paging options.
 
   ## Examples
-      iex> smart_contract_addresses_paging_options(%{"hash" => "0x123...", "transaction_count" => "100", "coin_balance" => "1000"})
+      iex> smart_contract_addresses_paging_options(%{"hash" => "0x123...", "transactions_count" => "100", "coin_balance" => "1000"})
       [paging_options: %{key: %{hash: ..., transactions_count: 100, fetched_coin_balance: 1000}}]
 
       iex> smart_contract_addresses_paging_options(%{"smart_contract_id" => "42"})
@@ -189,7 +189,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
     |> Chain.string_to_address_hash()
     |> case do
       {:ok, address_hash} ->
-        transactions_count = parse_integer(params["transaction_count"])
+        transactions_count = parse_integer(params["transactions_count"])
         coin_balance = parse_integer(params["coin_balance"])
 
         %{
@@ -226,7 +226,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
   ## Examples
       iex> address = %Explorer.Chain.Address{hash: "0x123...", transactions_count: 100, fetched_coin_balance: 1000}
       iex> smart_contract_addresses_paging_params(address)
-      %{"hash" => "0x123...", "transaction_count" => 100, "coin_balance" => 1000}
+      %{"hash" => "0x123...", "transactions_count" => 100, "coin_balance" => 1000}
   """
   @spec smart_contract_addresses_paging_params(Explorer.Chain.Address.t()) :: %{
           required(String.t()) => any()
@@ -238,8 +238,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       }) do
     %{
       "hash" => address_hash,
-      # todo: It should be removed in favour: transactions_count
-      "transaction_count" => transactions_count,
       "transactions_count" => transactions_count,
       "coin_balance" => coin_balance
     }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/stats_controller.ex
@@ -107,8 +107,7 @@ defmodule BlockScoutWeb.API.V2.StatsController do
     transaction_history_data =
       date_range
       |> Enum.map(fn row ->
-        # todo: `transaction_count` property should be removed in favour `transactions_count` property with the next release after 8.0.0
-        %{date: row.date, transaction_count: row.number_of_transactions, transactions_count: row.number_of_transactions}
+        %{date: row.date, transactions_count: row.number_of_transactions}
       end)
 
     json(conn, %{

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -78,9 +78,9 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
          {:not_found, true} <- {:not_found, Token.by_contract_address_hash_exists?(address_hash, @api_true)} do
-      {transfer_count, token_holder_count} = Chain.fetch_token_counters(address_hash, 30_000)
+      {transfers_count, holders_count} = Chain.fetch_token_counters(address_hash, 30_000)
 
-      json(conn, %{transfers_count: to_string(transfer_count), token_holders_count: to_string(token_holder_count)})
+      json(conn, %{transfers_count: to_string(transfers_count), token_holders_count: to_string(holders_count)})
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
@@ -74,14 +74,8 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
     conn
     |> json(%{
       validators_count: validators_counter,
-      # todo: It should be removed in favour `validators_count` property with the next release after 8.0.0
-      validators_counter: validators_counter,
       new_validators_count_24h: new_validators_counter,
-      # todo: It should be removed in favour `new_validators_count_24h` property with the next release after 8.0.0
-      new_validators_counter_24h: new_validators_counter,
       active_validators_count: active_validators_counter,
-      # todo: It should be removed in favour `active_validators_count` property with the next release after 8.0.0
-      active_validators_counter: active_validators_counter,
       active_validators_percentage:
         calculate_active_validators_percentage(active_validators_counter, validators_counter)
     })
@@ -129,11 +123,7 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
     conn
     |> json(%{
       validators_count: validators_counter,
-      # todo: It should be removed in favour `validators_count` property with the next release after 8.0.0
-      validators_counter: validators_counter,
-      new_validators_count_24h: new_validators_counter,
-      # todo: It should be removed in favour `new_validators_count_24h` property with the next release after 8.0.0
-      new_validators_counter_24h: new_validators_counter
+      new_validators_count_24h: new_validators_counter
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/withdrawal_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/withdrawal_controller.ex
@@ -38,10 +38,7 @@ defmodule BlockScoutWeb.API.V2.WithdrawalController do
     conn
     |> json(%{
       withdrawals_count: Chain.count_withdrawals_from_cache(api?: true),
-      withdrawals_sum: Chain.sum_withdrawals_from_cache(api?: true),
-      # todo: Both properties below should be removed in favour `withdrawals_count` and `withdrawals_sum` properties with the next release after 8.0.0
-      withdrawal_count: Chain.count_withdrawals_from_cache(api?: true),
-      withdrawal_sum: Chain.sum_withdrawals_from_cache(api?: true)
+      withdrawals_sum: Chain.sum_withdrawals_from_cache(api?: true)
     })
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/chain_controller.ex
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.ChainController do
   alias Phoenix.View
 
   def show(conn, _params) do
-    transaction_count = TransactionsCount.get()
+    transactions_count = TransactionsCount.get()
     total_gas_usage = GasUsageSum.total()
     block_count = BlocksCount.get()
     address_count = AddressesCount.fetch()
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.ChainController do
       chart_config_json: Jason.encode!(chart_config),
       chart_data_paths: chart_data_paths,
       market_cap_calculation: market_cap_calculation,
-      transaction_estimated_count: transaction_count,
+      transaction_estimated_count: transactions_count,
       total_gas_usage: total_gas_usage,
       transactions_path: recent_transactions_path(conn, :index),
       transaction_stats: transaction_stats,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/tokens/token_controller.ex
@@ -13,9 +13,9 @@ defmodule BlockScoutWeb.Tokens.TokenController do
   def token_counters(conn, %{"id" => address_hash_string}) do
     case Chain.string_to_address_hash(address_hash_string) do
       {:ok, address_hash} ->
-        {transfer_count, token_holder_count} = Chain.fetch_token_counters(address_hash, 30_000)
+        {transfers_count, holders_count} = Chain.fetch_token_counters(address_hash, 30_000)
 
-        json(conn, %{transfer_count: transfer_count, token_holder_count: token_holder_count})
+        json(conn, %{transfer_count: transfers_count, token_holder_count: holders_count})
 
       _ ->
         not_found(conn)

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -282,9 +282,6 @@ defmodule BlockScoutWeb.PagingHelper do
   defp do_tokens_sorting("fiat_value", "desc"), do: [desc_nulls_last: :fiat_value]
   defp do_tokens_sorting("holders_count", "asc"), do: [asc_nulls_first: :holder_count]
   defp do_tokens_sorting("holders_count", "desc"), do: [desc_nulls_last: :holder_count]
-  # todo: Next 2 clauses should be removed in favour `holders_count` property with the next release after 8.0.0
-  defp do_tokens_sorting("holder_count", "asc"), do: [asc_nulls_first: :holder_count]
-  defp do_tokens_sorting("holder_count", "desc"), do: [desc_nulls_last: :holder_count]
   defp do_tokens_sorting("circulating_market_cap", "asc"), do: [asc_nulls_first: :circulating_market_cap]
   defp do_tokens_sorting("circulating_market_cap", "desc"), do: [desc_nulls_last: :circulating_market_cap]
   defp do_tokens_sorting(_, _), do: []

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -49,7 +49,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
       description: "Token struct",
       type: :object,
       properties: %{
-        address: General.AddressHash,
+        address_hash: General.AddressHash,
         symbol: %Schema{type: :string, nullable: false},
         name: %Schema{type: :string, nullable: false},
         decimals: General.IntegerStringNullable,
@@ -57,7 +57,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
           anyOf: [Type],
           nullable: true
         },
-        holders: General.IntegerStringNullable,
+        holders_count: General.IntegerStringNullable,
         exchange_rate: General.FloatStringNullable,
         volume_24h: General.FloatStringNullable,
         total_supply: General.IntegerStringNullable,
@@ -65,12 +65,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
         circulating_market_cap: General.FloatStringNullable
       },
       required: [
-        :address,
+        :address_hash,
         :symbol,
         :name,
         :decimals,
         :type,
-        :holders,
+        :holders_count,
         :exchange_rate,
         :volume_24h,
         :total_supply,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -84,7 +84,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     - Map containing:
       - `:hash` - address hash
       - `:coin_balance` - current coin balance value
-      - `:transaction_count` - number of transactions as string
+      - `:transactions_count` - number of transactions as string
       - Additional address info fields from Helper.address_with_info/4
   """
   @spec prepare_address_for_list(Address.t()) :: map()
@@ -92,8 +92,6 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     nil
     |> Helper.address_with_info(address, address.hash, true)
     |> Map.put(:transactions_count, to_string(address.transactions_count))
-    # todo: It should be removed in favour `transaction_count` property with the next release after 8.0.0
-    |> Map.put(:transaction_count, to_string(address.transactions_count))
     |> Map.put(:coin_balance, if(address.fetched_coin_balance, do: address.fetched_coin_balance.value))
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/arbitrum_view.ex
@@ -29,8 +29,6 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
         %{
           "id" => msg.message_id,
           "origination_address_hash" => msg.originator_address,
-          # todo: It should be removed in favour `origination_address_hash` property with the next release after 8.0.0
-          "origination_address" => msg.originator_address,
           "origination_transaction_hash" => msg.originating_transaction_hash,
           "origination_timestamp" => msg.origination_timestamp,
           "origination_transaction_block_number" => msg.originating_transaction_block_number,
@@ -76,9 +74,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
   def render("arbitrum_claim_message.json", %{calldata: calldata, address: address}) do
     %{
       "calldata" => calldata,
-      "outbox_address_hash" => address,
-      # todo: It should be removed in favour `contract_address_hash` property with the next release after 8.0.0
-      "outbox_address" => address
+      "outbox_address_hash" => address
     }
   end
 
@@ -93,11 +89,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
           "id" => withdraw.message_id,
           "status" => withdraw.status,
           "caller_address_hash" => withdraw.caller,
-          # todo: "caller"" should be removed in favour `caller_address_hash` property with the next release after 8.0.0
-          "caller" => withdraw.caller,
           "destination_address_hash" => withdraw.destination,
-          # todo: "destination" should be removed in favour `destination_address_hash` property with the next release after 8.0.0
-          "destination" => withdraw.destination,
           "arb_block_number" => withdraw.arb_block_number,
           "eth_block_number" => withdraw.eth_block_number,
           "l2_timestamp" => withdraw.l2_timestamp,
@@ -124,16 +116,8 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
       "transactions_count" => batch.transactions_count,
       "start_block_number" => batch.start_block,
       "end_block_number" => batch.end_block,
-      # todo: It should be removed in favour `start_block_number` property with the next release after 8.0.0
-      "start_block" => batch.start_block,
-      # todo: It should be removed in favour `end_block_number` property with the next release after 8.0.0
-      "end_block" => batch.end_block,
       "before_acc_hash" => batch.before_acc,
-      # todo: It should be removed in favour `before_acc_hash` property with the next release after 8.0.0
-      "before_acc" => batch.before_acc,
-      "after_acc_hash" => batch.after_acc,
-      # todo: It should be removed in favour `after_acc_hash` property with the next release after 8.0.0
-      "after_acc" => batch.after_acc
+      "after_acc_hash" => batch.after_acc
     }
     |> add_l1_transaction_info(batch)
     |> add_da_info(batch)
@@ -670,8 +654,6 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     %{
       "message_id" => APIV2Helper.get_2map_data(arbitrum_transaction, :arbitrum_message_from_l2, :message_id),
       "associated_l1_transaction_hash" => l1_transaction,
-      # todo: It should be removed in favour `associated_l1_transaction_hash` property with the next release after 8.0.0
-      "associated_l1_transaction" => l1_transaction,
       "message_status" => status
     }
   end
@@ -724,8 +706,6 @@ defmodule BlockScoutWeb.API.V2.ArbitrumView do
     out_json
     |> Map.put("delayed_messages", Hash.to_integer(arbitrum_block.nonce))
     |> Map.put("l1_block_number", Map.get(arbitrum_block, :l1_block_number))
-    # todo: It should be removed in favour `l1_block_number` property with the next release after 8.0.0
-    |> Map.put("l1_block_height", Map.get(arbitrum_block, :l1_block_number))
     |> Map.put("send_count", Map.get(arbitrum_block, :send_count))
     |> Map.put("send_root", Map.get(arbitrum_block, :send_root))
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -48,8 +48,6 @@ defmodule BlockScoutWeb.API.V2.BlockView do
       "height" => block.number,
       "timestamp" => block.timestamp,
       "transactions_count" => block.transactions_count,
-      # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      "transaction_count" => block.transactions_count,
       "internal_transactions_count" => count_internal_transactions(block),
       "miner" => Helper.address_with_info(nil, block.miner, block.miner_hash, false),
       "size" => block.size,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
@@ -358,12 +358,12 @@ defmodule BlockScoutWeb.API.V2.CeloView do
 
   ## Example
       iex> transfers = %{
-      ...>   reserve_bolster_transfer: %{"token" => %{"address" => "0xABC..."}, "total" => %{"value" => Decimal.new("100")}},
-      ...>   community_transfer: %{"token" => %{"address" => "0xABC..."}, "total" => %{"value" => Decimal.new("200")}}
+      ...>   reserve_bolster_transfer: %{"token" => %{"address_hash" => "0xABC..."}, "total" => %{"value" => Decimal.new("100")}},
+      ...>   community_transfer: %{"token" => %{"address_hash" => "0xABC..."}, "total" => %{"value" => Decimal.new("200")}}
       ...> }
       iex> calculate_total_epoch_rewards(transfers)
       %{
-        token: %{"address" => "0xABC...", ...},
+        token: %{"address_hash" => "0xABC...", ...},
         total: %{decimals: Decimal.new("18"), value: Decimal.new("300")}
       }
   """
@@ -443,7 +443,7 @@ defmodule BlockScoutWeb.API.V2.CeloView do
   defp fee_handler_base_fee_breakdown(base_fee, block_number) do
     with {:ok, fee_handler_contract_address_hash} <-
            CeloCoreContracts.get_address(:fee_handler, block_number),
-         {:ok, %{"address" => fee_beneficiary_address_hash}} <-
+         {:ok, %{"address_hash" => fee_beneficiary_address_hash}} <-
            CeloCoreContracts.get_event(:fee_handler, :fee_beneficiary_set, block_number),
          {:ok, %{"value" => burn_fraction_fixidity_lib}} <-
            CeloCoreContracts.get_event(:fee_handler, :burn_fraction_set, block_number),

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/ethereum_view.ex
@@ -28,8 +28,6 @@ defmodule BlockScoutWeb.API.V2.EthereumView do
     extended_out_json =
       out_json
       |> Map.put("blob_transactions_count", blob_transaction_count)
-      # todo: It should be removed in favour `blob_transactions_count` property with the next release after 8.0.0
-      |> Map.put("blob_transaction_count", blob_transaction_count)
       |> Map.put("blob_gas_used", blob_gas_used)
       |> Map.put("excess_blob_gas", excess_blob_gas)
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
@@ -83,11 +83,7 @@ defmodule BlockScoutWeb.API.V2.MudView do
   defp prepare_world_for_list(%Address{} = address) do
     %{
       "address_hash" => Helper.address_with_info(address, address.hash),
-      # todo: "address" should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => Helper.address_with_info(address, address.hash),
       "transactions_count" => address.transactions_count,
-      # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      "transaction_count" => address.transactions_count,
       "coin_balance" => if(address.fetched_coin_balance, do: address.fetched_coin_balance.value)
     }
   end
@@ -95,9 +91,7 @@ defmodule BlockScoutWeb.API.V2.MudView do
   defp prepare_system_for_list({system_id, system}) do
     %{
       name: system_id |> Table.from() |> Map.get(:table_full_name),
-      address_hash: system,
-      # todo: "address" should be removed in favour `address_hash` property with the next release after 8.0.0
-      address: system
+      address_hash: system
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -20,7 +20,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
       batches
       |> Enum.map(fn batch ->
         Task.async(fn ->
-          transaction_count =
+          transactions_count =
             Repo.replica().aggregate(
               from(
                 t in Transaction,
@@ -34,9 +34,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
 
           %{
             "l2_block_number" => batch.l2_block_number,
-            "transactions_count" => transaction_count,
-            # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-            "transaction_count" => transaction_count,
+            "transactions_count" => transactions_count,
             "l1_transaction_hashes" => batch.frame_sequence.l1_transaction_hashes,
             "l1_timestamp" => batch.frame_sequence.l1_timestamp
           }
@@ -125,8 +123,6 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           %{
             "index" => g.index,
             "game_type" => g.game_type,
-            # todo: It should be removed in favour `contract_address_hash` property with the next release after 8.0.0
-            "contract_address" => g.address_hash,
             "contract_address_hash" => g.address_hash,
             "l2_block_number" => l2_block_number,
             "created_at" => g.created_at,
@@ -343,7 +339,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
   # - `internal_id`: The internal ID of the batch.
   # - `l2_block_number_from`: Start L2 block number of the batch block range.
   # - `l2_block_number_to`: End L2 block number of the batch block range.
-  # - `transaction_count`: The L2 transaction count included into the blocks of the range.
+  # - `transactions_count`: The L2 transaction count included into the blocks of the range.
   # - `batch`: Either an `Explorer.Chain.Optimism.FrameSequence` entry or a map with
   #            the corresponding fields.
   #
@@ -358,23 +354,19 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           | %{:l1_timestamp => DateTime.t(), :l1_transaction_hashes => list(), optional(any()) => any()}
         ) :: %{
           :number => non_neg_integer(),
-          :internal_id => non_neg_integer(),
           :l1_timestamp => DateTime.t(),
           :l2_start_block_number => non_neg_integer(),
-          :l2_block_start => non_neg_integer(),
           :l2_end_block_number => non_neg_integer(),
-          :l2_block_end => non_neg_integer(),
           :transactions_count => non_neg_integer(),
-          :transaction_count => non_neg_integer(),
           :l1_transaction_hashes => list(),
           :batch_data_container => :in_blob4844 | :in_celestia | :in_calldata | nil
         }
-  defp render_base_info_for_batch(internal_id, l2_block_number_from, l2_block_number_to, transaction_count, batch) do
+  defp render_base_info_for_batch(internal_id, l2_block_number_from, l2_block_number_to, transactions_count, batch) do
     FrameSequence.prepare_base_info_for_batch(
       internal_id,
       l2_block_number_from,
       l2_block_number_to,
-      transaction_count,
+      transactions_count,
       batch.batch_data_container,
       batch
     )
@@ -408,8 +400,6 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
       batch_info =
         %{
           "number" => frame_sequence.id,
-          # todo: It should be removed in favour `number` property with the next release after 8.0.0
-          "internal_id" => frame_sequence.id,
           "l1_timestamp" => frame_sequence.l1_timestamp,
           "l1_transaction_hashes" => frame_sequence.l1_transaction_hashes,
           "batch_data_container" => batch_data_container

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_zkevm_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/polygon_zkevm_view.ex
@@ -156,8 +156,6 @@ defmodule BlockScoutWeb.API.V2.PolygonZkevmView do
         "status" => batch_status(batch),
         "timestamp" => batch.timestamp,
         "transactions_count" => batch.l2_transactions_count,
-        # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-        "transaction_count" => batch.l2_transactions_count,
         "sequence_transaction_hash" => sequence_transaction_hash,
         "verify_transaction_hash" => verify_transaction_hash
       }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/scroll_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/scroll_view.ex
@@ -126,13 +126,7 @@ defmodule BlockScoutWeb.API.V2.ScrollView do
       },
       "start_block_number" => start_block_number,
       "end_block_number" => end_block_number,
-      # todo: It should be removed in favour `start_block_number` property with the next release after 8.0.0
-      "start_block" => start_block_number,
-      # todo: It should be removed in favour `end_block_number` property with the next release after 8.0.0
-      "end_block" => end_block_number,
-      "transactions_count" => transactions_count,
-      # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      "transaction_count" => transactions_count
+      "transactions_count" => transactions_count
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -32,8 +32,6 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "name" => search_result.name,
       "symbol" => search_result.symbol,
       "address_hash" => search_result.address_hash,
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => search_result.address_hash,
       "token_url" => token_path(Endpoint, :show, search_result.address_hash),
       "address_url" => address_path(Endpoint, :show, search_result.address_hash),
       "icon_url" => search_result.icon_url,
@@ -54,8 +52,6 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "type" => search_result.type,
       "name" => search_result.name,
       "address_hash" => search_result.address_hash,
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => search_result.address_hash,
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
@@ -70,8 +66,6 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "type" => search_result.type,
       "name" => search_result.name,
       "address_hash" => search_result.address_hash,
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => search_result.address_hash,
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
@@ -85,8 +79,6 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "type" => search_result.type,
       "name" => search_result.name,
       "address_hash" => search_result.address_hash,
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => search_result.address_hash,
       "url" => address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -313,8 +313,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         "compiler_version" => smart_contract.compiler_version,
         "optimization_enabled" => smart_contract.optimization,
         "transactions_count" => address.transactions_count,
-        # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-        "transaction_count" => address.transactions_count,
         "language" => SmartContract.language(smart_contract),
         "verified_at" => smart_contract.inserted_at,
         "market_cap" => token && token.circulating_market_cap,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -11,15 +11,11 @@ defmodule BlockScoutWeb.API.V2.TokenView do
   def render("token.json", %{token: nil = token, contract_address_hash: contract_address_hash}) do
     %{
       "address_hash" => Address.checksum(contract_address_hash),
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => Address.checksum(contract_address_hash),
       "symbol" => nil,
       "name" => nil,
       "decimals" => nil,
       "type" => nil,
       "holders_count" => nil,
-      # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-      "holders" => nil,
       "exchange_rate" => nil,
       "volume_24h" => nil,
       "total_supply" => nil,
@@ -36,15 +32,11 @@ defmodule BlockScoutWeb.API.V2.TokenView do
   def render("token.json", %{token: token}) do
     %{
       "address_hash" => Address.checksum(token.contract_address_hash),
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => Address.checksum(token.contract_address_hash),
       "symbol" => token.symbol,
       "name" => token.name,
       "decimals" => token.decimals,
       "type" => token.type,
       "holders_count" => prepare_holders_count(token.holder_count),
-      # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-      "holders" => prepare_holders_count(token.holder_count),
       "exchange_rate" => exchange_rate(token),
       "volume_24h" => token.volume_24h,
       "total_supply" => token.total_supply,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -380,8 +380,6 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   def prepare_signed_authorization(signed_authorization) do
     %{
       "address_hash" => Address.checksum(signed_authorization.address),
-      # todo: It should be removed in favour `address_hash` property with the next release after 8.0.0
-      "address" => Address.checksum(signed_authorization.address),
       "chain_id" => signed_authorization.chain_id,
       "nonce" => signed_authorization.nonce,
       "r" => signed_authorization.r,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/validator_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/validator_view.ex
@@ -49,11 +49,7 @@ defmodule BlockScoutWeb.API.V2.ValidatorView do
         "slashed" => validator.slashing_status_is_slashed,
         "block_number" => validator.slashing_status_by_block,
         "multiplier" => validator.slashing_status_multiplier
-      },
-      # todo: Next 3 props should be removed in favour `slashing_status` property with the next release after 8.0.0
-      "slashing_status_is_slashed" => validator.slashing_status_is_slashed,
-      "slashing_status_by_block" => validator.slashing_status_by_block,
-      "slashing_status_multiplier" => validator.slashing_status_multiplier
+      }
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/zksync_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/zksync_view.ex
@@ -16,19 +16,11 @@ defmodule BlockScoutWeb.API.V2.ZkSyncView do
       "timestamp" => batch.timestamp,
       "root_hash" => batch.root_hash,
       "l1_transactions_count" => batch.l1_transaction_count,
-      # todo: It should be removed in favour `l1_transactions_count` property with the next release after 8.0.0
-      "l1_transaction_count" => batch.l1_transaction_count,
       "l2_transactions_count" => batch.l2_transaction_count,
-      # todo: It should be removed in favour `l2_transactions_count` property with the next release after 8.0.0
-      "l2_transaction_count" => batch.l2_transaction_count,
       "l1_gas_price" => batch.l1_gas_price,
       "l2_fair_gas_price" => batch.l2_fair_gas_price,
       "start_block_number" => batch.start_block,
-      "end_block_number" => batch.end_block,
-      # todo: It should be removed in favour `start_block_number` property with the next release after 8.0.0
-      "start_block" => batch.start_block,
-      # todo: It should be removed in favour `end_block_number` property with the next release after 8.0.0
-      "end_block" => batch.end_block
+      "end_block_number" => batch.end_block
     }
     |> add_l1_transactions_info_and_status(batch)
   end
@@ -72,9 +64,7 @@ defmodule BlockScoutWeb.API.V2.ZkSyncView do
       %{
         "number" => batch.number,
         "timestamp" => batch.timestamp,
-        "transactions_count" => batch.l1_transaction_count + batch.l2_transaction_count,
-        # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-        "transaction_count" => batch.l1_transaction_count + batch.l2_transaction_count
+        "transactions_count" => batch.l1_transaction_count + batch.l2_transaction_count
       }
       |> add_l1_transactions_info_and_status(batch)
     end)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -328,7 +328,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "implementations" => [
                  %{
                    "address_hash" => ^checksummed_implementation_contract_address_hash,
-                   "address" => ^checksummed_implementation_contract_address_hash,
                    "name" => ^name
                  }
                ]
@@ -383,7 +382,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "implementations" => [
                  %{
                    "address_hash" => ^implementation_address_hash_string,
-                   "address" => ^implementation_address_hash_string,
                    "name" => nil
                  }
                ]
@@ -460,7 +458,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "implementations" => [
                  %{
                    "address_hash" => ^implementation_address_hash_string,
-                   "address" => ^implementation_address_hash_string,
                    "name" => nil
                  }
                ]
@@ -621,7 +618,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       insert(:block, miner: address)
 
-      Counters.transaction_count(address)
+      Counters.transactions_count(address)
       Counters.token_transfers_count(address)
       Counters.gas_usage_count(address)
 
@@ -3376,14 +3373,14 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                      :timer.seconds(1)
 
       assert Decimal.to_integer(ctb_erc_20["value"]) ==
-               other_balances[ctb_erc_20["token"]["address"] |> String.downcase()]
+               other_balances[ctb_erc_20["token"]["address_hash"] |> String.downcase()]
 
       assert Decimal.to_integer(ctb_erc_721["value"]) ==
-               other_balances[ctb_erc_721["token"]["address"] |> String.downcase()]
+               other_balances[ctb_erc_721["token"]["address_hash"] |> String.downcase()]
 
       assert Decimal.to_integer(ctb_erc_1155["value"]) ==
                balances_erc_1155[
-                 {ctb_erc_1155["token"]["address"] |> String.downcase(), to_string(ctb_erc_1155["token_id"])}
+                 {ctb_erc_1155["token"]["address_hash"] |> String.downcase(), to_string(ctb_erc_1155["token_id"])}
                ]
     end
   end
@@ -4459,7 +4456,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
   defp compare_item(%Address{} = address, json) do
     assert Address.checksum(address.hash) == json["hash"]
-    assert to_string(address.transactions_count) == json["transaction_count"]
+    assert to_string(address.transactions_count) == json["transactions_count"]
   end
 
   defp compare_item(%Transaction{} = transaction, json) do
@@ -4510,12 +4507,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   end
 
   defp compare_item(%Token{} = token, json) do
-    assert Address.checksum(token.contract_address_hash) == json["address"]
+    assert Address.checksum(token.contract_address_hash) == json["address_hash"]
     assert to_string(token.symbol) == json["symbol"]
     assert to_string(token.name) == json["name"]
     assert to_string(token.type) == json["type"]
     assert to_string(token.decimals) == json["decimals"]
-    assert (token.holder_count && to_string(token.holder_count)) == json["holders"]
+    assert (token.holder_count && to_string(token.holder_count)) == json["holders_count"]
     assert Map.has_key?(json, "exchange_rate")
   end
 
@@ -4549,7 +4546,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
              "id" => ^id,
              "metadata" => ^metadata,
              "owner" => nil,
-             "token" => %{"address" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
+             "token" => %{"address_hash" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
              "external_app_url" => ^app_url,
              "animation_url" => ^animation_url,
              "image_url" => ^image_url,
@@ -4573,7 +4570,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     end)
 
     assert %{
-             "token" => %{"address" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
+             "token" => %{"address_hash" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
              "amount" => ^amount
            } = json
   end
@@ -4594,7 +4591,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     end)
 
     assert %{
-             "token" => %{"address" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
+             "token" => %{"address_hash" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
              "amount" => ^amount
            } = json
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -102,7 +102,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
       assert item["type"] == "address"
       assert item["name"] == name.name
-      assert item["address"] == Address.checksum(address.hash)
+      assert item["address_hash"] == Address.checksum(address.hash)
       assert item["url"] =~ Address.checksum(address.hash)
       assert item["is_smart_contract_verified"] == address.verified
     end
@@ -120,7 +120,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
       assert item["type"] == "contract"
       assert item["name"] == contract.name
-      assert item["address"] == Address.checksum(contract.address_hash)
+      assert item["address_hash"] == Address.checksum(contract.address_hash)
       assert item["url"] =~ Address.checksum(contract.address_hash)
       assert item["is_smart_contract_verified"] == true
     end
@@ -205,7 +205,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(labels_from_api)
              |> Enum.all?(fn {label, item} ->
                label.tag.display_name == item["name"] && item["type"] == "label" &&
-                 item["address"] == Address.checksum(label.address_hash)
+                 item["address_hash"] == Address.checksum(label.address_hash)
              end)
 
       tokens_from_api = Enum.slice(response_2["items"], 1, 49) ++ Enum.slice(response_3["items"], 0, 2)
@@ -214,7 +214,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(tokens_from_api)
              |> Enum.all?(fn {token, item} ->
                token.name == item["name"] && item["type"] == "token" &&
-                 item["address"] == Address.checksum(token.contract_address_hash)
+                 item["address_hash"] == Address.checksum(token.contract_address_hash)
              end)
 
       contracts_from_api = Enum.slice(response_3["items"], 2, 48) ++ response_4["items"]
@@ -223,7 +223,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(contracts_from_api)
              |> Enum.all?(fn {contract, item} ->
                contract.name == item["name"] && item["type"] == "contract" &&
-                 item["address"] == Address.checksum(contract.address_hash)
+                 item["address_hash"] == Address.checksum(contract.address_hash)
              end)
     end
 
@@ -278,7 +278,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(labels_from_api)
              |> Enum.all?(fn {label, item} ->
                label.tag.display_name == item["name"] && item["type"] == "label" &&
-                 item["address"] == Address.checksum(label.address_hash)
+                 item["address_hash"] == Address.checksum(label.address_hash)
              end)
 
       tokens_from_api = Enum.slice(response_2["items"], 1, 49) ++ Enum.slice(response_3["items"], 0, 2)
@@ -287,7 +287,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(tokens_from_api)
              |> Enum.all?(fn {token, item} ->
                token.name == item["name"] && item["type"] == "token" &&
-                 item["address"] == Address.checksum(token.contract_address_hash)
+                 item["address_hash"] == Address.checksum(token.contract_address_hash)
              end)
 
       contracts_from_api = Enum.slice(response_3["items"], 2, 48) ++ response_4["items"]
@@ -296,7 +296,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(contracts_from_api)
              |> Enum.all?(fn {contract, item} ->
                contract.name == item["name"] && item["type"] == "contract" &&
-                 item["address"] == Address.checksum(contract.address_hash)
+                 item["address_hash"] == Address.checksum(contract.address_hash)
              end)
     end
 
@@ -314,7 +314,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert item["type"] == "token"
       assert item["name"] == token.name
       assert item["symbol"] == token.symbol
-      assert item["address"] == Address.checksum(token.contract_address_hash)
+      assert item["address_hash"] == Address.checksum(token.contract_address_hash)
       assert item["token_url"] =~ Address.checksum(token.contract_address_hash)
       assert item["address_url"] =~ Address.checksum(token.contract_address_hash)
       assert item["token_type"] == token.type
@@ -339,7 +339,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert item["type"] == "token"
       assert item["name"] == token.name
       assert item["symbol"] == token.symbol
-      assert item["address"] == Address.checksum(token.contract_address_hash)
+      assert item["address_hash"] == Address.checksum(token.contract_address_hash)
       assert item["token_url"] =~ Address.checksum(token.contract_address_hash)
       assert item["address_url"] =~ Address.checksum(token.contract_address_hash)
       assert item["token_type"] == token.type
@@ -410,7 +410,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       item = Enum.at(response["items"], 0)
 
       assert item["type"] == "label"
-      assert item["address"] == Address.checksum(tag.address.hash)
+      assert item["address_hash"] == Address.checksum(tag.address.hash)
       assert item["name"] == tag.tag.display_name
       assert item["url"] =~ Address.checksum(tag.address.hash)
       assert item["is_smart_contract_verified"] == tag.address.verified
@@ -723,7 +723,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(labels_from_api)
              |> Enum.all?(fn {label, item} ->
                label.tag.display_name == item["name"] && item["type"] == "label" &&
-                 item["address"] == Address.checksum(label.address_hash)
+                 item["address_hash"] == Address.checksum(label.address_hash)
              end)
 
       tokens_from_api = Enum.slice(response_2["items"], 2, 48) ++ Enum.slice(response_3["items"], 0, 3)
@@ -732,7 +732,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(tokens_from_api)
              |> Enum.all?(fn {token, item} ->
                token.name == item["name"] && item["type"] == "token" &&
-                 item["address"] == Address.checksum(token.contract_address_hash)
+                 item["address_hash"] == Address.checksum(token.contract_address_hash)
              end)
 
       contracts_from_api = Enum.slice(response_4["items"], 5, 45) ++ response_5["items"]
@@ -741,7 +741,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(contracts_from_api)
              |> Enum.all?(fn {contract, item} ->
                contract.name == item["name"] && item["type"] == "contract" &&
-                 item["address"] == Address.checksum(contract.address_hash)
+                 item["address_hash"] == Address.checksum(contract.address_hash)
              end)
 
       metadata_tags_from_api = Enum.slice(response_3["items"], 3, 47) ++ Enum.slice(response_4["items"], 0, 5)
@@ -760,11 +760,11 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.all?(fn {{address_hash, tag}, api_item} ->
                tag["name"] == api_item["metadata"]["name"] && tag["slug"] == api_item["metadata"]["slug"] &&
                  api_item["type"] == "metadata_tag" &&
-                 api_item["address"] == address_hash
+                 api_item["address_hash"] == address_hash
              end)
 
       ens = Enum.at(response["items"], 0)
-      assert ens["address"] == to_string(ens_address)
+      assert ens["address_hash"] == to_string(ens_address)
       assert ens["ens_info"]["name"] == name
     end
 
@@ -1077,7 +1077,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(labels_from_api)
              |> Enum.all?(fn {label, item} ->
                label.tag.display_name == item["name"] && item["type"] == "label" &&
-                 item["address"] == Address.checksum(label.address_hash)
+                 item["address_hash"] == Address.checksum(label.address_hash)
              end)
 
       tokens_from_api = Enum.slice(response_2["items"], 2, 48) ++ Enum.slice(response_3["items"], 0, 3)
@@ -1086,7 +1086,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(tokens_from_api)
              |> Enum.all?(fn {token, item} ->
                token.name == item["name"] && item["type"] == "token" &&
-                 item["address"] == Address.checksum(token.contract_address_hash)
+                 item["address_hash"] == Address.checksum(token.contract_address_hash)
              end)
 
       contracts_from_api = Enum.slice(response_4["items"], 5, 45) ++ response_5["items"]
@@ -1095,7 +1095,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.zip(contracts_from_api)
              |> Enum.all?(fn {contract, item} ->
                contract.name == item["name"] && item["type"] == "contract" &&
-                 item["address"] == Address.checksum(contract.address_hash)
+                 item["address_hash"] == Address.checksum(contract.address_hash)
              end)
 
       metadata_tags_from_api = Enum.slice(response_3["items"], 3, 47) ++ Enum.slice(response_4["items"], 0, 5)
@@ -1114,11 +1114,11 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.all?(fn {{address_hash, tag}, api_item} ->
                tag["name"] == api_item["metadata"]["name"] && tag["slug"] == api_item["metadata"]["slug"] &&
                  api_item["type"] == "metadata_tag" &&
-                 api_item["address"] == address_hash
+                 api_item["address_hash"] == address_hash
              end)
 
       ens = Enum.at(response["items"], 0)
-      assert ens["address"] == to_string(ens_address)
+      assert ens["address_hash"] == to_string(ens_address)
       assert ens["ens_info"]["name"] == name
     end
 
@@ -1678,7 +1678,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
       operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
 
-      transaction = insert(:transaction, hash: operation_id)
+      insert(:transaction, hash: operation_id)
 
       tac_first_response = """
       {
@@ -1863,16 +1863,16 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert response = json_response(request, 200)
       assert Enum.count(response) == 50
 
-      assert response |> Enum.filter(fn x -> x["type"] == "label" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "label" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                tags |> Enum.reverse() |> Enum.take(16) |> Enum.map(fn tag -> Address.checksum(tag.address.hash) end)
 
-      assert response |> Enum.filter(fn x -> x["type"] == "contract" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "contract" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                contracts
                |> Enum.reverse()
                |> Enum.take(16)
                |> Enum.map(fn contract -> Address.checksum(contract.address_hash) end)
 
-      assert response |> Enum.filter(fn x -> x["type"] == "token" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "token" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                tokens
                |> Enum.reverse()
                |> Enum.sort_by(fn x -> x.is_verified_via_admin_panel end, :desc)
@@ -2010,25 +2010,26 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert response = json_response(request, 200)
       assert Enum.count(response) == 50
 
-      assert response |> Enum.filter(fn x -> x["type"] == "label" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "label" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                tags |> Enum.reverse() |> Enum.take(12) |> Enum.map(fn tag -> Address.checksum(tag.address.hash) end)
 
-      assert response |> Enum.filter(fn x -> x["type"] == "contract" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "contract" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                contracts
                |> Enum.reverse()
                |> Enum.take(12)
                |> Enum.map(fn contract -> Address.checksum(contract.address_hash) end)
 
-      assert response |> Enum.filter(fn x -> x["type"] == "token" end) |> Enum.map(fn x -> x["address"] end) ==
+      assert response |> Enum.filter(fn x -> x["type"] == "token" end) |> Enum.map(fn x -> x["address_hash"] end) ==
                tokens
                |> Enum.reverse()
                |> Enum.sort_by(fn x -> x.is_verified_via_admin_panel end, :desc)
                |> Enum.take(13)
                |> Enum.map(fn token -> Address.checksum(token.contract_address_hash) end)
 
-      assert response |> Enum.filter(fn x -> x["type"] == "ens_domain" end) |> Enum.map(fn x -> x["address"] end) == [
-               to_string(ens_address)
-             ]
+      assert response |> Enum.filter(fn x -> x["type"] == "ens_domain" end) |> Enum.map(fn x -> x["address_hash"] end) ==
+               [
+                 to_string(ens_address)
+               ]
 
       metadata_tags = response |> Enum.filter(fn x -> x["type"] == "metadata_tag" end)
 
@@ -2037,7 +2038,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert metadata_tags
              |> Enum.with_index()
              |> Enum.all?(fn {x, index} ->
-               x["address"] == to_string(address_1) && x["metadata"]["name"] == "#{name} #{index}"
+               x["address_hash"] == to_string(address_1) && x["metadata"]["name"] == "#{name} #{index}"
              end)
     end
 
@@ -2296,7 +2297,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
       correct_response = [
         %{
-          "address" => address_hash,
           "address_hash" => address_hash,
           "certified" => false,
           "ens_info" => nil,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -204,7 +204,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "implementations" => [
           %{
             "address_hash" => formatted_implementation_address_hash_string,
-            "address" => formatted_implementation_address_hash_string,
             "name" => nil
           }
         ],
@@ -514,7 +513,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "implementations" => [
           %{
             "address_hash" => Address.checksum(implementation_contract.address_hash),
-            "address" => Address.checksum(implementation_contract.address_hash),
             "name" => implementation_contract.name
           }
         ]
@@ -670,7 +668,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       "implementations" => [
         %{
           "address_hash" => formatted_implementation_address_hash_string,
-          "address" => formatted_implementation_address_hash_string,
           "name" => implementation_contract.name
         }
       ],
@@ -1119,7 +1116,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "implementations" => [
                      prepare_implementation(%{
                        "address_hash" => formatted_implementation_address_hash_string,
-                       "address" => formatted_implementation_address_hash_string,
                        "name" => nil
                      })
                    ],
@@ -1137,7 +1133,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "implementations" => [
                    %{
                      "address_hash" => ^formatted_implementation_address_hash_string,
-                     "address" => ^formatted_implementation_address_hash_string,
                      "name" => nil
                    }
                  ]
@@ -1238,7 +1233,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "implementations" => [
                      prepare_implementation(%{
                        "address_hash" => formatted_implementation_address_hash_string,
-                       "address" => formatted_implementation_address_hash_string,
                        "name" => nil
                      })
                    ],
@@ -1256,7 +1250,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "implementations" => [
                    %{
                      "address_hash" => ^formatted_implementation_address_hash_string,
-                     "address" => ^formatted_implementation_address_hash_string,
                      "name" => nil
                    }
                  ]
@@ -1357,7 +1350,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                    "implementations" => [
                      prepare_implementation(%{
                        "address_hash" => formatted_implementation_address_hash_string,
-                       "address" => formatted_implementation_address_hash_string,
                        "name" => nil
                      })
                    ],
@@ -1375,7 +1367,6 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
                  "implementations" => [
                    %{
                      "address_hash" => ^formatted_implementation_address_hash_string,
-                     "address" => ^formatted_implementation_address_hash_string,
                      "name" => nil
                    }
                  ]
@@ -1787,7 +1778,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     Enum.map(items, &prepare_implementation/1)
   end
 
-  defp prepare_implementation(%{"address" => _, "name" => _} = implementation) do
+  defp prepare_implementation(%{"address_hash" => _, "name" => _} = implementation) do
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         Map.put(implementation, "filecoin_robust_address", nil)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -497,7 +497,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       tokens_ordered_by_holders = Enum.sort(tokens, &(&1.holder_count <= &2.holder_count))
 
       request_ordered_by_holders =
-        get(conn, "/api/v2/tokens", additional_params |> Map.merge(%{"sort" => "holder_count", "order" => "desc"}))
+        get(conn, "/api/v2/tokens", additional_params |> Map.merge(%{"sort" => "holders_count", "order" => "desc"}))
 
       assert response_ordered_by_holders = json_response(request_ordered_by_holders, 200)
 
@@ -506,7 +506,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
           conn,
           "/api/v2/tokens",
           additional_params
-          |> Map.merge(%{"sort" => "holder_count", "order" => "desc"})
+          |> Map.merge(%{"sort" => "holders_count", "order" => "desc"})
           |> Map.merge(response_ordered_by_holders["next_page_params"])
         )
 
@@ -521,7 +521,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       tokens_ordered_by_holders_asc = Enum.sort(tokens, &(&1.holder_count >= &2.holder_count))
 
       request_ordered_by_holders_asc =
-        get(conn, "/api/v2/tokens", additional_params |> Map.merge(%{"sort" => "holder_count", "order" => "asc"}))
+        get(conn, "/api/v2/tokens", additional_params |> Map.merge(%{"sort" => "holders_count", "order" => "asc"}))
 
       assert response_ordered_by_holders_asc = json_response(request_ordered_by_holders_asc, 200)
 
@@ -530,7 +530,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
           conn,
           "/api/v2/tokens",
           additional_params
-          |> Map.merge(%{"sort" => "holder_count", "order" => "asc"})
+          |> Map.merge(%{"sort" => "holders_count", "order" => "asc"})
           |> Map.merge(response_ordered_by_holders_asc["next_page_params"])
         )
 
@@ -2312,14 +2312,14 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
   end
 
   def compare_item(%Token{} = token, json) do
-    assert Address.checksum(token.contract_address.hash) == json["address"]
+    assert Address.checksum(token.contract_address.hash) == json["address_hash"]
     assert token.symbol == json["symbol"]
     assert token.name == json["name"]
     assert to_string(token.decimals) == json["decimals"]
     assert token.type == json["type"]
 
-    assert (is_nil(token.holder_count) and is_nil(json["holders"])) or
-             (to_string(token.holder_count) == json["holders"] and !is_nil(token.holder_count))
+    assert (is_nil(token.holder_count) and is_nil(json["holders_count"])) or
+             (to_string(token.holder_count) == json["holders_count"] and !is_nil(token.holder_count))
 
     assert to_string(token.total_supply) == json["total_supply"]
     assert Map.has_key?(json, "exchange_rate")
@@ -2360,7 +2360,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
              "value" => ^value,
              "id" => ^id,
              "metadata" => ^metadata,
-             "token" => %{"address" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
+             "token" => %{"address_hash" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
              "external_app_url" => ^app_url,
              "animation_url" => ^animation_url,
              "image_url" => ^image_url,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -1265,7 +1265,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                    %{
                      "celo" => %{
                        "gas_token" => %{
-                         "address" => ^token_address_hash,
+                         "address_hash" => ^token_address_hash,
                          "name" => ^token_name,
                          "symbol" => ^token_symbol,
                          "type" => ^token_type
@@ -1280,7 +1280,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         assert %{
                  "celo" => %{
                    "gas_token" => %{
-                     "address" => ^token_address_hash,
+                     "address_hash" => ^token_address_hash,
                      "name" => ^token_name,
                      "symbol" => ^token_symbol,
                      "type" => ^token_type
@@ -1295,7 +1295,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                    %{
                      "celo" => %{
                        "gas_token" => %{
-                         "address" => ^token_address_hash,
+                         "address_hash" => ^token_address_hash,
                          "name" => ^token_name,
                          "symbol" => ^token_symbol,
                          "type" => ^token_type
@@ -1311,7 +1311,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  %{
                    "celo" => %{
                      "gas_token" => %{
-                       "address" => ^token_address_hash,
+                       "address_hash" => ^token_address_hash,
                        "name" => ^token_name,
                        "symbol" => ^token_symbol,
                        "type" => ^token_type
@@ -1338,7 +1338,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                    %{
                      "celo" => %{
                        "gas_token" => %{
-                         "address" => ^unknown_token_address_hash
+                         "address_hash" => ^unknown_token_address_hash
                        }
                      }
                    }
@@ -1350,7 +1350,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         assert %{
                  "celo" => %{
                    "gas_token" => %{
-                     "address" => ^unknown_token_address_hash
+                     "address_hash" => ^unknown_token_address_hash
                    }
                  }
                } = json_response(request, 200)
@@ -1362,7 +1362,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                    %{
                      "celo" => %{
                        "gas_token" => %{
-                         "address" => ^unknown_token_address_hash
+                         "address_hash" => ^unknown_token_address_hash
                        }
                      }
                    }
@@ -1375,7 +1375,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  %{
                    "celo" => %{
                      "gas_token" => %{
-                       "address" => ^unknown_token_address_hash
+                       "address_hash" => ^unknown_token_address_hash
                      }
                    }
                  }
@@ -1491,7 +1491,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  "items" => [
                    %{
                      "stability_fee" => %{
-                       "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                       "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                        "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                        "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                        "total_fee" => "44136000000000",
@@ -1506,7 +1506,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
         assert %{
                  "stability_fee" => %{
-                   "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                   "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                    "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                    "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                    "total_fee" => "44136000000000",
@@ -1521,7 +1521,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  "items" => [
                    %{
                      "stability_fee" => %{
-                       "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                       "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                        "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                        "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                        "total_fee" => "44136000000000",
@@ -1553,7 +1553,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  "items" => [
                    %{
                      "stability_fee" => %{
-                       "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                       "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                        "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                        "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                        "total_fee" => "44136000000000",
@@ -1568,7 +1568,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
         assert %{
                  "stability_fee" => %{
-                   "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                   "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                    "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                    "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                    "total_fee" => "44136000000000",
@@ -1583,7 +1583,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  "items" => [
                    %{
                      "stability_fee" => %{
-                       "token" => %{"address" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
+                       "token" => %{"address_hash" => "0xDc2B93f3291030F3F7a6D9363ac37757f7AD5C43"},
                        "validator_address" => %{"hash" => "0x46B555CB3962bF9533c437cBD04A2f702dfdB999"},
                        "dapp_address" => %{"hash" => "0xFAf7a981360c2FAb3a5Ab7b3D6d8D0Cf97a91Eb9"},
                        "total_fee" => "44136000000000",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
@@ -179,10 +179,10 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
         request = get(conn, "/api/v2/validators/stability/counters")
 
         assert %{
-                 "active_validators_counter" => "3",
+                 "active_validators_count" => "3",
                  "active_validators_percentage" => ^percentage,
-                 "new_validators_counter_24h" => "6",
-                 "validators_counter" => "9"
+                 "new_validators_count_24h" => "6",
+                 "validators_count" => "9"
                } = json_response(request, 200)
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/withdrawal_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/withdrawal_controller_test.exs
@@ -43,8 +43,8 @@ defmodule BlockScoutWeb.API.V2.WithdrawalControllerTest do
       request = get(conn, "/api/v2/withdrawals/counters")
 
       assert %{
-               "withdrawal_count" => _,
-               "withdrawal_sum" => _
+               "withdrawals_count" => _,
+               "withdrawals_sum" => _
              } = json_response(request, 200)
     end
   end

--- a/apps/explorer/lib/explorer/arbitrum/claim_rollup_message.ex
+++ b/apps/explorer/lib/explorer/arbitrum/claim_rollup_message.ex
@@ -419,11 +419,7 @@ defmodule Explorer.Arbitrum.ClaimRollupMessage do
 
     %{
       address_hash: token_bin,
-      # todo: "address" should be removed in favour `address_hash` property with the next release after 8.0.0
-      address: token_bin,
       destination_address_hash: to_bin,
-      # todo: "destination" should be removed in favour `destination_address_hash` property with the next release after 8.0.0
-      destination: to_bin,
       amount: amount,
       decimals: token_info.decimals,
       name: token_info.name,

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -249,7 +249,7 @@ defmodule Explorer.Chain.Address.Counters do
       end)
 
     Task.start_link(fn ->
-      transaction_count(address)
+      transactions_count(address)
     end)
 
     Task.start_link(fn ->
@@ -279,7 +279,7 @@ defmodule Explorer.Chain.Address.Counters do
     |> List.to_tuple()
   end
 
-  def transaction_count(address) do
+  def transactions_count(address) do
     AddressTransactionsCount.fetch(address)
   end
 

--- a/apps/explorer/lib/explorer/chain/blackfort/validator.ex
+++ b/apps/explorer/lib/explorer/chain/blackfort/validator.ex
@@ -163,31 +163,35 @@ defmodule Explorer.Chain.Blackfort.Validator do
   defp parse_validators_info({:ok, validators}) do
     {:ok,
      validators
-     |> Enum.map(fn %{
-                      "address" => address_hash_string,
-                      "name" => name,
-                      "commission" => commission,
-                      "self_bonded_amount" => self_bonded_amount,
-                      "delegated_amount" => delegated_amount,
-                      "slashing_status" => %{
-                        "is_slashed" => slashing_status_is_slashed,
-                        "by_block" => slashing_status_by_block,
-                        "multiplier" => slashing_status_multiplier
-                      }
-                    } ->
-       {:ok, address_hash} = HashAddress.cast(address_hash_string)
+     |> Enum.map(
+       # todo: remove it in favour `address_hash` when the frontend is bound to the new filed (create the task to frontend repo).
+       fn %{
+            "address_hash" => address_hash_string,
+            "address" => address_hash_string,
+            "name" => name,
+            "commission" => commission,
+            "self_bonded_amount" => self_bonded_amount,
+            "delegated_amount" => delegated_amount,
+            "slashing_status" => %{
+              "is_slashed" => slashing_status_is_slashed,
+              "by_block" => slashing_status_by_block,
+              "multiplier" => slashing_status_multiplier
+            }
+          } ->
+         {:ok, address_hash} = HashAddress.cast(address_hash_string)
 
-       %{
-         address_hash: address_hash,
-         name: name,
-         commission: parse_number(commission),
-         self_bonded_amount: parse_number(self_bonded_amount),
-         delegated_amount: parse_number(delegated_amount),
-         slashing_status_is_slashed: slashing_status_is_slashed,
-         slashing_status_by_block: slashing_status_by_block,
-         slashing_status_multiplier: slashing_status_multiplier
-       }
-     end)}
+         %{
+           address_hash: address_hash,
+           name: name,
+           commission: parse_number(commission),
+           self_bonded_amount: parse_number(self_bonded_amount),
+           delegated_amount: parse_number(delegated_amount),
+           slashing_status_is_slashed: slashing_status_is_slashed,
+           slashing_status_by_block: slashing_status_by_block,
+           slashing_status_multiplier: slashing_status_multiplier
+         }
+       end
+     )}
   end
 
   defp parse_validators_info({:error, error}) do

--- a/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/frame_sequence.ex
@@ -107,7 +107,7 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
     if not is_nil(batch) do
       l2_block_number_from = TransactionBatch.edge_l2_block_number(internal_id, :min)
       l2_block_number_to = TransactionBatch.edge_l2_block_number(internal_id, :max)
-      transaction_count = Transaction.transaction_count_for_block_range(l2_block_number_from..l2_block_number_to)
+      transactions_count = Transaction.transaction_count_for_block_range(l2_block_number_from..l2_block_number_to)
 
       {batch_data_container, blobs} =
         if Keyword.get(options, :include_blobs?, true) do
@@ -121,7 +121,7 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
           internal_id,
           l2_block_number_from,
           l2_block_number_to,
-          transaction_count,
+          transactions_count,
           batch_data_container,
           batch
         )
@@ -144,7 +144,7 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
     - `internal_id`: The internal ID of the batch.
     - `l2_block_number_from`: Start L2 block number of the batch block range.
     - `l2_block_number_to`: End L2 block number of the batch block range.
-    - `transaction_count`: The L2 transaction count included into the blocks of the range.
+    - `transactions_count`: The L2 transaction count included into the blocks of the range.
     - `batch_data_container`: Designates where the batch info is stored: :in_blob4844, :in_celestia, or :in_calldata.
                               Can be `nil` if the container is unknown.
     - `batch`: Either an `Explorer.Chain.Optimism.FrameSequence` entry or a map with
@@ -163,14 +163,10 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
           | %{:l1_timestamp => DateTime.t(), :l1_transaction_hashes => list(), optional(any()) => any()}
         ) :: %{
           :number => non_neg_integer(),
-          :internal_id => non_neg_integer(),
           :l1_timestamp => DateTime.t(),
           :l2_start_block_number => non_neg_integer(),
-          :l2_block_start => non_neg_integer(),
           :l2_end_block_number => non_neg_integer(),
-          :l2_block_end => non_neg_integer(),
           :transactions_count => non_neg_integer(),
-          :transaction_count => non_neg_integer(),
           :l1_transaction_hashes => list(),
           :batch_data_container => :in_blob4844 | :in_celestia | :in_calldata | nil
         }
@@ -178,24 +174,16 @@ defmodule Explorer.Chain.Optimism.FrameSequence do
         internal_id,
         l2_block_number_from,
         l2_block_number_to,
-        transaction_count,
+        transactions_count,
         batch_data_container,
         batch
       ) do
     %{
       :number => internal_id,
-      # todo: "internal_id" should be removed in favour `number` property with the next release after 8.0.0
-      :internal_id => internal_id,
       :l1_timestamp => batch.l1_timestamp,
       :l2_start_block_number => l2_block_number_from,
-      # todo: It should be removed in favour `l2_start_block_number` property with the next release after 8.0.0
-      :l2_block_start => l2_block_number_from,
       :l2_end_block_number => l2_block_number_to,
-      # todo: It should be removed in favour `l2_end_block_number` property with the next release after 8.0.0
-      :l2_block_end => l2_block_number_to,
-      :transactions_count => transaction_count,
-      # todo: It should be removed in favour `transactions_count` property with the next release after 8.0.0
-      :transaction_count => transaction_count,
+      :transactions_count => transactions_count,
       :l1_transaction_hashes => batch.l1_transaction_hashes,
       :batch_data_container => batch_data_container
     }

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -825,9 +825,7 @@ defmodule Explorer.Chain.Search do
                "circulating_market_cap" => circulating_market_cap,
                "fiat_value" => fiat_value,
                "is_verified_via_admin_panel" => is_verified_via_admin_panel,
-               "holders_count" => holder_count,
-               # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-               "holder_count" => holder_count,
+               "holder_count" => holders_count,
                "name" => name,
                "inserted_at" => inserted_at
              }
@@ -843,7 +841,7 @@ defmodule Explorer.Chain.Search do
           circulating_market_cap: parse_possible_nil(circulating_market_cap),
           fiat_value: parse_possible_nil(fiat_value),
           is_verified_via_admin_panel: parse_possible_nil(is_verified_via_admin_panel),
-          holder_count: parse_possible_nil(holder_count),
+          holder_count: parse_possible_nil(holders_count),
           name: name,
           inserted_at: inserted_at
         },
@@ -1153,7 +1151,7 @@ defmodule Explorer.Chain.Search do
            circulating_market_cap: circulating_market_cap,
            exchange_rate: exchange_rate,
            is_verified_via_admin_panel: is_verified_via_admin_panel,
-           holder_count: holder_count,
+           holder_count: holders_count,
            name: name,
            inserted_at: inserted_at,
            type: "token"
@@ -1166,9 +1164,7 @@ defmodule Explorer.Chain.Search do
       "circulating_market_cap" => circulating_market_cap,
       "fiat_value" => exchange_rate,
       "is_verified_via_admin_panel" => is_verified_via_admin_panel,
-      "holders_count" => holder_count,
-      # todo: It should be removed in favour `holders_count` property with the next release after 8.0.0
-      "holder_count" => holder_count,
+      "holder_count" => holders_count,
       "name" => name,
       "inserted_at" => inserted_at_datetime
     }

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -499,10 +499,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
       case address do
         %Hash{} = address_hash ->
           [
-            # todo: "address" should be removed in favour `address_hash` property with the next release after 8.0.0 + UPDATE PATTERN MATCHING in `chain_type_fields()` function
             %{
               "address_hash" => Address.checksum(address_hash),
-              "address" => Address.checksum(address_hash),
               "name" => name
             }
             |> chain_type_fields(implementations_info)
@@ -513,8 +511,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
           with {:ok, address_hash} <- string_to_address_hash(address),
                checksummed_address <- Address.checksum(address_hash) do
             [
-              # todo: "address" should be removed in favour `address_hash` property with the next release after 8.0.0 + UPDATE PATTERN MATCHING in `chain_type_fields()` function
-              %{"address_hash" => checksummed_address, "address" => checksummed_address, "name" => name}
+              %{"address_hash" => checksummed_address, "name" => name}
               |> chain_type_fields(implementations_info)
               | acc
             ]
@@ -526,7 +523,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   end
 
   if @chain_type == :filecoin do
-    def chain_type_fields(%{"address" => address_hash} = address, implementations_info) do
+    def chain_type_fields(%{"address_hash" => address_hash} = address, implementations_info) do
       Map.put(address, "filecoin_robust_address", implementations_info[address_hash])
     end
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -409,13 +409,13 @@ defmodule Explorer.Chain.Token do
     It used by Explorer.Chain.Cache.Counters.TokenHoldersCount module.
   """
   @spec update_token_holder_count(Hash.Address.t(), integer()) :: {non_neg_integer(), nil}
-  def update_token_holder_count(contract_address_hash, holder_count) when not is_nil(holder_count) do
+  def update_token_holder_count(contract_address_hash, holders_count) when not is_nil(holders_count) do
     now = DateTime.utc_now()
 
     Repo.update_all(
       from(t in __MODULE__,
         where: t.contract_address_hash == ^contract_address_hash,
-        update: [set: [holder_count: ^holder_count, updated_at: ^now]]
+        update: [set: [holder_count: ^holders_count, updated_at: ^now]]
       ),
       [],
       timeout: @timeout

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -518,9 +518,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
           :transfers_count => String.t(),
           :holders_count => String.t()
         }
-  def prepare_token_counters_for_queue(transfer_count, holder_count) do
+  def prepare_token_counters_for_queue(transfers_count, holders_count) do
     if enabled?() do
-      %{transfers_count: to_string(transfer_count), holders_count: to_string(holder_count)}
+      %{transfers_count: to_string(transfers_count), holders_count: to_string(holders_count)}
     else
       %{}
     end

--- a/apps/explorer/test/explorer/chain/cache/counters/transactions_24h_count_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/counters/transactions_24h_count_test.exs
@@ -50,11 +50,11 @@ defmodule Explorer.Chain.Cache.Counters.Transactions24hCountTest do
     start_supervised!(Transactions24hCount)
     Transactions24hCount.consolidate()
 
-    transaction_count = Transactions24hCount.fetch_count([])
+    transactions_count = Transactions24hCount.fetch_count([])
     transaction_fee_sum = Transactions24hCount.fetch_fee_sum([])
     transaction_fee_average = Transactions24hCount.fetch_fee_average([])
 
-    assert transaction_count == Decimal.new("3")
+    assert transactions_count == Decimal.new("3")
     assert transaction_fee_sum == Decimal.new("35000")
     assert transaction_fee_average == Decimal.new("11667")
   end

--- a/apps/indexer/lib/indexer/fetcher/token_counters_updater.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_counters_updater.ex
@@ -63,9 +63,9 @@ defmodule Indexer.Fetcher.TokenCountersUpdater do
 
     entries
     |> Enum.reduce(%{}, fn token, acc ->
-      {transfer_count, holder_count} = Chain.fetch_token_counters(token.contract_address_hash, :infinity)
+      {transfers_count, holders_count} = Chain.fetch_token_counters(token.contract_address_hash, :infinity)
 
-      data_for_multichain = MultichainSearch.prepare_token_counters_for_queue(transfer_count, holder_count)
+      data_for_multichain = MultichainSearch.prepare_token_counters_for_queue(transfers_count, holders_count)
       Map.put(acc, token.contract_address_hash.bytes, data_for_multichain)
     end)
     |> MultichainSearch.send_token_info_to_queue(:counters)


### PR DESCRIPTION
## Motivation

Remove obsolete API response props which courrently have sibling which follows API naming policy.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated and duplicate fields from API responses and JSON outputs across multiple modules, simplifying data structures and reducing redundancy.
  * Unified and streamlined health status and batch information representations.
  * Updated internal logic to use only the latest, preferred field names in all relevant endpoints and views.
  * Eliminated legacy aliases and deprecated keys from search, token, contract, validator, withdrawal, and batch-related endpoints.
  * Updated test suites to reflect changes in JSON response key names, ensuring consistency with the new data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->