### PR TITLE
fix: Don't validate address hash for common blocks channels

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/channels/v2/block_channel.ex
+++ b/apps/block_scout_web/lib/block_scout_web/channels/v2/block_channel.ex
@@ -4,7 +4,8 @@ defmodule BlockScoutWeb.V2.BlockChannel do
   """
   use BlockScoutWeb, :channel
 
-  def join("blocks:new_block", _params, socket) do
+  def join("blocks:" <> common, _params, socket)
+      when common in ["new_block", "indexing", "indexing_internal_transactions"] do
     {:ok, %{}, socket}
   end
 

--- a/apps/block_scout_web/test/block_scout_web/channels/v2/block_channel_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/channels/v2/block_channel_test.exs
@@ -27,4 +27,15 @@ defmodule BlockScoutWeb.V2.BlockChannelTest do
         assert false, "Expected message received nothing."
     end
   end
+
+  test "user is able to join to common channels" do
+    common_channels = ["new_block", "indexing", "indexing_internal_transactions"]
+
+    Enum.each(common_channels, fn channel ->
+      assert {:ok, _reply, _socket} =
+               BlockScoutWeb.V2.UserSocket
+               |> socket("no_id", %{})
+               |> subscribe_and_join("blocks:#{channel}")
+    end)
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded real-time Blocks topics to include "indexing" and "indexing_internal_transactions" alongside "new_block," enabling subscriptions to indexing-related updates.
  * Preserves existing address-based subscriptions; no breaking changes for current clients.
  * Improves flexibility for integrating live block and indexing status streams.

* **Tests**
  * Added coverage verifying clients can join the new common Blocks topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->