### PR TITLE
fix: Remove requirement for beacon deposit indexes to be sequential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Auto assert_schema in tests ([#13029](https://github.com/blockscout/blockscout/issues/13029))
 
+### 🐛 Bug Fixes
+
+- Remove requirement for beacon deposit indexes to be sequential ([#13228](https://github.com/blockscout/blockscout/pull/13228))
+
 ### ⚙️ Miscellaneous Tasks
 
 - Refactoring reputation ([#13221](https://github.com/blockscout/blockscout/issues/13221))

--- a/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
+++ b/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
@@ -141,40 +141,45 @@ defmodule Indexer.Fetcher.Beacon.Deposit do
       )
       |> Enum.map(&log_to_deposit/1)
 
+    # todo: sequential? check is removed as a hard requirement for deposits indexing
+    # since block ranges are found where node doesn't return deposits
+    # thus making the deposit index sequence non-sequential.
+    # We need a separate process which will monitor missed deposits
+    # after we check the nature of those missing deposit indexes.
     case sequential?(deposit_index, deposits) do
       {:error, prev, curr} ->
         Logger.error("Non-sequential deposits detected: #{inspect(prev)} followed by #{inspect(curr)}")
-        Process.send_after(self(), :process_logs, interval * 10)
-        {:noreply, state}
 
       _ ->
-        {deposits_count, _} =
-          Repo.insert_all(Deposit, set_status(deposits, domain_deposit, genesis_fork_version),
-            on_conflict: :replace_all,
-            conflict_target: [:index]
-          )
-
-        if deposits_count < batch_size do
-          Process.send_after(self(), :process_logs, interval)
-        else
-          Process.send(self(), :process_logs, [])
-        end
-
-        last_deposit =
-          List.last(deposits, %{
-            index: state.deposit_index,
-            block_number: state.last_processed_log_block_number,
-            log_index: state.last_processed_log_index
-          })
-
-        {:noreply,
-         %__MODULE__{
-           state
-           | deposit_index: last_deposit.index,
-             last_processed_log_block_number: last_deposit.block_number,
-             last_processed_log_index: last_deposit.log_index
-         }}
+        :ok
     end
+
+    {deposits_count, _} =
+      Repo.insert_all(Deposit, set_status(deposits, domain_deposit, genesis_fork_version),
+        on_conflict: :replace_all,
+        conflict_target: [:index]
+      )
+
+    if deposits_count < batch_size do
+      Process.send_after(self(), :process_logs, interval)
+    else
+      Process.send(self(), :process_logs, [])
+    end
+
+    last_deposit =
+      List.last(deposits, %{
+        index: state.deposit_index,
+        block_number: state.last_processed_log_block_number,
+        log_index: state.last_processed_log_index
+      })
+
+    {:noreply,
+     %__MODULE__{
+       state
+       | deposit_index: last_deposit.index,
+         last_processed_log_block_number: last_deposit.block_number,
+         last_processed_log_index: last_deposit.log_index
+     }}
   end
 
   @abi ABI.parse_specification(


### PR DESCRIPTION
## Motivation

Block ranges exist where logs with deposits aren't exist, thus deposit indexes sequence is broken. Even re-fetch of those blocks doesn't help. This means either node doesn't contain those logs with deposits, or there is a bug in the indexing of logs on the indexer side. I suggest not to bound to sequential deposits indexes. Otherwise, it is a chance that deposits indexer will stuck without clear way how to resume it without manual intervention. Rather we should have a separate process which will monitor missed deposit indexes and re-fetch deposits fetching or even refetch logs for the corresponding block ranges.

## Changelog

### AI Agent summary

This pull request updates the deposit indexing logic in `Indexer.Fetcher.Beacon.Deposit` to remove the strict requirement for sequential deposit indexes. This change is necessary because there are block ranges where the node does not return deposits, making the sequence of deposit indexes non-sequential. The code now allows non-sequential deposits and suggests monitoring for missed deposits in a separate process.

Deposit indexing logic changes:

* Removed the strict enforcement of sequential deposit indexes in the deposit processing flow, allowing for non-sequential deposits when the node does not return them for certain block ranges.
* Added comments explaining the rationale for removing the sequential check and suggesting a future process to monitor missed deposits.

Code cleanup:

* Removed an unnecessary `end` statement after the log processing case block to tidy up the code structure.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Indexer continues processing when beacon deposit indexes are non-sequential, persisting deposits and maintaining progress without halts.
  - Scheduling unified after processing for more consistent handling of small and large batches.

- Bug Fixes
  - Removed premature stops caused by out-of-order deposit indexes, improving indexing robustness.

- Documentation
  - Changelog updated to document removal of the sequential deposit requirement and clarify formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->