### PR TITLE
fix: Exclude 0 index internal transactions from /api/v2/internal-transactions endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -93,6 +93,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   defp options(paging_options, params) do
     paging_options
     |> Keyword.put(:transaction_hash, params.transaction_hash)
+    |> Keyword.put(:exclude_origin_internal_transaction, true)
     |> Keyword.update(:paging_options, default_paging_options(), fn %PagingOptions{
                                                                       page_size: page_size
                                                                     } = paging_options ->

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
@@ -32,8 +32,8 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
         transaction_index: 0,
         block_number: tx.block_number,
         block_hash: tx.block_hash,
-        index: 0,
-        block_index: 0
+        index: 1,
+        block_index: 1
       )
 
       request = get(conn, "/api/v2/internal-transactions")
@@ -52,14 +52,14 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
           transaction_index: 0,
           block_number: transaction.block_number,
           block_hash: transaction.block_hash,
-          index: 0,
+          index: 1,
           block_index: 0
         )
 
       transaction_2 = insert(:transaction) |> with_block()
 
       internal_transactions =
-        for i <- 0..49 do
+        for i <- 1..50 do
           insert(:internal_transaction,
             transaction: transaction_2,
             transaction_index: 0,
@@ -79,6 +79,109 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
       assert response_2nd_page = json_response(request_2nd_page, 200)
 
       check_paginated_response(response, response_2nd_page, internal_transactions)
+    end
+
+    test "excludes zero index internal transaction when querying by transaction_hash", %{conn: conn} do
+      tx =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      # Insert internal transaction with index 0 (origin sender transaction) - should be excluded
+      insert(:internal_transaction,
+        transaction: tx,
+        transaction_index: 0,
+        block_number: tx.block_number,
+        block_hash: tx.block_hash,
+        index: 0,
+        block_index: 0,
+        type: :call
+      )
+
+      # Insert internal transaction with index 1 - should be included
+      it_1 =
+        insert(:internal_transaction,
+          transaction: tx,
+          transaction_index: 0,
+          block_number: tx.block_number,
+          block_hash: tx.block_hash,
+          index: 1,
+          block_index: 1,
+          type: :call
+        )
+
+      # Insert internal transaction with index 2 - should be included
+      it_2 =
+        insert(:internal_transaction,
+          transaction: tx,
+          transaction_index: 0,
+          block_number: tx.block_number,
+          block_hash: tx.block_hash,
+          index: 2,
+          block_index: 2,
+          type: :call
+        )
+
+      request = get(conn, "/api/v2/internal-transactions", %{"transaction_hash" => to_string(tx.hash)})
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 2
+      assert response["next_page_params"] == nil
+
+      # Verify that only index 1 and 2 are returned, not index 0
+      returned_indices = Enum.map(response["items"], & &1["index"])
+      assert 1 in returned_indices
+      assert 2 in returned_indices
+      refute 0 in returned_indices
+    end
+
+    test "pagination works correctly with zero index filtering", %{conn: conn} do
+      tx =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      # Insert internal transaction with index 0 - should be excluded
+      insert(:internal_transaction,
+        transaction: tx,
+        transaction_index: 0,
+        block_number: tx.block_number,
+        block_hash: tx.block_hash,
+        index: 0,
+        block_index: 0,
+        type: :call
+      )
+
+      # Insert 51 internal transactions with index 1-51
+      for i <- 1..51 do
+        insert(:internal_transaction,
+          transaction: tx,
+          transaction_index: 0,
+          block_number: tx.block_number,
+          block_hash: tx.block_hash,
+          index: i,
+          block_index: i,
+          type: :call
+        )
+      end
+
+      request = get(conn, "/api/v2/internal-transactions", %{"transaction_hash" => to_string(tx.hash)})
+      assert response = json_response(request, 200)
+
+      # Should return 50 items (excluding index 0)
+      assert Enum.count(response["items"]) == 50
+      assert response["next_page_params"] != nil
+
+      # First item should be index 1, not 0
+      assert List.first(response["items"])["index"] == 1
+
+      # Get second page
+      request_2nd_page = get(conn, "/api/v2/internal-transactions", response["next_page_params"])
+      assert response_2nd_page = json_response(request_2nd_page, 200)
+
+      # Second page should have 1 item
+      assert Enum.count(response_2nd_page["items"]) == 1
+      assert response_2nd_page["next_page_params"] == nil
     end
   end
 


### PR DESCRIPTION
## Motivation

Resolves https://github.com/blockscout/blockscout/issues/12587

## Changelog

### AI Agent Summary

This pull request introduces a new filtering option for internal transactions, allowing the exclusion of the origin (index 0, type :call) internal transaction when fetching data via the API. The changes add this option to both the API controller and the underlying query logic, ensuring more flexible and accurate results for API consumers.

**API improvements:**

* Added the `:exclude_origin_internal_transaction` option to the `options` used by `InternalTransactionController`, enabling API clients to request results that omit the origin internal transaction.

**Query and filtering enhancements:**

* Documented the new `:exclude_origin_internal_transaction` option in the `Explorer.Chain.InternalTransaction.fetch/1` function, explaining its effect and usage.
* Updated the `fetch/1` function to extract the `:exclude_origin_internal_transaction` option and use it when building the query.
* Added the `maybe_filter_origin_transaction/2` function to conditionally filter out the origin internal transaction based on the provided option, and integrated this filter into the main query pipeline. [[1]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cR1018) [[2]](diffhunk://#diff-6a05d044db92e8bc0ac8d422ed1e66252d93e64b67b35b5f907dec2db7b6b03cR1071-R1073)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal transaction API now excludes origin transactions (index 0) from query results.
* **Updates**
  * Pagination adjusted to reflect transaction filtering behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->