### PR TITLE
fix: Add reputation to token, rework reputation preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug Fixes
 
+- Add reputation to token, rework reputation preload ([#13149](https://github.com/blockscout/blockscout/pull/13149))
 - Replace get_constant_by_key with get_constant_value in get_last_processed_token_address_hash ([#13118](https://github.com/blockscout/blockscout/issues/13118))
 - Duplicates of smart contracts additional sources ([#13018](https://github.com/blockscout/blockscout/issues/13018))
 - Set  for read ops in NFT backfillers ([#13116](https://github.com/blockscout/blockscout/issues/13116))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -6,7 +6,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
 
   alias BlockScoutWeb.API.V2.{AdvancedFilterView, CsvExportController}
   alias Explorer.{Chain, PagingOptions}
-  alias Explorer.Chain.{AdvancedFilter, ContractMethod, Data, Token, Transaction}
+  alias Explorer.Chain.{Address.Reputation, AdvancedFilter, ContractMethod, Data, Token, Transaction}
   alias Explorer.Chain.CsvExport.Helper, as: CsvHelper
   alias Plug.Conn
 
@@ -45,6 +45,8 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
 
   @methods_filter_limit 20
   @tokens_filter_limit 20
+
+  @token_options [api?: true, necessity_by_association: %{Reputation.reputation_association() => :optional}]
 
   @doc """
   Function responsible for `api/v2/advanced-filters/` endpoint.
@@ -190,7 +192,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
     |> Enum.reject(&(&1 == "native"))
     |> Enum.uniq()
     |> Enum.take(@tokens_filter_limit)
-    |> Token.get_by_contract_address_hashes(@api_true)
+    |> Token.get_by_contract_address_hashes(@token_options)
     |> Map.new(fn token -> {token.contract_address_hash, token} end)
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -142,7 +142,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       ) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @token_options)},
          {:not_found, false} <- {:not_found, Chain.erc_20_token?(token)},
          {:format, {:ok, holder_address_hash}} <- {:format, Chain.string_to_address_hash(holder_address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(holder_address_hash_string, params) do
@@ -183,7 +183,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def instances(conn, %{"address_hash_param" => address_hash_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)} do
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @token_options)} do
       results_plus_one =
         Instance.address_to_unique_tokens(
           token.contract_address_hash,
@@ -209,7 +209,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   def instance(conn, %{"address_hash_param" => address_hash_string, "token_id" => token_id_string} = params) do
     with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
-         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
+         {:not_found, {:ok, token}} <- {:not_found, Chain.token_from_address_hash(address_hash, @token_options)},
          {:not_found, false} <- {:not_found, Chain.erc_20_token?(token)},
          {:format, {token_id, ""}} <- {:format, Integer.parse(token_id_string)},
          {:ok, token_instance} <-

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -29,6 +29,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   import Explorer.MicroserviceInterfaces.Metadata,
     only: [maybe_preload_metadata: 1, maybe_preload_metadata_to_transaction: 1]
 
+  import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
+
   import Ecto.Query,
     only: [
       preload: 2
@@ -104,13 +106,14 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
   @token_transfers_necessity_by_association %{
     [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-    [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional
+    [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
+    [token: reputation_association()] => :optional
   }
 
   @token_transfers_in_transaction_necessity_by_association %{
     [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
     [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-    token: :required
+    [token: reputation_association()] => :optional
   }
 
   @internal_transaction_necessity_by_association [

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -9,6 +9,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.Chain.{Data, InternalTransaction, Log, TokenTransfer, Transaction}
 
+  import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
+
   import Explorer.Chain.SmartContract.Proxy.Models.Implementation,
     only: [proxy_implementations_association: 0, proxy_implementations_smart_contracts_association: 0]
 
@@ -199,7 +201,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
       [
         necessity_by_association: %{
           [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-          [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional
+          [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
+          [token: reputation_association()] => :optional
         }
       ]
       |> Keyword.merge(@api_true)

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -32,6 +32,7 @@ defmodule BlockScoutWeb.Notifier do
   alias Explorer.Chain.{
     Address,
     Address.CoinBalance,
+    Address.Reputation,
     BlockNumberHelper,
     DenormalizationHelper,
     InternalTransaction,
@@ -263,7 +264,7 @@ defmodule BlockScoutWeb.Notifier do
       all_token_transfers
       |> Repo.preload(
         DenormalizationHelper.extend_transaction_preload([
-          :token,
+          [token: Reputation.reputation_association()],
           :transaction,
           from_address: [
             :scam_badge,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -184,7 +184,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
   defp prepare_nft(nft, token) do
     Map.merge(
-      %{"token_type" => token.type, "value" => value(token.type, nft), "reputation" => nft.reputation},
+      %{"token_type" => token.type, "value" => value(token.type, nft), "reputation" => token.reputation},
       TokenView.prepare_token_instance(nft, token)
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
@@ -174,7 +174,11 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
       token_transfer_index: advanced_filter.token_transfer_index,
       token_transfer_batch_index: advanced_filter.token_transfer_batch_index,
       fee: advanced_filter.fee,
-      reputation: advanced_filter.reputation
+      reputation:
+        if(advanced_filter.type != "coin_transfer",
+          do: advanced_filter.reputation,
+          else: nil
+        )
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -61,7 +61,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
       "block_number" => token_transfer.block_number,
       "log_index" => token_transfer.log_index,
       "token_type" => token_transfer.token_type,
-      "reputation" => token_transfer.reputation
+      "reputation" => token_transfer.token.reputation
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -25,7 +25,6 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   alias Explorer.Account.{Identity, WatchlistAddress}
   alias Explorer.Chain.Address.CurrentTokenBalance
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
-  alias Explorer.Chain.SmartContract.Proxy.ResolvedDelegateProxy
   alias Indexer.Fetcher.OnDemand.ContractCode, as: ContractCodeOnDemand
   alias Plug.Conn
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1779,7 +1779,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
     test "don't fetch token instance metadata for non-existent token instance", %{
       conn: conn,
-      v2_secret_key: v2_secret_key
+      v2_secret_key: _v2_secret_key
     } do
       token = insert(:token, type: "ERC-721")
       token_id = 0

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -3053,11 +3053,14 @@ defmodule Explorer.Chain do
     |> select_repo(options).all()
   end
 
-  @spec fetch_last_token_balances(Hash.Address.t(), [api?]) :: []
+  @spec fetch_last_token_balances(Hash.Address.t(), [api? | necessity_by_association_option]) :: []
   def fetch_last_token_balances(address_hash, options \\ []) do
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
     address_hash
     |> CurrentTokenBalance.last_token_balances()
     |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+    |> join_associations(necessity_by_association)
     |> select_repo(options).all()
   end
 
@@ -3066,6 +3069,7 @@ defmodule Explorer.Chain do
     filter = Keyword.get(options, :token_type)
     options = Keyword.delete(options, :token_type)
     paging_options = Keyword.get(options, :paging_options)
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
 
     case paging_options do
       %PagingOptions{key: {nil, 0, _id}} ->
@@ -3076,6 +3080,7 @@ defmodule Explorer.Chain do
         |> CurrentTokenBalance.last_token_balances(options, filter)
         |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
         |> page_current_token_balances(paging_options)
+        |> join_associations(necessity_by_association)
         |> select_repo(options).all()
     end
   end

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -89,7 +89,6 @@ defmodule Explorer.Chain.Address.Schema do
         field(:gas_used, :integer)
         field(:ens_domain_name, :string, virtual: true)
         field(:metadata, :any, virtual: true)
-        field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
         has_one(:smart_contract, SmartContract, references: :hash)
         has_one(:token, Token, foreign_key: :contract_address_hash, references: :hash)
@@ -112,6 +111,7 @@ defmodule Explorer.Chain.Address.Schema do
         has_many(:names, Address.Name, foreign_key: :address_hash, references: :hash)
         has_one(:scam_badge, Address.ScamBadgeToAddress, foreign_key: :address_hash, references: :hash)
         has_many(:withdrawals, Withdrawal, foreign_key: :address_hash, references: :hash)
+        has_one(:reputation, Reputation, foreign_key: :address_hash, references: :hash)
 
         # In practice, this is a one-to-many relationship, but we only need to check if any signed authorization
         # exists for a given address. This done this way to avoid loading all signed authorizations for an address.

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -40,7 +40,6 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
     field(:distinct_token_instances_count, :integer, virtual: true)
     field(:token_ids, {:array, :decimal}, virtual: true)
     field(:preloaded_token_instances, {:array, :any}, virtual: true)
-    field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
     # A transient field for deriving token holder count deltas during address_current_token_balances upserts
     field(:old_value, :decimal)
@@ -55,6 +54,8 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       type: Hash.Address,
       null: false
     )
+
+    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
 
     timestamps()
   end

--- a/apps/explorer/lib/explorer/chain/address/reputation.ex
+++ b/apps/explorer/lib/explorer/chain/address/reputation.ex
@@ -2,7 +2,47 @@ defmodule Explorer.Chain.Address.Reputation do
   @moduledoc """
   This module defines the reputation enum values.
   """
+  use Explorer.Schema
+
+  alias Explorer.Chain.Address.ScamBadgeToAddress
+  alias Explorer.Chain.Hash
+  alias Explorer.Repo
 
   @enum_values [:ok, :scam]
   def enum_values, do: @enum_values
+
+  @primary_key false
+  typed_embedded_schema do
+    field(:address_hash, Hash.Address)
+    field(:reputation, Ecto.Enum, values: @enum_values)
+  end
+
+  def preload_reputation(address_hashes) do
+    scam_badges =
+      if Application.get_env(:block_scout_web, :hide_scam_addresses) do
+        ScamBadgeToAddress
+        |> where([sb], sb.address_hash in ^address_hashes)
+        |> Repo.all()
+        |> Map.new(&{&1.address_hash, &1})
+      else
+        %{}
+      end
+
+    Enum.map(address_hashes, fn address_hash ->
+      case Map.get(scam_badges, address_hash) do
+        nil -> {address_hash, %__MODULE__{reputation: "ok"}}
+        _badge -> {address_hash, %__MODULE__{reputation: "scam"}}
+      end
+    end)
+  end
+
+  def reputation_association do
+    [reputation: &__MODULE__.preload_reputation/1]
+  end
+end
+
+defimpl Jason.Encoder, for: Explorer.Chain.Address.Reputation do
+  def encode(reputation, opts) do
+    Jason.Encode.string(reputation.reputation, opts)
+  end
 end

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -239,7 +239,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       transaction_index: token_transfer.transaction.index,
       token_transfer_index: token_transfer.log_index,
       token_transfer_batch_index: token_transfer.reverse_index_in_batch,
-      reputation: token_transfer.reputation
+      reputation: token_transfer.token.reputation
     }
   end
 
@@ -519,7 +519,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> page_token_transfers(paging_options)
 
     token_transfer_query
-    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
     |> limit_query(paging_options)
     |> query_function.(false)
     |> limit_query(paging_options)

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -30,7 +30,6 @@ defmodule Explorer.Chain.AdvancedFilter do
     field(:type, :string)
     field(:input, Data)
     field(:timestamp, :utc_datetime_usec)
-    field(:reputation, Ecto.Enum, values: Reputation.enum_values())
 
     belongs_to(
       :from_address,
@@ -59,6 +58,8 @@ defmodule Explorer.Chain.AdvancedFilter do
     field(:value, :decimal, null: true)
 
     has_one(:token_transfer, TokenTransfer, foreign_key: :transaction_hash, references: :hash, null: true)
+
+    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :hash)
 
     field(:fee, :decimal)
 
@@ -522,7 +523,7 @@ defmodule Explorer.Chain.AdvancedFilter do
     |> limit_query(paging_options)
     |> query_function.(false)
     |> limit_query(paging_options)
-    |> preload([:transaction, :token])
+    |> preload([:transaction, [token: ^Reputation.reputation_association()]])
     |> select_merge([token_transfer], %{token_ids: [token_transfer.token_id], amounts: [token_transfer.amount]})
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -64,7 +64,6 @@ defmodule Explorer.Chain.SmartContract.Schema do
         field(:certified, :boolean)
         field(:is_blueprint, :boolean)
         field(:language, Ecto.Enum, values: @languages_enum, default: :solidity)
-        field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
         belongs_to(
           :address,
@@ -79,6 +78,8 @@ defmodule Explorer.Chain.SmartContract.Schema do
           references: :address_hash,
           foreign_key: :address_hash
         )
+
+        has_one(:reputation, Reputation, foreign_key: :address_hash, references: :address_hash)
 
         timestamps()
 

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -386,9 +386,15 @@ defmodule Explorer.Chain.Token do
   @doc """
     Gets tokens with given contract address hashes.
   """
-  @spec get_by_contract_address_hashes([Hash.Address.t()], [Chain.api?()]) :: [Token.t()]
+  @spec get_by_contract_address_hashes([Hash.Address.t()], [Chain.api?() | Chain.necessity_by_association_option()]) ::
+          [Token.t()]
   def get_by_contract_address_hashes(hashes, options) do
-    Chain.select_repo(options).all(from(t in __MODULE__, where: t.contract_address_hash in ^hashes))
+    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+    __MODULE__
+    |> where([t], t.contract_address_hash in ^hashes)
+    |> Chain.join_associations(necessity_by_association)
+    |> Chain.select_repo(options).all()
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -34,7 +34,6 @@ defmodule Explorer.Chain.Token.Schema do
         field(:is_verified_via_admin_panel, :boolean)
         field(:volume_24h, :decimal)
         field(:transfer_count, :integer)
-        field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
         belongs_to(
           :contract_address,
@@ -45,6 +44,8 @@ defmodule Explorer.Chain.Token.Schema do
           type: Hash.Address,
           null: false
         )
+
+        has_one(:reputation, Reputation, foreign_key: :address_hash, references: :contract_address_hash)
 
         unquote_splicing(@bridged_field)
 

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -53,7 +53,6 @@ defmodule Explorer.Chain.Token.Instance do
     field(:cdn_upload_error, :string)
     field(:metadata_url, :string)
     field(:skip_metadata_url, :boolean)
-    field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
     belongs_to(:owner, Address, foreign_key: :owner_address_hash, references: :hash, type: Hash.Address)
 
@@ -66,6 +65,8 @@ defmodule Explorer.Chain.Token.Instance do
       primary_key: true,
       null: false
     )
+
+    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
 
     timestamps()
   end
@@ -396,7 +397,14 @@ defmodule Explorer.Chain.Token.Instance do
     |> limit(^paging_options.page_size)
     |> Chain.select_repo(options).all()
     |> Enum.map(&erc_1155_preload_nft(&1, address_hash, options))
-    |> Helper.custom_preload(options, Token, :token_contract_address_hash, :contract_address_hash, :token)
+    |> Helper.custom_preload(
+      options,
+      Token,
+      :token_contract_address_hash,
+      :contract_address_hash,
+      :token,
+      Reputation.reputation_association()
+    )
   end
 
   defp page_erc_1155_nft_collections(query, %PagingOptions{key: {contract_address_hash, "ERC-1155"}}) do
@@ -429,7 +437,14 @@ defmodule Explorer.Chain.Token.Instance do
     |> limit(^paging_options.page_size)
     |> Chain.select_repo(options).all()
     |> Enum.map(&erc_1155_preload_nft(&1, address_hash, options))
-    |> Helper.custom_preload(options, Token, :token_contract_address_hash, :contract_address_hash, :token)
+    |> Helper.custom_preload(
+      options,
+      Token,
+      :token_contract_address_hash,
+      :contract_address_hash,
+      :token,
+      Reputation.reputation_association()
+    )
   end
 
   defp page_erc_404_nft_collections(query, %PagingOptions{key: {contract_address_hash, "ERC-404"}}) do

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -275,7 +275,7 @@ defmodule Explorer.Chain.TokenTransfer do
         preloads =
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
-            :token,
+            [token: reputation_association()],
             [from_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]],
             [to_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]]
           ])

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -61,7 +61,6 @@ defmodule Explorer.Chain.TokenTransfer.Schema do
         field(:token_type, :string)
         field(:block_consensus, :boolean)
         field(:token_instance, :any, virtual: true) :: Instance.t() | nil
-        field(:reputation, Ecto.Enum, values: Reputation.enum_values(), virtual: true)
 
         belongs_to(:from_address, Address,
           foreign_key: :from_address_hash,
@@ -103,6 +102,8 @@ defmodule Explorer.Chain.TokenTransfer.Schema do
 
         has_one(:token, through: [:token_contract_address, :token])
 
+        has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
+
         timestamps()
 
         unquote_splicing(@transaction_field)
@@ -142,6 +143,7 @@ defmodule Explorer.Chain.TokenTransfer do
   require Explorer.Chain.TokenTransfer.Schema
 
   import Ecto.Changeset
+  import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
 
   alias Explorer.Chain
   alias Explorer.Chain.{DenormalizationHelper, Hash, Log, TokenTransfer}
@@ -246,7 +248,7 @@ defmodule Explorer.Chain.TokenTransfer do
         preloads =
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
-            :token,
+            [token: reputation_association()],
             [from_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]],
             [to_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]]
           ])
@@ -306,7 +308,7 @@ defmodule Explorer.Chain.TokenTransfer do
         preloads =
           DenormalizationHelper.extend_transaction_preload([
             :transaction,
-            :token,
+            [token: reputation_association()],
             [from_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]],
             [to_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]]
           ])
@@ -577,7 +579,7 @@ defmodule Explorer.Chain.TokenTransfer do
       |> join(:inner, [tt], token in assoc(tt, :token), as: :token)
       |> preload([token: token], [{:token, token}])
       |> filter_by_type(token_types)
-      |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+      |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
       |> handle_paging_options(paging_options)
     else
       to_address_hash_query =
@@ -587,7 +589,7 @@ defmodule Explorer.Chain.TokenTransfer do
         |> filter_by_token_address_hash(token_address_hash)
         |> filter_by_type(token_types)
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-        |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+        |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
         |> handle_paging_options(paging_options)
         |> Chain.wrapped_union_subquery()
 
@@ -598,7 +600,7 @@ defmodule Explorer.Chain.TokenTransfer do
         |> filter_by_token_address_hash(token_address_hash)
         |> filter_by_type(token_types)
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-        |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+        |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
         |> handle_paging_options(paging_options)
         |> Chain.wrapped_union_subquery()
 


### PR DESCRIPTION
## Motivation

## Changelog
- improve reputation preload
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Token reputation is now consistently loaded and returned across API v2 endpoints for balances, token lists, transfers, transactions, NFTs and collections; reputation values are exposed as structured ok/scam strings.
  - Advanced filter output omits reputation for coin_transfer filters.

- Bug Fixes
  - Token transfer responses now derive reputation from the related token for consistent results.
  - Improved scam/ok labeling when hiding scam addresses/tokens.

- Chores
  - Removed an unused test alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->