### PR TITLE
fix: duplicated block numbers in int txs queue

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -865,9 +865,11 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
 
   defp save_internal_transactions_for_delete(repo, non_consensus_blocks, %{timeout: timeout, timestamps: timestamps}) do
     insert_params =
-      Enum.map(non_consensus_blocks, fn {number, _hash} ->
+      non_consensus_blocks
+      |> Enum.map(fn {number, _hash} ->
         Map.put(timestamps, :block_number, number)
       end)
+      |> Enum.uniq()
 
     {_total, result} =
       repo.insert_all(


### PR DESCRIPTION
Fix #13555 

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate internal transaction entries during import by ensuring only unique entries are inserted, improving data integrity and import reliability.
  * Conflict handling and returned data remain unchanged; no public API or interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->