### PR TITLE
fix: Fix logic of checking finishing of heavy DB index operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix logic of checking finishing of heavy DB index operation ([#13231](https://github.com/blockscout/blockscout/pull/13231))
 - Remove requirement for beacon deposit indexes to be sequential ([#13228](https://github.com/blockscout/blockscout/pull/13228))
 
 ### ⚙️ Miscellaneous Tasks


### PR DESCRIPTION
## Motivation

Heavy DB index operations status doesn't change in some edge cases whereas index operations have been actually completed.

## Changelog

### AI Agent summary

This pull request refactors the logic for checking and starting heavy DB index operations in `Explorer.Migrator.HeavyDbIndexOperation`. It consolidates readiness checks into the index operation progress handler, removes a redundant message handler, and updates scheduling to streamline the process.

**Refactoring and simplification of index operation readiness checks:**

* Removed the `:check_if_db_operation_need_to_be_started` message handler and incorporated readiness checks directly into the `:check_db_index_operation_progress` handler, reducing indirection and simplifying the message flow.
* Updated the `schedule_next_db_operation_readiness_check` function to send the `:check_db_index_operation_progress` message instead of the removed `:check_if_db_operation_need_to_be_started` message, ensuring consistent scheduling.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents heavy index operations from starting before prerequisites are met, reducing conflicts and improving stability during migrations.
  - Ensures progress checks, restarts, and completion updates behave reliably, avoiding duplicate or premature triggers.

- Refactor
  - Consolidated index operation progress checks into a single pathway, simplifying scheduling logic and minimizing edge cases for long-running migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->