### PR TITLE
Add geas to the GraphQL language enum

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/graphql/schema/types.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/schema/types.ex
@@ -127,7 +127,7 @@ defmodule BlockScoutWeb.GraphQL.Schema.Types do
 
   # TODO: leverage `Ecto.Enum.values(SmartContract, :language)` to deduplicate
   # language definitions
-  @default_languages ~w(solidity vyper yul)a
+  @default_languages ~w(solidity vyper yul geas)a
 
   case @chain_type do
     :arbitrum ->

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/types_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/types_test.exs
@@ -1,0 +1,15 @@
+defmodule BlockScoutWeb.GraphQL.Schema.TypesTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Chain.SmartContract
+
+  test "language enum matches supported smart contract languages" do
+    graphql_languages =
+      Absinthe.Schema.lookup_type(BlockScoutWeb.GraphQL.Schema, :language).values
+      |> Map.keys()
+      |> Enum.map(&to_string/1)
+      |> Enum.sort()
+
+    assert graphql_languages == Enum.sort(SmartContract.language_strings())
+  end
+end


### PR DESCRIPTION
Closes #14082

This keeps the GraphQL schema aligned with the supported smart-contract languages after the recent `language` enum migration.

- add `geas` to the GraphQL `language` enum
- add a regression test that compares the GraphQL enum against `Explorer.Chain.SmartContract.language_strings()`

| Step | Before fix | After fix |
| --- | --- | --- |
| Reproduction command | `mise exec -- env MIX_ENV=test mix run --no-start -e 'graphql = Absinthe.Schema.lookup_type(BlockScoutWeb.GraphQL.Schema, :language).values |> Map.keys() |> Enum.map(&to_string/1) |> Enum.sort(); contract = Explorer.Chain.SmartContract.language_strings() |> Enum.sort(); IO.puts("graphql=" <> Jason.encode!(graphql)); IO.puts("contract=" <> Jason.encode!(contract)); IO.puts("missing=" <> Jason.encode!(contract -- graphql))'` | same command |\n| Key output | `missing=["geas"]` | `missing=[]` |\n| Test result | schema comparison showed GraphQL omitted `geas` | `mix run --no-start -e 'ExUnit.start(); Code.require_file("apps/block_scout_web/test/block_scout_web/graphql/schema/types_test.exs"); result = ExUnit.run(); IO.inspect(result, label: "exunit")'` -> `1 test, 0 failures` |\n\nTest notes:\n- `mise exec -- env MIX_ENV=test mix compile` passed\n- the direct schema lookup flipped from `missing=["geas"]` to `missing=[]`\n- the targeted ExUnit regression case passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "geas" as a supported smart contract programming language.

* **Tests**
  * Added test to validate language support consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->