### PR TITLE
fix: null-checks for distribution field in celo epochs api

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/celo_view.ex
@@ -20,9 +20,17 @@ defmodule BlockScoutWeb.API.RPC.CeloView do
       "endProcessingBlockHash" => epoch.end_processing_block && to_string(epoch.end_processing_block.hash),
       "endProcessingBlockNumber" => epoch.end_processing_block && to_string(epoch.end_processing_block.number),
       "carbonOffsettingTargetEpochRewards" =>
-        distribution.carbon_offsetting_transfer && distribution.carbon_offsetting_transfer.amount,
-      "communityTargetEpochRewards" => distribution.community_transfer && distribution.community_transfer.amount,
-      "reserveBolster" => distribution.reserve_bolster_transfer && distribution.reserve_bolster_transfer.amount,
+        distribution &&
+          distribution.carbon_offsetting_transfer &&
+          distribution.carbon_offsetting_transfer.amount,
+      "communityTargetEpochRewards" =>
+        distribution &&
+          distribution.community_transfer &&
+          distribution.community_transfer.amount,
+      "reserveBolster" =>
+        distribution &&
+          distribution.reserve_bolster_transfer &&
+          distribution.reserve_bolster_transfer.amount,
       "voterTargetEpochRewards" => aggregated_rewards.voter && aggregated_rewards.voter.total,
       "validatorTargetEpochRewards" => aggregated_rewards.validator && aggregated_rewards.validator.total
     }


### PR DESCRIPTION

The following APIv1 celo endpoint doesn't work for not yet fetched epochs

`/api?module=epoch&action=getepoch&epochNumber=...`

The error is:

```
2025-10-27T14:21:48.920 application=api request_id=GHJVOVBlC3gtQOoAAX4C [error] Error while calling RPC action"** (Plug.Conn.WrapperError) ** (KeyError) key :carbon_offsetting_transfer not found in: nil\n\nIf you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map\
...
```

Fixed by additional safe checks when accessing struct fields. 

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null-safety validation for Celo transfer operations (carbon offsetting, community, and reserve transfers) to prevent potential runtime errors and improve application stability during transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->