### PR TITLE
feat: Allow adding EOA with code to watchlist

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/user_controller_test.exs
@@ -576,6 +576,32 @@ defmodule BlockScoutWeb.Account.Api.V2.UserControllerTest do
       Application.put_env(:explorer, Explorer.Account, old_env)
     end
 
+    test "can't insert contract watchlist address", %{conn: conn} do
+      address = insert(:contract_address)
+
+      response =
+        conn
+        |> post(
+          "/api/account/v2/user/watchlist",
+          build(:watchlist_address) |> Map.put("address_hash", to_string(address.hash))
+        )
+        |> json_response(422)
+
+      assert response == %{"errors" => %{"address_hash" => ["This address isn't EOA"]}}
+    end
+
+    test "can insert EOA with code watchlist address", %{conn: conn, user: user} do
+      address = insert(:contract_address, contract_code: "0xef01000000000000000000000000000000000000000123")
+
+      response =
+        conn
+        |> post(
+          "/api/account/v2/user/watchlist",
+          build(:watchlist_address) |> Map.put("address_hash", to_string(address.hash))
+        )
+        |> json_response(200)
+    end
+
     test "check watchlist tags pagination", %{conn: conn, user: user} do
       tags_address =
         for _ <- 0..50 do

--- a/apps/explorer/lib/explorer/account/notifier/forbidden_address.ex
+++ b/apps/explorer/lib/explorer/account/notifier/forbidden_address.ex
@@ -49,7 +49,7 @@ defmodule Explorer.Account.Notifier.ForbiddenAddress do
   defp contract?(%Explorer.Chain.Hash{} = address_hash) do
     case hash_to_address(address_hash) do
       {:error, :not_found} -> false
-      {:ok, address} -> Address.smart_contract?(address)
+      {:ok, address} -> Address.smart_contract?(address) && !Address.eoa_with_code?(address)
     end
   end
 


### PR DESCRIPTION
Close #13095

## Changelog
- Allow adding EOA with code (EIP7702) to watchlist 

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined address classification logic to correctly handle EOA addresses containing code, improving watchlist validation accuracy.

* **Tests**
  * Added test coverage for watchlist address validation, ensuring proper rejection of non-EOA contracts and acceptance of EOA addresses with code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->