### PR TITLE
fix: Fix REST API token holders pagination

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -877,7 +877,7 @@ defmodule BlockScoutWeb.Chain do
   end
 
   defp paging_params(%CurrentTokenBalance{address_hash: address_hash, value: value}) do
-    %{"address_hash" => to_string(address_hash), "value" => Decimal.to_integer(value)}
+    %{address_hash: to_string(address_hash), value: to_string(Decimal.to_integer(value))}
   end
 
   defp paging_params(%CoinBalance{block_number: block_number}) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -189,20 +189,20 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   end
 
   operation :holders,
-    summary: "List holders for a specific token instance",
-    description: "Retrieves holders for a specific token instance, with optional filtering and pagination.",
+    summary: "List holders for a specific token",
+    description: "Retrieves holders for a specific token, with optional filtering and pagination.",
     parameters:
       base_params() ++
         [address_hash_param()] ++
-        define_paging_params(["address_hash_2", "value", "items_count"]),
+        define_paging_params(["address_hash_param", "value", "items_count"]),
     responses: [
       ok:
         {"List of token holders.", "application/json",
          paginated_response(
            items: Schemas.Token.Holder,
            next_page_params_example: %{
-             "address_hash_2" => "0x48bb9b14483e43c7726df702b271d410e7460656",
-             "value" => 200_000_000_000_000,
+             "address_hash" => "0x48bb9b14483e43c7726df702b271d410e7460656",
+             "value" => "200000000000000",
              "items_count" => 50
            },
            title_prefix: "TokenHolders"
@@ -446,17 +446,17 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     parameters:
       base_params() ++
         [address_hash_param(), token_id_param()] ++
-        define_paging_params(["address_hash_2", "items_count", "token_id", "value"]),
+        define_paging_params(["address_hash_param", "items_count", "token_id", "value"]),
     responses: [
       ok:
         {"List of token holders for the instance.", "application/json",
          paginated_response(
            items: Schemas.Token.Holder,
            next_page_params_example: %{
-             "address_hash_2" => "0x1d2c163fbda9486c3a384b6fa5e34c96fe948e9a",
+             "address_hash" => "0x1d2c163fbda9486c3a384b6fa5e34c96fe948e9a",
              "items_count" => 50,
              "token_id" => "0",
-             "value" => 4_217_417_051_704_137_590_935
+             "value" => "4217417051704137590935"
            },
            title_prefix: "TokenInstanceHolders"
          )},

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -678,20 +678,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       description: "Address hash for paging",
       name: :hash
     },
-    # todo: consider refactoring to eliminate _2 suffix
-    "address_hash_2" => %Parameter{
-      in: :query,
-      schema: AddressHash,
-      required: false,
-      description: "Address hash for paging",
-      name: :address_hash
-    },
     "address_hash_param" => %Parameter{
       in: :query,
       schema: AddressHash,
       required: false,
       description: "Address hash for paging",
-      name: :hash
+      name: :address_hash
     },
     "contract_address_hash" => %Parameter{
       in: :query,


### PR DESCRIPTION
## Motivation

```
{
    "errors": [
        {
            "title": "Invalid value",
            "source": {
                "pointer": "/value"
            },
            "detail": "Invalid format. Expected ~r/^-?([1-9][0-9]*|0)$/"
        }
    ]
}
```

in the request like `/api/v2/tokens/:token_address_hash/holders?address_hash=:address_hash&items_count=50&value=4e%2B21`

## Changelog

### AI Agent summary

This pull request updates the API and schema for token holder paging parameters to standardize naming and improve clarity. The main changes involve removing the ambiguous `address_hash_2` parameter and consistently using `address_hash` or `address_hash_param` across the codebase. This helps prevent confusion and aligns parameter names with their actual usage.

**API parameter naming standardization:**

* Removed the `address_hash_2` parameter from the paging parameters in `BlockScoutWeb.Schemas.API.V2.General` and replaced it with `address_hash_param`, ensuring the name matches usage throughout the API. (`apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex`)
* Updated API documentation and controller logic in `TokenController` to use `address_hash_param` instead of `address_hash_2` for paging, and changed all example responses to use `address_hash` in place of `address_hash_2`. (`apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex`) [[1]](diffhunk://#diff-95d76435450c661eb4e54054710772f7e709fa4be24c61b569b13d1eca378828L192-R204) [[2]](diffhunk://#diff-95d76435450c661eb4e54054710772f7e709fa4be24c61b569b13d1eca378828L449-R456)

**Internal parameter formatting:**

* Changed the format of the paging parameters returned by `paging_params/1` in `BlockScoutWeb.Chain` to use atom keys (`:address_hash`, `:value`) instead of string keys, improving consistency with Elixir conventions. (`apps/block_scout_web/lib/block_scout_web/chain.ex`)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized API parameter naming and formatting for token holder endpoints to enhance consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->