### PR TITLE
chore: Filter blocks by BLOCK_RANGES in add_ranges_by_block_numbers

### DIFF
--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -5,6 +5,7 @@ defmodule Explorer.Utility.MissingBlockRange do
   """
   use Explorer.Schema
 
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain.{Block, BlockNumberHelper}
   alias Explorer.Repo
 
@@ -110,6 +111,7 @@ defmodule Explorer.Utility.MissingBlockRange do
   @spec add_ranges_by_block_numbers([Block.block_number()], integer() | nil) :: :ok
   def add_ranges_by_block_numbers(numbers, priority \\ nil) do
     numbers
+    |> RangesHelper.filter_by_block_ranges()
     |> numbers_to_ranges()
     |> save_batch(priority)
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13658

## Motivation

In case when block became `refetch_needed=true` but is not present in `BLOCK_RANGES` it shouldn't be processed by catchup fetcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved block range processing with additional filtering for enhanced data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->