### PR TITLE
chore: Refactoring reputation

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -22,6 +22,12 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   @request_error_msg "Error while sending request to Transaction Interpretation Service"
   @api_true api?: true
   @items_limit 50
+  @token_options [
+    api?: true,
+    necessity_by_association: %{
+      reputation_association() => :optional
+    }
+  ]
   @internal_transaction_necessity_by_association [
     necessity_by_association: %{
       [created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] =>
@@ -316,13 +322,15 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   defp preload_template_variable(%{"type" => "token", "value" => %{"address" => address_hash_string} = value}),
     do: %{
       "type" => "token",
-      "value" => address_hash_string |> Chain.token_from_address_hash(@api_true) |> token_from_db() |> Map.merge(value)
+      "value" =>
+        address_hash_string |> Chain.token_from_address_hash(@token_options) |> token_from_db() |> Map.merge(value)
     }
 
   defp preload_template_variable(%{"type" => "token", "value" => %{"address_hash" => address_hash_string} = value}),
     do: %{
       "type" => "token",
-      "value" => address_hash_string |> Chain.token_from_address_hash(@api_true) |> token_from_db() |> Map.merge(value)
+      "value" =>
+        address_hash_string |> Chain.token_from_address_hash(@token_options) |> token_from_db() |> Map.merge(value)
     }
 
   defp preload_template_variable(%{"type" => "address", "value" => %{"hash" => address_hash_string} = value}),

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -340,6 +340,7 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
         address_hash_string
         |> Chain.hash_to_address(
           necessity_by_association: %{
+            :scam_badge => :optional,
             :names => :optional,
             :smart_contract => :optional,
             proxy_implementations_association() => :optional

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -306,7 +306,10 @@ defmodule BlockScoutWeb.Notifier do
       to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
     ]
 
-    preloads = if API_V2.enabled?(), do: [:token_transfers | base_preloads], else: base_preloads
+    preloads =
+      if API_V2.enabled?(),
+        do: base_preloads ++ [token_transfers: [token: Reputation.reputation_association()]],
+        else: base_preloads
 
     transactions
     |> Repo.preload(preloads)
@@ -403,7 +406,7 @@ defmodule BlockScoutWeb.Notifier do
       )
       when type in [:realtime, :on_demand] do
     address_current_token_balances
-    |> Repo.preload(:token)
+    |> Repo.preload(token: Reputation.reputation_association())
     |> Enum.group_by(& &1.token_type)
     |> Enum.each(fn {token_type, balances} ->
       broadcast_token_balances(address_hash, token_type, balances)

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -308,7 +308,7 @@ defmodule BlockScoutWeb.Notifier do
 
     preloads =
       if API_V2.enabled?(),
-        do: base_preloads ++ [token_transfers: [token: Reputation.reputation_association()]],
+        do: [{:token_transfers, [token: Reputation.reputation_association()]} | base_preloads],
         else: base_preloads
 
     transactions

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/token_balance.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/token_balance.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TokenBalance do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token, TokenInstance}
-  alias Explorer.Chain.Address.Reputation
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -14,15 +13,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TokenBalance do
       value: General.IntegerString,
       token: %Schema{allOf: [Token], nullable: true},
       token_id: General.IntegerStringNullable,
-      token_instance: %Schema{allOf: [TokenInstance], nullable: true},
-      reputation: %Schema{
-        type: :string,
-        enum: Reputation.enum_values(),
-        description: "Reputation of the token balance",
-        nullable: true
-      }
+      token_instance: %Schema{allOf: [TokenInstance], nullable: true}
     },
-    required: [:value, :token, :token_id, :token_instance, :reputation],
+    required: [:value, :token, :token_id, :token_instance],
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/nft_collection.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token, TokenInstanceInList}
-  alias Explorer.Chain.Address.Reputation
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -17,15 +16,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.NFTCollection do
         type: :array,
         items: TokenInstanceInList,
         nullable: false
-      },
-      reputation: %Schema{
-        type: :string,
-        enum: Reputation.enum_values(),
-        description: "Reputation of the token collection",
-        nullable: true
       }
     },
