### PR TITLE
fix: Fix multichain search queue export bug processing

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -867,14 +867,17 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       block_ranges_in_chunk = if index == 0, do: block_ranges, else: []
       address_token_balances_in_chunk = address_token_balances_chunk_by_index(address_token_balances, index)
 
+      address_coin_balances_chunk =
+        case Enum.fetch(indexed_address_coin_balances_chunks, index) do
+          {:ok, {chunk, ^index}} when is_list(chunk) -> chunk
+          _ -> []
+        end
+
       base_data_chunk
       |> Map.put(:addresses, addresses_chunk)
       |> Map.put(
         :address_coin_balances,
-        if(Enum.empty?(indexed_address_coin_balances_chunks),
-          do: [],
-          else: indexed_address_coin_balances_chunks |> Enum.at(index) |> elem(0) || []
-        )
+        address_coin_balances_chunk
       )
       |> Map.put(:hashes, hashes_in_chunk)
       |> Map.put(:block_ranges, block_ranges_in_chunk)


### PR DESCRIPTION
## Motivation

`{"time":"2025-08-21T11:45:41.693Z","severity":"error","message":"Task #PID<0.111835904.1> started from Explorer.Migrator.BackfillMultichainSearchDB terminating\n** (ArgumentError) errors were found at the given arguments:\n\n  * 2nd argument: not a tuple\n\n    :erlang.element(1, nil)\n    (explorer 9.0.2) lib/explorer/microservice_interfaces/multichain_search.ex:876: anonymous fn/6 in Explorer.MicroserviceInterfaces.MultichainSearch.prepare_chunk/4\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (explorer 9.0.2) lib/explorer/microservice_interfaces/multichain_search.ex:45: Explorer.MicroserviceInterfaces.MultichainSearch.batch_import/1\n    (explorer 9.0.2) lib/explorer/migrator/backfill_multichain_search_db.ex:139: Explorer.Migrator.BackfillMultichainSearchDB.update_batch/1\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\nFunction: #Function<2.117542878/0 in Explorer.Migrator.BackfillMultichainSearchDB.run_task/1>\n    Args: []","metadata":{"error":{"initial_call":null,"reason":"** (ArgumentError) errors were found at the given arguments:\n\n  * 2nd argument: not a tuple\n\n    :erlang.element(1, nil)\n    (explorer 9.0.2) lib/explorer/microservice_interfaces/multichain_search.ex:876: anonymous fn/6 in Explorer.MicroserviceInterfaces.MultichainSearch.prepare_chunk/4\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (explorer 9.0.2) lib/explorer/microservice_interfaces/multichain_search.ex:45: Explorer.MicroserviceInterfaces.MultichainSearch.batch_import/1\n    (explorer 9.0.2) lib/explorer/migrator/backfill_multichain_search_db.ex:139: Explorer.Migrator.BackfillMultichainSearchDB.update_batch/1\n    (elixir 1.17.3) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2\n    (elixir 1.17.3) lib/task/supervised.ex:36: Task.Supervised.reply/4\n"}}}
`

## Changelog

### AI Agent summary

This pull request updates the logic for extracting address coin balances from chunked data in the `Explorer.MicroserviceInterfaces.MultichainSearch` module. The main change is a refactor that improves the robustness and readability of how `address_coin_balances` are determined for each chunk.

Refactoring and logic improvement:

* Refactored the assignment of `address_coin_balances` in the chunk-building pipeline to use a new `indexed_address_coin_balances_chunk` variable, which safely checks for non-empty input and tuple structure before extracting data, reducing the risk of runtime errors.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of multichain search result assembly by safely handling missing or malformed response chunks. This prevents occasional crashes and returns empty results when data is unavailable, yielding a more reliable experience when viewing addresses and balances across chains. No user-facing workflows or APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->