### PR TITLE
fix: Prevent DeleteZeroValueInternalTransactions from running while ShrinkInternalTransactions is in progress

### DIFF
--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -18,6 +18,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
   alias Timex.Duration
 
   @migration_name "delete_zero_value_internal_transactions"
+  @shrink_internal_transactions_migration_name "shrink_internal_transactions"
   @not_completed_check_interval 10
   @default_check_interval :timer.minutes(1)
   @default_batch_size 100
@@ -41,22 +42,13 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
   end
 
   @impl true
-  def handle_continue(:ok, _state) do
-    state =
-      case MigrationStatus.fetch(@migration_name) do
-        nil ->
-          state = %{"max_block_number" => -1}
-          MigrationStatus.set_status(@migration_name, "started")
-          MigrationStatus.update_meta(@migration_name, state)
-          state
+  def handle_continue(:ok, state) do
+    check_dependency_and_start(state)
+  end
 
-        %{meta: meta} ->
-          meta
-      end
-
-    schedule_check()
-
-    {:noreply, state}
+  @impl true
+  def handle_info(:check_dependency, state) do
+    check_dependency_and_start(state)
   end
 
   @impl true
@@ -79,6 +71,32 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
     MigrationStatus.update_meta(@migration_name, new_state)
     schedule_check(completed?)
     {:noreply, new_state}
+  end
+
+  defp check_dependency_and_start(state) do
+    shrink_config = Application.get_env(:explorer, Explorer.Migrator.ShrinkInternalTransactions) || []
+    shrink_enabled? = shrink_config[:enabled] != false
+    shrink_status = MigrationStatus.get_status(@shrink_internal_transactions_migration_name)
+
+    if shrink_enabled? && shrink_status != "completed" do
+      schedule_dependency_check()
+      {:noreply, state}
+    else
+      state =
+        case MigrationStatus.fetch(@migration_name) do
+          nil ->
+            state = %{"max_block_number" => -1}
+            MigrationStatus.set_status(@migration_name, "started")
+            MigrationStatus.update_meta(@migration_name, state)
+            state
+
+          %{meta: meta} ->
+            meta
+        end
+
+      schedule_check()
+      {:noreply, state}
+    end
   end
 
   defp clear_from_delete_queue do
@@ -230,6 +248,11 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
 
   defp schedule_check(completed? \\ false) do
     Process.send_after(self(), :update, (completed? && completed_check_interval()) || @not_completed_check_interval)
+  end
+
+  defp schedule_dependency_check do
+    interval = Application.get_env(:explorer, __MODULE__)[:dependency_check_interval] || :timer.hours(1)
+    Process.send_after(self(), :check_dependency, interval)
   end
 
   defp completed_check_interval do


### PR DESCRIPTION
## Motivation

We should run `DeleteZeroValueInternalTransactions` only after `ShrinkInternalTransactions` migration has completed. Running them concurrently can lead to data inconsistencies and unpredictable results.

## Changelog

### AI Agent Summary

This pull request introduces dependency management between the `DeleteZeroValueInternalTransactions` migration and the `ShrinkInternalTransactions` migration, ensuring that zero-value internal transactions are only deleted after the shrink migration has completed. It also adds comprehensive tests to verify this behavior.

**Migration Dependency Management:**

* Added logic to `DeleteZeroValueInternalTransactions` to check if `ShrinkInternalTransactions` is enabled and completed before starting. If not completed, the migration waits and periodically checks the dependency status. [[1]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dR21) [[2]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dR76-R101) [[3]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dR253-R256)
* Refactored the migration initialization flow to use a new internal function `check_dependency_and_start`, which handles dependency checks and state initialization. [[1]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dL45-R51) [[2]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dR76-R101) [[3]](diffhunk://#diff-83de37f0ef747da394b54ddcce2dd9b7731f676535771e5b39f0bc83449cd42dR253-R256)

**Testing Improvements:**

* Added tests to ensure that `DeleteZeroValueInternalTransactions` waits for `ShrinkInternalTransactions` to complete before starting when enabled, and starts immediately when the dependency is disabled or not configured.

These changes help prevent data inconsistencies by ensuring migrations are executed in the correct order and provide robust test coverage for the new dependency logic.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved migration sequencing so a cleanup migration waits for a prerequisite migration to finish before starting.
  * Added deferred scheduling to ensure migrations start only after configured dependencies complete.

* **Tests**
  * Added tests verifying migrations wait for dependencies when enabled and start immediately when disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->