### PR TITLE
fix: Set 5 RPS for api/health/*

### DIFF
--- a/apps/block_scout_web/priv/rate_limit_config.json
+++ b/apps/block_scout_web/priv/rate_limit_config.json
@@ -107,6 +107,13 @@
     },
     "isolate_rate_limit?": true
   },
+  "api/health/*": {
+    "ip": {
+      "period": "1s",
+      "limit": 5
+    },
+    "isolate_rate_limit?": true
+  },
   "api/v2/*": {
     "static_api_key": true,
     "account_api_key": true,


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IP-based rate limiting for health check endpoints to improve stability under burst traffic.
  * Limit set to 5 requests per second per IP; excess requests may be throttled or receive rate-limit responses.
  * Applies to all paths under /api/health/.
  * No changes to limits or behavior for other API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->