### PR TITLE
fix: Fix no function clause matching in Explorer.Chain.Transaction.de…

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
@@ -70,7 +70,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address do
           type: :array,
           items: General.Implementation
         },
-        is_verified: %Schema{type: :boolean, description: "Has address associated source code?", nullable: false},
+        is_verified: %Schema{type: :boolean, description: "Has address associated source code?", nullable: true},
         ens_domain_name: %Schema{
           type: :string,
           description: "ENS domain name associated with the address",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1192,6 +1192,101 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
       assert_schema(response_2nd_page, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
     end
+
+    test "regression test for decoding issue", %{conn: conn} do
+      from_address = insert(:address)
+      to_address = build(:address)
+
+      transaction =
+        insert(:transaction, from_address: from_address, to_address_hash: to_address.hash, to_address: to_address)
+
+      Explorer.Repo.delete(to_address)
+
+      bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      chain_id = 1
+      Application.put_env(:block_scout_web, :chain_id, chain_id)
+
+      old_env_bens = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      old_env_metadata = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      Bypass.expect_once(bypass, "POST", "api/v1/#{chain_id}/addresses:batch_resolve_names", fn conn ->
+        Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "names" => %{
+              to_string(to_address) => "test.eth"
+            }
+          })
+        )
+      end)
+
+      Bypass.expect_once(bypass, "GET", "api/v1/metadata", fn conn ->
+        Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "addresses" => %{
+              to_string(to_address) => %{
+                "tags" => [
+                  %{
+                    "name" => "Proposer Fee Recipient",
+                    "ordinal" => 0,
+                    "slug" => "proposer-fee-recipient",
+                    "tagType" => "generic",
+                    "meta" => "{\"styles\":\"danger_high\"}"
+                  }
+                ]
+              }
+            }
+          })
+        )
+      end)
+
+      request = get(conn, "/api/v2/addresses/#{from_address.hash}/transactions")
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 1
+      assert response["next_page_params"] == nil
+
+      assert_schema(response, "AddressTransactionsPaginatedResponse", BlockScoutWeb.ApiSpec.spec())
+
+      transaction = Enum.at(response["items"], 0)
+      assert transaction["to"]["ens_domain_name"] == "test.eth"
+
+      assert transaction["to"]["metadata"] == %{
+               "tags" => [
+                 %{
+                   "slug" => "proposer-fee-recipient",
+                   "name" => "Proposer Fee Recipient",
+                   "ordinal" => 0,
+                   "tagType" => "generic",
+                   "meta" => %{"styles" => "danger_high"}
+                 }
+               ]
+             }
+
+      Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      Bypass.down(bypass)
+    end
   end
 
   describe "/addresses/{address_hash}/token-transfers" do

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -966,6 +966,15 @@ defmodule Explorer.Chain.Transaction do
     end
   end
 
+  def decoded_input_data(
+        %__MODULE__{to_address: %{metadata: _, ens_domain_name: _}},
+        _,
+        _,
+        _,
+        _
+      ),
+      do: {:error, :no_to_address}
+
   defp decode_function_call_via_sig_provider_wrapper(input, hash, skip_sig_provider?) do
     case decode_function_call_via_sig_provider(input, hash, skip_sig_provider?) do
       [] ->


### PR DESCRIPTION
…coded_input_data/5

## Motivation
```
  ** (FunctionClauseError) no function clause matching in Explorer.Chain.Transaction.decoded_input_data/5\n        (explorer 9.0.2) lib/explorer/chain/transaction.ex:798: Explorer.Chain.Transaction.decoded_input_data(%Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<47, 125, 26, 224, 176, 28, 105, 200, 133, 93, 28, 222, 161, 237, 79, 216, 96, 116, 182, 92, 13, 16, 195, 251, 197, 230, 101, 160, 116, 152, 165, 23>>}, block_number: 28065078, block_consensus: true, block_timestamp: ~U[2025-03-25 16:18:23.000000Z], cumulative_gas_used: Decimal.new(\"12113343\"), earliest_processing_start: nil, error: nil, gas: Decimal.new(\"22102\....
```
## Changelog
- Add new clause for `Explorer.Chain.Transaction.decoded_input_data/5`
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved decoding errors when transactions reference missing or proxied to-addresses (including ENS-resolved addresses), improving stability of transaction responses.
  - Ensures transaction responses continue to include resolved ENS names and associated metadata where available.

- API Changes
  - Updated Address V2 schema: is_verified may now be null while remaining required. Consumers should handle null values.

- Tests
  - Added regression tests covering ENS name resolution and metadata propagation in transaction responses, and scenarios with absent to-addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->