### PR TITLE
fix: limit `getlogs` after filtering consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🐛 Bug Fixes
 
+- Limit `getlogs` after filtering consensus ([#13934](https://github.com/blockscout/blockscout/pull/13934))
 - Handle nil in update_transactions_cache/2 ([#13911](https://github.com/blockscout/blockscout/pull/13911))
 - Fix token balances broadcasting function ([#13902](https://github.com/blockscout/blockscout/issues/13902))
 - Wrong `next_page_params` in OP Deposits ([#13870](https://github.com/blockscout/blockscout/issues/13870))

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -5,7 +5,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [from: 2, limit: 2, where: 3, subquery: 1, order_by: 3]
+  import Ecto.Query, only: [from: 2, where: 3, subquery: 1, order_by: 3]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{DenormalizationHelper, Log, Transaction}
@@ -81,7 +81,6 @@ defmodule Explorer.Etherscan.Logs do
       |> where([log], log.address_hash == ^address_hash)
       |> where([log], log.block_number >= ^prepared_filter.from_block)
       |> where([log], log.block_number <= ^prepared_filter.to_block)
-      |> limit(1000)
       |> page_logs(paging_options)
 
     if DenormalizationHelper.transactions_denormalization_finished?() do
@@ -99,7 +98,8 @@ defmodule Explorer.Etherscan.Logs do
             block_number: transaction.block_number,
             block_timestamp: transaction.block_timestamp,
             block_consensus: transaction.block_consensus
-          }
+          },
+          limit: 1000
         )
 
       all_transaction_logs_query
@@ -122,7 +122,8 @@ defmodule Explorer.Etherscan.Logs do
             block_number: transaction.block_number,
             block_timestamp: block.timestamp,
             block_consensus: block.consensus
-          }
+          },
+          limit: 1000
         )
 
       all_transaction_logs_query


### PR DESCRIPTION
Fix #13844

## Changelog
  - Move limit from subquery to outer query (performance tested on rsk-testnet and performance reduction is negligible)

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * getlogs results are now consistently limited to 1000 rows after filtering, preventing excess rows from being returned.

* **Refactor**
  * Internal query behavior was adjusted to enforce the 1000-row cap more reliably across different retrieval paths (no user-facing behavior change beyond the fixed cap).

* **Changelog**
  * Added bug fix note referencing the getlogs limit adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->