### PR TITLE
perf: remove join to "blocks" in api/v2/blocks/:block_number/transactions API endpoint

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -333,8 +333,7 @@ defmodule Explorer.Chain do
     options
     |> Keyword.get(:paging_options, @default_paging_options)
     |> fetch_transactions_in_ascending_order_by_index()
-    |> join(:inner, [transaction], block in assoc(transaction, :block))
-    |> where([_, block], block.hash == ^block_hash)
+    |> where([transaction], transaction.block_hash == ^block_hash)
     |> Transaction.apply_filter_by_type_to_transactions(type_filter)
     |> join_associations(necessity_by_association)
     |> Transaction.put_has_token_transfers_to_transaction(old_ui?)


### PR DESCRIPTION
## Motivation

Improve performance of api/v2/blocks/:block_number/transactions API endpoint.

## Changelog

This pull request updates the way transactions are filtered by block hash in the `Explorer.Chain` module. Instead of joining the `blocks` table to filter by block hash, the query now directly filters on the `block_hash` field in the `transactions` table, simplifying the query and potentially improving performance.

**Query simplification and optimization:**

* Changed the transaction query to filter directly on the `block_hash` field in the `transactions` table, removing the unnecessary join with the `blocks` table. (`apps/explorer/lib/explorer/chain.ex`)

Query before:
```
SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL FROM transactions AS t0 INNER JOIN blocks AS b1 ON b1.hash = t0.block_hash WHERE (b1.hash = '\x...') ORDER BY t0.index LIMIT 51;
```

Query after:
```
SELECT t0.*, (SELECT transaction_hash FROM token_transfers WHERE transaction_hash = t0.hash LIMIT 1) IS NOT NULL FROM transactions AS t0 WHERE (t0.block_hash = '\x...') ORDER BY t0.index LIMIT 51;
```

- Execution cost with join to "blocks": `Limit  (cost=1.27..97.23 rows=51 width=829)`
- Execution cost  without join to "blocks": `Limit  (cost=0.71..96.02 rows=51 width=829)`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined how transactions for a block are retrieved to improve query efficiency and reduce unnecessary work.
  * Preserves existing paging, type filtering, token-transfer preview/enrichment, and conditional token-transfer loading, so end-user results and performance remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->