-    required: [:token, :amount, :token_instances, :reputation],
+    required: [:token, :amount, :token_instances],
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_list.ex
@@ -6,8 +6,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
 
   alias BlockScoutWeb.Schemas.API.V2.{General, Token.Type, TokenInstance}
   alias BlockScoutWeb.Schemas.Helper
-  alias Explorer.Chain.Address.Reputation
-  alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(
     TokenInstance.schema()
@@ -15,15 +13,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInList do
       title: "TokenInstanceInList",
       properties: %{
         token_type: Type,
-        value: General.IntegerStringNullable,
-        reputation: %Schema{
-          type: :string,
-          enum: Reputation.enum_values(),
-          description: "Reputation of the token instance",
-          nullable: true
-        }
+        value: General.IntegerStringNullable
       },
-      required: [:token_type, :value, :reputation]
+      required: [:token_type, :value]
     )
   )
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_transfer.ex
@@ -31,7 +31,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
     TransactionHashCustomization
   }
 
-  alias Explorer.Chain.Address.Reputation
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -55,13 +54,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
       block_hash: General.FullHash,
       block_number: %Schema{type: :integer, nullable: false},
       log_index: %Schema{type: :integer, nullable: false},
-      token_type: Token.Type,
-      reputation: %Schema{
-        type: :string,
-        enum: Reputation.enum_values(),
-        description: "Reputation of the token transfer",
-        nullable: true
-      }
+      token_type: Token.Type
     },
     required: [
       :transaction_hash,
@@ -75,8 +68,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenTransfer do
       :block_hash,
       :block_number,
       :log_index,
-      :token_type,
-      :reputation
+      :token_type
     ],
     additionalProperties: false
   })

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -146,8 +146,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
               token_balance.address_hash,
               token_balance
             )
-        ),
-      "reputation" => token_balance.reputation
+        )
     }
   end
 
@@ -184,7 +183,7 @@ defmodule BlockScoutWeb.API.V2.AddressView do
 
   defp prepare_nft(nft, token) do
     Map.merge(
-      %{"token_type" => token.type, "value" => value(token.type, nft), "reputation" => token.reputation},
+      %{"token_type" => token.type, "value" => value(token.type, nft)},
       TokenView.prepare_token_instance(nft, token)
     )
   end
@@ -195,15 +194,14 @@ defmodule BlockScoutWeb.API.V2.AddressView do
       "amount" => string_or_null(collection.distinct_token_instances_count || collection.value),
       "token_instances" =>
         Enum.map(collection.preloaded_token_instances, fn instance ->
-          prepare_nft_for_collection(collection.token.type, instance, collection.reputation)
-        end),
-      "reputation" => collection.reputation
+          prepare_nft_for_collection(collection.token.type, instance)
+        end)
     }
   end
 
-  defp prepare_nft_for_collection(token_type, instance, reputation) do
+  defp prepare_nft_for_collection(token_type, instance) do
     Map.merge(
-      %{"token_type" => token_type, "value" => value(token_type, instance), "reputation" => reputation},
+      %{"token_type" => token_type, "value" => value(token_type, instance)},
       TokenView.prepare_token_instance(instance, nil)
     )
   end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
@@ -173,12 +173,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
       internal_transaction_index: advanced_filter.internal_transaction_index,
       token_transfer_index: advanced_filter.token_transfer_index,
       token_transfer_batch_index: advanced_filter.token_transfer_batch_index,
-      fee: advanced_filter.fee,
-      reputation:
-        if(advanced_filter.type != "coin_transfer",
-          do: advanced_filter.reputation,
-          else: nil
-        )
+      fee: advanced_filter.fee
     }
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_transfer_view.ex
@@ -60,8 +60,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferView do
       "block_hash" => to_string(token_transfer.block_hash),
       "block_number" => token_transfer.block_number,
       "log_index" => token_transfer.log_index,
-      "token_type" => token_transfer.token_type,
-      "reputation" => token_transfer.token.reputation
+      "token_type" => token_transfer.token_type
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -1225,7 +1225,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/token-transfers") |> json_response(200)
     end
