### PR TITLE
fix: Escape only significant characters in tokens

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/smart_contract_view.ex
@@ -109,22 +109,22 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   def values_with_type(value, string, names, index, _components) when string in ["string", :string],
-    do: render_type_value("string", Helper.sanitize_input(value), fetch_name(names, index))
+    do: render_type_value("string", Helper.escape_minimal(value), fetch_name(names, index))
 
   def values_with_type(value, "bytes" <> _ = bytes_type, names, index, _components),
-    do: render_type_value(bytes_type, Helper.sanitize_input(value), fetch_name(names, index))
+    do: render_type_value(bytes_type, Helper.escape_minimal(value), fetch_name(names, index))
 
   def values_with_type(value, bytes, names, index, _components) when bytes in [:bytes],
-    do: render_type_value("bytes", Helper.sanitize_input(value), fetch_name(names, index))
+    do: render_type_value("bytes", Helper.escape_minimal(value), fetch_name(names, index))
 
   def values_with_type(value, bool, names, index, _components) when bool in ["bool", :bool],
-    do: render_type_value("bool", Helper.sanitize_input(to_string(value)), fetch_name(names, index))
+    do: render_type_value("bool", Helper.escape_minimal(to_string(value)), fetch_name(names, index))
 
   def values_with_type(value, type, names, index, _components),
-    do: render_type_value(type, Helper.sanitize_input(value), fetch_name(names, index))
+    do: render_type_value(type, Helper.escape_minimal(value), fetch_name(names, index))
 
   def values_with_type(value, :error, _components),
-    do: render_type_value("error", Helper.sanitize_input(value), "error")
+    do: render_type_value("error", Helper.escape_minimal(value), "error")
 
   def cast_address(value) do
     case HashAddress.cast(value) do
@@ -166,11 +166,11 @@ defmodule BlockScoutWeb.SmartContractView do
   end
 
   defp render_type_value(type, value, type) do
-    "<div class=\"pl-3\"><i>(#{Helper.sanitize_input(type)})</i> : #{value}</div>"
+    "<div class=\"pl-3\"><i>(#{Helper.escape_minimal(type)})</i> : #{value}</div>"
   end
 
   defp render_type_value(type, value, name) do
