### PR TITLE
chore: silence multiple cspell complaints

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -21,7 +21,11 @@
     ],
     "ignoreRegExpList": [
         // Ignore filecoin f410f-like native addresses
-        "f410f[a-z2-7]{39}"
+        "f410f[a-z2-7]{39}",
+        // Ignore long base64/base58-style account identifiers (TON addresses, hashes, etc.)
+        "[A-Za-z0-9+\\-:]{40,}",
+        // Ignore escaped hex byte sequences inside strings
+        "\\\\x[0-9a-f]{2,}"
     ],
     // words - list of words to be always considered correct
     "words": [
@@ -735,6 +739,9 @@
         "WITHDRAWABILITY",
         "wobserver",
         "wysdvjkizxonu",
+        "x-ratelimit-limit",
+        "x-ratelimit-remaining",
+        "x-ratelimit-reset",
         "xact",
         "xakgj",
         "xbaddress",


### PR DESCRIPTION
Fix cspell complaints for:

- `x-ratelimit-*` headers
- TON address fixtures
- `\\x…` hex sequences

Before:

<img width="1140" height="431" alt="image" src="https://github.com/user-attachments/assets/815d758e-6da4-4349-8b93-0473b9fa69d3" />

After:

<img width="490" height="37" alt="image" src="https://github.com/user-attachments/assets/457efd87-2459-46d3-a1bb-7a4ef9988707" />

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated spell-checking configuration to recognize additional identifiers and rate-limit-related terms, improving development tooling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->