### PR TITLE
perf: optimize token balance synchronous import steps

### DIFF
--- a/apps/explorer/lib/explorer/query_helper.ex
+++ b/apps/explorer/lib/explorer/query_helper.ex
@@ -38,4 +38,63 @@ defmodule Explorer.QueryHelper do
     |> Code.eval_quoted()
     |> elem(0)
   end
+
+  @doc """
+  A macro generating a fragment that selects CTID column.
+
+  CTID - is a system column representing the physical location
+  of the row version within its table.
+
+  The macro is supposed to be used in `SELECT FOR UPDATE` part of update and delete statements
+  where corresponding rows are locked before modification in order to prevent deadlocks
+  (see docs: sharelock.md). Should be used along with `join_on_ctid/2`.
+
+  ## Example
+
+  ```
+    ordered_query =
+      from(table in Table,
+        select: select_ctid(table),
+        # Enforce Table ShareLocks order
+        order_by: [
+          table.column_1,
+          table.column_2,
+        ],
+        lock: "FOR UPDATE"
+      )
+
+    query =
+      from(table in Table,
+        inner_join: ordered_table in subquery(ordered_query),
+        on: join_on_ctid(table, ordered_table)
+      )
+    Repo.delete_all(query)
+  ```
+
+  Will be transformed to such SQL:
+  ```
+    DELETE
+    FROM "table" AS t0 USING (SELECT st0."ctid" AS "ctid"
+                              FROM "table" AS st0
+                              ORDER BY st0."column_1", st0."column_2" FOR UPDATE) AS s1
+    WHERE (t0."ctid" = s1."ctid");
+  ```
+  """
+  defmacro select_ctid(table_binding) do
+    quote do
+      %{ctid: fragment(~s(?."ctid"), unquote(table_binding))}
+    end
+  end
+
+  @doc """
+  A macro generating a fragment that joins 2 tables on CTID column.
+
+  It is supposed to be used as an `:on` option for joins.
+  See `select_ctid/1` for more details on usage.
+  """
+  defmacro join_on_ctid(first_table_binding, second_table_binding) do
+    quote do
+      fragment(~s(?."ctid" = ?."ctid"), unquote(first_table_binding), unquote(second_table_binding))
+    end
+  end
 end


### PR DESCRIPTION
Closes #12845 and part of #13037 

## Motivation

Some reorged blocks on gnosis mainnet cannot be processed due to `delete_address_current_token_balances` related query being executed for too long. E.g., https://gnosis.blockscout.com/block/39445564

<img width="1463" height="222" alt="image" src="https://github.com/user-attachments/assets/1ae80996-37ed-4732-a679-ed4901432a6f" />

