### PR TITLE
fix: state changes handle ERC-7984;  nil tx.value

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -9,7 +9,16 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
   import Explorer.Chain.SmartContract.Proxy.Models.Implementation, only: [proxy_implementations_association: 0]
 
   alias Explorer.{Chain, PagingOptions, Repo}
-  alias Explorer.Chain.{Address.CoinBalance, BlockNumberHelper, InternalTransaction, Transaction, Wei}
+
+  alias Explorer.Chain.{
+    Address.CoinBalance,
+    BlockNumberHelper,
+    DenormalizationHelper,
+    InternalTransaction,
+    Transaction,
+    Wei
+  }
+
   alias Explorer.Chain.Cache.StateChanges
   alias Explorer.Chain.Transaction.StateChange
   alias Indexer.Fetcher.OnDemand.CoinBalance, as: CoinBalanceOnDemand
@@ -195,8 +204,15 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
   end
 
   defp token_transfers_to_balances_reducer(transfer, balances, prev_block, options) do
+    token_type =
+      if DenormalizationHelper.tt_denormalization_finished?() do
+        transfer.token_type
+      else
+        transfer.token && transfer.token.type
+      end
+
     # Skip ERC-7984 (confidential) transfers - we can't track encrypted balances
-    if transfer.token && transfer.token.type == "ERC-7984" do
+    if token_type == "ERC-7984" do
       balances
     else
       from = transfer.from_address

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -1953,6 +1953,149 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       assert token_data["name"] == "Scam Token"
       assert token_data["address_hash"] == to_string(token.contract_address)
     end
