### PR TITLE
chore: Rollback metadata preloads at the main page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ### ⚡ Performance
 
-- Remove BENS, metadata preloads from the main page API endpoints ([#13442](https://github.com/blockscout/blockscout/pull/13442))
+- Remove BENS preload from the main page API endpoints ([#13442](https://github.com/blockscout/blockscout/pull/13442), [#13449](https://github.com/blockscout/blockscout/pull/13449))
 - Batch preload token transfers in `/api/v2/celo/epochs` ([#13398](https://github.com/blockscout/blockscout/issues/13398))
 - Optimize token balance synchronous import steps ([#13217](https://github.com/blockscout/blockscout/issues/13217))
 - Optimize `EmptyBlocksSanitizer` queries ([#13132](https://github.com/blockscout/blockscout/issues/13132))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -8,6 +8,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
   alias Explorer.Chain.Optimism.Deposit
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
+  import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
   import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
 
   case @chain_type do
@@ -49,7 +50,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     conn
     |> put_status(200)
     |> put_view(BlockView)
-    |> render(:blocks, %{blocks: blocks})
+    |> render(:blocks, %{blocks: blocks |> maybe_preload_metadata()})
   end
 
   def optimism_deposits(conn, _params) do
@@ -71,7 +72,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     conn
     |> put_status(200)
     |> put_view(TransactionView)
-    |> render(:transactions, %{transactions: recent_transactions})
+    |> render(:transactions, %{transactions: recent_transactions |> maybe_preload_metadata()})
   end
 
   def watchlist_transactions(conn, _params) do
@@ -82,7 +83,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
       |> put_status(200)
       |> put_view(TransactionView)
       |> render(:transactions_watchlist, %{
-        transactions: transactions,
+        transactions: transactions |> maybe_preload_metadata(),
         watchlist_names: watchlist_names
       })
     end


### PR DESCRIPTION
## Motivation

Finalization of https://github.com/blockscout/blockscout/pull/13442


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced metadata availability for blocks and transactions displayed on the main page.

* **Documentation**
  * Updated changelog entry for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->