### PR TITLE
feat: Add metadata to eth bytecode DB lookup request

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -198,8 +198,8 @@ defmodule Explorer.SmartContract.Helper do
     Metadata will be sent to a verifier microservice
   """
   @spec fetch_data_for_verification(binary() | Hash.t()) :: {binary() | nil, binary(), map()}
-  def fetch_data_for_verification(address_hash) do
-    deployed_bytecode = Chain.smart_contract_bytecode(address_hash)
+  def fetch_data_for_verification(address_hash, deployed_bytecode \\ nil) do
+    deployed_bytecode = deployed_bytecode || Chain.smart_contract_bytecode(address_hash)
 
     metadata = %{
       "contractAddress" => to_string(address_hash),

--- a/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface_behaviour.ex
+++ b/apps/explorer/lib/explorer/smart_contract/rust_verifier_interface_behaviour.ex
@@ -24,7 +24,7 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
             } = body,
             metadata
           ) do
-        http_post_request(solidity_multiple_files_verification_url(), append_metadata(body, metadata), true)
+        http_post_request(solidity_multiple_files_verification_url(), append_metadata(body, metadata))
       end
 
       def verify_standard_json_input(
@@ -36,7 +36,7 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
             } = body,
             metadata
           ) do
-        http_post_request(solidity_standard_json_verification_url(), append_metadata(body, metadata), true)
+        http_post_request(solidity_standard_json_verification_url(), append_metadata(body, metadata))
       end
 
       def zksync_verify_standard_json_input(
@@ -48,7 +48,7 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
             } = body,
             metadata
           ) do
-        http_post_request(solidity_standard_json_verification_url(), append_metadata(body, metadata), true)
+        http_post_request(solidity_standard_json_verification_url(), append_metadata(body, metadata))
       end
 
       def vyper_verify_multipart(
@@ -60,7 +60,7 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
             } = body,
             metadata
           ) do
-        http_post_request(vyper_multiple_files_verification_url(), append_metadata(body, metadata), true)
+        http_post_request(vyper_multiple_files_verification_url(), append_metadata(body, metadata))
       end
 
       def vyper_verify_standard_json(
@@ -72,15 +72,13 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
             } = body,
             metadata
           ) do
-        http_post_request(vyper_standard_json_verification_url(), append_metadata(body, metadata), true)
+        http_post_request(vyper_standard_json_verification_url(), append_metadata(body, metadata))
       end
 
-      def http_post_request(url, body, is_verification_request?, options \\ []) do
+      def http_post_request(url, body, options \\ []) do
         headers = [{"Content-Type", "application/json"}]
 
-        case HttpClient.post(url, Jason.encode!(body), maybe_put_api_key_header(headers, is_verification_request?),
-               recv_timeout: @post_timeout
-             ) do
+        case HttpClient.post(url, Jason.encode!(body), put_api_key_header(headers), recv_timeout: @post_timeout) do
           {:ok, %{body: body, status_code: _}} ->
             process_verifier_response(body, options)
 
@@ -100,9 +98,7 @@ defmodule Explorer.SmartContract.RustVerifierInterfaceBehaviour do
         end
       end
 
-      defp maybe_put_api_key_header(headers, false), do: headers
-
-      defp maybe_put_api_key_header(headers, true) do
+      defp put_api_key_header(headers) do
         api_key = Application.get_env(:explorer, Explorer.SmartContract.RustVerifierInterfaceBehaviour)[:api_key]
 
         if api_key do


### PR DESCRIPTION
Closes #13357


## Changelog
- Add metadata and x-api-key header to eth bytecode DB lookup request
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved smart contract verification data retrieval workflow.
  * Enhanced metadata handling for contract verification searches.
  * Simplified HTTP request processing for verification operations.
  * Optimized data flow across smart contract lookup and verification systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->