### PR TITLE
fix: Set timeout: :infinity for delete zero value migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug Fixes
 
+- Set timeout: :infinity for delete zero value migration ([#13708](https://github.com/blockscout/blockscout/pull/13708))
 - Limit batch size for placeholders insertion ([#13699](https://github.com/blockscout/blockscout/pull/13699))
 - Add missed reputation fetch ([#13695](https://github.com/blockscout/blockscout/pull/13695))
 - Fix NFTMediaHandler postgres parameters overflow error ([#13694](https://github.com/blockscout/blockscout/pull/13694))


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of a long-running data cleanup by extending transaction timeout and consolidating related operations into a single, atomic process to prevent timeouts and partial commits.

* **Chores**
  * Updated changelog entry noting the migration timeout and reliability improvement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->