@@ -1254,7 +1254,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-transfers")
       response = json_response(request, 200)
@@ -1281,7 +1281,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -1306,7 +1306,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get 200 on non existing address", %{conn: conn} do
@@ -2417,7 +2417,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response)["reputation"] == "ok"
+      assert List.first(response)["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/token-balances") |> json_response(200)
     end
@@ -2438,7 +2438,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response)["reputation"] == "scam"
+      assert List.first(response)["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-balances")
       response = json_response(request, 200)
@@ -2458,7 +2458,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-balances")
       response = json_response(request, 200)
 
-      assert List.first(response)["reputation"] == "ok"
+      assert List.first(response)["token"]["reputation"] == "ok"
     end
 
     test "get smart-contract with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -2475,7 +2475,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/token-balances")
       response = json_response(request, 200)
 
-      assert List.first(response)["reputation"] == "ok"
+      assert List.first(response)["token"]["reputation"] == "ok"
     end
 
     test "get empty list on non existing address", %{conn: conn} do
@@ -3130,7 +3130,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/addresses/#{address.hash}/tokens") |> json_response(200)
     end
@@ -3154,7 +3154,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
@@ -3178,7 +3178,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token balances with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -3200,7 +3200,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/tokens")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get empty list on non existing address", %{conn: conn} do
@@ -4107,7 +4107,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"}) |> json_response(200)
 
@@ -4116,7 +4116,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"}) |> json_response(200)
 
@@ -4125,7 +4125,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"}) |> json_response(200)
     end
@@ -4185,7 +4185,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
@@ -4198,7 +4198,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
@@ -4211,7 +4211,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
@@ -4268,17 +4268,17 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token with scam reputation with hide_scam_addresses=false", %{conn: conn, endpoint: endpoint} do
@@ -4335,17 +4335,17 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-721"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get(endpoint.(address.hash), %{"type" => "ERC-404"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get paginated ERC-721 nft", %{conn: conn, endpoint: endpoint} do
@@ -4832,7 +4832,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response ==
                conn
@@ -4846,7 +4846,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response ==
                conn
@@ -4860,7 +4860,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response ==
                conn
@@ -4958,7 +4958,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-721"})
       response = json_response(request, 200)
@@ -4972,7 +4972,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
       response = json_response(request, 200)
@@ -4986,7 +4986,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
       response = json_response(request, 200)
