### PR TITLE
chore: Set unique block numbers in handle_partially_imported_blocks/1

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -445,7 +445,7 @@ defmodule Explorer.Chain.Import do
   end
 
   defp handle_partially_imported_blocks(%{blocks: %{params: blocks_params}}) do
-    block_numbers = Enum.map(blocks_params, & &1.number)
+    block_numbers = blocks_params |> Enum.map(& &1.number) |> Enum.uniq()
     Block.set_refetch_needed(block_numbers)
     Import.Runner.Blocks.process_blocks_consensus(blocks_params)
 


### PR DESCRIPTION
## Motivation

I discovered such message in the Rootstock Mainnet instance:
```
Set refetch_needed for partially imported block because of error: [8265961, 8265961, 8265941, 8265961, 7537239]
```

## Changelog

This pull request introduces a minor improvement to the block import logic by ensuring that duplicate block numbers are removed before further processing. This helps prevent redundant work and potential issues during block consensus handling.

* Import logic improvement:
  * In `Explorer.Chain.Import`, the list of block numbers extracted from `blocks_params` is now deduplicated using `Enum.uniq/1` before being passed to `Block.set_refetch_needed` and `Import.Runner.Blocks.process_blocks_consensus`.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate processing of partially imported blocks by deduplicating reported block numbers, improving import stability.

* **Chores**
  * Added a warning log that lists involved block numbers when a refetch triggers consensus reprocessing, aiding monitoring and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->