### PR TITLE
feat: Add x-api-key header

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/plug/rate_limit_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/plug/rate_limit_test.exs
@@ -343,6 +343,12 @@ defmodule BlockScoutWeb.Plug.RateLimitTest do
       assert get_resp_header(request, "x-ratelimit-limit") == ["-1"]
       assert get_resp_header(request, "x-ratelimit-remaining") == ["-1"]
       assert get_resp_header(request, "x-ratelimit-reset") == ["-1"]
+
+      request = conn |> put_req_header("x-api-key", "123") |> get("/api/v2/transactions")
+      assert request.status == 200
+      assert get_resp_header(request, "x-ratelimit-limit") == ["-1"]
+      assert get_resp_header(request, "x-ratelimit-remaining") == ["-1"]
+      assert get_resp_header(request, "x-ratelimit-reset") == ["-1"]
     end
 
     test "enforces rate limit with invalid API key", %{conn: conn} do


### PR DESCRIPTION
## Motivation

## Changelog
- Add option to pass api key in header

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
