### PR TITLE
chore: Unescape ampersand in token's metadata

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -141,6 +141,7 @@ for migrator <- [
       Explorer.Migrator.ReindexDuplicatedInternalTransactions,
       Explorer.Migrator.MergeAdjacentMissingBlockRanges,
       Explorer.Migrator.UnescapeQuotesInTokens,
+      Explorer.Migrator.UnescapeAmpersandsInTokens,
       Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources,
       Explorer.Migrator.EmptyInternalTransactionsData
     ] do

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -74,6 +74,7 @@ for migrator <- [
       Explorer.Migrator.ReindexDuplicatedInternalTransactions,
       Explorer.Migrator.MergeAdjacentMissingBlockRanges,
       Explorer.Migrator.UnescapeQuotesInTokens,
+      Explorer.Migrator.UnescapeAmpersandsInTokens,
       Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources,
       Explorer.Migrator.DeleteZeroValueInternalTransactions,
       Explorer.Migrator.EmptyInternalTransactionsData,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -199,6 +199,7 @@ defmodule Explorer.Application do
         configure_mode_dependent_process(Explorer.Migrator.ReindexDuplicatedInternalTransactions, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.MergeAdjacentMissingBlockRanges, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.UnescapeQuotesInTokens, :indexer),
+        configure_mode_dependent_process(Explorer.Migrator.UnescapeAmpersandsInTokens, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.ReindexBlocksWithMissingTransactions, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.DeleteZeroValueInternalTransactions, :indexer),

--- a/apps/explorer/lib/explorer/migrator/unescape_ampersands_in_tokens.ex
+++ b/apps/explorer/lib/explorer/migrator/unescape_ampersands_in_tokens.ex
@@ -1,0 +1,65 @@
+defmodule Explorer.Migrator.UnescapeAmpersandsInTokens do
+  @moduledoc """
+  Unescapes ampersands in `name` and `symbol` token fields
+  """
+
+  use Explorer.Migrator.FillingMigration
+
+  import Ecto.Query
+
+  alias Explorer.Chain.Token
+  alias Explorer.Migrator.FillingMigration
+  alias Explorer.Repo
+
+  @migration_name "unescape_ampersands_in_tokens"
+
+  @impl FillingMigration
+  def migration_name, do: @migration_name
+
+  @impl FillingMigration
+  def last_unprocessed_identifiers(state) do
+    limit = batch_size() * concurrency()
+
+    ids =
+      unprocessed_data_query()
+      |> select([t], t.contract_address_hash)
+      |> limit(^limit)
+      |> Repo.all(timeout: :infinity)
+
+    {ids, state}
+  end
+
+  @impl FillingMigration
+  def unprocessed_data_query do
+    where(Token, [t], fragment("? ~ E'&amp;' or ? ~ E'&amp;'", t.name, t.symbol))
+  end
+
+  @impl FillingMigration
+  def update_batch(contract_address_hashes) do
+    params =
+      Token
+      |> where([t], t.contract_address_hash in ^contract_address_hashes)
+      |> Repo.all()
+      |> Enum.map(fn token ->
+        %{
+          contract_address_hash: token.contract_address_hash,
+          name: do_unescape(token.name),
+          symbol: do_unescape(token.symbol),
+          type: token.type,
+          inserted_at: token.inserted_at,
+          updated_at: token.updated_at
+        }
+      end)
+
+    Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+  end
+
+  @impl FillingMigration
+  def update_cache, do: :ok
+
+  defp do_unescape(nil), do: nil
+
+  defp do_unescape(string) do
+    String.replace(string, "&amp;", "&")
+  end
+end

--- a/apps/explorer/lib/explorer/smart_contract/helper.ex
+++ b/apps/explorer/lib/explorer/smart_contract/helper.ex
@@ -88,13 +88,11 @@ defmodule Explorer.SmartContract.Helper do
   end
 
   @doc """
-  Escapes only <, > and & symbols
+  Escapes only < and > symbols
   """
   @spec escape_minimal(any()) :: any()
   def escape_minimal(input) when is_binary(input) do
     input
-    # should always be the first to replace
-    |> String.replace("&", "&amp;")
     |> String.replace("<", "&lt;")
     |> String.replace(">", "&gt;")
   end

--- a/apps/explorer/test/explorer/migrator/unescape_ampersands_in_tokens_test.exs
+++ b/apps/explorer/test/explorer/migrator/unescape_ampersands_in_tokens_test.exs
@@ -1,0 +1,25 @@
+defmodule Explorer.Migrator.UnescapeAmpersandsInTokensTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Migrator.{UnescapeAmpersandsInTokens, MigrationStatus}
+  alias Explorer.Repo
+
+  test "Unescapes ampersands in tokens" do
+    escaped_name_token = insert(:token, name: "Rock &amp; Roll")
+    escaped_symbol_token = insert(:token, symbol: "R&amp;R")
+    escaped_both_token = insert(:token, name: "Tom &amp; Jerry", symbol: "T&amp;J")
+    common_token = :token |> insert() |> Repo.reload()
+
+    assert MigrationStatus.get_status("unescape_ampersands_in_tokens") == nil
+    UnescapeAmpersandsInTokens.start_link([])
+
+    Process.sleep(100)
+
+    assert Repo.reload(escaped_name_token).name == "Rock & Roll"
+    assert Repo.reload(escaped_symbol_token).symbol == "R&R"
+    assert %{name: "Tom & Jerry", symbol: "T&J"} = Repo.reload(escaped_both_token)
+    assert ^common_token = Repo.reload(common_token)
+
+    assert MigrationStatus.get_status("unescape_ampersands_in_tokens") == "completed"
+  end
+end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/issues/10732

## Motivation

Allow ampersands (`&`) to be stored as-is in token names and symbols without HTML escaping. Currently, ampersands are being escaped to &amp; during token insertion, which causes display issues and is unnecessary for database storage. This follows the same approach as PR #13078, which addressed similar issues with quotes.

## Changelog

• Modified `Explorer.SmartContract.Helper.escape_minimal/1` to escape only < and > characters (removed ampersand escaping).
• Added background migrator `Explorer.Migrator.UnescapeAmpersandsInTokens` to convert existing `&amp;` to `&` in token name and symbol fields.
• Wired the migrator into application configuration and startup.
• Added tests verifying the migration correctly unescapes ampersands in existing token data.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the display of token names and symbols that contain ampersands, ensuring they render correctly instead of showing escaped characters.

* **Tests**
  * Added test coverage to validate the data migration for ampersand unescaping in token records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->