### PR TITLE
fix: Allow fetching of stale token balances

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex
@@ -297,11 +297,6 @@ defmodule Explorer.Chain.Import.Runner.Address.CurrentTokenBalances do
   # ctb does not exist
   defp should_update?(_new_ctb, nil), do: true
 
-  # new ctb has no value
-  defp should_update?(%{value_fetched_at: fetched_at, value: nil}, _existing_ctb)
-       when not is_nil(fetched_at),
-       do: false
-
   # new ctb is newer
   defp should_update?(%{block_number: new_ctb_block_number}, %{block_number: existing_ctb_block_number})
        when new_ctb_block_number > existing_ctb_block_number,


### PR DESCRIPTION
Fixes #14153

## Changelog

### Bug Fixes

This PR allows stale token balances to be updated.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import logic for address token balances so updates no longer get skipped when incoming timestamps are missing. Updates now better preserve existing values when incoming amounts are absent, and only overwrite balances for newer or sufficiently complete incoming data. Result: more accurate, consistent balance information after imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->