### PR TITLE
feat: auto assert_schema in tests

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -40,6 +40,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     WithdrawalView
   }
 
+  alias BlockScoutWeb.Schemas.Helper, as: SchemasHelper
   alias Explorer.{Chain, Market, PagingOptions}
   alias Explorer.Chain.{Address, Beacon.Deposit, Hash, InternalTransaction, Transaction}
   alias Explorer.Chain.Address.{CoinBalance, Counters}
@@ -1013,11 +1014,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     responses: [
       ok:
         {"List of native coin holders with their balances, with pagination.", "application/json",
-         extend_schema(
+         SchemasHelper.extend_schema(
            paginated_response(
              items:
                Schemas.Address.schema()
-               |> extend_schema(
+               |> SchemasHelper.extend_schema(
                  title: "AddressWithCoinBalanceAndTransactionsCount",
                  properties: %{
                    coin_balance: Schemas.General.IntegerStringNullable,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -816,7 +816,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
              days: %Schema{type: :integer, nullable: false},
              items: %Schema{type: :array, items: Schemas.CoinBalanceByDay}
            },
-           nullable: false
+           nullable: false,
+           additionalProperties: false
          }},
       unprocessable_entity: JsonErrorResponse.response(),
       forbidden: ForbiddenResponse.response()
@@ -1012,28 +1013,39 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     responses: [
       ok:
         {"List of native coin holders with their balances, with pagination.", "application/json",
-         %Schema{
-           title: "AddressesList",
-           allOf: [
-             paginated_response(
-               items: Schemas.Address,
-               next_page_params_example: %{
-                 "fetched_coin_balance" => "124355417998347240251800",
-                 "hash" => "0x59708733fbbf64378d9293ec56b977c011a08fd2",
-                 "items_count" => 50,
-                 "transactions_count" => nil
-               },
-               title_prefix: "AddressList"
-             ),
-             %Schema{
-               properties: %{
-                 exchange_rate: Schemas.General.FloatStringNullable,
-                 total_supply: Schemas.General.FloatStringNullable
-               },
-               required: [:exchange_rate, :total_supply]
-             }
-           ]
-         }},
+         extend_schema(
+           paginated_response(
+             items:
+               Schemas.Address.schema()
+               |> extend_schema(
+                 title: "AddressWithCoinBalanceAndTransactionsCount",
+                 properties: %{
+                   coin_balance: Schemas.General.IntegerStringNullable,
+                   transactions_count: %Schema{
+                     anyOf: [
+                       Schemas.General.IntegerString,
+                       # TODO: replace empty string with null?
+                       Schemas.General.EmptyString
+                     ],
+                     nullable: true
+                   }
+                 },
+                 required: [:coin_balance, :transactions_count]
+               ),
+             next_page_params_example: %{
+               "fetched_coin_balance" => "124355417998347240251800",
+               "hash" => "0x59708733fbbf64378d9293ec56b977c011a08fd2",
+               "items_count" => 50,
+               "transactions_count" => nil
+             },
+             title_prefix: "AddressList"
+           ),
+           properties: %{
+             exchange_rate: Schemas.General.FloatStringNullable,
+             total_supply: Schemas.General.FloatStringNullable
+           },
+           required: [:exchange_rate, :total_supply]
+         )},
       forbidden: ForbiddenResponse.response()
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/ethereum/deposit_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/ethereum/deposit_controller.ex
@@ -91,7 +91,8 @@ defmodule BlockScoutWeb.API.V2.Ethereum.DepositController do
            properties: %{
              deposits_count: %Schema{type: :integer, nullable: false}
            },
-           required: [:deposits_count]
+           required: [:deposits_count],
+           additionalProperties: false
          }},
       forbidden: ForbiddenResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations do
   @moduledoc false
   require OpenApiSpex
 
+  alias BlockScoutWeb.Schemas.Helper
   alias Ecto.Enum, as: EctoEnum
   alias Explorer.Chain.Address
   alias OpenApiSpex.Schema
@@ -17,26 +18,30 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations do
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
-        |> put_in([:properties, :filecoin], %Schema{
-          type: :object,
+        |> Helper.extend_schema(
           properties: %{
-            id: %Schema{
-              type: :string,
-              description: "Short f0 Filecoin address that may change during chain reorgs",
-              example: "f03248220",
-              nullable: true
-            },
-            robust: @filecoin_robust_address_schema,
-            actor_type: %Schema{
-              type: :string,
-              description: "Type of actor associated with the Filecoin address",
-              enum: EctoEnum.values(Address, :filecoin_actor_type),
-              nullable: true
+            filecoin: %Schema{
+              type: :object,
+              properties: %{
+                id: %Schema{
+                  type: :string,
+                  description: "Short f0 Filecoin address that may change during chain reorgs",
+                  example: "f03248220",
+                  nullable: true
+                },
+                robust: @filecoin_robust_address_schema,
+                actor_type: %Schema{
+                  type: :string,
+                  description: "Type of actor associated with the Filecoin address",
+                  enum: EctoEnum.values(Address, :filecoin_actor_type),
+                  nullable: true
+                }
+              },
+              required: [:id, :robust, :actor_type],
+              additionalProperties: false
             }
-          },
-          required: [:id, :robust, :actor_type],
-          additionalProperties: false
-        })
+          }
+        )
 
       _ ->
         schema

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
@@ -34,7 +34,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations do
               nullable: true
             }
           },
-          required: [:id, :robust, :actor_type]
+          required: [:id, :robust, :actor_type],
+          additionalProperties: false
         })
 
       _ ->
@@ -114,7 +115,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address do
         :private_tags,
         :watchlist_names,
         :public_tags
-      ]
+      ],
+      additionalProperties: false
     }
     |> ChainTypeCustomizations.chain_type_fields()
   )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/counters.ex
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Counters do
       gas_usage_count: General.IntegerString,
       validations_count: General.IntegerString
     },
-    required: [:transactions_count, :token_transfers_count, :gas_usage_count, :validations_count]
+    required: [:transactions_count, :token_transfers_count, :gas_usage_count, :validations_count],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
   require OpenApiSpex
 
   alias OpenApiSpex.Schema
+  alias BlockScoutWeb.Schemas.API.V2.General
 
   @filecoin_robust_address_schema %Schema{
     type: :string,
@@ -33,13 +34,17 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
-        |> put_in([:properties, :creator_filecoin_robust_address], @filecoin_robust_address_schema)
-        |> update_in([:required], &[:creator_filecoin_robust_address | &1])
+        |> General.extend_schema(
+          properties: %{creator_filecoin_robust_address: @filecoin_robust_address_schema},
+          required: [:creator_filecoin_robust_address]
+        )
 
       :zilliqa ->
         schema
-        |> put_in([:properties, :zilliqa], @zilliqa_schema)
-        |> update_in([:required], &[:zilliqa | &1])
+        |> General.extend_schema(
+          properties: %{zilliqa: @zilliqa_schema},
+          required: [:zilliqa]
+        )
 
       _ ->
         schema

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -54,55 +54,50 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations
-  alias BlockScoutWeb.Schemas.API.V2.{General, Token}
+  alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(
-    %{
+    Address.schema()
+    |> General.extend_schema(
       title: "AddressResponse",
       description: "Address response",
-      type: :object,
-      properties:
-        BlockScoutWeb.Schemas.API.V2.Address.schema().properties
-        |> Map.merge(%{
-          creator_address_hash: General.AddressHashNullable,
-          creation_transaction_hash: General.FullHashNullable,
-          token: %Schema{allOf: [Token], nullable: true},
-          coin_balance: General.IntegerStringNullable,
-          exchange_rate: General.FloatStringNullable,
-          block_number_balance_updated_at: %Schema{type: :integer, minimum: 0, nullable: true},
-          has_validated_blocks: %Schema{type: :boolean, nullable: false},
-          has_logs: %Schema{type: :boolean, nullable: false},
-          has_tokens: %Schema{type: :boolean, nullable: false},
-          has_token_transfers: %Schema{type: :boolean, nullable: false},
-          watchlist_address_id: %Schema{type: :integer, nullable: true},
-          has_beacon_chain_withdrawals: %Schema{type: :boolean, nullable: false},
-          creation_status: %Schema{
-            type: :string,
-            description: "Creation status of the contract",
-            enum: ["success", "failed", "selfdestructed"],
-            nullable: true
-          }
-        }),
-      required:
-        BlockScoutWeb.Schemas.API.V2.Address.schema().required ++
-          [
-            :creator_address_hash,
-            :creation_transaction_hash,
-            :token,
-            :coin_balance,
-            :exchange_rate,
-            :block_number_balance_updated_at,
-            :has_validated_blocks,
-            :has_logs,
-            :has_tokens,
-            :has_token_transfers,
-            :watchlist_address_id,
-            :has_beacon_chain_withdrawals,
-            :creation_status
-          ],
-      additionalProperties: false
-    }
+      properties: %{
+        creator_address_hash: General.AddressHashNullable,
+        creation_transaction_hash: General.FullHashNullable,
+        token: %Schema{allOf: [Token], nullable: true},
+        coin_balance: General.IntegerStringNullable,
+        exchange_rate: General.FloatStringNullable,
+        block_number_balance_updated_at: %Schema{type: :integer, minimum: 0, nullable: true},
+        has_validated_blocks: %Schema{type: :boolean, nullable: false},
+        has_logs: %Schema{type: :boolean, nullable: false},
+        has_tokens: %Schema{type: :boolean, nullable: false},
+        has_token_transfers: %Schema{type: :boolean, nullable: false},
+        watchlist_address_id: %Schema{type: :integer, nullable: true},
+        has_beacon_chain_withdrawals: %Schema{type: :boolean, nullable: false},
+        creation_status: %Schema{
+          type: :string,
+          description: "Creation status of the contract",
+          enum: ["success", "failed", "selfdestructed"],
+          nullable: true
+        }
+      },
+      required: [
+        :creator_address_hash,
+        :creation_transaction_hash,
+        :token,
+        :coin_balance,
+        :exchange_rate,
+        :block_number_balance_updated_at,
+        :has_validated_blocks,
+        :has_logs,
+        :has_tokens,
+        :has_token_transfers,
+        :watchlist_address_id,
+        :has_beacon_chain_withdrawals,
+        :creation_status
+      ]
+    )
     |> ChainTypeCustomizations.chain_type_fields()
   )
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -2,8 +2,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
   @moduledoc false
   require OpenApiSpex
 
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
-  alias BlockScoutWeb.Schemas.API.V2.General
 
   @filecoin_robust_address_schema %Schema{
     type: :string,
@@ -34,14 +34,14 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
-        |> General.extend_schema(
+        |> Helper.extend_schema(
           properties: %{creator_filecoin_robust_address: @filecoin_robust_address_schema},
           required: [:creator_filecoin_robust_address]
         )
 
       :zilliqa ->
         schema
-        |> General.extend_schema(
+        |> Helper.extend_schema(
           properties: %{zilliqa: @zilliqa_schema},
           required: [:zilliqa]
         )
@@ -60,11 +60,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response do
 
   alias BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations
   alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(
     Address.schema()
-    |> General.extend_schema(
+    |> Helper.extend_schema(
       title: "AddressResponse",
       description: "Address response",
       properties: %{

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -57,37 +57,36 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response do
   alias BlockScoutWeb.Schemas.API.V2.{General, Token}
   alias OpenApiSpex.Schema
 
-  OpenApiSpex.schema(%{
-    title: "AddressResponse",
-    description: "Address response",
-    type: :object,
-    allOf: [
-      BlockScoutWeb.Schemas.API.V2.Address,
-      struct(
-        Schema,
-        %{
-          type: :object,
-          properties: %{
-            creator_address_hash: General.AddressHashNullable,
-            creation_transaction_hash: General.FullHashNullable,
-            token: %Schema{allOf: [Token], nullable: true},
-            coin_balance: General.IntegerStringNullable,
-            exchange_rate: General.FloatStringNullable,
-            block_number_balance_updated_at: %Schema{type: :integer, minimum: 0, nullable: true},
-            has_validated_blocks: %Schema{type: :boolean, nullable: false},
-            has_logs: %Schema{type: :boolean, nullable: false},
-            has_tokens: %Schema{type: :boolean, nullable: false},
-            has_token_transfers: %Schema{type: :boolean, nullable: false},
-            watchlist_address_id: %Schema{type: :integer, nullable: true},
-            has_beacon_chain_withdrawals: %Schema{type: :boolean, nullable: false},
-            creation_status: %Schema{
-              type: :string,
-              description: "Creation status of the contract",
-              enum: ["success", "failed", "selfdestructed"],
-              nullable: true
-            }
-          },
-          required: [
+  OpenApiSpex.schema(
+    %{
+      title: "AddressResponse",
+      description: "Address response",
+      type: :object,
+      properties:
+        BlockScoutWeb.Schemas.API.V2.Address.schema().properties
+        |> Map.merge(%{
+          creator_address_hash: General.AddressHashNullable,
+          creation_transaction_hash: General.FullHashNullable,
+          token: %Schema{allOf: [Token], nullable: true},
+          coin_balance: General.IntegerStringNullable,
+          exchange_rate: General.FloatStringNullable,
+          block_number_balance_updated_at: %Schema{type: :integer, minimum: 0, nullable: true},
+          has_validated_blocks: %Schema{type: :boolean, nullable: false},
+          has_logs: %Schema{type: :boolean, nullable: false},
+          has_tokens: %Schema{type: :boolean, nullable: false},
+          has_token_transfers: %Schema{type: :boolean, nullable: false},
+          watchlist_address_id: %Schema{type: :integer, nullable: true},
+          has_beacon_chain_withdrawals: %Schema{type: :boolean, nullable: false},
+          creation_status: %Schema{
+            type: :string,
+            description: "Creation status of the contract",
+            enum: ["success", "failed", "selfdestructed"],
+            nullable: true
+          }
+        }),
+      required:
+        BlockScoutWeb.Schemas.API.V2.Address.schema().required ++
+          [
             :creator_address_hash,
             :creation_transaction_hash,
             :token,
@@ -101,10 +100,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response do
             :watchlist_address_id,
             :has_beacon_chain_withdrawals,
             :creation_status
-          ]
-        }
-        |> ChainTypeCustomizations.chain_type_fields()
-      )
-    ]
-  })
+          ],
+      additionalProperties: false
+    }
+    |> ChainTypeCustomizations.chain_type_fields()
+  )
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -17,7 +17,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
     properties: %{
       is_scilla_contract: %Schema{type: :boolean, nullable: false}
     },
-    required: [:is_scilla_contract]
+    required: [:is_scilla_contract],
+    additionalProperties: false
   }
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
@@ -20,6 +20,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TabsCounters do
       validations_count: %Schema{type: :integer, nullable: false},
       celo_election_rewards_count: %Schema{type: :integer, nullable: false},
       beacon_deposits_count: %Schema{type: :integer, nullable: false}
-    }
+    },
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/token_balance.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/token_balance.ex
@@ -22,6 +22,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TokenBalance do
         nullable: true
       }
     },
-    required: [:value, :token, :token_id, :token_instance, :reputation]
+    required: [:value, :token, :token_id, :token_instance, :reputation],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/beacon/deposit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/beacon/deposit.ex
@@ -35,6 +35,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Beacon.Deposit do
       :signature,
       :status,
       :from_address
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -125,6 +125,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
     properties: %{
       is_epoch_block: %Schema{type: :boolean, nullable: false},
       epoch_number: %Schema{type: :integer, nullable: false},
+      l1_era_finalized_epoch_number: %Schema{type: :integer, nullable: true},
       base_fee: %Schema{
         type: :object,
         nullable: true,
@@ -151,7 +152,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
         additionalProperties: false
       }
     },
-    required: [:is_epoch_block, :epoch_number],
+    required: [:is_epoch_block, :epoch_number, :l1_era_finalized_epoch_number],
     additionalProperties: false
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -30,7 +30,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       :prove_transaction_timestamp,
       :execute_transaction_hash,
       :execute_transaction_timestamp
-    ]
+    ],
+    additionalProperties: false
   }
 
   @arbitrum_schema %Schema{
@@ -73,7 +74,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       send_count: %Schema{type: :integer, nullable: true},
       send_root: General.FullHashNullable
     },
