### PR TITLE
chore: Replace ReindexDuplicatedInternalTransactions grouping field

### DIFF
--- a/apps/explorer/lib/explorer/migrator/reindex_duplicated_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_duplicated_internal_transactions.ex
@@ -1,6 +1,6 @@
 defmodule Explorer.Migrator.ReindexDuplicatedInternalTransactions do
   @moduledoc """
-  Searches for all blocks that contains internal transactions with duplicated block_hash, transaction_index, index,
+  Searches for all blocks that contains internal transactions with duplicated block_number, transaction_index, index,
   deletes all internal transactions for such blocks and adds them to pending operations.
   """
 
@@ -43,25 +43,25 @@ defmodule Explorer.Migrator.ReindexDuplicatedInternalTransactions do
   def unprocessed_data_query do
     from(
       it in InternalTransaction,
-      group_by: [it.block_hash, it.transaction_index, it.index],
+      group_by: [it.block_number, it.transaction_index, it.index],
       having: count("*") > 1,
-      select: it.block_hash
+      select: it.block_number
     )
   end
 
   @impl FillingMigration
-  def update_batch(block_hashes) do
+  def update_batch(block_numbers) do
     now = DateTime.utc_now()
 
     result =
       Repo.transaction(fn ->
         InternalTransaction
-        |> where([it], it.block_hash in ^block_hashes)
+        |> where([it], it.block_number in ^block_numbers)
         |> Repo.delete_all()
 
         pbo_params =
           Block
-          |> where([b], b.hash in ^block_hashes)
+          |> where([b], b.number in ^block_numbers)
           |> where([b], b.consensus == true)
           |> select([b], %{block_hash: b.hash, block_number: b.number})
           |> Repo.all()


### PR DESCRIPTION
## Motivation

Since there is no `block_hash` index on internal transactions but there is a `block_number` index, it's more efficient to group and search by `block_number` instead of `block_hash`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminates duplicated internal transactions by updating the reindexing logic, improving data accuracy and consistency in transaction views.
* **Chores**
  * Aligns reindexing workflow to use more reliable identifiers for batching and lookups, reducing edge cases during data migration and refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->