### PR TITLE
fix: Fix condition in Indexer.Fetcher.OnDemand.TokenTotalSupply fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug Fixes
 
+- Fix condition in Indexer.Fetcher.OnDemand.TokenTotalSupply fetcher ([#13240](https://github.com/blockscout/blockscout/pull/13240))
 - Add reputation preload to state changes and bridged tokens ([#13235](https://github.com/blockscout/blockscout/pull/13235))
 - Soften deposits deletion condition ([#13234](https://github.com/blockscout/blockscout/pull/13234))
 - Fix logic of checking finishing of heavy DB index operation ([#13231](https://github.com/blockscout/blockscout/pull/13231))

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.ex
@@ -49,7 +49,8 @@ defmodule Indexer.Fetcher.OnDemand.TokenTotalSupply do
     token = Repo.replica().get_by(Token, contract_address_hash: address_hash)
 
     if (token && !token.skip_metadata && is_nil(token.total_supply_updated_at_block)) or
-         BlockNumber.get_max() - token.total_supply_updated_at_block > @ttl_in_blocks do
+         (!is_nil(token.total_supply_updated_at_block) &&
+            BlockNumber.get_max() - token.total_supply_updated_at_block > @ttl_in_blocks) do
       token_address_hash_string = to_string(address_hash)
 
       token_params = MetadataRetriever.get_total_supply_of(token_address_hash_string)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.ex
@@ -49,7 +49,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenTotalSupply do
     token = Repo.replica().get_by(Token, contract_address_hash: address_hash)
 
     if (token && !token.skip_metadata && is_nil(token.total_supply_updated_at_block)) or
-         (!is_nil(token.total_supply_updated_at_block) &&
+         (token && !is_nil(token.total_supply_updated_at_block) &&
             BlockNumber.get_max() - token.total_supply_updated_at_block > @ttl_in_blocks) do
       token_address_hash_string = to_string(address_hash)
 


### PR DESCRIPTION
## Motivation

An error is observed on some envs:
`{"time":"2025-09-18T10:39:08.726Z","severity":"error","message":"GenServer Indexer.Fetcher.OnDemand.TokenTotalSupply terminating\n** (ArithmeticError) bad argument in arithmetic expression\n    :erlang.-(42183506, nil)\n    (indexer 9.1.1) lib/indexer/fetcher/on_demand/token_total_supply.ex:52: Indexer.Fetcher.OnDemand.TokenTotalSupply.do_fetch/1\n    (indexer 9.1.1) lib/indexer/fetcher/on_demand/token_total_supply.ex:41: Indexer.Fetcher.OnDemand.TokenTotalSupply.handle_cast/2\n    (stdlib 6.2.2) gen_server.erl:2371: :gen_server.try_handle_cast/3\n    (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\n    (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3\nLast message: {:\"$gen_cast\", {:fetch_and_update, %Explorer.Chain.Hash{byte_count: 20, bytes: <<193, 44, 30, 80, 171, 180, 80, 214, 32, 94, 162, 195, 250, 134, 27, 59, 131, 77, 19, 232>>}}}\nState: [supervisor: #PID<0.7844.0>]","metadata":{"error":{"initial_call":null,"reason":"** (ArithmeticError) bad argument in arithmetic expression\n    :erlang.-(42183506, nil)\n    (indexer 9.1.1) lib/indexer/fetcher/on_demand/token_total_supply.ex:52: Indexer.Fetcher.OnDemand.TokenTotalSupply.do_fetch/1\n    (indexer 9.1.1) lib/indexer/fetcher/on_demand/token_total_supply.ex:41: Indexer.Fetcher.OnDemand.TokenTotalSupply.handle_cast/2\n    (stdlib 6.2.2) gen_server.erl:2371: :gen_server.try_handle_cast/3\n    (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\n    (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3\n"}}}`

## Changelog

### AI Agent summary

This pull request updates the logic for deciding when to fetch a token's total supply in `Indexer.Fetcher.OnDemand.TokenTotalSupply`. The change improves the conditional check to ensure that the code only attempts to fetch the total supply when necessary, preventing potential errors when `total_supply_updated_at_block` is `nil`.

Logic improvement for token supply fetching:

* Refined the conditional statement to check that `token.total_supply_updated_at_block` is not `nil` before comparing block numbers, ensuring correct behavior and preventing errors when the field is unset. (`apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.ex`, [apps/indexer/lib/indexer/fetcher/on_demand/token_total_supply.exL52-R53](diffhunk://#diff-1695306231491fef9b11cbe806c34128d64a7ef97a5189067d371e3e0eb72047L52-R53))

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed condition that could trigger erroneous token total supply refreshes when prior update timestamps were absent.

* **Performance**
  * Avoided unnecessary TTL-based refresh checks by ensuring they're only evaluated when a previous update exists.

* **Reliability**
  * Made token total supply refresh behavior more consistent and predictable by tightening refresh conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->