### PR TITLE
fix: Sanitize internal transaction error before insertion

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -456,6 +456,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         entry
         |> Map.put(:block_hash, block_hash)
         |> Map.put(:block_index, index)
+        |> sanitize_error()
       end)
     else
       []
@@ -493,6 +494,21 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     else
       {:ok, internal_transactions}
     end
+  end
+
+  defp sanitize_error(entry) do
+    error = Map.get(entry, :error)
+
+    sanitized_error =
+      if is_binary(error) and not String.printable?(error) do
+        error
+        |> inspect(binaries: :as_strings)
+        |> String.trim("\"")
+      else
+        error
+      end
+
+    Map.put(entry, :error, sanitized_error)
   end
 
   def defer_internal_transactions_primary_key(repo) do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13343

## Motivation

In cases when an error in trace has non UTF8 characters there will be error on insertion like this

`ERROR 22021 (character_not_in_repertoire) invalid byte sequence for encoding "UTF8"`

## Changelog

If error is not printable, convert it to printable string before insertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal transaction error messages are now consistently readable; previously, non-printable data could appear as garbled characters.
  * Aligns error field formatting across processing paths, reducing inconsistencies users might see in lists, details, and exports.
  * Improves clarity when reviewing failed internal transactions, making error information easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->