### PR TITLE
fix: Set timeout: :infinity for DeleteZeroValueInternalTransactions

### DIFF
--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -104,7 +104,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
           on: join_on_ctid(it, locked_it)
         )
 
-      Repo.delete_all(delete_query)
+      Repo.delete_all(delete_query, timeout: :infinity)
     end)
   end
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background database cleanup operations by enhancing timeout handling to prevent interruptions during long-running deletion processes, ensuring critical internal data maintenance tasks complete successfully without timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->