### PR TITLE
chore: Add final check for ReindexDuplicatedInternalTransactions

### DIFF
--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -62,7 +62,7 @@ defmodule Explorer.Migrator.FillingMigration do
     limiting is handled within `last_unprocessed_identifiers/1`.
   """
   @callback unprocessed_data_query :: Ecto.Query.t() | nil
-  @callback unprocessed_data_query(any()) :: Ecto.Query.t() | nil
+  @callback unprocessed_data_query(map()) :: Ecto.Query.t() | nil
 
   @doc """
     This callback retrieves the next batch of data for migration processing. It returns

--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -62,6 +62,7 @@ defmodule Explorer.Migrator.FillingMigration do
     limiting is handled within `last_unprocessed_identifiers/1`.
   """
   @callback unprocessed_data_query :: Ecto.Query.t() | nil
+  @callback unprocessed_data_query(any()) :: Ecto.Query.t() | nil
 
   @doc """
     This callback retrieves the next batch of data for migration processing. It returns
@@ -152,6 +153,8 @@ defmodule Explorer.Migrator.FillingMigration do
     - `:ignore` by default
   """
   @callback before_start :: any()
+
+  @optional_callbacks unprocessed_data_query: 0, unprocessed_data_query: 1
 
   defmacro __using__(opts) do
     quote do


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved two‑phase deduplication to reliably remove duplicates by step and queue affected blocks for reprocessing.

* **New Features**
  * Reindexing accepts both block numbers and block hashes and dynamically handles either input.
  * The unprocessed-data query can optionally receive state to target different fields during migration.

* **Tests**
  * Expanded tests to validate reindexing across multiple invalid blocks and verify pending operations for each.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->