### PR TITLE
fix: Don't insert PTO for non-traceable transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -125,6 +125,7 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
         sorted_pending_ops =
           inserted_transactions
           |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
+          |> Transaction.filter_non_traceable_transactions()
           |> Enum.reject(&is_nil(&1.block_number))
           |> Enum.map(&%{transaction_hash: &1.hash})
           |> Enum.sort()

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -115,8 +115,10 @@ defmodule Explorer.Chain.PendingOperationsHelper do
         pto_params =
           Transaction
           |> where([t], t.block_number in ^pbo_block_numbers)
-          |> select([t], %{transaction_hash: t.hash})
+          |> select([t], %{hash: t.hash, type: t.type})
           |> Repo.all()
+          |> Transaction.filter_non_traceable_transactions()
+          |> Enum.map(&%{transaction_hash: &1.hash})
           |> Helper.add_timestamps()
 
         Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -363,6 +363,8 @@ defmodule Explorer.Chain.Transaction do
 
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
 
+  alias Explorer.Chain.Zilliqa.Helper, as: ZilliqaHelper
+
   alias Explorer.SmartContract.SigProviderInterface
 
   @optional_attrs ~w(max_priority_fee_per_gas max_fee_per_gas block_hash block_number
@@ -2336,6 +2338,19 @@ defmodule Explorer.Chain.Transaction do
         smart_contract_full_abi_map
       )
     )
+  end
+
+  @zetachain_non_traceable_type 88
+  @doc """
+  Filters out transactions that are known to not have traceable internal transactions.
+  """
+  @spec filter_non_traceable_transactions([__MODULE__.t() | map()]) :: [__MODULE__.t() | map()]
+  def filter_non_traceable_transactions(transactions) do
+    case Application.get_env(:explorer, :chain_type) do
+      :zetachain -> Enum.reject(transactions, &(Map.get(&1, :type) == @zetachain_non_traceable_type))
+      :zilliqa -> Enum.reject(transactions, &ZilliqaHelper.scilla_transaction?(Map.get(&1, :type)))
+      _ -> transactions
+    end
   end
 
   if @chain_identity == {:optimism, :celo} do

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -1028,4 +1028,17 @@ defmodule Explorer.Chain.TransactionTest do
                |> Enum.reverse()
     end
   end
+
+  describe "filter_non_traceable_transactions/1" do
+    test "does not raise when transaction params do not include type on zetachain" do
+      chain_type = Application.get_env(:explorer, :chain_type)
+      Application.put_env(:explorer, :chain_type, :zetachain)
+
+      on_exit(fn -> Application.put_env(:explorer, :chain_type, chain_type) end)
+
+      transaction_params = %{block_number: 13_393_871, hash: "0x123", index: 427}
+
+      assert [transaction_params] == Transaction.filter_non_traceable_transactions([transaction_params])
+    end
+  end
 end

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -24,7 +24,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Explorer.Chain
   alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
-  alias Explorer.Chain.Zilliqa.Helper, as: ZilliqaHelper
   alias Indexer.{BufferedTask, Tracer}
   alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
   alias Indexer.Transform.{AddressCoinBalances, Addresses, AddressTokenBalances}
@@ -258,7 +257,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   defp fetch_internal_transactions_by_transactions(transactions, json_rpc_named_arguments) do
     transactions
-    |> filter_non_traceable_transactions()
+    |> Transaction.filter_non_traceable_transactions()
     |> Enum.map(&params/1)
     |> case do
       [] ->
@@ -271,20 +270,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
           :exit, error ->
             {:error, error, __STACKTRACE__}
         end
-    end
-  end
-
-  # TODO: should we cover this with tests?
-  @zetachain_non_traceable_type 88
-  @doc """
-  Filters out transactions that are known to not have traceable internal transactions.
-  """
-  @spec filter_non_traceable_transactions([Transaction.t() | map()]) :: [Transaction.t() | map()]
-  def filter_non_traceable_transactions(transactions) do
-    case Application.get_env(:explorer, :chain_type) do
-      :zetachain -> Enum.reject(transactions, &(Map.get(&1, :type) == @zetachain_non_traceable_type))
-      :zilliqa -> Enum.reject(transactions, &ZilliqaHelper.scilla_transaction?/1)
-      _ -> transactions
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction/delete_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction/delete_queue.ex
@@ -92,6 +92,7 @@ defmodule Indexer.Fetcher.InternalTransaction.DeleteQueue do
 
         pto_params =
           transactions
+          |> Transaction.filter_non_traceable_transactions()
           |> Enum.map(&%{transaction_hash: &1.hash})
           |> ExplorerHelper.add_timestamps()
 

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -539,7 +539,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
       Enum.reduce(block_numbers, [], fn block_number, acc_list ->
         block_number
         |> Transaction.get_transactions_of_block_number()
-        |> InternalTransactionFetcher.filter_non_traceable_transactions()
+        |> Transaction.filter_non_traceable_transactions()
         |> Enum.map(
           &%{
             block_number: &1.block_number,

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -524,19 +524,6 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
     assert %{block_number: ^block_number, block_hash: ^block_hash} = Repo.one(PendingBlockOperation)
   end
 
-  describe "filter_non_traceable_transactions/1" do
-    test "does not raise when transaction params do not include type on zetachain" do
-      chain_type = Application.get_env(:explorer, :chain_type)
-      Application.put_env(:explorer, :chain_type, :zetachain)
-
-      on_exit(fn -> Application.put_env(:explorer, :chain_type, chain_type) end)
-
-      transaction_params = %{block_number: 13_393_871, hash: "0x123", index: 427}
-
-      assert [transaction_params] == InternalTransaction.filter_non_traceable_transactions([transaction_params])
-    end
-  end
-
   if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     test "fetches internal transactions from Arbitrum", %{
       json_rpc_named_arguments: json_rpc_named_arguments


### PR DESCRIPTION
## Motivation

Non-traceable transactions are filtered out in internal transactions fetcher but they are still inserted in `PendingTransactionOperation` which means that they will never be deleted from there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized transaction filtering to ensure consistent exclusion of non‑traceable transactions across supported chains.

* **Tests**
  * Updated test coverage around transaction filtering (added focused coverage and removed legacy test).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->