### PR TITLE
chore: Change 429 error text

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/access_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/access_helper.ex
@@ -86,7 +86,7 @@ defmodule BlockScoutWeb.AccessHelper do
     conn
     |> Conn.put_status(429)
     |> put_view(view)
-    |> render(tag, %{tag => "Too Many Requests"})
+    |> render(tag, %{tag => "Too many requests. Increase limits now at https://dev.blockscout.com"})
     |> Conn.halt()
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2153,7 +2153,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         |> put_req_header("scoped-recaptcha-bypass-token", "wrong_scoped_token")
         |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
 
-      assert %{"message" => "Too Many Requests"} = json_response(request, 429)
+      assert %{"message" => "Too many requests. Increase limits now at https://dev.blockscout.com"} =
+               json_response(request, 429)
 
       :timer.sleep(100)
 
@@ -2247,7 +2248,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         |> put_req_header("scoped-recaptcha-bypass-token", "some_token_that_does_not_exist")
         |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
 
-      assert %{"message" => "Too Many Requests"} = json_response(request, 429)
+      assert %{"message" => "Too many requests. Increase limits now at https://dev.blockscout.com"} =
+               json_response(request, 429)
 
       request =
         Phoenix.ConnTest.build_conn()
@@ -2255,7 +2257,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         |> put_req_header("scoped-recaptcha-bypass-token", "")
         |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
 
-      assert %{"message" => "Too Many Requests"} = json_response(request, 429)
+      assert %{"message" => "Too many requests. Increase limits now at https://dev.blockscout.com"} =
+               json_response(request, 429)
 
       :timer.sleep(100)
 


### PR DESCRIPTION
## Motivation

Change 429 error text.

## Changelog

### AI Agent Summary

This pull request updates the rate limit error messaging to provide more actionable feedback to users. The new message not only informs users about the rate limit but also directs them to increase their limits via a provided URL. Corresponding test assertions have been updated to match the new message.

**User experience improvements:**

* Updated the 429 "Too Many Requests" error message in `BlockScoutWeb.AccessHelper` to: "Too many requests. Increase limits now at https://dev.blockscout.com"

**Test updates:**

* Modified assertions in `BlockScoutWeb.API.V2.TokenControllerTest` to expect the new error message when rate limits are hit, ensuring tests reflect the updated user-facing message [[1]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05L2156-R2156) [[2]](diffhunk://#diff-242d2eddbcddeffc3b44d62662a079abc3cffeb75ea7d3098412e4309020fc05L2250-R2258)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Updated rate-limit response message to provide users with guidance on increasing their request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->