### PR TITLE
chore: Update and format pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,36 @@
-*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*
+_[GitHub keywords to close any associated issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/closing-issues-using-keywords)_
 
 ## Motivation
 
-*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*
+_Why we should merge these changes. If using GitHub keywords to close [issues](https://github.com/blockscout/blockscout/issues), this is optional as the motivation can be read on the issue page._
 
 ## Changelog
 
 ### Enhancements
 
-*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*
+_Things you added that don't break anything. Regression tests for Bug Fixes count as Enhancements._
 
 ### Bug Fixes
 
-*Things you changed that fix bugs.  If it fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*
+_Things you changed that fix bugs. If it fixes a bug but, in so doing, adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should also be added to "Incompatible Changes" below._
 
 ### Incompatible Changes
 
-*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*
+_Things you broke while doing Enhancements and Bug Fixes. Breaking changes include (1) adding new requirements and (2) removing code. Renaming counts as (2) because a rename is a removal followed by an add._
 
 ## Upgrading
 
-*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*
+_If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally. A common upgrading step is "Database reset and re-index required"._
 
 ## Checklist for your Pull Request (PR)
 
+- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
 - [ ] If I added new functionality, I added tests covering it.
 - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
-- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
-- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
+- [ ] I updated documentation if needed:
+  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
+  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
+  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
+- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
 - [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
 - [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


### PR DESCRIPTION
## Motivation

Breaking API changes got lost in last release, update checklist may help not to forget it further

## Changelog

- Add an item about breaking changes to changelist
- Format
- Some minor improvements from Coderabbit 

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted the pull request template for clearer structure and consistent emphasis (italicized sections).
  * Consolidated the documentation checklist into a single "I updated documentation if needed" section with options for general docs, env vars (now pointing to docs repo/master), and deprecated vars.
  * Preserved checklist items for testing, DB indices, and chain type adjustments.

* **Chores**
  * Editorial/template wording and layout updates only; no functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->