### PR TITLE
fix: Soften deposits deletion condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- Soften deposits deletion condition ([#13234](https://github.com/blockscout/blockscout/pull/13234))
 - Fix logic of checking finishing of heavy DB index operation ([#13231](https://github.com/blockscout/blockscout/pull/13231))
 - Remove requirement for beacon deposit indexes to be sequential ([#13228](https://github.com/blockscout/blockscout/pull/13228))
 

--- a/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
+++ b/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
@@ -93,9 +93,16 @@ defmodule Indexer.Fetcher.Beacon.Deposit do
 
   @impl GenServer
   def handle_cast({:lost_consensus, block_number}, %__MODULE__{} = state) do
+    max_reorg_depth_block_number = block_number + 64
+
     {_deleted_deposits_count, deleted_deposits} =
       Repo.delete_all(
-        from(d in Deposit, where: d.block_number >= ^block_number, select: d.index),
+        from(
+          d in Deposit,
+          where: d.block_number > ^block_number,
+          where: d.block_number <= ^max_reorg_depth_block_number,
+          select: d.index
+        ),
         timeout: :infinity
       )
 


### PR DESCRIPTION
## Motivation

Deposits are continuously removed in the loop

## Changelog

### AI Agent summary

This pull request refines the logic for deleting deposit records in the `handle_cast/2` function of the `Indexer.Fetcher.Beacon.Deposit` module. The update ensures that only deposits within a specific block number range are deleted when consensus is lost, improving data integrity during blockchain reorganizations.

### Improved deposit deletion logic:

* Updated the query in `handle_cast/2` to delete only deposits with `block_number` greater than the lost consensus block and less than or equal to the maximum reorg depth (`block_number + 64`), rather than deleting all deposits from the lost block onwards.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted beacon deposit reorg handling to a 64-block window, removing only recent deposits within that range.
  * Improves stability and accuracy of deposit data during short-lived network reorganizations, reducing temporary inconsistencies in views and histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->