-    required: [:batch_number, :status, :commitment_transaction, :confirmation_transaction]
+    required: [:batch_number, :status, :commitment_transaction, :confirmation_transaction],
+    additionalProperties: false
   }
 
   @blob4844_schema %Schema{
@@ -84,7 +86,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       l1_transaction_hash: General.FullHashNullable,
       l1_timestamp: General.TimestampNullable
     },
-    required: [:hash, :l1_transaction_hash, :l1_timestamp]
+    required: [:hash, :l1_transaction_hash, :l1_timestamp],
+    additionalProperties: false
   }
 
   @celestia_schema %Schema{
@@ -97,7 +100,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       l1_transaction_hash: General.FullHashNullable,
       l1_timestamp: General.TimestampNullable
     },
-    required: [:height, :namespace, :commitment, :l1_transaction_hash, :l1_timestamp]
+    required: [:height, :namespace, :commitment, :l1_transaction_hash, :l1_timestamp],
+    additionalProperties: false
   }
 
   @optimism_schema %Schema{
@@ -110,7 +114,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       batch_data_container: %Schema{type: :string, nullable: false, enum: ["in_blob4844", "in_celestia", "in_calldata"]},
       blobs: %Schema{type: :array, items: %Schema{anyOf: [@blob4844_schema, @celestia_schema]}, nullable: false}
     },
-    required: [:number, :l1_timestamp, :l1_transaction_hashes, :batch_data_container]
+    required: [:number, :l1_timestamp, :l1_transaction_hashes, :batch_data_container],
+    additionalProperties: false
   }
 
   @celo_schema %Schema{
@@ -135,15 +140,18 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
                 amount: General.IntegerString,
                 percentage: %Schema{type: :number, nullable: false}
               },
-              required: [:address, :amount, :percentage]
+              required: [:address, :amount, :percentage],
+              additionalProperties: false
             },
             nullable: false
           }
         },
-        required: [:recipient, :amount, :token, :breakdown]
+        required: [:recipient, :amount, :token, :breakdown],
+        additionalProperties: false
       }
     },
-    required: [:is_epoch_block, :epoch_number]
+    required: [:is_epoch_block, :epoch_number],
+    additionalProperties: false
   }
 
   @zilliqa_schema %Schema{
@@ -159,7 +167,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
           signature: General.HexString,
           signers: %Schema{type: :array, items: %Schema{type: :integer, nullable: false}, nullable: false}
         },
-        required: [:view, :signature, :signers]
+        required: [:view, :signature, :signers],
+        additionalProperties: false
       },
       aggregate_quorum_certificate: %Schema{
         type: :object,
@@ -178,15 +187,18 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
                 proposed_by_validator_index: %Schema{type: :integer, nullable: false},
                 signers: %Schema{type: :array, items: %Schema{type: :integer, nullable: false}, nullable: false}
               },
-              required: [:view, :signature, :proposed_by_validator_index, :signers]
+              required: [:view, :signature, :proposed_by_validator_index, :signers],
+              additionalProperties: false
             },
             nullable: false
           }
         },
-        required: [:view, :signature, :signers, :nested_quorum_certificates]
+        required: [:view, :signature, :signers, :nested_quorum_certificates],
+        additionalProperties: false
       }
     },
-    required: [:view]
+    required: [:view],
+    additionalProperties: false
   }
 
   @doc """
@@ -280,7 +292,13 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block do
         priority_fee: General.IntegerStringNullable,
         uncles_hashes: %Schema{
           type: :array,
-          items: %Schema{type: :object, properties: %{hash: General.FullHash}, required: [:hash], nullable: false},
+          items: %Schema{
+            type: :object,
+            properties: %{hash: General.FullHash},
+            required: [:hash],
+            nullable: false,
+            additionalProperties: false
+          },
           nullable: false
         },
         rewards: %Schema{
@@ -291,7 +309,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block do
               type: %Schema{type: :string, nullable: false},
               reward: General.IntegerString
             },
-            required: [:type, :reward]
+            required: [:type, :reward],
+            additionalProperties: false
           },
           nullable: false
         },

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -349,7 +349,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block do
         :transaction_fees,
         :withdrawals_count,
         :is_pending_update
-      ]
+      ],
+      additionalProperties: false
     }
     |> ChainTypeCustomizations.chain_type_fields()
   )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
   @moduledoc false
   alias BlockScoutWeb.API.V2.ZkSyncView
   alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   @zksync_schema %Schema{
@@ -215,45 +216,44 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
     case Application.get_env(:explorer, :chain_type) do
       :rsk ->
         schema
-        |> put_in([:properties, :minimum_gas_price], General.IntegerString)
-        |> put_in([:properties, :bitcoin_merged_mining_header], General.HexString)
-        |> put_in([:properties, :bitcoin_merged_mining_coinbase_transaction], General.HexString)
-        |> put_in([:properties, :bitcoin_merged_mining_merkle_proof], General.HexString)
-        |> put_in([:properties, :hash_for_merged_mining], General.FullHash)
+        |> Helper.extend_schema(
+          properties: %{
+            minimum_gas_price: General.IntegerString,
+            bitcoin_merged_mining_header: General.HexString,
+            bitcoin_merged_mining_coinbase_transaction: General.HexString,
+            bitcoin_merged_mining_merkle_proof: General.HexString,
+            hash_for_merged_mining: General.FullHash
+          }
+        )
 
       :optimism ->
-        schema
-        |> put_in([:properties, :optimism], @optimism_schema)
+        schema |> Helper.extend_schema(properties: %{optimism: @optimism_schema})
 
       :zksync ->
-        schema
-        |> put_in([:properties, :zksync], @zksync_schema)
+        schema |> Helper.extend_schema(properties: %{zksync: @zksync_schema})
 
       :arbitrum ->
-        schema
-        |> put_in([:properties, :arbitrum], @arbitrum_schema)
+        schema |> Helper.extend_schema(properties: %{arbitrum: @arbitrum_schema})
 
       :ethereum ->
         schema
-        |> put_in([:properties, :blob_transactions_count], %Schema{type: :integer, nullable: false})
-        |> put_in([:properties, :blob_gas_used], General.IntegerStringNullable)
-        |> put_in([:properties, :excess_blob_gas], General.IntegerStringNullable)
-        |> put_in([:properties, :blob_gas_price], General.IntegerString)
-        |> put_in([:properties, :burnt_blob_fees], General.IntegerString)
-        |> put_in([:properties, :beacon_deposits_count], %Schema{type: :integer, nullable: true})
-        |> update_in(
-          [:required],
-          &([:blob_transactions_count, :blob_gas_used, :excess_blob_gas, :beacon_deposits_count] ++ &1)
+        |> Helper.extend_schema(
+          properties: %{
+            blob_transactions_count: %Schema{type: :integer, nullable: false},
+            blob_gas_used: General.IntegerStringNullable,
+            excess_blob_gas: General.IntegerStringNullable,
+            blob_gas_price: General.IntegerString,
+            burnt_blob_fees: General.IntegerString,
+            beacon_deposits_count: %Schema{type: :integer, nullable: true}
+          },
+          required: [:blob_transactions_count, :blob_gas_used, :excess_blob_gas, :beacon_deposits_count]
         )
 
       :celo ->
-        schema
-        |> put_in([:properties, :celo], @celo_schema)
-        |> update_in([:required], &[:celo | &1])
+        schema |> Helper.extend_schema(properties: %{celo: @celo_schema}, required: [:celo])
 
       :zilliqa ->
-        schema
-        |> put_in([:properties, :zilliqa], @zilliqa_schema)
+        schema |> Helper.extend_schema(properties: %{zilliqa: @zilliqa_schema})
 
       _ ->
         schema

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
@@ -23,7 +23,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward do
     required: [
       :amount,
       :account,
-      :associated_account
+      :associated_account,
+      :epoch_number
     ],
     additionalProperties: false
   })

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
@@ -24,6 +24,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward do
       :amount,
       :account,
       :associated_account
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/coin_balance.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/coin_balance.ex
@@ -22,6 +22,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.CoinBalance do
       :delta,
       :value,
       :block_timestamp
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/coin_balance_by_day.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/coin_balance_by_day.ex
@@ -13,6 +13,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.CoinBalanceByDay do
       date: %Schema{type: :string, format: :date, nullable: false},
       value: General.IntegerString
     },
-    required: [:date, :value]
+    required: [:date, :value],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/error_responses.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/error_responses.ex
@@ -18,7 +18,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.ErrorResponses do
           description: "Error message indicating the user is not authorized to access the resource",
           example: "Restricted access"
         }
-      }
+      },
+      additionalProperties: false
     })
 
     @spec response() :: {String.t(), String.t(), module()}

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -98,7 +98,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
           address_hash: AddressHash,
           name: %Schema{type: :string, nullable: true}
         },
-        required: [:address_hash, :name]
+        required: [:address_hash, :name],
+        additionalProperties: false
       }
       |> ChainTypeCustomizations.chain_type_fields()
     )
@@ -114,7 +115,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
         display_name: %Schema{type: :string, nullable: false},
         label: %Schema{type: :string, nullable: false}
       },
-      required: [:address_hash, :display_name, :label]
+      required: [:address_hash, :display_name, :label],
+      additionalProperties: false
     })
   end
 
@@ -127,7 +129,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
         display_name: %Schema{type: :string, nullable: false},
         label: %Schema{type: :string, nullable: false}
       },
-      required: [:display_name, :label]
+      required: [:display_name, :label],
+      additionalProperties: false
     })
   end
 
@@ -198,12 +201,14 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
                 nullable: false
               }
             },
-            nullable: false
+            nullable: false,
+            additionalProperties: false
           }
         }
       },
       required: [:method_id, :method_call, :parameters],
-      nullable: false
+      nullable: false,
+      additionalProperties: false
     })
   end
 
@@ -238,13 +243,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
               }
             },
             required: [:name, :type, :indexed, :value],
-            nullable: false
+            nullable: false,
+            additionalProperties: false
           },
           nullable: false
         }
       },
       required: [:method_id, :method_call, :parameters],
-      nullable: false
+      nullable: false,
+      additionalProperties: false
     })
   end
 
@@ -479,8 +486,21 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
         }
       },
       required: [:items, :next_page_params],
-      nullable: false
+      nullable: false,
+      additionalProperties: false
     }
+  end
+
+  @doc """
+  Extends a schema with additional properties and required fields.
+  """
+  @spec extend_schema(Schema.t(), Keyword.t()) :: Schema.t()
+  def extend_schema(schema, options) do
+    schema
+    |> Map.update!(:properties, &Map.merge(&1, Keyword.get(options, :properties, %{})))
+    |> Map.update!(:required, &(&1 ++ Keyword.get(options, :required, [])))
+    |> Map.put(:title, Keyword.get(options, :title, schema.title))
+    |> Map.put(:description, Keyword.get(options, :description, schema.description))
   end
 
   # `%Schema{anyOf: [%Schema{type: :integer}, EmptyString]}` is used because,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -6,6 +6,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
 
   alias BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward.Type, as: CeloElectionRewardType
   alias BlockScoutWeb.Schemas.API.V2.Token.Type, as: TokenType
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.{Parameter, Schema}
 
   defmodule AddressHash do
@@ -68,15 +69,16 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       case Application.get_env(:explorer, :chain_type) do
         :filecoin ->
           schema
-          |> put_in(
-            [:properties, :filecoin_robust_address],
-            %Schema{
-              type: :string,
-              example: "f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
-              nullable: true
-            }
+          |> Helper.extend_schema(
+            properties: %{
+              filecoin_robust_address: %Schema{
+                type: :string,
+                example: "f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
+                nullable: true
+              }
+            },
+            required: [:filecoin_robust_address]
           )
-          |> update_in([:required], &[:filecoin_robust_address | &1])
 
         _ ->
           schema
@@ -489,18 +491,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       nullable: false,
       additionalProperties: false
     }
-  end
-
-  @doc """
-  Extends a schema with additional properties and required fields.
-  """
-  @spec extend_schema(Schema.t(), Keyword.t()) :: Schema.t()
-  def extend_schema(schema, options) do
-    schema
-    |> Map.update!(:properties, &Map.merge(&1, Keyword.get(options, :properties, %{})))
-    |> Map.update!(:required, &(&1 ++ Keyword.get(options, :required, [])))
-    |> Map.put(:title, Keyword.get(options, :title, schema.title))
-    |> Map.put(:description, Keyword.get(options, :description, schema.description))
   end
 
   # `%Schema{anyOf: [%Schema{type: :integer}, EmptyString]}` is used because,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/internal_transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/internal_transaction.ex
@@ -65,6 +65,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.InternalTransaction do
       :index,
       :gas_limit,
       :block_index
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/log.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/log.ex
@@ -15,8 +15,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Log do
       topics: %Schema{type: :array, items: General.HexStringNullable, nullable: false},
       data: General.HexString,
       index: %Schema{type: :integer, nullable: false},
-      decoded: %Schema{allOf: [General.DecodedInput], nullable: true},
-      smart_contract: %Schema{oneOf: [Address], nullable: true},
+      decoded: %Schema{allOf: [General.DecodedLogInput], nullable: true},
+      smart_contract: %Schema{allOf: [Address], nullable: true},
       block_hash: General.FullHash,
       block_number: %Schema{type: :integer, nullable: false}
     },
@@ -30,6 +30,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Log do
       :smart_contract,
       :block_hash,
       :block_number
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
   """
   require OpenApiSpex
 
-  alias BlockScoutWeb.Schemas.API.V2.{General, Token, Token.Type, TokenInstance}
+  alias BlockScoutWeb.Schemas.API.V2.{General, Token, TokenInstanceInList}
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -14,24 +14,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
       amount: General.IntegerStringNullable,
       token_instances: %Schema{
         type: :array,
-        items: %Schema{
-          allOf: [
-            TokenInstance,
-            %Schema{
-              type: :object,
-              nullable: false,
-              properties: %{
-                token_type: Type,
-                value: General.IntegerStringNullable
-              },
-              required: [:token_type, :value]
-            }
-          ],
-          nullable: true
-        },
+        items: TokenInstanceInList,
         nullable: false
       }
     },
