### PR TITLE
fix: authentication provider token redis key

### DIFF
--- a/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/auth0.ex
@@ -5,7 +5,7 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
   require Logger
 
   alias Explorer.Account.{Authentication, Identity}
-  alias Explorer.HttpClient
+  alias Explorer.{Helper, HttpClient}
   alias Explorer.ThirdPartyIntegrations.Auth0.Internal
   alias Explorer.ThirdPartyIntegrations.Dynamic
   alias Ueberauth.Strategy.Auth0.OAuth
@@ -32,7 +32,7 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
   """
   @spec get_m2m_jwt() :: nil | String.t()
   def get_m2m_jwt do
-    get_m2m_jwt_inner(Redix.command(:redix, ["GET", Internal.redis_key()]))
+    get_m2m_jwt_inner(Redix.command(:redix, ["GET", m2m_jwt_key()]))
   end
 
   defp get_m2m_jwt_inner({:ok, token}) when not is_nil(token), do: token
@@ -64,9 +64,11 @@ defmodule Explorer.ThirdPartyIntegrations.Auth0 do
   end
 
   defp cache_token(token, ttl) do
-    Redix.command(:redix, ["SET", Internal.redis_key(), token, "EX", ttl])
+    Redix.command(:redix, ["SET", m2m_jwt_key(), token, "EX", ttl])
     token
   end
+
+  defp m2m_jwt_key, do: Helper.redis_key(Internal.redis_key())
 
   @doc """
   Sends a one-time password (OTP) for linking an email to an existing account.

--- a/apps/explorer/lib/explorer/third_party_integrations/keycloak.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/keycloak.ex
@@ -307,7 +307,7 @@ defmodule Explorer.ThirdPartyIntegrations.Keycloak do
     end
   end
 
-  defp admin_token_key, do: "keycloak:#{client_id()}:admin_token"
+  defp admin_token_key, do: Helper.redis_key("keycloak:#{client_id()}:admin_token")
 
   defp handle_error({:ok, response}, error_message) do
     Logger.error("#{error_message}: status=#{response.status_code} body=#{response.body}")


### PR DESCRIPTION
After adding encryption of authentication token, key should be unique as each instance have it's own key to decrypt token, so initial idea of sharing token and do less requests for new tokens does not work

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Redis cache key generation for authentication token storage in Auth0 integration through improved helper function integration.
  * Standardized cache key handling for Keycloak admin token storage, improving consistency across authentication integrations and simplifying key management across third-party authentication systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->