### PR TITLE
fix: Update InternalTransactionsAddressPlaceholder upserts

### DIFF
--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -202,7 +202,10 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
         end)
         |> Enum.sort_by(&{&1.address_id, &1.block_number})
 
-      Repo.insert_all(InternalTransactionsAddressPlaceholder, placeholders_params)
+      Repo.insert_all(InternalTransactionsAddressPlaceholder, placeholders_params,
+        on_conflict: :replace_all,
+        conflict_target: [:address_id, :block_number]
+      )
     end)
   end
 


### PR DESCRIPTION
## Motivation

In cases of handling `ZeroValueDeleteQueue` records, new `InternalTransactionsAddressPlaceholder` records may intersect with existing ones. We should allow it to happen and just update placeholders in that case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data migration handling to improve conflict resolution and ensure data consistency when processing internal transaction records during system updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->