### PR TITLE
feat: Add is_scam property where applicable

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -146,7 +146,8 @@ defmodule BlockScoutWeb.API.V2.AddressView do
               token_balance.address_hash,
               token_balance
             )
-        )
+        ),
+      "is_scam" => token_balance.is_scam || false
     }
   end
 
@@ -183,7 +184,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
   defp prepare_nft(nft, token) do
     Map.merge(
-      %{"token_type" => token.type, "value" => value(token.type, nft)},
+      %{"token_type" => token.type, "value" => value(token.type, nft), "is_scam" => nft.is_scam || false},
       TokenView.prepare_token_instance(nft, token)
     )
   end
@@ -195,7 +196,8 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "token_instances" =>
         Enum.map(collection.preloaded_token_instances, fn instance ->
           prepare_nft_for_collection(collection.token.type, instance)
-        end)
+        end),
+      "is_scam" => collection[:is_scam] || false
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
@@ -173,7 +173,8 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
       internal_transaction_index: advanced_filter.internal_transaction_index,
       token_transfer_index: advanced_filter.token_transfer_index,
       token_transfer_batch_index: advanced_filter.token_transfer_batch_index,
-      fee: advanced_filter.fee
+      fee: advanced_filter.fee,
+      is_scam: advanced_filter.is_scam || false
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -43,7 +43,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
         search_result.circulating_market_cap && to_string(search_result.circulating_market_cap),
       "is_verified_via_admin_panel" => search_result.is_verified_via_admin_panel,
       "certified" => search_result.certified || false,
-      "priority" => search_result.priority
+      "priority" => search_result.priority,
+      "is_scam" => search_result.is_scam
     }
   end
 
@@ -56,7 +57,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
       "certified" => if(search_result.certified, do: search_result.certified, else: false),
-      "priority" => search_result.priority
+      "priority" => search_result.priority,
+      "is_scam" => search_result.is_scam
     }
   end
 
@@ -70,7 +72,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
       "certified" => if(search_result.certified, do: search_result.certified, else: false),
-      "priority" => search_result.priority
+      "priority" => search_result.priority,
+      "is_scam" => search_result.is_scam
     }
   end
 
@@ -84,7 +87,8 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "ens_info" => search_result[:ens_info],
       "certified" => if(search_result.certified, do: search_result.certified, else: false),
       "priority" => search_result.priority,
-      "metadata" => search_result.metadata
+      "metadata" => search_result.metadata,
+      "is_scam" => search_result.is_scam
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -319,7 +319,8 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
         "has_constructor_args" => !is_nil(smart_contract.constructor_arguments),
         "coin_balance" => if(address.fetched_coin_balance, do: address.fetched_coin_balance.value),
         "license_type" => smart_contract.license_type,
-        "certified" => if(smart_contract.certified, do: smart_contract.certified, else: false)
+        "certified" => if(smart_contract.certified, do: smart_contract.certified, else: false),
+        "is_scam" => smart_contract.is_scam || false
       }
 
     smart_contract_info

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -60,7 +60,8 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
       "block_hash" => to_string(token_transfer.block_hash),
       "block_number" => token_transfer.block_number,
       "log_index" => token_transfer.log_index,
-      "token_type" => token_transfer.token_type
+      "token_type" => token_transfer.token_type,
+      "is_scam" => token_transfer.is_scam || false
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -20,7 +20,8 @@ defmodule BlockScoutWeb.API.V2.TokenView do
       "volume_24h" => nil,
       "total_supply" => nil,
       "icon_url" => nil,
-      "circulating_market_cap" => nil
+      "circulating_market_cap" => nil,
+      "is_scam" => nil
     }
     |> maybe_append_bridged_info(token)
   end
@@ -41,7 +42,8 @@ defmodule BlockScoutWeb.API.V2.TokenView do
       "volume_24h" => token.volume_24h,
       "total_supply" => token.total_supply,
       "icon_url" => token.icon_url,
-      "circulating_market_cap" => token.circulating_market_cap
+      "circulating_market_cap" => token.circulating_market_cap,
+      "is_scam" => token.is_scam || false
     }
     |> maybe_append_bridged_info(token)
     |> chain_type_fields(%{address: token.contract_address, field_prefix: nil})

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -40,6 +40,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     field(:distinct_token_instances_count, :integer, virtual: true)
     field(:token_ids, {:array, :decimal}, virtual: true)
     field(:preloaded_token_instances, {:array, :any}, virtual: true)
+    field(:is_scam, :boolean, virtual: true)
 
     # A transient field for deriving token holder count deltas during address_current_token_balances upserts
     field(:old_value, :decimal)

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -19,6 +19,7 @@ defmodule Explorer.Chain.AdvancedFilter do
     field(:type, :string)
     field(:input, Data)
     field(:timestamp, :utc_datetime_usec)