@@ -5076,17 +5076,17 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-721"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get nft collections with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -5177,17 +5177,17 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-721"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       request = conn |> get("/api/v2/addresses/#{address.hash}/nft/collections", %{type: "ERC-404"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get 200 on non existing address", %{conn: conn, endpoint: endpoint} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
@@ -22,7 +22,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response ==
                conn
@@ -47,7 +47,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/advanced-filters", %{"transaction_types" => "ERC-20,ERC-404,ERC-721,ERC-1155"})
       response = json_response(request, 200)
@@ -67,7 +67,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       request = conn |> get("/api/v2/advanced-filters", %{"transaction_types" => "ERC-20,ERC-404,ERC-721,ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token-transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       request = conn |> get("/api/v2/advanced-filters", %{"transaction_types" => "ERC-20,ERC-404,ERC-721,ERC-1155"})
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "empty list", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_transfer_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_transfer_controller_test.exs
@@ -19,7 +19,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/token-transfers") |> json_response(200)
     end
@@ -40,7 +40,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/token-transfers")
       response = json_response(request, 200)
@@ -63,7 +63,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferControllerTest do
       request = conn |> get("/api/v2/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token-transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -82,7 +82,7 @@ defmodule BlockScoutWeb.API.V2.TokenTransferControllerTest do
       request = conn |> get("/api/v2/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "empty list", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -231,7 +231,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/transactions/#{transaction.hash}")
       response = json_response(request, 200)
 
-      assert List.first(response["token_transfers"])["reputation"] == "ok"
+      assert List.first(response["token_transfers"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/transactions/#{transaction.hash}") |> json_response(200)
     end
@@ -263,7 +263,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> put_req_cookie("show_scam_tokens", "true") |> get("/api/v2/transactions/#{transaction.hash}")
       response = json_response(request, 200)
 
-      assert List.first(response["token_transfers"])["reputation"] == "scam"
+      assert List.first(response["token_transfers"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/transactions/#{transaction.hash}")
       response = json_response(request, 200)
@@ -296,7 +296,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> get("/api/v2/transactions/#{transaction.hash}")
       response = json_response(request, 200)
 
-      assert List.first(response["token_transfers"])["reputation"] == "ok"
+      assert List.first(response["token_transfers"])["token"]["reputation"] == "ok"
     end
 
     test "get token-transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -326,7 +326,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> get("/api/v2/transactions/#{transaction.hash}")
       response = json_response(request, 200)
 
-      assert List.first(response["token_transfers"])["reputation"] == "ok"
+      assert List.first(response["token_transfers"])["token"]["reputation"] == "ok"
     end
 
     test "return 404 on non existing transaction", %{conn: conn} do
@@ -796,7 +796,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
 
       assert response == conn |> get("/api/v2/transactions/#{transaction.hash}/token-transfers") |> json_response(200)
     end
@@ -832,7 +832,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "scam"
+      assert List.first(response["items"])["token"]["reputation"] == "scam"
 
       request = conn |> get("/api/v2/transactions/#{transaction.hash}/token-transfers")
       response = json_response(request, 200)
@@ -865,7 +865,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> get("/api/v2/transactions/#{transaction.hash}/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "get token-transfers with scam reputation with hide_scam_addresses=false", %{conn: conn} do
@@ -895,7 +895,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       request = conn |> get("/api/v2/transactions/#{transaction.hash}/token-transfers")
       response = json_response(request, 200)
 
-      assert List.first(response["items"])["reputation"] == "ok"
+      assert List.first(response["items"])["token"]["reputation"] == "ok"
     end
 
     test "return 404 on non existing transaction", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -4,10 +4,9 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
   import Explorer.Chain, only: [hash_to_lower_case_string: 1]
   import Mox
-  import Ecto.Query, only: [from: 2]
 
   alias Explorer.Account.{Identity, WatchlistAddress}
-  alias Explorer.Chain.{Address, Data, InternalTransaction, Log, Token, TokenTransfer, Transaction, Wei}
+  alias Explorer.Chain.{Address, InternalTransaction, Log, Token, TokenTransfer, Transaction, Wei}
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
   alias Explorer.{Repo, TestHelper}
 
@@ -1975,36 +1974,6 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     assert check_total(Repo.preload(token_transfer, [{:token, :contract_address}]).token, json["total"], token_transfer)
   end
 
-  defp compare_item(%Transaction{} = transaction, json, wl_names) do
-    assert to_string(transaction.hash) == json["hash"]
-    assert transaction.block_number == json["block_number"]
-    assert to_string(transaction.value.value) == json["value"]
-    assert Address.checksum(transaction.from_address_hash) == json["from"]["hash"]
-    assert Address.checksum(transaction.to_address_hash) == json["to"]["hash"]
-
-    assert json["to"]["watchlist_names"] ==
-             if(wl_names[transaction.to_address_hash],
-               do: [
-                 %{
-                   "display_name" => wl_names[transaction.to_address_hash],
-                   "label" => wl_names[transaction.to_address_hash]
-                 }
-               ],
-               else: []
-             )
-
-    assert json["from"]["watchlist_names"] ==
-             if(wl_names[transaction.from_address_hash],
-               do: [
-                 %{
-                   "display_name" => wl_names[transaction.from_address_hash],
-                   "label" => wl_names[transaction.from_address_hash]
-                 }
-               ],
-               else: []
-             )
-  end
-
   defp compare_item(%BeaconDeposit{} = deposit, json) do
     index = deposit.index
     transaction_hash = to_string(deposit.transaction_hash)
@@ -2042,6 +2011,36 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                "from_address" => %{"hash" => ^from_address_hash}
              } = json
     end
+  end
+
+  defp compare_item(%Transaction{} = transaction, json, wl_names) do
+    assert to_string(transaction.hash) == json["hash"]
+    assert transaction.block_number == json["block_number"]
+    assert to_string(transaction.value.value) == json["value"]
+    assert Address.checksum(transaction.from_address_hash) == json["from"]["hash"]
+    assert Address.checksum(transaction.to_address_hash) == json["to"]["hash"]
+
+    assert json["to"]["watchlist_names"] ==
+             if(wl_names[transaction.to_address_hash],
+               do: [
+                 %{
+                   "display_name" => wl_names[transaction.to_address_hash],
+                   "label" => wl_names[transaction.to_address_hash]
+                 }
+               ],
+               else: []
+             )
+
+    assert json["from"]["watchlist_names"] ==
+             if(wl_names[transaction.from_address_hash],
+               do: [
+                 %{
+                   "display_name" => wl_names[transaction.from_address_hash],
+                   "label" => wl_names[transaction.from_address_hash]
+                 }
+               ],
+               else: []
+             )
   end
 
   defp check_paginated_response(first_page_resp, second_page_resp, transactions) do
@@ -2413,18 +2412,17 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       transaction = :transaction |> insert() |> with_block()
 
-      log =
-        insert(:log,
-          transaction: transaction,
-          first_topic: TestHelper.topic(topic1),
-          second_topic: TestHelper.topic(topic2),
-          third_topic: nil,
-          fourth_topic: nil,
-          data: log_data,
-          address: address,
-          block: transaction.block,
-          block_number: transaction.block_number
-        )
+      insert(:log,
+        transaction: transaction,
+        first_topic: TestHelper.topic(topic1),
+        second_topic: TestHelper.topic(topic2),
+        third_topic: nil,
+        fourth_topic: nil,
+        data: log_data,
+        address: address,
+        block: transaction.block,
+        block_number: transaction.block_number
+      )
 
       insert(:proxy_implementation,
         proxy_address_hash: address.hash,
@@ -2495,18 +2493,17 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       transaction = :transaction |> insert() |> with_block()
 
-      log =
-        insert(:log,
-          transaction: transaction,
-          first_topic: TestHelper.topic(topic1),
-          second_topic: TestHelper.topic(topic2),
-          third_topic: nil,
-          fourth_topic: nil,
-          data: log_data,
-          address: address,
-          block: transaction.block,
-          block_number: transaction.block_number
-        )
+      insert(:log,
+        transaction: transaction,
+        first_topic: TestHelper.topic(topic1),
+        second_topic: TestHelper.topic(topic2),
+        third_topic: nil,
+        fourth_topic: nil,
+        data: log_data,
+        address: address,
+        block: transaction.block,
+        block_number: transaction.block_number
+      )
 
       insert(:proxy_implementation,
         proxy_address_hash: address.hash,
@@ -2527,9 +2524,229 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     end
   end
 
-  if @chain_type == :neon do
-    import Ecto.Query, only: [from: 2]
+  describe "/transactions/{transaction_hash}/summary" do
+    setup do
+      original_config =
+        Application.get_env(:block_scout_web, BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation)
 
+      original_tesla_adapter = Application.get_env(:tesla, :adapter)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      on_exit(fn ->
+        Application.put_env(
+          :block_scout_web,
+          BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation,
+          original_config
+        )
+
+        Application.put_env(:tesla, :adapter, original_tesla_adapter)
+      end)
+    end
+
+    test "success preload template variables", %{conn: conn} do
+      bypass = Bypass.open()
+
+      Application.put_env(:block_scout_web, BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation,
+        enabled: true,
+        service_url: "http://localhost:#{bypass.port}"
+      )
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :ok)
+
+      token = insert(:token)
+      address = insert(:address)
+
+      tx_interpretation_response = """
+       {
+        "success": true,
+        "data": {
+            "summaries": [
+                {
+                    "summary_template": "{action_type} {outgoing_amount} {native} for {incoming_amount} {incoming_token} on {market}",
+                    "summary_template_variables": {
+                        "action_type": {
+                            "type": "string",
+                            "value": "Swap"
+                        },
+                        "outgoing_amount": {
+                            "type": "currency",
+                            "value": "0.3"
+                        },
+                        "incoming_amount": {
+                            "type": "currency",
+                            "value": "9693.997876398680187001"
+                        },
+                        "incoming_token": {
+                            "type": "token",
+                            "value": {
+                                "address_hash": "#{token.contract_address_hash}"
+                            }
+                        },
+                        "rnd_address": {
+                            "type": "address",
+                            "value": {
+                                "hash": "#{address.hash}"
+                            }
+                        },
+                        "market": {
+                            "type": "dexTag",
+                            "value": {
+                                "name": "Uniswap V3",
+                                "icon": "https://blockscout-content.s3.amazonaws.com/uniswap.png",
+                                "url": "https://uniswap.org/?utm_source=Blockscout"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+      }
+      """
+
+      Bypass.expect_once(
+        bypass,
+        "GET",
+        "/cache/#{to_string(transaction.hash)}",
+        fn conn ->
+          Plug.Conn.resp(conn, 404, "Not Found")
+        end
+      )
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/transactions/summary",
+        fn conn ->
+          Plug.Conn.resp(conn, 200, tx_interpretation_response)
+        end
+      )
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/summary")
+      assert response = json_response(request, 200)
+
+      token_json = Enum.at(response["data"]["summaries"], 0)["summary_template_variables"]["incoming_token"]["value"]
+      assert token_json["address_hash"] == to_string(token.contract_address_hash)
+      assert token_json["symbol"] == token.symbol
+      assert token_json["reputation"] == "ok"
+
+      address_json = Enum.at(response["data"]["summaries"], 0)["summary_template_variables"]["rnd_address"]["value"]
+      assert Map.has_key?(address_json, "ens_domain_name")
+      assert address_json["hash"] == to_string(address.hash)
+
+      Bypass.down(bypass)
+    end
+
+    test "success preload template variables when scam token", %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      bypass = Bypass.open()
+
+      Application.put_env(:block_scout_web, BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation,
+        enabled: true,
+        service_url: "http://localhost:#{bypass.port}"
+      )
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :ok)
+
+      token = insert(:token)
+      address = insert(:address)
+
+      insert(:scam_badge_to_address, address_hash: token.contract_address_hash)
+      insert(:scam_badge_to_address, address_hash: address.hash)
+
+      tx_interpretation_response = """
+       {
+        "success": true,
+        "data": {
+            "summaries": [
+                {
+                    "summary_template": "{action_type} {outgoing_amount} {native} for {incoming_amount} {incoming_token} on {market}",
+                    "summary_template_variables": {
+                        "action_type": {
+                            "type": "string",
+                            "value": "Swap"
+                        },
+                        "outgoing_amount": {
+                            "type": "currency",
+                            "value": "0.3"
+                        },
+                        "incoming_amount": {
+                            "type": "currency",
+                            "value": "9693.997876398680187001"
+                        },
+                        "incoming_token": {
+                            "type": "token",
+                            "value": {
+                                "address_hash": "#{token.contract_address_hash}"
+                            }
+                        },
+                        "rnd_address": {
+                            "type": "address",
+                            "value": {
+                                "hash": "#{address.hash}"
+                            }
+                        },
+                        "market": {
+                            "type": "dexTag",
+                            "value": {
+                                "name": "Uniswap V3",
+                                "icon": "https://blockscout-content.s3.amazonaws.com/uniswap.png",
+                                "url": "https://uniswap.org/?utm_source=Blockscout"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+      }
+      """
+
+      Bypass.expect_once(
+        bypass,
+        "GET",
+        "/cache/#{to_string(transaction.hash)}",
+        fn conn ->
+          Plug.Conn.resp(conn, 404, "Not Found")
+        end
+      )
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/transactions/summary",
+        fn conn ->
+          Plug.Conn.resp(conn, 200, tx_interpretation_response)
+        end
+      )
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/summary")
+      assert response = json_response(request, 200)
+
+      token_json = Enum.at(response["data"]["summaries"], 0)["summary_template_variables"]["incoming_token"]["value"]
+      dbg(token_json)
+      assert token_json["address_hash"] == to_string(token.contract_address_hash)
+      assert token_json["symbol"] == token.symbol
+      assert token_json["reputation"] == "scam"
+
+      address_json = Enum.at(response["data"]["summaries"], 0)["summary_template_variables"]["rnd_address"]["value"]
+      assert Map.has_key?(address_json, "ens_domain_name")
+      assert address_json["hash"] == to_string(address.hash)
+      assert address_json["reputation"] == "scam"
+      assert address_json["is_scam"] == true
+
+      Bypass.down(bypass)
+    end
+  end
+
+  if @chain_type == :neon do
     describe "neon linked transactions service" do
       test "fetches data from the node and caches in the db", %{conn: conn} do
         transaction = insert(:transaction)

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
 
   alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, CurrencyHelper, Hash, Token}
-  alias Explorer.Chain.Address.{Reputation, TokenBalance}
+  alias Explorer.Chain.Address.TokenBalance
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -54,8 +54,6 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
       type: Hash.Address,
       null: false
     )
-
-    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
 
     timestamps()
   end

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -59,8 +59,6 @@ defmodule Explorer.Chain.AdvancedFilter do
 
     has_one(:token_transfer, TokenTransfer, foreign_key: :transaction_hash, references: :hash, null: true)
 
-    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :hash)
-
     field(:fee, :decimal)
 
     field(:block_number, :integer)
@@ -238,8 +236,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       block_number: token_transfer.block_number,
       transaction_index: token_transfer.transaction.index,
       token_transfer_index: token_transfer.log_index,
-      token_transfer_batch_index: token_transfer.reverse_index_in_batch,
-      reputation: token_transfer.token.reputation
+      token_transfer_batch_index: token_transfer.reverse_index_in_batch
     }
   end
 
@@ -519,7 +516,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> page_token_transfers(paging_options)
 
     token_transfer_query
-    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
     |> limit_query(paging_options)
     |> query_function.(false)
     |> limit_query(paging_options)

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -552,7 +552,7 @@ defmodule Explorer.Chain.Search do
     base_query
     |> apply_sorting([], @token_sorting)
     |> page_search_results(paging_options, "token")
-    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_for_search(:contract_address_hash, options)
     |> select(^(token_search_fields() |> add_reputation_to_search_fields(options)))
   end
 
@@ -567,7 +567,7 @@ defmodule Explorer.Chain.Search do
       )
 
     query
-    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_for_search(:contract_address_hash, options)
     |> select(^(token_search_fields() |> add_reputation_to_search_fields(options)))
   end
 
@@ -590,7 +590,7 @@ defmodule Explorer.Chain.Search do
       )
 
     base_query
-    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_for_search(:address_hash, options)
     |> select(^contract_search_fields)
     |> apply_sorting([], @contract_sorting)
     |> page_search_results(paging_options, "contract")
@@ -755,7 +755,7 @@ defmodule Explorer.Chain.Search do
       as: :metadata_tag,
       on: address.hash == tag.address_hash
     )
