### PR TITLE
fix: Set default internal transactions advanced filter value to 0

### DIFF
--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -260,7 +260,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       from_address_hash: internal_transaction.from_address_hash,
       to_address_hash: internal_transaction.to_address_hash,
       created_contract_address_hash: internal_transaction.created_contract_address_hash,
-      value: internal_transaction.value && internal_transaction.value.value,
+      value: (internal_transaction.value && internal_transaction.value.value) || Decimal.new(0),
       fee:
         internal_transaction.transaction.gas_price && internal_transaction.gas_used &&
           Decimal.mult(internal_transaction.transaction.gas_price.value, internal_transaction.gas_used),


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Advanced filter now treats missing internal transaction values as zero, preventing undefined values. This yields consistent fee calculations and stable sorting results when filtering internal transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->