### PR TITLE
fix: `confirm_otp` after `OpenApiSpex` integration

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/authenticate_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/api/v2/authenticate_controller.ex
@@ -157,42 +157,38 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateController do
     }
 
   @doc """
-  Confirms a one-time password (OTP) for a given email and updates the session.
+  Confirms a one-time password (OTP) for the email in the request body and establishes a user session on success.
 
-  This function verifies the OTP provided for a specific email address. If the
-  OTP is valid, it retrieves the authentication information and updates the
-  user's session accordingly.
-
-  The function performs the following steps:
-  1. Confirms the OTP with Auth0 and retrieves the authentication information.
-  2. If successful, updates the session with the new authentication data.
+  Verifies the OTP via `Auth0.confirm_otp_and_get_auth/3`. On successful
+  verification, retrieves or creates the user's identity and
+  updates the session via `put_auth_to_session/2`.
 
   ## Parameters
-  - `conn`: The `Plug.Conn` struct representing the current connection.
-  - `params`: A map containing:
-    - `"email"`: The email address associated with the OTP.
-    - `"otp"`: The one-time password to be confirmed.
+  - `conn`: The `Plug.Conn` struct. The request body must
+    contain `:email` and `:otp` fields.
+  - `_params`: Unused. Email and OTP are read from
+    `conn.body_params`.
 
   ## Returns
-  - `:error`: If there's an unexpected error during the process.
-  - `{:error, any()}`: If there's a specific error during OTP confirmation or
-    session update. The error details are included.
-  - `Conn.t()`: A modified connection struct with updated session information
-    if the OTP is successfully confirmed.
+  - `Conn.t()` with a 200 status and rendered user info on
+    successful OTP confirmation.
+  - `{:enabled, false}` if Auth0 authentication is not enabled.
+  - `{:error, any()}` if OTP verification or session creation
+    fails.
+  - `:error` if an unexpected error occurs during OTP
+    verification or session creation.
 
   ## Notes
-  - Errors are handled later in `BlockScoutWeb.Account.API.V2.FallbackController`.
-  - This function relies on the Auth0 service to confirm the OTP and retrieve
-    the authentication information.
-  - The function handles both existing and newly created users.
-  - For newly created users, it may create a new authentication record if the
-    user is not immediately found in the search after OTP confirmation.
-  - The session update is handled by the `put_auth_to_session/2` function, which
-    perform additional operations such as setting cookies or rendering user
-    information.
+  - Errors are handled by
+    `BlockScoutWeb.Account.API.V2.FallbackController`.
+  - The client's IP address is forwarded to Auth0 for rate
+    limiting.
   """
   @spec confirm_otp(Conn.t(), map()) :: :error | {:error, any()} | {:enabled, false} | Conn.t()
-  def confirm_otp(conn, %{email: email, otp: otp}) do
+  def confirm_otp(conn, _params) do
+    email = Map.get(conn.body_params, :email)
+    otp = Map.get(conn.body_params, :otp)
+
     with {:enabled, true} <- {:enabled, Auth0.enabled?()},
          {:ok, auth} <- Auth0.confirm_otp_and_get_auth(email, otp, AccessHelper.conn_to_ip_string(conn)) do
       put_auth_to_session(conn, auth)

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/authenticate_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/api/v2/authenticate_controller_test.exs
@@ -275,6 +275,171 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateControllerTest do
     end
   end
 
