### PR TITLE
feat: account username change

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/account/auth_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/account/auth_controller.ex
@@ -8,25 +8,65 @@ defmodule BlockScoutWeb.Account.AuthController do
 
   plug(Ueberauth)
 
+  @doc """
+  Handles OAuth login request.
+  """
   def request(conn, _) do
     not_found(conn)
   end
 
+  @doc """
+  Handles user logout.
+  """
   def logout(conn, _params) do
     conn
     |> configure_session(drop: true)
     |> redirect(to: root())
   end
 
+  @doc """
+  Displays the user profile page.
+  """
   def profile(conn, _params),
     do: conn |> get_session(:current_user) |> do_profile(conn)
 
-  defp do_profile(nil, conn),
+  @doc """
+  Updates the user's account nickname.
+  """
+  def update_nickname(conn, %{"identity" => %{"nickname" => nickname}}) do
+    user = get_session(conn, :current_user)
+
+    case Account.update_nickname(user, nickname) do
+      {:ok, user_struct} ->
+        new_user = Map.put(user, :nickname, user_struct.nickname)
+
+        conn
+        |> put_session(:current_user, new_user)
+        |> put_flash(:info, "Nickname updated successfully")
+        |> redirect(to: "/account/auth/profile")
+
+      {:error, changeset} ->
+        do_profile(user, conn, changeset)
+    end
+  end
+
+  defp do_profile(nil, conn, _changeset),
     do: redirect(conn, to: root())
 
-  defp do_profile(%{} = user, conn),
-    do: render(conn, :profile, user: user)
+  defp do_profile(%{} = user, conn, changeset \\ nil) do
+    changeset =
+      changeset ||
+        Identity.update_nickname_changeset(
+          %Identity{id: user.id, nickname: user.nickname},
+          %{}
+        )
 
+    render(conn, :profile, user: user, changeset: changeset)
+  end
+
+  @doc """
+  Handles OAuth callback from Ueberauth.
+  """
   def callback(%{assigns: %{ueberauth_failure: _fails}} = conn, _params) do
     conn
     |> put_flash(:error, "Failed to authenticate.")

--- a/apps/block_scout_web/lib/block_scout_web/routers/account_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/account_router.ex
@@ -111,6 +111,8 @@ defmodule BlockScoutWeb.Routers.AccountRouter do
       only: [:new, :create, :edit, :update, :delete, :index],
       as: :custom_abi
     )
+
+    patch("/settings/nickname", Account.AuthController, :update_nickname)
   end
 
   scope "/v2", as: :account_v2 do

--- a/apps/block_scout_web/lib/block_scout_web/templates/account/auth/profile.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/account/auth/profile.html.eex
@@ -20,7 +20,15 @@
             <div class="mb-4 row">
               <label for="static-nickname" class="col-sm-6 col-form-label label-account">Nickname</label>
               <div class="col-sm">
-                <input type="text" readonly class="form-control-plaintext profile-item" id="static-nickname" value="<%= @user.nickname %>">
+                <%= form_for @changeset, "/account/settings/nickname", [method: :patch], fn f -> %>
+                  <div class="input-group">
+                    <%= text_input f, :nickname, class: "form-control profile-item", id: "static-nickname" %>
+                    <div class="input-group-append">
+                      <%= submit "Save nickname", class: "btn btn-primary" %>
+                    </div>
+                  </div>
+                  <%= error_tag f, :nickname %>
+                <% end %>
               </div>
             </div>
             <div class="mb-4 row">
@@ -33,4 +41,5 @@
         </div>
       </div>
     </div>
+  </div>
 </section>

--- a/apps/block_scout_web/test/block_scout_web/controllers/account/auth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/account/auth_controller_test.exs
@@ -33,8 +33,14 @@ defmodule BlockScoutWeb.Account.AuthControllerTest do
       assert get_flash(conn, :info) == "Nickname updated successfully"
 
       # Verify DB update
