### PR TITLE
Fix RangesHelper.sanitize_ranges for empty list

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -68,19 +68,43 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
   def parse_block_ranges(block_ranges_string) do
     block_ranges_string
     |> String.split(",")
-    |> Enum.map(fn string_range ->
+    |> Enum.reduce({[], nil}, fn string_range, {ranges, to_latest} ->
       case String.split(string_range, "..") do
         [from_string, "latest"] ->
-          parse_integer(from_string)
+          {ranges, parse_integer(from_string)}
 
         [from_string, to_string] ->
-          get_from_to(from_string, to_string)
+          {[get_from_to(from_string, to_string) | ranges], to_latest}
 
         _ ->
-          nil
+          {ranges, to_latest}
       end
     end)
-    |> sanitize_ranges()
+    |> then(fn
+      {ranges, nil} ->
+        sanitize_ranges(ranges)
+
+      {ranges, to_latest} ->
+        ranges
+        |> sanitize_ranges()
+        |> Enum.reduce([], fn
+          first..last//1 = range, acc ->
+            cond do
+              first >= to_latest -> acc
+              last >= to_latest -> [first..(to_latest - 1) | acc]
+              true -> [range | acc]
+            end
+
+          first..last//-1 = range, acc ->
+            cond do
+              last >= to_latest -> acc
+              first >= to_latest -> [(to_latest - 1)..last | acc]
+              true -> [range | acc]
+            end
+        end)
+        |> Enum.reverse()
+        |> Kernel.++([to_latest])
+    end)
   end
 
   @doc """
@@ -136,42 +160,11 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
   @doc """
   Rejects empty ranges and merges adjacent ranges
   """
-  @spec sanitize_ranges([Range.t() | integer()]) :: [Range.t() | integer()]
+  @spec sanitize_ranges([Range.t() | nil]) :: [Range.t()]
   def sanitize_ranges(ranges) do
     ranges
     |> Enum.reject(&is_nil/1)
-    |> Enum.sort_by(
-      fn
-        from.._to//_ -> from
-        el -> el
-      end,
-      :asc
-    )
-    |> Enum.chunk_while(
-      nil,
-      fn
-        _from.._to//_ = chunk, nil ->
-          {:cont, chunk}
-
-        _ch_from..ch_to//_ = chunk, acc_from..acc_to//_ = acc ->
-          if Range.disjoint?(chunk, acc),
-            do: {:cont, acc, chunk},
-            else: {:cont, acc_from..max(ch_to, acc_to)}
-
-        num, nil ->
-          {:halt, num}
-
-        num, acc_from.._//_ = acc ->
-          if Range.disjoint?(num..num, acc), do: {:cont, acc, num}, else: {:halt, acc_from}
-
-        _, num ->
-          {:halt, num}
-      end,
-      fn
-        nil -> {:cont, nil}
-        remainder -> {:cont, remainder, nil}
-      end
-    )
+    |> do_sanitize_ranges()
   end
 
   @doc """
@@ -214,6 +207,30 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
         reducer.(block_number, acc)
       end
     end
+  end
+
+  defp do_sanitize_ranges([]), do: []
+
+  defp do_sanitize_ranges([_.._//step | _] = ranges) do
+    ranges
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(fn first..last//_ -> min(first, last)..max(first, last) end)
+    |> Enum.sort_by(fn first.._last//_ -> first end)
+    |> Enum.reduce([], fn
+      range, [] ->
+        [range]
+
+      first..last//_ = range, [previous_first..previous_last//_ | rest] = acc ->
+        if first <= previous_last + 1 do
+          [previous_first..max(previous_last, last) | rest]
+        else
+          [range | acc]
+        end
+    end)
+    |> Enum.reverse()
+    |> Enum.map(fn first..last//_ ->
+      if step == 1, do: first..last, else: last..first//-1
+    end)
   end
 
   defp extract_block_number(%{block_number: block_number}), do: block_number

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/utility/ranges_helper_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/utility/ranges_helper_test.exs
@@ -1,0 +1,24 @@
+defmodule EthereumJSONRPC.Utility.RangesHelperTest do
+  use ExUnit.Case, async: true
+
+  alias EthereumJSONRPC.Utility.RangesHelper
+
+  describe "sanitize_ranges/1" do
+    test "list of ranges" do
+      assert RangesHelper.sanitize_ranges([1..2, 1..4, 3..6, 7..9, 11..12]) == [1..9, 11..12]
+      assert RangesHelper.sanitize_ranges([10..7//-1, 6..4//-1, 3..1//-1]) == [10..1//-1]
+      assert RangesHelper.sanitize_ranges([10..7//-1, 5..3//-1]) == [5..3//-1, 10..7//-1]
+      assert RangesHelper.sanitize_ranges([1..3, 7..9, 5..6]) == [1..3, 5..9]
+      assert RangesHelper.sanitize_ranges([1..3, 5..7, 4..4]) == [1..7]
+      assert RangesHelper.sanitize_ranges([]) == []
+    end
+  end
+
+  describe "parse_block_ranges/1" do
+    test "ranges string" do
+      assert RangesHelper.parse_block_ranges("100..200,300..400,500..latest") == [100..200, 300..400, 500]
+      assert RangesHelper.parse_block_ranges("100..200,150..300") == [100..300]
+      assert RangesHelper.parse_block_ranges("") == []
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
+++ b/apps/indexer/lib/indexer/block/catchup/missing_ranges_collector.ex
@@ -62,7 +62,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   use Utils.CompileTimeEnvHelper, future_check_interval: [:indexer, [__MODULE__, :future_check_interval]]
 
   alias EthereumJSONRPC.Utility.RangesHelper
-  alias Explorer.{Chain, Helper, Repo}
+  alias Explorer.{Chain, Repo}
   alias Explorer.Chain.Cache.Counters.LastFetchedCounter
   alias Explorer.Utility.{MissingBlockRange, MissingRangesManipulator}
 
@@ -480,22 +480,7 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
   @spec parse_block_ranges(binary()) ::
           {:finite_ranges, [Range.t()]} | {:infinite_ranges, [Range.t()], non_neg_integer()} | :no_ranges
   def parse_block_ranges(block_ranges_string) do
-    ranges =
-      block_ranges_string
-      |> String.split(",")
-      |> Enum.map(fn string_range ->
-        case String.split(string_range, "..") do
-          [from_string, "latest"] ->
-            Helper.parse_integer(from_string)
-
-          [from_string, to_string] ->
-            get_from_to(from_string, to_string)
-
-          _ ->
-            nil
-        end
-      end)
-      |> RangesHelper.sanitize_ranges()
+    ranges = RangesHelper.parse_block_ranges(block_ranges_string)
 
     case List.last(ranges) do
       _from.._to//_ ->
@@ -506,17 +491,6 @@ defmodule Indexer.Block.Catchup.MissingRangesCollector do
 
       num ->
         {:infinite_ranges, List.delete_at(ranges, -1), num - 1}
-    end
-  end
-
-  # Creates a range from string boundaries, returning nil if parsing fails or if from > to
-  @spec get_from_to(binary(), binary()) :: Range.t() | nil
-  defp get_from_to(from_string, to_string) do
-    with {from, ""} <- Integer.parse(from_string),
-         {to, ""} <- Integer.parse(to_string) do
-      if from <= to, do: from..to, else: nil
-    else
-      _ -> nil
     end
   end
 end


### PR DESCRIPTION
## Motivation

For empty list `RangesHelper.sanitize_ranges/1` returns `[nil]`, also it works incorrect for ranges with `-1` step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range parsing now supports a trailing "latest" marker and adds a helper to get the minimum block from a range string.

* **Bug Fixes**
  * Improved merging/sanitization of overlapping and adjacent ranges; preserves ascending/descending direction, ordering, and is more nil-safe.

* **Refactor**
  * Centralized parsing logic into a shared utility and reused by other components.

* **Tests**
  * Added tests covering parsing, merging, ordering, edge cases, and empty input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->