### PR TITLE
feat: Fetch transaction receipts by block

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -251,7 +251,9 @@ config :ethereum_jsonrpc,
   ipc_path: System.get_env("IPC_PATH"),
   disable_archive_balances?:
     trace_url_missing? or ConfigHelper.parse_bool_env_var("ETHEREUM_JSONRPC_DISABLE_ARCHIVE_BALANCES"),
-  archive_balances_window: ConfigHelper.parse_integer_env_var("ETHEREUM_JSONRPC_ARCHIVE_BALANCES_WINDOW", 200)
+  archive_balances_window: ConfigHelper.parse_integer_env_var("ETHEREUM_JSONRPC_ARCHIVE_BALANCES_WINDOW", 200),
+  receipts_by_block?: ConfigHelper.parse_bool_env_var("ETHEREUM_JSONRPC_RECEIPTS_BY_BLOCK", "false"),
+  max_receipts_by_block: ConfigHelper.parse_integer_env_var("ETHEREUM_JSONRPC_MAX_RECEIPTS_BY_BLOCK", 1000)
 
 config :ethereum_jsonrpc, EthereumJSONRPC.HTTP,
   headers:


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/9954#issuecomment-2079330048

Docs update: https://github.com/blockscout/docs/pull/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to fetch receipts in a block-aware mode, enabling processing of receipts either by block or by transaction input shapes and preserving accumulated logs and receipts across runs.

* **Chores**
  * New runtime configuration keys to toggle block-aware receipts and set a maximum receipts-per-block limit (default 1000).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->