### PR TITLE
fix: Properly handle ERC-404 in address' NFT functions

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -146,30 +146,30 @@ defmodule Explorer.Chain.Token.Instance do
     erc_721_token_instances_by_owner_address_hash(address_hash, options)
   end
 
-  defp nft_list(address_hash, ["ERC-404"], options) do
-    erc_404_token_instances_by_address_hash(address_hash, options)
-  end
-
   defp nft_list(address_hash, ["ERC-1155"], options) do
     erc_1155_token_instances_by_address_hash(address_hash, options)
   end
 
-  # Priority: ERC-721, ERC-404, ERC-1155
+  defp nft_list(address_hash, ["ERC-404"], options) do
+    erc_404_token_instances_by_address_hash(address_hash, options)
+  end
+
+  # Priority: ERC-721, ERC-1155, ERC-404
   defp nft_list(address_hash, _, options) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
     case paging_options do
-      %PagingOptions{key: {_contract_address_hash, _token_id, "ERC-1155"}} ->
-        erc_1155_token_instances_by_address_hash(address_hash, options)
-
       %PagingOptions{key: {_contract_address_hash, _token_id, "ERC-404"}} ->
-        erc_404 = erc_404_token_instances_by_address_hash(address_hash, options)
+        erc_404_token_instances_by_address_hash(address_hash, options)
 
-        if length(erc_404) == paging_options.page_size do
-          erc_404
+      %PagingOptions{key: {_contract_address_hash, _token_id, "ERC-1155"}} ->
+        erc_1155 = erc_1155_token_instances_by_address_hash(address_hash, options)
+
+        if length(erc_1155) == paging_options.page_size do
+          erc_1155
         else
-          erc_1155 = erc_1155_token_instances_by_address_hash(address_hash, options)
-          (erc_404 ++ erc_1155) |> Enum.take(paging_options.page_size)
+          erc_404 = erc_404_token_instances_by_address_hash(address_hash, options)
+          (erc_1155 ++ erc_404) |> Enum.take(paging_options.page_size)
         end
 
       _ ->
@@ -178,14 +178,14 @@ defmodule Explorer.Chain.Token.Instance do
         if length(erc_721) == paging_options.page_size do
           erc_721
         else
-          erc_404 = erc_404_token_instances_by_address_hash(address_hash, options)
-          erc_721_404 = erc_721 ++ erc_404
+          erc_1155 = erc_1155_token_instances_by_address_hash(address_hash, options)
+          erc_721_1155 = erc_721 ++ erc_1155
 
-          erc_1155 =
-            (length(erc_721_404) >= paging_options.page_size && []) ||
-              erc_1155_token_instances_by_address_hash(address_hash, options)
+          erc_404 =
+            (length(erc_721_1155) >= paging_options.page_size && []) ||
+              erc_404_token_instances_by_address_hash(address_hash, options)
 
-          (erc_721_404 ++ erc_1155) |> Enum.take(paging_options.page_size)
+          (erc_721_1155 ++ erc_404) |> Enum.take(paging_options.page_size)
         end
     end
   end
@@ -333,30 +333,30 @@ defmodule Explorer.Chain.Token.Instance do
     erc_721_collections_by_address_hash(address_hash, options)
   end
 
-  defp nft_collections(address_hash, ["ERC-404"], options) do
-    erc_404_collections_by_address_hash(address_hash, options)
-  end
-
   defp nft_collections(address_hash, ["ERC-1155"], options) do
     erc_1155_collections_by_address_hash(address_hash, options)
   end
 
-  # Priority: ERC-721, ERC-404, ERC-1155
+  defp nft_collections(address_hash, ["ERC-404"], options) do
+    erc_404_collections_by_address_hash(address_hash, options)
+  end
+
+  # Priority: ERC-721, ERC-1155, ERC-404
   defp nft_collections(address_hash, _, options) do
     paging_options = Keyword.get(options, :paging_options, Chain.default_paging_options())
 
     case paging_options do
-      %PagingOptions{key: {_contract_address_hash, "ERC-1155"}} ->
-        erc_1155_collections_by_address_hash(address_hash, options)
-
       %PagingOptions{key: {_contract_address_hash, "ERC-404"}} ->
-        erc_404 = erc_404_collections_by_address_hash(address_hash, options)
+        erc_404_collections_by_address_hash(address_hash, options)
 
-        if length(erc_404) == paging_options.page_size do
-          erc_404
+      %PagingOptions{key: {_contract_address_hash, "ERC-1155"}} ->
+        erc_1155 = erc_1155_collections_by_address_hash(address_hash, options)
+
+        if length(erc_1155) == paging_options.page_size do
+          erc_1155
         else
-          erc_1155 = erc_1155_collections_by_address_hash(address_hash, options)
-          (erc_404 ++ erc_1155) |> Enum.take(paging_options.page_size)
+          erc_404 = erc_404_collections_by_address_hash(address_hash, options)
+          (erc_1155 ++ erc_404) |> Enum.take(paging_options.page_size)
         end
 
       _ ->
@@ -365,14 +365,14 @@ defmodule Explorer.Chain.Token.Instance do
         if length(erc_721) == paging_options.page_size do
           erc_721
         else
-          erc_404 = erc_404_collections_by_address_hash(address_hash, options)
-          erc_721_404 = erc_721 ++ erc_404
+          erc_1155 = erc_1155_collections_by_address_hash(address_hash, options)
+          erc_721_1155 = erc_721 ++ erc_1155
 
-          erc_1155 =
-            (length(erc_721_404) >= paging_options.page_size && []) ||
-              erc_1155_collections_by_address_hash(address_hash, options)
+          erc_404 =
+            (length(erc_721_1155) >= paging_options.page_size && []) ||
+              erc_404_collections_by_address_hash(address_hash, options)
 
-          (erc_721_404 ++ erc_1155) |> Enum.take(paging_options.page_size)
+          (erc_721_1155 ++ erc_404) |> Enum.take(paging_options.page_size)
         end
     end
   end


### PR DESCRIPTION
## Motivation


## Changelog


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFT browsing now prioritizes ERC-721, then ERC-1155, then ERC-404.
  * Paging fetches higher-priority types first and uses ERC-404 only as a fallback.
  * Explicit paging behavior for ERC-1155 and ERC-404; results trimmed to requested page size.
  * Fewer unnecessary ERC-404 loads for faster, more predictable browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->