### PR TITLE
fix: Handle nil value in internal transactions

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -128,7 +128,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
        do: acc
 
   defp internal_transaction_to_coin_balances(internal_transaction, previous_block_number, options, acc) do
-    if internal_transaction.value |> Wei.to(:wei) |> Decimal.positive?() do
+    if not is_nil(internal_transaction.value) and Decimal.positive?(Wei.to(internal_transaction.value, :wei)) do
       acc
       |> Map.put_new_lazy(internal_transaction.from_address_hash, fn ->
         {internal_transaction.from_address,

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -251,8 +251,6 @@ defmodule Explorer.Chain.AdvancedFilter do
   end
 
   defp to_advanced_filter(%InternalTransaction{} = internal_transaction) do
-    %{value: decimal_internal_transaction_value} = internal_transaction.value
-
     %__MODULE__{
       hash: internal_transaction.transaction.hash,
       created_from: :internal_transaction,
@@ -262,7 +260,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       from_address_hash: internal_transaction.from_address_hash,
       to_address_hash: internal_transaction.to_address_hash,
       created_contract_address_hash: internal_transaction.created_contract_address_hash,
-      value: decimal_internal_transaction_value,
+      value: internal_transaction.value && internal_transaction.value.value,
       fee:
         internal_transaction.transaction.gas_price && internal_transaction.gas_used &&
           Decimal.mult(internal_transaction.transaction.gas_price.value, internal_transaction.gas_used),

--- a/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
@@ -92,7 +92,7 @@ defmodule Indexer.Transform.Celo.TransactionTokenTransfers do
     token_transfers =
       internal_transactions
       |> Enum.filter(fn internal_transaction ->
-        internal_transaction.value > 0 &&
+        not is_nil(internal_transaction.value) && internal_transaction.value > 0 &&
           internal_transaction.index > 0 &&
           not Map.has_key?(internal_transaction, :error) &&
           (not Map.has_key?(internal_transaction, :call_type) || internal_transaction.call_type != "delegatecall")


### PR DESCRIPTION
## Motivation

After nilifying the internal transactions `value` field in https://github.com/blockscout/blockscout/pull/13893 there are still places where we don't expect `value` to be `nil`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced internal transaction processing with improved nil-safety checks for transaction value handling. These changes prevent potential errors when transaction values are missing, improving the reliability of transaction processing, balance tracking, and overall platform stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->