-    "<div class=\"pl-3\"><i><span style=\"color: black\">#{Helper.sanitize_input(name)}</span> (#{Helper.sanitize_input(type)})</i> : #{value}</div>"
+    "<div class=\"pl-3\"><i><span style=\"color: black\">#{Helper.escape_minimal(name)}</span> (#{Helper.escape_minimal(type)})</i> : #{value}</div>"
   end
 
   defp render_array_type_value(type, values, name) do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -134,7 +134,8 @@ for migrator <- [
       Explorer.Migrator.BackfillMetadataURL,
       Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds,
       Explorer.Migrator.ReindexDuplicatedInternalTransactions,
-      Explorer.Migrator.MergeAdjacentMissingBlockRanges
+      Explorer.Migrator.MergeAdjacentMissingBlockRanges,
+      Explorer.Migrator.UnescapeQuotesInTokens
     ] do
   config :explorer, migrator, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -73,6 +73,7 @@ for migrator <- [
       Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds,
       Explorer.Migrator.ReindexDuplicatedInternalTransactions,
       Explorer.Migrator.MergeAdjacentMissingBlockRanges,
+      Explorer.Migrator.UnescapeQuotesInTokens,
 
       # Heavy DB index operations
       Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -191,6 +191,7 @@ defmodule Explorer.Application do
         configure_mode_dependent_process(Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.ReindexDuplicatedInternalTransactions, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.MergeAdjacentMissingBlockRanges, :indexer),
+        configure_mode_dependent_process(Explorer.Migrator.UnescapeQuotesInTokens, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.ReindexBlocksWithMissingTransactions, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesVerifiedIndex,

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -171,7 +171,7 @@ defmodule Explorer.Chain.Token do
         changeset
 
       property ->
-        put_change(changeset, key, Helper.sanitize_input(property))
+        put_change(changeset, key, Helper.escape_minimal(property))
     end
   end
 

--- a/apps/explorer/lib/explorer/migrator/unescape_quotes_in_tokens.ex
+++ b/apps/explorer/lib/explorer/migrator/unescape_quotes_in_tokens.ex
@@ -1,0 +1,67 @@
+defmodule Explorer.Migrator.UnescapeQuotesInTokens do
+  @moduledoc """
+  Unescapes single and double quotes in `name` and `symbol` token fields
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Token
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "unescape_quotes_in_tokens"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(state) do
+    limit = batch_size() * concurrency()
+
+    ids =
+      unprocessed_data_query()
+      |> select([t], t.contract_address_hash)
+      |> limit(^limit)
+      |> Repo.all(timeout: :infinity)
+
+    {ids, state}
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    where(Token, [t], fragment("? ~ E'(&#39;|&quot;)' or ? ~ E'(&#39;|&quot;)'", t.name, t.symbol))
+  end
+
+  @impl FillingMigration
+  def update_batch(contract_address_hashes) do
+    params =
+      Token
+      |> where([t], t.contract_address_hash in ^contract_address_hashes)
+      |> Repo.all()
+      |> Enum.map(fn token ->
+        %{
+          contract_address_hash: token.contract_address_hash,
+          name: do_unescape(token.name),
+          symbol: do_unescape(token.symbol),
+          type: token.type,
+          inserted_at: token.inserted_at,
+          updated_at: token.updated_at
+        }
+      end)
+
+    Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+
+  defp do_unescape(nil), do: nil
+
+  defp do_unescape(string) do
+    string
+    |> String.replace("&quot;", "\"")
+    |> String.replace("&#39;", "'")
+  end
+end

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -93,6 +93,20 @@ defmodule Explorer.SmartContract.Helper do
     |> String.trim()
   end
 
+  @doc """
+  Escapes only <, > and & symbols
+  """
+  @spec escape_minimal(any()) :: any()
+  def escape_minimal(input) when is_binary(input) do
+    input
+    # should always be the first to replace
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+  end
+
+  def escape_minimal(other), do: other
+
   def sol_file?(filename) do
     case List.last(String.split(String.downcase(filename), ".")) do
       "sol" ->

--- a/apps/explorer/test/explorer/migrator/unescape_quotes_in_tokens_test.exs
+++ b/apps/explorer/test/explorer/migrator/unescape_quotes_in_tokens_test.exs
@@ -1,0 +1,25 @@
+defmodule Explorer.Migrator.UnescapeQuotesInTokensTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Migrator.{UnescapeQuotesInTokens, MigrationStatus}
+  alias Explorer.Repo
+
+  test "Unescapes quotes in tokens" do
+    escaped_name_token = insert(:token, name: "Smth&#39;s")
+    escaped_symbol_token = insert(:token, symbol: "&quot;Double quoted&quot;")
+    escaped_both_token = insert(:token, name: "Smth&#39;s", symbol: "&quot;Double quoted&quot;")
+    common_token = :token |> insert() |> Repo.reload()
+
+    assert MigrationStatus.get_status("unescape_quotes_in_tokens") == nil
+    UnescapeQuotesInTokens.start_link([])
+
+    Process.sleep(100)
+
+    assert Repo.reload(escaped_name_token).name == "Smth's"
+    assert Repo.reload(escaped_symbol_token).symbol == "\"Double quoted\""
+    assert %{name: "Smth's", symbol: "\"Double quoted\""} = Repo.reload(escaped_both_token)
+    assert ^common_token = Repo.reload(common_token)
+
+    assert MigrationStatus.get_status("unescape_quotes_in_tokens") == "completed"
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10732

## Changelog

- Escape only `<`, `>` and `&` characters on token insertion
- Migrate existing tokens to keep quotes in original state for `name` and `symbol`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Correctly display quotes in token names and symbols (no more &quot; or &#39;).
  - Improve smart contract value and type rendering with minimal HTML escaping to avoid over-escaping.

- **Chores**
  - Added and enabled a background migrator to unescape existing token data during startup/configuration.

- **Tests**
  - Added tests verifying the token unescape migration runs and updates data as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->