### PR TITLE
fix: Clear bytecode for smart-contracts self destructed in a separate transaction

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -11,6 +11,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   alias EthereumJSONRPC.Utility.RangesHelper
 
   alias Explorer.Chain.{
+    Address,
     Block,
     Hash,
     Import,
@@ -199,6 +200,17 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         :block_pending,
         :internal_transactions,
         :save_zero_value_to_delete
+      )
+    end)
+    |> Multi.run(:empty_selfdestructed_contracts_bytecode, fn repo,
+                                                              %{
+                                                                valid_internal_transactions: valid_internal_transactions
+                                                              } ->
+      Instrumenter.block_import_stage_runner(
+        fn -> empty_selfdestructed_contracts_bytecode(repo, valid_internal_transactions, timestamps) end,
+        :block_pending,
+        :internal_transactions,
+        :empty_selfdestructed_contracts_bytecode
       )
     end)
   end
@@ -898,6 +910,54 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       end
     else
       _ -> {:ok, []}
+    end
+  end
+
+  defp empty_selfdestructed_contracts_bytecode(repo, valid_internal_transactions, timestamps) do
+    # Find all selfdestruct internal transactions
+    selfdestruct_addresses =
+      valid_internal_transactions
+      |> Enum.filter(&(&1.type == :selfdestruct))
+      |> Enum.map(&{&1.transaction_hash, &1.from_address_hash})
+      |> MapSet.new()
+
+    # Find all create/create2 internal transactions in the same transactions
+    created_addresses =
+      valid_internal_transactions
+      |> Enum.filter(&(&1.type in [:create, :create2]))
+      |> Enum.map(&{&1.transaction_hash, Map.get(&1, :created_contract_address_hash)})
+      |> Enum.reject(fn {_tx_hash, address_hash} -> is_nil(address_hash) end)
+      |> MapSet.new()
+
+    # Filter to find addresses that were selfdestructed but NOT created in the same transaction
+    addresses_to_empty =
+      selfdestruct_addresses
+      |> Enum.reject(fn {tx_hash, address_hash} ->
+        MapSet.member?(created_addresses, {tx_hash, address_hash})
+      end)
+      |> Enum.map(fn {_tx_hash, address_hash} -> address_hash end)
+      |> Enum.uniq()
+
+    if Enum.empty?(addresses_to_empty) do
+      {:ok, []}
+    else
+      # Update the addresses to have empty contract_code
+      empty_contract_code = %Explorer.Chain.Data{bytes: <<>>}
+
+      update_query =
+        from(
+          address in Address,
+          where: address.hash in ^addresses_to_empty,
+          update: [set: [contract_code: ^empty_contract_code, updated_at: ^timestamps.updated_at]]
+        )
+
+      {count, _} = repo.update_all(update_query, [])
+
+      Logger.info(
+        "Emptied contract_code for #{count} selfdestructed contracts: #{inspect(addresses_to_empty, limit: :infinity)}"
+      )
+
+      {:ok, count}
     end
   end
 

