### PR TITLE
chore: Add internal transactions not null constraints

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -176,6 +176,7 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesTransactionsCountDescPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesTransactionsCountAscCoinBalanceDescHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.ValidateInternalTransactionsBlockNumberTransactionIndexNotNull,
       Explorer.Migrator.HeavyDbIndexOperation.CreateSmartContractAdditionalSourcesUniqueIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenInstancesTokenIdIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateTokensNamePartialFtsIndex,

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -106,6 +106,7 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesTransactionsCountDescPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesTransactionsCountAscCoinBalanceDescHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.ValidateInternalTransactionsBlockNumberTransactionIndexNotNull,
       Explorer.Migrator.HeavyDbIndexOperation.CreateSmartContractAdditionalSourcesUniqueIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropTokenInstancesTokenIdIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateTokensNamePartialFtsIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -314,6 +314,10 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.ValidateInternalTransactionsBlockNumberTransactionIndexNotNull,
+          :indexer
+        ),
+        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateSmartContractAdditionalSourcesUniqueIndex,
           :indexer
         ),

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/update_internal_transactions_primary_key.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/update_internal_transactions_primary_key.ex
@@ -9,7 +9,12 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.UpdateInternalTransactionsPrim
 
   alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
-  alias Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex
+
+  alias Explorer.Migrator.HeavyDbIndexOperation.{
+    CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex,
+    ValidateInternalTransactionsBlockNumberTransactionIndexNotNull
+  }
+
   alias Explorer.Repo
 
   @table_name :internal_transactions
