### PR TITLE
Don't broadcast current token balances from realtime fetcher

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -396,14 +396,22 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   @current_token_balances_limit 50
-  def handle_event({:chain_event, :address_current_token_balances, type, address_current_token_balances})
+  def handle_event(
+        {:chain_event, :address_current_token_balances, type,
+         %{address_current_token_balances: address_current_token_balances, address_hash: address_hash}}
+      )
       when type in [:realtime, :on_demand] do
-    address_current_token_balances.address_current_token_balances
+    address_current_token_balances
     |> Repo.preload(:token)
     |> Enum.group_by(& &1.token_type)
     |> Enum.each(fn {token_type, balances} ->
-      broadcast_token_balances(address_current_token_balances.address_hash, token_type, balances)
+      broadcast_token_balances(address_hash, token_type, balances)
     end)
+  end
+
+  def handle_event({:chain_event, :address_current_token_balances, :realtime, _empty_balances_params}) do
+    # Don't broadcast empty balances params from realtime block fetcher
+    :ok
   end
 
   case @chain_type do


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/12787

## Motivation

`address_current_token_balances` params coming from realtime block fetcher shouldn't be broadcasted since they are empty at the moment and will be broadcasted after fetching from a separate fetcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Prevents empty real-time token balance updates from being broadcast, reducing confusing or misleading balance changes in the UI.
  * Improves reliability of address token balance updates across real-time and on-demand events.

* Refactor
  * Streamlined event handling for address token balances to improve consistency and performance without altering user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->