### PR TITLE
fix: Fix pending ops migration overflow by adaptive batching and chunked inserts

### DIFF
--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -102,9 +102,13 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   end
 
   defp from_blocks_to_transactions_function do
+    from_blocks_to_transactions_function(@blocks_batch_size)
+  end
+
+  defp from_blocks_to_transactions_function(blocks_batch_size) do
     pbo_block_numbers_query =
       PendingBlockOperation
-      |> limit(@blocks_batch_size)
+      |> limit(^blocks_batch_size)
       |> select([pbo], pbo.block_number)
 
     case Repo.all(pbo_block_numbers_query) do
@@ -119,15 +123,49 @@ defmodule Explorer.Chain.PendingOperationsHelper do
           |> Repo.all()
           |> Helper.add_timestamps()
 
-        Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
+        case insert_pending_transaction_operations(pto_params) do
+          :ok ->
+            delete_pending_block_operations(pbo_block_numbers)
 
-        PendingBlockOperation
-        |> where([pbo], pbo.block_number in ^pbo_block_numbers)
-        |> Repo.delete_all()
+            :continue
 
-        :continue
+          {:error, :too_many_parameters} when blocks_batch_size > 1 ->
+            from_blocks_to_transactions_function(max(div(blocks_batch_size, 2), 1))
+
+          {:error, :too_many_parameters} ->
+            Repo.safe_insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
+            delete_pending_block_operations(pbo_block_numbers)
+
+            :continue
+        end
     end
   end
+
+  defp insert_pending_transaction_operations([]), do: :ok
+
+  defp insert_pending_transaction_operations(pto_params) do
+    Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
+    :ok
+  rescue
+    error in Postgrex.QueryError ->
+      if too_many_parameters_error?(error) do
+        {:error, :too_many_parameters}
+      else
+        reraise error, __STACKTRACE__
+      end
+  end
+
+  defp delete_pending_block_operations(pbo_block_numbers) do
+    PendingBlockOperation
+    |> where([pbo], pbo.block_number in ^pbo_block_numbers)
+    |> Repo.delete_all()
+  end
+
+  defp too_many_parameters_error?(%Postgrex.QueryError{message: message}) when is_binary(message) do
+    Regex.match?(~r/postgresql protocol can not handle \d+ parameters, the maximum is \d+/i, message)
+  end
+
+  defp too_many_parameters_error?(_), do: false
 
   @doc """
   Generates a query to find pending block operations that match any of the given block hashes.

--- a/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
+++ b/apps/explorer/test/explorer/migrator/switch_pending_operations_test.exs
@@ -48,6 +48,56 @@ defmodule Explorer.Migrator.SwitchPendingOperationsTest do
       assert [_, _, _, _, _] = Repo.all(PendingTransactionOperation)
     end
 
+    test "from pbo to pto handles parameter overflow and still completes" do
+      block = insert(:block)
+      insert(:pending_block_operation, block_number: block.number, block_hash: block.hash)
+
+      5
+      |> insert_list(:transaction)
+      |> with_block(block)
+
+      json_rpc_config = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+      Application.put_env(
+        :explorer,
+        :json_rpc_named_arguments,
+        Keyword.put(json_rpc_config, :variant, EthereumJSONRPC.Geth)
+      )
+
+      geth_config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(geth_config, :block_traceable?, false))
+
+      overflow_raised? = :atomics.new(1, [])
+
+      :meck.new(Repo, [:passthrough])
+
+      :meck.expect(Repo, :insert_all, fn kind, elements, opts ->
+        if kind == PendingTransactionOperation and :atomics.get(overflow_raised?, 1) == 0 do
+          :atomics.put(overflow_raised?, 1, 1)
+
+          raise Postgrex.QueryError,
+            message: "postgresql protocol can not handle 135090 parameters, the maximum is 65535"
+        else
+          :meck.passthrough([kind, elements, opts])
+        end
+      end)
+
+      on_exit(fn ->
+        try do
+          :meck.unload(Repo)
+        catch
+          _, _ -> :ok
+        end
+      end)
+
+      SwitchPendingOperations.start_link([])
+      Process.sleep(100)
+
+      assert :atomics.get(overflow_raised?, 1) == 1
+      assert [] = Repo.all(PendingBlockOperation)
+      assert [_, _, _, _, _] = Repo.all(PendingTransactionOperation)
+    end
+
     test "from pto to pbo" do
       first_block = insert(:block)
       second_block = insert(:block)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14121

## Motivation

`Explorer.Migrator.SwitchPendingOperations` could crash while moving data from pending blocks to pending transactions when a single `insert_all` exceeded PostgreSQL bind parameter limits.

Observed failure shape:
- `postgresql protocol can not handle <N> parameters, the maximum is <M>`

This made migration progress fragile on chains/periods with very large transaction volumes per selected block batch.


## Changelog

- Added adaptive retry logic for `from_blocks_to_transactions_function/0`:
  - Start with configured block batch size.
  - On PostgreSQL parameter-overflow error, retry with half batch size (down to 1).
- Added final fallback for extreme cases:
  - If overflow still happens at batch size 1, split `insert_all` payload into safe chunks and insert incrementally.
- Refactored block cleanup into a dedicated helper and keep deletion only after successful insert path.
- Improved overflow error detection:
  - Replaced hardcoded `"maximum is 65535"` check with a regex matching
    `"postgresql protocol can not handle <N> parameters, the maximum is <M>"`,
    so it works even if limits/messages vary by environment.
- Added defensive chunk-size calculation to avoid division-by-zero and ensure minimum chunk size of 1.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database parameter limits during pending transaction processing with automatic retry logic and batch size reduction.
  * Enhanced system resilience to gracefully manage large-scale operation batches and prevent processing failures under edge case conditions.

* **Tests**
  * Added test coverage for database parameter overflow scenarios to ensure recovery and proper operation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->