### PR TITLE
fix: Fix reputation preload for ERC-404 collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix reputation preload for ERC-404 collections ([#13174](https://github.com/blockscout/blockscout/pull/13174))
 - Add reputation to token, rework reputation preload ([#13149](https://github.com/blockscout/blockscout/pull/13149))
 - Replace get_constant_by_key with get_constant_value in get_last_processed_token_address_hash ([#13118](https://github.com/blockscout/blockscout/issues/13118))
 - Duplicates of smart contracts additional sources ([#13018](https://github.com/blockscout/blockscout/issues/13018))

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -432,7 +432,7 @@ defmodule Explorer.Chain.Token.Instance do
       distinct_token_instances_count: fragment("COUNT(*)"),
       token_ids: fragment("array_agg(?)", ctb.token_id)
     })
-    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_with_aggregate(:token_contract_address_hash, options)
     |> page_erc_404_nft_collections(paging_options)
     |> limit(^paging_options.page_size)
     |> Chain.select_repo(options).all()


### PR DESCRIPTION
## Motivation

```
#PID<0.1483473.0> running BlockScoutWeb.Endpoint (connection #PID<0.1483383.0>, stream id 2) terminated\nServer: eth-sepolia.k8s-dev.blockscout.com:80 (http)\nRequest: GET /api/v2/addresses/0x91be515287A961a8d09Fd4cA3DFb5E76Ed01575e/nft/collections?type=\n** (exit) an exception was raised:\n    ** (Postgrex.Error) ERROR 42803 (grouping_error) column \"s1.address_hash\" must appear in the GROUP BY clause or be used in an aggregate function\n\n    query: SELECT a0.\"token_contract_address_hash\", COUNT(*), array_agg(a0.\"token_id\"), CASE WHEN s1.\"address_hash\" IS NULL THEN 'ok' ELSE 'scam' END FROM \"address_current_token_balances\" AS a0 LEFT OUTER JOIN \"scam_address_badge_mappings\" AS s1 ON s1.\"address_hash\" = a0.\"token_contract_address_hash\" WHERE (((a0.\"address_hash\" = $1) AND NOT (a0.\"token_id\" IS NULL)) AND (a0.\"token_type\" = 'ERC-404')) GROUP BY a0.\"token_contract_address_hash\" ORDER BY a0.\"token_contract_address_hash\" LIMIT $2\n        (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1\n        (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:996: Ecto.Adapters.SQL.execute/6\n        (ecto 3.13.2) lib/ecto/repo/queryable.ex:241: Ecto.Repo.Queryable.execute/4\n        (ecto 3.13.2) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3\n        (explorer 9.1.0) lib/explorer/chain/token/instance.ex:438: Explorer.Chain.Token.Instance.erc_404_collections_by_address_hash/2\n        (explorer 9.1.0) lib/explorer/chain/token/instance.ex:347: Explorer.Chain.Token.Instance.nft_collections/3\n        (block_scout_web 9.1.0) lib/block_scout_web/controllers/api/v2/address_controller.ex:1273: BlockScoutWeb.API.V2.AddressController.nft_collections/2\n        (block_scout_web 9.1.0) lib/block_scout_web/controllers/api/v2/address_controller.ex:1: BlockScoutWeb.API.V2.AddressController.action/2
```
## Changelog
- use `maybe_hide_scam_addresses_with_aggregate/3` for ERC-404 collections
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved handling of ERC-404 NFTs across collections, tokens, and transfers, ensuring accurate filtering, pagination, and mixed-type queries.
- Bug Fixes
  - Corrected reputation preload for ERC-404 NFT collections; “ok” and “scam” statuses now display consistently, including when hiding scam addresses is enabled.
- Documentation
  - Updated changelog with the ERC-404 reputation fix under 9.1.0 Bug Fixes.
- Tests
  - Added extensive test coverage for ERC-404 scenarios, including pagination, multi-type filtering (ERC-721/1155/404), transfers, and reputation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->