### PR TITLE
fix: Return date to logs

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,12 +12,21 @@ config :logger, :default_handler,
     (if config_env() == :prod do
        LoggerJSON.Formatters.Basic.new(metadata: ConfigHelper.logger_backend_metadata())
      else
-       Logger.Formatter.new(metadata: ConfigHelper.logger_backend_metadata())
+       Logger.Formatter.new(
+         format: "$dateT$time $metadata[$level] $message\n",
+         metadata: ConfigHelper.logger_backend_metadata()
+       )
      end)
 
-config :logger, :api, metadata: ConfigHelper.logger_metadata(), metadata_filter: [application: :api]
+config :logger, :api,
+  format: "$dateT$time $metadata[$level] $message\n",
+  metadata: ConfigHelper.logger_metadata(),
+  metadata_filter: [application: :api]
 
-config :logger, :api_v2, metadata: ConfigHelper.logger_metadata(), metadata_filter: [application: :api_v2]
+config :logger, :api_v2,
+  format: "$dateT$time $metadata[$level] $message\n",
+  metadata: ConfigHelper.logger_metadata(),
+  metadata_filter: [application: :api_v2]
 
 microservice_multichain_search_url = ConfigHelper.parse_url_env_var("MICROSERVICE_MULTICHAIN_SEARCH_URL")
 transactions_stats_enabled = ConfigHelper.parse_bool_env_var("TXS_STATS_ENABLED", "true")


### PR DESCRIPTION
## Motivation

After the changes in https://github.com/blockscout/blockscout/pull/12783, log records do not contain date info:
```
14:08:50.878 application=api_v2 request_id=GIri8FuEwRp1EPAAAKsB [info] Sent 200 in 5211ms on GET /api/v2/addresses?
```

## Changelog

The PR is aimed to return date to the log record:
```
2026-01-15T14:16:56.958 application=api_v2 request_id=GIrjYqV7z81LWjYAAAMF [info] Sent 200 in 422ms on GET /api/v2/addresses?

```

### AI Agent Summary

This pull request updates the logger configuration to standardize the log message format across all environments and handlers. The changes ensure that logs are consistently formatted, making them easier to read and parse.

Logger configuration improvements:

* Updated the default logger handler in `config/runtime.exs` to use a consistent log format string for both production and non-production environments.
* Added the same log format string to the `:api` and `:api_v2` logger configurations, ensuring uniformity in log output.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized logging configuration: added explicit log formatting and unified metadata handling across default and API-specific loggers, and updated metadata filters for consistent, timestamped log output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->