### PR TITLE
fix: Add dependency between heavy internal transactions migrations

### DIFF
--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_internal_transactions_block_hash_transaction_index_index_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_internal_transactions_block_hash_transaction_index_index_index.ex
@@ -11,6 +11,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockH
     MigrationStatus
   }
 
+  alias Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashPartialIndex
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
   @table_name :internal_transactions
@@ -29,7 +30,8 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockH
   @impl HeavyDbIndexOperation
   def dependent_from_migrations do
     [
-      EmptyInternalTransactionsData.migration_name()
+      EmptyInternalTransactionsData.migration_name(),
+      DropInternalTransactionsCreatedContractAddressHashPartialIndex.migration_name()
     ]
   end
 


### PR DESCRIPTION
## Motivation

To avoid deadlock in `running_other_heavy_migration_exists?` condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration dependencies to improve maintenance of internal indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->