### PR TITLE
chore: Update devcontainer image to use Elixir 1.19

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Since this is a copy of https://github.com/blockscout/devcontainer-elixir/blob/main/Dockerfile
 # So after successful testing this file, the original one must be updated as well.
-ARG VARIANT="1.17.3-erlang-27.1.3-debian-bookworm-20250811"
+ARG VARIANT="1.19.3-erlang-27.3.4.5-debian-bookworm-20251117"
 FROM hexpm/elixir:${VARIANT}
 
 # ARGs declared before FROM are not persisted beyond the FROM instruction.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elixir:
-    image: ghcr.io/blockscout/devcontainer-elixir:1.17.3-erlang-27.1.3
+    image: ghcr.io/blockscout/devcontainer-elixir:1.19.3-erlang-27.3.4.5
 
     # Uncomment next lines to use test Dockerfile with new Elixir version
     # build:


### PR DESCRIPTION
## Motivation

Related to https://github.com/blockscout/blockscout/pull/13566.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container images with newer Elixir and Erlang runtime versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->