### PR TITLE
fix: AverageBlockTime for sub-second blocks

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/chain/cache/counters/average_block_time.ex
@@ -96,7 +96,14 @@ defmodule Explorer.Chain.Cache.Counters.AverageBlockTime do
 
     timestamps =
       raw_timestamps
-      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &Timex.after?/2)
+      |> Enum.sort(fn
+        {number_a, timestamp_a}, {number_b, timestamp_b} ->
+          case Timex.compare(timestamp_a, timestamp_b) do
+            1 -> true
+            -1 -> false
+            0 -> number_a > number_b
+          end
+      end)
       |> Enum.map(fn {number, timestamp} ->
         {number, DateTime.to_unix(timestamp, :millisecond)}
       end)

--- a/apps/explorer/test/explorer/chain/cache/counters/average_block_time_test.exs
+++ b/apps/explorer/test/explorer/chain/cache/counters/average_block_time_test.exs
@@ -183,5 +183,31 @@ defmodule Explorer.Chain.Cache.Counters.AverageBlockTimeTest do
 
       assert Timex.Duration.to_milliseconds(AverageBlockTime.average_block_time()) == 3000
     end
+
+    test "handles sub-second blocks" do
+      block_number = 99_999_999
+
+      first_timestamp = Timex.now()
+
+      Enum.each(1..200//2, fn i ->
+        insert(:block,
+          number: block_number + i,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: div(i + 1, 2))
+        )
+
+        insert(:block,
+          number: block_number + i + 1,
+          consensus: true,
+          timestamp: Timex.shift(first_timestamp, seconds: div(i + 1, 2))
+        )
+      end)
+
+      AverageBlockTime.refresh()
+
+      avg_time = Timex.Duration.to_milliseconds(AverageBlockTime.average_block_time())
+
+      assert avg_time > 490 and avg_time < 510
+    end
   end
 end


### PR DESCRIPTION
Fix #13469 

## Changelog

Now we sort `{number, timestamp}` tuples only by timestamp from query, so we can get something like this 
`[{4, 10}, {5, 10}, {2, 9}, {3, 9}]` and calculations are wrong
Added number to the sort, so after these changes result will be
`[{5, 10}, {4, 10}, {3, 9}, {2, 9}]`

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