+
+    test "return state changes with null value internal transaction", %{conn: conn} do
+      block_before = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :ok)
+
+      internal_transaction =
+        insert(:internal_transaction,
+          call_type: :call,
+          transaction_hash: transaction.hash,
+          transaction: transaction,
+          index: 1,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index,
+          block_hash: transaction.block_hash,
+          value: %Wei{value: Decimal.new(1000)}
+        )
+
+      insert(:internal_transaction,
+        call_type: :call,
+        transaction_hash: transaction.hash,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        block_hash: transaction.block_hash,
+        value: nil,
+        from_address_hash: internal_transaction.from_address_hash,
+        from_address: internal_transaction.from_address,
+        to_address_hash: internal_transaction.to_address_hash,
+        to_address: internal_transaction.to_address
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.from_address,
+        address_hash: transaction.from_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.to_address,
+        address_hash: transaction.to_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.block.miner,
+        address_hash: transaction.block.miner_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: internal_transaction.from_address,
+        address_hash: internal_transaction.from_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: internal_transaction.to_address,
+        address_hash: internal_transaction.to_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/state-changes")
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 5
+    end
+
+    test "return state changes with ERC-7984 token transfer", %{conn: conn} do
+      block_before = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(status: :ok)
+
+      confidential_token = insert(:token, type: "ERC-7984", symbol: "CT", name: "Confidential Token")
+      erc20_token = insert(:token, type: "ERC-20", symbol: "ERC20", name: "ERC20 Token")
+
+      erc20_token_transfer =
+        insert(:token_transfer,
+          token_type: "ERC-20",
+          transaction: transaction,
+          transaction_hash: transaction.hash,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          token_contract_address: erc20_token.contract_address,
+          amount: Decimal.new(100),
+          token_ids: nil
+        )
+
+      from_address = erc20_token_transfer.from_address
+      to_address = erc20_token_transfer.to_address
+
+      # Create ERC-7984 token transfer - should be skipped in state changes
+      insert(:token_transfer,
+        token_type: "ERC-7984",
+        transaction: transaction,
+        transaction_hash: transaction.hash,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        token_contract_address: confidential_token.contract_address,
+        from_address: from_address,
+        to_address: to_address,
+        amount: nil,
+        token_ids: nil
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.from_address,
+        address_hash: transaction.from_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.to_address,
+        address_hash: transaction.to_address_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      insert(:address_coin_balance,
+        address: transaction.block.miner,
+        address_hash: transaction.block.miner_hash,
+        block_number: block_before.number,
+        value: %Wei{value: Decimal.new(1000)}
+      )
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/state-changes")
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 5
+    end
   end
 
   if @chain_identity == {:optimism, :celo} do

--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -112,8 +112,15 @@ defmodule Explorer.Chain.Transaction.StateChange do
   end
 
   defp token_transfers_balances_reducer(transfer, state_balances_map, include_transfers) do
+    token_type =
+      if DenormalizationHelper.tt_denormalization_finished?() do
+        transfer.token_type
+      else
+        transfer.token && transfer.token.type
+      end
+
     # Skip ERC-7984 (confidential) transfers - we can't track encrypted balances
-    if transfer.token && transfer.token.type == "ERC-7984" do
+    if token_type == "ERC-7984" do
       state_balances_map
     else
       from = transfer.from_address


### PR DESCRIPTION
## Motivation
Two bugs:

```
** (ArgumentError) errors were found at the given arguments:

       * 2nd argument: not a tuple
     
     code: request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/state-changes")
     stacktrace:
       (erts 15.2.7.4) :erlang.element(2, nil)
       (explorer 10.0.1) lib/explorer/chain/transaction/state_change.ex:358: anonymous fn/6 in Explorer.Chain.Transaction.StateChange.token_entries/2
       (stdlib 6.2.2.2) maps.erl:860: :maps.fold_1/4
       (explorer 10.0.1) lib/explorer/chain/transaction/state_change.ex:352: Explorer.Chain.Transaction.StateChange.token_entries/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:101: BlockScoutWeb.Models.TransactionStateHelper.do_state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:49: BlockScoutWeb.Models.TransactionStateHelper.get_and_cache_state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:36: BlockScoutWeb.Models.TransactionStateHelper.state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:909: BlockScoutWeb.API.V2.TransactionController.state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.action/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.phoenix_controller_pipeline/2
       (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
       (phoenix 1.6.16) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
       (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
       (block_scout_web 10.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
       (block_scout_web 10.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 3)"/2
```
related to https://github.com/blockscout/blockscout/pull/13593
```
 ** (FunctionClauseError) no function clause matching in Explorer.Chain.Wei.sum/2

     The following arguments were given to Explorer.Chain.Wei.sum/2:

         # 1
         #Explorer.Chain.Wei<2000>

         # 2
         nil

     Attempted function clauses (showing 3 out of 3):

         def sum(%Explorer.Chain.Wei{value: wei_1}, %Explorer.Chain.Wei{value: nil})
         def sum(%Explorer.Chain.Wei{value: nil}, %Explorer.Chain.Wei{value: wei_2})
         def sum(%Explorer.Chain.Wei{value: wei_1}, %Explorer.Chain.Wei{value: wei_2})

     code: request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/state-changes")
     stacktrace:
       (explorer 10.0.1) lib/explorer/chain/wei.ex:151: Explorer.Chain.Wei.sum/2
       (explorer 10.0.1) lib/explorer/chain/transaction/state_change.ex:333: anonymous fn/2 in Explorer.Chain.Transaction.StateChange.update_balance/3
       (elixir 1.19.4) lib/map.ex:682: Map.update/4
       (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (explorer 10.0.1) lib/explorer/chain/transaction/state_change.ex:296: Explorer.Chain.Transaction.StateChange.native_coin_entries/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:94: BlockScoutWeb.Models.TransactionStateHelper.do_state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:49: BlockScoutWeb.Models.TransactionStateHelper.get_and_cache_state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/models/transaction_state_helper.ex:36: BlockScoutWeb.Models.TransactionStateHelper.state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:909: BlockScoutWeb.API.V2.TransactionController.state_changes/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.action/2
       (block_scout_web 10.0.1) lib/block_scout_web/controllers/api/v2/transaction_controller.ex:1: BlockScoutWeb.API.V2.TransactionController.phoenix_controller_pipeline/2
       (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
       (phoenix 1.6.16) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
       (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
       (block_scout_web 10.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint.plug_builder_call/2
       (block_scout_web 10.0.1) lib/block_scout_web/endpoint.ex:1: BlockScoutWeb.Endpoint."call (overridable 3)"/2
```
related to https://github.com/blockscout/blockscout/pull/13893

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