+  describe "POST api/account/v2/confirm_otp" do
+    setup do
+      initial_config = Application.get_env(:ueberauth, Ueberauth.Strategy.Auth0.OAuth)
+
+      Application.put_env(
+        :ueberauth,
+        Ueberauth.Strategy.Auth0.OAuth,
+        Keyword.put(initial_config, :auth0_application_id, "test_app")
+      )
+
+      on_exit(fn ->
+        Application.put_env(:ueberauth, Ueberauth.Strategy.Auth0.OAuth, initial_config)
+      end)
+
+      :ok
+    end
+
+    # Regression test: after OpenApiSpex integration, confirm_otp must read
+    # email and otp from conn.body_params instead of the action's params argument.
+    # See commit dbf589ae25.
+    test "confirm OTP successfully", %{conn: conn} do
+      id_token = build_test_jwt(%{"sub" => "email|123", "email" => "test@example.com"})
+
+      user_json =
+        JSON.encode!(%{
+          "user_id" => "email|123",
+          "email" => "test@example.com",
+          "email_verified" => true,
+          "name" => "Test User",
+          "nickname" => "test",
+          "picture" => "https://example.com/avatar.png",
+          "user_metadata" => %{
+            "test_app" => %{
+              "user_id" => "email|123",
+              "name" => "Test User",
+              "nickname" => "test",
+              "picture" => "https://example.com/avatar.png"
+            }
+          }
+        })
+
+      Tesla.Test.expect_tesla_call(
+        times: 3,
+        returns: fn
+          # OTP confirmation via OAuth2.Client
+          %{
+            method: :post,
+            url: "https://example.com/oauth/token",
+            headers: [
+              {"accept", "application/json"},
+              {"auth0-forwarded-for", _ip},
+              {"content-type", "application/json"}
+            ]
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: ~s({"access_token":"test_access","id_token":"#{id_token}","token_type":"Bearer"})
+             }}
+
+          # M2M JWT via HttpClient
+          %{
+            method: :post,
+            url: "https://example.com/oauth/token",
+            query: [],
+            headers: [{"Content-type", "application/json"}]
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: ~s({"access_token": "test_token", "expires_in": 86400})
+             }}
+
+          # Get user by ID via OAuth2.Client
+          %Tesla.Env{
+            method: :get,
+            url: "https://example.com/api/v2/users/" <> _,
+            headers: [{"accept", "application/json"}, {"authorization", "Bearer test_token"}],
+            body: ""
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 200,
+               body: user_json
+             }}
+        end
+      )
+
+      response =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/v2/confirm_otp", JSON.encode!(%{"email" => "test@example.com", "otp" => "123456"}))
+        |> json_response(200)
+
+      assert response["email"] == "test@example.com"
+      assert response["name"] == "Test User"
+    end
+
+    test "return error for wrong verification code", %{conn: conn} do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn
+          %{
+            method: :post,
+            url: "https://example.com/oauth/token",
+            headers: [
+              {"accept", "application/json"},
+              {"auth0-forwarded-for", _ip},
+              {"content-type", "application/json"}
+            ]
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 403,
+               body: ~s({"error":"invalid_grant","error_description":"Wrong email or verification code."})
+             }}
+        end
+      )
+
+      response =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/v2/confirm_otp", JSON.encode!(%{"email" => "test@example.com", "otp" => "000000"}))
+        |> json_response(500)
+
+      assert response == %{"message" => "Wrong verification code."}
+    end
+
+    test "return error when max attempts reached", %{conn: conn} do
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn
+          %{
+            method: :post,
+            url: "https://example.com/oauth/token",
+            headers: [
+              {"accept", "application/json"},
+              {"auth0-forwarded-for", _ip},
+              {"content-type", "application/json"}
+            ]
+          },
+          _opts ->
+            {:ok,
+             %Tesla.Env{
+               status: 403,
+               body:
+                 ~s({"error":"invalid_grant","error_description":"You've reached the maximum number of attempts. Please try to login again."})
+             }}
+        end
+      )
+
+      response =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/account/v2/confirm_otp", JSON.encode!(%{"email" => "test@example.com", "otp" => "000000"}))
+        |> json_response(500)
+
+      assert response == %{"message" => "Max attempts reached. Please resend code."}
+    end
+  end
+
   describe "GET api/account/v2/siwe_message" do
     test "get SIWE message successfully", %{conn: conn} do
       address = build(:address)
@@ -493,5 +658,12 @@ defmodule BlockScoutWeb.Account.API.V2.AuthenticateControllerTest do
 
       assert response == %{"message" => "Dynamic integration is disabled"}
     end
+  end
+
+  defp build_test_jwt(claims) do
+    header = Base.url_encode64(JSON.encode!(%{"alg" => "HS256", "typ" => "JWT"}), padding: false)
+    payload = Base.url_encode64(JSON.encode!(claims), padding: false)
+    signature = Base.url_encode64("test_signature", padding: false)
+    "#{header}.#{payload}.#{signature}"
   end
 end


### PR DESCRIPTION
400 on `api/account/v2/confirm_otp`

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for OTP confirmation endpoint including successful verification, invalid code handling, and max attempt scenarios.

* **Documentation**
  * Updated OTP verification documentation to reflect Auth0 integration and session handling behavior, including error cases.

* **Bug Fixes**
  * Enhanced error handling and validation for OTP confirmation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->