### PR TITLE
chore: disable Auth0 when dynamic enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Disable Auth0 when Dynamic enabled ([#13912](https://github.com/blockscout/blockscout/pull/13912))
 - Add swagger spec for account abstraction endpoints ([#13897](https://github.com/blockscout/blockscout/issues/13897))
 - Clear token "skip_metadata" property ([#13891](https://github.com/blockscout/blockscout/issues/13891))
 - Refactor internal transaction logic from "block_index" to "transaction_index" and "index" ([#12474](https://github.com/blockscout/blockscout/issues/12474))

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/authenticate_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/authenticate_controller.ex
@@ -117,13 +117,14 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
   @spec send_otp(Conn.t(), map()) ::
           :error
           | {:error, String.t()}
+          | {:enabled, false}
           | {:format, :email}
           | {:interval, integer()}
           | Conn.t()
   def send_otp(conn, _params) do
     email = Map.get(conn.body_params, :email)
 
-    case conn |> current_user() do
+    case Auth0.enabled?() && conn |> current_user() do
       nil ->
         with :ok <- Auth0.send_otp(email, AccessHelper.conn_to_ip_string(conn)) do
           conn |> put_status(200) |> json(%{message: "Success"})
@@ -139,6 +140,9 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
         |> put_status(500)
         |> put_view(UserView)
         |> render(:message, %{message: "This account already has an email"})
+
+      false ->
+        {:enabled, false}
     end
   end
 
@@ -187,9 +191,10 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
     perform additional operations such as setting cookies or rendering user
     information.
   """
-  @spec confirm_otp(Conn.t(), map()) :: :error | {:error, any()} | Conn.t()
+  @spec confirm_otp(Conn.t(), map()) :: :error | {:error, any()} | {:enabled, false} | Conn.t()
   def confirm_otp(conn, %{email: email, otp: otp}) do
-    with {:ok, auth} <- Auth0.confirm_otp_and_get_auth(email, otp, AccessHelper.conn_to_ip_string(conn)) do
+    with {:enabled, true} <- {:enabled, Auth0.enabled?()},
+         {:ok, auth} <- Auth0.confirm_otp_and_get_auth(email, otp, AccessHelper.conn_to_ip_string(conn)) do
       put_auth_to_session(conn, auth)
     end
   end
@@ -248,9 +253,10 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
   - The nonce is cached for the address to prevent replay attacks.
   - The SIWE message expires after 300 seconds from generation.
   """
-  @spec siwe_message(Conn.t(), map()) :: {:error, String.t()} | {:format, :error} | Conn.t()
+  @spec siwe_message(Conn.t(), map()) :: {:error, String.t()} | {:enabled, false} | {:format, :error} | Conn.t()
   def siwe_message(conn, %{address: address}) do
-    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address)},
+    with {:enabled, true} <- {:enabled, Auth0.enabled?()},
+         {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address)},
          {:ok, message} <- Auth0.generate_siwe_message(Address.checksum(address_hash)) do
       conn |> put_status(200) |> json(%{siwe_message: message})
     end
@@ -299,12 +305,13 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
     perform additional operations such as setting cookies or rendering user
     information.
   """
-  @spec authenticate_via_wallet(Conn.t(), map()) :: :error | {:error, any()} | Conn.t()
+  @spec authenticate_via_wallet(Conn.t(), map()) :: :error | {:error, any()} | {:enabled, false} | Conn.t()
   def authenticate_via_wallet(conn, _params) do
     message = Map.get(conn.body_params, :message)
     signature = Map.get(conn.body_params, :signature)
 
-    with {:ok, auth} <- Auth0.get_auth_with_web3(message, signature) do
+    with {:enabled, true} <- {:enabled, Auth0.enabled?()},
+         {:ok, auth} <- Auth0.get_auth_with_web3(message, signature) do
       put_auth_to_session(conn, auth)
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/email_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/email_controller.ex
@@ -17,7 +17,8 @@ defmodule BlockScoutWeb.Account.API.V2.EmailController do
   plug(:fetch_cookies, signed: [@invalid_session_key])
 
   def resend_email(conn, _params) do
-    with user <- conn.cookies[@invalid_session_key],
+    with {:enabled, true} <- {:enabled, Auth0.enabled?()},
+         user <- conn.cookies[@invalid_session_key],
          {:auth, false} <- {:auth, is_nil(user)},
          {:email_verified, false} <- {:email_verified, user[:email_verified]},
          {:identity, %Identity{} = identity} <- {:identity, Identity.find_identity(user[:id])},

--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/fallback_controller.ex
@@ -146,6 +146,13 @@ defmodule BlockScoutWeb.Account.API.V2.FallbackController do
     |> render(:message, %{message: "No Bearer token"})
   end
 
+  def call(conn, {:enabled, false}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(UserView)
+    |> render(:message, %{message: "This endpoint is not configured"})
+  end
+
   defp unauthorized_error(%{email_verified: false, email: email}) do
     %{message: "Unverified email", email: email}
   end


### PR DESCRIPTION

## Changelog

Return 404 on Auth0 related endpoints if Dynamic is enabled

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to disable Auth0 when Dynamic authentication is enabled.
  * Authentication endpoints now check Auth0 availability before proceeding.
* **Behavior Changes**
  * When Auth0 is disabled, affected endpoints short-circuit and return "endpoint not configured" (404).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->