### PR TITLE
fix: check token presence in address current token balance

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -473,17 +473,18 @@ defmodule BlockScoutWeb.Notifier do
     %{view: view, compiler: compiler}
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp broadcast_token_balances(address_hash, token_type, balances) do
     sorted =
       Enum.sort_by(
         balances,
         fn ctb ->
           value =
-            if ctb.token.decimals,
+            if ctb.token && ctb.token.decimals,
               do: Decimal.div(ctb.value, Decimal.new(Integer.pow(10, Decimal.to_integer(ctb.token.decimals)))),
               else: ctb.value
 
-          {(ctb.token.fiat_value && Decimal.mult(value, ctb.token.fiat_value)) || Decimal.new(0), value}
+          {(ctb.token && ctb.token.fiat_value && Decimal.mult(value, ctb.token.fiat_value)) || Decimal.new(0), value}
         end,
         fn {fiat_value_1, value_1}, {fiat_value_2, value_2} ->
           case {Decimal.compare(fiat_value_1, fiat_value_2), Decimal.compare(value_1, value_2)} do


### PR DESCRIPTION
## Motivation

```
{"message":"GenServer BlockScoutWeb.RealtimeEventHandlers.Main terminating\n** (BadMapError) expected a map, got:\n\n    nil\n\n    (block_scout_web 9.3.2) lib/block_scout_web/notifier.ex:482: anonymous fn/1 in BlockScoutWeb.Notifier.broadcast_token_balances/3\n    (elixir 1.19.4) lib/enum.ex:3347: anonymous fn/2 in Enum.sort_by/3\n    (elixir 1.19.4) lib/enum.ex:1688: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.19.4) lib/enum.ex:3347: Enum.sort_by/3\n    (block_scout_web 9.3.2) lib/block_scout_web/notifier.ex:478: BlockScoutWeb.Notifier.broadcast_token_balances/3\n    (elixir 1.19.4) lib/enum.ex:966: anonymous fn/3 in Enum.each/2\n    (stdlib 6.2.2.2) maps.erl:860: :maps.fold_1/4\n    (elixir 1.19.4) lib/enum.ex:2532: Enum.each/2\nLast message: {:chain_event, :address_current_token_balances, :realtime, %{address_hash: \"0x0cae3da8c78ea729330b90af5275929b92079e5c\", address_current_token_balances: [%Explorer.Chain.Address.CurrentTokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_current_token_balances\">, id: 14127251558, value: Decimal.new(\"10000000000000000000000000\"), block_number: 41102429, max_block_number: nil, value_fetched_at: ~U[2026-01-21 11:16:52.086036Z], token_id: nil, token_type: \"ERC-20\", fiat_value: nil, distinct_token_instances_count: nil, token_ids: nil, preloaded_token_instances: nil, old_value: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<12, 174, 61, 168, 199, 142, 167, 41, 51, 11, 144, 175, 82, 117, 146, 155, 146, 7, 158, 92>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<208, 181, 223, 246, 155, 174, 80, 54, 119, 72, 246, 122, 168, 188, 18, 180, 66, 215, 246, 43>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, inserted_at: ~U[2026-01-21 11:16:52.166394Z], updated_at: ~U[2026-01-21 11:16:52.166394Z]}]}}","time":"2026-01-21T11:17:22.004Z","metadata":{},"severity":"error"}
```

## Changelog

### AI Agent Summary

This pull request makes a small but important fix to the `broadcast_token_balances` function in `BlockScoutWeb.Notifier`. The main change is to add additional checks to ensure that `ctb.token` is not `nil` before accessing its fields, which improves the function's robustness and prevents potential runtime errors.

- Added checks to ensure `ctb.token` is present before accessing `decimals` and `fiat_value` fields in the sorting logic of `broadcast_token_balances`, preventing possible `nil` errors.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where missing token data could cause errors during balance calculations and sorting operations. The system now gracefully handles absent token information without raising exceptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->