### PR TITLE
feat: Add methodId to txlist rpc method

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/etherscan.ex
+++ b/apps/block_scout_web/lib/block_scout_web/etherscan.ex
@@ -82,7 +82,8 @@ defmodule BlockScoutWeb.Etherscan do
         "contractAddress" => "",
         "cumulativeGasUsed" => "122207",
         "gasUsed" => "122207",
-        "confirmations" => "5994246"
+        "confirmations" => "5994246",
+        "methodId" => "0xf00d4b5d"
       }
     ]
   }
@@ -665,6 +666,12 @@ defmodule BlockScoutWeb.Etherscan do
     example: ~s("6005998")
   }
 
+  @method_id_type %{
+    type: "string",
+    definition: "Method signature used in transaction (0x for simple coin transfers)",
+    example: ~s("0xf00d4b5d")
+  }
+
   @transaction_index_type %{
     type: "transaction index",
     definition: "Index of the transaction in it's block.",
@@ -786,7 +793,8 @@ defmodule BlockScoutWeb.Etherscan do
       contractAddress: @address_hash_type,
       cumulativeGasUsed: @gas_type,
       gasUsed: @gas_type,
-      confirmations: @confirmation_type
+      confirmations: @confirmation_type,
+      methodId: @method_id_type
     }
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -129,7 +129,8 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
       "contractAddress" => "#{transaction.created_contract_address_hash}",
       "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
       "gasUsed" => "#{transaction.gas_used}",
-      "confirmations" => "#{transaction.confirmations}"
+      "confirmations" => "#{transaction.confirmations}",
+      "methodId" => Transaction.method_id(transaction)
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -670,7 +670,8 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           "contractAddress" => "#{transaction.created_contract_address_hash}",
           "cumulativeGasUsed" => "#{transaction.cumulative_gas_used}",
           "gasUsed" => "#{transaction.gas_used}",
-          "confirmations" => "0"
+          "confirmations" => "0",
+          "methodId" => "0x"
         }
       ]
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2239,4 +2239,15 @@ defmodule Explorer.Chain.Transaction do
   def method_name(_, _, _) do
     nil
   end
+
+  @doc """
+    Return method id used in transaction
+  """
+  def method_id(%__MODULE__{
+        created_contract_address_hash: nil,
+        input: %{bytes: <<method_id::binary-size(4), _::binary>>}
+      }),
+      do: "0x" <> Base.encode16(method_id, case: :lower)
+
+  def method_id(_transaction), do: "0x"
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12939

Docs update: https://github.com/blockscout/docs/pull/46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions now include a methodId field in API responses (e.g., txlist), exposing the 4‑byte method selector derived from transaction input.
  * For simple transfers, contract creations, or absent input, methodId returns "0x" as a fallback.

* **Documentation**
  * Etherscan integration docs and examples updated to show the new methodId field and expected format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->