### PR TITLE
chore: Add support of Scroll codecv8

### DIFF
--- a/apps/explorer/lib/explorer/chain/scroll/batch.ex
+++ b/apps/explorer/lib/explorer/chain/scroll/batch.ex
@@ -21,7 +21,7 @@ defmodule Explorer.Chain.Scroll.Batch do
 
   @required_attrs ~w(number commit_transaction_hash commit_block_number commit_timestamp container)a
   @zstd_magic_number <<0x28, 0xB5, 0x2F, 0xFD>>
-  @codec_version 7
+  @codec_min_version 7
 
   @typedoc """
     Descriptor of the batch:
@@ -103,7 +103,7 @@ defmodule Explorer.Chain.Scroll.Batch do
     <<version, blob_payload_size::size(24), is_compressed::size(8), rest::binary>> = blob_data_raw
 
     # ensure we have correct version, blob envelope size doesn't exceed the raw data size, and compression flag is correct
-    with {:version_is_supported, true} <- {:version_is_supported, version == @codec_version},
+    with {:version_is_supported, true} <- {:version_is_supported, version >= @codec_min_version},
          {:size_is_correct, true} <- {:size_is_correct, blob_payload_size + 5 <= byte_size(blob_data_raw)},
          {:compression_flag_is_correct, true} <-
            {:compression_flag_is_correct, is_compressed in [0, 1]},
@@ -113,7 +113,7 @@ defmodule Explorer.Chain.Scroll.Batch do
       decompressed
     else
       {:version_is_supported, false} ->
-        Logger.error("Codec version #{version} is not supported. Expected: #{@codec_version}.")
+        Logger.error("Codec version #{version} is not supported. Expected: >=#{@codec_min_version}")
         nil
 
       {:size_is_correct, false} ->


### PR DESCRIPTION
## Motivation

Starting from batch number `112749` on Scroll Sepolia and batch number `368300` on Scroll Mainnet, the `Indexer.Fetcher.Scroll.Batch` module stopped to retrieve L2 block ranges for the batches.

The reason is that Scroll introduced [v8 of a codec](https://github.com/scroll-tech/da-codec/blob/main/encoding/codecv8.go) (as a small compression improvement of v7) which is failed the strict equality test on this line of code: https://github.com/blockscout/blockscout/blob/2426c2ce7c7ac3b0dd1c9abe68ebeda51b4b39c7/apps/explorer/lib/explorer/chain/scroll/batch.ex#L106

The new version didn't affect any indexer code, so it was decided to change `==` to `>=` in the condition to support codec versions greater than `7`.

## Upgrading

This change requires executing the following SQL queries on Scroll Blockscout instances after their upgrading (but before their start) to reindex batches without L2 block ranges.

### Scroll Sepolia

```sql
DELETE FROM scroll_batches WHERE number >= 112749;
DELETE FROM scroll_batch_bundles WHERE final_batch_number >= 112749;
```

### Scroll Mainnet

```sql
DELETE FROM scroll_batches WHERE number >= 368300;
DELETE FROM scroll_batch_bundles WHERE final_batch_number >= 368300;
```

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
