### PR TITLE
fix: ERC-1155 value in advanced filters csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug Fixes
 
+- ERC-1155 value in advanced filters csv ([#13474](https://github.com/blockscout/blockscout/pull/13474))
 - Fix /api/v2/tokens endpoints: allow back limit param ([#13473](https://github.com/blockscout/blockscout/pull/13473))
 - Incorrect average block time for sub-second blocks ([#13469](https://github.com/blockscout/blockscout/issues/13469))
 - Remove transaction_has_multiple_internal_transactions filter ([#13453](https://github.com/blockscout/blockscout/pull/13453))

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/advanced_filter_view.ex
@@ -114,10 +114,16 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterView do
       Address.checksum(advanced_filter.token_transfer.token.contract_address_hash),
       decimal_to_string(token_transfer_total["decimals"], :normal),
       advanced_filter.token_transfer.token.symbol,
-      token_transfer_total["decimals"] &&
-        token_transfer_total["value"]
-        |> Decimal.div(Integer.pow(10, Decimal.to_integer(token_transfer_total["decimals"])))
-        |> decimal_to_string(:xsd),
+      case token_transfer_total["decimals"] do
+        nil ->
+          decimal_to_string(token_transfer_total["value"], :xsd)
+
+        decimals ->
+          token_transfer_total["value"] &&
+            token_transfer_total["value"]
+            |> Decimal.div(Integer.pow(10, Decimal.to_integer(decimals)))
+            |> decimal_to_string(:xsd)
+      end,
       token_transfer_total["token_id"],
       advanced_filter.block_number,
       decimal_to_string(advanced_filter.fee, :normal),


### PR DESCRIPTION
## Motivation

Missing token value in csv for ERC-1155

## Changelog

I didn't take into account that ERC-1155 does not have decimals, so now it processed correctly

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ERC-1155 token values in Advanced Filters CSV export when decimal info is missing so numeric values display properly.
  * Ensured CSV export preserves consistent column structure for token transfers by adding empty placeholders when specific token fields are absent, keeping rows aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->