### PR TITLE
fix: Apply traceable block ranges to stream_blocks_with_unfetched_internal_transactions function

### DIFF
--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -7,6 +7,7 @@ defmodule Explorer.Chain.PendingBlockOperation do
 
   import Explorer.Chain, only: [add_fetcher_limit: 2]
 
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain.{Block, Hash}
   alias Explorer.Repo
 
@@ -92,8 +93,11 @@ defmodule Explorer.Chain.PendingBlockOperation do
         order_by: [{^direction, po.block_number}]
       )
 
+    # Wrap the reducer to filter out non-traceable blocks based on TRACE_BLOCK_RANGES
+    traceable_reducer = RangesHelper.stream_reducer_traceable(reducer)
+
     query
     |> add_fetcher_limit(limited?)
-    |> Repo.stream_reduce(initial, reducer)
+    |> Repo.stream_reduce(initial, traceable_reducer)
   end
 end


### PR DESCRIPTION
## Motivation

state of the `Indexer.Fetcher.InternalTransaction` fetcher contains block numbers, which are below, than configured
```
TRACE_FIRST_BLOCK: '105235062'
```
on the backend:

```
:sys.get_state(Indexer.Fetcher.InternalTransaction).bound_queue
%Explorer.BoundQueue{queue: {[], [105235062]}, size: 1, maximum_size: nil}
iex(blockscout@10.42.195.12)20> :sys.get_state(Indexer.Fetcher.InternalTransaction).bound_queue
%Explorer.BoundQueue{
  queue: {[985, 1244152, 123322, 1135391], [105235062]},
  size: 5,
  maximum_size: nil
}
```

## Changelog

### Ai Agent Summary

This pull request updates the `PendingBlockOperation` module to ensure that only traceable blocks are processed during stream reduction. The main improvement is the integration of a new reducer wrapper that filters out non-traceable blocks based on predefined trace block ranges.

**Enhancements to block streaming and filtering:**

* Imported the `RangesHelper` module from `EthereumJSONRPC.Utility` to enable block range filtering functionality.
* Wrapped the stream reducer with `RangesHelper.stream_reducer_traceable`, ensuring that only traceable blocks (as defined by `TRACE_BLOCK_RANGES`) are included during the streaming and reduction process.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block processing to better handle non-traceable blocks during stream operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->