### PR TITLE
fix: Change signed_authorizations chain_id type to numeric

### DIFF
--- a/apps/explorer/lib/explorer/chain/signed_authorization.ex
+++ b/apps/explorer/lib/explorer/chain/signed_authorization.ex
@@ -24,9 +24,9 @@ defmodule Explorer.Chain.SignedAuthorization do
   @type to_import :: %{
           transaction_hash: binary(),
           index: non_neg_integer(),
-          chain_id: non_neg_integer(),
+          chain_id: non_neg_integer() | Decimal.t(),
           address: binary(),
-          nonce: non_neg_integer(),
+          nonce: non_neg_integer() | Decimal.t(),
           r: non_neg_integer(),
           s: non_neg_integer(),
           v: non_neg_integer(),
@@ -52,7 +52,7 @@ defmodule Explorer.Chain.SignedAuthorization do
   @primary_key false
   typed_schema "signed_authorizations" do
     field(:index, :integer, primary_key: true, null: false)
-    field(:chain_id, :integer, null: false)
+    field(:chain_id, :decimal, null: false)
     field(:address, Hash.Address, null: false)
     field(:nonce, :decimal, null: false)
     field(:r, :decimal, null: false)
@@ -136,10 +136,10 @@ defmodule Explorer.Chain.SignedAuthorization do
     chain_id = ChainId.get_id()
 
     cond do
-      struct.chain_id != 0 and !is_nil(chain_id) and struct.chain_id != chain_id ->
+      not Decimal.eq?(struct.chain_id, 0) and !is_nil(chain_id) and not Decimal.eq?(struct.chain_id, chain_id) ->
         :invalid_chain_id
 
-      struct.chain_id != 0 and is_nil(chain_id) ->
+      not Decimal.eq?(struct.chain_id, 0) and is_nil(chain_id) ->
         nil
 
       struct.nonce |> Decimal.gte?(2 ** 64 - 1) ->

--- a/apps/explorer/priv/repo/migrations/20250820121833_change_chain_id_type_in_signed_authorization.exs
+++ b/apps/explorer/priv/repo/migrations/20250820121833_change_chain_id_type_in_signed_authorization.exs
@@ -1,0 +1,15 @@
+defmodule Explorer.Repo.Migrations.ChangeChainIdTypeInSignedAuthorization do
+  use Ecto.Migration
+
+  def up do
+    alter table(:signed_authorizations) do
+      modify(:chain_id, :numeric, precision: 78, scale: 0)
+    end
+  end
+
+  def down do
+    alter table(:signed_authorizations) do
+      modify(:chain_id, :bigint)
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated stored chain ID, nonce and signature numeric fields to high‑precision numeric types.
  * Added a database migration to apply and revert the schema change.

* **Refactor**
  * Aligned schema and validation logic to use high‑precision numeric comparisons.

* **Notes**
  * No user interface changes; behavior remains unchanged for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->