### PR TITLE
fix: API v2 errors logging to the proper log file

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -344,4 +344,11 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> put_status(code)
     |> json(response)
   end
+
+  def call(conn, :unknown_action) do
+    conn
+    |> put_status(400)
+    |> put_view(ApiView)
+    |> render(:message, %{message: "Unknown API v2 action"})
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/routers/account_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/account_router.ex
@@ -36,7 +36,7 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
     plug(BlockScoutWeb.ChecksumAddress)
   end
 
-  pipeline :account_api do
+  pipeline :account_api_v2 do
     plug(
       Plug.Parsers,
       parsers: [:urlencoded, :multipart, :json],
@@ -46,14 +46,14 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
       json_decoder: Poison
     )
 
-    plug(BlockScoutWeb.Plug.Logger, application: :api)
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
     plug(:accepts, ["json"])
     plug(:fetch_session)
     plug(:protect_from_forgery)
     plug(CheckAccountAPI)
   end
 
-  pipeline :api do
+  pipeline :api_v2 do
     plug(
       Plug.Parsers,
       parsers: [:urlencoded, :multipart, :json],
@@ -63,7 +63,7 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
       json_decoder: Poison
     )
 
-    plug(BlockScoutWeb.Plug.Logger, application: :api)
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
     plug(:accepts, ["json"])
   end
 
@@ -112,7 +112,7 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
   end
 
   scope "/v2", as: :account_v2 do
-    pipe_through(:account_api)
+    pipe_through(:account_api_v2)
 
     get("/authenticate", AuthenticateController, :authenticate_get)
     post("/authenticate", AuthenticateController, :authenticate_post)
@@ -163,8 +163,7 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
   end
 
   scope "/v2" do
-    pipe_through(:api)
-    pipe_through(:account_api)
+    pipe_through([:api_v2, :account_api_v2])
 
     scope "/tags" do
       get("/address/:address_hash", TagsController, :tags_address)
@@ -174,7 +173,7 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
   end
 
   scope "/v2" do
-    pipe_through(:api)
+    pipe_through(:api_v2)
 
     post("/authenticate_via_wallet", AuthenticateController, :authenticate_via_wallet)
     post("/send_otp", AuthenticateController, :send_otp)

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -548,6 +548,12 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     get("/multichain-search-export", BlockScoutWeb.API.HealthController, :multichain_search_db_export)
   end
 
+  scope "/v2" do
+    pipe_through(:api_v2)
+
+    get("/*path", BlockScoutWeb.API.V2.FallbackController, :unknown_action)
+  end
+
   scope "/" do
     pipe_through(:api)
     alias BlockScoutWeb.API.{EthRPC, RPC}


### PR DESCRIPTION
## Motivation

Unsupported on the explorer instance API v2 calls are logged in the `api.log` file instead of `api_v2.log`.
E.g. this call on the ETH Sepolia instance is registered in `api.log` file:
```
2025-09-02T01:02:30.949 application=api request_id=57f4...6822 [info] Sent 400 in 58µs on GET /api/v2/zkevm/deposits?
```

## Changelog

### AI Agent summary

This pull request refactors the API v2 routing and error handling in the BlockScout web application. The main changes include introducing new pipelines for API v2, updating route definitions to use these pipelines, and adding a fallback controller to handle unknown API v2 actions with a clear error message.

**API v2 Pipeline Refactoring:**

* Renamed the existing `:account_api` and `:api` pipelines to `:account_api_v2` and `:api_v2`, respectively, and updated their configuration to use the new application context `:api_v2` for logging. (`apps/block_scout_web/lib/block_scout_web/routers/account_router.ex`) [[1]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL39-R39) [[2]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL49-R56) [[3]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL66-R66)
* Updated all `/v2` route scopes to use the new pipelines, ensuring consistent middleware and logging for API v2 endpoints. (`apps/block_scout_web/lib/block_scout_web/routers/account_router.ex`) [[1]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL115-R115) [[2]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL166-R166) [[3]](diffhunk://#diff-69265bb713c9a111e55a5b94214b678ea896966a9e0bfd015752c898f8ee4f4aL177-R176)

**Error Handling Improvements:**

* Added a new `call/2` clause to `BlockScoutWeb.API.V2.FallbackController` to handle unknown API v2 actions, returning a 400 status and a clear error message. (`apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex`)
* Registered a catch-all route for `/v2/*path` in `ApiRouter` that uses the fallback controller to provide a helpful error response for unrecognized API v2 endpoints. (`apps/block_scout_web/lib/block_scout_web/routers/api_router.ex`)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unknown API v2 endpoints now return a clear HTTP 400 error with “Unknown API v2 action.”

- Improvements
  - Added a catch‑all handler for API v2 routes to provide consistent error responses for unsupported paths.
  - Standardized API v2 routing through updated pipelines to ensure consistent middleware and logging across v2 endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->