### PR TITLE
fix: Fix 500 for pending tx in `tokentx` RPC API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug Fixes
 
+- Fix 500 for pending tx in tokentx RPC API endpoint ([#13666](https://github.com/blockscout/blockscout/pull/13666))
+- Fix 500 for pending tx in gettxinfo RPC API endpoint([#13665](https://github.com/blockscout/blockscout/pull/13665))
 - `Mix.env()` in `runtime.exs` ([#13641](https://github.com/blockscout/blockscout/issues/13641))
 - Celo aggregated election rewards migrator test ([#13639](https://github.com/blockscout/blockscout/issues/13639))
 - Fix filecoin web tests ([#13634](https://github.com/blockscout/blockscout/issues/13634))
@@ -36,7 +38,6 @@
 
 ### ⚙️ Miscellaneous Tasks
 
-- Fix 500 for pending tx in gettxinfo RPC API endpoint([#13665](https://github.com/blockscout/blockscout/pull/13665))
 - Use chain id `31337` for `anvil` ([#13644](https://github.com/blockscout/blockscout/issues/13644))
 - Update devcontainer image to use Elixir 1.19.4 ([#13645](https://github.com/blockscout/blockscout/issues/13645))
 - Elixir 1.19.3 -> 1.19.4 ([#13643](https://github.com/blockscout/blockscout/issues/13643))

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/address_view.ex
@@ -157,9 +157,21 @@ defmodule BlockScoutWeb.API.RPC.AddressView do
   defp prepare_common_token_transfer(token_transfer, max_block_number, decoded_input) do
     tt_denormalization_fields =
       if DenormalizationHelper.tt_denormalization_finished?() do
-        %{"timeStamp" => to_string(DateTime.to_unix(token_transfer.transaction.block_timestamp))}
+        %{
+          "timeStamp" =>
+            if(token_transfer.transaction.block_timestamp,
+              do: to_string(DateTime.to_unix(token_transfer.transaction.block_timestamp)),
+              else: ""
+            )
+        }
       else
-        %{"timeStamp" => to_string(DateTime.to_unix(token_transfer.block.timestamp))}
+        %{
+          "timeStamp" =>
+            if(token_transfer.block.timestamp,
+              do: to_string(DateTime.to_unix(token_transfer.block.timestamp)),
+              else: ""
+            )
+        }
       end
 
     %{


### PR DESCRIPTION
## Motivation

The error in `tokentx` RPC API endpoint for pending transaction:

```
Error while calling RPC action"** (Plug.Conn.WrapperError) ** (FunctionClauseError) no function clause matching in DateTime.to_unix/2\n    (elixir 1.17.3) lib/calendar/datetime.ex:903: DateTime.to_unix(nil, :second)\n    (block_scout_web 9.2.2) lib/block_scout_web/views/api/rpc/address_view.ex:160: BlockScoutWeb.API.RPC.AddressView.prepare_common_token_transfer/3\n    (block_scout_web 9.2.2) lib/block_scout_web/views/api/rpc/address_view.ex:210: BlockScoutWeb.API.RPC.AddressView.prepare_token_transfer/3\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.17.3) lib/enum.ex:1703: Enum.\"-map/2-lists^map/1-1-\"/2\n    (block_scout_web 9.2.2) lib/block_scout_web/views/api/rpc/address_view.ex:48: BlockScoutWeb.API.RPC.AddressView.render/2\n    (phoenix_view 2.0.4) lib/phoenix_view.ex:577: Phoenix.View.render_to_iodata/3\n    (phoenix 1.6.16) lib/phoenix/controller.ex:772: Phoenix.Controller.render_and_send/4\n"
```

## Changelog

### AI Agent summary

This pull request introduces a small but important improvement to how token transfer timestamps are handled in the `BlockScoutWeb.API.RPC.AddressView` module. The change ensures that if a block timestamp is missing (`nil`), the `"timeStamp"` field will return an empty string instead of raising an error.

* Improved robustness of the `prepare_common_token_transfer` function by safely handling missing block timestamps and returning an empty string for `"timeStamp"` when the timestamp is not present.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed 500 error responses when querying pending transactions through the tokentx RPC API endpoint.
  - Fixed 500 error responses when querying pending transactions through the gettxinfo RPC API endpoint.
  - Improved timestamp handling in token transfer responses to gracefully handle missing timestamp data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->