### PR TITLE
chore: Add "openapi_spec_folder_name" to the response of api/v2/config/backend endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -19,7 +19,13 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
     responses: [
       ok:
         {"Backend environment configuration.", "application/json",
-         %Schema{type: :object, properties: %{chain_type: %Schema{type: :string, nullable: true}}}},
+         %Schema{
+           type: :object,
+           properties: %{
+             chain_type: %Schema{type: :string, nullable: true},
+             openapi_spec_folder_name: %Schema{type: :string, nullable: true}
+           }
+         }},
       unprocessable_entity: JsonErrorResponse.response()
     ]
 
@@ -32,7 +38,19 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
 
     conn
     |> put_status(200)
-    |> json(%{"chain_type" => chain_type})
+    |> json(%{
+      "chain_type" => chain_type,
+      "openapi_spec_folder_name" => chain_type_translate_to_openapi_spec_folder_name()
+    })
+  end
+
+  @spec chain_type_translate_to_openapi_spec_folder_name() :: String.t()
+  defp chain_type_translate_to_openapi_spec_folder_name do
+    if Application.get_env(:explorer, Explorer.Chain.Mud)[:enabled] do
+      "mud"
+    else
+      chain_type() || "default"
+    end
   end
 
   operation :backend_version,


### PR DESCRIPTION
## Motivation

It is required by https://github.com/blockscout/frontend/issues/3204.

## Changelog

GET `api/v2/config/backend`:

Response example:
```
{
    "chain_type": "optimism",
    "openapi_spec_folder_name": "mud"
}
```

### AI Agent Summary

This pull request enhances the API response from the `ConfigController` by including additional information about the OpenAPI specification folder name, which is determined based on the chain type configuration.

**API response improvements:**

* The JSON response from the `show` action now includes an `openapi_spec_folder_name` field, which provides the folder name for the OpenAPI spec based on the current chain type or Mud chain configuration.
* Added a private helper function `chain_type_translate_to_openapi_spec_folder_name/0` to determine the appropriate folder name, returning `"mud"` if the Mud chain is enabled, or the current chain type otherwise.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend configuration API now returns an openapi_spec_folder_name to indicate which OpenAPI spec folder to use (reflects Mud explorer availability).
* **Documentation**
  * API response schema updated to document the new openapi_spec_folder_name property.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->