### PR TITLE
fix: Reset ResetSanitizeDuplicatedLogsMigration status

### DIFF
--- a/apps/explorer/priv/repo/migrations/20251111085348_reset_sanitize_duplicated_logs_migration.exs
+++ b/apps/explorer/priv/repo/migrations/20251111085348_reset_sanitize_duplicated_logs_migration.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.ResetSanitizeDuplicatedLogsMigration do
+  use Ecto.Migration
+
+  def change do
+    execute("DELETE FROM migrations_status WHERE migration_name = 'sanitize_duplicated_log_index_logs'")
+  end
+end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13308

## Motivation

We should restart the migration after fix since its direction has changed from forward to backward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database maintenance migration to reset log sanitization status, ensuring proper synchronization of database migration records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->