### PR TITLE
fix: Limit batch size for placeholders insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug Fixes
 
+- Limit batch size for placeholders insertion ([#13699](https://github.com/blockscout/blockscout/pull/13699))
 - Add missed reputation fetch ([#13695](https://github.com/blockscout/blockscout/pull/13695))
 - Fix NFTMediaHandler postgres parameters overflow error ([#13694](https://github.com/blockscout/blockscout/pull/13694))
 - Add smart contract preload to hot contracts query ([#13691](https://github.com/blockscout/blockscout/pull/13691))

--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -202,10 +202,14 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
         end)
         |> Enum.sort_by(&{&1.address_id, &1.block_number})
 
-      Repo.insert_all(InternalTransactionsAddressPlaceholder, placeholders_params,
-        on_conflict: :replace_all,
-        conflict_target: [:address_id, :block_number]
-      )
+      placeholders_params
+      |> Enum.chunk_every(1000)
+      |> Enum.each(fn placeholders_batch ->
+        Repo.insert_all(InternalTransactionsAddressPlaceholder, placeholders_batch,
+          on_conflict: :replace_all,
+          conflict_target: [:address_id, :block_number]
+        )
+      end)
     end)
   end
 


### PR DESCRIPTION
## Motivation

To avoid overflow of the number of parameters in a Postgres query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limit batch size for placeholder inserts to avoid large single writes, improving stability during large data processing.

* **Chores**
  * Updated internal write strategy to perform smaller, repeated database writes for more reliable reconciliation and reduced resource spikes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->