### PR TITLE
Add EXPOSE and HEALTHCHECK to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,4 +89,9 @@ COPY --from=builder --chown=${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app/config/a
 
 RUN mkdir dets && mkdir temp && chown -R ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP} /app
 
+# Expose default web port and add a basic healthcheck so orchestrators can verify the app is responsive.
+EXPOSE 4000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:4000/ || exit 1
+
 USER ${BLOCKSCOUT_USER}:${BLOCKSCOUT_GROUP}


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/closing-issues-using-keywords)_

## Motivation

_Why we should merge these changes. If using GitHub keywords to close [issues](https://github.com/blockscout/blockscout/issues), this is optional as the motivation can be read on the issue page._

## Changelog

Add EXPOSE and HEALTHCHECK to Dockerfile

Expose port 4000 in the final image to document the web service port and help container runtimes.
Add a basic HEALTHCHECK that probes http://localhost:4000/ using curl. This provides a simple liveness check for orchestrators (Docker, Kubernetes) and helps detect unresponsive containers sooner.
No behavioral changes to the application; healthcheck is lightweight and configurable if alternative endpoint or settings are needed.
Notes:

If your app uses a different port or a dedicated health endpoint, adjust the EXPOSE and HEALTHCHECK accordingly.

### Enhancements

_Things you added that don't break anything. Regression tests for Bug Fixes count as Enhancements._

### Bug Fixes

_Things you changed that fix bugs. If it fixes a bug but, in so doing, adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should also be added to "Incompatible Changes" below._

### Incompatible Changes

_Things you broke while doing Enhancements and Bug Fixes. Breaking changes include (1) adding new requirements and (2) removing code. Renaming counts as (2) because a rename is a removal followed by an add._

## Upgrading

_If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally. A common upgrading step is "Database reset and re-index required"._

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker deployment configuration with automated health monitoring to enhance service reliability and readiness verification.
  * Added health checks with configurable parameters to ensure service availability during container startup and runtime.
  * Enhanced port configuration for optimal accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->