-    |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_for_search(:hash, options)
     |> select(^(metadata_tags_search_fields() |> add_reputation_to_search_fields(options)))
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -1475,7 +1475,7 @@ defmodule Explorer.Chain.SmartContract do
       end
 
     addresses_query
-    |> ExplorerHelper.maybe_hide_scam_addresses(:hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses_with_select(:hash, options)
     |> SortingHelper.apply_sorting(sorting_options, default_sorting_options)
     |> SortingHelper.page_with_sorting(paging_options, sorting_options, default_sorting_options)
     |> Chain.join_associations(necessity_by_association)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -365,7 +365,7 @@ defmodule Explorer.Chain.Token do
     sorted_paginated_query =
       Token
       |> Chain.join_associations(necessity_by_association)
-      |> ExplorerHelper.maybe_hide_scam_addresses(:contract_address_hash, options)
+      |> ExplorerHelper.maybe_hide_scam_addresses_with_select(:contract_address_hash, options)
       |> apply_filter(token_type)
       |> SortingHelper.apply_sorting(sorting, @default_sorting)
       |> SortingHelper.page_with_sorting(paging_options, sorting, @default_sorting)

--- a/apps/explorer/lib/explorer/chain/token/instance.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance.ex
@@ -66,8 +66,6 @@ defmodule Explorer.Chain.Token.Instance do
       null: false
     )
 
