### PR TITLE
fix: Fix logic of disable token exchange rate

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -500,7 +500,7 @@ config :explorer, Explorer.Market.Fetcher.Coin,
   enable_consolidation: true,
   cache_period: ConfigHelper.parse_time_env_var("MARKET_COIN_CACHE_PERIOD", "10m")
 
-disable_token_exchange_rates? =  ConfigHelper.parse_bool_env_var("DISABLE_TOKEN_EXCHANGE_RATE")
+disable_token_exchange_rates? = ConfigHelper.parse_bool_env_var("DISABLE_TOKEN_EXCHANGE_RATE")
 market_tokens_fetcher_enabled? = ConfigHelper.parse_bool_env_var("MARKET_TOKENS_FETCHER_ENABLED", "true")
 
 config :explorer, Explorer.Market.Fetcher.Token,


### PR DESCRIPTION

## Motivation



## Changelog

### Bug Fixes

Fixed boolean logic of the `DISABLE_TOKEN_EXCHANGE_RATE` ENV.


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added new environment toggles to control token exchange-rate behavior and market token fetching, allowing finer runtime control.
  * Market token fetcher enabling logic updated to require both exchange-rate support and the new fetcher-specific toggle before activating.
  * Removed a public chain cache configuration entry for uncles (ttl_check_interval and global_ttl) to simplify and reduce exposed runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->