### PR TITLE
fix: add missing query params in user ops swagger spec

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/account_abstraction_controller.ex
@@ -259,7 +259,7 @@ defmodule BlockScoutWeb.API.V2.Proxy.AccountAbstractionController do
   operation :accounts,
     summary: "List of account abstraction wallets",
     description: "Retrieves a list of account abstraction wallets.",
-    parameters: base_params() ++ define_paging_params(["page_size", "page_token"]),
+    parameters: [factory_address_hash_param() | base_params()] ++ define_paging_params(["page_size", "page_token"]),
     responses: [
       ok:
         {"List of account abstraction wallets with pagination.", "application/json",
@@ -287,7 +287,10 @@ defmodule BlockScoutWeb.API.V2.Proxy.AccountAbstractionController do
   operation :bundles,
     summary: "List of recent bundles",
     description: "Retrieves a list of recent bundles.",
-    parameters: base_params() ++ define_paging_params(["page_size", "page_token"]),
+    parameters:
+      base_params() ++
+        [bundler_address_hash_param(), entry_point_address_hash_param()] ++
+        define_paging_params(["page_size", "page_token"]),
     responses: [
       ok:
         {"List of bundles with pagination.", "application/json",
@@ -315,7 +318,18 @@ defmodule BlockScoutWeb.API.V2.Proxy.AccountAbstractionController do
   operation :operations,
     summary: "List of recent user operations",
     description: "Retrieves a list of recent user operations.",
-    parameters: base_params() ++ define_paging_params(["page_size", "page_token"]),
+    parameters:
+      base_params() ++
+        [
+          sender_address_hash_param(),
+          bundler_address_hash_param(),
+          paymaster_address_hash_param(),
+          factory_address_hash_param(),
+          query_transaction_hash_param(),
+          entry_point_address_hash_param(),
+          bundle_index_param(),
+          query_block_number_param()
+        ] ++ define_paging_params(["page_size", "page_token"]),
     responses: [
       ok:
         {"List of user operations with pagination.", "application/json",

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -853,6 +853,104 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @doc """
+  Returns a parameter definition for a user operation sender address hash in the query.
+  """
+  @spec sender_address_hash_param() :: Parameter.t()
+  def sender_address_hash_param do
+    %Parameter{
+      name: :sender,
+      in: :query,
+      schema: AddressHash,
+      required: false,
+      description: "User operation sender address hash"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation bundler address hash in the query.
+  """
+  @spec bundler_address_hash_param() :: Parameter.t()
+  def bundler_address_hash_param do
+    %Parameter{
+      name: :bundler,
+      in: :query,
+      schema: AddressHash,
+      required: false,
+      description: "User operation bundler address hash"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation paymaster address hash in the query.
+  """
+  @spec paymaster_address_hash_param() :: Parameter.t()
+  def paymaster_address_hash_param do
+    %Parameter{
+      name: :paymaster,
+      in: :query,
+      schema: AddressHash,
+      required: false,
+      description: "User operation paymaster address hash"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation factory address hash in the query.
+  """
+  @spec factory_address_hash_param() :: Parameter.t()
+  def factory_address_hash_param do
+    %Parameter{
+      name: :factory,
+      in: :query,
+      schema: AddressHash,
+      required: false,
+      description: "User operation factory address hash"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation entry point address hash in the query.
+  """
+  @spec entry_point_address_hash_param() :: Parameter.t()
+  def entry_point_address_hash_param do
+    %Parameter{
+      name: :entry_point,
+      in: :query,
+      schema: AddressHash,
+      required: false,
+      description: "User operation entry point address hash"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation bundle index in the query.
+  """
+  @spec bundle_index_param() :: Parameter.t()
+  def bundle_index_param do
+    %Parameter{
+      name: :bundle_index,
+      in: :query,
+      schema: %Schema{type: :integer, minimum: 0},
+      required: false,
+      description: "User operation bundle index"
+    }
+  end
+
+  @doc """
+  Returns a parameter definition for a user operation block number in the query.
+  """
+  @spec query_block_number_param() :: Parameter.t()
+  def query_block_number_param do
+    %Parameter{
+      name: :block_number,
+      in: :query,
+      schema: %Schema{type: :integer, minimum: 0},
+      required: false,
+      description: "User operation block number"
+    }
+  end
+
+  @doc """
   Returns a list of base parameters (api_key and key).
   """
   @spec base_params() :: [Parameter.t()]


### PR DESCRIPTION
## Changelog

Add missing query params definition for proxied user operations endpoints.

## Checklist for your Pull Request (PR)

- [X] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended account abstraction API endpoints with new query parameters: sender address, bundler address, paymaster address, factory address, entry point address, bundle index, and block number filters across accounts, bundles, and operations endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->