### PR TITLE
chore(ReindexDuplicatedInternalTransactions): optimize migration performance

### DIFF
--- a/apps/explorer/test/explorer/migrator/reindex_duplicated_internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/migrator/reindex_duplicated_internal_transactions_test.exs
@@ -5,6 +5,20 @@ defmodule Explorer.Migrator.ReindexDuplicatedInternalTransactionsTest do
   alias Explorer.Migrator.{MigrationStatus, ReindexDuplicatedInternalTransactions}
   alias Explorer.Repo
 
+  setup_all do
+    opts = Application.get_env(:explorer, Explorer.Migrator.ReindexDuplicatedInternalTransactions)
+
+    Application.put_env(:explorer, Explorer.Migrator.ReindexDuplicatedInternalTransactions,
+      batch_size: 1,
+      concurrency: 1,
+      timeout: 0
+    )
+
+    on_exit(fn ->
+      Application.put_env(:explorer, Explorer.Migrator.ReindexDuplicatedInternalTransactions, opts)
+    end)
+  end
+
   test "Reindex duplicated internal transactions" do
     transaction_from_invalid_block_1 =
       :transaction
@@ -57,7 +71,7 @@ defmodule Explorer.Migrator.ReindexDuplicatedInternalTransactionsTest do
         :internal_transaction,
         transaction: transaction_from_invalid_block_2,
         index: index - 10,
-        block_number: nil,
+        block_number: transaction_from_invalid_block_2.block_number,
         transaction_index: transaction_from_invalid_block_2.index,
         block_hash: transaction_from_invalid_block_2.block_hash,
         block_index: index


### PR DESCRIPTION
## Motivation

After replacing `block_hash` with `block_number` in https://github.com/blockscout/blockscout/pull/13084, the migration performance improved. But right now it still requires ~1 hour to complete one iteration on eth-mainnet and is tending to increase over time.

That happens because in order to find the value to delete, migration iterates through the whole `internal_transactions_block_number_DESC_transaction_index_DESC_` index until it finds the required number of blocks, and as the size of the index is quite big, it takes time.

The issue is that on each iteration the migration starts over and every time goes through the index from the very beginning. That job is absolutely redundant though, as once checked block numbers lying in that range will always be valid. 

### Enhancements

This PR adds the mechanism to follow the last processed block number which starts the next iteration exactly from the last unchecked block. That is expected to reduce the migration time significantly, resulting in just exactly one index scan being enough to process all affected blocks.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
