### PR TITLE
fix: Handle nil coin balance in "broadcast_address_coin_balance/1" function

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -574,7 +574,7 @@ defmodule BlockScoutWeb.Notifier do
   defp broadcast_address_coin_balance(%{address_hash: address_hash, block_number: block_number}) do
     coin_balance = CoinBalance.get_coin_balance(address_hash, block_number, @api_true)
 
-    if coin_balance.delta && !Decimal.eq?(coin_balance.delta, Decimal.new(0)) do
+    if coin_balance && coin_balance.delta && !Decimal.eq?(coin_balance.delta, Decimal.new(0)) do
       # TODO: delete duplicated event when old UI becomes deprecated
       Endpoint.broadcast("addresses_old:#{address_hash}", "coin_balance", %{
         block_number: block_number,
@@ -582,7 +582,7 @@ defmodule BlockScoutWeb.Notifier do
       })
     end
 
-    if coin_balance.value && coin_balance.delta && !Decimal.eq?(coin_balance.delta, Decimal.new(0)) do
+    if coin_balance && coin_balance.value && coin_balance.delta && !Decimal.eq?(coin_balance.delta, Decimal.new(0)) do
       rendered_coin_balance = AddressView.render("coin_balance.json", %{coin_balance: coin_balance})
 
       Endpoint.broadcast("addresses:#{address_hash}", "coin_balance", %{


### PR DESCRIPTION
## Motivation

Such error is observed in the logs:

`{"message":"GenServer BlockScoutWeb.RealtimeEventHandlers.Main terminating\n** (BadMapError) expected a map, got:\n\n    nil\n\n    (block_scout_web 10.0.0) lib/block_scout_web/notifier.ex:577: BlockScoutWeb.Notifier.broadcast_address_coin_balance/1\n    (elixir 1.19.4) lib/enum.ex:961: Enum.\"-each/2-lists^foreach/1-0-\"/2\n    (block_scout_web 10.0.0) lib/block_scout_web/realtime_event_handlers/main.ex:63: BlockScoutWeb.RealtimeEventHandlers.Main.handle_info/2\n    (stdlib 6.2.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3\n    (stdlib 6.2.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\n    (stdlib 6.2.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3\nLast message: {:chain_event, :address_coin_balances, :realtime, [%{value: #Explorer.Chain.Wei<34892200604058118>, block_number: 10326023, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<174, 31, 127, 82, 202, 187, 184, 66, 92, 123, 189, 230, 108, 246, 158, 199, 230, 3, 88, 218>>}}, %{value: #Explorer.Chain.Wei<1228022150531784837>, block_number: 10326023, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<174, 227, 72, 224, 213, 77, 19, 55, 42, 16, 221, 213, 225, 134, 181, 41, 127, 199, 29, 96>>}}, %{value: #Explorer.Chain.Wei<63276578541429851>, block_number: 10326023, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<178, 206, 7, 175, 152, 129, 83, 137, 126, 101, 141, 13, 10, 229, 94, 178, 36, 65, 127, 31>>}}, %{value: #Explorer.Chain.Wei<227233924533090601>, block_number: 10326023, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<180, 214, 112, 1, 6, 97, 112, 237, 63, 242, 180, 207, ...>>}}, ...]}","time":"2026-02-24T08:50:54.852Z","metadata":{},"severity":"error"}`

## Changelog

Handle nil coin balance on address before given block number.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of balance notifications by adding safeguards to prevent errors when processing incomplete or absent balance data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->