### PR TITLE
feat: Fields for OP Withdrawal Claim button

### DIFF
--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -145,6 +145,12 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     For each withdrawal associated with this transaction,
     returns the status, the corresponding L1 transaction hash if the status is `Relayed`,
     and withdrawal message's data (such as nonce, sender, target, etc.).
+
+    ## Parameters
+    - `l2_transaction_hash`: The transaction hash associated with the withdrawal.
+
+    ## Returns
+    - A tuple containing the withdrawal message nonce, the withdrawal status, and a map with other message's data.
   """
   @spec transaction_statuses(Hash.t()) :: [{non_neg_integer(), String.t(), map()}]
   def transaction_statuses(l2_transaction_hash) do
@@ -454,10 +460,27 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     end
   end
 
+  @doc """
+    Returns a signature of the `MessagePassed` event emitted by `L2ToL1MessagePasser` contract
+    in form of 0x-prefixed string.
+
+    ## Returns
+    - A 0x-prefixed string representing the signature.
+  """
+  @spec message_passed_event() :: String.t()
   def message_passed_event, do: @message_passed_event
 
-  def portal_contract_address_constant, do: "optimism_portal_contract_address"
+  @doc """
+    Returns `OptimismPortal` contract address. First, the function tries to get the address from the
+    `INDEXER_OPTIMISM_L1_PORTAL_CONTRACT` env variable. If that's not defined, the address is retrieved
+    from the database (constants table) where it was saved by other modules. If the address is unknown,
+    the function returns `nil`.
 
+    ## Returns
+    - The OptimismPortal contract address in form of 0x-prefixed string.
+    - `nil` if the address cannot be determined.
+  """
+  @spec portal_contract_address() :: String.t() | nil
   def portal_contract_address do
     portal_address = Application.get_all_env(:indexer)[Indexer.Fetcher.Optimism][:portal]
 
@@ -467,4 +490,6 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
       Constants.get_constant_value(portal_contract_address_constant(), @api_true)
     end
   end
+
+  def portal_contract_address_constant, do: "optimism_portal_contract_address"
 end

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -491,5 +491,9 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     end
   end
 
+  @doc """
+  Returns the name of the optimism_portal_contract_address constant.
+  """
+  @spec portal_contract_address_constant() :: binary()
   def portal_contract_address_constant, do: "optimism_portal_contract_address"
 end

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -80,7 +80,7 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
             left_join: log in Log,
             on:
               log.transaction_hash == w.l2_transaction_hash and log.first_topic == ^@message_passed_event and
-                log.second_topic == fragment("convert_numeric_to_bytea(msg_nonce)"),
+                log.second_topic == fragment("numeric_to_bytea32(msg_nonce)"),
             select: %{
               msg_nonce: w.msg_nonce,
               hash: w.hash,
@@ -164,7 +164,7 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
         left_join: log in Log,
         on:
           log.transaction_hash == w.l2_transaction_hash and log.first_topic == ^@message_passed_event and
-            log.second_topic == fragment("convert_numeric_to_bytea(msg_nonce)"),
+            log.second_topic == fragment("numeric_to_bytea32(msg_nonce)"),
         select: %{
           hash: w.hash,
           l2_block_number: w.l2_block_number,

--- a/apps/explorer/lib/explorer/helper.ex
+++ b/apps/explorer/lib/explorer/helper.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Helper do
   address.
 
   ## Parameters
-  - `address_hash` (`EthereumJSONRPC.hash()` | `nil`): The full address hash to
+  - `address_hash` (`EthereumJSONRPC.hash()` | `Hash.t()` | `nil`): The full address hash to
     be truncated, or `nil`.
 
   ## Returns
@@ -51,11 +51,20 @@ defmodule Explorer.Helper do
       iex> truncate_address_hash("0x000000000000000000000000abcdef1234567890abcdef1234567890abcdef")
       "0xabcdef1234567890abcdef1234567890abcdef"
 
+      iex> truncate_address_hash(%Explorer.Chain.Hash{byte_count: 32, bytes: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7>>})
+      "0x4200000000000000000000000000000000000007"
+
       iex> truncate_address_hash(nil)
       "0x0000000000000000000000000000000000000000"
   """
-  @spec truncate_address_hash(EthereumJSONRPC.hash() | nil) :: EthereumJSONRPC.address()
+  @spec truncate_address_hash(EthereumJSONRPC.hash() | Hash.t() | nil) :: EthereumJSONRPC.address()
   def truncate_address_hash(address_hash)
+
+  def truncate_address_hash(%Hash{} = address_hash) do
+    address_hash
+    |> Hash.to_string()
+    |> truncate_address_hash()
+  end
 
   def truncate_address_hash(nil), do: burn_address_hash_string()
 

