### PR TITLE
fix: Mark completed deposits in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug Fixes
 
+- Mark completed deposits in batches ([#13210](https://github.com/blockscout/blockscout/pull/13210))
 - Adjustments in address nft and collections endpoints ([#13192](https://github.com/blockscout/blockscout/pull/13192))
 - Fix batch's number processing from the socket event ([#13181](https://github.com/blockscout/blockscout/pull/13181))
 - Delete PTOs for forked transactions ([#13145](https://github.com/blockscout/blockscout/pull/13145))


### PR DESCRIPTION
## Motivation

A subset of data for marking deposits as completed might be very huge for a single DB update operation.

## Changelog

### AI Agent summary

This pull request refactors how pending deposits are updated to "completed" status in the `Indexer.Fetcher.Beacon.Deposit.Status` module. Instead of updating all matching records in a single query, the update is now performed in batches to improve performance and reduce database load.

**Performance and reliability improvements:**

* Changed the update process in `Indexer.Fetcher.Beacon.Deposit.Status` to use batching (`batch_size = 100`). Now, deposits with pending status are updated in groups of 100 using `Repo.stream` and `Stream.chunk_every`, which helps prevent timeouts and reduces strain on the database.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Processing of pending deposit status updates now runs in controlled batches and streams results to reduce memory usage and DB contention.
  - Improves reliability and stability when handling large backlogs, leading to more consistent and timely status updates.
  - No changes to public interfaces; user-visible behavior is preserved but more resilient under high load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->