### PR TITLE
feat: REST API endpoint to list uncompleted DB migrations

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
   use OpenApiSpex.ControllerSpecs
 
   alias Explorer.Chain.SmartContract
+  alias Explorer.Migrator.MigrationStatus
   alias OpenApiSpex.Schema
 
   plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
@@ -169,5 +170,56 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
     conn
     |> put_status(200)
     |> json(%{languages: SmartContract.language_strings()})
+  end
+
+  operation :db_background_migrations,
+    summary: "Uncompleted background migrations",
+    description: "Returns list of background migrations that are not yet completed.",
+    parameters: base_params(),
+    responses: [
+      ok:
+        {"Uncompleted background migrations.", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             migrations: %Schema{
+               type: :array,
+               items: %Schema{
+                 type: :object,
+                 properties: %{
+                   migration_name: %Schema{type: :string},
+                   status: %Schema{type: :string},
+                   inserted_at: %Schema{type: :string, format: "date-time"},
+                   updated_at: %Schema{type: :string, format: "date-time"},
+                   meta: %Schema{type: :object, nullable: true}
+                 }
+               }
+             }
+           }
+         }},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
+
+  @doc """
+    Function to handle GET requests to `/api/v2/config/db_background_migrations` endpoint.
+  """
+  @spec db_background_migrations(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def db_background_migrations(conn, _params) do
+    migrations = MigrationStatus.fetch_uncompleted_migrations()
+
+    conn
+    |> put_status(200)
+    |> json(%{
+      migrations:
+        Enum.map(migrations, fn migration ->
+          %{
+            migration_name: migration.migration_name,
+            status: migration.status,
+            inserted_at: migration.inserted_at,
+            updated_at: migration.updated_at,
+            meta: migration.meta
+          }
+        end)
+    })
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -143,6 +143,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/indexer", V2.ConfigController, :indexer)
       get("/public-metrics", V2.ConfigController, :public_metrics)
       get("/smart-contracts/languages", V2.ConfigController, :languages_list)
+      get("/db-background-migrations", V2.ConfigController, :db_background_migrations)
 
       if @chain_identity == {:optimism, :celo} do
         get("/celo", V2.ConfigController, :celo)

--- a/apps/explorer/lib/explorer/migrator/migration_status.ex
+++ b/apps/explorer/lib/explorer/migrator/migration_status.ex
@@ -169,4 +169,19 @@ defmodule Explorer.Migrator.MigrationStatus do
     |> fetch_migration_statuses_query()
     |> Repo.all()
   end
+
+  @doc """
+  Fetches all uncompleted migrations (status != 'completed').
+
+  ## Returns
+
+    - A list of uncompleted migration status structs.
+
+  """
+  @spec fetch_uncompleted_migrations() :: list(__MODULE__.t())
+  def fetch_uncompleted_migrations do
+    __MODULE__
+    |> where([ms], ms.status != "completed")
+    |> Repo.all()
+  end
 end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -1679,4 +1679,12 @@ defmodule Explorer.Factory do
       transaction: transaction
     }
   end
+
+  def migration_status_factory do
+    %MigrationStatus{
+      migration_name: sequence("migration_", &"migration_#{&1}"),
+      status: "started",
+      meta: nil
+    }
+  end
 end


### PR DESCRIPTION
## Motivation

Enhance observability of the background DB migrations completion.

## Changelog

### AI Agent Summary

This pull request adds a new API endpoint to expose uncompleted background database migrations, along with the backend logic to fetch this data. The changes include updates to the API controller, router, and the migration status module.

**API Enhancements:**

* Added a new `GET /api/v2/config/db-background-migrations` endpoint in the API router and `ConfigController` to return a list of background migrations that are not yet completed. [[1]](diffhunk://#diff-7b31aa9ca8af99c00b6548ddcef75c78c1824715a3cd6d5e10dbcc6ace229780R146) [[2]](diffhunk://#diff-3455c148d1de33cfbbfc27072800d08f106c8a3cbdcb5f934740c8153a055acbR174-R224)
* Defined the OpenAPI operation and response schema for the new endpoint, including migration details such as name, status, timestamps, and metadata.

**Backend Logic:**

* Implemented the `fetch_uncompleted_migrations/0` function in `MigrationStatus` to retrieve all migrations where the status is not `"completed"`.
* Imported the `MigrationStatus` module in the controller to support the new endpoint.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoint to retrieve database background migrations status, providing details for uncompleted migrations including name, status, timestamps, and metadata.

* **Tests**
  * Added comprehensive test coverage for the new endpoint, validating handling of empty migrations, filtering of completed migrations, and metadata inclusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->