### PR TITLE
fix: Fix error in Indexer.Fetcher.OnDemand.TokenBalance module

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -126,7 +126,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
   defp prepare_ctb_params(current_token_balances, initial_acc, block_number) do
     Enum.reduce(current_token_balances, initial_acc, fn %{token_id: token_id} = stale_current_token_balance, acc ->
       prepared_ctb = %{
-        token_contract_address_hash: to_string(stale_current_token_balance.token.contract_address_hash),
+        token_contract_address_hash: to_string(stale_current_token_balance.token_contract_address_hash),
         address_hash: to_string(stale_current_token_balance.address_hash),
         block_number: block_number,
         token_id: token_id && Decimal.to_integer(token_id),
@@ -136,7 +136,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
       updated_tokens =
         Map.put_new(
           acc[:tokens],
-          stale_current_token_balance.token.contract_address_hash.bytes,
+          stale_current_token_balance.token_contract_address_hash.bytes,
           stale_current_token_balance.token
         )
 


### PR DESCRIPTION
## Motivation

Error like this occurrence on Base instance:
```
{"message":"Task #PID<0.1735309.0> started from Indexer.Fetcher.OnDemand.TokenBalance terminating\n** (BadMapError) expected a map, got:\n\n    nil\n\n    (indexer 9.3.2) lib/indexer/fetcher/on_demand/token_balance.ex:129: anonymous fn/3 in Indexer.Fetcher.OnDemand.TokenBalance.prepare_ctb_params/3\n    (elixir 1.19.4) lib/enum.ex:2520: Enum.\"-reduce/3-lists^foldl/2-0-\"/3\n    (indexer 9.3.2) lib/indexer/fetcher/on_demand/token_balance.ex:80: Indexer.Fetcher.OnDemand.TokenBalance.run/2\n    (elixir 1.19.4) lib/task/supervised.ex:105: Task.Supervised.invoke_mfa/2\n    (elixir 1.19.4) lib/task/supervised.ex:40: Task.Supervised.reply/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [fetcher: :token_balance_on_demand], callback_module: Indexer.Fetcher.OnDemand.TokenBalance, batch: [fetch: %Explorer.Chain.Hash{byte_count: 20, bytes: <<149, 164, 61, 242, 37, 227, 182, 19, 241, 174, 72, 122, 8, 13, 140, 147, 66, 37, 234, 175>>}, fetch: %Explorer.Chain.Hash{byte_count: 20, bytes: <<83, 15, 20, 107, 255, 66, 236, 47, 147, 81, 174, 113, 129, 126, 246, 191, 158, 230, 71, 23>>}, fetch: %Explorer.Chain.Hash{byte_count: 20, bytes: <<51, 126, 120, 7, 3, 249, 159, 17, 23, 120, 144, 48, 155, 229, 68, 36, 234, 154, 172, 185>>}, fetch: %Explorer.Chain.Hash{byte_count: 20, bytes: <<24, 176, 244, 84, 122, 137, 254, 76, 95, 232, 79, 37, 139, 234, 54, 1, 250, 40, 30, 159>>}, fetch: %Explorer.Chain.Hash{byte_count: 20, bytes: <<...>>}, ...], ...}]","time":"2026-01-21T08:30:25.065Z","metadata":{"fetcher":"token_balance_on_demand"},"severity":"error"}
```

## Changelog

The cause of the error is that `token` object is null:
```
"%Explorer.Chain.Address.CurrentTokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_current_token_balances\">, id: 13940874053, value: nil, block_number: 30843400, max_block_number: nil, value_fetched_at: nil, token_id: Decimal.new(\"0\"), token_type: \"ERC-1155\", fiat_value: nil, distinct_token_instances_count: nil, token_ids: nil, preloaded_token_instances: nil, old_value: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<13, 7, 7, 150, 57, 82, 242, 251, 165, 157, 208, 111, 43, 66, 90, 206, 64, 180, 146, 254>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<53, 5, 157, 200, 164, 229, 70, 129, 212, 83, 188, 114, 15, 205, 132, 234, 161, 57, 154, 7>>}, token: nil, inserted_at: ~U[2025-12-23 21:36:11.329826Z], updated_at: ~U[2025-12-23 21:36:11.329826Z]}"
```

However, `token_contract_address_hash` is not empty, switching to it in the module.


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token contract address handling in token balance fetching for fungible and non-fungible tokens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->