### PR TITLE
chore: Increase multichain queues sizes

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/balances_export_queue.ex
@@ -19,7 +19,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue do
   @behaviour BufferedTask
 
   @delete_queries_chunk_size 10
-  @default_max_batch_size 1000
+  @default_max_batch_size 3000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch balances export retry to the Multichain Search DB failed"
 

--- a/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/multichain_search_db/main_export_queue.ex
@@ -18,7 +18,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueue do
   @behaviour BufferedTask
 
   @delete_queries_chunk_size 100
-  @default_max_batch_size 1000
+  @default_max_batch_size 3000
   @default_max_concurrency 10
   @failed_to_re_export_data_error "Batch main export retry to the Multichain Search DB failed"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1142,21 +1142,21 @@ config :indexer, Indexer.Migrator.RecoveryWETHTokenTransfers,
 
 config :indexer, Indexer.Fetcher.MultichainSearchDb.MainExportQueue,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_CONCURRENCY", 10),
-  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_BATCH_SIZE", 1_000),
+  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_BATCH_SIZE", 3_000),
   enqueue_busy_waiting_timeout:
     ConfigHelper.parse_time_env_var(
       "INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_ENQUEUE_BUSY_WAITING_TIMEOUT",
       "1s"
     ),
   max_queue_size:
-    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_MAX_QUEUE_SIZE", 1_000),
+    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_MAX_QUEUE_SIZE", 3_000),
   init_limit:
-    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_INIT_QUERY_LIMIT", 1_000)
+    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_MAIN_QUEUE_INIT_QUERY_LIMIT", 3_000)
 
 config :indexer, Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue,
   concurrency: ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_CONCURRENCY", 10),
   batch_size:
-    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_BATCH_SIZE", 1_000),
+    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_BATCH_SIZE", 3_000),
   enqueue_busy_waiting_timeout:
     ConfigHelper.parse_time_env_var(
       "INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_ENQUEUE_BUSY_WAITING_TIMEOUT",
@@ -1165,10 +1165,10 @@ config :indexer, Indexer.Fetcher.MultichainSearchDb.BalancesExportQueue,
   max_queue_size:
     ConfigHelper.parse_integer_env_var(
       "INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_MAX_QUEUE_SIZE",
-      1_000
+      3_000
     ),
   init_limit:
-    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_INIT_QUERY_LIMIT", 1_000)
+    ConfigHelper.parse_integer_env_var("INDEXER_MULTICHAIN_SEARCH_DB_EXPORT_BALANCES_QUEUE_INIT_QUERY_LIMIT", 3_000)
 
 config :indexer, Indexer.Fetcher.MultichainSearchDb.TokenInfoExportQueue,
   concurrency:


### PR DESCRIPTION
## Motivation

Main and balances export queues to the Multichain service are filled faster than processed on some instances.

## Changelog

This pull request increases the batch size and queue limits for both the Main Export Queue and Balances Export Queue in the Multichain Search DB indexer. The changes are aimed at improving throughput by allowing larger batches and higher queue capacities.

**Configuration updates for higher throughput:**

* Increased `@default_max_batch_size` from 1,000 to 3,000 in `main_export_queue.ex` and `balances_export_queue.ex` to allow larger export batches. [[1]](diffhunk://#diff-57739dedcbcd5024323a30f39030e2a1e24e0e9c534571276dad5b95daf0d5b1L21-R21) [[2]](diffhunk://#diff-c25c589d1540ee188152e63a1473e3584f27cc4603ed754ad964a087872718d1L22-R22)
* Updated `batch_size`, `max_queue_size`, and `init_limit` default values from 1,000 to 3,000 for both Main Export Queue and Balances Export Queue in `runtime.exs` configuration. [[1]](diffhunk://#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092L1145-R1159) [[2]](diffhunk://#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092L1168-R1171)

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased batch sizes and queue capacities for export processes, enabling higher throughput and faster processing.
  * Raised initial limits to better handle larger backlogs without delays.
  * Improves responsiveness under heavy load while keeping existing concurrency settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->