### PR TITLE
fix: Fix batch_number_param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Incorrect average block time for sub-second blocks ([#13469](https://github.com/blockscout/blockscout/issues/13469))
 - Remove transaction_has_multiple_internal_transactions filter ([#13453](https://github.com/blockscout/blockscout/pull/13453))
 - celo accounts transformer ([#13423](https://github.com/blockscout/blockscout/pull/13423))
-- Fix broken txn batch blocks API endpoint ([#13438](https://github.com/blockscout/blockscout/pull/13438), [#13482](https://github.com/blockscout/blockscout/pull/13482))
+- Fix broken txn batch blocks API endpoint ([#13438](https://github.com/blockscout/blockscout/pull/13438), [#13483](https://github.com/blockscout/blockscout/pull/13483))
 - Set timeout: :infinity for DeleteZeroValueInternalTransactions ([#13434](https://github.com/blockscout/blockscout/pull/13434))
 - Fix DeleteZeroValueInternalTransactions state keys ([#13431](https://github.com/blockscout/blockscout/pull/13431))
 - dump block_hash to binary when querying celo epoch distributions ([#13410](https://github.com/blockscout/blockscout/pull/13410))

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -222,6 +222,7 @@ defmodule BlockScoutWeb.PagingHelper do
     params
     |> Map.drop([
       :address_hash_param,
+      :batch_number_param,
       :block_hash_or_number_param,
       :token_id_param,
       :token_id,
@@ -242,9 +243,8 @@ defmodule BlockScoutWeb.PagingHelper do
       "state_filter",
       "l2_block_range_start",
       "l2_block_range_end",
-      # remove in favour batch_number_param in the future when all batch - related API endpoints are covered with OpenAPI spec.
-      "batch_number",
-      "batch_number_param"
+      # remove in favour :batch_number_param in the future when all batch - related API endpoints are covered with OpenAPI spec.
+      "batch_number"
     ])
   end
 


### PR DESCRIPTION
## Motivation

Finalization of #13438, #13482

## Changelog

### AI Agent summary

This pull request makes a small update to the `BlockScoutWeb.PagingHelper` module to clarify and standardize how batch number parameters are handled in API endpoint filtering.

* The `Map.drop/2` function now drops the atom key `:batch_number_param` instead of the string key `"batch_number_param"`, aligning with the usage of atom keys for parameters.
* The comment and filtering logic in the string keys list have been updated to remove `"batch_number_param"` and clarify that `"batch_number"` will be removed in favor of `:batch_number_param` once all batch-related endpoints are covered by the OpenAPI spec.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination parameter handling to ensure proper cleanup of unnecessary parameters during page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->