-    required: [:token, :amount, :token_instances]
+    required: [:token, :amount, :token_instances],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token, TokenInstanceInList}
+  alias Explorer.Chain.Address.Reputation
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -16,9 +17,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
         type: :array,
         items: TokenInstanceInList,
         nullable: false
+      },
+      reputation: %Schema{
+        type: :string,
+        enum: Reputation.enum_values(),
+        description: "Reputation of the token collection",
+        nullable: true
       }
     },
-    required: [:token, :amount, :token_instances],
+    required: [:token, :amount, :token_instances, :reputation],
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/proxy/metadata.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/proxy/metadata.ex
@@ -13,6 +13,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Proxy.Metadata do
     properties: %{
       tags: %Schema{description: "Metadata tags linked with the address", type: :array, items: MetadataTag}
     },
-    required: [:tags]
+    required: [:tags],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/proxy/metadata_tag.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/proxy/metadata_tag.ex
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Proxy.MetadataTag do
       ordinal: %Schema{type: :integer, nullable: false},
       meta: %Schema{type: :object, nullable: false}
     },
-    required: [:slug, :name, :tagType, :ordinal, :meta]
+    required: [:slug, :name, :tagType, :ordinal, :meta],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/signed_authorization.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/signed_authorization.ex
@@ -16,8 +16,14 @@ defmodule BlockScoutWeb.Schemas.API.V2.SignedAuthorization do
       r: General.IntegerString,
       s: General.IntegerString,
       v: %Schema{type: :integer, nullable: false},
-      authority: General.AddressHash
+      authority: General.AddressHash,
+      status: %Schema{
+        type: :string,
+        enum: ["ok", "invalid_chain_id", "invalid_signature", "invalid_nonce"],
+        nullable: true
+      }
     },
-    required: [:address_hash, :chain_id, :nonce, :r, :s, :v, :authority]
+    required: [:address_hash, :chain_id, :nonce, :r, :s, :v, :authority],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/signed_authorization.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/signed_authorization.ex
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.SignedAuthorization do
         nullable: true
       }
     },
-    required: [:address_hash, :chain_id, :nonce, :r, :s, :v, :authority],
+    required: [:address_hash, :chain_id, :nonce, :r, :s, :v, :authority, :status],
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -2,6 +2,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token.ChainTypeCustomizations do
   @moduledoc false
   require OpenApiSpex
 
+  alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
   alias Explorer.Chain.BridgedToken
   alias OpenApiSpex.Schema
 
@@ -15,8 +17,10 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token.ChainTypeCustomizations do
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
-        |> put_in([:properties, :filecoin_robust_address], @filecoin_robust_address_schema)
-        |> update_in([:required], &[:filecoin_robust_address | &1])
+        |> Helper.extend_schema(
+          properties: %{filecoin_robust_address: @filecoin_robust_address_schema},
+          required: [:filecoin_robust_address]
+        )
 
       _ ->
         schema

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -55,8 +55,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
       type: :object,
       properties: %{
         address_hash: General.AddressHash,
-        symbol: %Schema{type: :string, nullable: false},
-        name: %Schema{type: :string, nullable: false},
+        symbol: %Schema{type: :string, nullable: true},
+        name: %Schema{type: :string, nullable: true},
         decimals: General.IntegerStringNullable,
         type: %Schema{allOf: [Type], nullable: true},
         holders_count: General.IntegerStringNullable,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -54,10 +54,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
         symbol: %Schema{type: :string, nullable: false},
         name: %Schema{type: :string, nullable: false},
         decimals: General.IntegerStringNullable,
-        type: %Schema{
-          anyOf: [Type],
-          nullable: true
-        },
+        type: %Schema{allOf: [Type], nullable: true},
         holders_count: General.IntegerStringNullable,
         exchange_rate: General.FloatStringNullable,
         volume_24h: General.FloatStringNullable,
@@ -84,7 +81,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
         :icon_url,
         :circulating_market_cap,
         :reputation
-      ]
+      ],
+      additionalProperties: false
     }
     |> ChainTypeCustomizations.chain_type_fields()
     |> ChainTypeCustomizations.maybe_append_bridged_info()

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance.ex
@@ -53,6 +53,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstance do
       :thumbnails,
       :media_type,
       :media_url
-    ]
+    ],
+    nullable: false,
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
@@ -5,10 +5,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token.Type, TokenInstance}
+  alias BlockScoutWeb.Schemas.Helper
 
   OpenApiSpex.schema(
     TokenInstance.schema()
-    |> General.extend_schema(
+    |> Helper.extend_schema(
       title: "TokenInstanceInList",
       properties: %{
         token_type: Type,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
@@ -5,21 +5,16 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token.Type, TokenInstance}
-  alias OpenApiSpex.Schema
 
-  OpenApiSpex.schema(%{
-    allOf: [
-      TokenInstance,
-      %Schema{
-        type: :object,
-        nullable: false,
-        properties: %{
-          token_type: Type,
-          value: General.IntegerStringNullable
-        },
-        required: [:token_type, :value]
-      }
-    ],
-    type: :object
-  })
+  OpenApiSpex.schema(
+    TokenInstance.schema()
+    |> General.extend_schema(
+      title: "TokenInstanceInList",
+      properties: %{
+        token_type: Type,
+        value: General.IntegerStringNullable
+      },
+      required: [:token_type, :value]
+    )
+  )
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
@@ -6,6 +6,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token.Type, TokenInstance}
   alias BlockScoutWeb.Schemas.Helper
+  alias Explorer.Chain.Address.Reputation
+  alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(
     TokenInstance.schema()
@@ -13,9 +15,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
       title: "TokenInstanceInList",
       properties: %{
         token_type: Type,
-        value: General.IntegerStringNullable
+        value: General.IntegerStringNullable,
+        reputation: %Schema{
+          type: :string,
+          enum: Reputation.enum_values(),
+          description: "Reputation of the token instance",
+          nullable: true
+        }
       },
-      required: [:token_type, :value]
+      required: [:token_type, :value, :reputation]
     )
   )
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
@@ -77,7 +77,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
       :log_index,
       :token_type,
       :reputation
-    ]
+    ],
+    additionalProperties: false
   })
 end
 
@@ -92,9 +93,10 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer.TotalERC721 do
     type: :object,
     properties: %{
       token_id: General.IntegerStringNullable,
-      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true}
+      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true, additionalProperties: false}
     },
-    required: [:token_id, :token_instance]
+    required: [:token_id, :token_instance],
+    additionalProperties: false
   })
 end
 
@@ -111,9 +113,10 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer.TotalERC1155 do
       token_id: General.IntegerStringNullable,
       value: General.IntegerStringNullable,
       decimals: General.IntegerStringNullable,
-      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true}
+      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true, additionalProperties: false}
     },
-    required: [:token_id, :value, :decimals, :token_instance]
+    required: [:token_id, :value, :decimals, :token_instance],
+    additionalProperties: false
   })
 end
 
@@ -129,6 +132,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer.Total do
       value: General.IntegerStringNullable,
       decimals: General.IntegerStringNullable
     },
-    required: [:value, :decimals]
+    required: [:value, :decimals],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
@@ -93,7 +93,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer.TotalERC721 do
     type: :object,
     properties: %{
       token_id: General.IntegerStringNullable,
-      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true, additionalProperties: false}
+      token_instance: %Schema{allOf: [TokenInstance], nullable: true}
     },
     required: [:token_id, :token_instance],
     additionalProperties: false
@@ -113,7 +113,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer.TotalERC1155 do
       token_id: General.IntegerStringNullable,
       value: General.IntegerStringNullable,
       decimals: General.IntegerStringNullable,
-      token_instance: %Schema{type: :object, anyOf: [TokenInstance], nullable: true, additionalProperties: false}
+      token_instance: %Schema{allOf: [TokenInstance], nullable: true}
     },
     required: [:token_id, :value, :decimals, :token_instance],
     additionalProperties: false

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
   alias BlockScoutWeb.API.V2.ZkSyncView
   alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
   alias BlockScoutWeb.Schemas.API.V2.Transaction.Fee
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   @zksync_schema %Schema{
@@ -151,129 +152,154 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
     case Application.get_env(:explorer, :chain_type) do
       :polygon_zkevm ->
         schema
-        |> put_in([:properties, :zkevm_batch_number], %Schema{type: :integer, nullable: true})
-        |> put_in([:properties, :zkevm_sequence_hash], General.FullHash)
-        |> put_in([:properties, :zkevm_verify_hash], General.FullHash)
-        |> put_in([:properties, :zkevm_status], %Schema{
-          type: :string,
-          enum: ["Confirmed by Sequencer", "L1 Confirmed"],
-          nullable: false
-        })
+        |> Helper.extend_schema(
+          properties: %{
+            zkevm_batch_number: %Schema{type: :integer, nullable: true},
+            zkevm_sequence_hash: General.FullHash,
+            zkevm_verify_hash: General.FullHash,
+            zkevm_status: %Schema{
+              type: :string,
+              enum: ["Confirmed by Sequencer", "L1 Confirmed"],
+              nullable: false
+            }
+          }
+        )
 
       :zksync ->
-        schema
-        |> put_in([:properties, :zksync], @zksync_schema)
+        schema |> Helper.extend_schema(properties: %{zksync: @zksync_schema})
 
       :arbitrum ->
-        schema
-        |> put_in([:properties, :arbitrum], @arbitrum_schema)
+        schema |> Helper.extend_schema(properties: %{arbitrum: @arbitrum_schema})
 
       :optimism ->
         schema
-        |> put_in([:properties, :l1_fee], General.IntegerString)
-        |> put_in([:properties, :l1_fee_scalar], General.IntegerString)
-        |> put_in([:properties, :l1_gas_price], General.IntegerString)
-        |> put_in([:properties, :l1_gas_used], General.IntegerString)
-        |> put_in([:properties, :op_withdrawals], %Schema{
-          type: :array,
-          items: @optimism_withdrawal_schema,
-          nullable: false
-        })
-        |> put_in([:properties, :op_interop], %Schema{
-          type: :object,
-          nullable: false,
+        |> Helper.extend_schema(
           properties: %{
-            nonce: %Schema{type: :integer},
-            status: %Schema{type: :string, nullable: false, enum: ["Sent", "Relayed", "Failed"]},
-            sender_address_hash: General.AddressHashNullable,
-            target_address_hash: General.AddressHashNullable,
-            payload: General.HexString,
-            relay_chain: %Schema{type: :object, nullable: true},
-            relay_transaction_hash: General.FullHashNullable,
-            init_chain: %Schema{type: :object, nullable: true},
-            init_transaction_hash: General.FullHashNullable
-          },
-          required: [:nonce, :status, :sender_address_hash, :target_address_hash, :payload],
-          additionalProperties: false
-        })
+            l1_fee: General.IntegerString,
+            l1_fee_scalar: General.IntegerString,
+            l1_gas_price: General.IntegerString,
+            l1_gas_used: General.IntegerString,
+            op_withdrawals: %Schema{
+              type: :array,
+              items: @optimism_withdrawal_schema,
+              nullable: false
+            },
+            op_interop: %Schema{
+              type: :object,
+              nullable: false,
+              properties: %{
+                nonce: %Schema{type: :integer},
+                status: %Schema{type: :string, nullable: false, enum: ["Sent", "Relayed", "Failed"]},
+                sender_address_hash: General.AddressHashNullable,
+                target_address_hash: General.AddressHashNullable,
+                payload: General.HexString,
+                relay_chain: %Schema{type: :object, nullable: true},
+                relay_transaction_hash: General.FullHashNullable,
+                init_chain: %Schema{type: :object, nullable: true},
+                init_transaction_hash: General.FullHashNullable
+              },
+              required: [:nonce, :status, :sender_address_hash, :target_address_hash, :payload],
+              additionalProperties: false
+            }
+          }
+        )
 
       :scroll ->
-        schema
-        |> put_in([:properties, :scroll], @scroll_schema)
+        schema |> Helper.extend_schema(properties: %{scroll: @scroll_schema})
 
       :suave ->
         schema
-        |> put_in([:properties, :allowed_peekers], %Schema{type: :array, items: General.AddressHash, nullable: false})
-        |> put_in([:properties, :execution_node], Address)
-        |> put_in([:properties, :wrapped], %Schema{
-          type: :object,
-          nullable: false,
+        |> Helper.extend_schema(
           properties: %{
-            type: %Schema{type: :integer},
-            nonce: %Schema{type: :integer, nullable: true},
-            to: Address,
-            gas_limit: General.IntegerStringNullable,
-            gas_price: General.IntegerStringNullable,
-            fee: Fee,
-            max_priority_fee_per_gas: General.IntegerStringNullable,
-            max_fee_per_gas: General.IntegerStringNullable,
-            value: General.IntegerStringNullable,
-            hash: General.FullHash,
-            method: General.MethodNameNullable,
-            decoded_input: %Schema{allOf: [General.DecodedInput], nullable: true},
-            raw_input: General.HexString
-          },
-          additionalProperties: false
-        })
+            allowed_peekers: %Schema{type: :array, items: General.AddressHash, nullable: false},
+            execution_node: Address,
+            wrapped: %Schema{
+              type: :object,
+              nullable: false,
+              properties: %{
+                type: %Schema{type: :integer},
+                nonce: %Schema{type: :integer, nullable: true},
+                to: Address,
+                gas_limit: General.IntegerStringNullable,
+                gas_price: General.IntegerStringNullable,
+                fee: Fee,
+                max_priority_fee_per_gas: General.IntegerStringNullable,
+                max_fee_per_gas: General.IntegerStringNullable,
+                value: General.IntegerStringNullable,
+                hash: General.FullHash,
+                method: General.MethodNameNullable,
+                decoded_input: %Schema{allOf: [General.DecodedInput], nullable: true},
+                raw_input: General.HexString
+              },
+              additionalProperties: false
+            }
+          }
+        )
 
       :stability ->
         schema
-        |> put_in([:properties, :stability_fee], %Schema{
-          type: :object,
-          nullable: false,
+        |> Helper.extend_schema(
           properties: %{
-            token: Token,
-            validator_address: Address,
-            dapp_address: Address,
-            total_fee: General.IntegerString,
-            dapp_fee: General.IntegerString,
-            validator_fee: General.IntegerString
-          },
-          required: [:token, :validator_address, :dapp_address, :total_fee, :dapp_fee, :validator_fee],
-          additionalProperties: false
-        })
+            stability_fee: %Schema{
+              type: :object,
+              nullable: false,
+              properties: %{
+                token: Token,
+                validator_address: Address,
+                dapp_address: Address,
+                total_fee: General.IntegerString,
+                dapp_fee: General.IntegerString,
+                validator_fee: General.IntegerString
+              },
+              required: [:token, :validator_address, :dapp_address, :total_fee, :dapp_fee, :validator_fee],
+              additionalProperties: false
+            }
+          }
+        )
 
       :ethereum ->
         schema
