### PR TITLE
fix: Replace get_constant_by_key with get_constant_value in get_last_…

### DIFF
--- a/apps/explorer/lib/explorer/application/constants.ex
+++ b/apps/explorer/lib/explorer/application/constants.ex
@@ -100,6 +100,6 @@ defmodule Explorer.Application.Constants do
   """
   @spec get_last_processed_token_address_hash(keyword()) :: nil | Explorer.Chain.Hash.t()
   def get_last_processed_token_address_hash(options \\ []) do
-    @last_processed_erc_721_token |> get_constant_by_key(options) |> Chain.string_to_address_hash_or_nil()
+    @last_processed_erc_721_token |> get_constant_value(options) |> Chain.string_to_address_hash_or_nil()
   end
 end

--- a/apps/indexer/test/indexer/fetcher/token_instance/sanitize_erc721_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/sanitize_erc721_test.exs
@@ -3,8 +3,20 @@ defmodule Indexer.Fetcher.TokenInstance.SanitizeERC721Test do
 
   alias Explorer.Repo
   alias Explorer.Chain.Token.Instance
+  alias Explorer.Application.Constants
+  alias Explorer.Migrator.MigrationStatus
 
   describe "sanitizer test" do
+    setup do
+      initial_env = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.SanitizeERC721)
+
+      on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.TokenInstance.SanitizeERC721, initial_env)
+      end)
+
+      {:ok, initial_env: initial_env}
+    end
+
     test "imports token instances" do
       for x <- 0..3 do
         erc_721_token = insert(:token, type: "ERC-721")
@@ -34,6 +46,152 @@ defmodule Indexer.Fetcher.TokenInstance.SanitizeERC721Test do
 
       assert Enum.count(instances) == 4
       assert Enum.all?(instances, fn instance -> !is_nil(instance.error) and is_nil(instance.metadata) end)
+      assert MigrationStatus.get_status("backfill_erc721") == "completed"
+    end
+
+    test "imports token instances with low tokens queue size", %{initial_env: initial_env} do
+      tokens =
+        for x <- 0..5 do
+          erc_721_token = insert(:token, type: "ERC-721")
+
+          transaction = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          address = insert(:address)
+
+          insert(:token_transfer,
+            transaction: transaction,
+            block: transaction.block,
+            block_number: transaction.block_number,
+            from_address: address,
+            token_contract_address: erc_721_token.contract_address,
+            token_ids: [x]
+          )
+
+          erc_721_token
+        end
+
+      assert [] = Repo.all(Instance)
+
+      Application.put_env(
+        :indexer,
+        Indexer.Fetcher.TokenInstance.SanitizeERC721,
+        Keyword.put(initial_env, :tokens_queue_size, 1)
+      )
+
+      start_supervised!({Indexer.Fetcher.TokenInstance.SanitizeERC721, []})
+      start_supervised!({Indexer.Fetcher.TokenInstance.Sanitize.Supervisor, [[flush_interval: 1]]})
+
+      :timer.sleep(500)
+
+      instances = Repo.all(Instance)
+
+      assert Enum.count(instances) == 6
+      assert Enum.all?(instances, fn instance -> !is_nil(instance.error) and is_nil(instance.metadata) end)
+
+      assert MigrationStatus.get_status("backfill_erc721") == "completed"
+      assert List.last(tokens).contract_address_hash == Constants.get_last_processed_token_address_hash()
+    end
+
+    test "don't start if completed" do
+      MigrationStatus.set_status("backfill_erc721", "completed")
+
+      for x <- 0..5 do
+        erc_721_token = insert(:token, type: "ERC-721")
+
+        transaction = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+        address = insert(:address)
+
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          from_address: address,
+          token_contract_address: erc_721_token.contract_address,
+          token_ids: [x]
+        )
+      end
+
+      assert [] = Repo.all(Instance)
+
+      start_supervised!({Indexer.Fetcher.TokenInstance.SanitizeERC721, []})
+      start_supervised!({Indexer.Fetcher.TokenInstance.Sanitize.Supervisor, [[flush_interval: 1]]})
+
+      :timer.sleep(500)
+
+      instances = Repo.all(Instance)
+
+      assert Enum.count(instances) == 0
+
+      assert MigrationStatus.get_status("backfill_erc721") == "completed"
+    end
+
+    test "takes into account the last processed token address hash" do
+      tokens =
+        for x <- 0..5 do
+          erc_721_token = insert(:token, type: "ERC-721")
+
+          transaction = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+          address = insert(:address)
+
+          insert(:token_transfer,
+            transaction: transaction,
+            block: transaction.block,
+            block_number: transaction.block_number,
+            from_address: address,
+            token_contract_address: erc_721_token.contract_address,
+            token_ids: [x]
+          )
+
+          erc_721_token
+        end
+
+      assert [] = Repo.all(Instance)
+
+      pid_sanitize_erc721 = start_supervised!({Indexer.Fetcher.TokenInstance.SanitizeERC721, []})
+      start_supervised!({Indexer.Fetcher.TokenInstance.Sanitize.Supervisor, [[flush_interval: 1]]})
+
+      :timer.sleep(500)
+
+      instances = Repo.all(Instance)
+
+      assert Enum.count(instances) == 6
+      last_token = List.last(tokens)
+      assert MigrationStatus.get_status("backfill_erc721") == "completed"
+      assert last_token.contract_address_hash == Constants.get_last_processed_token_address_hash()
+      refute Process.alive?(pid_sanitize_erc721)
+
+      first_token = List.first(tokens)
+
+      transaction = insert(:transaction, input: "0xabcd010203040506") |> with_block()
+
+      address = insert(:address)
+
+      insert(:token_transfer,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        from_address: address,
+        token_contract_address: first_token.contract_address,
+        token_ids: [6]
+      )
+
+      MigrationStatus.set_status("backfill_erc721", "started")
+
+      {:ok, supervisor} = ExUnit.fetch_test_supervisor()
+
+      {:ok, _pid_sanitize_erc721} =
+        Supervisor.restart_child(supervisor, Indexer.Fetcher.TokenInstance.SanitizeERC721)
+
+      :timer.sleep(500)
+
+      assert MigrationStatus.get_status("backfill_erc721") == "completed"
+      assert last_token.contract_address_hash == Constants.get_last_processed_token_address_hash()
+
+      instances = Repo.all(Instance)
+
+      assert Enum.count(instances) == 6
     end
   end
 end


### PR DESCRIPTION
…processed_token_address_hash

## Motivation
Because of misuse `get_constant_by_key` function all the progress was rejected every time when `Indexer.Fetcher.TokenInstance.SanitizeERC721` was restarted

## Changelog
- Use appropriate function in `get_last_processed_token_address_hash/1`


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined retrieval of the last processed token address hash to improve reliability without changing behavior.
- Tests
  - Expanded ERC-721 sanitizer test coverage: verifies backfill completion, behavior with low queue sizes, no-ops when already completed, and correct resumption from the last processed address. Ensures stable process lifecycle and consistent token instance outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->