### PR TITLE
fix: Fix web tests after hiding compile-time chain types routes

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -5496,8 +5496,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     end
   end
 
-  describe "/addresses/{address_hash}/beacon/deposits" do
-    if Application.compile_env(:explorer, :chain_type) == :ethereum do
+  if @chain_type == :ethereum do
+    describe "/addresses/{address_hash}/beacon/deposits" do
       test "get empty list on non-existing address", %{conn: conn} do
         address = build(:address)
 
@@ -5530,16 +5530,12 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         request = get(conn, "/api/v2/addresses/#{address.hash}/beacon/deposits")
         assert response = json_response(request, 200)
 
-        request_2nd_page = get(conn, "/api/v2/addresses/#{address.hash}/beacon/deposits", response["next_page_params"])
+        request_2nd_page =
+          get(conn, "/api/v2/addresses/#{address.hash}/beacon/deposits", response["next_page_params"])
+
         assert response_2nd_page = json_response(request_2nd_page, 200)
 
         check_paginated_response(response, response_2nd_page, deposits)
-      end
-    else
-      test "returns an error about chain type", %{conn: conn} do
-        request = get(conn, "/api/v2/addresses/address/beacon/deposits")
-        assert response = json_response(request, 404)
-        assert %{"message" => "Endpoint not available for current chain type"} = response
       end
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -905,8 +905,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     end
   end
 
-  describe "blocks/{block_hash_or_number}/beacon/deposits" do
-    if Application.compile_env(:explorer, :chain_type) == :ethereum do
+  if @chain_type == :ethereum do
+    describe "blocks/{block_hash_or_number}/beacon/deposits" do
       test "get 404 on non-existing block", %{conn: conn} do
         block = build(:block)
 
@@ -976,13 +976,6 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
         assert response_2nd_page = json_response(request_2nd_page, 200)
 
         check_paginated_response(response, response_2nd_page, deposits)
-      end
-    else
-      test "returns an error about chain type", %{conn: conn} do
-        block = insert(:block)
-        request = get(conn, "/api/v2/blocks/#{block.hash}/beacon/deposits")
-        assert response = json_response(request, 404)
-        assert %{"message" => "Endpoint not available for current chain type"} = response
       end
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/ethereum/deposit_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/ethereum/deposit_controller_test.exs
@@ -1,9 +1,10 @@
 defmodule BlockScoutWeb.Api.V2.Ethereum.DepositControllerTest do
   use BlockScoutWeb.ConnCase
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Explorer.Repo
 
-  if Application.compile_env(:explorer, :chain_type) == :ethereum do
+  if @chain_type == :ethereum do
     describe "/beacon/deposits" do
       test "get empty list when no deposits exist", %{conn: conn} do
         request = get(conn, "/api/v2/beacon/deposits")
@@ -48,22 +49,6 @@ defmodule BlockScoutWeb.Api.V2.Ethereum.DepositControllerTest do
         request = get(conn, "/api/v2/beacon/deposits/count")
         assert response = json_response(request, 200)
         assert %{"deposits_count" => ^deposits_count} = response
-      end
-    end
-  else
-    describe "/beacon/deposits" do
-      test "returns an error about chain type", %{conn: conn} do
-        request = get(conn, "/api/v2/beacon/deposits/count")
-        assert response = json_response(request, 404)
-        assert %{"message" => "Endpoint not available for current chain type"} = response
-      end
-    end
-
-    describe "/beacon/deposits/count" do
-      test "returns an error about chain type", %{conn: conn} do
-        request = get(conn, "/api/v2/beacon/deposits/count")
-        assert response = json_response(request, 404)
-        assert %{"message" => "Endpoint not available for current chain type"} = response
       end
     end
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/optimism_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/optimism_controller_test.exs
@@ -36,11 +36,6 @@ defmodule BlockScoutWeb.API.V2.OptimismControllerTest do
                  "next_page_params" => nil
                } = json_response(conn, 200)
       end
-    else
-      test "returns 404 in non optimism chain type", %{conn: conn} do
-        conn = get(conn, "/api/v2/optimism/interop/messages")
-        assert json_response(conn, 404) == %{"message" => "Endpoint not available for current chain type"}
-      end
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -2085,8 +2085,8 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     end
   end
 
-  describe "transactions/{transaction_hash}/beacon/deposits" do
-    if Application.compile_env(:explorer, :chain_type) == :ethereum do
+  if @chain_type == :ethereum do
+    describe "transactions/{transaction_hash}/beacon/deposits" do
       test "get 404 on non-existing transaction", %{conn: conn} do
         transaction = build(:transaction)
 
@@ -2110,13 +2110,6 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         assert response_2nd_page = json_response(request_2nd_page, 200)
 
         check_paginated_response(response, response_2nd_page, deposits)
-      end
-    else
-      test "returns an error about chain type", %{conn: conn} do
-        transaction = insert(:transaction)
-        request = get(conn, "/api/v2/transactions/#{transaction.hash}/beacon/deposits")
-        assert response = json_response(request, 404)
-        assert %{"message" => "Endpoint not available for current chain type"} = response
       end
     end
   end


### PR DESCRIPTION
## Motivation

Some web tests are in failed state after merging [13309](https://github.com/blockscout/blockscout/pull/13309).

## Changelog

Hide corresponding web tests under compile-time chain type.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Consolidated Ethereum-specific beacon/deposit tests so they run only on Ethereum, and removed now-irrelevant fallback 404 tests for non-Ethereum chains.
  - Consolidated Optimism interop tests to run only on Optimism; removed non-Optimism fallback test.
  - Minor test flow and pagination formatting adjustments preserved.
  - No user-facing changes; production behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->