-        |> put_in([:properties, :max_fee_per_blob_gas], General.IntegerString)
-        |> put_in([:properties, :blob_versioned_hashes], %Schema{type: :array, items: General.FullHash, nullable: false})
-        |> put_in([:properties, :blob_gas_used], General.IntegerString)
-        |> put_in([:properties, :blob_gas_price], General.IntegerString)
-        |> put_in([:properties, :burnt_blob_fee], General.IntegerString)
+        |> Helper.extend_schema(
+          properties: %{
+            max_fee_per_blob_gas: General.IntegerString,
+            blob_versioned_hashes: %Schema{type: :array, items: General.FullHash, nullable: false},
+            blob_gas_used: General.IntegerString,
+            blob_gas_price: General.IntegerString,
+            burnt_blob_fee: General.IntegerString
+          }
+        )
 
       :celo ->
         schema
-        |> put_in([:properties, :celo], %Schema{
-          type: :object,
-          nullable: false,
-          properties: %{gas_token: %Schema{allOf: [Token], nullable: true}},
-          required: [:gas_token],
-          additionalProperties: false
-        })
-        |> update_in([:required], &[:celo | &1])
+        |> Helper.extend_schema(
+          properties: %{
+            celo: %Schema{
+              type: :object,
+              nullable: false,
+              properties: %{gas_token: %Schema{allOf: [Token], nullable: true}},
+              required: [:gas_token],
+              additionalProperties: false
+            }
+          },
+          required: [:celo]
+        )
 
       :zilliqa ->
         schema
-        |> put_in([:properties, :zilliqa], %Schema{
-          type: :object,
-          nullable: false,
+        |> Helper.extend_schema(
           properties: %{
-            is_scilla: %Schema{type: :boolean, nullable: false}
+            zilliqa: %Schema{
+              type: :object,
+              nullable: false,
+              properties: %{
+                is_scilla: %Schema{type: :boolean, nullable: false}
+              },
+              required: [:is_scilla],
+              additionalProperties: false
+            }
           },
-          required: [:is_scilla],
-          additionalProperties: false
-        })
-        |> update_in([:required], &[:zilliqa | &1])
+          required: [:zilliqa]
+        )
 
       _ ->
         schema

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
@@ -31,7 +31,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
       :prove_transaction_timestamp,
       :execute_transaction_hash,
       :execute_transaction_timestamp
-    ]
+    ],
+    additionalProperties: false
   }
 
   @arbitrum_commitment_transaction_schema %Schema{
@@ -42,7 +43,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
       timestamp: General.TimestampNullable,
       status: %Schema{type: :string, enum: ["unfinalized", "finalized"], nullable: true}
     },
-    required: [:hash, :timestamp, :status]
+    required: [:hash, :timestamp, :status],
+    additionalProperties: false
   }
 
   @arbitrum_schema %Schema{
@@ -76,14 +78,16 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
             ],
             nullable: false
           }
-        }
+        },
+        additionalProperties: false
       },
       gas_used_for_l1: General.IntegerString,
       gas_used_for_l2: General.IntegerString,
       poster_fee: General.IntegerString,
       network_fee: General.IntegerString
     },
-    required: [:gas_used_for_l1, :gas_used_for_l2, :poster_fee, :network_fee]
+    required: [:gas_used_for_l1, :gas_used_for_l2, :poster_fee, :network_fee],
+    additionalProperties: false
   }
 
   @optimism_withdrawal_schema %Schema{
@@ -94,7 +98,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
       status: %Schema{type: :string, nullable: false},
       l1_transaction_hash: General.FullHashNullable
     },
