### PR TITLE
chore: Empty trace_address value in the `internal_transactions` table

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/transaction_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/transaction_test.exs
@@ -198,7 +198,7 @@ defmodule BlockScoutWeb.GraphQL.Schema.Query.TransactionTest do
                            "init" => to_string(internal_transaction.init),
                            "input" => nil,
                            "output" => nil,
-                           "trace_address" => Jason.encode!(internal_transaction.trace_address),
+                           "trace_address" => internal_transaction.trace_address,
                            "type" => internal_transaction.type |> to_string() |> String.upcase(),
                            "value" => to_string(internal_transaction.value.value),
                            "block_number" => internal_transaction.block_number,

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -141,7 +141,8 @@ for migrator <- [
       Explorer.Migrator.ReindexDuplicatedInternalTransactions,
       Explorer.Migrator.MergeAdjacentMissingBlockRanges,
       Explorer.Migrator.UnescapeQuotesInTokens,
-      Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources
+      Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources,
+      Explorer.Migrator.EmptyInternalTransactionsTraceAddress
     ] do
   config :explorer, migrator, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -76,6 +76,7 @@ for migrator <- [
       Explorer.Migrator.UnescapeQuotesInTokens,
       Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources,
       Explorer.Migrator.DeleteZeroValueInternalTransactions,
+      Explorer.Migrator.EmptyInternalTransactionsTraceAddress,
 
       # Heavy DB index operations
       Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -174,6 +174,7 @@ defmodule Explorer.Application do
         |> configure_multichain_search_microservice(),
         configure_mode_dependent_process(Explorer.Migrator.ArbitrumDaRecordsNormalization, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.ShrinkInternalTransactions, :indexer),
+        configure_mode_dependent_process(Explorer.Migrator.EmptyInternalTransactionsTraceAddress, :indexer),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.Counters.Blackfort.ValidatorsCount, :blackfort),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.Counters.Stability.ValidatorsCount, :stability),
         configure_chain_type_dependent_process(Explorer.Chain.Cache.LatestL1BlockNumber, [

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -239,7 +239,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
        when is_list(valid_internal_transactions) do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
-    ordered_changes_list = Enum.sort_by(valid_internal_transactions, &{&1.transaction_hash, &1.index})
+    ordered_changes_list =
+      valid_internal_transactions
+      |> Enum.map(fn internal_transaction ->
+        Map.put(internal_transaction, :trace_address, nil)
+      end)
+      |> Enum.sort_by(&{&1.transaction_hash, &1.index})
 
     {:ok, internal_transactions} =
       Import.insert_changes_list(
@@ -274,7 +279,6 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
           input: fragment("EXCLUDED.input"),
           output: fragment("EXCLUDED.output"),
           to_address_hash: fragment("EXCLUDED.to_address_hash"),
-          trace_address: fragment("EXCLUDED.trace_address"),
           transaction_hash: fragment("EXCLUDED.transaction_hash"),
           transaction_index: fragment("EXCLUDED.transaction_index"),
           type: fragment("EXCLUDED.type"),

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -418,7 +418,7 @@ defmodule Explorer.Chain.InternalTransaction do
   end
 
   @call_optional_fields ~w(error gas_used output block_number transaction_index)a
-  @call_required_fields ~w(call_type from_address_hash gas index input to_address_hash trace_address transaction_hash value)a
+  @call_required_fields ~w(call_type from_address_hash gas index input to_address_hash transaction_hash value)a
   @call_allowed_fields @call_optional_fields ++ @call_required_fields
 
   defp type_changeset(changeset, attrs, :call) do
@@ -434,7 +434,7 @@ defmodule Explorer.Chain.InternalTransaction do
   end
 
   @create_optional_fields ~w(error created_contract_code created_contract_address_hash gas_used block_number transaction_index)a
-  @create_required_fields ~w(from_address_hash gas index init trace_address transaction_hash value)a
+  @create_required_fields ~w(from_address_hash gas index init transaction_hash value)a
   @create_allowed_fields @create_optional_fields ++ @create_required_fields
 
   defp type_changeset(changeset, attrs, type) when type in [:create, :create2] do
@@ -449,7 +449,7 @@ defmodule Explorer.Chain.InternalTransaction do
   end
 
   @selfdestruct_optional_fields ~w(block_number transaction_index)a
-  @selfdestruct_required_fields ~w(from_address_hash index to_address_hash trace_address transaction_hash type value)a
+  @selfdestruct_required_fields ~w(from_address_hash index to_address_hash transaction_hash type value)a
   @selfdestruct_allowed_fields @selfdestruct_optional_fields ++ @selfdestruct_required_fields
 
   defp type_changeset(changeset, attrs, :selfdestruct) do
@@ -460,7 +460,7 @@ defmodule Explorer.Chain.InternalTransaction do
   end
 
   @stop_optional_fields ~w(from_address_hash gas gas_used error)a
-  @stop_required_fields ~w(block_number transaction_hash transaction_index index type value trace_address)a
+  @stop_required_fields ~w(block_number transaction_hash transaction_index index type value)a
   @stop_allowed_fields @stop_optional_fields ++ @stop_required_fields
 
   defp type_changeset(changeset, attrs, :stop) do

--- a/apps/explorer/lib/explorer/migrator/empty_internal_transactions_trace_address.ex
+++ b/apps/explorer/lib/explorer/migrator/empty_internal_transactions_trace_address.ex
@@ -1,0 +1,69 @@
+defmodule Explorer.Migrator.EmptyInternalTransactionsTraceAddress do
+  @moduledoc """
+  Searches for all internal transactions with non-empty trace_address and empties it.
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Ecto.Multi
+  alias Explorer.Chain.InternalTransaction
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "empty_internal_transactions_trace_address"
+
+  @fields ~w(block_hash transaction_index index)a
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(state) do
+    limit = batch_size() * concurrency()
+
+    internal_transactions =
+      unprocessed_data_query()
+      |> select([it], ^@fields)
+      |> limit(^limit)
+      |> Repo.all(timeout: :infinity)
+
+    {internal_transactions, state}
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    from(
+      internal_transaction in InternalTransaction,
+      where: not is_nil(internal_transaction.trace_address)
+    )
+  end
+
+  # sobelow_skip ["DOS.StringToAtom"]
+  @impl FillingMigration
+  def update_batch(internal_transactions) do
+    update_transaction =
+      internal_transactions
+      |> Enum.with_index()
+      |> Enum.reduce(Multi.new(), fn {internal_transaction, ind}, acc ->
+        acc
+        |> Multi.update_all(
+          String.to_atom("update_internal_transactions_trace_address_#{ind}"),
+          from(
+            it in InternalTransaction,
+            where: it.block_hash == ^internal_transaction.block_hash,
+            where: it.transaction_index == ^internal_transaction.transaction_index,
+            where: it.index == ^internal_transaction.index
+          ),
+          set: [trace_address: nil]
+        )
+      end)
+
+    update_transaction
+    |> Repo.transact()
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+end

--- a/apps/explorer/priv/repo/migrations/20250808104827_internal_transactions_trace_address_drop_not_null_constraint.exs
+++ b/apps/explorer/priv/repo/migrations/20250808104827_internal_transactions_trace_address_drop_not_null_constraint.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.InternalTransactionsTraceAddressDropNotNullConstraint do
+  use Ecto.Migration
+
+  def up do
+    alter table(:internal_transactions) do
+      modify(:trace_address, {:array, :integer}, null: true)
+    end
+  end
+
+  def down do
+    alter table(:internal_transactions) do
+      modify(:trace_address, {:array, :integer}, null: false)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1224,7 +1224,7 @@ defmodule Explorer.ChainTest do
                           231, 234, 137, 179, 40, 255, 234, 134, 26, 179, 239>>
                     },
                     output: %Data{bytes: ""},
-                    trace_address: [],
+                    trace_address: nil,
                     type: :call,
                     block_number: 37,
                     transaction_index: nil,

--- a/apps/explorer/test/explorer/migrator/empty_internal_transactions_trace_address.exs
+++ b/apps/explorer/test/explorer/migrator/empty_internal_transactions_trace_address.exs
@@ -1,0 +1,43 @@
+defmodule Explorer.Migrator.EmptyInternalTransactionsTraceAddressTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.InternalTransaction
+  alias Explorer.Migrator.{EmptyInternalTransactionsTraceAddress, MigrationStatus}
+  alias Explorer.Repo
+
+  describe "EmptyInternalTransactionsTraceAddress" do
+    test "Empties internal transactions trace_address" do
+      Enum.each(1..5, fn i ->
+        block = insert(:block)
+        transaction = :transaction |> insert() |> with_block(block, status: :ok)
+
+        insert(:internal_transaction,
+          index: 10,
+          transaction: transaction,
+          block: block,
+          block_number: block.number,
+          block_index: i,
+          transaction_index: 0,
+          error: nil,
+          trace_address: []
+        )
+      end)
+
+      assert MigrationStatus.get_status("empty_internal_transactions_trace_address") == nil
+      assert Repo.aggregate(InternalTransaction, :count) == 5
+
+      EmptyInternalTransactionsTraceAddress.start_link([])
+      Process.sleep(100)
+
+      trace_addresses =
+        InternalTransaction
+        |> Repo.all()
+        |> Enum.map(& &1.trace_address)
+        |> Enum.uniq()
+
+      assert [nil] == trace_addresses
+
+      assert MigrationStatus.get_status("empty_internal_transactions_trace_address") == "completed"
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -833,7 +833,7 @@ defmodule Explorer.Factory do
       input: %Data{bytes: <<1>>},
       output: %Data{bytes: <<2>>},
       # caller MUST supply `index`
-      trace_address: [],
+      trace_address: nil,
       # caller MUST supply `transaction` because it can't be built lazily to allow overrides without creating an extra
       # transaction
       # caller MUST supply `block_hash` (usually the same as the transaction's)
@@ -857,7 +857,7 @@ defmodule Explorer.Factory do
       gas_used: gas_used,
       # caller MUST supply `index`
       init: data(:internal_transaction_init),
-      trace_address: [],
+      trace_address: nil,
       # caller MUST supply `transaction` because it can't be built lazily to allow overrides without creating an extra
       # transaction
       # caller MUST supply `block_hash` (usually the same as the transaction's)
@@ -870,7 +870,7 @@ defmodule Explorer.Factory do
   def internal_transaction_selfdestruct_factory() do
     %InternalTransaction{
       from_address: build(:address),
-      trace_address: [],
+      trace_address: nil,
       # caller MUST supply `transaction` because it can't be built lazily to allow overrides without creating an extra
       # transaction
       type: :selfdestruct,


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/12874

## Changelog

### AI Agent summary

This pull request introduces a migration to clean up and standardize the `trace_address` field in internal transactions by setting it to `nil` when empty, and updates the schema, migration logic, and related test and factory code to reflect this change. It also adds a new migrator to automate this process and modifies the database constraint to allow `trace_address` to be nullable. The changes ensure consistency across the codebase and improve data integrity for internal transactions.

**Migration and Schema Updates**

* Added a new migrator `Explorer.Migrator.EmptyInternalTransactionsTraceAddress` that finds all internal transactions with a non-empty `trace_address` and sets it to `nil`. This migrator is now enabled in configuration and started as part of the application supervision tree. [[1]](diffhunk://#diff-87e728e34fd998bc6072d6ce99c7cffd559e83ffd9ba5362428c1e9ad46225c6R1-R69) [[2]](diffhunk://#diff-6b55dcfaff9da4493d035ae7761adde966eeb3c49a5e7fe6fe3bbbe51f554a34L137-R138) [[3]](diffhunk://#diff-2a7b515158d1020b750590c83542d598a8e744d5fa2c2bbd6bceaa9dc36e4f84R76) [[4]](diffhunk://#diff-7cee1d60caaf8c01dd15bd0a6dc52794001768b02b995eea1752e64ea3b0a287R171)
* Introduced a database migration to drop the NOT NULL constraint on the `trace_address` column, allowing it to be nullable.

**Internal Transaction Model and Import Logic**

* Removed `trace_address` from required fields in all internal transaction types and updated import logic to explicitly set `trace_address` to `nil` for new internal transactions. [[1]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cL417-R417) [[2]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cL433-R433) [[3]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cL448-R448) [[4]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cL459-R459) [[5]](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211L232-R237)

**Testing and Factory Adjustments**

* Updated factories and tests to use `trace_address: nil` instead of an empty array, and removed helper functions that previously set `trace_address` to an empty list. [[1]](diffhunk://#diff-825aca4935bfc3fc143527f3ba20ccbdef83e5b5e20d1638c400e1a18dfa90e4L800-R800) [[2]](diffhunk://#diff-825aca4935bfc3fc143527f3ba20ccbdef83e5b5e20d1638c400e1a18dfa90e4L824-R824) [[3]](diffhunk://#diff-825aca4935bfc3fc143527f3ba20ccbdef83e5b5e20d1638c400e1a18dfa90e4L837-R837) [[4]](diffhunk://#diff-b5537bec41cd3aeeafc1fc4d1045904cdfb63fd87228df177d24c2251f226899L1326-R1326) [[5]](diffhunk://#diff-d623035c064645f64e06ee02e1f2e012734b202913756d9e450083c6c48ea066L1092-L1139) [[6]](diffhunk://#diff-1cadeb102bf0b3fe2ce109c8f67f717f33996bdfc2d4c750525704a8f2fb5e52R1-R43)

**GraphQL and API Consistency**

* Modified GraphQL transaction tests to expect the raw value of `trace_address` instead of its JSON-encoded form, aligning with the new data format.

**Minor Cleanups**

* Removed unused aliases and made minor improvements in test modules for clarity and consistency. [[1]](diffhunk://#diff-d623035c064645f64e06ee02e1f2e012734b202913756d9e450083c6c48ea066L4-L9) [[2]](diffhunk://#diff-0a99a2dd86da6ab87f2eb051545433e8346cd4a801779564cb217c8279b7e684L4) [[3]](diffhunk://#diff-4bc6fecb1bae7913d0455d3987d54e2651101811da5c1f7ca8c3fae381d435adL239-R239)

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a background migration to clear the trace address field for internal transactions where present.
  * Added a database migration allowing the trace address field to be nullable.

* **Bug Fixes**
  * Updated internal transaction handling to ensure the trace address field is consistently set to nil when not present.
  * Adjusted validations to no longer require the trace address field for certain internal transaction types.

* **Tests**
  * Added tests to verify the migration that clears the trace address field.
  * Updated test data and factories to reflect changes in the trace address field handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->