### PR TITLE
chore: Remove address-related props from sending to multichain service

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -23,7 +23,6 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
   @max_concurrency 5
   @post_timeout :timer.minutes(5)
-  @unspecified "UNSPECIFIED"
 
   @doc """
   Processes a batch import of data by splitting the input parameters into chunks and sending each chunk as an HTTP POST request to a configured microservice endpoint.

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -1321,31 +1321,19 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                  hash: "0x" <> Base.encode16(address_1.hash.bytes, case: :lower),
                  is_contract: false,
                  is_verified_contract: false,
-                 contract_name: nil,
-                 token_name: nil,
-                 token_type: "UNSPECIFIED",
-                 is_token: false,
-                 ens_name: "te.eth"
+                 contract_name: nil
                },
                %{
                  hash: "0x" <> Base.encode16(address_2.hash.bytes, case: :lower),
                  is_contract: true,
                  is_verified_contract: false,
-                 contract_name: nil,
-                 token_name: nil,
-                 token_type: "UNSPECIFIED",
-                 is_token: false,
-                 ens_name: nil
+                 contract_name: nil
                },
                %{
                  hash: "0x" <> Base.encode16(address_3.hash.bytes, case: :lower),
                  is_contract: true,
                  is_verified_contract: true,
-                 contract_name: "SimpleStorage",
-                 token_name: "Main Token",
-                 token_type: "ERC-721",
-                 is_token: true,
-                 ens_name: nil
+                 contract_name: "SimpleStorage"
                }
              ]
 
@@ -1371,12 +1359,8 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
   defp address_export_data(address) do
     %{
       hash: "0x" <> Base.encode16(address.hash.bytes, case: :lower),
-      token_type: "UNSPECIFIED",
       is_contract: false,
-      token_name: nil,
       contract_name: nil,
-      ens_name: nil,
-      is_token: false,
       is_verified_contract: false
     }
   end

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/main_export_queue_test.exs
@@ -178,22 +178,14 @@ defmodule Indexer.Fetcher.MultichainSearchDb.MainExportQueueTest do
                     addresses: [
                       %{
                         hash: ^address_2_hash_string,
-                        token_type: "UNSPECIFIED",
                         is_contract: false,
-                        token_name: nil,
                         contract_name: nil,
-                        ens_name: nil,
-                        is_token: false,
                         is_verified_contract: false
                       },
                       %{
                         hash: ^address_1_hash_string,
-                        token_type: "UNSPECIFIED",
                         is_contract: false,
-                        token_name: nil,
                         contract_name: nil,
-                        ens_name: nil,
-                        is_token: false,
                         is_verified_contract: false
                       }
                     ],


### PR DESCRIPTION
## Motivation

Props:
- ens_name
- token_name
- token_type
- is_token

are ignored in the latest release (v2.0.0) of the multichain service.

## Changelog

### AI Agent summary

This pull request simplifies the `Explorer.MicroserviceInterfaces.MultichainSearch` module by removing all logic and fields related to token information from the address serialization process. This streamlines the code and reduces unnecessary complexity when dealing with address data.

**Address serialization simplification:**

* Removed the `is_token`, `token_name`, `token_type`, and `ens_name` fields from the address serialization output in the `to_serializable_address/1` function.
* Deleted the private helper functions `token?/1`, `get_token_name/1`, and `get_token_type/1`, which were previously used to extract token-related information from address data.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed token-related metadata from address export/formatting, producing a leaner address representation in multichain exports.

* **Tests**
  * Updated test fixtures and expectations to match the new, simplified address data shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->