--- a/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
+++ b/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
@@ -1,0 +1,152 @@
+defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
+  @moduledoc """
+  Finds all existing selfdestruct internal transactions and empties the contract_code
+  for addresses that still have bytecode, excluding contracts that were created and
+  selfdestructed in the same transaction.
+
+  This migration processes blocks from the head of the chain down to the first block,
+  identifying selfdestruct operations and clearing the bytecode of affected contracts.
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.{Address, Data, InternalTransaction}
+  alias Explorer.Chain.Cache.BlockNumber
+  alias Explorer.Migrator.{FillingMigration, MigrationStatus}
+  alias Explorer.Repo
+
+  require Logger
+
+  @migration_name "empty_bytecode_for_selfdestructed_smart_contracts"
+  @empty_contract_code %Data{bytes: <<>>}
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(%{"min_block_number" => min_block_number} = state)
+      when not is_nil(min_block_number) and min_block_number < 0 do
+    {[], state}
+  end
+
+  def last_unprocessed_identifiers(%{"min_block_number" => min_block_number} = state)
+      when not is_nil(min_block_number) do
+    limit = batch_size() * concurrency()
+    from_block_number = min_block_number
+    to_block_number = max(from_block_number - limit + 1, 0)
+
+    block_numbers = Enum.to_list(from_block_number..to_block_number//-1)
+
+    {block_numbers, %{state | "min_block_number" => to_block_number - 1}}
+  end
+
+  def last_unprocessed_identifiers(state) do
+    query =
+      from(
+        migration_status in MigrationStatus,
+        where: migration_status.migration_name == ^@migration_name,
+        select: migration_status.meta
+      )
+
+    meta = Repo.one(query, timeout: :infinity)
+
+    state
+    |> Map.put("min_block_number", (meta && meta["min_block_number"]) || BlockNumber.get_max())
+    |> last_unprocessed_identifiers()
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query, do: nil
+
+  @impl FillingMigration
+  def update_batch(block_numbers) do
+    if Enum.empty?(block_numbers) do
+      {:ok, []}
+    else
+      # Find all selfdestruct internal transactions in these blocks
+      selfdestruct_query =
+        from(
+          it in InternalTransaction,
+          where: it.block_number in ^block_numbers,
+          where: it.type == :selfdestruct,
+          select: %{
+            transaction_hash: it.transaction_hash,
+            from_address_hash: it.from_address_hash,
+            block_number: it.block_number
+          }
+        )
+
+      selfdestruct_transactions = Repo.all(selfdestruct_query, timeout: :infinity)
+
+      if Enum.empty?(selfdestruct_transactions) do
+        {:ok, []}
+      else
+        # Get unique transaction hashes to check for create/create2
+        transaction_hashes =
+          selfdestruct_transactions
+          |> Enum.map(& &1.transaction_hash)
+          |> Enum.uniq()
+
+        # Find all create/create2 internal transactions in the same transactions
+        create_query =
+          from(
+            it in InternalTransaction,
+            where: it.transaction_hash in ^transaction_hashes,
+            where: it.type in [:create, :create2],
+            select: %{
+              transaction_hash: it.transaction_hash,
+              created_contract_address_hash: it.created_contract_address_hash
+            }
+          )
+
+        created_contracts = Repo.all(create_query, timeout: :infinity)
+
+        # Build a set of {transaction_hash, address_hash} for contracts created in same tx
+        created_in_same_tx =
+          created_contracts
+          |> Enum.map(&{&1.transaction_hash, &1.created_contract_address_hash})
+          |> MapSet.new()
+
+        # Filter to find addresses that were selfdestructed but NOT created in the same transaction
+        addresses_to_empty =
+          selfdestruct_transactions
+          |> Enum.reject(fn sd ->
+            MapSet.member?(created_in_same_tx, {sd.transaction_hash, sd.from_address_hash})
+          end)
+          |> Enum.map(& &1.from_address_hash)
+          |> Enum.uniq()
+
+        if Enum.empty?(addresses_to_empty) do
+          {:ok, []}
+        else
+          # Only update addresses that still have non-empty contract_code
+          update_query =
+            from(
+              address in Address,
+              where: address.hash in ^addresses_to_empty,
+              where: not is_nil(address.contract_code),
+              where: fragment("octet_length(?) > 0", address.contract_code),
+              update: [set: [contract_code: ^@empty_contract_code]],
+              select: address.hash
+            )
+
+          {count, updated_hashes} = Repo.update_all(update_query, [], timeout: :infinity)
+
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          if count > 0 do
+            Logger.info(
+              "Emptied contract_code for #{count} selfdestructed contracts in blocks #{inspect(block_numbers)}: #{inspect(updated_hashes, limit: :infinity)}"
+            )
+          end
+
+          {:ok, count}
+        end
+      end
+    end
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+end

--- a/apps/explorer/test/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts_test.exs
+++ b/apps/explorer/test/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts_test.exs
@@ -1,0 +1,457 @@
+defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.{Address, Data}
+  alias Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts
+  alias Explorer.Repo
+
+  describe "migration_name/0" do
+    test "returns the correct migration name" do
+      assert EmptyBytecodeForSelfdestructedSmartContracts.migration_name() ==
+               "empty_bytecode_for_selfdestructed_smart_contracts"
+    end
+  end
+
+  describe "update_batch/1" do
+    test "returns {:ok, []} when block_numbers is empty" do
+      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([])
+    end
+
+    test "returns {:ok, []} when no selfdestruct transactions exist in blocks" do
+      block = insert(:block, number: 100)
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        type: :call
+      )
+
+      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+    end
+
+    test "empties contract_code for address with selfdestruct transaction" do
+      block = insert(:block, number: 200)
+      contract_code = %Data{bytes: <<1, 2, 3, 4, 5>>}
+
+      # Create a contract with bytecode
+      contract_address = insert(:address, contract_code: contract_code)
+      recipient_address = insert(:address)
+
+      # Create a transaction with selfdestruct
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code is now empty
+      updated_address = Repo.get(Address, contract_address.hash)
+      assert updated_address.contract_code == %Data{bytes: <<>>}
+    end
+
+    test "does NOT empty contract_code when contract created and selfdestructed in same transaction" do
+      block = insert(:block, number: 300)
+      contract_code = %Data{bytes: <<1, 2, 3, 4, 5>>}
+
+      # Create a contract with bytecode
+      contract_address = insert(:address, contract_code: contract_code)
+      recipient_address = insert(:address)
+
+      # Create a transaction with both create and selfdestruct
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction_create,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        created_contract_address: contract_address,
+        created_contract_code: contract_code
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 1,
+        block_index: 1,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code is still present
+      updated_address = Repo.get(Address, contract_address.hash)
+      assert updated_address.contract_code == contract_code
+    end
+
+    test "does NOT empty contract_code when contract created with create2 and selfdestructed in same transaction" do
+      block = insert(:block, number: 350)
+      contract_code = %Data{bytes: <<1, 2, 3, 4, 5>>}
+
+      # Create a contract with bytecode
+      contract_address = insert(:address, contract_code: contract_code)
+      recipient_address = insert(:address)
+
+      # Create a transaction with both create2 and selfdestruct
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction_create,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        type: :create2,
+        created_contract_address: contract_address,
+        created_contract_code: contract_code
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 1,
+        block_index: 1,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code is still present
+      updated_address = Repo.get(Address, contract_address.hash)
+      assert updated_address.contract_code == contract_code
+    end
+
+    test "handles multiple selfdestruct transactions in same block" do
+      block = insert(:block, number: 400)
+      contract_code_1 = %Data{bytes: <<1, 2, 3>>}
+      contract_code_2 = %Data{bytes: <<4, 5, 6>>}
+
+      # Create two contracts with bytecode
+      contract_address_1 = insert(:address, contract_code: contract_code_1)
+      contract_address_2 = insert(:address, contract_code: contract_code_2)
+      recipient_address_1 = insert(:address)
+      recipient_address_2 = insert(:address)
+
+      # Create separate transactions for each selfdestruct
+      transaction_1 = insert(:transaction, gas: 21_000) |> with_block(block)
+      transaction_2 = insert(:transaction, gas: 22_000) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction_1,
+        block_hash: transaction_1.block_hash,
+        block_number: transaction_1.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address_1,
+        to_address: recipient_address_1,
+        gas: nil
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction_2,
+        block_hash: transaction_2.block_hash,
+        block_number: transaction_2.block_number,
+        index: 0,
+        block_index: 1,
+        type: :selfdestruct,
+        from_address: contract_address_2,
+        to_address: recipient_address_2,
+        gas: nil
+      )
+
+      assert {:ok, 2} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify both contracts have empty contract_code
+      updated_address_1 = Repo.get(Address, contract_address_1.hash)
+      updated_address_2 = Repo.get(Address, contract_address_2.hash)
+      assert updated_address_1.contract_code == %Data{bytes: <<>>}
+      assert updated_address_2.contract_code == %Data{bytes: <<>>}
+    end
+
+    test "does NOT update address that already has empty contract_code" do
+      block = insert(:block, number: 500)
+      empty_contract_code = %Data{bytes: <<>>}
+
+      # Create a contract with already empty bytecode
+      contract_address = insert(:address, contract_code: empty_contract_code)
+      recipient_address = insert(:address)
+
+      # Create a transaction with selfdestruct
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      assert {:ok, 0} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code remains empty (no update occurred)
+      updated_address = Repo.get(Address, contract_address.hash)
+      assert updated_address.contract_code == empty_contract_code
+    end
+
+    test "does NOT update address with nil contract_code" do
+      block = insert(:block, number: 550)
+
+      # Create a regular address (not a contract, contract_code is nil)
+      address = insert(:address, contract_code: nil)
+      recipient_address = insert(:address)
+
+      # Create a transaction with selfdestruct
+      transaction = insert(:transaction) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        block_hash: transaction.block_hash,
+        block_number: transaction.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      assert {:ok, 0} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code remains nil
+      updated_address = Repo.get(Address, address.hash)
+      assert updated_address.contract_code == nil
+    end
+
+    test "handles multiple blocks in one batch" do
+      block_1 = insert(:block, number: 600)
+      block_2 = insert(:block, number: 601)
+      contract_code_1 = %Data{bytes: <<1, 2, 3>>}
+      contract_code_2 = %Data{bytes: <<4, 5, 6>>}
+
+      # Create two contracts with bytecode
+      contract_address_1 = insert(:address, contract_code: contract_code_1)
+      contract_address_2 = insert(:address, contract_code: contract_code_2)
+      recipient_address_1 = insert(:address)
+      recipient_address_2 = insert(:address)
+
+      # Create selfdestruct in first block
+      transaction_1 = insert(:transaction, gas: 21_000) |> with_block(block_1)
+
+      insert(:internal_transaction,
+        transaction: transaction_1,
+        block_hash: transaction_1.block_hash,
+        block_number: transaction_1.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address_1,
+        to_address: recipient_address_1,
+        gas: nil
+      )
+
+      # Create selfdestruct in second block
+      transaction_2 = insert(:transaction, gas: 22_000) |> with_block(block_2)
+
+      insert(:internal_transaction,
+        transaction: transaction_2,
+        block_hash: transaction_2.block_hash,
+        block_number: transaction_2.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address_2,
+        to_address: recipient_address_2,
+        gas: nil
+      )
+
+      assert {:ok, 2} =
+               EmptyBytecodeForSelfdestructedSmartContracts.update_batch([
+                 block_1.number,
+                 block_2.number
+               ])
+
+      # Verify both contracts have empty contract_code
+      updated_address_1 = Repo.get(Address, contract_address_1.hash)
+      updated_address_2 = Repo.get(Address, contract_address_2.hash)
+      assert updated_address_1.contract_code == %Data{bytes: <<>>}
+      assert updated_address_2.contract_code == %Data{bytes: <<>>}
+    end
+
+    test "handles mixed scenario: one should empty, one should not" do
+      block = insert(:block, number: 700)
+      contract_code_1 = %Data{bytes: <<1, 2, 3>>}
+      contract_code_2 = %Data{bytes: <<4, 5, 6>>}
+
+      # Create two contracts
+      contract_address_1 = insert(:address, contract_code: contract_code_1)
+      contract_address_2 = insert(:address, contract_code: contract_code_2)
+      recipient_address_1 = insert(:address)
+      recipient_address_2 = insert(:address)
+
+      # First transaction: selfdestruct without create (should empty)
+      transaction_1 = insert(:transaction, gas: 21_000) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction_hash: transaction_1.hash,
+        block_hash: transaction_1.block_hash,
+        block_number: transaction_1.block_number,
+        index: 0,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address_1,
+        to_address: recipient_address_1,
+        gas: nil
+      )
+
+      # Second transaction: create + selfdestruct (should NOT empty)
+      transaction_2 = insert(:transaction, gas: 22_000) |> with_block(block)
+
+      insert(:internal_transaction_create,
+        transaction_hash: transaction_2.hash,
+        block_hash: transaction_2.block_hash,
+        block_number: transaction_2.block_number,
+        index: 0,
+        transaction_index: transaction_2.index,
+        block_index: 1,
+        created_contract_address: contract_address_2,
+        created_contract_code: contract_code_2
+      )
+
+      insert(:internal_transaction,
+        transaction_hash: transaction_2.hash,
+        block_hash: transaction_2.block_hash,
+        block_number: transaction_2.block_number,
+        index: 1,
+        transaction_index: transaction_2.index,
+        block_index: 2,
+        type: :selfdestruct,
+        from_address: contract_address_2,
+        to_address: recipient_address_2,
+        gas: nil
+      )
+
+      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify first contract is empty, second is not
+      updated_address_1 = Repo.get(Address, contract_address_1.hash)
+      updated_address_2 = Repo.get(Address, contract_address_2.hash)
+      assert updated_address_1.contract_code == %Data{bytes: <<>>}
+      assert updated_address_2.contract_code == contract_code_2
+    end
+
+    test "handles same contract selfdestructed multiple times in different transactions" do
+      block = insert(:block, number: 800)
+      contract_code = %Data{bytes: <<1, 2, 3, 4, 5>>}
+
+      # Create a contract with bytecode
+      contract_address = insert(:address, contract_code: contract_code)
+      recipient_address = insert(:address)
+
+      # Create two different transactions with selfdestruct for the same address
+      transaction_1 = insert(:transaction, gas: 21_000) |> with_block(block)
+      transaction_2 = insert(:transaction, gas: 22_000) |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction_hash: transaction_1.hash,
+        block_hash: transaction_1.block_hash,
+        block_number: transaction_1.block_number,
+        index: 0,
+        transaction_index: transaction_1.index,
+        block_index: 0,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      insert(:internal_transaction,
+        transaction_hash: transaction_2.hash,
+        block_hash: transaction_2.block_hash,
+        block_number: transaction_2.block_number,
+        index: 0,
+        transaction_index: transaction_2.index,
+        block_index: 1,
+        type: :selfdestruct,
+        from_address: contract_address,
+        to_address: recipient_address,
+        gas: nil
+      )
+
+      # Should still only update once since it's the same address
+      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+
+      # Verify contract_code is empty
+      updated_address = Repo.get(Address, contract_address.hash)
+      assert updated_address.contract_code == %Data{bytes: <<>>}
+    end
+  end
+
+  describe "last_unprocessed_identifiers/1" do
+    test "returns empty list when min_block_number is negative" do
+      state = %{"min_block_number" => -1}
+
+      assert {[], %{"min_block_number" => -1}} =
+               EmptyBytecodeForSelfdestructedSmartContracts.last_unprocessed_identifiers(state)
+    end
+
+    test "returns block numbers in descending order" do
+      state = %{"min_block_number" => 100}
+
+      {block_numbers, new_state} =
+        EmptyBytecodeForSelfdestructedSmartContracts.last_unprocessed_identifiers(state)
+
+      # Should return blocks in descending order
+      assert length(block_numbers) > 0
+      assert block_numbers == Enum.sort(block_numbers, :desc)
+      assert hd(block_numbers) == 100
+      assert new_state["min_block_number"] < 100
+    end
+
+    test "handles blocks down to zero" do
+      # Set a small number to test boundary
+      state = %{"min_block_number" => 5}
+
+      {block_numbers, new_state} =
+        EmptyBytecodeForSelfdestructedSmartContracts.last_unprocessed_identifiers(state)
+
+      assert length(block_numbers) > 0
+      assert Enum.min(block_numbers) >= 0
+      assert new_state["min_block_number"] <= 0
+    end
+  end
+
+  describe "update_cache/0" do
+    test "returns :ok" do
+      assert :ok = EmptyBytecodeForSelfdestructedSmartContracts.update_cache()
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/8923

## Changelog

### AI Agent Summary

This pull request introduces logic to empty the bytecode (`contract_code`) of smart contracts that have been selfdestructed, except for contracts that were created and selfdestructed within the same transaction. The changes include both runtime logic in the internal transaction import process and a new migration for existing data. Comprehensive tests are added to ensure correct behavior in various scenarios.

**Internal Transaction Import Logic:**

* Added a step to the internal transaction import pipeline to empty the `contract_code` for addresses that were selfdestructed, unless they were also created in the same transaction. This ensures that contract bytecode is removed only for contracts that truly no longer exist. [[1]](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211R205-R215) [[2]](diffhunk://#diff-ac792f8a8aa0e6910e76fccd5228611c5758ef6e43bcf1771e01543d4eb70211R916-R962)
* Refactored to include the `Address` module in the relevant import for bytecode updates.

**Database Migration:**

* Introduced a new migration module, `Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts`, which processes historical data to empty `contract_code` for all previously selfdestructed contracts, again skipping those created and destroyed in the same transaction. This migration works in batches for efficiency.

**Testing Enhancements:**

* Added comprehensive tests covering:
  - Emptying bytecode for contracts selfdestructed in a different transaction from creation.
  - Not emptying bytecode when creation and selfdestruct happen in the same transaction (for both `create` and `create2`).
  - Handling of multiple contracts and non-existent addresses gracefully.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart contract bytecode is cleared for contracts that self-destruct in separate transactions; a migration was added to process historical cases.

* **Bug Fixes**
  * Bytecode is preserved when a contract is created and self-destructs within the same transaction; handles multiple contracts and non-existent addresses gracefully.

* **Tests**
  * Extensive tests added covering creation/self-destruct edge cases, multi-contract scenarios, and the migration behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->