### PR TITLE
chore: Add error_id to internal transactions

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/csv_export/address/internal_transactions_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/csv_export/address/internal_transactions_test.exs
@@ -198,6 +198,8 @@ defmodule BlockScoutWeb.CsvExport.Address.InternalTransactionsTest do
         |> insert()
         |> with_block()
 
+      transaction_error = insert(:transaction_error, message: "reverted")
+
       internal_transaction =
         insert(:internal_transaction,
           index: 1,
@@ -207,6 +209,7 @@ defmodule BlockScoutWeb.CsvExport.Address.InternalTransactionsTest do
           block_hash: transaction.block_hash,
           transaction_index: transaction.index,
           error: "reverted",
+          error_id: transaction_error.id,
           gas_used: nil,
           output: nil
         )

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -852,7 +852,7 @@ defmodule Explorer.Chain.Address do
       it in InternalTransaction,
       where: it.index > 0,
       order_by: [
-        asc_nulls_first: it.error,
+        asc_nulls_first: coalesce(it.error, type(it.error_id, :string)),
         desc: it.block_number,
         desc: it.transaction_index,
         desc: it.index

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -308,6 +308,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
     |> limit(1)
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp preload_internal_transaction_query(balance) do
     InternalTransaction
     |> where(
@@ -315,7 +316,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
       internal_transaction.block_number == ^balance.block_number and
         internal_transaction.type in ~w(call create create2 selfdestruct)a and
         (is_nil(internal_transaction.call_type) or internal_transaction.call_type == :call) and
-        internal_transaction.value > ^0 and is_nil(internal_transaction.error) and
+        internal_transaction.value > ^0 and is_nil(internal_transaction.error) and is_nil(internal_transaction.error_id) and
         (internal_transaction.to_address_hash == ^balance.address_hash or
            internal_transaction.from_address_hash == ^balance.address_hash or
            internal_transaction.created_contract_address_hash == ^balance.address_hash)

--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -18,7 +18,8 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     InternalTransaction,
     PendingOperationsHelper,
     PendingTransactionOperation,
-    Transaction
+    Transaction,
+    TransactionError
   }
 
   alias Explorer.Chain.Events.Publisher
@@ -284,7 +285,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
             call_type: fragment("EXCLUDED.call_type"),
             created_contract_address_hash: fragment("EXCLUDED.created_contract_address_hash"),
             created_contract_code: fragment("EXCLUDED.created_contract_code"),
-            error: fragment("EXCLUDED.error"),
+            error_id: fragment("EXCLUDED.error_id"),
             from_address_hash: fragment("EXCLUDED.from_address_hash"),
             gas: fragment("EXCLUDED.gas"),
             gas_used: fragment("EXCLUDED.gas_used"),
@@ -306,12 +307,12 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         # `IS DISTINCT FROM` is used because it allows `NULL` to be equal to itself
         where:
           fragment(
-            "(EXCLUDED.transaction_hash, EXCLUDED.call_type, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code, EXCLUDED.error, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_used, EXCLUDED.init, EXCLUDED.input, EXCLUDED.output, EXCLUDED.to_address_hash, EXCLUDED.trace_address, EXCLUDED.type, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "(EXCLUDED.transaction_hash, EXCLUDED.call_type, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code, EXCLUDED.error_id, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_used, EXCLUDED.init, EXCLUDED.input, EXCLUDED.output, EXCLUDED.to_address_hash, EXCLUDED.trace_address, EXCLUDED.type, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             internal_transaction.transaction_hash,
             internal_transaction.call_type,
             internal_transaction.created_contract_address_hash,
             internal_transaction.created_contract_code,
-            internal_transaction.error,
+            internal_transaction.error_id,
             internal_transaction.from_address_hash,
             internal_transaction.gas,
             internal_transaction.gas_used,
@@ -333,7 +334,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
             call_type: fragment("EXCLUDED.call_type"),
             created_contract_address_hash: fragment("EXCLUDED.created_contract_address_hash"),
             created_contract_code: fragment("EXCLUDED.created_contract_code"),
-            error: fragment("EXCLUDED.error"),
+            error_id: fragment("EXCLUDED.error_id"),
             from_address_hash: fragment("EXCLUDED.from_address_hash"),
             gas: fragment("EXCLUDED.gas"),
             gas_used: fragment("EXCLUDED.gas_used"),
@@ -356,13 +357,13 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
         # `IS DISTINCT FROM` is used because it allows `NULL` to be equal to itself
         where:
           fragment(
-            "(EXCLUDED.transaction_hash, EXCLUDED.index, EXCLUDED.call_type, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code, EXCLUDED.error, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_used, EXCLUDED.init, EXCLUDED.input, EXCLUDED.output, EXCLUDED.to_address_hash, EXCLUDED.trace_address, EXCLUDED.transaction_index, EXCLUDED.type, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "(EXCLUDED.transaction_hash, EXCLUDED.index, EXCLUDED.call_type, EXCLUDED.created_contract_address_hash, EXCLUDED.created_contract_code, EXCLUDED.error_id, EXCLUDED.from_address_hash, EXCLUDED.gas, EXCLUDED.gas_used, EXCLUDED.init, EXCLUDED.input, EXCLUDED.output, EXCLUDED.to_address_hash, EXCLUDED.trace_address, EXCLUDED.transaction_index, EXCLUDED.type, EXCLUDED.value) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             internal_transaction.transaction_hash,
             internal_transaction.index,
             internal_transaction.call_type,
             internal_transaction.created_contract_address_hash,
             internal_transaction.created_contract_code,
-            internal_transaction.error,
+            internal_transaction.error_id,
             internal_transaction.from_address_hash,
             internal_transaction.gas,
             internal_transaction.gas_used,
@@ -505,34 +506,43 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     else
       blocks_map = Map.new(transactions, &{&1.block_number, &1.block_hash})
 
+      error_to_error_id_map =
+        internal_transactions_params
+        |> Enum.map(&sanitize_error/1)
+        |> Enum.map(&Map.get(&1, :error))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+        |> TransactionError.find_or_create_multiple()
+
       valid_internal_transactions =
         internal_transactions_params
         |> Enum.group_by(& &1.block_number)
         |> Map.drop(invalid_block_numbers)
         |> Enum.flat_map(fn item ->
-          compose_entry_wrapper(item, blocks_map)
+          compose_entry_wrapper(item, blocks_map, error_to_error_id_map)
         end)
 
       {:ok, valid_internal_transactions}
     end
   end
 
-  defp compose_entry_wrapper(item, blocks_map) do
+  defp compose_entry_wrapper(item, blocks_map, error_to_error_id_map) do
     case item do
       {block_number, entries} ->
-        compose_entry(entries, blocks_map, block_number)
+        compose_entry(entries, blocks_map, error_to_error_id_map, block_number)
 
       _ ->
         []
     end
   end
 
-  defp compose_entry(entries, blocks_map, block_number) do
+  defp compose_entry(entries, blocks_map, error_to_error_id_map, block_number) do
     if Map.has_key?(blocks_map, block_number) do
       if InternalTransactionHelper.primary_key_updated?() do
         Enum.map(entries, fn entry ->
           entry
           |> sanitize_error()
+          |> put_error_id(error_to_error_id_map)
           |> shift_created_contract_address_hash()
         end)
       else
@@ -549,12 +559,17 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
           |> Map.put(:block_hash, block_hash)
           |> Map.put(:block_index, index)
           |> sanitize_error()
+          |> put_error_id(error_to_error_id_map)
           |> shift_created_contract_address_hash()
         end)
       end
     else
       []
     end
+  end
+
+  defp put_error_id(entry, error_to_error_id_map) do
+    Map.put(entry, :error_id, error_to_error_id_map[Map.get(entry, :error)])
   end
 
   defp valid_internal_transactions_without_first_trace(valid_internal_transactions) do

--- a/apps/explorer/lib/explorer/chain/transaction_error.ex
+++ b/apps/explorer/lib/explorer/chain/transaction_error.ex
@@ -1,0 +1,44 @@
+defmodule Explorer.Chain.TransactionError do
+  @moduledoc """
+  Stores errors for transactions and internal transactions.
+  """
+
+  use Explorer.Schema
+
+  alias Explorer.Repo
+
+  typed_schema "transaction_errors" do
+    field(:message, :string, null: false)
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(%__MODULE__{} = transaction_error, attrs) do
+    cast(transaction_error, attrs, [:message])
+  end
+
+  def find_or_create_multiple(error_messages) do
+    existing_map =
+      __MODULE__
+      |> where([te], te.message in ^error_messages)
+      |> select([te], {te.message, te.id})
+      |> Repo.all()
+      |> Map.new()
+
+    missing_errors = error_messages -- Map.keys(existing_map)
+
+    now = DateTime.utc_now()
+    insert_params = Enum.map(missing_errors, &%{message: &1, inserted_at: now})
+
+    {_total, inserted} =
+      Repo.insert_all(__MODULE__, insert_params,
+        on_conflict: {:replace, [:inserted_at]},
+        conflict_target: [:message],
+        returning: true
+      )
+
+    new_records_map = Map.new(inserted, &{&1.message, &1.id})
+
+    Map.merge(existing_map, new_records_map)
+  end
+end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -96,6 +96,7 @@ defmodule Explorer.Etherscan do
     gas
     gas_used
     error
+    error_id
   )a
 
   @doc """
@@ -158,6 +159,7 @@ defmodule Explorer.Etherscan do
     |> InternalTransaction.where_nonpending_operation()
     |> InternalTransaction.include_zero_value(options.include_zero_value)
     |> Repo.replica().all()
+    |> InternalTransaction.preload_error()
   end
 
   def list_internal_transactions(
@@ -204,6 +206,7 @@ defmodule Explorer.Etherscan do
     |> offset(^options_to_offset(options))
     |> limit(^options.page_size)
     |> Repo.replica().all()
+    |> InternalTransaction.preload_error()
   end
 
   def list_internal_transactions(
@@ -221,6 +224,7 @@ defmodule Explorer.Etherscan do
     |> where_start_block_match_internal_transaction(options)
     |> where_end_block_match_internal_transaction(options)
     |> Repo.replica().all()
+    |> InternalTransaction.preload_error()
   end
 
   defp consensus_internal_transactions_with_transactions_and_blocks_query(options) do

--- a/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
@@ -59,7 +59,9 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
     it_error_query =
       from(
         it in InternalTransaction,
-        where: parent_as(:transaction).hash == it.transaction_hash and not is_nil(it.error) and it.index > 0,
+        where:
+          parent_as(:transaction).hash == it.transaction_hash and it.index > 0 and
+            (not is_nil(it.error) or not is_nil(it.error_id)),
         select: 1
       )
 

--- a/apps/explorer/priv/repo/migrations/20250915135943_create_transaction_errors.exs
+++ b/apps/explorer/priv/repo/migrations/20250915135943_create_transaction_errors.exs
@@ -1,0 +1,74 @@
+defmodule Explorer.Repo.Migrations.CreateTransactionErrors do
+  use Ecto.Migration
+
+  def change do
+    create table(:transaction_errors, primary_key: false) do
+      add(:id, :smallserial, primary_key: true)
+      add(:message, :string, null: false)
+
+      timestamps(updated_at: false)
+    end
+
+    create(unique_index(:transaction_errors, [:message]))
+
+    alter table(:internal_transactions) do
+      add(:error_id, references(:transaction_errors, column: :id, type: :smallint))
+    end
+
+    drop_if_exists(
+      constraint(
+        :internal_transactions,
+        :create_has_error_or_result,
+        check: """
+        type != 'create' OR
+        (gas IS NOT NULL AND
+         ((error IS NULL AND created_contract_address_hash IS NOT NULL AND created_contract_code IS NOT NULL AND gas_used IS NOT NULL) OR
+          (error IS NOT NULL AND created_contract_address_hash IS NULL AND created_contract_code IS NULL AND gas_used IS NULL)))
+        """,
+        validate: false
+      )
+    )
+
+    create(
+      constraint(
+        :internal_transactions,
+        :create_has_error_id_or_result,
+        check: """
+        type != 'create' OR
+        (gas IS NOT NULL AND
+         ((error_id IS NULL AND created_contract_address_hash IS NOT NULL AND created_contract_code IS NOT NULL AND gas_used IS NOT NULL) OR
+          (error_id IS NOT NULL AND created_contract_address_hash IS NULL AND created_contract_code IS NULL AND gas_used IS NULL)))
+        """,
+        validate: false
+      )
+    )
+
+    drop_if_exists(
+      constraint(
+        :internal_transactions,
+        :call_has_error_or_result,
+        check: """
+        type != 'call' OR
+        (gas IS NOT NULL AND
+         ((error IS NULL AND gas_used IS NOT NULL AND output IS NOT NULL) OR
+          (error IS NOT NULL AND output is NULL)))
+        """,
+        validate: false
+      )
+    )
+
+    create(
+      constraint(
+        :internal_transactions,
+        :call_has_error_id_or_result,
+        check: """
+        type != 'call' OR
+        (gas IS NOT NULL AND
+         ((error_id IS NULL AND gas_used IS NOT NULL AND output IS NOT NULL) OR
+          (error_id IS NOT NULL AND output is NULL)))
+        """,
+        validate: false
+      )
+    )
+  end
+end

--- a/apps/explorer/priv/shrunk_internal_transactions/migrations/20250919150023_drop_call_has_error_id_or_result_constraint.exs
+++ b/apps/explorer/priv/shrunk_internal_transactions/migrations/20250919150023_drop_call_has_error_id_or_result_constraint.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.ShrunkInternalTransactions.Migrations.DropCallHasErrorIdOrResultConstraint do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      constraint(
+        :internal_transactions,
+        :call_has_error_id_or_result,
+        check: """
+        type != 'call' OR
+        (gas IS NOT NULL AND
+         ((error_id IS NULL AND gas_used IS NOT NULL AND output IS NOT NULL) OR
+          (error_id IS NOT NULL AND output is NULL)))
+        """,
+        validate: false
+      )
+    )
+  end
+end

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -873,7 +873,8 @@ defmodule Explorer.EtherscanTest do
         call_type: internal_transaction.call_type,
         gas: internal_transaction.gas,
         gas_used: internal_transaction.gas_used,
-        error: internal_transaction.error
+        error: internal_transaction.error,
+        error_id: internal_transaction.error_id
       }
 
       assert found_internal_transaction == expected

--- a/apps/explorer/test/explorer/migrator/reindex_internal_transactions_with_incompatible_status_test.exs
+++ b/apps/explorer/test/explorer/migrator/reindex_internal_transactions_with_incompatible_status_test.exs
@@ -31,6 +31,8 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatusTes
           block.number
         end)
 
+      transaction_error = insert(:transaction_error, message: "error")
+
       Enum.each(1..5, fn i ->
         block = insert(:block)
         transaction = :transaction |> insert() |> with_block(block, status: :error)
@@ -42,6 +44,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatusTes
           block: block,
           block_number: block.number,
           error: "error",
+          error_id: transaction_error.id,
           output: nil
         )
       end)

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -51,6 +51,7 @@ defmodule Explorer.Factory do
     TokenTransfer,
     Token.Instance,
     Transaction,
+    TransactionError,
     Wei,
     Withdrawal
   }
@@ -873,6 +874,12 @@ defmodule Explorer.Factory do
       # transaction
       type: :selfdestruct,
       value: sequence("internal_transaction_value", &Decimal.new(&1))
+    }
+  end
+
+  def transaction_error_factory do
+    %TransactionError{
+      message: sequence("transaction_error_message", & &1)
     }
   end
 

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -126,6 +126,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
         |> page_internal_transaction(paging_options)
         |> Enum.take(paging_options.page_size)
         |> Repo.preload(:block)
+        |> InternalTransaction.preload_error()
 
       :ignore ->
         [transaction.block_number]
@@ -139,6 +140,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
         |> page_internal_transaction(paging_options)
         |> Enum.take(paging_options.page_size)
         |> Repo.preload(:block)
+        |> InternalTransaction.preload_error()
 
       error ->
         Logger.error(
@@ -191,6 +193,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
     |> then(&if unlimited?, do: &1, else: Enum.take(&1, paging_options.page_size))
     |> add_block_hashes(block.hash)
     |> join_associations(necessity_by_association)
+    |> InternalTransaction.preload_error()
   end
 
   @doc """
@@ -270,6 +273,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
     |> add_block_hashes()
     |> join_associations(necessity_by_association)
     |> Repo.preload(:block)
+    |> InternalTransaction.preload_error()
   end
 
   defp do_fetch_for_address(address_id, to_block, from_block, limit, sum_mode, sort_direction, acc \\ [])

--- a/cspell.json
+++ b/cspell.json
@@ -595,6 +595,7 @@
         "siwe",
         "SJONRPC",
         "smallint",
+        "smallserial",
         "smth",
         "snapshotted",
         "snapshotting",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internal transactions now reference a centralized TransactionError entity and automatically preload human-readable error messages across fetches and listings.
  * Added creation and deduplicated lookup for transaction errors.

* **Bug Fixes**
  * Improved ordering and filtering of internal-transaction error data, including handling of nulls and consistent error association.

* **Chores**
  * DB migrations add transaction_errors, an error_id on internal transactions, and update related constraints; tests updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->