### PR TITLE
fix: Fix recollated transactions deadlock

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -667,7 +667,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           where: block.hash in ^all_block_hashes,
           # Enforce Block ShareLocks order (see docs: sharelocks.md)
           order_by: [asc: block.hash],
-          lock: "FOR NO KEY UPDATE"
+          lock: "FOR UPDATE"
         )
 
       transactions_query =


### PR DESCRIPTION
## Motivation

Existing blocks locks may happen twice in transactions runner since they are first explicitly updated in `discard_blocks_for_recollated_transactions` and then implicitly locked by transactions insert (as a FK check). This may lead to a deadlocks.

## Changelog

Acquire lock for all blocks that will be affected by transactions runner cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures all relevant blocks are consistently selected and updated during imports, preventing missed or partial updates and keeping block/transaction views accurate.

* **Performance Improvements**
  * Streamlines block filtering to avoid redundant updates, improving import stability and throughput.

* **Refactor**
  * Harmonizes selection and update logic and strengthens update locking to ensure predictable, consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->