### PR TITLE
fix: Convert token id to string from refetch metadata in the socket

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -368,7 +368,7 @@ defmodule BlockScoutWeb.Notifier do
     Endpoint.broadcast(
       "token_instances:#{token_contract_address_hash_string}",
       "fetched_token_instance_metadata",
-      %{token_id: token_id, fetched_metadata: fetched_token_instance_metadata}
+      %{token_id: to_string(token_id), fetched_metadata: fetched_token_instance_metadata}
     )
   end
 
@@ -379,7 +379,7 @@ defmodule BlockScoutWeb.Notifier do
     Endpoint.broadcast(
       "token_instances:#{token_contract_address_hash_string}",
       "not_fetched_token_instance_metadata",
-      %{token_id: token_id, reason: reason}
+      %{token_id: to_string(token_id), reason: reason}
     )
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1769,8 +1769,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, fetched_metadata: ^metadata},
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
                        event: "fetched_token_instance_metadata",
                        topic: ^topic
                      },
@@ -1812,8 +1814,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, fetched_metadata: ^metadata},
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
                        event: "fetched_token_instance_metadata",
                        topic: ^topic
                      },
@@ -1880,8 +1884,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, fetched_metadata: ^metadata},
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
                        event: "fetched_token_instance_metadata",
                        topic: ^topic
                      },
@@ -1943,8 +1949,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, "error"]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, reason: "error"},
+                       payload: %{token_id: ^token_id_string, reason: "error"},
                        event: "not_fetched_token_instance_metadata",
                        topic: ^topic
                      },
@@ -2012,8 +2020,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, fetched_metadata: ^metadata},
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
                        event: "fetched_token_instance_metadata",
                        topic: ^topic
                      },
@@ -2051,8 +2061,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [^token_contract_address_hash_string, ^token_id, ^metadata]}
       )
 
+      token_id_string = to_string(token_id)
+
       assert_receive %Phoenix.Socket.Message{
-                       payload: %{token_id: ^token_id, fetched_metadata: ^metadata},
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
                        event: "fetched_token_instance_metadata",
                        topic: ^topic
                      },


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/13761

## Changelog

### AI Agent summary

This pull request standardizes the format of the `token_id` field in both the notifier module and its related tests by ensuring it is always sent as a string, rather than an integer. This change improves consistency in the payloads sent over Phoenix channels and aligns the tests with the new behavior.

**Notifier payload consistency:**

* Updated the `BlockScoutWeb.Notifier` module to always broadcast the `token_id` as a string in both the `"fetched_token_instance_metadata"` and `"not_fetched_token_instance_metadata"` events. [[1]](diffhunk://#diff-d59b45b0e46e86f8722a2aa4486ab7ed86b2ef8272365336541aa43b2bf6efe4L371-R371) [[2]](diffhunk://#diff-d59b45b0e46e86f8722a2aa4486ab7ed86b2ef8272365336541aa43b2bf6efe4L382-R382)

**Test updates for payload format:**

* Modified the `BlockScoutWeb.API.V2.TokenControllerTest` tests to expect `token_id` as a string in the payloads for both fetched and not-fetched token instance metadata events. This includes updating all relevant assertions to compare against the string version of `token_id`. [[1]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R1772-R1775) [[2]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R1817-R1820) [[3]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R1887-R1890) [[4]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R1952-R1955) [[5]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R2023-R2026) [[6]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05R2064-R2067)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token ID values in broadcast notification events are now transmitted as strings across all token instance metadata events and notification streams.

* **Tests**
  * Updated test suites to assert token ID string representation in event payloads, socket event expectations, and on-demand notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->