### PR TITLE
feat: Setup universal proxy config from the JSON content in ENV variable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -926,12 +926,21 @@ config :explorer, Explorer.Utility.RateLimiter,
   hammer_backend_module:
     if(rate_limiter_redis_url, do: Explorer.Utility.Hammer.Redis, else: Explorer.Utility.Hammer.ETS)
 
+universal_proxy_config_url =
+  ConfigHelper.parse_url_env_var(
+    "UNIVERSAL_PROXY_CONFIG_URL",
+    "https://raw.githubusercontent.com/blockscout/backend-configs/refs/heads/main/universal-proxy-config.json"
+  )
+
+universal_proxy_config = System.get_env("UNIVERSAL_PROXY_CONFIG")
+
+if System.get_env("UNIVERSAL_PROXY_CONFIG_URL") && universal_proxy_config do
+  raise "UNIVERSAL_PROXY_CONFIG_URL and UNIVERSAL_PROXY_CONFIG are both set; choose only one"
+end
+
 config :explorer, Explorer.ThirdPartyIntegrations.UniversalProxy,
-  config_url:
-    ConfigHelper.parse_url_env_var(
-      "UNIVERSAL_PROXY_CONFIG_URL",
-      "https://raw.githubusercontent.com/blockscout/backend-configs/refs/heads/main/universal-proxy-config.json"
-    )
+  config_url: universal_proxy_config_url,
+  config_json: universal_proxy_config
 
 config :explorer, Explorer.Chain.Mud, enabled: ConfigHelper.parse_bool_env_var("MUD_INDEXER_ENABLED")
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/13595

## Changelog

### AI Agent Summary

This pull request updates the configuration logic for `Explorer.ThirdPartyIntegrations.UniversalProxy` to support loading configuration from an environment variable in addition to the previous HTTP-based approach. It also adds safeguards to prevent conflicting configuration sources and includes new tests to ensure the correct behavior.

Configuration loading improvements:

* Added support for loading the UniversalProxy configuration from an inline JSON environment variable (`UNIVERSAL_PROXY_CONFIG`), in addition to the existing HTTP fetch from `UNIVERSAL_PROXY_CONFIG_URL`. [[1]](diffhunk://#diff-fe8440d0c762840f586b8957d9014127d10dd7932abe371ddb7fdcfa24263f5aR360-R370) [[2]](diffhunk://#diff-fe8440d0c762840f586b8957d9014127d10dd7932abe371ddb7fdcfa24263f5aR386-R399) [[3]](diffhunk://#diff-e43c5cbf91db7a8062b6cb860cbf118296c1b4c7ee32fdcf702e54234ba38092L911-R926)
* Updated the runtime configuration to raise an error if both `UNIVERSAL_PROXY_CONFIG_URL` and `UNIVERSAL_PROXY_CONFIG` are set, preventing ambiguous configuration.

Testing enhancements:

* Added a test to verify that inline environment config is used directly and no HTTP request is made when `UNIVERSAL_PROXY_CONFIG` is set.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`. https://github.com/blockscout/docs/pull/83
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UniversalProxy can be configured via an inline JSON environment variable in addition to remote URL loading.
  * Runtime validation prevents setting both inline config and remote URL simultaneously.

* **Tests**
  * Added test coverage verifying environment-based config is parsed and used without performing an HTTP fetch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->