### PR TITLE
chore: Bump actions major versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -92,7 +92,7 @@ jobs:
     name: Build and Cache deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -218,7 +218,7 @@ jobs:
       - build-and-cache
       - matrix-builder
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -376,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -426,7 +426,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -467,7 +467,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -519,7 +519,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -583,7 +583,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -659,7 +659,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -732,7 +732,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}

--- a/.github/workflows/generate-swagger.yml
+++ b/.github/workflows/generate-swagger.yml
@@ -64,7 +64,7 @@ jobs:
     name: Build and Cache deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -108,7 +108,7 @@ jobs:
       - build-and-cache
       - matrix-builder
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.OTP_VERSION }}
@@ -156,14 +156,14 @@ jobs:
           fi
 
       - name: Checkout specs repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ vars.API_SPECS_REPOSITORY }}
           token: ${{ secrets.API_SPECS_PAT }}
           path: api-specs
 
       - name: Download all swagger specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: openapi-spec-*
           merge-multiple: true

--- a/.github/workflows/pre-release-arbitrum.yml
+++ b/.github/workflows/pre-release-arbitrum.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-celo.yml
+++ b/.github/workflows/pre-release-celo.yml
@@ -19,7 +19,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       API_GRAPHQL_MAX_COMPLEXITY: 10400
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-eth.yml
+++ b/.github/workflows/pre-release-eth.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-filecoin.yml
+++ b/.github/workflows/pre-release-filecoin.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-fuse.yml
+++ b/.github/workflows/pre-release-fuse.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-optimism.yml
+++ b/.github/workflows/pre-release-optimism.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-polygon-zkevm.yml
+++ b/.github/workflows/pre-release-polygon-zkevm.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-rootstock.yml
+++ b/.github/workflows/pre-release-rootstock.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-scroll.yml
+++ b/.github/workflows/pre-release-scroll.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-zilliqa.yml
+++ b/.github/workflows/pre-release-zilliqa.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release-zksync.yml
+++ b/.github/workflows/pre-release-zksync.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-custom-build.yml
+++ b/.github/workflows/publish-docker-image-custom-build.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-every-push.yml
+++ b/.github/workflows/publish-docker-image-every-push.yml
@@ -18,7 +18,7 @@ jobs:
     name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-arbitrum.yml
+++ b/.github/workflows/publish-docker-image-for-arbitrum.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: arbitrum
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-celo.yml
+++ b/.github/workflows/publish-docker-image-for-celo.yml
@@ -14,7 +14,7 @@ jobs:
       DOCKER_CHAIN_NAME: celo
       API_GRAPHQL_MAX_COMPLEXITY: 10400
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-core.yml
+++ b/.github/workflows/publish-docker-image-for-core.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: poa
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-eth-sepolia.yml
+++ b/.github/workflows/publish-docker-image-for-eth-sepolia.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: eth-sepolia
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-eth.yml
+++ b/.github/workflows/publish-docker-image-for-eth.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: ethereum
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-filecoin.yml
+++ b/.github/workflows/publish-docker-image-for-filecoin.yml
@@ -12,7 +12,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: filecoin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-fuse.yml
+++ b/.github/workflows/publish-docker-image-for-fuse.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: fuse
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-gnosis-chain.yml
+++ b/.github/workflows/publish-docker-image-for-gnosis-chain.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: xdai
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-l2-staging.yml
+++ b/.github/workflows/publish-docker-image-for-l2-staging.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: optimism-l2-advanced
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-lukso.yml
+++ b/.github/workflows/publish-docker-image-for-lukso.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: lukso
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-optimism-interop.yml
+++ b/.github/workflows/publish-docker-image-for-optimism-interop.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: optimism
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-optimism.yml
+++ b/.github/workflows/publish-docker-image-for-optimism.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: optimism
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-rootstock.yml
+++ b/.github/workflows/publish-docker-image-for-rootstock.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: rsk
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-scroll.yml
+++ b/.github/workflows/publish-docker-image-for-scroll.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: scroll
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-suave.yml
+++ b/.github/workflows/publish-docker-image-for-suave.yml
@@ -16,7 +16,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: suave
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-zetachain.yml
+++ b/.github/workflows/publish-docker-image-for-zetachain.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: zetachain
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-zilliqa.yml
+++ b/.github/workflows/publish-docker-image-for-zilliqa.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: zilliqa
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-zkevm.yml
+++ b/.github/workflows/publish-docker-image-for-zkevm.yml
@@ -13,7 +13,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: zkevm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-for-zksync.yml
+++ b/.github/workflows/publish-docker-image-for-zksync.yml
@@ -12,7 +12,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       DOCKER_CHAIN_NAME: zksync
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-old-ui.yml
+++ b/.github/workflows/publish-docker-image-old-ui.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-docker-image-staging-on-demand.yml
+++ b/.github/workflows/publish-docker-image-staging-on-demand.yml
@@ -19,7 +19,7 @@ jobs:
     name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/publish-regular-docker-image-on-demand.yml
+++ b/.github/workflows/publish-regular-docker-image-on-demand.yml
@@ -12,7 +12,7 @@ jobs:
     name: Push Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-arbitrum.yml
