### PR TITLE
fix: keycloak address displaying

### DIFF
--- a/apps/explorer/lib/explorer/third_party_integrations/keycloak.ex
+++ b/apps/explorer/lib/explorer/third_party_integrations/keycloak.ex
@@ -475,7 +475,7 @@ defmodule Explorer.ThirdPartyIntegrations.Keycloak do
   defp do_send_registration_webhook(_email, nil), do: :ok
 
   defp create_auth(user, address_hash \\ nil) do
-    address_hash = address_hash || List.first(user["attributes"]["address"] || [])
+    address_hash = address_hash || List.last(user["attributes"]["address"] || [])
 
     %Auth{
       uid: user["id"],


### PR DESCRIPTION
Issue related to how multivalued attributes are encrypted in keycloak

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected address selection logic in Keycloak authentication to use the appropriate address entry when multiple addresses are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->