-      user = Repo.account_repo().one(Identity)
-      assert user.nickname == "new_nickname"
+      user_in_db = Repo.account_repo().one(Identity)
+      assert user_in_db.nickname == "new_nickname"
+
+      # Verify session update (must be a map, not a struct)
+      updated_user = get_session(conn, :current_user)
+      assert is_map(updated_user)
+      refute is_struct(updated_user)
+      assert updated_user.nickname == "new_nickname"
     end
 
     test "re-renders form with errors on invalid input", %{conn: conn} do

--- a/apps/explorer/lib/explorer/account.ex
+++ b/apps/explorer/lib/explorer/account.ex
@@ -18,6 +18,10 @@ defmodule Explorer.Account do
 
   alias Explorer.Repo
 
+  @doc """
+  Returns whether the account module is enabled.
+  """
+  @spec enabled?() :: boolean()
   def enabled? do
     Application.get_env(:explorer, __MODULE__)[:enabled]
   end
@@ -82,5 +86,31 @@ defmodule Explorer.Account do
 
   def merge([]) do
     {{:ok, 0}, nil}
+  end
+
+  @doc """
+  Updates the nickname for an account identity.
+  Returns {:ok, Identity.t()} on success or {:error, Ecto.Changeset.t()} on failure.
+  """
+  @spec update_nickname(Identity.t() | map(), String.t()) :: {:ok, Identity.t()} | {:error, Ecto.Changeset.t()}
+  def update_nickname(identity, nickname) do
+    identity_struct =
+      if is_map(identity) and not is_struct(identity) do
+        Repo.account_repo().get(Identity, identity.id)
+      else
+        identity
+      end
+
+    if identity_struct do
+      identity_struct
+      |> Identity.update_nickname_changeset(%{nickname: nickname})
+      |> Repo.account_repo().update()
+    else
+      changeset =
+        Identity.update_nickname_changeset(%Identity{}, %{nickname: nickname})
+        |> Ecto.Changeset.add_error(:identity, "not found")
+
+      {:error, changeset}
+    end
   end
 end

--- a/apps/explorer/lib/explorer/account/identity.ex
+++ b/apps/explorer/lib/explorer/account/identity.ex
@@ -33,7 +33,7 @@ defmodule Explorer.Account.Identity do
     field(:uid, Explorer.Encrypted.Binary, null: false)
     field(:email, Explorer.Encrypted.Binary, null: false)
     field(:name, :string, virtual: true)
-    field(:nickname, :string, virtual: true)
+    field(:nickname, :string)
     field(:address_hash, Hash.Address, virtual: true)
     field(:avatar, Explorer.Encrypted.Binary)
     field(:verification_email_sent_at, :utc_datetime_usec)
@@ -53,6 +53,26 @@ defmodule Explorer.Account.Identity do
     |> cast(attrs, [:uid, :email, :name, :nickname, :avatar, :verification_email_sent_at, :otp_sent_at])
     |> validate_required([:uid])
     |> put_hashed_fields()
+  end
+
+  @doc """
+  Creates a changeset for updating an identity's nickname.
+  Validates length (3-50 chars), format (alphanumeric, underscore, hyphen), and uniqueness.
+  """
+  @spec update_nickname_changeset(t(), map()) :: Ecto.Changeset.t()
+  def update_nickname_changeset(identity, attrs) do
+    identity
+    |> cast(attrs, [:nickname])
+    |> validate_required([:nickname])
+    |> validate_length(:nickname, min: 3, max: 50)
+    |> validate_format(:nickname, ~r/^[a-zA-Z0-9_-]+$/)
+    |> validate_unique_nickname()
+  end
+
+  defp validate_unique_nickname(changeset) do
+    changeset
+    |> unsafe_validate_unique(:nickname, Repo.account_repo())
+    |> unique_constraint(:nickname)
   end
 
   defp put_hashed_fields(changeset) do
@@ -265,7 +285,7 @@ defmodule Explorer.Account.Identity do
         uid: auth.uid,
         email: email_from_auth(auth),
         name: name_from_auth(auth),
-        nickname: nickname_from_auth(auth),
+        nickname: identity.nickname || nickname_from_auth(auth),
         avatar: avatar_from_auth(auth),
         address_hash: address_hash_from_auth(auth),
         watchlist_id: watchlist.id,