+    field(:is_scam, :boolean, virtual: true)
 
     belongs_to(
       :from_address,
@@ -225,7 +226,8 @@ defmodule Explorer.Chain.AdvancedFilter do
       block_number: token_transfer.block_number,
       transaction_index: token_transfer.transaction.index,
       token_transfer_index: token_transfer.log_index,
-      token_transfer_batch_index: token_transfer.reverse_index_in_batch
+      token_transfer_batch_index: token_transfer.reverse_index_in_batch,
+      is_scam: token_transfer.is_scam || false
     }
   end
 

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -174,8 +174,7 @@ defmodule Explorer.Chain.Search do
 
   defp address_hash_search_if_first_page(%PagingOptions{key: nil}, address_hash, options) do
     address_hash
-    |> search_token_by_address_hash_query()
-    |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+    |> search_token_by_address_hash_query(options)
     |> union_all(
       ^(address_hash
         |> search_address_by_address_hash_query())
@@ -311,18 +310,15 @@ defmodule Explorer.Chain.Search do
   defp search_by_string(term, paging_options, metadata_tags, options) do
     tokens_query_certified =
       term
-      |> search_token_query_certified(paging_options)
-      |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+      |> search_token_query_certified(paging_options, options)
 
     tokens_query_not_certified =
       term
-      |> search_token_query_not_certified(paging_options)
-      |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+      |> search_token_query_not_certified(paging_options, options)
 
     metadata_tags_addresses_query = join_metadata_tags_with_addresses(metadata_tags, options)
 
-    contracts_query =
-      term |> search_contract_query(paging_options) |> ExplorerHelper.maybe_hide_scam_addresses(:address_hash, options)
+    contracts_query = term |> search_contract_query(paging_options, options)
 
     labels_query = search_label_query(term, paging_options)
 
@@ -440,18 +436,15 @@ defmodule Explorer.Chain.Search do
 
     tokens_results =
       (term
-       |> search_token_query_certified(paging_options)
-       |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+       |> search_token_query_certified(paging_options, options)
        |> select_repo(options).all()) ++
         (term
-         |> search_token_query_not_certified(paging_options)
-         |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+         |> search_token_query_not_certified(paging_options, options)
          |> select_repo(options).all())
 
     contracts_results =
       term
-      |> search_contract_query(paging_options)
-      |> ExplorerHelper.maybe_hide_scam_addresses(:address_hash, options)
+      |> search_contract_query(paging_options, options)
       |> select_repo(options).all()
 
     labels_results = term |> search_label_query(paging_options) |> select_repo(options).all()
@@ -534,44 +527,51 @@ defmodule Explorer.Chain.Search do
     |> page_search_results(paging_options, "label")
   end
 
-  defp search_token_query_not_certified(term, paging_options) do
+  defp search_token_query_not_certified(term, paging_options, options) do
     term
-    |> search_token_by_symbol_or_name_query(paging_options)
+    |> search_token_by_symbol_or_name_query(paging_options, options)
     |> where([smart_contract: smart_contract], is_nil(smart_contract.certified) or not smart_contract.certified)
   end
 
-  defp search_token_query_certified(term, paging_options) do
+  defp search_token_query_certified(term, paging_options, options) do
     term
-    |> search_token_by_symbol_or_name_query(paging_options)
+    |> search_token_by_symbol_or_name_query(paging_options, options)
     |> where([smart_contract: smart_contract], smart_contract.certified)
   end
 
-  defp search_token_by_symbol_or_name_query(term, paging_options) do
+  defp search_token_by_symbol_or_name_query(term, paging_options, options) do
     base_query =
       from(token in Token,
         as: :token,
         left_join: smart_contract in SmartContract,
         as: :smart_contract,
         on: token.contract_address_hash == smart_contract.address_hash,
-        where: fragment("to_tsvector('english', ? || ' ' || ?) @@ to_tsquery(?)", token.symbol, token.name, ^term),
-        select: ^token_search_fields()
+        where: fragment("to_tsvector('english', ? || ' ' || ?) @@ to_tsquery(?)", token.symbol, token.name, ^term)
       )
 
-    base_query |> apply_sorting([], @token_sorting) |> page_search_results(paging_options, "token")
+    base_query
+    |> apply_sorting([], @token_sorting)
+    |> page_search_results(paging_options, "token")
+    |> ExplorerHelper.maybe_hide_scam_addresses_without_select_merge(:contract_address_hash, options)
+    |> select(^(token_search_fields() |> add_is_scam_to_search_fields(options)))
   end
 
-  defp search_token_by_address_hash_query(address_hash) do
-    from(token in Token,
-      as: :token,
-      left_join: smart_contract in SmartContract,
-      as: :smart_contract,
-      on: token.contract_address_hash == smart_contract.address_hash,
-      where: token.contract_address_hash == ^address_hash,
-      select: ^token_search_fields()
-    )
+  defp search_token_by_address_hash_query(address_hash, options) do
+    query =
+      from(token in Token,
+        as: :token,
+        left_join: smart_contract in SmartContract,
+        as: :smart_contract,
+        on: token.contract_address_hash == smart_contract.address_hash,
+        where: token.contract_address_hash == ^address_hash
+      )
+
+    query
+    |> ExplorerHelper.maybe_hide_scam_addresses_without_select_merge(:contract_address_hash, options)
+    |> select(^(token_search_fields() |> add_is_scam_to_search_fields(options)))
   end
 
-  defp search_contract_query(term, paging_options) do
+  defp search_contract_query(term, paging_options, options) do
     contract_search_fields =
       search_fields()
       |> Map.put(:address_hash, dynamic([smart_contract: smart_contract], smart_contract.address_hash))
@@ -581,15 +581,17 @@ defmodule Explorer.Chain.Search do
       |> Map.put(:certified, dynamic([smart_contract: smart_contract], smart_contract.certified))
       |> Map.put(:verified, true)
       |> Map.put(:priority, 0)
+      |> add_is_scam_to_search_fields(options)
 
     base_query =
       from(smart_contract in SmartContract,
         as: :smart_contract,
-        where: fragment("to_tsvector('english', ?) @@ to_tsquery(?)", smart_contract.name, ^term),
-        select: ^contract_search_fields
+        where: fragment("to_tsvector('english', ?) @@ to_tsquery(?)", smart_contract.name, ^term)
       )
 
     base_query
+    |> ExplorerHelper.maybe_hide_scam_addresses_without_select_merge(:address_hash, options)
+    |> select(^contract_search_fields)
     |> apply_sorting([], @contract_sorting)
     |> page_search_results(paging_options, "contract")
   end
@@ -753,8 +755,8 @@ defmodule Explorer.Chain.Search do
       as: :metadata_tag,
       on: address.hash == tag.address_hash
     )