That happens because current implementation tries to join on `"fetched_current_token_balances" UNIQUE, btree (address_hash, token_contract_address_hash, COALESCE(token_id, '-1'::integer::numeric))` index, but does not specify the `token_id` column correctly (doesn't use `coalesce` statement) resulting in that value not being able to be effectively used. The issue occurs on gnosis mainnet only, because the instance's `address_current_token_balances` table size is bigger than usual (~1Tb) and because there are some `(address_hash, token_contract_address_hash)` pairs where number of corresponding token_ids is big (see explain analyze below: lookup of just one balance value executes more than a minute). As a result, even small number of such rows being joined results in unacceptable execution time.

```sql
explain analyze select *
from address_current_token_balances AS a0
WHERE a0.address_hash = '\xb8e9bb58591c5f3922b3c4cbee7a2b69b4e9ba38'
  and a0.token_contract_address_hash = '\x3cb124e1cdceecf6e464bb185325608dbe635f5d'
  and a0.token_id = 1746180000001;
                                                                                                        QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on address_current_token_balances a0  (cost=33355.20..33411.44 rows=14 width=99) (actual time=98704.054..98704.061 rows=1 loops=1)
   Recheck Cond: ((token_id = '1746180000001'::numeric) AND (address_hash = '\xb8e9bb58591c5f3922b3c4cbee7a2b69b4e9ba38'::bytea) AND (token_contract_address_hash = '\x3cb124e1cdceecf6e464bb185325608dbe635f5d'::bytea))
   Heap Blocks: exact=1
   ->  BitmapAnd  (cost=33355.20..33355.20 rows=14 width=0) (actual time=98703.788..98703.791 rows=0 loops=1)
         ->  Bitmap Index Scan on address_current_token_balances_token_id_idx  (cost=0.00..7271.58 rows=261183 width=0) (actual time=1.090..1.090 rows=1 loops=1)
               Index Cond: (token_id = '1746180000001'::numeric)
         ->  Bitmap Index Scan on fetched_current_token_balances  (cost=0.00..26083.37 rows=441866 width=0) (actual time=98672.546..98672.546 rows=17862012 loops=1)
               Index Cond: ((address_hash = '\xb8e9bb58591c5f3922b3c4cbee7a2b69b4e9ba38'::bytea) AND (token_contract_address_hash = '\x3cb124e1cdceecf6e464bb185325608dbe635f5d'::bytea))
 Planning Time: 0.083 ms
 Execution Time: 98704.134 ms
(10 rows)
```

## Solution
In this PR we propose using `ctid` system column to join on. CTID specifies the physical location of the row version within its table, and thus allows to locate required rows in the most efficient way. 

As will be seen in the results, it makes the `delete_address_current_token_balances` query to be executed really fast. We also updated `delete_address_token_balances` query to use `ctid` column which also improved the execution time even though it was not so bad before. Finally, we simplified `derive_address_current_token_balances` query not to use window functions and use index on `token_id` column.

The CTID approach may be effectively used in patterns where we `SELECT rows FOR UPDATE` and then join on selected rows in UPDATE or DELETE statements. Thus, we extracted those parts of query into macros, so they can be re-used by other functions.

## Results
All queries were executed on Gnosis Mainnet instance.
### delete_address_token_balances
Before:
```sql
DELETE
FROM "address_token_balances" AS a0 USING (SELECT sa0."address_hash"                AS "address_hash",
                                                  sa0."token_contract_address_hash" AS "token_contract_address_hash",
                                                  sa0."token_id"                    AS "token_id",
                                                  sa0."block_number"                AS "block_number"
                                           FROM "address_token_balances" AS sa0
                                           WHERE (sa0."block_number" =  ANY ('{39445564}'::bigint[]))
                                           ORDER BY sa0."token_contract_address_hash", sa0."token_id",
                                                    sa0."address_hash", sa0."block_number" FOR UPDATE) AS s1
WHERE ((((s1."address_hash" = a0."address_hash") AND
         (s1."token_contract_address_hash" = a0."token_contract_address_hash")) AND
        (((s1."token_id" IS NULL) AND (a0."token_id" IS NULL)) OR
         (((s1."token_id" = a0."token_id") AND NOT (s1."token_id" IS NULL)) AND NOT (a0."token_id" IS NULL)))) AND
       (s1."block_number" = a0."block_number"))
RETURNING a0."address_hash", a0."token_contract_address_hash", a0."block_number";


                                                                                                                                      QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on address_token_balances a0  (cost=787245.92..2855255.68 rows=3 width=83) (actual time=232.734..234.925 rows=146 loops=1)
   ->  Nested Loop  (cost=787245.92..2855255.68 rows=3 width=83) (actual time=232.726..234.812 rows=146 loops=1)
         ->  Subquery Scan on s1  (cost=787245.21..792557.10 rows=236084 width=130) (actual time=232.692..233.553 rows=146 loops=1)
               ->  LockRows  (cost=787245.21..790196.26 rows=236084 width=59) (actual time=232.652..233.479 rows=146 loops=1)
                     ->  Sort  (cost=787245.21..787835.42 rows=236084 width=59) (actual time=232.546..232.554 rows=146 loops=1)
                           Sort Key: sa0.token_contract_address_hash, sa0.token_id, sa0.address_hash, sa0.block_number
                           Sort Method: quicksort  Memory: 40kB
                           ->  Index Scan using address_token_balances_block_number_address_hash_index on address_token_balances sa0  (cost=0.71..766175.96 rows=236084 width=59) (actual time=229.946..232.347 rows=146 loops=1)
                                 Index Cond: (block_number = ANY ('{39445564}'::bigint[]))
         ->  Index Scan using address_token_balances_block_number_address_hash_index on address_token_balances a0  (cost=0.71..8.73 rows=1 width=59) (actual time=0.005..0.008 rows=1 loops=146)
               Index Cond: ((block_number = s1.block_number) AND (address_hash = s1.address_hash))
               Filter: (((token_id IS NULL) OR (token_id IS NOT NULL)) AND (((s1.token_id IS NULL) AND (token_id IS NULL)) OR ((s1.token_id = token_id) AND (s1.token_id IS NOT NULL) AND (token_id IS NOT NULL))) AND (s1.token_contract_address_hash = token_contract_address_hash))
               Rows Removed by Filter: 35
 Planning Time: 2.522 ms
 JIT:
   Functions: 16
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 1.465 ms, Inlining 16.040 ms, Optimization 153.168 ms, Emission 59.515 ms, Total 230.188 ms
 Execution Time: 236.518 ms
(19 rows)
```
After:
```sql
DELETE
FROM "address_token_balances" AS a0 USING (SELECT sa0."ctid" AS "ctid"
                                           FROM "address_token_balances" AS sa0
                                           WHERE (sa0."block_number" =  ANY ('{39445564}'::bigint[]))
                                           ORDER BY sa0."token_contract_address_hash", sa0."token_id",
                                                    sa0."address_hash", sa0."block_number" FOR UPDATE) AS s1
WHERE (a0."ctid" = s1."ctid")
RETURNING a0."address_hash", a0."token_contract_address_hash", a0."block_number";


                                                                                                           QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on address_token_balances a0  (cost=787245.21..1742204.99 rows=236084 width=36) (actual time=59.798..60.859 rows=146 loops=1)
   ->  Nested Loop  (cost=787245.21..1742204.99 rows=236084 width=36) (actual time=59.788..60.765 rows=146 loops=1)
         ->  Subquery Scan on s1  (cost=787245.21..792557.10 rows=236084 width=36) (actual time=59.777..60.650 rows=146 loops=1)
               ->  LockRows  (cost=787245.21..790196.26 rows=236084 width=65) (actual time=59.756..60.606 rows=146 loops=1)
                     ->  Sort  (cost=787245.21..787835.42 rows=236084 width=65) (actual time=59.629..59.636 rows=146 loops=1)
                           Sort Key: sa0.token_contract_address_hash, sa0.token_id, sa0.address_hash, sa0.block_number
                           Sort Method: quicksort  Memory: 41kB
                           ->  Index Scan using address_token_balances_block_number_address_hash_index on address_token_balances sa0  (cost=0.71..766175.96 rows=236084 width=65) (actual time=56.821..59.469 rows=146 loops=1)
                                 Index Cond: (block_number = ANY ('{39445564}'::bigint[]))
         ->  Tid Scan on address_token_balances a0  (cost=0.00..4.01 rows=1 width=6) (actual time=0.000..0.000 rows=1 loops=146)
               TID Cond: (ctid = s1.ctid)
 Planning Time: 0.369 ms
 JIT:
   Functions: 10
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 0.863 ms, Inlining 5.397 ms, Optimization 30.217 ms, Emission 19.824 ms, Total 56.301 ms
 Execution Time: 61.826 ms
(17 rows)
```

### delete_address_current_token_balances
Before (explain analyze were not executed as this query executes longer than 24 hours):
```sql
DELETE
FROM "address_current_token_balances" AS a0 USING (SELECT sa0."address_hash"                AS "address_hash",
                                                          sa0."token_contract_address_hash" AS "token_contract_address_hash",
                                                          sa0."token_id"                    AS "token_id"
                                                   FROM "address_current_token_balances" AS sa0
                                                   WHERE (sa0."block_number" = ANY ('{39445564}'::bigint[]))
                                                   ORDER BY sa0."token_contract_address_hash", sa0."token_id",
                                                            sa0."address_hash" FOR UPDATE) AS s1
WHERE (((s1."address_hash" = a0."address_hash") AND
        (s1."token_contract_address_hash" = a0."token_contract_address_hash")) AND
       (((s1."token_id" IS NULL) AND (a0."token_id" IS NULL)) OR
        (((s1."token_id" = a0."token_id") AND NOT (s1."token_id" IS NULL)) AND NOT (a0."token_id" IS NULL))))
RETURNING a0."address_hash", a0."token_contract_address_hash", a0."token_id", a0."value";
```

After:
```sql
DELETE
FROM "address_current_token_balances" AS a0 USING (SELECT sa0."ctid" AS "ctid"
                                                   FROM "address_current_token_balances" AS sa0
                                                   WHERE (sa0."block_number" = ANY ('{39445564}'::bigint[]))
                                                   ORDER BY sa0."token_contract_address_hash", sa0."token_id",
                                                            sa0."address_hash" FOR UPDATE) AS s1
WHERE (a0."ctid" = s1."ctid")
RETURNING a0."address_hash", a0."token_contract_address_hash", a0."token_id", a0."value";


                                                                                                    QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on address_current_token_balances a0  (cost=493800.33..1266322.51 rows=190982 width=36) (actual time=86.650..87.676 rows=116 loops=1)
   ->  Nested Loop  (cost=493800.33..1266322.51 rows=190982 width=36) (actual time=86.638..87.532 rows=116 loops=1)
         ->  Subquery Scan on s1  (cost=493800.32..498097.42 rows=190982 width=36) (actual time=86.619..87.389 rows=116 loops=1)
               ->  LockRows  (cost=493800.32..496187.60 rows=190982 width=57) (actual time=85.586..86.325 rows=116 loops=1)
                     ->  Sort  (cost=493800.32..494277.78 rows=190982 width=57) (actual time=85.441..85.450 rows=116 loops=1)
                           Sort Key: sa0.token_contract_address_hash, sa0.token_id, sa0.address_hash
                           Sort Method: quicksort  Memory: 37kB
                           ->  Index Scan using address_cur_token_balances_index on address_current_token_balances sa0  (cost=0.71..477048.26 rows=190982 width=57) (actual time=83.239..85.186 rows=116 loops=1)
                                 Index Cond: (block_number = ANY ('{39445564}'::bigint[]))
         ->  Tid Scan on address_current_token_balances a0  (cost=0.00..4.01 rows=1 width=6) (actual time=0.000..0.001 rows=1 loops=116)
               TID Cond: (ctid = s1.ctid)
 Planning Time: 0.521 ms
 JIT:
   Functions: 10
   Options: Inlining true, Optimization true, Expressions true, Deforming true
   Timing: Generation 0.642 ms, Inlining 6.594 ms, Optimization 44.577 ms, Emission 30.577 ms, Total 82.390 ms
 Execution Time: 88.433 ms
(17 rows)
```

### derive_address_current_token_balances
Before:
```sql
SELECT s0."address_hash",
       s0."token_contract_address_hash",
       s0."token_id",
       a1."token_type",
       s0."block_number",
       a1."value",
       a1."value_fetched_at",
       min(a1."inserted_at") OVER "w",
       max(a1."updated_at") OVER "w"
FROM (SELECT sa0."address_hash"                AS "address_hash",
             sa0."token_contract_address_hash" AS "token_contract_address_hash",
             sa0."token_id"                    AS "token_id",
             max(sa0."block_number")           AS "block_number"
      FROM "address_token_balances" AS sa0
      WHERE (((sa0."address_hash" = '\x0733888bd60522227ab9d03815fe9e0db1a0d817') AND
              (sa0."token_contract_address_hash" = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd')) AND
             (sa0."token_id" IS NULL))
         OR (((sa0."address_hash" = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b') AND
              (sa0."token_contract_address_hash" = '\xd69240a976db2c11ef52628279dc165c439a5945')) AND
             (sa0."token_id" = 0))
      GROUP BY sa0."address_hash", sa0."token_contract_address_hash", sa0."token_id") AS s0
         INNER JOIN "address_token_balances" AS a1 ON (((a1."address_hash" = s0."address_hash") AND
                                                        (a1."token_contract_address_hash" = s0."token_contract_address_hash")) AND
                                                       (((a1."token_id" IS NULL) AND (s0."token_id" IS NULL)) OR
                                                        (((a1."token_id" = s0."token_id") AND NOT (a1."token_id" IS NULL)) AND
                                                         NOT (s0."token_id" IS NULL)))) AND
                                                      (a1."block_number" = s0."block_number")
WINDOW "w" AS (PARTITION BY a1."address_hash", a1."token_contract_address_hash", a1."token_id");


                                                         QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 WindowAgg  (cost=22.25..26.41 rows=2 width=133) (actual time=1.796..1.800 rows=2 loops=1)
   ->  Incremental Sort  (cost=22.25..26.36 rows=2 width=133) (actual time=1.787..1.789 rows=2 loops=1)
         Sort Key: a1.address_hash, a1.token_contract_address_hash, a1.token_id
         Presorted Key: a1.address_hash, a1.token_contract_address_hash
         Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 25kB  Peak Memory: 25kB
         ->  Nested Loop  (cost=18.20..26.27 rows=1 width=133) (actual time=1.752..1.769 rows=2 loops=1)
               ->  GroupAggregate  (cost=17.49..17.52 rows=1 width=53) (actual time=1.729..1.732 rows=2 loops=1)
                     Group Key: sa0.address_hash, sa0.token_contract_address_hash, sa0.token_id
                     ->  Sort  (cost=17.49..17.50 rows=1 width=53) (actual time=1.724..1.725 rows=2 loops=1)
                           Sort Key: sa0.address_hash, sa0.token_contract_address_hash, sa0.token_id
                           Sort Method: quicksort  Memory: 25kB
                           ->  Bitmap Heap Scan on address_token_balances sa0  (cost=9.44..17.48 rows=1 width=53) (actual time=1.674..1.717 rows=2 loops=1)
                                 Recheck Cond: (((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea)) OR ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea)))
                                 Filter: (((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea) AND (token_id IS NULL)) OR ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea) AND (token_id = '0'::numeric)))
                                 Heap Blocks: exact=2
                                 ->  BitmapOr  (cost=9.44..9.44 rows=2 width=0) (actual time=1.641..1.641 rows=0 loops=1)
                                       ->  Bitmap Index Scan on fetched_token_balances  (cost=0.00..4.72 rows=1 width=0) (actual time=0.945..0.945 rows=1 loops=1)
                                             Index Cond: ((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea))
                                       ->  Bitmap Index Scan on fetched_token_balances  (cost=0.00..4.72 rows=1 width=0) (actual time=0.694..0.695 rows=1 loops=1)
                                             Index Cond: ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea))
               ->  Index Scan using fetched_token_balances on address_token_balances a1  (cost=0.71..8.73 rows=1 width=88) (actual time=0.016..0.016 rows=1 loops=2)
                     Index Cond: ((address_hash = sa0.address_hash) AND (token_contract_address_hash = sa0.token_contract_address_hash) AND (block_number = (max(sa0.block_number))))
                     Filter: (((token_id IS NULL) OR (token_id IS NOT NULL)) AND (((token_id IS NULL) AND (sa0.token_id IS NULL)) OR ((token_id = sa0.token_id) AND (token_id IS NOT NULL) AND (sa0.token_id IS NOT NULL))))
 Planning Time: 27.394 ms
 Execution Time: 1.899 ms
(25 rows)
```

After: we can see that there is no drastic improvement, but the query itself becomes simpler and (not shown here) in cases when there are lots of `token_id` values corresponding to the same `(address_hash, token_contract_address_hash)` pairs, the index on `coalesce(a0."token_id", -1::numeric)` also starts to be used
```sql
SELECT DISTINCT ON (a0."address_hash", a0."token_contract_address_hash", COALESCE(a0."token_id", -1::numeric)) a0."address_hash",
                                                                                                               a0."token_contract_address_hash",
                                                                                                               a0."token_id",
                                                                                                               a0."block_number",
                                                                                                               a0."token_type",
                                                                                                               a0."value",
                                                                                                               a0."value_fetched_at"
FROM "address_token_balances" AS a0
WHERE (((a0."address_hash" = '\x0733888bd60522227ab9d03815fe9e0db1a0d817') AND
        (a0."token_contract_address_hash" = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd')) AND
       coalesce(a0."token_id", -1::numeric) = coalesce(NULL::numeric, -1::numeric))
   OR (((a0."address_hash" = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b') AND
        (a0."token_contract_address_hash" = '\xd69240a976db2c11ef52628279dc165c439a5945')) AND
       coalesce(a0."token_id", -1::numeric) = coalesce(0::numeric, -1::numeric))
ORDER BY a0."address_hash", a0."token_contract_address_hash", COALESCE(a0."token_id", -1::numeric), a0."block_number"
    DESC;


                                                         QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=17.50..17.51 rows=1 width=104) (actual time=1.657..1.660 rows=2 loops=1)
   ->  Sort  (cost=17.50..17.50 rows=1 width=104) (actual time=1.657..1.658 rows=2 loops=1)
         Sort Key: address_hash, token_contract_address_hash, (COALESCE(token_id, '-1'::numeric)), block_number DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Bitmap Heap Scan on address_token_balances a0  (cost=9.44..17.49 rows=1 width=104) (actual time=1.633..1.648 rows=2 loops=1)
               Recheck Cond: (((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea)) OR ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea)))
               Filter: (((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea) AND (COALESCE(token_id, '-1'::numeric) = '-1'::numeric)) OR ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea) AND (COALESCE(token_id, '-1'::numeric) = '0'::numeric)))
               Heap Blocks: exact=2
               ->  BitmapOr  (cost=9.44..9.44 rows=2 width=0) (actual time=1.601..1.601 rows=0 loops=1)
                     ->  Bitmap Index Scan on address_token_balances_address_hash_token_contract_address__idx  (cost=0.00..4.72 rows=1 width=0) (actual time=0.941..0.941 rows=1 loops=1)
                           Index Cond: ((address_hash = '\x0733888bd60522227ab9d03815fe9e0db1a0d817'::bytea) AND (token_contract_address_hash = '\x536dd2e72686d3d7d6a1d4a6febd69ec1b7c05bd'::bytea))
                     ->  Bitmap Index Scan on address_token_balances_address_hash_token_contract_address__idx  (cost=0.00..4.72 rows=1 width=0) (actual time=0.660..0.660 rows=1 loops=1)
                           Index Cond: ((address_hash = '\x13b90bf7871fa664c7abdfef659c13dbe4b0628b'::bytea) AND (token_contract_address_hash = '\xd69240a976db2c11ef52628279dc165c439a5945'::bytea))
 Planning Time: 0.799 ms
 Execution Time: 1.686 ms
(15 rows)


```

## Changelog

### Enhancements

- Optimizes queries resulting from `delete_address_token_balances`, `delete_address_current_token_balances` and `derive_address_current_token_balances` functions
- Adds `QueryHelper.select_ctid/1` and `QueryHelper.join_on_ctid/2` macros
- Adds 2 test cases for `derive_address_current_token_balances` query

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced DB contention during block imports, speeding up token-balance processing.
* **Bug Fixes**
  * Current token balances now reliably reflect latest state and update only affected entries; handles missing token IDs without extra reprocessing or deletions.
* **Tests**
  * Added coverage for deriving balances and deletion-only update paths (tests duplicated in this change).
* **Chores**
  * Added safer row-matching helpers to improve update/delete reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->