### PR TITLE
fix: Set `timeout: :infinity` for read ops in NFT backfillers

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_instance/sanitize_erc1155.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/sanitize_erc1155.ex
@@ -43,7 +43,7 @@ defmodule Indexer.Fetcher.TokenInstance.SanitizeERC1155 do
     instances_to_fetch =
       (concurrency * batch_size)
       |> Instance.not_inserted_erc_1155_token_instances()
-      |> Repo.all()
+      |> Repo.all(timeout: :infinity)
 
     if Enum.empty?(instances_to_fetch) do
       MigrationStatus.set_status(@migration_name, "completed")

--- a/apps/indexer/lib/indexer/fetcher/token_instance/sanitize_erc721.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/sanitize_erc721.ex
@@ -54,7 +54,7 @@ defmodule Indexer.Fetcher.TokenInstance.SanitizeERC721 do
     address_hashes =
       state[:tokens_queue_size]
       |> Token.ordered_erc_721_token_address_hashes_list_query(state[:last_token_address_hash])
-      |> Repo.all()
+      |> Repo.all(timeout: :infinity)
 
     if Enum.empty?(address_hashes) do
       MigrationStatus.set_status(@migration_name, "completed")
@@ -81,7 +81,7 @@ defmodule Indexer.Fetcher.TokenInstance.SanitizeERC721 do
     instances_to_fetch =
       (concurrency * batch_size)
       |> Instance.not_inserted_token_instances_query_by_token(current_address_hash)
-      |> Repo.all()
+      |> Repo.all(timeout: :infinity)
 
     if Enum.empty?(instances_to_fetch) do
       Constants.insert_last_processed_token_address_hash(current_address_hash)


### PR DESCRIPTION
## Motivation
Stucked migrations
`GenServer Indexer.Fetcher.TokenInstance.SanitizeERC721 terminating\n** (Postgrex.Error) ERROR 57014 (query_canceled) canceling statement due to user request`
`GenServer Indexer.Fetcher.TokenInstance.SanitizeERC1155 terminating\n** (Postgrex.Error) ERROR 57014 (query_canceled) canceling statement due to user request`
## Changelog
- Set `timeout: :infinity` for `Repo.all()`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented database timeouts during long-running ERC‑721 backfill, reducing stalled migrations and ensuring continuous indexing of token instances for improved data completeness.
  * Prevented database timeouts during ERC‑1155 token instance sanitization, improving resilience of backfill runs and reducing missed records.
  * Overall, indexing operations are more stable with fewer interruptions and retries during high-volume processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->