-    |> select(^metadata_tags_search_fields())
-    |> ExplorerHelper.maybe_hide_scam_addresses(:hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_without_select_merge(:hash, options)
+    |> select(^(metadata_tags_search_fields() |> add_is_scam_to_search_fields(options)))
   end
 
   defp page_search_results(
@@ -1036,7 +1038,8 @@ defmodule Explorer.Chain.Search do
       is_verified_via_admin_panel: nil,
       order: 0,
       metadata: dynamic(type(^nil, :map)),
-      addresses_index: 0
+      addresses_index: 0,
+      is_scam: false
     }
   end
 
@@ -1069,6 +1072,16 @@ defmodule Explorer.Chain.Search do
     |> Map.put(:addresses_index, dynamic([metadata_tag: tag], tag.addresses_index))
     |> Map.put(:verified, dynamic([address: address], address.verified))
     |> Map.put(:priority, 1)
+  end
+
+  defp add_is_scam_to_search_fields(search_fields, options) do
+    if ExplorerHelper.force_show_scam_addresses?(options) do
+      search_fields
+      |> Map.put(:is_scam, dynamic([sabm: sabm], not is_nil(sabm.address_hash)))
+    else
+      search_fields
+      # |> Map.put(:is_scam, false)
+    end
   end
 
   @paginated_types ["label", "contract", "token", "metadata_tag", "tac_operation"]

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -63,6 +63,7 @@ defmodule Explorer.Chain.SmartContract.Schema do
         field(:certified, :boolean)
         field(:is_blueprint, :boolean)
         field(:language, Ecto.Enum, values: @languages_enum, default: :solidity)
+        field(:is_scam, :boolean, virtual: true)
 
         belongs_to(
           :address,

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Chain.Token.Schema do
         field(:is_verified_via_admin_panel, :boolean)
         field(:volume_24h, :decimal)
         field(:transfer_count, :integer)
+        field(:is_scam, :boolean, virtual: true)
 
         belongs_to(
           :contract_address,

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -53,6 +53,7 @@ defmodule Explorer.Chain.Token.Instance do
     field(:cdn_upload_error, :string)
     field(:metadata_url, :string)
     field(:skip_metadata_url, :boolean)
+    field(:is_scam, :boolean, virtual: true)
 
     belongs_to(:owner, Address, foreign_key: :owner_address_hash, references: :hash, type: Hash.Address)
 

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -60,6 +60,7 @@ defmodule Explorer.Chain.TokenTransfer.Schema do
         field(:token_type, :string)
         field(:block_consensus, :boolean)
         field(:token_instance, :any, virtual: true) :: Instance.t() | nil
+        field(:is_scam, :boolean, virtual: true)
 
         belongs_to(:from_address, Address,
           foreign_key: :from_address_hash,


### PR DESCRIPTION
Closes #12953 

## Changelog
- Add `is_scam` json field to API responses:
  - 

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