+++ b/.github/workflows/release-arbitrum.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-celo.yml
+++ b/.github/workflows/release-celo.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_VERSION: 9.0.2
       API_GRAPHQL_MAX_COMPLEXITY: 10400
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-eth.yml
+++ b/.github/workflows/release-eth.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-filecoin.yml
+++ b/.github/workflows/release-filecoin.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-fuse.yml
+++ b/.github/workflows/release-fuse.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-gnosis.yml
+++ b/.github/workflows/release-gnosis.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-optimism.yml
+++ b/.github/workflows/release-optimism.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-polygon-zkevm.yml
+++ b/.github/workflows/release-polygon-zkevm.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-rootstock.yml
+++ b/.github/workflows/release-rootstock.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-scroll.yml
+++ b/.github/workflows/release-scroll.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-suave.yml
+++ b/.github/workflows/release-suave.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-zetachain.yml
+++ b/.github/workflows/release-zetachain.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-zilliqa.yml
+++ b/.github/workflows/release-zilliqa.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release-zksync.yml
+++ b/.github/workflows/release-zksync.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RELEASE_VERSION: 9.0.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup repo
         uses: ./.github/actions/setup-repo
         id: setup
@@ -121,7 +121,7 @@ jobs:
   #       production-rsk
   #       production-immutable
   #   steps:
-  #   - uses: actions/checkout@v4
+  #   - uses: actions/checkout@v5
   #   - name: Set Git config
   #     run: |
   #         git config --local user.email "actions@github.com"


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/pull/13047

## Motivation

Bump GH actions major versions.

## Changelog

### AI Agent summary

This pull request updates the GitHub Actions workflows to use the latest version of the `actions/checkout` and `actions/download-artifact` actions. The main change is upgrading from version 4 to version 5, which ensures compatibility with the most recent features and security patches provided by GitHub.

Workflow action upgrades:

* Updated all instances of `actions/checkout@v4` to `actions/checkout@v5` across workflow files such as `.github/workflows/config.yml`, `.github/workflows/codeql-analysis.yml`, `.github/workflows/generate-swagger.yml`, and all pre-release and publish-docker-image workflows. [[1]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L95-R95) [[2]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L41-R41) [[3]](diffhunk://#diff-8e9b4a2309cd3dd895c67ea014e5c6f0bd629ce1a143136c352cdf35bc5b281cL67-R67) [[4]](diffhunk://#diff-7cd3f8b468295722f8171b8a54d8d22acd5fc733a31316480d7e0c475d3ae29bL21-R21) [[5]](diffhunk://#diff-939082057c114c7762f629dec17b4092e2074aa7e0dfa0960bd20c89fc04e568L22-R22) [[6]](diffhunk://#diff-f5586ef379ef9fd05f7407c7bc4e8d8c9efd8d2e0e7edbfb62f19bd73a15e8baL21-R21) [[7]](diffhunk://#diff-f16fef57893ddebf29c4bd700ffa7d424a2ce6fe8e60e111a785e1d63c7b13eeL21-R21) [[8]](diffhunk://#diff-f9521a15d1642e404811de775719cc915b9da2036eb35138c608753392fe0798L21-R21) [[9]](diffhunk://#diff-a70a0b49061fb0bc6841f4713ff5f37da77227a3d184bfa70c40ae76e61c1b29L21-R21) [[10]](diffhunk://#diff-fdd1def9e9a589b441f736d4c7dccbb22fd11eb054d926168c1ef52bbd868b04L21-R21) [[11]](diffhunk://#diff-4415556b89e9bbbe9d040a3b39019592af645f3a8ac5135b18db51545db019a9L21-R21) [[12]](diffhunk://#diff-fd8c724c35793a3e9a6239dcd51c789fcd1ffc68449209278f7aaf71254e2416L21-R21) [[13]](diffhunk://#diff-6163a9312c1b4b8d28c8b4ac4afaa1632921fc9a3f45fd81b8ad9db53f419ef3L21-R21) [[14]](diffhunk://#diff-4e459cfc1177032529977def69a19ac299c8e377ea2b6c16780b2b91ff473428L21-R21) [[15]](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L21-R21) [[16]](diffhunk://#diff-8e342784762ba2a86c38d049cb509e98041268e283e34db4154da1aa9f9a3793L15-R15) [[17]](diffhunk://#diff-8a68ab14e3a2e99e92dcfa39924ecc69425b180c3f554411f76a6c37f9f1d621L21-R21) [[18]](diffhunk://#diff-f1e05e2302890e481a8042b2970118d4ec035bf31edd93f8afc23bab3ad5f71aL16-R16) [[19]](diffhunk://#diff-3ad867dd3a18c14071c0fdce07ddc542d0c8b57dc4bda3a18ef8aa5189f315f0L17-R17) [[20]](diffhunk://#diff-896816a29e3aa6bd145588466825b9e3173805b213270ada616e64f0b48ed3f8L16-R16)
* Updated `actions/download-artifact@v4` to `actions/download-artifact@v5` in `.github/workflows/generate-swagger.yml`.

These upgrades help keep CI pipelines secure and up to date with the latest improvements from GitHub Actions.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Upgraded GitHub Actions checkout to v5 across CI workflows (releases, pre-releases, Docker image publishing, CodeQL, and spec generation) for improved reliability and maintenance.
  - No changes to build, test, or release behavior; existing steps and configurations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->