--- a/apps/explorer/priv/optimism/migrations/20250919073011_op_withdrawal_claim_button.exs
+++ b/apps/explorer/priv/optimism/migrations/20250919073011_op_withdrawal_claim_button.exs
@@ -1,0 +1,31 @@
+defmodule Explorer.Repo.Optimism.Migrations.OPWithdrawalClaimButton do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    CREATE OR REPLACE FUNCTION convert_numeric_to_bytea(n NUMERIC, zero_left_pad INT default 32) RETURNS BYTEA AS $$
+    DECLARE
+        result BYTEA := '';
+        v INT;
+        i INT := 0;
+    BEGIN
+        WHILE n > 0 LOOP
+            v := n % 256;
+            result := SET_BYTE(('\\x00' || result), 0, v);
+            n := (n - v) / 256;
+            i := i + 1;
+        END LOOP;
+
+        i := zero_left_pad - i;
+
+        WHILE i > 0 LOOP
+          result := '\\x00'::bytea || result;
+          i := i - 1;
+        END LOOP;
+
+        RETURN result;
+    END;
+    $$ LANGUAGE PLPGSQL IMMUTABLE STRICT;
+    """)
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -18,8 +18,10 @@ defmodule Indexer.Fetcher.Optimism do
 
   alias EthereumJSONRPC.Block.{ByHash, ByNumber}
   alias EthereumJSONRPC.{Blocks, Contract}
+  alias Explorer.Application.Constants
   alias Explorer.Chain.Cache.ChainId
   alias Explorer.Chain.Cache.Counters.LastFetchedCounter
+  alias Explorer.Chain.Optimism.Withdrawal
   alias Explorer.Chain.RollupReorgMonitorQueue
   alias Explorer.Repo
   alias Indexer.Fetcher.RollupL1ReorgMonitor
@@ -245,6 +247,10 @@ defmodule Indexer.Fetcher.Optimism do
             |> Enum.at(1)
             |> Map.get(:result, fallback_start_block)
             |> quantity_to_integer()
+
+          if not is_nil(optimism_portal) do
+            Constants.set_constant_value(Withdrawal.portal_contract_address_constant(), optimism_portal)
+          end
 
           {optimism_portal, start_block}
 

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -249,6 +249,7 @@ defmodule Indexer.Fetcher.Optimism do
             |> quantity_to_integer()
 
           if not is_nil(optimism_portal) do
+            # we save the OptimismPortal contract address to use it in other modules (e.g. by `BlockScoutWeb.API.V2.OptimismView`)
             Constants.set_constant_value(Withdrawal.portal_contract_address_constant(), optimism_portal)
           end
 

--- a/apps/indexer/lib/indexer/transform/optimism/withdrawals.ex
+++ b/apps/indexer/lib/indexer/transform/optimism/withdrawals.ex
@@ -5,11 +5,9 @@ defmodule Indexer.Transform.Optimism.Withdrawals do
 
   require Logger
 
+  alias Explorer.Chain.Optimism.Withdrawal
   alias Indexer.Fetcher.Optimism.Withdrawal, as: OptimismWithdrawal
   alias Indexer.Helper
-
-  # 32-byte signature of the event MessagePassed(uint256 indexed nonce, address indexed sender, address indexed target, uint256 value, uint256 gasLimit, bytes data, bytes32 withdrawalHash)
-  @message_passed_event "0x02a52367d10742d8032712c1bb8e0144ff1ec5ffda1ed7d70bb05a2744955054"
 
   @doc """
   Returns a list of withdrawals given a list of logs.
@@ -23,10 +21,11 @@ defmodule Indexer.Transform.Optimism.Withdrawals do
            message_passer = Application.get_env(:indexer, OptimismWithdrawal)[:message_passer],
            true <- Helper.address_correct?(message_passer) do
         message_passer = String.downcase(message_passer)
