### PR TITLE
fix: Add reputation preload to celo base fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug Fixes
 
+- Fix token transfer test for celo ([#13250](https://github.com/blockscout/blockscout/pull/13250))
+- Add reputation preload to celo base fee ([#13248](https://github.com/blockscout/blockscout/pull/13248))
 - Add reputation preload for user op body for transaction interpreter ([#13241](https://github.com/blockscout/blockscout/pull/13241))
 - Fix condition in Indexer.Fetcher.OnDemand.TokenTotalSupply fetcher ([#13240](https://github.com/blockscout/blockscout/pull/13240))
 - Add reputation preload to state changes and bridged tokens ([#13235](https://github.com/blockscout/blockscout/pull/13235))

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
@@ -13,13 +13,20 @@ defmodule BlockScoutWeb.API.V2.CeloView do
   alias Explorer.Chain.Cache.{CeloCoreContracts, CeloEpochs}
   alias Explorer.Chain.Celo.Helper, as: CeloHelper
   alias Explorer.Chain.Celo.{Epoch, EpochReward}
-  alias Explorer.Chain.{Block, Token, TokenTransfer, Transaction, Wei}
+  alias Explorer.Chain.{Address.Reputation, Block, Token, TokenTransfer, Transaction, Wei}
 
   @address_params [
     necessity_by_association: %{
       :names => :optional,
       :smart_contract => :optional,
       proxy_implementations_association() => :optional
+    },
+    api?: true
+  ]
+
+  @token_params [
+    necessity_by_association: %{
+      Reputation.reputation_association() => :optional
     },
     api?: true
   ]
@@ -499,7 +506,7 @@ defmodule BlockScoutWeb.API.V2.CeloView do
           }
         )
 
-      celo_token = Token.get_by_contract_address_hash(celo_token_address_hash, api?: true)
+      celo_token = Token.get_by_contract_address_hash(celo_token_address_hash, @token_params)
 
       %{
         recipient: fee_handler_contract_address_info,
@@ -566,7 +573,7 @@ defmodule BlockScoutWeb.API.V2.CeloView do
           address_hash
         )
 
-      celo_token = Token.get_by_contract_address_hash(celo_token_address_hash, api?: true)
+      celo_token = Token.get_by_contract_address_hash(celo_token_address_hash, @token_params)
 
       %{
         recipient: address_with_info,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -287,28 +287,28 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         original_celo_config = Application.get_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts)
 
         # Set up Celo core contracts configuration for base fee
-        fee_handler_address = "0x" <> String.duplicate("1", 40)
-        governance_address = "0x" <> String.duplicate("2", 40)
-        celo_token_address = "0x" <> String.duplicate("3", 40)
+        fee_handler_address = insert(:address)
+        governance_address = insert(:address)
+        celo_token_address = insert(:address)
 
         celo_config = [
           contracts: %{
             "addresses" => %{
               "FeeHandler" => [
                 %{
-                  "address" => fee_handler_address,
+                  "address" => to_string(fee_handler_address.hash),
                   "updated_at_block_number" => 0
                 }
               ],
               "Governance" => [
                 %{
-                  "address" => governance_address,
+                  "address" => to_string(governance_address.hash),
                   "updated_at_block_number" => 0
                 }
               ],
               "GoldToken" => [
                 %{
-                  "address" => celo_token_address,
+                  "address" => to_string(celo_token_address.hash),
                   "updated_at_block_number" => 0
                 }
               ]
@@ -317,7 +317,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
               "FeeHandler" => %{
                 "FeeBeneficiarySet" => [
                   %{
-                    "address_hash" => "0x" <> String.duplicate("4", 40),
+                    "address_hash" => to_string(insert(:address).hash),
                     "updated_at_block_number" => 0
                   }
                 ],
@@ -334,21 +334,14 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
         Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts, celo_config)
 
-        address = insert(:address, hash: celo_token_address)
-
         # Create a CELO token for the response
-        celo_token =
-          insert(:token,
-            contract_address_hash: celo_token_address,
-            contract_address: address,
-            symbol: "CELO",
-            name: "Celo",
-            type: "ERC-20"
-          )
-
-        # Create addresses for fee handler and beneficiary
-        fee_handler_address_record = insert(:address, hash: fee_handler_address)
-        fee_beneficiary_address_record = insert(:address, hash: "0x" <> String.duplicate("4", 40))
+        insert(:token,
+          contract_address_hash: celo_token_address.hash,
+          contract_address: celo_token_address,
+          symbol: "CELO",
+          name: "Celo",
+          type: "ERC-20"
+        )
 
         # Create a block with base fee and transactions
         block =
@@ -358,20 +351,19 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
           )
 
         # Create transactions for the block to calculate burnt fees
-        transactions =
-          for index <- 0..2 do
-            insert(:transaction,
-              block_hash: block.hash,
-              block_number: block.number,
-              # 2 gwei
-              gas_price: 2_000_000_000,
-              gas_used: 21_000,
-              max_fee_per_gas: 2_000_000_000,
-              max_priority_fee_per_gas: 1_000_000_000,
-              cumulative_gas_used: 21_000,
-              index: index
-            )
-          end
+        for index <- 0..2 do
+          insert(:transaction,
+            block_hash: block.hash,
+            block_number: block.number,
+            # 2 gwei
+            gas_price: 2_000_000_000,
+            gas_used: 21_000,
+            max_fee_per_gas: 2_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            cumulative_gas_used: 21_000,
+            index: index
+          )
+        end
 
         # Make the request
         request = get(conn, "/api/v2/blocks/#{block.hash}")
@@ -423,21 +415,21 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         original_celo_config = Application.get_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts)
 
         # Set up Celo core contracts configuration with only governance (no fee handler)
-        governance_address = "0x" <> String.duplicate("2", 40)
-        celo_token_address = "0x" <> String.duplicate("3", 40)
+        governance_address = insert(:address)
+        celo_token_address = insert(:address)
 
         celo_config = [
           contracts: %{
             "addresses" => %{
               "Governance" => [
                 %{
-                  "address" => governance_address,
+                  "address" => to_string(governance_address.hash),
                   "updated_at_block_number" => 0
                 }
               ],
               "GoldToken" => [
                 %{
-                  "address" => celo_token_address,
+                  "address" => to_string(celo_token_address.hash),
                   "updated_at_block_number" => 0
                 }
               ]
@@ -447,19 +439,14 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
         Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts, celo_config)
 
-        address = insert(:address, hash: celo_token_address)
         # Create a CELO token for the response
-        celo_token =
-          insert(:token,
-            contract_address_hash: celo_token_address,
-            contract_address: address,
-            symbol: "CELO",
-            name: "Celo",
-            type: "ERC-20"
-          )
-
-        # Create governance address
-        governance_address_record = insert(:address, hash: governance_address)
+        insert(:token,
+          contract_address_hash: celo_token_address.hash,
+          contract_address: celo_token_address,
+          symbol: "CELO",
+          name: "Celo",
+          type: "ERC-20"
+        )
 
         # Create a block with base fee and transactions
         block =
@@ -469,20 +456,19 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
           )
 
         # Create transactions for the block to calculate burnt fees
-        transactions =
-          for index <- 0..2 do
-            insert(:transaction,
-              block_hash: block.hash,
-              block_number: block.number,
-              # 2 gwei
-              gas_price: 2_000_000_000,
-              gas_used: 21_000,
-              max_fee_per_gas: 2_000_000_000,
-              max_priority_fee_per_gas: 1_000_000_000,
-              cumulative_gas_used: 21_000,
-              index: index
-            )
-          end
+        for index <- 0..2 do
+          insert(:transaction,
+            block_hash: block.hash,
+            block_number: block.number,
+            # 2 gwei
+            gas_price: 2_000_000_000,
+            gas_used: 21_000,
+            max_fee_per_gas: 2_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            cumulative_gas_used: 21_000,
+            index: index
+          )
+        end
 
         # Make the request
         request = get(conn, "/api/v2/blocks/#{block.hash}")


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - API v2 block responses for Celo include detailed base fee info: recipient, amount, token metadata (e.g., CELO), and breakdown.
  - Added Celo-specific fields in block responses: epoch_number and is_epoch_block.
  - Improved token metadata resolution to consider reputation context.
  - Graceful fallback when the fee handler is unavailable: base_fee is returned with an empty breakdown.

- Tests
  - Added comprehensive Celo-focused tests validating base fee details and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->