@@ -276,7 +296,7 @@ defmodule Explorer.Account.Identity do
         id: identity.id,
         uid: auth.uid,
         email: email_from_auth(auth),
-        nickname: nickname_from_auth(auth),
+        nickname: identity.nickname || nickname_from_auth(auth),
         avatar: avatar_from_auth(auth),
         address_hash: address_hash_from_auth(auth),
         email_verified: false
@@ -288,7 +308,6 @@ defmodule Explorer.Account.Identity do
     %{
       email: email_from_auth(auth),
       name: name_from_auth(auth),
-      nickname: nickname_from_auth(auth),
       avatar: avatar_from_auth(auth),
       address_hash: address_hash_from_auth(auth)
     }

--- a/apps/explorer/priv/account/migrations/20260318090242_add_nickname_to_identities.exs
+++ b/apps/explorer/priv/account/migrations/20260318090242_add_nickname_to_identities.exs
@@ -1,0 +1,11 @@
+defmodule Explorer.Repo.Account.Migrations.AddNicknameToIdentities do
+  use Ecto.Migration
+
+  def change do
+    alter table(:account_identities) do
+      add :nickname, :string
+    end
+
+    create unique_index(:account_identities, [:nickname])
+  end
+end

--- a/apps/explorer/test/explorer/account/identity_test.exs
+++ b/apps/explorer/test/explorer/account/identity_test.exs
@@ -99,6 +99,8 @@ defmodule Explorer.Account.IdentityTest do
                 watchlist_id: ^watchlist_id
               }} = user_data
     end
+  end
+
   describe "update_nickname_changeset/2" do
     test "accepts valid nickname" do
       identity = %Identity{nickname: "old_nickname"}
@@ -139,6 +141,18 @@ defmodule Explorer.Account.IdentityTest do
 
       refute changeset.valid?
       assert %{nickname: ["has invalid format"]} = errors_on(changeset)
+    end
+    test "rejects duplicate nickname" do
+      # UseRepo.account_repo().insert to create the first one since factory might not be loaded in all environments
+      Repo.account_repo().insert!(%Identity{uid: "user1", email: "user1@example.com", nickname: "taken_nickname"})
+
+      identity2 = %Identity{}
+      changeset = Identity.update_nickname_changeset(identity2, %{nickname: "taken_nickname"})
+
+      # Since it's a unique_constraint, we need to try to insert it to trigger the error if it was just unique_constraint
+      # But unsafe_validate_unique handles it before insert.
+      refute changeset.valid?
+      assert %{nickname: ["has already been taken"]} = errors_on(changeset)
     end
   end
 end


### PR DESCRIPTION
Closes #11686

## Motivation
This PR implements the requested feature to allow users to change their account nickname directly within Blockscout. Previously, the nickname was a virtual field; it is now persisted in the `account_identities` table to allow for local overrides and uniqueness validation.

## Changelog

### Enhancements
- Added a database migration for the persistent `nickname` column in the `account_identities` table with a unique index.
- Updated the `Explorer.Account.Identity` schema with `update_nickname_changeset/2` (length 3-50 chars, alphanumeric/underscore/hyphen, uniqueness check).
- Implemented `update_nickname/2` in `AuthController` and added the `PATCH` route.
- Updated the Profile settings template to include an editable form and error reporting.

### Bug Fixes
- Added regression tests for both schema-level nickname validation and controller-level PATCH request handling to prevent future regressions.

## Incompatible Changes
- None. This is a backward-compatible enhancement to the account system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can edit and save their account nickname from the profile; successful updates show confirmation and return to the profile.

* **Validation**
  * Nicknames must be 3–50 characters, allow letters, numbers, underscores and hyphens, and must be unique; invalid input re-renders the form with errors.

* **Database**
  * Nickname persisted on identities with a uniqueness constraint.

* **Tests**
  * Controller and model tests cover updates, success flows and validation errors.

* **Documentation**
  * Added doc comments for account and OAuth-related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->