### PR TITLE
fix: state changes use token transfer type

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -7,7 +7,18 @@ defmodule Explorer.Chain.Transaction.StateChange do
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
   alias Explorer.Chain
-  alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, TokenTransfer, Transaction, Wei}
+
+  alias Explorer.Chain.{
+    Address,
+    Block,
+    DenormalizationHelper,
+    Hash,
+    InternalTransaction,
+    TokenTransfer,
+    Transaction,
+    Wei
+  }
+
   alias Explorer.Chain.Transaction.StateChange
 
   defstruct [:coin_or_token_transfers, :address, :token_id, :balance_before, :balance_after, :balance_diff, :miner?]
@@ -148,7 +159,14 @@ defmodule Explorer.Chain.Transaction.StateChange do
   end
 
   defp do_update_balance(old_val, type, transfer, _) do
-    token_ids = if transfer.token.type == "ERC-1155", do: transfer.token_ids, else: [nil]
+    token_type =
+      if DenormalizationHelper.tt_denormalization_finished?() do
+        transfer.token_type
+      else
+        transfer.token.type
+      end
+
+    token_ids = if token_type == "ERC-1155", do: transfer.token_ids, else: [nil]
     transfer_amounts = transfer.amounts || [transfer.amount || 1]
 
     sub_or_add =
@@ -332,7 +350,10 @@ defmodule Explorer.Chain.Transaction.StateChange do
       balance_diff = Decimal.sub(balance, balance_before)
       transfer = elem(List.first(transfers), 1)
 
-      if transfer.token.type not in ["ERC-20", "ZRC-2"] or has_diff?(balance_diff) do
+      token_type =
+        if DenormalizationHelper.tt_denormalization_finished?(), do: transfer.token_type, else: transfer.token.type
+
+      if token_type not in ["ERC-20", "ZRC-2"] or has_diff?(balance_diff) do
         %StateChange{
           coin_or_token_transfers: transfers,
           address: address,


### PR DESCRIPTION
## Motivation

500 on https://eth.blockscout.com/tx/0x708966f2e87fa41991b21ec7d143837e2b1bc54565a1f86576bc3f3c90239630?tab=state

```
{"message":"#PID<0.9259175.0> running BlockScoutWeb.Endpoint (connection #PID<0.9256746.0>, stream id 2) terminated
Server: eth.blockscout.com:80 (http)
Request: GET /api/v2/transactions/0x708966f2e87fa41991b21ec7d143837e2b1bc54565a1f86576bc3f3c90239630/state-changes
** (exit) an exception was raised:
    ** (Protocol.UndefinedError) protocol Enumerable not implemented for Atom. This protocol is implemented for: Cldr.Unit.Range, DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, Explorer.BoundQueue, File.Stream, Floki.HTMLTree, Flow, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Stream, Timex.Interval

Got value:

    nil

        (elixir 1.19.4) lib/enum.ex:5: Enumerable.impl_for!/1
        (elixir 1.19.4) lib/enum.ex:170: Enumerable.reduce/3
        (stdlib 6.2.2.2) lists.erl:2310: :lists.foreach_1/2
        (elixir 1.19.4) lib/stream/reducers.ex:78: Stream.Reducers.do_zip_enum/4
        (elixir 1.19.4) lib/enum.ex:4570: Enum.reduce/3
        (explorer 9.3.2) lib/explorer/chain/transaction/state_change.ex:110: Explorer.Chain.Transaction.StateChange.token_transfers_balances_reducer/3
        (elixir 1.19.4) lib/enum.ex:2520: Enum.\"-reduce/3-lists^foldl/2-0-\"/3
        (explorer 9.3.2) lib/explorer/chain/transaction/state_change.ex:290: Explorer.Chain.Transaction.StateChange.token_entries/2","time":"2026-03-04T15:04:54.796Z","request":{"connection":{"status":null,"path":"/api/v2/transactions/0x708966f2e87fa41991b21ec7d143837e2b1bc54565a1f86576bc3f3c90239630/state-changes","protocol":"HTTP/1.1","method":"GET"},"client":{"ip":"95.164.115.41","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"}},"metadata":{},"severity":"error"}
```

the reason is the following: (ERC-20 token transfer from ERC-1155 contract)
```
+----------+----------------------+-------+---------+--------+
|token_type|amount                |amounts|token_ids|token.type |
+----------+----------------------+-------+---------+--------+
|ERC-20    |317200000000000000    |null   |null     |ERC-20  |
|ERC-1155  |1030623683693371561533|null   |{0}      |ERC-1155|
|ERC-20    |1030623683693371561533|null   |null     |ERC-1155|
|ERC-20    |317200000000000000    |null   |null     |ERC-20  |
|ERC-1155  |1030623683693371561533|null   |{0}      |ERC-1155|
|ERC-20    |1030623683693371561533|null   |null     |ERC-1155|
|ERC-1155  |1030623683693371561533|null   |{0}      |ERC-1155|
|ERC-20    |1030623683693371561533|null   |null     |ERC-1155|
+----------+----------------------+-------+---------+--------+

```

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token balance update handling with more robust fallback logic for token type determination.
  * Enhanced processing to better support ERC-1155 and other token types with improved data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->