### PR TITLE
fix: pagination and filtering issues in `/addresses/:hash/nft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug Fixes
 
+- Pagination and filtering issues in `/addresses/:hash/nft` ([#13175](https://github.com/blockscout/blockscout/pull/13175))
 - Add reputation to token, rework reputation preload ([#13149](https://github.com/blockscout/blockscout/pull/13149))
 - Replace get_constant_by_key with get_constant_value in get_last_processed_token_address_hash ([#13118](https://github.com/blockscout/blockscout/issues/13118))
 - Duplicates of smart contracts additional sources ([#13018](https://github.com/blockscout/blockscout/issues/13018))

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -231,6 +231,7 @@ defmodule BlockScoutWeb.PagingHelper do
     params
     |> Map.drop([
       :address_hash_param,
+      :type,
       :apikey,
       "apikey",
       "block_hash_or_number",

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -73,6 +73,9 @@ defmodule BlockScoutWeb.PagingHelper do
 
   def stability_validators_state_options(_), do: [state: []]
 
+  @doc """
+    Parse 'type' query parameter from request option map
+  """
   @spec token_transfers_types_options(map()) :: [{:token_type, list}]
   def token_transfers_types_options(%{"type" => filters}) do
     [

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -4926,7 +4926,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
              } = Enum.frequencies_by(page2_resp["items"], & &1["token_type"])
     end
 
-    test "multi-type filter excludes unrequested types (ERC-404,ERC-1155)", %{conn: conn, endpoint: endpoint} do
+    test "multi-type filter includes only requested types", %{conn: conn, endpoint: endpoint} do
       address = insert(:address)
 
       # ERC-721 tokens (should be excluded by filter)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -143,6 +143,17 @@ defmodule Explorer.Chain.Token do
   @required_attrs ~w(contract_address_hash type)a
   @optional_attrs ~w(cataloged decimals name symbol total_supply skip_metadata total_supply_updated_at_block metadata_updated_at updated_at fiat_value circulating_market_cap icon_url is_verified_via_admin_panel volume_24h)a
 
+  @doc """
+    Returns the list of allowed NFT type labels.
+  """
+  @spec allowed_nft_type_labels() :: [String.t()]
+  def allowed_nft_type_labels,
+    do: [
+      "ERC-1155",
+      "ERC-404",
+      "ERC-721"
+    ]
+
   @doc false
   def changeset(%Token{} = token, params \\ %{}) do
     additional_attrs = if BridgedToken.enabled?(), do: [:bridged], else: []


### PR DESCRIPTION
Closes #13166.

## Changelog

- Fix issue when multi-type filter (e.g `ERC-404,ERC-1155`) also included not requested types
- Unified NFT pagination across ERC-1155, ERC-404, and ERC-721.
- Resolved edge cases causing sparse pages or skipped types during NFT pagination.

## Checklist for your Pull Request (PR)

- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [ ] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/setup/env-variables/README.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/setup/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/setup/env-variables).
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified NFT pagination across ERC-1155, ERC-404, and ERC-721 so pages fill by continuing across types when one is exhausted.
  - Exposed a canonical list of allowed NFT type labels.
  - Multi-type filters support comma-separated types and respect requested type sets.

- Bug Fixes
  - Pagination ordering adjusted for predictable type sequencing.
  - Next-page links no longer leak the original composite type filter.

- Tests
  - Added comprehensive multi-type pagination and filtering tests for NFT endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->