### PR TITLE
fix: Fix error on loading thumbnails when public_r2_url is missed

### DIFF
--- a/apps/explorer/lib/explorer/chain/token/instance/media_urls.ex
+++ b/apps/explorer/lib/explorer/chain/token/instance/media_urls.ex
@@ -20,24 +20,27 @@ defmodule Explorer.Chain.Token.Instance.Thumbnails do
   def cast(_), do: :error
 
   def load([file_path, sizes, original_uploaded?]) do
-    uri =
-      Application.get_env(:ex_aws, :s3)[:public_r2_url] |> URI.parse() |> URI.append_path(file_path) |> URI.to_string()
+    if public_r2_url = Application.get_env(:ex_aws, :s3)[:public_r2_url] do
+      uri = public_r2_url |> URI.parse() |> URI.append_path(file_path) |> URI.to_string()
 
-    thumbnails =
-      sizes
-      |> Enum.map(fn size ->
-        key = "#{size}x#{size}"
-        {key, String.replace(uri, "{}", key)}
-      end)
-      |> Enum.into(%{})
+      thumbnails =
+        sizes
+        |> Enum.map(fn size ->
+          key = "#{size}x#{size}"
+          {key, String.replace(uri, "{}", key)}
+        end)
+        |> Enum.into(%{})
 
-    {:ok,
-     if original_uploaded? do
-       key = "original"
-       Map.put(thumbnails, key, String.replace(uri, "{}", key))
-     else
-       thumbnails
-     end}
+      {:ok,
+       if original_uploaded? do
+         key = "original"
+         Map.put(thumbnails, key, String.replace(uri, "{}", key))
+       else
+         thumbnails
+       end}
+    else
+      {:ok, nil}
+    end
   end
 
   def load(_), do: :error


### PR DESCRIPTION
## Motivation
```
** (FunctionClauseError) no function clause matching in URI.parse/1
    (elixir 1.19.4) lib/uri.ex:787: URI.parse(nil)
    (explorer 9.3.2) lib/explorer/chain/token/instance/media_urls.ex:24: Explorer.Chain.Token.Instance.Thumbnails.load/1
    (ecto 3.13.5) lib/ecto/type.ex:1032: Ecto.Type.process_loaders/3
```
## Changelog
- Add check on `Application.get_env(:ex_aws, :s3)[:public_r2_url]` in `Explorer.Chain.Token.Instance.Thumbnails.load/1`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in token media URL processing to gracefully handle cases where required data is unavailable, preventing potential system crashes and ensuring consistent operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->