### PR TITLE
fix: Return internal transactions for consensus blocks only in /api/v2/internal-transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -1000,9 +1000,8 @@ defmodule Explorer.Chain.InternalTransaction do
       |> where([_internal_transaction, transaction], transaction.block_consensus == true)
     else
       query
-      |> join(:inner, [internal_transaction], transaction in assoc(internal_transaction, :transaction))
-      |> join(:inner, [transaction], block in assoc(transaction, :block))
-      |> where([_internal_transaction, _transaction, block], block.consensus == true)
+      |> join(:inner, [internal_transaction], block in assoc(internal_transaction, :block))
+      |> where([_internal_transaction, block], block.consensus == true)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -997,6 +997,7 @@ defmodule Explorer.Chain.InternalTransaction do
     if DenormalizationHelper.transactions_denormalization_finished?() do
       query
       |> join(:inner, [internal_transaction], transaction in assoc(internal_transaction, :transaction))
+      |> where([internal_transaction, transaction], transaction.block_hash == internal_transaction.block_hash)
       |> where([_internal_transaction, transaction], transaction.block_consensus == true)
     else
       query

--- a/apps/explorer/test/explorer/chain/internal_transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/internal_transaction_test.exs
@@ -1090,51 +1090,54 @@ defmodule Explorer.Chain.InternalTransactionTest do
     end
   end
 
-  defp call_type(opts) do
-    defaults = [
-      type: :call,
-      call_type: :call,
-      to_address_hash: Factory.address_hash(),
-      from_address_hash: Factory.address_hash(),
-      input: Factory.transaction_input(),
-      output: Factory.transaction_input(),
-      gas: Decimal.new(50_000),
-      gas_used: Decimal.new(25_000),
-      value: %Wei{value: 100},
-      index: 0,
-      trace_address: []
-    ]
+  describe "fetch/1" do
+    test "with consensus transactions only" do
+      block_non_consensus = insert(:block, number: 2000, consensus: false)
+      block_consensus = insert(:block, number: 3000)
 
-    struct!(InternalTransaction, Keyword.merge(defaults, opts))
-  end
+      transaction_1 =
+        :transaction
+        |> insert(
+          block_hash: block_non_consensus.hash,
+          block_number: block_non_consensus.number,
+          block_consensus: false,
+          cumulative_gas_used: 100_500,
+          gas_used: 100_500,
+          index: 1
+        )
 
-  defp create_type(opts) do
-    defaults = [
-      type: :create,
-      from_address_hash: Factory.address_hash(),
-      gas: Decimal.new(50_000),
-      gas_used: Decimal.new(25_000),
-      value: %Wei{value: 100},
-      index: 0,
-      init: Factory.transaction_input(),
-      trace_address: []
-    ]
+      transaction_2 =
+        :transaction
+        |> insert()
+        |> with_block(block_consensus)
 
-    struct!(InternalTransaction, Keyword.merge(defaults, opts))
-  end
+      %InternalTransaction{transaction_hash: first_transaction_hash, index: first_index} =
+        insert(:internal_transaction,
+          index: 1,
+          transaction: transaction_1,
+          block_number: transaction_1.block_number,
+          block_hash: transaction_1.block_hash,
+          block_index: 1,
+          transaction_index: transaction_1.index
+        )
 
-  defp selfdestruct_type(opts) do
-    defaults = [
-      type: :selfdestruct,
-      from_address_hash: Factory.address_hash(),
-      to_address_hash: Factory.address_hash(),
-      gas: Decimal.new(50_000),
-      gas_used: Decimal.new(25_000),
-      value: %Wei{value: 100},
-      index: 0,
-      trace_address: []
-    ]
+      %InternalTransaction{transaction_hash: second_transaction_hash, index: second_index} =
+        insert(:internal_transaction,
+          index: 2,
+          transaction: transaction_2,
+          block_number: transaction_2.block_number,
+          block_hash: transaction_2.block_hash,
+          block_index: 2,
+          transaction_index: transaction_2.index
+        )
 
-    struct!(InternalTransaction, Keyword.merge(defaults, opts))
+      result =
+        []
+        |> InternalTransaction.fetch()
+        |> Enum.map(&{&1.transaction_hash, &1.index})
+
+      refute Enum.member?(result, {first_transaction_hash, first_index})
+      assert Enum.member?(result, {second_transaction_hash, second_index})
+    end
   end
 end


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/12765

## Changelog

### AI Agent summary

This pull request updates how internal transactions are filtered to ensure only those associated with consensus blocks or transactions are returned. It introduces a new filtering function and adds corresponding tests to verify this behavior.

### Filtering logic improvements

* Added the `where_consensus_transactions/1` function to `Explorer.Chain.InternalTransaction`, which filters internal transactions based on consensus status. The filter adapts depending on whether transaction denormalization has finished, checking either the transaction or block consensus flag.
* Integrated the new consensus filter into the main query pipeline for internal transactions, ensuring that only consensus transactions are included in results.

### Testing updates

* Added a test to `Explorer.Chain.InternalTransactionTest` that verifies only consensus transactions are returned by `fetch/1`. The test creates both consensus and non-consensus blocks/transactions and asserts the correct filtering.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal transactions now only include those tied to consensus (finalized) blocks.

* **New Features**
  * Added an option to exclude zero-value internal transfers so call-type zero transfers can be hidden.

* **Refactor**
  * Streamlined query and filtering to reliably restrict results to consensus transactions.

* **Tests**
  * Added/updated tests validating consensus-only filtering and zero-value exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->