### PR TITLE
fix: Fix token balances broadcasting function

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -38,6 +38,7 @@ defmodule BlockScoutWeb.Notifier do
     BlockNumberHelper,
     DenormalizationHelper,
     InternalTransaction,
+    Token,
     Token.Instance,
     Transaction
   }
@@ -339,7 +340,7 @@ defmodule BlockScoutWeb.Notifier do
 
   def handle_event(
         {:chain_event, :token_total_supply, :on_demand,
-         [%Explorer.Chain.Token{contract_address_hash: contract_address_hash, total_supply: total_supply} = token]}
+         [%Token{contract_address_hash: contract_address_hash, total_supply: total_supply} = token]}
       )
       when not is_nil(total_supply) do
     # TODO: delete duplicated event when old UI becomes deprecated
@@ -479,12 +480,14 @@ defmodule BlockScoutWeb.Notifier do
       Enum.sort_by(
         balances,
         fn ctb ->
-          value =
-            if ctb.token && ctb.token.decimals,
-              do: Decimal.div(ctb.value, Decimal.new(Integer.pow(10, Decimal.to_integer(ctb.token.decimals)))),
-              else: ctb.value
+          case ctb.token do
+            %Token{decimals: decimals, fiat_value: fiat_value} when not is_nil(decimals) ->
+              value = Decimal.div(ctb.value, Decimal.new(Integer.pow(10, Decimal.to_integer(decimals))))
+              {(fiat_value && Decimal.mult(value, fiat_value)) || Decimal.new(0), value}
 
-          {(ctb.token && ctb.token.fiat_value && Decimal.mult(value, ctb.token.fiat_value)) || Decimal.new(0), value}
+            _ ->
+              {Decimal.new(0), ctb.value}
+          end
         end,
         fn {fiat_value_1, value_1}, {fiat_value_2, value_2} ->
           case {Decimal.compare(fiat_value_1, fiat_value_2), Decimal.compare(value_1, value_2)} do


### PR DESCRIPTION
## Motivation

Previous fix https://github.com/blockscout/blockscout/pull/13892 didn't cover the case when `token: #Ecto.Association.NotLoaded<association :token is not loaded>`

```
{"message":"GenServer BlockScoutWeb.RealtimeEventHandlers.Main terminating\n** (FunctionClauseError) no function clause matching in Decimal.decimal/1\n    (decimal 2.3.0) lib/decimal.ex:2041: Decimal.decimal(nil)\n    (decimal 2.3.0) lib/decimal.ex:683: Decimal.div/2\n    (block_scout_web 9.3.2) lib/block_scout_web/notifier.ex:484: anonymous fn/1 in BlockScoutWeb.Notifier.broadcast_token_balances/3\n    (elixir 1.19.4) lib/enum.ex:3347: anonymous fn/2 in Enum.sort_by/3\n    (elixir 1.19.4) lib/enum.ex:1688: Enum.\"-map/2-lists^map/1-1-\"/2\n    (elixir 1.19.4) lib/enum.ex:3347: Enum.sort_by/3\n    (block_scout_web 9.3.2) lib/block_scout_web/notifier.ex:479: BlockScoutWeb.Notifier.broadcast_token_balances/3\n    (elixir 1.19.4) lib/enum.ex:966: anonymous fn/3 in Enum.each/2\nLast message: {:chain_event, :address_current_token_balances, :realtime, %{address_hash: \"0xab8fdaf6b28620d4b5b1bd5bcdecb41ffe12a52b\", address_current_token_balances: [%Explorer.Chain.Address.CurrentTokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_current_token_balances\">, id: 14132809093, value: nil, block_number: 41148176, max_block_number: nil, value_fetched_at: nil, token_id: nil, token_type: \"ERC-20\", fiat_value: nil, distinct_token_instances_count: nil, token_ids: nil, preloaded_token_instances: nil, old_value: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<171, 143, 218, 246, 178, 134, 32, 212, 181, 177, 189, 91, 205, 236, 180, 31, 254, 18, 165, 43>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<28, 10, 29, 164, 145, 245, 235, 95, 84, 183, 148, 57, 88, 124, 158, 153, 220, 80, 253, 4>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, inserted_at: ~U[2026-01-22 12:59:22.039519Z], updated_at: ~U[2026-01-22 12:59:22.039519Z]}]}}","time":"2026-01-22T12:59:22.892Z","metadata":{},"severity":"error"}
```

## Changelog

### AI Agent Summary

This pull request updates the `BlockScoutWeb.Notifier` module to use the `Token` module more consistently and improves the handling of token-related data, especially in sorting logic for balances. The changes help standardize token handling and make the code more robust and maintainable.

**Improvements to Token Handling:**

* Added the `Token` module to the list of imported modules, allowing it to be referenced directly throughout the file.
* Updated the pattern match in the `:token_total_supply` event handler to use `%Token{}` instead of `%Explorer.Chain.Token{}`, ensuring consistency in token struct usage.

**Enhancements to Balance Sorting Logic:**

* Refactored the sorting function for balances to explicitly match on `%Token{}` and safely handle `decimals` and `fiat_value`, improving clarity and robustness when calculating and sorting by fiat value and token value.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved token balance calculation and sorting for more accurate decimal handling and fiat-value conversions, and refined on-demand token supply handling to produce more consistent totals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->