### PR TITLE
fix: Add missing DenormalizationHelper alias in state changes

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -7,7 +7,18 @@ defmodule Explorer.Chain.Transaction.StateChange do
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
   alias Explorer.Chain
-  alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, TokenTransfer, Transaction, Wei}
+
+  alias Explorer.Chain.{
+    Address,
+    Block,
+    DenormalizationHelper,
+    Hash,
+    InternalTransaction,
+    TokenTransfer,
+    Transaction,
+    Wei
+  }
+
   alias Explorer.Chain.Transaction.StateChange
 
   defstruct [:coin_or_token_transfers, :address, :token_id, :balance_before, :balance_after, :balance_diff, :miner?]


### PR DESCRIPTION
## Motivation

Resolve this compilation warning:
```
     warning: DenormalizationHelper.tt_denormalization_finished?/0 is undefined (module DenormalizationHelper is not available or is yet to be defined). Did you mean:

           * Explorer.Chain.DenormalizationHelper.tt_denormalization_finished?/0

     │
 115 │       if DenormalizationHelper.tt_denormalization_finished?() do
     │                                ~
     │
     └─ (explorer 10.0.6) lib/explorer/chain/transaction/state_change.ex:115:32: Explorer.Chain.Transaction.StateChange.token_transfers_balances_reducer/3
```

## Changelog

### AI Agent summary

This pull request introduces a small refactor to the alias declarations in the `Explorer.Chain.Transaction.StateChange` module. The change improves code readability and maintainability by grouping aliases and adding a new module to the list.

* Refactored alias declarations in `apps/explorer/lib/explorer/chain/transaction/state_change.ex` to use multi-line formatting and included the `DenormalizationHelper` module for easier referencing throughout the file.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
