### PR TITLE
fix: celo election rewards csv export

### DIFF
--- a/apps/explorer/lib/explorer/chain/celo/election_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/election_reward.ex
@@ -356,29 +356,25 @@ defmodule Explorer.Chain.Celo.ElectionReward do
     end)
   end
 
-  @doc """
-  Custom filter for `ElectionReward`, inspired by
-  `Explorer.Chain.Block.Reader.General.where_block_number_in_period/3`
-  """
   @spec where_epoch_number_in_period(
           Ecto.Query.t(),
           String.t() | integer() | nil,
           String.t() | integer() | nil
         ) :: Ecto.Query.t()
-  def where_epoch_number_in_period(base_query, nil, nil),
+  defp where_epoch_number_in_period(base_query, nil, nil),
     do: base_query
 
-  def where_epoch_number_in_period(base_query, nil, to_epoch),
-    do: where(base_query, [reward], reward.epoch_number < ^to_epoch)
+  defp where_epoch_number_in_period(base_query, nil, to_epoch),
+    do: where(base_query, [reward], reward.epoch_number <= ^to_epoch)
 
-  def where_epoch_number_in_period(base_query, from_epoch, nil),
+  defp where_epoch_number_in_period(base_query, from_epoch, nil),
     do: where(base_query, [reward], reward.epoch_number >= ^from_epoch)
 
-  def where_epoch_number_in_period(base_query, from_epoch, to_epoch),
+  defp where_epoch_number_in_period(base_query, from_epoch, to_epoch),
     do:
       where(
         base_query,
         [reward],
-        reward.epoch_number >= ^from_epoch and reward.epoch_number < ^to_epoch
+        reward.epoch_number >= ^from_epoch and reward.epoch_number <= ^to_epoch
       )
 end


### PR DESCRIPTION
selecting close dates leads to an incorrect empty response

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Celo election reward filtering logic to adjust epoch number range boundaries.

* **Refactor**
  * Improved code encapsulation by restricting internal helper function visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->