### PR TITLE
fix: Hide compile-time chain type API routes in other chain type swaggers

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -121,7 +121,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
 
     get("/smart-contracts/:address_hash_param", V2.ImportController, :try_to_search_contract)
 
-    chain_scope :optimism do
+    if @chain_type == :optimism do
       post("/optimism/interop/", V2.OptimismController, :interop_import)
     end
   end
@@ -141,7 +141,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/csv-export", V2.ConfigController, :csv_export)
       get("/public-metrics", V2.ConfigController, :public_metrics)
 
-      chain_scope :celo do
+      if @chain_type == :celo do
         get("/celo", V2.ConfigController, :celo)
       end
     end
@@ -163,7 +163,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/arbitrum-batch/:batch_number", V2.TransactionController, :arbitrum_batch)
       end
 
-      chain_scope :optimism do
+      if @chain_type == :optimism do
         get("/optimism-batch/:batch_number", V2.TransactionController, :optimism_batch)
       end
 
@@ -191,7 +191,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/:transaction_hash_param/blobs", V2.TransactionController, :blobs)
       end
 
-      chain_scope :ethereum do
+      if @chain_type == :ethereum do
         get("/:transaction_hash_param/beacon/deposits", V2.TransactionController, :beacon_deposits)
       end
     end
@@ -216,7 +216,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/arbitrum-batch/:batch_number_param", V2.BlockController, :arbitrum_batch)
       end
 
-      chain_scope :optimism do
+      if @chain_type == :optimism do
         get("/optimism-batch/:batch_number_param", V2.BlockController, :optimism_batch)
       end
 
@@ -224,7 +224,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         get("/scroll-batch/:batch_number_param", V2.BlockController, :scroll_batch)
       end
 
-      chain_scope :ethereum do
+      if @chain_type == :ethereum do
         get("/:block_hash_or_number_param/beacon/deposits", V2.BlockController, :beacon_deposits)
       end
     end
@@ -251,12 +251,12 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:address_hash_param/nft", V2.AddressController, :nft_list)
       get("/:address_hash_param/nft/collections", V2.AddressController, :nft_collections)
 
-      chain_scope :celo do
+      if @chain_type == :celo do
         get("/:address_hash_param/celo/election-rewards", V2.AddressController, :celo_election_rewards)
         get("/:address_hash_param/celo/election-rewards/csv", V2.CsvExportController, :celo_election_rewards_csv)
       end
 
-      chain_scope :ethereum do
+      if @chain_type == :ethereum do
         get("/:address_hash_param/beacon/deposits", V2.AddressController, :beacon_deposits)
       end
     end
@@ -267,7 +267,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/transactions/watchlist", V2.MainPageController, :watchlist_transactions)
       get("/indexing-status", V2.MainPageController, :indexing_status)
 
-      chain_scope :optimism do
+      if @chain_type == :optimism do
         get("/optimism-deposits", V2.MainPageController, :optimism_deposits)
       end
 
@@ -298,7 +298,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       end
     end
 
-    chain_scope :optimism do
+    if @chain_type == :optimism do
       scope "/optimism" do
         get("/txn-batches", V2.OptimismController, :transaction_batches)
         get("/txn-batches/count", V2.OptimismController, :transaction_batches_count)
@@ -322,7 +322,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       end
     end
 
-    chain_scope :celo do
+    if @chain_type == :celo do
       scope "/celo/epochs" do
         get("/", V2.CeloController, :epochs)
         get("/:number", V2.CeloController, :epoch)
@@ -431,7 +431,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       end
     end
 
-    chain_scope :ethereum do
+    if @chain_type == :ethereum do
       scope "/beacon" do
         get("/deposits", V2.Ethereum.DepositController, :list)
         get("/deposits/count", V2.Ethereum.DepositController, :count)


### PR DESCRIPTION
## Motivation

API endpoints - related to compile-time chain types appeared in the Swagger API spec files for other chain types. For instance, https://github.com/blockscout/swaggers/blob/master/blockscout/9.1.1/default/swagger.yaml contains API endpoints:

```
GET /api/v2/blocks/optimism-batch/{batch_number_param} - effectively, "optimism" chain_type-related
GET /api/v2/addresses/{address_hash_param}/beacon/deposits - effectively, "ethereum" chain_type-related
GET /api/v2/addresses/{address_hash_param}/celo/election-rewards - effectively, "celo" chain_type-related
...
```

## Changelog

Switch from runtime to compile-time comparison of `CHAIN_TYPE` for the appearance of API endpoints bound to compile-time chain types such as ethereum, optimism, celo.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined API route registration to respect the configured chain type at runtime.
  * Networks now expose only the routes relevant to their chain, improving consistency across deployments.
  * No changes to endpoint paths; route availability may vary by network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->