### PR TITLE
fix: ignore old reorgs in beacon deposits fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
+++ b/apps/indexer/lib/indexer/fetcher/beacon/deposit.ex
@@ -93,30 +93,25 @@ defmodule Indexer.Fetcher.Beacon.Deposit do
 
   @impl GenServer
   def handle_cast({:lost_consensus, block_number}, %__MODULE__{} = state) do
-    max_reorg_depth_block_number = block_number + 64
-
-    {_deleted_deposits_count, _deleted_deposits} =
+    {_deleted_deposits_count, deleted_deposits} =
       Repo.delete_all(
         from(
           d in Deposit,
           where: d.block_number > ^block_number,
-          where: d.block_number <= ^max_reorg_depth_block_number,
           select: d.index
         ),
         timeout: :infinity
       )
 
-    # todo: temporarily do not modify state of the indexer on reorgs.
-    # It should be handled by a separate process.
-    # deposit_index = Enum.min(deleted_deposits, fn -> state.deposit_index + 1 end)
-    # {:noreply,
-    #  %{
-    #    state
-    #    | deposit_index: deposit_index - 1,
-    #      last_processed_log_block_number: block_number,
-    #      last_processed_log_index: -1
-    #  }}
-    {:noreply, state}
+    deposit_index = Enum.min(deleted_deposits, fn -> state.deposit_index + 1 end)
+
+    {:noreply,
+     %{
+       state
+       | deposit_index: deposit_index - 1,
+         last_processed_log_block_number: block_number,
+         last_processed_log_index: -1
+     }}
   rescue
     postgrex_error in Postgrex.Error ->
       Logger.error(


### PR DESCRIPTION
Fix #13404

## Changelog
Trigger reorg handling only if reorg is not 64 blocks older than a maximum known block

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined consensus block removal handling with more precise signaling logic for recent blocks.
  * Enhanced beacon deposit reorganization processing with improved state tracking and deposit index management.

* **Tests**
  * Added test coverage for beacon deposit reorg handling across different block scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->