### PR TITLE
Fix: Fix batch's number processing from the socket event

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -155,13 +155,13 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
   end
 
   @doc """
-    Function to handle GET requests to `/api/v2/optimism/batches/:internal_id` endpoint.
+    Function to handle GET requests to `/api/v2/optimism/batches/:number` endpoint.
   """
-  @spec batch_by_internal_id(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def batch_by_internal_id(conn, %{"internal_id" => internal_id}) do
-    {internal_id, ""} = Integer.parse(internal_id)
+  @spec batch_by_number(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def batch_by_number(conn, %{"number" => number}) do
+    {number, ""} = Integer.parse(number)
 
-    batch = FrameSequence.batch_by_internal_id(internal_id, api?: true)
+    batch = FrameSequence.batch_by_number(number, api?: true)
 
     if is_nil(batch) do
       {:error, :not_found}

--- a/apps/block_scout_web/lib/block_scout_web/notifiers/optimism.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifiers/optimism.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.Notifiers.Optimism do
 
   def handle_event({:chain_event, :new_optimism_batches, :realtime, batches}) do
     batches
-    |> Enum.sort_by(& &1.internal_id, :asc)
+    |> Enum.sort_by(& &1.number, :asc)
     |> Enum.each(fn batch ->
       Endpoint.broadcast("optimism:new_batch", "new_optimism_batch", %{
         batch: batch

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -306,7 +306,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/batches", V2.OptimismController, :batches)
         get("/batches/count", V2.OptimismController, :batches_count)
         get("/batches/da/celestia/:height/:commitment", V2.OptimismController, :batch_by_celestia_blob)
-        get("/batches/:internal_id", V2.OptimismController, :batch_by_internal_id)
+        get("/batches/:number", V2.OptimismController, :batch_by_number)
         get("/output-roots", V2.OptimismController, :output_roots)
         get("/output-roots/count", V2.OptimismController, :output_roots_count)
         get("/deposits", V2.OptimismController, :deposits)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/optimism_view.ex
@@ -338,7 +338,7 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
   # includes basic batch information.
   #
   # ## Parameters
-  # - `internal_id`: The internal ID of the batch.
+  # - `number`: The internal ID of the batch.
   # - `l2_block_number_from`: Start L2 block number of the batch block range.
   # - `l2_block_number_to`: End L2 block number of the batch block range.
   # - `transactions_count`: The L2 transaction count included into the blocks of the range.
@@ -363,9 +363,9 @@ defmodule BlockScoutWeb.API.V2.OptimismView do
           :l1_transaction_hashes => list(),
           :batch_data_container => :in_blob4844 | :in_celestia | :in_calldata | nil
         }
-  defp render_base_info_for_batch(internal_id, l2_block_number_from, l2_block_number_to, transactions_count, batch) do
+  defp render_base_info_for_batch(number, l2_block_number_from, l2_block_number_to, transactions_count, batch) do
     FrameSequence.prepare_base_info_for_batch(
-      internal_id,
+      number,
       l2_block_number_from,
       l2_block_number_to,
       transactions_count,

--- a/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
@@ -310,8 +310,7 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
 
             Publisher.broadcast(
               %{
-                new_optimism_batches:
-                  Enum.map(sequences, &FrameSequence.batch_by_internal_id(&1.id, include_blobs?: false))
+                new_optimism_batches: Enum.map(sequences, &FrameSequence.batch_by_number(&1.id, include_blobs?: false))
               },
               :realtime
             )


### PR DESCRIPTION
## Motivation

The error of kind: `{"time":"2025-09-10T12:17:01.618Z","severity":"error","message":"GenServer BlockScoutWeb.RealtimeEventHandlers.Main terminating\n** (KeyError) key :internal_id not found in: %{\n  number: 2181743,\n  transactions_count: 542,\n  l1_timestamp: ~U[2025-09-10 12:16:48.000000Z],\n  l1_transaction_hashes: [\n    %Explorer.Chain.Hash{\n      byte_count: 32,\n      bytes: <<240, 248, 23, 211, 206, 249, 96, 65, 200, 202, 202, 248, 200,\n        105, 223, 147, 133, 25, 129, 178, 157, 203, 10, 154, 27, 218, 113, 193,\n        87, 102, 119, 150>>\n    }\n  ],\n  batch_data_container: nil,\n  l2_end_block_number: 32852030,\n  l2_start_block_number: 32851919\n}\n    (block_scout_web 9.1.0) lib/block_scout_web/notifiers/optimism.ex:12: anonymous fn/1 in BlockScoutWeb.Notifiers.Optimism.handle_event/1\n    (elixir 1.17.3) lib/enum.ex:3348: anonymous fn/2 in Enum.sort_by/3\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:3348: Enum.sort_by/3\n    (block_scout_web 9.1.0) lib/block_scout_web/notifiers/optimism.ex:12: BlockScoutWeb.Notifiers.Optimism.handle_event/1\n    (block_scout_web 9.1.0) lib/block_scout_web/realtime_event_handlers/main.ex:63: BlockScoutWeb.RealtimeEventHandlers.Main.handle_info/2\n    (stdlib 6.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3\n    (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\nLast message: {:chain_event, :new_optimism_batches, :realtime, [%{number: 2181743, transactions_count: 542, l1_timestamp: ~U[2025-09-10 12:16:48.000000Z], l1_transaction_hashes: [%Explorer.Chain.Hash{byte_count: 32, bytes: <<240, 248, 23, 211, 206, 249, 96, 65, 200, 202, 202, 248, 200, 105, 223, 147, 133, 25, 129, 178, 157, 203, 10, 154, 27, 218, 113, 193, 87, 102, 119, 150>>}], batch_data_container: nil, l2_end_block_number: 32852030, l2_start_block_number: 32851919}]}\nState: []","metadata":{"error":{"initial_call":null,"reason":"** (KeyError) key :internal_id not found in: %{\n  number: 2181743,\n  transactions_count: 542,\n  l1_timestamp: ~U[2025-09-10 12:16:48.000000Z],\n  l1_transaction_hashes: [\n    %Explorer.Chain.Hash{\n      byte_count: 32,\n      bytes: <<240, 248, 23, 211, 206, 249, 96, 65, 200, 202, 202, 248, 200,\n        105, 223, 147, 133, 25, 129, 178, 157, 203, 10, 154, 27, 218, 113, 193,\n        87, 102, 119, 150>>\n    }\n  ],\n  batch_data_container: nil,\n  l2_end_block_number: 32852030,\n  l2_start_block_number: 32851919\n}\n    (block_scout_web 9.1.0) lib/block_scout_web/notifiers/optimism.ex:12: anonymous fn/1 in BlockScoutWeb.Notifiers.Optimism.handle_event/1\n    (elixir 1.17.3) lib/enum.ex:3348: anonymous fn/2 in Enum.sort_by/3\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:3348: Enum.sort_by/3\n    (block_scout_web 9.1.0) lib/block_scout_web/notifiers/optimism.ex:12: BlockScoutWeb.Notifiers.Optimism.handle_event/1\n    (block_scout_web 9.1.0) lib/block_scout_web/realtime_event_handlers/main.ex:63: BlockScoutWeb.RealtimeEventHandlers.Main.handle_info/2\n    (stdlib 6.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3\n    (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\n"}}}`.

## Changelog

### AI Agent summary

This pull request refactors the Optimism batch API and related modules to consistently use the batch `number` as the primary identifier instead of the internal ID. This change affects API endpoints, controller logic, views, and internal data access patterns, ensuring that all references and documentation align with the new identifier.

**API and Controller Changes:**

* The `/api/v2/optimism/batches/:internal_id` endpoint is replaced with `/api/v2/optimism/batches/:number`, and the controller action is renamed from `batch_by_internal_id` to `batch_by_number`. All related logic now parses and uses the `number` parameter. [[1]](diffhunk://#diff-a56b2b654a7e7bdd51095a3de8e1f40b0b46592422137a9b8372f1c511d6e7dbL158-R164) [[2]](diffhunk://#diff-7b31aa9ca8af99c00b6548ddcef75c78c1824715a3cd6d5e10dbcc6ace229780L309-R309)

**Data Access and Internal Logic:**

* The `FrameSequence` module replaces `batch_by_internal_id` with `batch_by_number` throughout, including function names, specs, and internal queries. All usages now operate on the `number` field, and associated documentation is updated accordingly. [[1]](diffhunk://#diff-1fff7484b2952d3ef5a6ec649cc549775e89ff7adceba6dc633801e2cfb02990L90-R121) [[2]](diffhunk://#diff-1fff7484b2952d3ef5a6ec649cc549775e89ff7adceba6dc633801e2cfb02990L81-R81) [[3]](diffhunk://#diff-1fff7484b2952d3ef5a6ec649cc549775e89ff7adceba6dc633801e2cfb02990L144-R144) [[4]](diffhunk://#diff-1fff7484b2952d3ef5a6ec649cc549775e89ff7adceba6dc633801e2cfb02990L174-R182)
* The `TransactionBatch` and related publisher logic now call `FrameSequence.batch_by_number` instead of `batch_by_internal_id`.

**View and Presentation Updates:**

* The view functions and documentation in `OptimismView` are updated to use `number` instead of `internal_id`, both in parameter names and in function signatures. [[1]](diffhunk://#diff-afa212378357fe3bf8c9fe9610a003a2e90fbb194677cc54099bb3cd17b36053L341-R341) [[2]](diffhunk://#diff-afa212378357fe3bf8c9fe9610a003a2e90fbb194677cc54099bb3cd17b36053L366-R368)

**Sorting and Notification Adjustments:**

* Batch notification logic now sorts batches by `number` instead of `internal_id` before broadcasting.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
