### PR TITLE
fix: Improve timeout exception definition

### DIFF
--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -254,10 +254,18 @@ defmodule Indexer.Block.Catchup.Fetcher do
   end
 
   defp timeout_exception?(%{message: message}) when is_binary(message) do
-    String.match?(message, ~r/due to a timeout/) or String.match?(message, ~r/due to user request/)
+    match_timeout_exception?(message)
+  end
+
+  defp timeout_exception?(%{postgres: %{message: message}}) when is_binary(message) do
+    match_timeout_exception?(message)
   end
 
   defp timeout_exception?(_exception), do: false
+
+  defp match_timeout_exception?(error_message) do
+    String.match?(error_message, ~r/due to a timeout/) or String.match?(error_message, ~r/due to user request/)
+  end
 
   defp add_range_to_massive_blocks(range) do
     clear_missing_ranges(range)


### PR DESCRIPTION
## Changelog

Added `timeout_exception?` case for errors of `Postgrex.Error` type where error message is under the `postgres.message`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability when detecting database timeout and user-cancel errors, including nested messages, reducing misclassified failures and improving stability during indexing operations.

* **Refactor**
  * Consolidates timeout detection into a single helper for consistent behavior and easier maintenance across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->