### PR TITLE
fix: Fix Mud worlds API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix Mud worlds API endpoint ([#12991](https://github.com/blockscout/blockscout/pull/12991))
 - Set 5 RPS for api/health/* ([#12990]https://github.com/blockscout/blockscout/pull/12990)
 - Pagination with atoms in paging_params ([#12986](https://github.com/blockscout/blockscout/issues/12986))
 - Fix RangesHelper.sanitize_ranges for empty list ([#12946](https://github.com/blockscout/blockscout/issues/12946))

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/mud_view.ex
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.API.V2.MudView do
 
   defp prepare_world_for_list(%Address{} = address) do
     %{
-      "address_hash" => Helper.address_with_info(address, address.hash),
+      "address" => Helper.address_with_info(address, address.hash),
       "transactions_count" => address.transactions_count,
       "coin_balance" => if(address.fetched_coin_balance, do: address.fetched_coin_balance.value)
     }


### PR DESCRIPTION
## Motivation

Address object should be returned in `address` property, and not in `address_hash`.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Mud worlds API endpoint response: world entries now use the "address" field instead of "address_hash". Other fields (e.g., transactions_count, coin_balance) remain unchanged.

* **Documentation**
  * Updated CHANGELOG for version 9.0.2 to include the Mud worlds API fix (PR #12991).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->