-    has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
-
     timestamps()
   end
 
@@ -429,7 +427,7 @@ defmodule Explorer.Chain.Token.Instance do
       distinct_token_instances_count: fragment("COUNT(*)"),
       token_ids: fragment("array_agg(?)", ctb.token_id)
     })
-    |> ExplorerHelper.maybe_hide_scam_addresses_with_aggregate(:token_contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
     |> page_erc_1155_nft_collections(paging_options)
     |> limit(^paging_options.page_size)
     |> Chain.select_repo(options).all()
@@ -469,7 +467,7 @@ defmodule Explorer.Chain.Token.Instance do
       distinct_token_instances_count: fragment("COUNT(*)"),
       token_ids: fragment("array_agg(?)", ctb.token_id)
     })
-    |> ExplorerHelper.maybe_hide_scam_addresses_with_aggregate(:token_contract_address_hash, options)
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
     |> page_erc_404_nft_collections(paging_options)
     |> limit(^paging_options.page_size)
     |> Chain.select_repo(options).all()

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -9,7 +9,6 @@ defmodule Explorer.Chain.TokenTransfer.Schema do
 
   alias Explorer.Chain.{
     Address,
-    Address.Reputation,
     Block,
     Hash,
     Transaction
@@ -101,8 +100,6 @@ defmodule Explorer.Chain.TokenTransfer.Schema do
         )
 
         has_one(:token, through: [:token_contract_address, :token])