+        message_passed_event = Withdrawal.message_passed_event()
 
         logs
         |> Enum.filter(fn log ->
-          !is_nil(log.first_topic) && String.downcase(log.first_topic) == @message_passed_event &&
+          !is_nil(log.first_topic) && String.downcase(log.first_topic) == message_passed_event &&
             String.downcase(Helper.address_hash_to_string(log.address_hash)) == message_passer
         end)
         |> Enum.map(fn log ->


### PR DESCRIPTION
The current `Ready for relay` link in the `Status` column on the [OP Withdrawals](https://explorer.optimism.io/withdrawals) page refers to an external page like https://app.optimism.io/bridge/withdraw (which is defined with `NEXT_PUBLIC_ROLLUP_L2_WITHDRAWAL_URL` env variable on the frontend side). The corresponding `Claim funds` button on L2 transaction page (e.g. [this one](https://explorer.optimism.io/tx/0x7b316519fcf0b7b4cb387dbffeea1e16636c3c44400c90e0644e75a25cda073c)) has the same reference.

To improve user experience, the `Claim` button can directly call the `finalizeWithdrawalTransactionExternalProof` function of the `OptimismPortal` contract: https://github.com/ethereum-optimism/optimism/blob/ca32a273895b45794e7adf5e72d5695b752d69a6/packages/contracts-bedrock/src/L1/OptimismPortal2.sol#L432-L435. So, when a user clicks the button, MetaMask (or other wallet) window can be opened to perform the finalization transaction.

Related frontend task: https://github.com/blockscout/frontend/issues/3022

To do the call, according to the `finalizeWithdrawalTransactionExternalProof` source code, we need to know the following parameters:
- `uint256 nonce`
- `address sender`
- `address target`
- `uint256 value`
- `uint256 gasLimit`
- `bytes data`
- `address _proofSubmitter`

When these parameters are known, we can call the `finalizeWithdrawalTransactionExternalProof` as follows: `finalizeWithdrawalTransactionExternalProof((uint256 nonce, address sender, address target, uint256 value, uint256 gasLimit, bytes data), address _proofSubmitter)`.

This ABI encoding should be done on the frontend side. For that, the first 6 parameters can be taken from the following fields of API responses (`/api/v2/optimism/withdrawals` or `/api/v2/transactions/:transaction_hash_param`):
- `msg_nonce_raw`
- `msg_sender_address_hash`
- `msg_target_address_hash`
- `msg_value`
- `msg_gas_limit`
- `msg_data`

The `_proofSubmitter` value should be taken from the `from` field of the corresponding API response. The address of the `OptimismPortal` contract is taken from the `portal_contract_address_hash` field (see examples below).

Example of `/api/v2/optimism/withdrawals` response when the fields are known:

```
     ...
     "msg_data": "0xd764ad0b",
     "msg_gas_limit": "492846",
     "msg_nonce_raw": "1766847064778384329583297500742918515827483896875618958121606201292644896",
     "msg_sender_address_hash": "0x4200000000000000000000000000000000000007",
     "msg_target_address_hash": "0xdc40a14d9abd6f410226f1e6de71ae03441ca506",
     "msg_value": "6429402968663914968",
     "portal_contract_address_hash": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
     ...
```

Example of `/api/v2/optimism/withdrawals` response when the fields are unknown:

```
     ...
     "msg_data": null,
     "msg_gas_limit": null,
     "msg_nonce_raw": "1766847064778384329583297500742918515827483896875618958121606201292644896",
     "msg_sender_address_hash": null,
     "msg_target_address_hash": null,
     "msg_value": null,
     "portal_contract_address_hash": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
     ...
```

Example of `/api/v2/transactions/:transaction_hash_param` response when the fields are known:

```
  "op_withdrawals": [
    {
      ...
      "msg_data": "0xd764ad0b",
      "msg_gas_limit": "492846",
      "msg_nonce_raw": "1766847064778384329583297500742918515827483896875618958121606201292644896",
      "msg_sender_address_hash": "0x4200000000000000000000000000000000000007",
      "msg_target_address_hash": "0xdc40a14d9abd6f410226f1e6de71ae03441ca506",
      "msg_value": "6429402968663914968",
      "portal_contract_address_hash": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
      ...
    }
  ]
```

Example of `/api/v2/transactions/:transaction_hash_param` response when the fields are unknown:

```
  "op_withdrawals": [
    {
      ...
      "msg_data": null,
      "msg_gas_limit": null,
      "msg_nonce_raw": "1766847064778384329583297500742918515827483896875618958121606201292644896",
      "msg_sender_address_hash": null,
      "msg_target_address_hash": null,
      "msg_value": null,
      "portal_contract_address_hash": "0x1a0ad011913a150f69f6a19df447a0cfd9551054",
      ...
    }
  ]
```

If at least one of the `msg_*` fields or `portal_contract_address_hash` is `null`, the frontend should use a URL defined in `NEXT_PUBLIC_ROLLUP_L2_WITHDRAWAL_URL` env as fallback.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimism withdrawals and interop messages now include sender, target, value, gas limit, data, and portal contract address in API responses.

* **Improvements**
  * Portal contract address is auto-detected and surfaced where applicable.
  * Centralized MessagePassed event detection for more reliable message handling.
  * Address truncation accepts additional hash formats for consistent display.

* **Chores**
  * DB migration adds numeric-to-bytes utility to support withdrawal claim operations.
  * Initialization persists the Optimism portal address in app constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->