### PR TITLE
feat: Show ENS domains without resolved address in search

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -68,7 +68,7 @@ defmodule BlockScoutWeb.API.V2.SearchView do
       "type" => search_result.type,
       "name" => search_result.name,
       "address_hash" => search_result.address_hash,
-      "url" => address_path(Endpoint, :show, search_result.address_hash),
+      "url" => search_result.address_hash && address_path(Endpoint, :show, search_result.address_hash),
       "is_smart_contract_verified" => search_result.verified,
       "ens_info" => search_result[:ens_info],
       "certified" => if(search_result.certified, do: search_result.certified, else: false),
@@ -169,8 +169,12 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{"type" => "address", "parameter" => Address.checksum(item.hash)}
   end
 
-  defp redirect_search_results(%{address_hash: address_hash}) do
+  defp redirect_search_results(%{address_hash: address_hash}) when not is_nil(address_hash) do
     %{"type" => "address", "parameter" => address_hash}
+  end
+
+  defp redirect_search_results(%{name: name, protocol: _protocol}) do
+    %{"type" => "ens_domain", "parameter" => name}
   end
 
   defp redirect_search_results(%Block{} = item) do

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -962,6 +962,11 @@ defmodule Explorer.Chain.Search do
 
   defp search_ens_name(search_query, options) do
     case search_ens_name_in_bens(search_query) do
+      {ens_result, nil} ->
+        [
+          merge_address_search_result_with_ens_info(nil, ens_result)
+        ]
+
       {ens_result, address_hash} ->
         [
           address_hash
@@ -1012,23 +1017,32 @@ defmodule Explorer.Chain.Search do
   @spec search_ens_name_in_bens(binary()) ::
           nil
           | {%{
-               address_hash: binary(),
+               address_hash: binary() | nil,
                expiry_date: any(),
                name: any(),
                names_count: non_neg_integer(),
                protocol: any()
-             }, Hash.Address.t()}
+             }, Hash.Address.t() | nil}
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 
     with true <- Regex.match?(~r/\w+\.\w+/, trimmed_query),
-         %{address_hash: address_hash_string} = result <- ens_domain_name_lookup(search_query),
-         {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string) do
+         %{address_hash: address_hash_string_or_nil} = result <- ens_domain_name_lookup(search_query),
+         address_hash <- address_hash_string_or_nil && Chain.string_to_address_hash_or_nil(address_hash_string_or_nil) do
       {result, address_hash}
     else
       _ ->
         nil
     end
+  end
+
+  defp merge_address_search_result_with_ens_info(nil, ens_info) do
+    search_fields()
+    |> Map.put(:address_hash, nil)
+    |> Map.put(:type, "ens_domain")
+    |> Map.put(:ens_info, ens_info)
+    |> Map.put(:timestamp, nil)
+    |> Map.put(:priority, 4)
   end
 
   defp merge_address_search_result_with_ens_info([], ens_info) do


### PR DESCRIPTION
Closes #12752 

## Breaking changes !!!
- Should wait for the new frontend release with support this search update 
## Changelog
- Show ENS domains without resolved address in search => now it's possible to get `null` in `address_hash` ,`url` and `ens_info.address_hash`  for search result of`ens_domain` type
- new type (`ens_domain`) in check-redirect endpoint: `{"parameter":"truthmatrix.eth","redirect":true,"type":"ens_domain"}` 
Returned for domains without resolved address



## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENS domain search to display results even when not associated with an on-chain address
  * Enhanced search result handling and redirect logic for ENS domain lookups

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->