### PR TITLE
fix: Filter traceable data in InternalTransaction.async_fetch

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -57,7 +57,11 @@ defmodule Indexer.Fetcher.InternalTransaction do
     if InternalTransactionSupervisor.disabled?() do
       :ok
     else
-      data = data_for_buffer(block_numbers, transactions)
+      data =
+        block_numbers
+        |> data_for_buffer(transactions)
+        |> RangesHelper.filter_traceable_block_numbers()
+
       BufferedTask.buffer(__MODULE__, data, realtime?, timeout)
     end
   end


### PR DESCRIPTION
## Motivation

Non-traceable blocks may leak into internal transaction fetcher via `async_fetch` since there is no filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block indexing reliability by filtering non-traceable blocks earlier in the transaction processing pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->