### PR TITLE
feat: Expose CHAIN_TYPE in the REST API

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -2,6 +2,8 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
   use BlockScoutWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  use Utils.RuntimeEnvHelper, chain_type: [:explorer, :chain_type]
+
   alias Explorer.Chain.SmartContract
   alias Explorer.Migrator.MigrationStatus
   alias OpenApiSpex.Schema
@@ -9,6 +11,29 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
   plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
 
   tags(["config"])
+
+  operation :backend,
+    summary: "Get backend environment configuration",
+    description: "Returns non-secret backend environment variables in the snake case (e.g., chain_type).",
+    parameters: base_params(),
+    responses: [
+      ok:
+        {"Backend environment configuration.", "application/json",
+         %Schema{type: :object, properties: %{chain_type: %Schema{type: :string, nullable: true}}}},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
+
+  @doc """
+    Function to handle GET requests to `/api/v2/config/backend` endpoint.
+  """
+  @spec backend(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def backend(conn, _params) do
+    chain_type = chain_type()
+
+    conn
+    |> put_status(200)
+    |> json(%{"chain_type" => chain_type})
+  end
 
   operation :backend_version,
     summary: "Get backend version",

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -138,6 +138,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     end
 
     scope "/config" do
+      get("/backend", V2.ConfigController, :backend)
       get("/backend-version", V2.ConfigController, :backend_version)
       get("/csv-export", V2.ConfigController, :csv_export)
       get("/indexer", V2.ConfigController, :indexer)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
@@ -1,6 +1,29 @@
 defmodule BlockScoutWeb.API.V2.ConfigControllerTest do
   use BlockScoutWeb.ConnCase
 
+  @chain_type Application.compile_env(:explorer, :chain_type)
+
+  describe "/config/backend" do
+    test "returns chain_type when configured", %{conn: conn} do
+      request = get(conn, "/api/v2/config/backend")
+      response = json_response(request, 200)
+
+      assert %{"chain_type" => chain_type} = response
+      assert is_binary(chain_type)
+    end
+
+    test "returns the configured chain type value", %{conn: conn} do
+      request = get(conn, "/api/v2/config/backend")
+      response = json_response(request, 200)
+
+      assert %{"chain_type" => chain_type} = response
+
+      # Compare string representations
+      expected_chain_type = if is_atom(@chain_type), do: Atom.to_string(@chain_type), else: @chain_type
+      assert chain_type == expected_chain_type
+    end
+  end
+
   describe "/config/backend-version" do
     test "get json rps url if set", %{conn: conn} do
       version = "v6.3.0-beta"


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/13801

## Changelog

### AI Agent Summary

This pull request adds a new API endpoint to expose non-secret backend environment configuration, specifically the `chain_type`, through the `/api/v2/config/backend` route. It includes updates to the controller, router, and comprehensive tests to ensure correct behavior.

**New API Endpoint for Backend Configuration:**

* Added a new `backend` operation and handler in `V2.ConfigController` to return the `chain_type` environment variable in snake case as JSON. [[1]](diffhunk://#diff-3455c148d1de33cfbbfc27072800d08f106c8a3cbdcb5f934740c8153a055acbR5-R6) [[2]](diffhunk://#diff-3455c148d1de33cfbbfc27072800d08f106c8a3cbdcb5f934740c8153a055acbR15-R37)
* Registered the `/api/v2/config/backend` route in the API router to point to the new controller action.

**Testing:**

* Added tests in `config_controller_test.exs` to verify that the new endpoint returns the correct `chain_type` value and ensures it matches the configured environment variable.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GET API endpoint /v2/config/backend that returns the configured chain_type as JSON (chain_type may be null).
* **Tests**
  * Added tests verifying the /v2/config/backend response includes a chain_type field and that its value matches the compiled configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->