### PR TITLE
fix: Fix api/v2/addresses/{hash}/celo/election-rewards pagination

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -1308,14 +1308,15 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     parameters:
       base_params() ++
         [address_hash_param()] ++
-        define_paging_params(["epoch_number", "amount", "associated_account_address_hash", "type"]),
+        define_paging_params(["items_count", "epoch_number", "amount", "associated_account_address_hash", "type"]),
     responses: [
       ok:
         {"Celo election rewards for the specified address.", "application/json",
          paginated_response(
            items: Schemas.Celo.ElectionReward,
            next_page_params_example: %{
-             "block_number" => 100,
+             "epoch_number" => 100,
+             "items_count" => 50,
              "amount" => "1000000000000000000",
              "associated_account_address_hash" => "0x1234567890123456789012345678901234567890",
              "type" => "validator"

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward/type.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward/type.ex
@@ -4,5 +4,5 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward.Type do
 
   alias Explorer.Chain.Celo.ElectionReward
 
-  OpenApiSpex.schema(%{type: :string, nullable: false, enum: ElectionReward.types()})
+  OpenApiSpex.schema(%{type: :string, nullable: false, enum: ElectionReward.types(), title: "CeloElectionRewardType"})
 end


### PR DESCRIPTION
## Motivation
```
{
 errors: [
  {
   title: "Invalid value",
   source: {
   pointer: "/type"
   },
  detail: "Invalid value for enum"
 }
 ]
}
```
## Changelog
- Fix spec
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
