### PR TITLE
chore: restore `getblocknobytime` response format to use `blockNumber` key

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/block_view.ex
@@ -78,7 +78,14 @@ defmodule BlockScoutWeb.API.RPC.BlockView do
   end
 
   def render("getblocknobytime.json", %{block_number: block_number}) do
-    RPCView.render("show.json", data: to_string(block_number))
+    # TODO: migrate to the following format in the next release
+    # RPCView.render("show.json", data: to_string(block_number))
+
+    RPCView.render("show.json",
+      data: %{
+        "blockNumber" => to_string(block_number)
+      }
+    )
   end
 
   def render("eth_block_number.json", %{number: number, id: id}) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
@@ -321,7 +321,9 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
                })
                |> json_response(200)
 
-      assert response["result"] == "#{block.number}"
+      # TODO: migrate to the following format in the next release
+      # assert response["result"] == "#{block.number}"
+      assert response["result"] == %{"blockNumber" => "#{block.number}"}
       assert response["status"] == "1"
       assert response["message"] == "OK"
       schema = resolve_getblocknobytime_schema()
@@ -349,7 +351,9 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
                })
                |> json_response(200)
 
-      assert response["result"] == "#{block.number}"
+      # TODO: migrate to the following format in the next release
+      # assert response["result"] == "#{block.number}"
+      assert response["result"] == %{"blockNumber" => "#{block.number}"}
       assert response["status"] == "1"
       assert response["message"] == "OK"
       schema = resolve_getblocknobytime_schema()
@@ -377,7 +381,9 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
                })
                |> json_response(200)
 
-      assert response["result"] == "#{block.number}"
+      # TODO: migrate to the following format in the next release
+      # assert response["result"] == "#{block.number}"
+      assert response["result"] == %{"blockNumber" => "#{block.number}"}
       assert response["status"] == "1"
       assert response["message"] == "OK"
       schema = resolve_getblocknobytime_schema()

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/block_controller_test.exs
@@ -447,9 +447,17 @@ defmodule BlockScoutWeb.API.RPC.BlockControllerTest do
       "properties" => %{
         "message" => %{"type" => "string"},
         "status" => %{"type" => "string"},
+        # TODO: migrate to the following format in the next release
+        #
+        # "result" => %{
+        #   "type" => ["string", "null"],
+        #   "description" => "Block number as a string or null if not found"
+        # }
         "result" => %{
-          "type" => ["string", "null"],
-          "description" => "Block number as a string or null if not found"
+          "type" => ["object", "null"],
+          "properties" => %{
+            "blockNumber" => %{"type" => "string"}
+          }
         }
       }
     })


### PR DESCRIPTION
Restore `getblocknobytime` response format to use `blockNumber` key.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * getblocknobytime RPC now returns a JSON object with a "blockNumber" field (string) instead of a raw string; clients should update parsing accordingly.

* **Tests**
  * API tests updated to validate the new object-based response structure for getblocknobytime, including schema adjustments to expect result as an object (or null) containing "blockNumber".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->