@@ -28,7 +33,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.UpdateInternalTransactionsPrim
   @impl HeavyDbIndexOperation
   def dependent_from_migrations,
     do: [
-      CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex.migration_name()
+      ValidateInternalTransactionsBlockNumberTransactionIndexNotNull.migration_name()
     ]
 
   @impl HeavyDbIndexOperation

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/validate_internal_transactions_block_number_transaction_index_not_null.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/validate_internal_transactions_block_number_transaction_index_not_null.ex
@@ -1,0 +1,142 @@
+defmodule Explorer.Migrator.HeavyDbIndexOperation.ValidateInternalTransactionsBlockNumberTransactionIndexNotNull do
+  @moduledoc """
+  Validate `NOT NULL` constraints for `internal_transactions` (`block_number`, `transaction_index`).
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  require Logger
+
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex
+  alias Explorer.Repo
+
+  @table_name :internal_transactions
+  @index_name "internal_transactions_not_null_constraints"
+  @operation_type :create
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations,
+    do: [
+      CreateInternalTransactionsBlockNumberTransactionIndexIndexUniqueIndex.migration_name()
+    ]
+
+  @impl HeavyDbIndexOperation
+  # sobelow_skip ["SQL"]
+  def db_index_operation do
+    result =
+      Repo.transaction(fn ->
+        with {:ok, _} <- Repo.query(validate_constraint_query_string("block_number")),
+             {:ok, _} <- Repo.query(validate_constraint_query_string("transaction_index")),
+             {:ok, _} <- Repo.query(set_not_null_query_string("block_number")),
+             {:ok, _} <- Repo.query(set_not_null_query_string("transaction_index")) do
+          :ok
+        else
+          {:error, error} ->
+            Repo.rollback(error)
+        end
+      end)
+
+    case result do
+      {:ok, :ok} ->
+        :ok
+
+      {:error, error} ->
+        Logger.error(
+          "Migration ValidateInternalTransactionsBlockNumberTransactionIndexNotNull failed: #{inspect(error)}"
+        )
+
+        :error
+    end
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    all_operations = [
+      validate_constraint_query_string("block_number"),
+      validate_constraint_query_string("transaction_index"),
+      set_not_null_query_string("block_number"),
+      set_not_null_query_string("transaction_index")
+    ]
+
+    Enum.reduce_while(all_operations, :finished_or_not_started, fn operation, acc ->
+      case HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation) do
+        :finished_or_not_started -> {:cont, acc}
+        progress -> {:halt, progress}
+      end
+    end)
+  end
+
+  @impl HeavyDbIndexOperation
+  # credo:disable-for-next-line /Complexity/
+  def db_index_operation_status do
+    completed? =
+      case Repo.query("""
+           SELECT is_nullable
+           FROM information_schema.columns
+           WHERE table_name = '#{@table_name}' AND (column_name = 'block_number' OR column_name = 'transaction_index');
+           """) do
+        {:ok, %Postgrex.Result{rows: [["NO"], ["NO"]]}} -> true
+        {:ok, %Postgrex.Result{rows: [_, _]}} -> false
+        _ -> nil
+      end
+
+    started? =
+      case Repo.query("""
+           SELECT convalidated
+           FROM pg_constraint
+           WHERE conname = '#{@table_name}_block_number_not_null';
+           """) do
+        {:ok, %Postgrex.Result{rows: [[true]]}} -> true
+        {:ok, %Postgrex.Result{rows: [[false]]}} -> false
+        _ -> nil
+      end
+
+    cond do
+      completed? == true -> :completed
+      started? == true -> :not_completed
+      is_nil(completed?) or is_nil(started?) -> :unknown
+      true -> :not_initialized
+    end
+  end
+
+  @impl HeavyDbIndexOperation
+  # sobelow_skip ["SQL"]
+  def restart_db_index_operation do
+    case Repo.query("""
+         SELECT pg_cancel_backend(pid)
+         FROM pg_stat_activity
+         WHERE pid <> pg_backend_pid()
+           AND (query ILIKE '%#{validate_constraint_query_string("block_number")}%' OR query ILIKE '%#{validate_constraint_query_string("transaction_index")}%')
+           AND state = 'active';
+         """) do
+      {:ok, _} -> :ok
+      _ -> :error
+    end
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache, do: :ok
+
+  defp validate_constraint_query_string(column) do
+    "ALTER TABLE #{@table_name} VALIDATE CONSTRAINT #{@table_name}_#{column}_not_null;"
+  end
+
+  defp set_not_null_query_string(column) do
+    "ALTER TABLE #{@table_name} ALTER COLUMN #{column} SET NOT NULL;"
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20260213092943_add_internal_transactions_pk_not_null_constraint.exs
+++ b/apps/explorer/priv/repo/migrations/20260213092943_add_internal_transactions_pk_not_null_constraint.exs
@@ -1,0 +1,19 @@
+defmodule Explorer.Repo.Migrations.AddInternalTransactionsPkNotNullConstraint do
+  use Ecto.Migration
+
+  def change do
+    create(
+      constraint(:internal_transactions, :internal_transactions_block_number_not_null,
+        check: "block_number IS NOT NULL",
+        validate: false
+      )
+    )
+
+    create(
+      constraint(:internal_transactions, :internal_transactions_transaction_index_not_null,
+        check: "transaction_index IS NOT NULL",
+        validate: false
+      )
+    )
+  end
+end

--- a/cspell.json
+++ b/cspell.json
@@ -169,6 +169,7 @@
         "contractaddress",
         "contractaddresses",
         "contractname",
+        "convalidated",
         "cookiejar",
         "cooldown",
         "cooltesthost",


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/12474

## Motivation

PK update command takes a long time because there is no `NOT NULL` constraint on the `block_number` and `transaction_index` columns.

## Changelog

- Foreground migration that creates a `NOT VALID` `NOT NULL` constraints
- Background migration that validates mentioned constraints and marks columns as not nullable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background migration that validates and then enforces NOT NULL on internal transaction block number and transaction index to improve data integrity.
  * The migrator is now registered in startup configuration and in test runtime but remains disabled by default; it can be enabled to run in indexer mode.

* **Chores**
  * Minor spelling list update for developer tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->