### PR TITLE
chore: Put backend versions into constants on launch

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -115,6 +115,8 @@ config :explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions, enabled
 
 config :explorer, Explorer.Chain.Mud, enabled: ConfigHelper.parse_bool_env_var("MUD_INDEXER_ENABLED")
 
+config :explorer, Explorer.Utility.VersionConstantsUpdater, enabled: true
+
 for migrator <- [
       # Background migrations
       Explorer.Migrator.TransactionsDenormalization,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -116,6 +116,7 @@ defmodule Explorer.Application do
   defp configurable_children do
     configurable_children_set =
       [
+        configure_mode_dependent_process(Explorer.Utility.VersionConstantsUpdater, :indexer),
         configure_mode_dependent_process(Explorer.Market.Fetcher.Coin, :api),
         configure_mode_dependent_process(Explorer.Market.Fetcher.Token, :indexer),
         configure_mode_dependent_process(Explorer.Market.Fetcher.History, :indexer),

--- a/apps/explorer/lib/explorer/application/constants.ex
+++ b/apps/explorer/lib/explorer/application/constants.ex
@@ -9,6 +9,8 @@ defmodule Explorer.Application.Constants do
 
   @keys_manager_contract_address_key "keys_manager_contract_address"
   @last_processed_erc_721_token "token_instance_sanitizer_last_processed_erc_721_token"
+  @previous_backend_version_key "previous_backend_version"
+  @current_backend_version_key "current_backend_version"
 
   @primary_key false
   typed_schema "constants" do
@@ -101,5 +103,55 @@ defmodule Explorer.Application.Constants do
   @spec get_last_processed_token_address_hash(keyword()) :: nil | Explorer.Chain.Hash.t()
   def get_last_processed_token_address_hash(options \\ []) do
     @last_processed_erc_721_token |> get_constant_value(options) |> Chain.string_to_address_hash_or_nil()
+  end
+
+  @doc """
+  Inserts the previously running backend version into constants storage.
+
+  ## Parameters
+  - `version`: Backend version string to persist.
+
+  ## Returns
+  - The inserted or updated `%Explorer.Application.Constants{}` record.
+  """
+  @spec insert_previous_backend_version(String.t()) :: Ecto.Schema.t()
+  def insert_previous_backend_version(version) do
+    set_constant_value(@previous_backend_version_key, version)
+  end
+
+  @doc """
+  Fetches the previously running backend version from constants storage.
+
+  ## Returns
+  - Previous backend version.
+  """
+  @spec get_previous_backend_version() :: nil | String.t()
+  def get_previous_backend_version do
+    get_constant_value(@previous_backend_version_key)
+  end
+
+  @doc """
+  Inserts the current running backend version into constants storage.
+
+  ## Parameters
+  - `version`: Backend version string to persist.
+
+  ## Returns
+  - The inserted or updated `%Explorer.Application.Constants{}` record.
+  """
+  @spec insert_current_backend_version(String.t()) :: Ecto.Schema.t()
+  def insert_current_backend_version(version) do
+    set_constant_value(@current_backend_version_key, version)
+  end
+
+  @doc """
+  Fetches the current running backend version from constants storage.
+
+  ## Returns
+  - Current backend version.
+  """
+  @spec get_current_backend_version() :: nil | String.t()
+  def get_current_backend_version do
+    get_constant_value(@current_backend_version_key)
   end
 end

--- a/apps/explorer/lib/explorer/utility/version_constants_updater.ex
+++ b/apps/explorer/lib/explorer/utility/version_constants_updater.ex
@@ -1,0 +1,32 @@
+defmodule Explorer.Utility.VersionConstantsUpdater do
+  @moduledoc """
+  Module responsible for updating current and previous backend version in table `constants`.
+  """
+
+  use GenServer
+
+  alias Explorer.Application.Constants
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    set_versions()
+    :ignore
+  end
+
+  defp set_versions do
+    stored_current_version = Constants.get_current_backend_version()
+    current_version = to_string(Application.spec(:explorer, :vsn))
+
+    if not is_nil(stored_current_version) and stored_current_version != current_version do
+      Constants.insert_previous_backend_version(stored_current_version)
+    end
+
+    if stored_current_version != current_version do
+      Constants.insert_current_backend_version(current_version)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Future major versions may need to have information about the previous version from where backend was updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented persistent storage for previous and current backend version values.
  * Added public APIs to read and write stored previous and current backend version entries.
  * Introduced a configuration toggle to enable the version-updater at startup.

* **New Features**
  * Added a startup task that updates stored version values when the app launches.
  * On startup, the task moves the prior current value into the previous-version slot before saving the new value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->