### PR TITLE
fix: make `find_history_and_token_fetchers` public

### DIFF
--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -144,5 +144,22 @@ defmodule Explorer.Market do
     :persistent_term.get(@history_key, false)
   end
 
-  defp find_history_and_token_fetchers, do: {GenServer.whereis(HistoryFetcher), GenServer.whereis(TokenFetcher)}
+  @doc """
+  Locates the running processes for the market history and token fiat value fetchers.
+
+  This function checks whether the `Explorer.Market.Fetcher.History` and
+  `Explorer.Market.Fetcher.Token` GenServer processes are currently running
+  and returns their process identifiers.
+
+  ## Parameters
+  None.
+
+  ## Returns
+  - A tuple `{history_fetcher, token_fetcher}` where each element is:
+    - `nil` if the corresponding fetcher process is not running
+    - A `pid()` if the process is registered locally
+    - A `{atom(), atom()}` tuple if registered via `:global` or `:via`
+  """
+  @spec find_history_and_token_fetchers() :: {nil | pid() | {atom(), atom()}, nil | pid() | {atom(), atom()}}
+  def find_history_and_token_fetchers, do: {GenServer.whereis(HistoryFetcher), GenServer.whereis(TokenFetcher)}
 end


### PR DESCRIPTION

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made an internal helper function publicly accessible to simplify module API without changing runtime behavior.
* **Documentation**
  * Added comprehensive documentation and type information for the exposed helper to clarify usage and expected results.
* **Notes**
  * No user-facing behavior changes; compatibility preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->