### PR TITLE
fix: Remove apikey from next_page_params

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -228,6 +228,8 @@ defmodule BlockScoutWeb.PagingHelper do
     params
     |> Map.drop([
       :address_hash_param,
+      :apikey,
+      "apikey",
       "block_hash_or_number",
       "transaction_hash_param",
       "address_hash_param",


### PR DESCRIPTION
## Motivation
apikey disclosed in next_page_params
```
next_page_params: {
   block_number: 23124007,
   apikey: "qweqwe",
   items_count: 50
}
```
## Changelog
- Cut apikey from next_page_params

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed API key parameters from pagination URLs (next-page links) to prevent accidental exposure when sharing links.
  * Cleaned up next-page parameter handling to avoid including sensitive query parameters in both string and atom forms.
  * No impact on pagination behavior or other filters; users should see cleaner, safer pagination links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->