-
-        has_one(:reputation, Reputation, foreign_key: :address_hash, references: :token_contract_address_hash)
 
         timestamps()
 
@@ -579,7 +576,7 @@ defmodule Explorer.Chain.TokenTransfer do
       |> join(:inner, [tt], token in assoc(tt, :token), as: :token)
       |> preload([token: token], [{:token, token}])
       |> filter_by_type(token_types)
-      |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
+      |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
       |> handle_paging_options(paging_options)
     else
       to_address_hash_query =
@@ -589,7 +586,7 @@ defmodule Explorer.Chain.TokenTransfer do
         |> filter_by_token_address_hash(token_address_hash)
         |> filter_by_type(token_types)
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-        |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
+        |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
         |> handle_paging_options(paging_options)
         |> Chain.wrapped_union_subquery()
 
@@ -600,7 +597,7 @@ defmodule Explorer.Chain.TokenTransfer do
         |> filter_by_token_address_hash(token_address_hash)
         |> filter_by_type(token_types)
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
-        |> ExplorerHelper.maybe_hide_scam_addresses_without_select(:token_contract_address_hash, options)
+        |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
         |> handle_paging_options(paging_options)
         |> Chain.wrapped_union_subquery()
 

--- a/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
@@ -125,7 +125,6 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
           :token,
           :transaction,
           :token_instance,
-          :reputation,
           :__meta__
         ])
       end)
@@ -161,7 +160,6 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
           :is_unique,
           :owner,
           :token,
-          :reputation,
           :__meta__
         ])
       end)


### PR DESCRIPTION
## Motivation

## Changelog
- leave reputation only in token struct where possible
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Breaking Changes**
  - Reputation is no longer a top-level field in many API v2 responses/items; it is now nested under each token (response shape changed).

- **Improvements**
  - Scam-address hiding/filtering behavior standardized across searches, listings, and contract queries.
  - Reputation is now returned only where intended (selection and preload behavior made explicit), reducing unexpected reputation values in some endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->