### PR TITLE
fix: Resolve TLS version issue on application startup

### DIFF
--- a/config/runtime/dev.exs
+++ b/config/runtime/dev.exs
@@ -21,7 +21,7 @@ config :block_scout_web, BlockScoutWeb.Endpoint,
   ],
   https: [
     port: port + 1,
-    cipher_suite: :strong,
+    cipher_suite: :compatible,
     certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",
     keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
   ]
@@ -38,7 +38,7 @@ config :block_scout_web, BlockScoutWeb.HealthEndpoint,
   ],
   https: [
     port: port + 1,
-    cipher_suite: :strong,
+    cipher_suite: :compatible,
     certfile: System.get_env("CERTFILE") || "priv/cert/selfsigned.pem",
     keyfile: System.get_env("KEYFILE") || "priv/cert/selfsigned_key.pem"
   ]


### PR DESCRIPTION
## Motivation

The error at startup:
```
** (Mix) Could not start application block_scout_web: BlockScoutWeb.Application.start(:normal, []) returned an error: shutdown: failed to start child: BlockScoutWeb.Endpoint
    ** (EXIT) shutdown: failed to start child: {:ranch_listener_sup, BlockScoutWeb.Endpoint.HTTPS}
        ** (EXIT) shutdown: failed to start child: :ranch_acceptors_sup
            ** (EXIT) an exception was raised:
                ** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom

                    (erts 15.2.7.4) :erlang.atom_to_binary({:options, :incompatible, [:next_protocols_advertised, {:versions, [:"tlsv1.3"]}]})
                    (stdlib 6.2.2.2) erl_posix_msg.erl:176: :erl_posix_msg.message_1/1
                    (stdlib 6.2.2.2) erl_posix_msg.erl:30: :erl_posix_msg.message/1
                    (ranch 1.8.1) /Users/viktor/Documents/code/blockscout/deps/ranch/src/ranch_acceptors_sup.erl:65: :ranch_acceptors_sup.listen_error/5
                    (stdlib 6.2.2.2) supervisor.erl:869: :supervisor.init/1
                    (stdlib 6.2.2.2) gen_server.erl:2229: :gen_server.init_it/2
                    (stdlib 6.2.2.2) gen_server.erl:2184: :gen_server.init_it/6
                    (stdlib 6.2.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

## Changelog

This PR resolves an application startup failure caused by a TLS configuration conflict introduced by recent Phoenix/Plug dependency updates.

### Summary

- Identified an incompatibility between:
  - `plug_cowboy 2.7.5`, which enables ALPN and advertises HTTP/2
  - `plug 1.19.1` with `cipher_suite: :strong`, which configures TLSv1.3 only
- The combination caused a configuration conflict during TLS setup.
- Updated HTTPS endpoint configurations to use `cipher_suite: :compatible`.

### Changes

**File:** `dev.exs`

- `BlockScoutWeb.Endpoint`
  - Changed `cipher_suite` from `:strong` to `:compatible`
- `BlockScoutWeb.HealthEndpoint`
  - Changed `cipher_suite` from `:strong` to `:compatible`

### Why This Works

- `:compatible` supports both TLSv1.2 and TLSv1.3
- Enables proper ALPN protocol negotiation (HTTP/2 support)
- Maintains strong security guarantees
- Preserves compatibility with older clients

### Verification

- ✅ Application starts successfully without TLS-related `ArgumentError`
- ✅ HTTP and HTTPS endpoints start and listen correctly
- ✅ No breaking changes to application functionality

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTPS configuration settings in the development environment to improve compatibility with client systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->