### PR TITLE
chore: Bump default rps to 5

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -132,11 +132,11 @@ config :block_scout_web, :api_rate_limit,
     period: ConfigHelper.parse_time_env_var("API_RATE_LIMIT_BY_WHITELISTED_IP_TIME_INTERVAL", "1s")
   },
   ip: %{
-    limit: ConfigHelper.parse_integer_env_var("API_RATE_LIMIT_BY_IP", 500),
-    period: ConfigHelper.parse_time_env_var("API_RATE_LIMIT_BY_IP_TIME_INTERVAL", "15m")
+    limit: ConfigHelper.parse_integer_env_var("API_RATE_LIMIT_BY_IP", 300),
+    period: ConfigHelper.parse_time_env_var("API_RATE_LIMIT_BY_IP_TIME_INTERVAL", "1m")
   },
   temporary_token: %{
-    limit: ConfigHelper.parse_integer_env_var("API_RATE_LIMIT_UI_V2_WITH_TOKEN", 4),
+    limit: ConfigHelper.parse_integer_env_var("API_RATE_LIMIT_UI_V2_WITH_TOKEN", 5),
     period: ConfigHelper.parse_time_env_var("API_RATE_LIMIT_UI_V2_WITH_TOKEN_TIME_INTERVAL", "1s")
   },
   account_api_key: %{


### PR DESCRIPTION
## Motivation

## Changelog
- set default rate limit to 5 rps
https://github.com/blockscout/docs/pull/55
## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated API rate limiting:
    - IP-based: 300 requests per minute (was 500 per 15 minutes) for more granular throttling.
    - UI v2 token-based: 5 requests per second (was 4).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->