-    required: [:nonce, :status, :l1_transaction_hash]
+    required: [:nonce, :status, :l1_transaction_hash],
+    additionalProperties: false
   }
 
   @scroll_schema %Schema{
@@ -127,7 +132,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
       :l1_gas_used,
       :l2_fee,
       :l2_block_status
-    ]
+    ],
+    additionalProperties: false
   }
 
   @doc """
@@ -187,7 +193,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
             init_chain: %Schema{type: :object, nullable: true},
             init_transaction_hash: General.FullHashNullable
           },
-          required: [:nonce, :status, :sender_address_hash, :target_address_hash, :payload]
+          required: [:nonce, :status, :sender_address_hash, :target_address_hash, :payload],
+          additionalProperties: false
         })
 
       :scroll ->
@@ -215,7 +222,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
             method: General.MethodNameNullable,
             decoded_input: %Schema{allOf: [General.DecodedInput], nullable: true},
             raw_input: General.HexString
-          }
+          },
+          additionalProperties: false
         })
 
       :stability ->
@@ -231,7 +239,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
             dapp_fee: General.IntegerString,
             validator_fee: General.IntegerString
           },
-          required: [:token, :validator_address, :dapp_address, :total_fee, :dapp_fee, :validator_fee]
+          required: [:token, :validator_address, :dapp_address, :total_fee, :dapp_fee, :validator_fee],
+          additionalProperties: false
         })
 
       :ethereum ->
@@ -247,8 +256,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
         |> put_in([:properties, :celo], %Schema{
           type: :object,
           nullable: false,
-          properties: %{gas_token: %Schema{oneOf: [Token], nullable: true}},
-          required: [:gas_token]
+          properties: %{gas_token: %Schema{allOf: [Token], nullable: true}},
+          required: [:gas_token],
+          additionalProperties: false
         })
         |> update_in([:required], &[:celo | &1])
 
@@ -260,7 +270,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
           properties: %{
             is_scilla: %Schema{type: :boolean, nullable: false}
           },
-          required: [:is_scilla]
+          required: [:is_scilla],
+          additionalProperties: false
         })
         |> update_in([:required], &[:zilliqa | &1])
 
@@ -360,7 +371,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction do
               type: :object,
               properties: %{raw: %Schema{anyOf: [General.HexString, %Schema{type: :string}], nullable: true}},
               required: [:raw],
-              nullable: false
+              nullable: false,
+              additionalProperties: false
             }
           ],
           nullable: true
@@ -390,7 +402,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction do
                 description: "Transaction action details (json formatted)",
                 nullable: false
               }
-            }
+            },
+            additionalProperties: false
           },
           nullable: true
         },
@@ -462,7 +475,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction do
         :has_error_in_internal_transactions,
         :authorization_list,
         :is_pending_update
-      ]
+      ],
+      additionalProperties: false
     }
     |> ChainTypeCustomizations.chain_type_fields()
   )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/fee.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/fee.ex
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.Fee do
         enum: ["maximum", "actual"]
       },
       value: General.IntegerStringNullable
-    }
+    },
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/withdrawal.ex
@@ -20,6 +20,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Withdrawal do
       :index,
       :validator_index,
       :amount
-    ]
+    ],
+    additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/helper.ex
@@ -1,0 +1,28 @@
+defmodule BlockScoutWeb.Schemas.Helper do
+  @moduledoc false
+
+  alias OpenApiSpex.Schema
+
+  @doc """
+  Extends a schema with additional properties and required fields.
+  """
+  @spec extend_schema(Schema.t() | map(), Keyword.t()) :: Schema.t() | map()
+  def extend_schema(schema, options) do
+    updated_schema =
+      schema
+      |> Map.update!(:properties, &Map.merge(&1, Keyword.get(options, :properties, %{})))
+      |> Map.update!(:required, &(&1 ++ Keyword.get(options, :required, [])))
+
+    updated_schema_with_title =
+      if Keyword.has_key?(options, :title),
+        do: Map.put(updated_schema, :title, Keyword.get(options, :title)),
+        else: updated_schema
+
+    updated_schema_with_description =
+      if Keyword.has_key?(options, :description),
+        do: Map.put(updated_schema_with_title, :description, Keyword.get(options, :description)),
+        else: updated_schema_with_title
+
+    updated_schema_with_description
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -195,15 +195,15 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "amount" => string_or_null(collection.distinct_token_instances_count || collection.value),
       "token_instances" =>
         Enum.map(collection.preloaded_token_instances, fn instance ->
-          prepare_nft_for_collection(collection.token.type, instance)
+          prepare_nft_for_collection(collection.token.type, instance, collection.reputation)
         end),
       "reputation" => collection.reputation
     }
   end
 
-  defp prepare_nft_for_collection(token_type, instance) do
+  defp prepare_nft_for_collection(token_type, instance, reputation) do
     Map.merge(
-      %{"token_type" => token_type, "value" => value(token_type, instance)},
+      %{"token_type" => token_type, "value" => value(token_type, instance), "reputation" => reputation},
       TokenView.prepare_token_instance(instance, nil)
     )
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -30,7 +30,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
   import Explorer.Chain, only: [hash_to_lower_case_string: 1]
   import Mox
-  import OpenApiSpex.TestAssertions
 
   @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
   @instances_amount_in_collection 9

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -4406,7 +4406,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert not is_nil(response["next_page_params"])
       refute Map.has_key?(response["next_page_params"], "type")
       assert Map.has_key?(response["next_page_params"], "token_type")
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get paginated ERC-1155 nft", %{conn: conn, endpoint: endpoint} do
@@ -4736,8 +4735,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       filter = %{"type" => "ERC-404,ERC-1155"}
       request = get(conn, endpoint.(address.hash), filter)
       response = json_response(request, 200)
-
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert Enum.count(response["items"]) == 10
       assert Enum.all?(response["items"], fn item -> item["token_type"] in ["ERC-404", "ERC-1155"] end)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -89,7 +89,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{Address.checksum(address.hash)}")
       json_response = json_response(request, 200)
       check_response(correct_response, json_response)
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -106,8 +105,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get address & get the same response for checksummed and downcased parameter", %{conn: conn} do
@@ -146,12 +143,10 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{Address.checksum(address.hash)}")
       json_response = json_response(request, 200)
       check_response(correct_response, json_response)
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
 
       request = get(conn, "/api/v2/addresses/#{String.downcase(to_string(address.hash))}")
       json_response = json_response(request, 200)
       check_response(correct_response, json_response)
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "returns successful creation transaction for a contract when both failed and successful transactions exist",
@@ -181,8 +176,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["is_contract"]
       assert response["creation_transaction_hash"] == to_string(succeeded_transaction.hash)
       assert response["creation_status"] == "success"
-
-      assert_schema(response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "returns failed creation transaction for a contract",
@@ -204,8 +197,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["is_contract"]
       assert response["creation_transaction_hash"] == to_string(failed_transaction.hash)
       assert response["creation_status"] == "failed"
-
-      assert_schema(response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     defp check_response(pattern_response, response) do
@@ -334,8 +325,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get EIP-1967 proxy contract info", %{conn: conn} do
@@ -390,8 +379,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get Resolved Delegate Proxy contract info", %{conn: conn} do
@@ -449,8 +436,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get watchlist id", %{conn: conn} do
@@ -485,8 +470,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response = json_response(request, 200)
 
       assert response["watchlist_address_id"] == watchlist_address.id
-
-      assert_schema(response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "broadcasts fetched_bytecode event", %{conn: conn} do
@@ -518,7 +501,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = get(conn, "/api/v2/addresses/#{address.hash}")
       assert response = json_response(request, 200)
-      assert_schema(response, "AddressResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert_receive %Phoenix.Socket.Message{
                        payload: %{fetched_bytecode: ^contract_code},
@@ -543,8 +525,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "gas_usage_count" => "0",
                "validations_count" => "0"
              } = json_response
-
-      assert_schema(json_response, "AddressCounters", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -561,8 +541,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get counters with 0s", %{conn: conn} do
@@ -578,8 +556,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "gas_usage_count" => "0",
                "validations_count" => "0"
              } = json_response
-
-      assert_schema(json_response, "AddressCounters", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get counters", %{conn: conn} do
@@ -619,8 +595,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "gas_usage_count" => ^gas_used,
                "validations_count" => "1"
              } = json_response
-
-      assert_schema(json_response, "AddressCounters", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -632,8 +606,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       json_response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = json_response
-
-      assert_schema(json_response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -650,8 +622,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get relevant transaction", %{conn: conn} do
@@ -668,7 +638,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(transaction, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get pending transaction", %{conn: conn} do
@@ -688,7 +657,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       compare_item(pending_transaction, Enum.at(response["items"], 0))
       compare_item(transaction, Enum.at(response["items"], 1))
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get only :to transaction", %{conn: conn} do
@@ -704,7 +672,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(transaction, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get only :from transactions", %{conn: conn} do
@@ -720,7 +687,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(transaction, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "validated transactions can paginate", %{conn: conn} do
@@ -735,8 +701,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "pending transactions can paginate", %{conn: conn} do
@@ -751,7 +715,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "pending + validated transactions can paginate", %{conn: conn} do
@@ -763,12 +726,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/transactions")
       assert response = json_response(request, 200)
 
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request_2nd_page = get(conn, "/api/v2/addresses/#{address.hash}/transactions", response["next_page_params"])
       assert response_2nd_page = json_response(request_2nd_page, 200)
-
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert Enum.count(response["items"]) == 50
       assert response["next_page_params"] != nil
@@ -789,8 +748,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         response,
         transactions_validated ++ [Enum.at(transactions_pending, 0)]
       )
-
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":to transactions can paginate", %{conn: conn} do
@@ -809,8 +766,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":from transactions can paginate", %{conn: conn} do
@@ -829,8 +784,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":from + :to transactions can paginate", %{conn: conn} do
@@ -862,10 +815,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_3rd_page = json_response(request_3rd_page, 200)
 
       check_paginated_response(response_2nd_page, response_3rd_page, transactions_from ++ [Enum.at(transactions_to, 0)])
-
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_3rd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "422 on wrong ordering params", %{conn: conn} do
@@ -890,8 +839,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "backward compatible with legacy paging params", %{conn: conn} do
@@ -915,8 +862,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "backward compatible with legacy paging params for pending transactions", %{conn: conn} do
@@ -942,8 +887,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page_pending = json_response(request_2nd_page_pending, 200)
 
       check_paginated_response(response, response_2nd_page_pending, transactions)
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page_pending, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by fee ascending", %{conn: conn} do
@@ -983,8 +926,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by fee descending", %{conn: conn} do
@@ -1024,8 +965,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by value ascending", %{conn: conn} do
@@ -1060,8 +999,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by value descending", %{conn: conn} do
@@ -1096,8 +1033,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by block number ascending", %{conn: conn} do
@@ -1136,8 +1071,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "can order and paginate by block number descending", %{conn: conn} do
@@ -1176,8 +1109,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(Enum.at(transactions, 50), Enum.at(response_2nd_page["items"], 0))
 
       check_paginated_response(response, response_2nd_page, transactions |> Enum.reverse())
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "regression test for decoding issue", %{conn: conn} do
@@ -1250,8 +1181,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(response["items"]) == 1
       assert response["next_page_params"] == nil
 
-      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       transaction = Enum.at(response["items"], 0)
       assert transaction["to"]["ens_domain_name"] == "test.eth"
 
@@ -1300,8 +1229,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert List.first(response["items"])["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/token-transfers") |> json_response(200)
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token transfers with scam reputation", %{conn: conn} do
@@ -1327,7 +1254,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/addresses/#{address.hash}/token-transfers")
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
@@ -1335,8 +1261,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert response["items"] == []
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token transfers with ok reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -1359,8 +1283,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -1386,8 +1308,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 200 on non existing address", %{conn: conn} do
@@ -1397,7 +1317,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       json_response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = json_response
-      assert_schema(json_response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -1414,8 +1333,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 200 on non existing address of token", %{conn: conn} do
@@ -1427,7 +1344,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       json_response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = json_response
-      assert_schema(json_response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid token address hash", %{conn: conn} do
@@ -1446,8 +1362,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get relevant token transfer", %{conn: conn} do
@@ -1476,7 +1390,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(token_transfer, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "method in token transfer could be decoded", %{conn: conn} do
@@ -1528,8 +1441,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
       compare_item(token_transfer, Enum.at(response["items"], 0))
       assert Enum.at(response["items"], 0)["method"] == "mint"
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get relevant token transfer filtered by token", %{conn: conn} do
@@ -1571,7 +1482,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(token_transfer, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "token transfers by token can paginate", %{conn: conn} do
@@ -1609,9 +1519,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get only :to token transfer", %{conn: conn} do
@@ -1641,7 +1548,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(token_transfer, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get only :from token transfer", %{conn: conn} do
@@ -1671,7 +1577,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(token_transfer, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "token transfers can paginate", %{conn: conn} do
@@ -1696,8 +1601,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":to token transfers can paginate", %{conn: conn} do
@@ -1736,8 +1639,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":from token transfers can paginate", %{conn: conn} do
@@ -1776,8 +1677,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test ":from + :to tt can paginate", %{conn: conn} do
@@ -1830,9 +1729,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_3rd_page = json_response(request_3rd_page, 200)
 
       check_paginated_response(response_2nd_page, response_3rd_page, tt_from ++ [Enum.at(tt_to, 0)])
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_3rd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check token type filters", %{conn: conn} do
@@ -1899,8 +1795,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, erc_20_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       # -- ------ --
 
       # -- ERC-721 --
@@ -1914,8 +1808,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, erc_721_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       # -- ------ --
 
       # -- ERC-1155 --
@@ -1929,8 +1821,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, erc_1155_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       # -- ------ --
 
       # two filters simultaneously
@@ -1966,9 +1856,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_3rd_page["next_page_params"] == nil
       compare_item(Enum.at(erc_20_tt, 1), Enum.at(response_3rd_page["items"], 0))
       compare_item(Enum.at(erc_20_tt, 0), Enum.at(response_3rd_page["items"], 1))
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_3rd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       # -- ------ --
     end
 
@@ -2027,8 +1914,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert response_2nd_page = json_response(request_2nd_page, 200)
       check_paginated_response(response, response_2nd_page, erc_721_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       filter = %{"type" => "ERC-721,ERC-20", "filter" => "to"}
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-transfers", filter)
       assert response = json_response(request, 200)
@@ -2039,8 +1924,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, erc_721_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-721,ERC-20", "filter" => "from"}
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-transfers", filter)
@@ -2052,8 +1935,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, erc_20_tt)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check that same token_ids within batch squashes", %{conn: conn} do
@@ -2094,8 +1975,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check that pagination works for 721 tokens", %{conn: conn} do
@@ -2126,8 +2005,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check that pagination works fine with 1155 batches #1 (large batch) + check filters", %{conn: conn} do
@@ -2164,16 +2041,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-1155", "filter" => "from"}
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-transfers", filter)
       assert response = json_response(request, 200)
       assert %{"items" => [], "next_page_params" => nil} = response
-
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check that pagination works fine with 1155 batches #2 some batches on the first page and one on the second",
@@ -2240,8 +2113,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers_1 ++ token_transfers_2 ++ [tt_3])
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check that pagination works fine with 1155 batches #3", %{conn: conn} do
@@ -2295,8 +2166,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_transfers_1 ++ token_transfers_2)
-      assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     if @chain_type == :celo do
@@ -2319,7 +2188,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         assert response["next_page_params"] == nil
 
         compare_item(token_transfer, Enum.at(response["items"], 0), true)
-        assert_schema(response, "AddressTokenTransfersPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
     end
   end
@@ -2332,7 +2200,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2349,8 +2216,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get internal transaction and filter working", %{conn: conn} do
@@ -2391,7 +2256,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       compare_item(internal_transaction_from, Enum.at(response["items"], 1))
       compare_item(internal_transaction_to, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions", %{"filter" => "from"})
 
@@ -2400,7 +2264,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(internal_transaction_from, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions", %{"filter" => "to"})
 
@@ -2408,7 +2271,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(response["items"]) == 1
       assert response["next_page_params"] == nil
       compare_item(internal_transaction_to, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "internal transactions can paginate", %{conn: conn} do
@@ -2441,8 +2303,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, internal_transactions_from)
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       internal_transactions_to =
         for i <- 52..102 do
@@ -2471,8 +2331,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, internal_transactions_to)
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"filter" => "from"}
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions", filter)
@@ -2488,8 +2346,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, internal_transactions_from)
-      assert_schema(response, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressInternalTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -2500,7 +2356,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/blocks-validated")
       assert response = json_response(request, 200)
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressBlocksValidatedPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2517,8 +2372,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get relevant block validated", %{conn: conn} do
@@ -2533,7 +2386,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(block, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressBlocksValidatedPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "blocks validated can be paginated", %{conn: conn} do
@@ -2548,8 +2400,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, blocks)
-      assert_schema(response, "AddressBlocksValidatedPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressBlocksValidatedPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -2571,8 +2421,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert List.first(response)["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/token-balances") |> json_response(200)
-
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token balances with scam reputation", %{conn: conn} do
@@ -2590,7 +2438,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/addresses/#{address.hash}/token-balances")
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response)["reputation"] == "scam"
 
@@ -2598,8 +2445,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert response == []
-
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get smart-contract with ok reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -2615,8 +2460,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response)["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get smart-contract with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -2634,8 +2477,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response)["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get empty list on non existing address", %{conn: conn} do
@@ -2644,7 +2485,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/token-balances")
       assert response = json_response(request, 200)
       assert response == []
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2661,8 +2501,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token balance", %{conn: conn} do
@@ -2681,8 +2519,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       for i <- 0..50 do
         compare_item(Enum.at(ctbs, i), Enum.at(response, i))
       end
-
-      assert_schema(response, "AddressTokenBalances", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -2694,7 +2530,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressCoinBalanceHistoryPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2711,8 +2546,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get coin balance history", %{conn: conn} do
@@ -2728,7 +2561,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(acb, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressCoinBalanceHistoryPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get coin balance with transaction", %{conn: conn} do
@@ -2794,8 +2626,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, acbs)
-      assert_schema(response, "AddressCoinBalanceHistoryPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressCoinBalanceHistoryPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -2814,8 +2644,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "days" => ^days_count,
                "items" => []
              } = response
-
-      assert_schema(response, "AddressCoinBalanceHistoryByDay", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2832,8 +2660,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get coin balance history by day", %{conn: conn} do
@@ -2858,8 +2684,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  %{"date" => _, "value" => "1000"}
                ]
              } = response
-
-      assert_schema(response, "AddressCoinBalanceHistoryByDay", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -2870,7 +2694,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/logs")
       response = json_response(request, 200)
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -2887,8 +2710,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get log", %{conn: conn} do
@@ -2915,7 +2736,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(log, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     # for some reasons test does not work if run as single test
@@ -2944,8 +2764,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request_2nd_page = get(conn, "/api/v2/addresses/#{address.hash}/logs", response["next_page_params"])
       assert response_2nd_page = json_response(request_2nd_page, 200)
       check_paginated_response(response, response_2nd_page, logs)
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     # https://github.com/blockscout/blockscout/issues/9926
@@ -3029,7 +2847,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(log, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       log = Enum.at(response["items"], 0)
       assert log["address"]["ens_domain_name"] == "test.eth"
@@ -3091,7 +2908,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response["next_page_params"] == nil
 
       compare_item(log, Enum.at(response["items"], 0))
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "log could be decoded via verified implementation", %{conn: conn} do
@@ -3191,8 +3007,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              }
-
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "test corner case, when preload functions face absent smart contract", %{conn: conn} do
@@ -3235,7 +3049,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       log_from_api = Enum.at(response["items"], 0)
 
       compare_item(log, log_from_api)
-      assert_schema(response, "AddressLogsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "ignore logs without topics when trying to decode with sig provider", %{conn: conn} do
@@ -3321,8 +3134,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert List.first(response["items"])["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/tokens") |> json_response(200)
-
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token balances with scam reputation", %{conn: conn} do
@@ -3343,7 +3154,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
@@ -3351,8 +3161,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert response["items"] == []
-
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token balances with ok reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -3372,8 +3180,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token balances with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -3396,8 +3202,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get empty list on non existing address", %{conn: conn} do
@@ -3407,7 +3211,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -3424,8 +3227,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get tokens", %{conn: conn} do
@@ -3474,8 +3275,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, ctbs_erc_20)
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-721"}
       request = get(conn, "/api/v2/addresses/#{address.hash}/tokens", filter)
@@ -3487,8 +3286,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, ctbs_erc_721)
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-1155"}
       request = get(conn, "/api/v2/addresses/#{address.hash}/tokens", filter)
@@ -3500,8 +3297,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, ctbs_erc_1155)
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       # Test multiple token types (the fix for the original issue)
       filter = %{"type" => "ERC-721,ERC-1155"}
@@ -3516,7 +3311,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         |> Enum.sort()
 
       assert response_token_types == ["ERC-1155", "ERC-721"]
-      assert_schema(response, "AddressTokensPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -3809,7 +3603,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressWithdrawalsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -3826,8 +3619,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get withdrawals", %{conn: conn} do
@@ -3841,8 +3632,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, address.withdrawals)
-      assert_schema(response, "AddressWithdrawalsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressWithdrawalsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -3858,7 +3647,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert pattern_response["items"] == response["items"]
       assert pattern_response["next_page_params"] == response["next_page_params"]
       assert pattern_response["total_supply"] == response["total_supply"]
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check pagination", %{conn: conn} do
@@ -3878,9 +3666,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert Enum.at(response["items"], 0)["coin_balance"] ==
                to_string(Enum.at(addresses, 50).fetched_coin_balance.value)
-
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check nil", %{conn: conn} do
@@ -3891,7 +3676,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert %{"items" => [address_json], "next_page_params" => nil} = response
 
       compare_item(address, address_json)
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check smart contract preload", %{conn: conn} do
@@ -3904,7 +3688,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert String.downcase(address["hash"]) == to_string(smart_contract.address_hash)
       assert address["is_contract"] == true
       assert address["is_verified"] == true
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check sorting by balance asc", %{conn: conn} do
@@ -3926,9 +3709,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         response_2nd_page,
         Enum.sort_by(addresses, &Decimal.to_integer(&1.fetched_coin_balance.value), :desc)
       )
-
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check sorting by transactions count asc", %{conn: conn} do
@@ -3946,9 +3726,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, Enum.sort_by(addresses, & &1.transactions_count, :desc))
-
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check sorting by balance desc", %{conn: conn} do
@@ -3970,9 +3747,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         response_2nd_page,
         Enum.sort_by(addresses, &Decimal.to_integer(&1.fetched_coin_balance.value), :asc)
       )
-
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check sorting by transactions count desc", %{conn: conn} do
@@ -3990,9 +3764,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, Enum.sort_by(addresses, & &1.transactions_count, :asc))
-
-      assert_schema(response, "AddressesList", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressesList", BlockScoutWeb.ApiSpec.spec())
     end
   end
 
@@ -4013,8 +3784,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "internal_transactions_count" => 0,
                "celo_election_rewards_count" => 0
              } = response
-
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn} do
@@ -4031,8 +3800,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get counters with 0s", %{conn: conn} do
@@ -4050,8 +3817,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "withdrawals_count" => 0,
                "internal_transactions_count" => 0
              } = response
-
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get counters and check that cache works", %{conn: conn} do
@@ -4126,8 +3891,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "internal_transactions_count" => 2
              } = response
 
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
-
       for x <- 3..4 do
         insert(:internal_transaction,
           transaction: transaction,
@@ -4152,8 +3915,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "withdrawals_count" => 51,
                "internal_transactions_count" => 2
              } = response
-
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "check counters cache ttl", %{conn: conn} do
@@ -4228,8 +3989,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "internal_transactions_count" => 2
              } = response
 
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
-
       old_env = Application.get_env(:explorer, Explorer.Chain.Cache.Counters.AddressTabsElementsCount)
       Application.put_env(:explorer, Explorer.Chain.Cache.Counters.AddressTabsElementsCount, ttl: 200)
       :timer.sleep(200)
@@ -4262,8 +4021,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                "internal_transactions_count" => 4
              } = response
 
-      assert_schema(response, "AddressTabsCounters", BlockScoutWeb.ApiSpec.spec())
-
       Application.put_env(:explorer, Explorer.Chain.Cache.Counters.AddressTabsElementsCount, old_env)
     end
   end
@@ -4280,7 +4037,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert %{"items" => [], "next_page_params" => nil} = response
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn, endpoint: endpoint} do
@@ -4297,8 +4053,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get token with ok reputation", %{conn: conn, endpoint: endpoint} do
@@ -4353,7 +4107,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
@@ -4363,7 +4116,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
@@ -4373,7 +4125,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
@@ -4434,13 +4185,11 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert response["items"] == []
 
@@ -4449,13 +4198,11 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert response["items"] == []
 
@@ -4464,13 +4211,11 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         conn |> put_req_cookie("show_scam_tokens", "true") |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert response["items"] == []
     end
@@ -4523,19 +4268,16 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
     end
@@ -4593,19 +4335,16 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "ok"
     end
@@ -4635,8 +4374,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_instances)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "next_page_params does not leak original type filter", %{conn: conn, endpoint: endpoint} do
@@ -4707,8 +4444,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_instances)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get paginated ERC-404 nft", %{conn: conn, endpoint: endpoint} do
@@ -4745,8 +4480,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_instances)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "test filters", %{conn: conn, endpoint: endpoint} do
@@ -4798,8 +4531,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_instances_721)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-1155"}
       request = get(conn, endpoint.(address.hash), filter)
@@ -4809,8 +4540,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, token_instances_1155)
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "return all token instances", %{conn: conn, endpoint: endpoint} do
@@ -4880,10 +4609,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       compare_item(Enum.at(token_instances_1155, 1), Enum.at(response_3rd_page["items"], 0))
       compare_item(Enum.at(token_instances_1155, 0), Enum.at(response_3rd_page["items"], 1))
-
-      assert_schema(response, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_3rd_page, "AddressNFTsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "paginates across types after intermediate type exhaustion (should include next type)", %{
@@ -5118,8 +4843,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-721"})
                |> json_response(200)
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request =
         conn
         |> put_req_cookie("show_scam_tokens", "true")
@@ -5134,8 +4857,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
                |> json_response(200)
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request =
         conn
         |> put_req_cookie("show_scam_tokens", "true")
@@ -5149,8 +4870,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                conn
                |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
                |> json_response(200)
-
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get nft collections with scam reputation", %{conn: conn} do
@@ -5242,7 +4961,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-721"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
@@ -5251,15 +4969,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert response["items"] == []
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request =
         conn
         |> put_req_cookie("show_scam_tokens", "true")
         |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
@@ -5268,15 +4983,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert response["items"] == []
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request =
         conn
         |> put_req_cookie("show_scam_tokens", "true")
         |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
 
       response = json_response(request, 200)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       assert List.first(response["items"])["reputation"] == "scam"
 
@@ -5284,8 +4996,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       response = json_response(request, 200)
 
       assert response["items"] == []
-
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get nft collections with ok reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -5372,21 +5082,15 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert List.first(response["items"])["reputation"] == "ok"
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get nft collections with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -5479,21 +5183,15 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       assert List.first(response["items"])["reputation"] == "ok"
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
 
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
       response = json_response(request, 200)
 
       assert List.first(response["items"])["reputation"] == "ok"
-
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 200 on non existing address", %{conn: conn, endpoint: endpoint} do
@@ -5503,8 +5201,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
       assert %{"items" => [], "next_page_params" => nil} = response
-
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get 422 on invalid address", %{conn: conn, endpoint: endpoint} do
@@ -5521,8 +5217,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              } = json_response
-
-      assert_schema(json_response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get paginated erc-721 collection", %{conn: conn, endpoint: endpoint} do
@@ -5570,8 +5264,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, ctbs)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "get paginated erc-1155 collection", %{conn: conn, endpoint: endpoint} do
@@ -5618,8 +5310,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, collections)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "test filters", %{conn: conn, endpoint: endpoint} do
@@ -5700,8 +5390,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, ctbs)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
 
       filter = %{"type" => "ERC-1155"}
       request = get(conn, endpoint.(address.hash), filter)
@@ -5711,8 +5399,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, collections)
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
 
     test "return all collections", %{conn: conn, endpoint: endpoint} do
@@ -5811,9 +5497,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       compare_item(Enum.at(collections_1155, 1), Enum.at(response_3rd_page["items"], 0))
       compare_item(Enum.at(collections_1155, 0), Enum.at(response_3rd_page["items"], 1))
-      assert_schema(response, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_2nd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-      assert_schema(response_3rd_page, "AddressNFTCollectionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -5508,7 +5508,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         response = json_response(request, 200)
 
         assert %{"items" => [], "next_page_params" => nil} = response
-        assert_schema(response, "AddressBeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
 
       test "get 422 on invalid address", %{conn: conn} do
@@ -5524,8 +5523,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                    }
                  ]
                } = response
-
-        assert_schema(response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
       end
 
       test "get deposits", %{conn: conn} do
@@ -5540,8 +5537,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         assert response_2nd_page = json_response(request_2nd_page, 200)
 
         check_paginated_response(response, response_2nd_page, deposits)
-        assert_schema(response, "AddressBeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-        assert_schema(response_2nd_page, "AddressBeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
     else
       test "returns an error about chain type", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -499,7 +499,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         |> subscribe_and_join(topic)
 
       request = get(conn, "/api/v2/addresses/#{address.hash}")
-      assert response = json_response(request, 200)
+      assert _response = json_response(request, 200)
 
       assert_receive %Phoenix.Socket.Message{
                        payload: %{fetched_bytecode: ^contract_code},

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -524,25 +524,16 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         block = build(:block)
 
         request = get(conn, "/api/v2/blocks/#{block.hash}/beacon/deposits")
-        response = json_response(request, 404)
+        json_response(request, 404)
       end
 
-      # test "get 422 on invalid block", %{conn: conn} do
-      #   request = get(conn, "/api/v2/blocks/invalid/beacon/deposits")
-      #   response = json_response(request, 422)
+      test "get 422 on invalid block", %{conn: conn} do
+        request_1 = get(conn, "/api/v2/blocks/0x123123/beacon/deposits")
+        assert %{"message" => "Invalid hash"} = json_response(request_1, 422)
 
-      #   assert %{
-      #            "errors" => [
-      #              %{
-      #                "detail" => "Invalid format. Expected ~r/^0x([A-Fa-f0-9]{40})$/",
-      #                "source" => %{"pointer" => "/address_hash_param"},
-      #                "title" => "Invalid value"
-      #              }
-      #            ]
-      #          } = response
-
-      #   assert_schema(response, "JsonErrorResponse", BlockScoutWeb.ApiSpec.spec())
-      # end
+        request_2 = get(conn, "/api/v2/blocks/123qwe/beacon/deposits")
+        assert %{"message" => "Invalid number"} = json_response(request_2, 422)
+      end
 
       test "get deposits", %{conn: conn} do
         block = insert(:block)
@@ -558,8 +549,6 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         assert response_2nd_page = json_response(request_2nd_page, 200)
 
         check_paginated_response(response, response_2nd_page, deposits)
-        # assert_schema(response, "BlockBeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
-        # assert_schema(response_2nd_page, "BlockBeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
     else
       test "returns an error about chain type", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/ethereum/deposit_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/ethereum/deposit_controller_test.exs
@@ -3,15 +3,12 @@ defmodule BlockScoutWeb.Api.V2.Ethereum.DepositControllerTest do
 
   alias Explorer.Repo
 
-  import OpenApiSpex.TestAssertions
-
   if Application.compile_env(:explorer, :chain_type) == :ethereum do
     describe "/beacon/deposits" do
       test "get empty list when no deposits exist", %{conn: conn} do
         request = get(conn, "/api/v2/beacon/deposits")
         assert response = json_response(request, 200)
         assert %{"items" => []} = response
-        assert_schema(response, "BeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
 
       test "get deposits", %{conn: conn} do
@@ -30,8 +27,6 @@ defmodule BlockScoutWeb.Api.V2.Ethereum.DepositControllerTest do
                  deposits
                  |> Enum.reverse()
                  |> Enum.map(&{&1.index, to_string(&1.transaction_hash), to_string(&1.block_hash)})
-
-        assert_schema(response, "BeaconDepositsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       end
     end
 
@@ -43,13 +38,16 @@ defmodule BlockScoutWeb.Api.V2.Ethereum.DepositControllerTest do
       end
 
       test "returns deposit count", %{conn: conn} do
+        Repo.delete_all(Explorer.Chain.Beacon.Deposit)
+        ExMachina.Sequence.reset("beacon_deposit_index")
+
         insert_list(3, :beacon_deposit)
 
         deposits_count = Repo.aggregate(Explorer.Chain.Beacon.Deposit, :count, :index)
 
         request = get(conn, "/api/v2/beacon/deposits/count")
         assert response = json_response(request, 200)
-        assert %{"deposits_count" => deposits_count} = response
+        assert %{"deposits_count" => ^deposits_count} = response
       end
     end
   else

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -1193,629 +1193,643 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       assert ens["ens_info"]["name"] == name
     end
 
-    test "finds a TAC operation", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect_once(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{operation_id}")
-
-      assert %{
-               "items" => [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => operation_id,
-                     "sender" => nil,
-                     "timestamp" => "2025-05-14T19:16:38.000Z",
-                     "type" => "TON_TAC_TON"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ],
-               "next_page_params" => nil
-             } == json_response(request, 200)
-    end
-
-    test "handles no results from TAC microservice", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
-
-      tac_response = """
-      {
-        "items": [],
-        "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{operation_id}")
-
-      assert %{
-               "items" => [],
-               "next_page_params" => nil
-             } == json_response(request, 200)
-    end
-
-    test "finds a TAC operation with transaction", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      transaction = insert(:transaction) |> with_block()
-
-      operation_id = "#{transaction.hash}"
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{operation_id}")
-      assert response = json_response(request, 200)
-
-      # tl to check order
-      assert %{
-               "priority" => 0,
-               "tac_operation" => %{
-                 "operation_id" => operation_id,
-                 "sender" => nil,
-                 "timestamp" => "2025-05-14T19:16:38.000Z",
-                 "type" => "TON_TAC_TON"
-               },
-               "type" => "tac_operation"
-             } in tl(response["items"])
-
-      assert %{
-               "priority" => 0,
-               "transaction_hash" => "#{transaction.hash}",
-               "type" => "transaction",
-               "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
-               "url" => "/tx/#{transaction.hash}"
-             } in response["items"]
-    end
-
-    test "finds a TAC operation with block", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      transaction = insert(:transaction) |> with_block()
-
-      operation_id = "#{transaction.block_hash}"
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{operation_id}")
-      assert response = json_response(request, 200)
-
-      # tl to check order
-      assert %{
-               "priority" => 0,
-               "tac_operation" => %{
-                 "operation_id" => operation_id,
-                 "sender" => nil,
-                 "timestamp" => "2025-05-14T19:16:38.000Z",
-                 "type" => "TON_TAC_TON"
-               },
-               "type" => "tac_operation"
-             } in tl(response["items"])
-
-      assert %{
-               "block_hash" => "#{transaction.block_hash}",
-               "block_number" => transaction.block_number,
-               "block_type" => "block",
-               "priority" => 3,
-               "type" => "block",
-               "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
-               "url" => "/block/#{transaction.block_hash}"
-             } in response["items"]
-    end
-
-    test "finds TAC operations by sender and paginates", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      address_hash = Address.checksum(insert(:address).hash)
-      operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
-
-      tac_first_response = """
-      {
-        "items": [
-        #{for i <- 10..59, do: """
-        {
-          "operation_id": "#{operation_id}",
-          "sender": "#{address_hash}",
-          "timestamp": "2025-05-14T19:16:#{i}.000Z",
-          "type": "TON_TAC_TON"
-        }#{if i == 59, do: "", else: ","}
-      """}
-        ],
-        "next_page_params": {
-          "page_token": 1747250219,
-          "page_size": 50
-        }
-      }
-      """
-
-      tac_second_response = """
-      {
-        "items": [
-        #{for i <- 10..59, do: """
-        {
-          "operation_id": "#{operation_id}",
-          "sender": "#{address_hash}",
-          "timestamp": "#{if i == 0, do: "2025-05-14T19:16:59.000Z", else: "2025-05-14T19:17:#{i}.000Z"}",
-          "type": "TON_TAC_TON"
-        }#{if i == 59, do: "", else: ","}
-      """}
-        ],
-        "next_page_params": {
-          "page_token": 1747250279,
-          "page_size": 50
-        }
-      }
-      """
-
-      tac_third_response = """
-      {
-        "items": [
-        {
-          "operation_id": "#{operation_id}",
-          "sender": "#{address_hash}",
-          "timestamp": "2025-05-14T19:18:01.000Z",
-          "type": "TON_TAC_TON"
-        }
-        ],
-        "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          case conn.params["page_token"] do
-            nil -> Plug.Conn.resp(conn, 200, tac_first_response)
-            "1747250218" -> Plug.Conn.resp(conn, 200, tac_second_response)
-            "1747250279" -> Plug.Conn.resp(conn, 200, tac_third_response)
-            _ -> raise "Unexpected page_token"
-          end
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{address_hash}")
-      assert response = json_response(request, 200)
-
-      second_page_request =
-        get(conn, "/api/v2/search", response["next_page_params"] |> Query.encode() |> Query.decode())
-
-      second_page_response = json_response(second_page_request, 200)
-
-      third_page_request =
-        get(conn, "/api/v2/search", second_page_response["next_page_params"] |> Query.encode() |> Query.decode())
-
-      assert %{
-               "items" => [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => operation_id,
-                     "sender" => address_hash,
-                     "timestamp" => "2025-05-14T19:18:01.000Z",
-                     "type" => "TON_TAC_TON"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ],
-               "next_page_params" => nil
-             } == json_response(third_page_request, 200)
-    end
-
-    test "finds TAC operations by TON sender", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-            "type": "ROLLBACK",
-            "timestamp": "2025-06-05T12:21:11.000Z",
-            "sender": {
-                "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                "blockchain": "TON"
-            }
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          case conn.params["q"] do
-            expected_q
-            when expected_q in [
-                   "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                   "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt",
-                   "UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko",
-                   "kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n",
-                   "0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi",
-                   "0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d"
-                 ] ->
-              Plug.Conn.resp(conn, 200, tac_response)
-
-            q ->
-              raise "Unexpected 'q' parameter #{inspect(q)}"
-          end
-        end
-      )
-
-      request = get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response["items"]
-
-      request = get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response["items"]
-
-      request = get(conn, "/api/v2/search?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response["items"]
-
-      request = get(conn, "/api/v2/search?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response["items"]
-
-      request = get(conn, "/api/v2/search?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response["items"]
-
-      request =
-        get(
-          conn,
-          "/api/v2/search?q=#{URI.encode_www_form("0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d")}"
+    if Application.compile_env(:explorer, :chain_type) == :default do
+      test "finds a TAC operation", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
         )
 
-      assert response = json_response(request, 200)
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
-      assert [
-               %{
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
+
+        tac_response = """
+        {
+        "items": [
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:38.000Z",
+              "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect_once(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+
+        assert %{
+                 "items" => [
+                   %{
+                     "priority" => 0,
+                     "tac_operation" => %{
+                       "operation_id" => operation_id,
+                       "sender" => nil,
+                       "timestamp" => "2025-05-14T19:16:38.000Z",
+                       "type" => "TON_TAC_TON"
+                     },
+                     "type" => "tac_operation"
+                   }
+                 ],
+                 "next_page_params" => nil
+               } == json_response(request, 200)
+      end
+
+      test "handles no results from TAC microservice", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
+
+        tac_response = """
+        {
+          "items": [],
+          "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+
+        assert %{
+                 "items" => [],
+                 "next_page_params" => nil
+               } == json_response(request, 200)
+      end
+
+      test "finds a TAC operation with transaction", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        transaction = insert(:transaction) |> with_block()
+
+        operation_id = "#{transaction.hash}"
+
+        tac_response = """
+        {
+        "items": [
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:38.000Z",
+              "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+        assert response = json_response(request, 200)
+
+        # tl to check order
+        assert %{
                  "priority" => 0,
                  "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
+                   "operation_id" => operation_id,
+                   "sender" => nil,
+                   "timestamp" => "2025-05-14T19:16:38.000Z",
+                   "type" => "TON_TAC_TON"
                  },
                  "type" => "tac_operation"
-               }
-             ] == response["items"]
-    end
+               } in tl(response["items"])
 
-    test "finds TAC operations with transaction and paginates", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+        assert %{
+                 "priority" => 0,
+                 "transaction_hash" => "#{transaction.hash}",
+                 "type" => "transaction",
+                 "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
+                 "url" => "/tx/#{transaction.hash}"
+               } in response["items"]
+      end
 
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
+      test "finds a TAC operation with block", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
 
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
 
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
-      operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
 
-      insert(:transaction, hash: operation_id)
+        transaction = insert(:transaction) |> with_block()
 
-      tac_first_response = """
-      {
+        operation_id = "#{transaction.block_hash}"
+
+        tac_response = """
+        {
         "items": [
-        #{for i <- 0..49, do: """
-        {
-          "operation_id": "#{operation_id}",
-          "sender": null,
-          "timestamp": "2025-05-14T19:16:#{i}.000Z",
-          "type": "TON_TAC_TON"
-        }#{if i == 49, do: "", else: ","}
-      """}
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:38.000Z",
+              "type": "TON_TAC_TON"
+          }
         ],
-        "next_page_params": {
-          "page_token": 1747250209,
-          "page_size": 50
+        "next_page_params": null
         }
-      }
-      """
+        """
 
-      tac_second_response = """
-      {
-      "items": [
-        {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:50.000Z",
-            "type": "TON_TAC_TON"
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          case conn.params["page_token"] do
-            nil -> Plug.Conn.resp(conn, 200, tac_first_response)
-            "1747250208" -> Plug.Conn.resp(conn, 200, tac_second_response)
-            _ -> raise "Unexpected page_token"
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
           end
-        end
-      )
+        )
 
-      request = get(conn, "/api/v2/search?q=#{operation_id}")
-      assert response = json_response(request, 200)
-      next_page_request = get(conn, "/api/v2/search", response["next_page_params"] |> Query.encode() |> Query.decode())
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+        assert response = json_response(request, 200)
 
-      assert %{
-               "items" => [
+        # tl to check order
+        assert %{
+                 "priority" => 0,
+                 "tac_operation" => %{
+                   "operation_id" => operation_id,
+                   "sender" => nil,
+                   "timestamp" => "2025-05-14T19:16:38.000Z",
+                   "type" => "TON_TAC_TON"
+                 },
+                 "type" => "tac_operation"
+               } in tl(response["items"])
+
+        assert %{
+                 "block_hash" => "#{transaction.block_hash}",
+                 "block_number" => transaction.block_number,
+                 "block_type" => "block",
+                 "priority" => 3,
+                 "type" => "block",
+                 "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
+                 "url" => "/block/#{transaction.block_hash}"
+               } in response["items"]
+      end
+
+      test "finds TAC operations by sender and paginates", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        address_hash = Address.checksum(insert(:address).hash)
+        operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
+
+        tac_first_response = """
+        {
+          "items": [
+          #{for i <- 10..59, do: """
+          {
+            "operation_id": "#{operation_id}",
+            "sender": "#{address_hash}",
+            "timestamp": "2025-05-14T19:16:#{i}.000Z",
+            "type": "TON_TAC_TON"
+          }#{if i == 59, do: "", else: ","}
+        """}
+          ],
+          "next_page_params": {
+            "page_token": 1747250219,
+            "page_size": 50
+          }
+        }
+        """
+
+        tac_second_response = """
+        {
+          "items": [
+          #{for i <- 10..59, do: """
+          {
+            "operation_id": "#{operation_id}",
+            "sender": "#{address_hash}",
+            "timestamp": "#{if i == 0, do: "2025-05-14T19:16:59.000Z", else: "2025-05-14T19:17:#{i}.000Z"}",
+            "type": "TON_TAC_TON"
+          }#{if i == 59, do: "", else: ","}
+        """}
+          ],
+          "next_page_params": {
+            "page_token": 1747250279,
+            "page_size": 50
+          }
+        }
+        """
+
+        tac_third_response = """
+        {
+          "items": [
+          {
+            "operation_id": "#{operation_id}",
+            "sender": "#{address_hash}",
+            "timestamp": "2025-05-14T19:18:01.000Z",
+            "type": "TON_TAC_TON"
+          }
+          ],
+          "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            case conn.params["page_token"] do
+              nil -> Plug.Conn.resp(conn, 200, tac_first_response)
+              "1747250218" -> Plug.Conn.resp(conn, 200, tac_second_response)
+              "1747250279" -> Plug.Conn.resp(conn, 200, tac_third_response)
+              _ -> raise "Unexpected page_token"
+            end
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{address_hash}")
+        assert response = json_response(request, 200)
+
+        second_page_request =
+          get(conn, "/api/v2/search", response["next_page_params"] |> Query.encode() |> Query.decode())
+
+        second_page_response = json_response(second_page_request, 200)
+
+        third_page_request =
+          get(conn, "/api/v2/search", second_page_response["next_page_params"] |> Query.encode() |> Query.decode())
+
+        assert %{
+                 "items" => [
+                   %{
+                     "priority" => 0,
+                     "tac_operation" => %{
+                       "operation_id" => operation_id,
+                       "sender" => address_hash,
+                       "timestamp" => "2025-05-14T19:18:01.000Z",
+                       "type" => "TON_TAC_TON"
+                     },
+                     "type" => "tac_operation"
+                   }
+                 ],
+                 "next_page_params" => nil
+               } == json_response(third_page_request, 200)
+      end
+
+      test "finds TAC operations by TON sender", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        tac_response = """
+        {
+        "items": [
+          {
+              "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+              "type": "ROLLBACK",
+              "timestamp": "2025-06-05T12:21:11.000Z",
+              "sender": {
+                  "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                  "blockchain": "TON"
+              }
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            case conn.params["q"] do
+              expected_q
+              when expected_q in [
+                     "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                     "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt",
+                     "UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko",
+                     "kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n",
+                     "0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi",
+                     "0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d"
+                   ] ->
+                Plug.Conn.resp(conn, 200, tac_response)
+
+              q ->
+                raise "Unexpected 'q' parameter #{inspect(q)}"
+            end
+          end
+        )
+
+        request =
+          get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
                  %{
                    "priority" => 0,
                    "tac_operation" => %{
-                     "operation_id" => operation_id,
-                     "sender" => nil,
-                     "timestamp" => "2025-05-14T19:16:50.000Z",
-                     "type" => "TON_TAC_TON"
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
                    },
                    "type" => "tac_operation"
                  }
-               ],
-               "next_page_params" => nil
-             } == json_response(next_page_request, 200)
+               ] == response["items"]
+
+        request =
+          get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response["items"]
+
+        request =
+          get(conn, "/api/v2/search?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response["items"]
+
+        request =
+          get(conn, "/api/v2/search?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response["items"]
+
+        request =
+          get(conn, "/api/v2/search?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response["items"]
+
+        request =
+          get(
+            conn,
+            "/api/v2/search?q=#{URI.encode_www_form("0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d")}"
+          )
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response["items"]
+      end
+
+      test "finds TAC operations with transaction and paginates", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
+
+        insert(:transaction, hash: operation_id)
+
+        tac_first_response = """
+        {
+          "items": [
+          #{for i <- 0..49, do: """
+          {
+            "operation_id": "#{operation_id}",
+            "sender": null,
+            "timestamp": "2025-05-14T19:16:#{i}.000Z",
+            "type": "TON_TAC_TON"
+          }#{if i == 49, do: "", else: ","}
+        """}
+          ],
+          "next_page_params": {
+            "page_token": 1747250209,
+            "page_size": 50
+          }
+        }
+        """
+
+        tac_second_response = """
+        {
+        "items": [
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:50.000Z",
+              "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            case conn.params["page_token"] do
+              nil -> Plug.Conn.resp(conn, 200, tac_first_response)
+              "1747250208" -> Plug.Conn.resp(conn, 200, tac_second_response)
+              _ -> raise "Unexpected page_token"
+            end
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+        assert response = json_response(request, 200)
+
+        next_page_request =
+          get(conn, "/api/v2/search", response["next_page_params"] |> Query.encode() |> Query.decode())
+
+        assert %{
+                 "items" => [
+                   %{
+                     "priority" => 0,
+                     "tac_operation" => %{
+                       "operation_id" => operation_id,
+                       "sender" => nil,
+                       "timestamp" => "2025-05-14T19:16:50.000Z",
+                       "type" => "TON_TAC_TON"
+                     },
+                     "type" => "tac_operation"
+                   }
+                 ],
+                 "next_page_params" => nil
+               } == json_response(next_page_request, 200)
+      end
     end
   end
 
@@ -2183,53 +2197,116 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              end)
     end
 
-    test "finds a TAC operation", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+    if Application.compile_env(:explorer, :chain_type) == :default do
+      test "finds a TAC operation", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
 
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
 
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
 
-      operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
+        operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
 
-      tac_response = """
-      {
-      "items": [
+        tac_response = """
         {
-          "operation_id": "#{operation_id}",
-          "sender": null,
-          "timestamp": "2025-05-14T19:16:38.000Z",
-          "type": "TON_TAC_TON"
+        "items": [
+          {
+            "operation_id": "#{operation_id}",
+            "sender": null,
+            "timestamp": "2025-05-14T19:16:38.000Z",
+            "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
         }
-      ],
-      "next_page_params": null
-      }
-      """
+        """
 
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
 
-      request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
+        request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
 
-      assert [
-               %{
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => operation_id,
+                     "sender" => nil,
+                     "timestamp" => "2025-05-14T19:16:38.000Z",
+                     "type" => "TON_TAC_TON"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == json_response(request, 200)
+      end
+
+      test "finds a TAC operation with transaction", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        transaction = insert(:transaction) |> with_block()
+
+        operation_id = "#{transaction.hash}"
+
+        tac_response = """
+        {
+        "items": [
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:38.000Z",
+              "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
+        assert response = json_response(request, 200)
+
+        # tl to check order
+        assert %{
                  "priority" => 0,
                  "tac_operation" => %{
                    "operation_id" => operation_id,
@@ -2238,178 +2315,388 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                    "type" => "TON_TAC_TON"
                  },
                  "type" => "tac_operation"
-               }
-             ] == json_response(request, 200)
-    end
+               } in tl(response)
 
-    test "finds a TAC operation with transaction", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+        assert %{
+                 "priority" => 0,
+                 "transaction_hash" => "#{transaction.hash}",
+                 "type" => "transaction",
+                 "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
+                 "url" => "/tx/#{transaction.hash}"
+               } in response
+      end
 
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
+      test "finds a TAC operation with block", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
 
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
 
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
-      transaction = insert(:transaction) |> with_block()
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
 
-      operation_id = "#{transaction.hash}"
+        transaction = insert(:transaction) |> with_block()
 
-      tac_response = """
-      {
-      "items": [
+        operation_id = "#{transaction.block_hash}"
+
+        tac_response = """
         {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
+        "items": [
+          {
+              "operation_id": "#{operation_id}",
+              "sender": null,
+              "timestamp": "2025-05-14T19:16:38.000Z",
+              "type": "TON_TAC_TON"
+          }
+        ],
+        "next_page_params": null
         }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
-      assert response = json_response(request, 200)
-
-      # tl to check order
-      assert %{
-               "priority" => 0,
-               "tac_operation" => %{
-                 "operation_id" => operation_id,
-                 "sender" => nil,
-                 "timestamp" => "2025-05-14T19:16:38.000Z",
-                 "type" => "TON_TAC_TON"
-               },
-               "type" => "tac_operation"
-             } in tl(response)
-
-      assert %{
-               "priority" => 0,
-               "transaction_hash" => "#{transaction.hash}",
-               "type" => "transaction",
-               "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
-               "url" => "/tx/#{transaction.hash}"
-             } in response
-    end
-
-    test "finds a TAC operation with block", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      transaction = insert(:transaction) |> with_block()
-
-      operation_id = "#{transaction.block_hash}"
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "#{operation_id}",
-            "sender": null,
-            "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
-      assert response = json_response(request, 200)
-
-      # tl to check order
-      assert %{
-               "priority" => 0,
-               "tac_operation" => %{
-                 "operation_id" => operation_id,
-                 "sender" => nil,
-                 "timestamp" => "2025-05-14T19:16:38.000Z",
-                 "type" => "TON_TAC_TON"
-               },
-               "type" => "tac_operation"
-             } in tl(response)
-
-      assert %{
-               "block_hash" => "#{transaction.block_hash}",
-               "block_number" => transaction.block_number,
-               "block_type" => "block",
-               "priority" => 3,
-               "type" => "block",
-               "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
-               "url" => "/block/#{transaction.block_hash}"
-             } in response
-    end
-
-    test "finds a lot of TAC operations with address", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      address_hash = Address.checksum(insert(:address).hash)
-      operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
-
-      tac_response =
         """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
+        assert response = json_response(request, 200)
+
+        # tl to check order
+        assert %{
+                 "priority" => 0,
+                 "tac_operation" => %{
+                   "operation_id" => operation_id,
+                   "sender" => nil,
+                   "timestamp" => "2025-05-14T19:16:38.000Z",
+                   "type" => "TON_TAC_TON"
+                 },
+                 "type" => "tac_operation"
+               } in tl(response)
+
+        assert %{
+                 "block_hash" => "#{transaction.block_hash}",
+                 "block_number" => transaction.block_number,
+                 "block_type" => "block",
+                 "priority" => 3,
+                 "type" => "block",
+                 "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
+                 "url" => "/block/#{transaction.block_hash}"
+               } in response
+      end
+
+      test "finds a lot of TAC operations with address", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        address_hash = Address.checksum(insert(:address).hash)
+        operation_id = "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2"
+
+        tac_response =
+          """
+          {
+            "items": [
+            #{for i <- 0..49, do: """
+            {
+              "operation_id": "#{operation_id}",
+              "sender": "#{address_hash}",
+              "timestamp": "2025-05-14T19:16:#{i}.000Z",
+              "type": "TON_TAC_TON"
+            }#{if i == 49, do: "", else: ","}
+          """}
+            ],
+            "next_page_params": {
+              "page_token": "2025-05-14T19:16:49.000Z",
+              "page_size": 50
+            }
+          }
+          """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == address_hash
+
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search/quick?q=#{address_hash}")
+        assert response = json_response(request, 200)
+
+        correct_response = [
+          %{
+            "address_hash" => address_hash,
+            "certified" => false,
+            "ens_info" => nil,
+            "is_smart_contract_verified" => false,
+            "name" => nil,
+            "priority" => 0,
+            "type" => "address",
+            "url" => "/address/#{address_hash}"
+          }
+          | for(
+              i <- 0..48,
+              do: %{
+                "priority" => 0,
+                "tac_operation" => %{
+                  "operation_id" => operation_id,
+                  "sender" => address_hash,
+                  "timestamp" => "2025-05-14T19:16:#{i}.000Z",
+                  "type" => "TON_TAC_TON"
+                },
+                "type" => "tac_operation"
+              }
+            )
+        ]
+
+        assert correct_response == response
+      end
+
+      test "finds a TAC operation with TON address", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        tac_response = """
+        {
+        "items": [
+          {
+              "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+              "type": "ROLLBACK",
+              "timestamp": "2025-06-05T12:21:11.000Z",
+              "sender": {
+                  "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                  "blockchain": "TON"
+              }
+          }
+        ],
+        "next_page_params": null
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            case conn.params["q"] do
+              expected_q
+              when expected_q in [
+                     "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                     "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt",
+                     "UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko",
+                     "kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n",
+                     "0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi",
+                     "0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d"
+                   ] ->
+                Plug.Conn.resp(conn, 200, tac_response)
+
+              q ->
+                raise "Unexpected 'q' parameter #{inspect(q)}"
+            end
+          end
+        )
+
+        request =
+          get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+
+        request =
+          get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+
+        request =
+          get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+
+        request =
+          get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+
+        request =
+          get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+
+        request =
+          get(
+            conn,
+            "/api/v2/search/quick?q=#{URI.encode_www_form("0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d")}"
+          )
+
+        assert response = json_response(request, 200)
+
+        assert [
+                 %{
+                   "priority" => 0,
+                   "tac_operation" => %{
+                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+                     "sender" => %{
+                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                       "blockchain" => "TON"
+                     },
+                     "timestamp" => "2025-06-05T12:21:11.000Z",
+                     "type" => "ROLLBACK"
+                   },
+                   "type" => "tac_operation"
+                 }
+               ] == response
+      end
+
+      test "finds a lot if TAC operations with transaction", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        transaction =
+          insert(:transaction, hash: "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2")
+          |> with_block()
+
+        operation_id = "#{transaction.hash}"
+
+        tac_response = """
         {
           "items": [
           #{for i <- 0..49, do: """
           {
             "operation_id": "#{operation_id}",
-            "sender": "#{address_hash}",
+            "sender": null,
             "timestamp": "2025-05-14T19:16:#{i}.000Z",
             "type": "TON_TAC_TON"
           }#{if i == 49, do: "", else: ","}
@@ -2422,318 +2709,45 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         }
         """
 
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == address_hash
+        Bypass.expect(
+          bypass,
+          "GET",
+          "/api/v1/tac/operations",
+          fn conn ->
+            assert conn.params["q"] == operation_id
 
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search/quick?q=#{address_hash}")
-      assert response = json_response(request, 200)
-
-      address_result = %{
-        "address_hash" => address_hash,
-        "certified" => false,
-        "ens_info" => nil,
-        "is_smart_contract_verified" => false,
-        "name" => nil,
-        "priority" => 0,
-        "type" => "address",
-        "url" => "/address/#{address_hash}",
-        "reputation" => "ok"
-      }
-
-      correct_response = [
-        if(@chain_type == :filecoin, do: Map.put(address_result, "filecoin_robust_address", nil), else: address_result)
-        | for(
-            i <- 0..48,
-            do: %{
-              "priority" => 0,
-              "tac_operation" => %{
-                "operation_id" => operation_id,
-                "sender" => address_hash,
-                "timestamp" => "2025-05-14T19:16:#{i}.000Z",
-                "type" => "TON_TAC_TON"
-              },
-              "type" => "tac_operation"
-            }
-          )
-      ]
-
-      assert correct_response == response
-    end
-
-    test "finds a TAC operation with TON address", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      tac_response = """
-      {
-      "items": [
-        {
-            "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-            "type": "ROLLBACK",
-            "timestamp": "2025-06-05T12:21:11.000Z",
-            "sender": {
-                "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                "blockchain": "TON"
-            }
-        }
-      ],
-      "next_page_params": null
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          case conn.params["q"] do
-            expected_q
-            when expected_q in [
-                   "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                   "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt",
-                   "UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko",
-                   "kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n",
-                   "0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi",
-                   "0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d"
-                 ] ->
-              Plug.Conn.resp(conn, 200, tac_response)
-
-            q ->
-              raise "Unexpected 'q' parameter #{inspect(q)}"
+            Plug.Conn.resp(conn, 200, tac_response)
           end
-        end
-      )
-
-      request =
-        get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
-
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-
-      request =
-        get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
-
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-
-      request =
-        get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
-
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-
-      request =
-        get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
-
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-
-      request =
-        get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
-
-      assert response = json_response(request, 200)
-
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-
-      request =
-        get(
-          conn,
-          "/api/v2/search/quick?q=#{URI.encode_www_form("0:67560e31eae4c26bc8e5ae1f185f25a99c9277a31c6b741436f99c3cc9aa319d")}"
         )
 
-      assert response = json_response(request, 200)
+        request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
+        assert response = json_response(request, 200)
 
-      assert [
-               %{
-                 "priority" => 0,
-                 "tac_operation" => %{
-                   "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                   "sender" => %{
-                     "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                     "blockchain" => "TON"
-                   },
-                   "timestamp" => "2025-06-05T12:21:11.000Z",
-                   "type" => "ROLLBACK"
-                 },
-                 "type" => "tac_operation"
-               }
-             ] == response
-    end
+        correct_response = [
+          %{
+            "priority" => 0,
+            "transaction_hash" => "#{transaction.hash}",
+            "type" => "transaction",
+            "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
+            "url" => "/tx/#{transaction.hash}"
+          }
+          | for(
+              i <- 0..48,
+              do: %{
+                "priority" => 0,
+                "tac_operation" => %{
+                  "operation_id" => operation_id,
+                  "sender" => nil,
+                  "timestamp" => "2025-05-14T19:16:#{i}.000Z",
+                  "type" => "TON_TAC_TON"
+                },
+                "type" => "tac_operation"
+              }
+            )
+        ]
 
-    test "finds a lot if TAC operations with transaction", %{conn: conn} do
-      bypass = Bypass.open()
-      tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
-      )
-
-      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
-
-      on_exit(fn ->
-        Bypass.down(bypass)
-        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
-        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      end)
-
-      transaction =
-        insert(:transaction, hash: "0x07d74803dd6fd1a684b50494c09e366f3a6be20cd09928ebdf80d178ce41b5a2") |> with_block()
-
-      operation_id = "#{transaction.hash}"
-
-      tac_response = """
-      {
-        "items": [
-        #{for i <- 0..49, do: """
-        {
-          "operation_id": "#{operation_id}",
-          "sender": null,
-          "timestamp": "2025-05-14T19:16:#{i}.000Z",
-          "type": "TON_TAC_TON"
-        }#{if i == 49, do: "", else: ","}
-      """}
-        ],
-        "next_page_params": {
-          "page_token": "2025-05-14T19:16:49.000Z",
-          "page_size": 50
-        }
-      }
-      """
-
-      Bypass.expect(
-        bypass,
-        "GET",
-        "/api/v1/tac/operations",
-        fn conn ->
-          assert conn.params["q"] == operation_id
-
-          Plug.Conn.resp(conn, 200, tac_response)
-        end
-      )
-
-      request = get(conn, "/api/v2/search/quick?q=#{operation_id}")
-      assert response = json_response(request, 200)
-
-      correct_response = [
-        %{
-          "priority" => 0,
-          "transaction_hash" => "#{transaction.hash}",
-          "type" => "transaction",
-          "timestamp" => "#{transaction.block_timestamp}" |> String.replace(" ", "T"),
-          "url" => "/tx/#{transaction.hash}"
-        }
-        | for(
-            i <- 0..48,
-            do: %{
-              "priority" => 0,
-              "tac_operation" => %{
-                "operation_id" => operation_id,
-                "sender" => nil,
-                "timestamp" => "2025-05-14T19:16:#{i}.000Z",
-                "type" => "TON_TAC_TON"
-              },
-              "type" => "tac_operation"
-            }
-          )
-      ]
-
-      assert correct_response == response
+        assert correct_response == response
+      end
     end
 
     test "returns empty list and don't crash", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -2460,7 +2460,8 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
             "name" => nil,
             "priority" => 0,
             "type" => "address",
-            "url" => "/address/#{address_hash}"
+            "url" => "/address/#{address_hash}",
+            "reputation" => "ok"
           }
           | for(
               i <- 0..48,

--- a/apps/block_scout_web/test/support/api_schema_assertions.ex
+++ b/apps/block_scout_web/test/support/api_schema_assertions.ex
@@ -1,0 +1,121 @@
+defmodule BlockScoutWeb.TestApiSchemaAssertions do
+  @moduledoc """
+  Test helper that automatically validates JSON responses against the OpenAPI schema
+  for every GET request to `/api/*` endpoints.
+
+  It wraps `Phoenix.ConnTest.json_response/2` to perform schema validation using
+  `OpenApiSpex.TestAssertions.assert_schema/3` based on the current request path,
+  HTTP method and status code.
+  """
+
+  # import Phoenix.ConnTest, except: [json_response: 2]
+
+  require Logger
+  alias OpenApiSpex.{Operation, PathItem}
+
+  @spec json_response(Plug.Conn.t(), non_neg_integer()) :: map() | list()
+  def json_response(%Plug.Conn{} = conn, status_code) when is_integer(status_code) do
+    json = Phoenix.ConnTest.json_response(conn, status_code)
+
+    maybe_assert_schema(conn, status_code, json)
+
+    json
+  end
+
+  defp maybe_assert_schema(%Plug.Conn{method: "GET", request_path: request_path} = _conn, status_code, json)
+       when is_integer(status_code) and is_binary(request_path) do
+    if String.starts_with?(request_path, "/api/") do
+      spec = BlockScoutWeb.ApiSpec.spec()
+
+      case find_path_item(spec, request_path) do
+        {:ok, %PathItem{} = path_item} ->
+          case Map.get(path_item, :get) do
+            %Operation{} = operation ->
+              case find_response_schema(operation, status_code) do
+                {:ok, schema} ->
+                  Logger.info(
+                    "Validated response against schema for path: #{request_path} and status code: #{status_code}"
+                  )
+
+                  OpenApiSpex.TestAssertions.assert_raw_schema(json, schema, spec)
+
+                :error ->
+                  Logger.warning("No schema found for path: #{request_path} and status code: #{status_code}")
+                  :ok
+              end
+
+            _ ->
+              :ok
+          end
+
+        :error ->
+          Logger.warning("No schema found for path: #{request_path}")
+          :ok
+      end
+    end
+  end
+
+  defp maybe_assert_schema(_conn, _status_code, _json), do: :ok
+
+  defp find_path_item(%{paths: paths} = _spec, request_path) when is_map(paths) do
+    api_relative = strip_api_prefix(request_path)
+
+    with {:ok, {_, path_item}} <- match_template_path(paths, api_relative) do
+      {:ok, path_item}
+    else
+      _ -> :error
+    end
+  end
+
+  defp strip_api_prefix("/api" <> rest), do: rest
+  defp strip_api_prefix(path), do: path
+
+  defp match_template_path(paths_map, actual_path) do
+    actual_segments = split_path(actual_path)
+
+    Enum.find_value(paths_map, fn {template_path, %PathItem{} = item} ->
+      template_segments = split_path(template_path)
+
+      if segments_match?(template_segments, actual_segments) do
+        {:ok, {template_path, item}}
+      else
+        false
+      end
+    end) || :error
+  end
+
+  defp split_path(path) when is_binary(path) do
+    path
+    |> String.split("?", parts: 2)
+    |> hd()
+    |> String.split("/", trim: true)
+  end
+
+  defp segments_match?(template_segments, actual_segments) when length(template_segments) == length(actual_segments) do
+    Enum.zip(template_segments, actual_segments)
+    |> Enum.all?(fn {t, a} -> dynamic_segment?(t) or t == a end)
+  end
+
+  defp segments_match?(_template_segments, _actual_segments), do: false
+
+  defp dynamic_segment?(segment) when is_binary(segment) do
+    String.starts_with?(segment, "{") and String.ends_with?(segment, "}")
+  end
+
+  defp find_response_schema(%Operation{responses: responses}, status_code) when is_map(responses) do
+    key = Integer.to_string(status_code)
+
+    response = Map.get(responses, key) || Map.get(responses, status_code) || Map.get(responses, "default")
+
+    case response do
+      %OpenApiSpex.Response{content: %{"application/json" => %OpenApiSpex.MediaType{schema: schema}}} ->
+        {:ok, schema}
+
+      %OpenApiSpex.Reference{} = ref ->
+        {:ok, ref}
+
+      _ ->
+        :error
+    end
+  end
+end

--- a/apps/block_scout_web/test/support/conn_case.ex
+++ b/apps/block_scout_web/test/support/conn_case.ex
@@ -19,7 +19,8 @@ defmodule BlockScoutWeb.ConnCase do
     quote do
       # Import conveniences for testing with connections
       import Plug.Conn
-      import Phoenix.ConnTest
+      import Phoenix.ConnTest, except: [json_response: 2]
+      import BlockScoutWeb.TestApiSchemaAssertions, only: [json_response: 2]
       import BlockScoutWeb.Router.Helpers
       import BlockScoutWeb.Routers.WebRouter.Helpers, except: [static_path: 2]
       import BlockScoutWeb.Routers.AccountRouter.Helpers, except: [static_path: 2]

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -178,7 +178,7 @@ defmodule Explorer.Application do
         ]),
         configure_chain_type_dependent_con_cache(),
         Explorer.Migrator.SanitizeDuplicatedLogIndexLogs
-        |> configure()
+        |> configure_mode_dependent_process(:indexer)
         |> configure_chain_type_dependent_process([
           :polygon_zkevm,
           :rsk,

--- a/apps/explorer/test/explorer/migrator/sanitize_duplicated_log_index_logs_test.exs
+++ b/apps/explorer/test/explorer/migrator/sanitize_duplicated_log_index_logs_test.exs
@@ -9,6 +9,20 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogsTest do
 
   if Application.compile_env(:explorer, :chain_type) in [:polygon_zkevm, :rsk, :filecoin] do
     describe "Sanitize duplicated log index logs" do
+      setup do
+        configuration = Application.get_env(:explorer, SanitizeDuplicatedLogIndexLogs)
+
+        Application.put_env(
+          :explorer,
+          SanitizeDuplicatedLogIndexLogs,
+          Keyword.merge(configuration, batch_size: 50_000, concurrency: 10)
+        )
+
+        on_exit(fn ->
+          Application.put_env(:explorer, SanitizeDuplicatedLogIndexLogs, configuration)
+        end)
+      end
+
       test "correctly identifies and updates duplicated log index logs" do
         block = insert(:block)
 

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -1509,7 +1509,7 @@ defmodule Explorer.Factory do
 
     amount = Map.get(attrs, :deposit_amount, sequence("beacon_deposit_amount", & &1))
     signature_raw = Map.get(attrs, :deposit_signature, sequence("beacon_deposit_signature", &<<&1::768>>))
-    index = Map.get(attrs, :deposit_index, sequence("beacon_deposit_index", & &1))
+    index = Map.get_lazy(attrs, :deposit_index, fn -> sequence("beacon_deposit_index", & &1) end)
 
     <<_::bytes-4, data_raw::binary>> =
       ABI.TypeEncoder.encode(


### PR DESCRIPTION
## Changelog

### Enhancements

Automate `assert_schema` for json response format by looking for relevant schema based on URI format and HTTP status code.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - NFT collections and items now include a reputation field in API responses.
  - Search results surface additional TAC/multi-category items and pagination improvements.

- API Changes
  - Many responses tightened to reject unknown fields (OpenAPI stricter schemas).
  - SignedAuthorization responses include a nullable status field.
  - Token symbol and name may be null; address/list responses include coin balance and transactions_count fields.

- Tests
  - Schema assertion flow refactored; GET response validation routed through a new test helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->