### PR TITLE
fix: enforce legacy query usage when sort by id

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -1455,19 +1455,23 @@ defmodule Explorer.Chain.SmartContract do
     # If no sorting options are provided, we sort by `:id` descending only. If
     # there are some sorting options supplied, we sort by `:hash` ascending as a
     # secondary key.
-    {sorting_options, default_sorting_options} =
+    {sorting_options, default_sorting_options, use_legacy_query?} =
       options
       |> Keyword.get(:sorting)
       |> case do
         nil ->
-          {[], [{:desc, :id, :smart_contract}]}
+          {[], [{:desc, :id, :smart_contract}], true}
 
         options ->
-          {options, [asc: :hash]}
+          {options, [asc: :hash], false}
       end
 
+    # We don't use alias so the mock of background_migrations_finished?/0 in
+    # tests is working properly
+    #
+    # credo:disable-for-lines:2 Credo.Check.Design.AliasUsage
     addresses_query =
-      if background_migrations_finished?() do
+      if Explorer.Chain.SmartContract.background_migrations_finished?() and not use_legacy_query? do
         verified_addresses_query(options)
       else
         # Legacy query approach - will be removed in future releases


### PR DESCRIPTION
## Changelog

### Bug Fixes

This bug happened due to https://github.com/blockscout/blockscout/pull/12767. By default, results are sorted by id. In case when background migrations are finished, we don't use legacy query. However, the new query is inefficient when sorting by id is applied. Thus, we should use the legacy one. 

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability of the Verified Contracts list across environments, ensuring consistent results during background data migrations.
  * Resolves inconsistencies when viewing the list without an explicit sort.

* **Performance**
  * Enhances responsiveness of the Verified Contracts list by choosing the most suitable query based on sorting and migration state.
  * Reduces the likelihood of timeouts or slow loads when browsing or sorting verified contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->