### PR TITLE
fix: Check if CoinBalance Realtime fetcher is disabled

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/coin_balance/realtime.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance/realtime.ex
@@ -8,6 +8,7 @@ defmodule Indexer.Fetcher.CoinBalance.Realtime do
 
   alias Explorer.Chain.{Block, Hash}
   alias Indexer.{BufferedTask, Tracer}
+  alias Indexer.Fetcher.CoinBalance.Realtime.Supervisor, as: CoinBalanceSupervisor
   alias Indexer.Fetcher.CoinBalance.Helper
 
   @behaviour BufferedTask
@@ -22,9 +23,13 @@ defmodule Indexer.Fetcher.CoinBalance.Realtime do
           %{required(:address_hash) => Hash.Address.t(), required(:block_number) => Block.block_number()}
         ]) :: :ok
   def async_fetch_balances(balance_fields) when is_list(balance_fields) do
-    entries = Enum.map(balance_fields, &Helper.entry/1)
+    if CoinBalanceSupervisor.disabled?() do
+      :ok
+    else
+      entries = Enum.map(balance_fields, &Helper.entry/1)
 
-    BufferedTask.buffer(__MODULE__, entries, true)
+      BufferedTask.buffer(__MODULE__, entries, true)
+    end
   end
 
   def child_spec(params) do


### PR DESCRIPTION
Resolves #13222 

## Changelog


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a runtime switch to temporarily disable real-time coin balance updates. When disabled, the system skips processing; when enabled, behavior remains unchanged.

- Chores
  - Improved control flow to gracefully handle disabled state, reducing unnecessary background work and improving stability under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->