### PR TITLE
chore: Allow api_key in the query string for api/v2/tokens/:address_hash/instances/refetch-metadata endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Allow api_key in the query string for api/v2/tokens/:address_hash/instances/refetch-metadata endpoint ([#13412](https://github.com/blockscout/blockscout/pull/13412))
 - Add migration to delete zero-value calls ([#13305](https://github.com/blockscout/blockscout/issues/13305))
 - *(ReindexDuplicatedInternalTransactions)* Optimize migration performance ([#13363](https://github.com/blockscout/blockscout/issues/13363))
 - OpenAPI spec for the REST API endpoints in  token and CSV export controllers ([#13311](https://github.com/blockscout/blockscout/issues/13311))

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -482,7 +482,21 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @doc """
-  Returns a parameter definition for API key used in rate limiting.
+  Returns a parameter definition for API key for sensitive endpoints in the query string.
+  """
+  @spec admin_api_key_param_query() :: Parameter.t()
+  def admin_api_key_param_query do
+    %Parameter{
+      name: :api_key,
+      in: :query,
+      schema: %Schema{type: :string},
+      required: false,
+      description: "API key required for sensitive endpoints"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for API key header for sensitive endpoints.
   """
   @spec admin_api_key_param() :: Parameter.t()
   def admin_api_key_param do
@@ -518,7 +532,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       in: :query,
       schema: %Schema{type: :string},
       required: false,
-      description: "API key for rate limiting",
+      description: "API key for rate limiting or for sensitive endpoints",
       name: :apikey
     }
   end


### PR DESCRIPTION
## Motivation

Return allowance of `api_key` in the query string for api/v2/tokens/:address_hash/instances/refetch-metadata endpoint

## Changelog

### AI Agent summary

This pull request updates how API keys are retrieved for sensitive endpoints in the `TokenController`, improving flexibility and maintainability. The main change is refactoring the logic to support API key extraction from both request headers and query parameters, and updating documentation to reflect this.

API key handling improvements:

* Refactored API key extraction in `TokenController` to use a new private function `get_api_key/1`, which checks the `x-api-key` header first and falls back to the `api_key` query parameter. This makes authentication more robust and easier to maintain. [[1]](diffhunk://#diff-95d76435450c661eb4e54054710772f7e709fa4be24c61b569b13d1eca378828L716-R717) [[2]](diffhunk://#diff-95d76435450c661eb4e54054710772f7e709fa4be24c61b569b13d1eca378828R730-R739)
* Added `Plug.Conn` alias to support usage of `get_req_header` for cleaner code in API key extraction.

Documentation update:

* Updated the API schema description for the API key parameter to clarify that it is used for both rate limiting and sensitive endpoints.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The token metadata refetch endpoint now accepts the API key via query string in addition to the header.

* **Documentation**
  * Clarified that the API key may be used for rate limiting and for sensitive endpoints, and noted query-string support for the refetch endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->