### PR TITLE
fix: Enhance drop_tokens_contract_address_hash_index DB migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Internal transaction, Token transfer, Withdrawal, Smart-contracts, Main Page, Stats, Config and Search controllers OpenAPI specs ([#13557](https://github.com/blockscout/blockscout/issues/13557))
 - Using own runner for build ([#13624](https://github.com/blockscout/blockscout/issues/13624))
 - Drop token_instances_token_id_index index ([#13598](https://github.com/blockscout/blockscout/issues/13598))
-- Add migration to drop unique tokens_contract_address_hash_index index ([#13596](https://github.com/blockscout/blockscout/issues/13596))
+- Add migration to drop unique tokens_contract_address_hash_index index ([#13596](https://github.com/blockscout/blockscout/issues/13596), [#13655](https://github.com/blockscout/blockscout/pull/13655))
 - Elixir 1.17 -> 1.19 ([#13566](https://github.com/blockscout/blockscout/issues/13566))
 - Handle `NativeCoin*ed` events on Arc chain to make dual token balances synced ([#13452](https://github.com/blockscout/blockscout/issues/13452))
 - Improve DeleteZeroValueInternalTransactions migration ([#13569](https://github.com/blockscout/blockscout/issues/13569))

--- a/apps/explorer/priv/repo/migrations/20251115202635_drop_tokens_contract_address_hash_index.exs
+++ b/apps/explorer/priv/repo/migrations/20251115202635_drop_tokens_contract_address_hash_index.exs
@@ -15,7 +15,7 @@ defmodule Explorer.Repo.Migrations.DropTokensContractAddressHashIndex do
     ) THEN
       RAISE NOTICE 'Index tokens_contract_address_hash_index exists. Proceeding...';
 
-      -- 2. Drop the FK constraint (only if it exists)
+      -- 2. Drop the token_instances_token_contract_address_hash_fkey FK constraint (only if it exists)
       IF EXISTS (
           SELECT 1
           FROM pg_constraint
@@ -29,11 +29,31 @@ defmodule Explorer.Repo.Migrations.DropTokensContractAddressHashIndex do
           ';
       END IF;
 
-      -- 3. Drop the redundant index
+      -- 3. Drop the bridged_tokens_home_token_contract_address_hash_fkey FK constraint (only if it exists)
+      IF EXISTS (
+          SELECT 1 FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relname = 'bridged_tokens' AND n.nspname = 'public'
+      ) THEN
+        IF EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conname = 'bridged_tokens_home_token_contract_address_hash_fkey'
+              AND conrelid = 'public.bridged_tokens'::regclass
+        ) THEN
+            RAISE NOTICE 'Dropping foreign key bridged_tokens_home_token_contract_address_hash_fkey...';
+            EXECUTE '
+                ALTER TABLE public.bridged_tokens
+                DROP CONSTRAINT bridged_tokens_home_token_contract_address_hash_fkey
+            ';
+        END IF;
+      END IF;
+
+      -- 4. Drop the redundant index
       RAISE NOTICE 'Dropping index tokens_contract_address_hash_index...';
       EXECUTE 'DROP INDEX public.tokens_contract_address_hash_index';
 
-      -- 4. Recreate the FK constraint
+      -- 5. Recreate the token_instances_token_contract_address_hash_fkey FK constraint
       RAISE NOTICE 'Recreating foreign key token_instances_token_contract_address_hash_fkey...';
       EXECUTE '
           ALTER TABLE public.token_instances
@@ -41,6 +61,21 @@ defmodule Explorer.Repo.Migrations.DropTokensContractAddressHashIndex do
           FOREIGN KEY (token_contract_address_hash)
           REFERENCES public.tokens(contract_address_hash)
       ';
+
+      -- 6. Recreate the bridged_tokens_home_token_contract_address_hash_fkey FK constraint (only if table exists)
+      IF EXISTS (
+          SELECT 1 FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE c.relname = 'bridged_tokens' AND n.nspname = 'public'
+      ) THEN
+        RAISE NOTICE 'Recreating foreign key bridged_tokens_home_token_contract_address_hash_fkey...';
+        EXECUTE '
+            ALTER TABLE public.bridged_tokens
+            ADD CONSTRAINT bridged_tokens_home_token_contract_address_hash_fkey
+            FOREIGN KEY (home_token_contract_address_hash)
+            REFERENCES public.tokens(contract_address_hash)
+        ';
+      END IF;
     ELSE
       RAISE NOTICE 'Index tokens_contract_address_hash_index does NOT exist. Nothing to do.';
     END IF;


### PR DESCRIPTION
## Motivation

Error while running the migration occurend in stg env:
```
{"message":"== Running 20251115202635 Explorer.Repo.Migrations.DropTokensContractAddressHashIndex.change/0 forward","time":"2025-12-01T10:46:02.880Z","metadata":{"application":"ecto_sql"},"severity":"info"}
{"message":"execute \"DO $$\\nBEGIN\\n-- 1. Check if the index exists\\nIF EXISTS (\\n  SELECT 1\\n  FROM pg_class c\\n  JOIN pg_namespace n ON n.oid = c.relnamespace\\n  WHERE c.relname = 'tokens_contract_address_hash_index'\\n    AND n.nspname = 'public'\\n) THEN\\n  RAISE NOTICE 'Index tokens_contract_address_hash_index exists. Proceeding...';\\n\\n  -- 2. Drop the FK constraint (only if it exists)\\n  IF EXISTS (\\n      SELECT 1\\n      FROM pg_constraint\\n      WHERE conname = 'token_instances_token_contract_address_hash_fkey'\\n        AND conrelid = 'public.token_instances'::regclass\\n  ) THEN\\n      RAISE NOTICE 'Dropping foreign key token_instances_token_contract_address_hash_fkey...';\\n      EXECUTE '\\n          ALTER TABLE public.token_instances\\n          DROP CONSTRAINT token_instances_token_contract_address_hash_fkey\\n      ';\\n  END IF;\\n\\n  -- 3. Drop the redundant index\\n  RAISE NOTICE 'Dropping index tokens_contract_address_hash_index...';\\n  EXECUTE 'DROP INDEX public.tokens_contract_address_hash_index';\\n\\n  -- 4. Recreate the FK constraint\\n  RAISE NOTICE 'Recreating foreign key token_instances_token_contract_address_hash_fkey...';\\n  EXECUTE '\\n      ALTER TABLE public.token_instances\\n      ADD CONSTRAINT token_instances_token_contract_address_hash_fkey\\n      FOREIGN KEY (token_contract_address_hash)\\n      REFERENCES public.tokens(contract_address_hash)\\n  ';\\nELSE\\n  RAISE NOTICE 'Index tokens_contract_address_hash_index does NOT exist. Nothing to do.';\\nEND IF;\\nEND $$;\\n\"","time":"2025-12-01T10:46:02.881Z","metadata":{"application":"ecto_sql"},"severity":"info"}
** (Postgrex.Error) ERROR 2BP01 (dependent_objects_still_exist) cannot drop index tokens_contract_address_hash_index because other objects depend on it

    hint: Use DROP ... CASCADE to drop the dependent objects too.

constraint bridged_tokens_home_token_contract_address_hash_fkey on table bridged_tokens depends on index tokens_contract_address_hash_index
    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1098: Ecto.Adapters.SQL.raise_sql_call_error/1
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.13.2) lib/ecto/adapters/sql.ex:1219: Ecto.Adapters.SQL.execute_ddl/4
    (ecto_sql 3.13.2) lib/ecto/migration/runner.ex:348: Ecto.Migration.Runner.log_and_execute_ddl/3
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.13.2) lib/ecto/migration/runner.ex:311: Ecto.Migration.Runner.perform_operation/3
    (stdlib 6.2.2.2) timer.erl:595: :timer.tc/2
```

## Changelog

### AI Agent summary

This pull request updates the migration logic for managing foreign key constraints and indexes on the `token_instances` table. The changes ensure that both the `token_instances_token_contract_address_hash_fkey` and `bridged_tokens_home_token_contract_address_hash_fkey` constraints are properly dropped and recreated, improving the reliability and clarity of the migration process.

**Migration improvements:**

* The migration now explicitly drops the `bridged_tokens_home_token_contract_address_hash_fkey` foreign key constraint from `token_instances` if it exists, in addition to the existing logic for `token_instances_token_contract_address_hash_fkey`.
* After dropping the redundant index, both foreign key constraints (`token_instances_token_contract_address_hash_fkey` and `bridged_tokens_home_token_contract_address_hash_fkey`) are recreated on the `token_instances` table, ensuring referential integrity is restored.
* Updated comments to clarify each step, including specifying which foreign key constraint is being dropped or recreated. [[1]](diffhunk://#diff-2eda9e52965f2129db391ecdab73210aa7f03221dffeae1c1e3d8f2e363b7b37L18-R18) [[2]](diffhunk://#diff-2eda9e52965f2129db391ecdab73210aa7f03221dffeae1c1e3d8f2e363b7b37L32-R66)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Safer database migration: added guarded checks and conditional drop/recreate around a foreign-key and related index to preserve schema consistency and avoid errors during migration.
  * Adjusted operation ordering and added notices to improve migration robustness.

* **Documentation**
  * Changelog updated to reference the additional related migration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->