### PR TITLE
chore: Allow "scoped_recaptcha_bypass_token" in query string for NFT metadata re-fetch

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -676,7 +676,8 @@ defmodule BlockScoutWeb.API.V2.TokenController do
         [
           address_hash_param(),
           token_id_param(),
-          recaptcha_response_param()
+          recaptcha_response_param(),
+          scoped_recaptcha_bypass_token_param()
         ],
     responses: [
       ok:

--- a/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
@@ -184,7 +184,10 @@ defmodule BlockScoutWeb.RateLimit do
     recaptcha_response = get_header_or_nil(conn, "recaptcha-v2-response")
     recaptcha_v3_response = get_header_or_nil(conn, "recaptcha-v3-response")
     recaptcha_bypass_token = get_header_or_nil(conn, "recaptcha-bypass-token")
-    scoped_recaptcha_bypass_token = get_header_or_nil(conn, "scoped-recaptcha-bypass-token")
+
+    scoped_recaptcha_bypass_token =
+      get_header_or_nil(conn, "scoped-recaptcha-bypass-token") ||
+        get_query_param_or_nil(conn, "scoped_recaptcha_bypass_token")
 
     cond do
       recaptcha_response ->
@@ -216,6 +219,18 @@ defmodule BlockScoutWeb.RateLimit do
     case Conn.get_req_header(conn, header_name) do
       [response] ->
         response
+
+      _ ->
+        nil
+    end
+  end
+
+  defp get_query_param_or_nil(conn, param_name) do
+    conn = Conn.fetch_query_params(conn)
+
+    case Map.get(conn.query_params, param_name) do
+      value when is_binary(value) ->
+        value
 
       _ ->
         nil

--- a/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
@@ -225,9 +225,6 @@ defmodule BlockScoutWeb.RateLimit do
           "" -> nil
           trimmed -> trimmed
         end
-
-      other ->
-        other
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
@@ -186,8 +186,8 @@ defmodule BlockScoutWeb.RateLimit do
     recaptcha_bypass_token = get_header_or_nil(conn, "recaptcha-bypass-token")
 
     scoped_recaptcha_bypass_token =
-      get_header_or_nil(conn, "scoped-recaptcha-bypass-token") ||
-        get_query_param_or_nil(conn, "scoped_recaptcha_bypass_token")
+      normalize_blank_to_nil(get_header_or_nil(conn, "scoped-recaptcha-bypass-token")) ||
+        normalize_blank_to_nil(get_query_param_or_nil(conn, "scoped_recaptcha_bypass_token"))
 
     cond do
       recaptcha_response ->
@@ -212,6 +212,22 @@ defmodule BlockScoutWeb.RateLimit do
 
       true ->
         %{}
+    end
+  end
+
+  defp normalize_blank_to_nil(value) do
+    case value do
+      nil ->
+        nil
+
+      binary when is_binary(binary) ->
+        case String.trim(binary) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      other ->
+        other
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/rate_limit.ex
@@ -239,8 +239,6 @@ defmodule BlockScoutWeb.RateLimit do
   end
 
   defp get_query_param_or_nil(conn, param_name) do
-    conn = Conn.fetch_query_params(conn)
-
     case Map.get(conn.query_params, param_name) do
       value when is_binary(value) ->
         value

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -698,6 +698,20 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @doc """
+  Returns a parameter definition for scoped reCAPTCHA bypass token.
+  """
+  @spec scoped_recaptcha_bypass_token_param() :: Parameter.t()
+  def scoped_recaptcha_bypass_token_param do
+    %Parameter{
+      name: :scoped_recaptcha_bypass_token,
+      in: :query,
+      schema: %Schema{type: :string},
+      required: false,
+      description: "Scoped reCAPTCHA bypass token for trusted clients"
+    }
+  end
+
+  @doc """
   Returns a parameter definition for API key used in rate limiting.
   """
   @spec api_key_param() :: Parameter.t()

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2035,7 +2035,11 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
         |> subscribe_and_join(topic)
 
       request =
-        patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
+        patch(
+          conn,
+          "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata?scoped_recaptcha_bypass_token=#{scoped_bypass_token}",
+          %{}
+        )
 
       assert %{"message" => "OK"} = json_response(request, 200)
 
@@ -2075,8 +2079,10 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       request =
         Phoenix.ConnTest.build_conn()
         |> put_req_header("user-agent", "test-agent")
-        |> put_req_header("scoped-recaptcha-bypass-token", scoped_bypass_token)
-        |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
+        |> patch(
+          "/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata?scoped_recaptcha_bypass_token=#{scoped_bypass_token}",
+          %{}
+        )
 
       assert %{"message" => "OK"} = json_response(request, 200)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2107,6 +2107,40 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       assert(token_instance_from_db)
       assert token_instance_from_db.metadata == metadata
+
+      # Verify header-based scoped bypass token also works (prevent regression)
+      request =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("user-agent", "test-agent")
+        |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
+
+      assert json_response(request, 429)
+
+      TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
+
+      token_instance_success_metadata_expectation(url, metadata)
+
+      request =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("user-agent", "test-agent")
+        |> put_req_header("scoped-recaptcha-bypass-token", scoped_bypass_token)
+        |> patch("/api/v2/tokens/#{token.contract_address.hash}/instances/#{token_id}/refetch-metadata", %{})
+
+      assert %{"message" => "OK"} = json_response(request, 200)
+
+      :timer.sleep(100)
+
+      assert_receive(
+        {:chain_event, :fetched_token_instance_metadata, :on_demand,
+         [^token_contract_address_hash_string, ^token_id, ^metadata]}
+      )
+
+      assert_receive %Phoenix.Socket.Message{
+                       payload: %{token_id: ^token_id_string, fetched_metadata: ^metadata},
+                       event: "fetched_token_instance_metadata",
+                       topic: ^topic
+                     },
+                     :timer.seconds(1)
     end
 
     test "falls back to normal reCAPTCHA when incorrect scoped bypass api key is supplied", %{


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13513

## Motivation

Starting from 9.2.x, `OpenApiSpex.Plug.CastAndValidate` began rejecting `scoped_recaptcha_bypass_token` in query params for:

`/api/v2/tokens/:token_address_hash/instances/:token_instance_id/refetch-metadata`

As a result, requests like:

`.../refetch-metadata?scoped_recaptcha_bypass_token=...`

failed with:

`"Unexpected field: scoped_recaptcha_bypass_token"`

This PR restores support for passing scoped reCAPTCHA bypass token in query string for this endpoint and ensures rate-limit bypass logic reads it from query params in the expected `scoped_recaptcha_bypass_token` form.

## Changelog

- Added OpenAPI query parameter definition for scoped bypass token:
  - `scoped_recaptcha_bypass_token_param/0` in `apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex`
- Included `scoped_recaptcha_bypass_token_param()` in the `refetch_metadata` operation parameters:
  - `apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex`
- Updated rate-limit CAPTCHA token collection to support query-string fallback for scoped token:
  - `apps/block_scout_web/lib/block_scout_web/rate_limit.ex`
  - fallback now accepts only `scoped_recaptcha_bypass_token` from query string
  - existing header support (`scoped-recaptcha-bypass-token`) remains intact
- Updated tests to verify scoped bypass works via query string:
  - `apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token metadata refresh now accepts a scoped reCAPTCHA bypass token via query parameter or header; blank values are treated as absent so header falls back to query.

* **Bug Fixes**
  * Blank bypass-token values are normalized to absent to ensure consistent fallback behavior.

* **Tests**
  * Updated and expanded tests covering header and query-parameter paths, fallback behavior, and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->