### PR TITLE
feat: Add token_type to token transfer API response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
   """
   require OpenApiSpex
 
-  alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
+  alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token, Token.Type}
   alias BlockScoutWeb.Schemas.API.V2.TokenTransfer.{Total, TotalERC1155, TotalERC721}
   alias OpenApiSpex.Schema
 
@@ -28,7 +28,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
       method: General.MethodNameNullable,
       block_hash: General.FullHash,
       block_number: %Schema{type: :integer, nullable: false},
-      log_index: %Schema{type: :integer, nullable: false}
+      log_index: %Schema{type: :integer, nullable: false},
+      token_type: Type
     },
     required: [
       :transaction_hash,
@@ -41,7 +42,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
       :method,
       :block_hash,
       :block_number,
-      :log_index
+      :log_index,
+      :token_type
     ]
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -59,7 +59,8 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
       "method" => Transaction.method_name(token_transfer.transaction, decoded_input, true),
       "block_hash" => to_string(token_transfer.block_hash),
       "block_number" => token_transfer.block_number,
-      "log_index" => token_transfer.log_index
+      "log_index" => token_transfer.log_index,
+      "token_type" => token_transfer.token_type
     }
   end
 


### PR DESCRIPTION
Closes #12675 


## Changelog
- Add token_type to token transfer API response
- Update API spec

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Token transfer API responses now include a token_type field, providing the token standard/type for each transfer.
  - API documentation updated to reflect the new field.
  - The token_type field is required in token transfer payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->