### PR TITLE
fix: Add missing query binding to txlistinternal query

### DIFF
--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -242,6 +242,7 @@ defmodule Explorer.Etherscan do
   defp internal_transactions_query(options, consensus_blocks) do
     from(
       it in InternalTransaction,
+      as: :internal_transaction,
       inner_join: block in subquery(consensus_blocks),
       on: it.block_number == block.number,
       order_by: [


### PR DESCRIPTION
## Motivation

`(Ecto.QueryError) unknown bind name :internal_transaction in query: ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal query performance and structure for transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->