### PR TITLE
fix: handle unknown call types in callTracer to prevent Zilliqa warnings

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -462,7 +462,12 @@ defmodule EthereumJSONRPC.Geth do
   end
 
   defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?) do
-    if !allow_empty_traces?(), do: log_unknown_type(call)
+    call_type = call |> Map.get("type", "") |> to_string() |> String.downcase()
+
+    known_type =
+      call_type in ~w(call callcode delegatecall staticcall create create2 selfdestruct revert stop invalid)
+
+    if !known_type and !allow_empty_traces?(), do: log_unknown_type(call)
     acc
   end
 

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth/tracer_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth/tracer_test.exs
@@ -1,6 +1,8 @@
 defmodule EthereumJSONRPC.Geth.TracerTest do
   use EthereumJSONRPC.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias EthereumJSONRPC.Geth
   alias EthereumJSONRPC.Geth.{Calls, Tracer}
 
@@ -48,6 +50,54 @@ defmodule EthereumJSONRPC.Geth.TracerTest do
       assert sl_calls == ct_calls
 
       Application.put_env(:ethereum_jsonrpc, Geth, tracer: init_tracer)
+    end
+  end
+
+  describe "prepare_calls/1 with call_tracer" do
+    setup do
+      config = Application.get_env(:ethereum_jsonrpc, Geth)
+      init_tracer = if is_list(config), do: Keyword.get(config, :tracer), else: config
+
+      Application.put_env(:ethereum_jsonrpc, Geth, tracer: "call_tracer")
+
+      on_exit(fn ->
+        Application.put_env(:ethereum_jsonrpc, Geth, tracer: init_tracer)
+      end)
+
+      :ok
+    end
+
+    test "does not emit a warning for DELEGATECALL type without 'from' field" do
+      call = %{"type" => "DELEGATECALL", "to" => "0xabc"}
+
+      log =
+        capture_log(fn ->
+          Geth.prepare_calls(call)
+        end)
+
+      refute log =~ "unknown type"
+    end
+
+    test "does not emit a warning for STATICCALL type without 'from' field" do
+      call = %{"type" => "STATICCALL", "to" => "0xabc"}
+
+      log =
+        capture_log(fn ->
+          Geth.prepare_calls(call)
+        end)
+
+      refute log =~ "unknown type"
+    end
+
+    test "still emits a warning for a truly unknown call type" do
+      call = %{"type" => "UNKNOWNTYPE", "from" => "0xabc", "to" => "0xdef"}
+
+      log =
+        capture_log(fn ->
+          Geth.prepare_calls(call)
+        end)
+
+      assert log =~ "unknown type"
     end
   end
 end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth/tracer_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth/tracer_test.exs
@@ -55,13 +55,12 @@ defmodule EthereumJSONRPC.Geth.TracerTest do
 
   describe "prepare_calls/1 with call_tracer" do
     setup do
-      config = Application.get_env(:ethereum_jsonrpc, Geth)
-      init_tracer = if is_list(config), do: Keyword.get(config, :tracer), else: config
-
-      Application.put_env(:ethereum_jsonrpc, Geth, tracer: "call_tracer")
+      original_config = Application.get_env(:ethereum_jsonrpc, Geth)
+      updated_config = Keyword.put(original_config, :tracer, "call_tracer")
+      Application.put_env(:ethereum_jsonrpc, Geth, updated_config)
 
       on_exit(fn ->
-        Application.put_env(:ethereum_jsonrpc, Geth, tracer: init_tracer)
+        Application.put_env(:ethereum_jsonrpc, Geth, original_config)
       end)
 
       :ok
@@ -90,7 +89,7 @@ defmodule EthereumJSONRPC.Geth.TracerTest do
     end
 
     test "still emits a warning for a truly unknown call type" do
-      call = %{"type" => "UNKNOWNTYPE", "from" => "0xabc", "to" => "0xdef"}
+      call = %{"type" => "UNKNOWN", "from" => "0xabc", "to" => "0xdef"}
 
       log =
         capture_log(fn ->


### PR DESCRIPTION
Closes #13804

When Zilliqa instances use `debug_traceTransaction` with `callTracer`, the response contains call types such as `DELEGATECALL` and `STATICCALL` that were not handled in the callTracer parser, causing repeated warnings: `Call from a callTracer with an unknown type`.

This fix adds explicit handling for the missing call types so the warning only fires for truly unknown types, not for valid EVM call types that Zilliqa returns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace-type handling so common call types (e.g., DELEGATECALL, STATICCALL) are normalized and no longer spuriously logged as unknown; logging now only appears for truly unrecognized types unless empty traces are allowed.

* **Tests**
  * Added tests verifying logging behavior for known and unknown call types and ensuring expected suppression of warnings for standard trace shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->