### PR TITLE
fix: Fix Postgres errors in Explorer.Migrator.BackfillMetadataURL

### DIFF
--- a/apps/explorer/lib/explorer/metadata_uri_validator.ex
+++ b/apps/explorer/lib/explorer/metadata_uri_validator.ex
@@ -63,7 +63,8 @@ defmodule Explorer.MetadataURIValidator do
   """
   @spec validate_uri(String.t()) :: :ok | {:error, atom()}
   def validate_uri(uri) do
-    with {:empty_host, %URI{host: host, scheme: scheme}} when host not in ["", nil] <- {:empty_host, URI.parse(uri)},
+    with {:not_printable, false} <- {:not_printable, not String.printable?(uri)},
+         {:empty_host, %URI{host: host, scheme: scheme}} when host not in ["", nil] <- {:empty_host, URI.parse(uri)},
          {:disallowed_protocol, false} <- {:disallowed_protocol, scheme not in allowed_uri_protocols()},
          {:nxdomain, ip_list} when not is_nil(ip_list) <- {:nxdomain, host_to_ip_list(host)},
          {:blacklist, false} <- {:blacklist, not Enum.all?(ip_list, &allowed_ip?/1)} do

--- a/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
@@ -143,7 +143,7 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
   defp process_common_url(url) do
     case MetadataURIValidator.validate_uri(url) do
       :ok ->
-        %{metadata_url: url, skip_metadata_url: false}
+        %{metadata_url: String.slice(url, 0, 2048), skip_metadata_url: false}
 
       {:error, reason} ->
         %{


### PR DESCRIPTION
Closes #12389 

## Changelog
- Trim urls by 2048 symbols 
- Check urls for `String.printable?`

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to reject metadata URLs with non-printable characters, preventing downstream failures.
  * Truncate overly long metadata URLs to 2048 characters during backfill to avoid storage and processing issues.
  * Increased reliability of metadata backfill, ensuring migrations complete successfully under edge cases.

* **Tests**
  * Added regression coverage for extremely long URLs and non-printable character handling to ensure consistent behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->