### PR TITLE
fix: celo api schema discrepancies

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -125,6 +125,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
     properties: %{
       is_epoch_block: %Schema{type: :boolean, nullable: false},
       epoch_number: %Schema{type: :integer, nullable: false},
+      l1_era_finalized_epoch_number: %Schema{type: :integer, nullable: true},
       base_fee: %Schema{
         type: :object,
         nullable: true,
@@ -151,7 +152,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
         additionalProperties: false
       }
     },
-    required: [:is_epoch_block, :epoch_number],
+    required: [:is_epoch_block, :epoch_number, :l1_era_finalized_epoch_number],
     additionalProperties: false
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -54,8 +54,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Token do
       type: :object,
       properties: %{
         address_hash: General.AddressHash,
-        symbol: %Schema{type: :string, nullable: false},
-        name: %Schema{type: :string, nullable: false},
+        symbol: %Schema{type: :string, nullable: true},
+        name: %Schema{type: :string, nullable: true},
         decimals: General.IntegerStringNullable,
         type: %Schema{allOf: [Type], nullable: true},
         holders_count: General.IntegerStringNullable,


### PR DESCRIPTION
Should be merged after #13029.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Addresses list items now include coin_balance and transactions_count.
  - Added status to Signed Authorization responses (ok, invalid_chain_id, invalid_signature, invalid_nonce).
  - Celo blocks expose l1_era_finalized_epoch_number.

- Changes
  - API schemas are stricter across many endpoints: extra/unknown properties are rejected.
  - Token schema: symbol and name can be null; overall structure tightened.
  - NFT collections: token_instances array is no longer nullable.
  - Expanded chain-specific fields for Filecoin, Zilliqa, Optimism, Arbitrum, zkSync, Polygon zkEVM, Scroll, Celo, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->