### PR TITLE
fix: Add reputation preload to state changes and bridged tokens

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -65,8 +65,9 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
           paging_options: 1
         ]
 
+      # credo:disable-for-lines:2 Credo.Check.Design.AliasUsage
       bridged_tokens =
-        if BridgedToken.enabled?() do
+        if Explorer.Chain.BridgedToken.enabled?() do
           options =
             params
             |> paging_options()
@@ -74,7 +75,8 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
             |> Keyword.merge(tokens_sorting(params))
             |> Keyword.merge(@api_true)
 
-          "" |> BridgedToken.list_top_bridged_tokens(options)
+          # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+          "" |> Explorer.Chain.BridgedToken.list_top_bridged_tokens(options)
         else
           []
         end

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
     Transaction state changes related functions
   """
 
+  import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
   import Explorer.PagingOptions, only: [default_paging_options: 0]
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
   import Explorer.Chain.SmartContract.Proxy.Models.Implementation, only: [proxy_implementations_association: 0]
@@ -70,6 +71,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
       |> Enum.find(&(&1.hash == transaction.hash))
       |> Repo.preload(
         token_transfers: [
+          token: reputation_association(),
           from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
           to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
         ],

--- a/apps/explorer/lib/explorer/chain/bridged_token.ex
+++ b/apps/explorer/lib/explorer/chain/bridged_token.ex
@@ -6,6 +6,7 @@ defmodule Explorer.Chain.BridgedToken do
 
   import Ecto.Changeset
   import EthereumJSONRPC, only: [json_rpc: 2]
+  import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
 
   import Ecto.Query,
     only: [
@@ -943,7 +944,7 @@ defmodule Explorer.Chain.BridgedToken do
         where: t.total_supply > ^0,
         where: t.bridged,
         select: {t, bt},
-        preload: [:contract_address]
+        preload: [:contract_address, ^reputation_association()]
       )
 
     base_query_with_paging =


### PR DESCRIPTION
## Motivation
## Changelog


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
