### PR TITLE
fix: Fix filecoin web tests

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address.ex
@@ -14,6 +14,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations do
     nullable: true
   }
 
+  @doc """
+   OpenAPI schema for Filecoin robust address.
+  """
+  @spec filecoin_robust_address_schema() :: Schema.t()
+  def filecoin_robust_address_schema, do: @filecoin_robust_address_schema
+
   def chain_type_fields(schema) do
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/response.ex
@@ -1,18 +1,12 @@
 defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations do
   @moduledoc false
   require OpenApiSpex
+  import BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations, only: [filecoin_robust_address_schema: 0]
 
   alias BlockScoutWeb.Schemas.{API.V2.Address, Helper}
   alias OpenApiSpex.Schema
 
   use Utils.RuntimeEnvHelper, chain_identity: [:explorer, :chain_identity]
-
-  @filecoin_robust_address_schema %Schema{
-    type: :string,
-    description: "Robust f0/f1/f2/f3/f4 Filecoin address",
-    example: "f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
-    nullable: true
-  }
 
   @zilliqa_schema %Schema{
     type: :object,
@@ -84,7 +78,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations 
       {:filecoin, nil} ->
         schema
         |> Helper.extend_schema(
-          properties: %{creator_filecoin_robust_address: @filecoin_robust_address_schema},
+          properties: %{creator_filecoin_robust_address: filecoin_robust_address_schema()},
           required: [:creator_filecoin_robust_address]
         )
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/implementation/chain_type_customizations.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/implementation/chain_type_customizations.ex
@@ -1,6 +1,6 @@
 defmodule BlockScoutWeb.Schemas.API.V2.General.Implementation.ChainTypeCustomizations do
   @moduledoc false
-  alias OpenApiSpex.Schema
+  import BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations, only: [filecoin_robust_address_schema: 0]
 
   @doc """
    Applies chain-specific field customizations to the given schema based on the configured chain type.
@@ -14,18 +14,13 @@ defmodule BlockScoutWeb.Schemas.API.V2.General.Implementation.ChainTypeCustomiza
   @spec chain_type_fields(map()) :: map()
   def chain_type_fields(schema) do
     alias BlockScoutWeb.Schemas.Helper
-    alias OpenApiSpex.Schema
 
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
         |> Helper.extend_schema(
           properties: %{
-            filecoin_robust_address: %Schema{
-              type: :string,
-              example: "f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
-              nullable: true
-            }
+            filecoin_robust_address: filecoin_robust_address_schema()
           },
           required: [:filecoin_robust_address]
         )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
@@ -1,5 +1,6 @@
 defmodule BlockScoutWeb.Schemas.API.V2.SmartContract.ChainTypeCustomizations do
   @moduledoc false
+  import BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations, only: [filecoin_robust_address_schema: 0]
   alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
@@ -31,6 +32,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.SmartContract.ChainTypeCustomizations do
         |> Helper.extend_schema(
           properties: %{
             zk_compiler_version: %Schema{type: :string, nullable: true}
+          },
+          required: []
+        )
+
+      :filecoin ->
+        schema
+        |> Helper.extend_schema(
+          properties: %{
+            verified_twin_filecoin_robust_address: filecoin_robust_address_schema()
           },
           required: []
         )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token.ex
@@ -1,24 +1,19 @@
 defmodule BlockScoutWeb.Schemas.API.V2.Token.ChainTypeCustomizations do
   @moduledoc false
   require OpenApiSpex
+  import BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations, only: [filecoin_robust_address_schema: 0]
 
   alias BlockScoutWeb.Schemas.API.V2.General
   alias BlockScoutWeb.Schemas.Helper
   alias Explorer.Chain.BridgedToken
   alias OpenApiSpex.Schema
 
-  @filecoin_robust_address_schema %Schema{
-    type: :string,
-    example: "f25nml2cfbljvn4goqtclhifepvfnicv6g7mfmmvq",
-    nullable: true
-  }
-
   def chain_type_fields(schema) do
     case Application.get_env(:explorer, :chain_type) do
       :filecoin ->
         schema
         |> Helper.extend_schema(
-          properties: %{filecoin_robust_address: @filecoin_robust_address_schema},
+          properties: %{filecoin_robust_address: filecoin_robust_address_schema()},
           required: [:filecoin_robust_address]
         )
 


### PR DESCRIPTION
## Motivation

Failed web tests for `filecoin` chain type such as:
```
  1) test /api/v2/smart-contracts/{address_hash}/verification/via/vyper-code blueprint contract verification (BlockScoutWeb.API.V2.VerificationControllerTest)

Error:      test/block_scout_web/controllers/api/v2/verification_controller_test.exs:360

     Value does not conform to schema SmartContract: Unexpected field: verified_twin_filecoin_robust_address at /verified_twin_filecoin_robust_address

     %{"file_path" => nil, "creation_status" => "success", "source_code" => "initialized: public(bool)\nvalue: public(uint256)\n\n@external\ndef __init__(_value: uint256):\n    self.value = _value\n    self.initialized = False", "deployed_bytecode" => "0xfe7100346100235760206100995f395f516001555f5f5561005f61002760003961005f6000f35b5f80fd5f3560e01c60026001821660011b61005b01601e395f51565b63158ef93e81186100535734610057575f5460405260206040f3610053565b633fa4f245811861005357346100575760015460405260206040f35b5f5ffd5b5f80fd0018003784185f810400a16576797065728300030a0013", "optimization_enabled" => true, "verified_twin_address_hash" => nil, "is_verified" => true, "compiler_settings" => nil, "optimization_runs" => nil, "sourcify_repo_url" => nil, "decoded_constructor_args" => nil, "compiler_version" => "v0.3.10+commit.91361694", "is_verified_via_verifier_alliance" => false, "verified_at" => "2025-11-26T14:01:13.040693Z", "implementations" => [], "proxy_type" => nil, "external_libraries" => [], "creation_bytecode" => "0x61009c3d81600a3d39f3fe7100346100235760206100995f395f516001555f5f5561005f61002760003961005f6000f35b5f80fd5f3560e01c60026001821660011b61005b01601e395f51565b63158ef93e81186100535734610057575f5460405260206040f3610053565b633fa4f245811861005357346100575760015460405260206040f35b5f5ffd5b5f80fd0018003784185f810400a16576797065728300030a0013", "name" => "Test", "is_blueprint" => true, "license_type" => "none", "is_fully_verified" => false, "is_verified_via_eth_bytecode_db" => false, "language" => "vyper", "evm_version" => nil, "can_be_visualized_via_sol2uml" => false, "is_verified_via_sourcify" => false, "additional_sources" => [], "certified" => false, "conflicting_implementations" => nil, "abi" => [%{"inputs" => [%{"name" => "_value", "type" => "uint256"}], "outputs" => [], "stateMutability" => "nonpayable", "type" => "constructor"}, %{"inputs" => [], "name" => "initialized", "outputs" => [%{"name" => "", "type" => "bool"}], "stateMutability" => "view", "type" => "function"}, %{"inputs" => [], "name" => "value", "outputs" => [%{"name" => "", "type" => "uint256"}], "stateMutability" => "view", "type" => "function"}], "is_changed_bytecode" => false, "is_partially_verified" => true, "verified_twin_filecoin_robust_address" => nil, "constructor_args" => nil}
```

It was caused by https://github.com/blockscout/blockscout/pull/13557.

## Changelog

### AI Agent summary

This pull request refactors how the Filecoin robust address OpenAPI schema is defined and used across several modules. The main improvement is the centralization of the robust address schema definition in `BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations`, which is now imported and reused in other modules instead of being duplicated. This change enhances maintainability and consistency for Filecoin-specific customizations.

**Centralization of Filecoin robust address schema:**

* The robust address schema for Filecoin is now defined once as `filecoin_robust_address_schema/0` in `BlockScoutWeb.Schemas.API.V2.Address.ChainTypeCustomizations`, replacing previous inline or duplicated definitions.

**Refactoring usages to use the centralized schema:**

* Updated `BlockScoutWeb.Schemas.API.V2.Address.Response.ChainTypeCustomizations` to import and use `filecoin_robust_address_schema/0` instead of its own local schema definition. [[1]](diffhunk://#diff-fbeee940441d666a0994381e41708800cf459056b00b31a9b63038e4c2cfe1cbR4-L16) [[2]](diffhunk://#diff-fbeee940441d666a0994381e41708800cf459056b00b31a9b63038e4c2cfe1cbL87-R81)
* Updated `BlockScoutWeb.Schemas.API.V2.General.Implementation.ChainTypeCustomizations` to import and use the centralized schema for Filecoin robust address fields. [[1]](diffhunk://#diff-8d8f54faef06e6e875ab70dfa8073821f627ec0e6e36575c8550dccda6560409L3-R3) [[2]](diffhunk://#diff-8d8f54faef06e6e875ab70dfa8073821f627ec0e6e36575c8550dccda6560409L17-R23)
* Updated `BlockScoutWeb.Schemas.API.V2.Token.ChainTypeCustomizations` to use the centralized schema, removing its local definition.
* Added support for Filecoin robust address schema in `BlockScoutWeb.Schemas.API.V2.SmartContract.ChainTypeCustomizations` by importing and utilizing the centralized definition. [[1]](diffhunk://#diff-fb01a35f434a43d9d816c5fdf253fd5979a08024e53cd007e0374f5b2beaeef0R3) [[2]](diffhunk://#diff-fb01a35f434a43d9d816c5fdf253fd5979a08024e53cd007e0374f5b2beaeef0R39-R47)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API schema organization for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->