### PR TITLE
perf: optimize optional address preloads across tx endpoints

### DIFF
--- a/.agents/skills/elixir-clause-grouping/SKILL.md
+++ b/.agents/skills/elixir-clause-grouping/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: elixir-clause-grouping
+description: Use when refactoring Elixir multi-clause functions, extracting helper functions, or fixing Credo readability warnings caused by placing `defp` helpers between clauses of the same function. Keeps function clauses contiguous and moves helpers below the full clause group.
+---
+
+## Overview
+
+In Elixir modules, all clauses of the same function should stay together. Inserting a `defp` helper between clauses of a `def` or `defp` makes the function harder to read and can trigger Credo readability warnings. When shared logic needs to be extracted, keep the original clause group contiguous and place the helper after the full group.
+
+## When to Use
+
+- When refactoring a multi-clause `def` or `defp`
+- When extracting duplicated logic from multiple function clauses
+- When addressing Credo warnings about clause grouping or readability
+- When editing controller, view, or context modules with several clauses of the same function
+- During review when a helper was added in the middle of another function's clauses
+
+## Core Rule
+
+- Keep all clauses of the same function contiguous
+- Do not place `defp` helpers between clauses of another function
+- Extract shared logic into a helper placed after the full clause group
+
+## Anti-Pattern
+
+```elixir
+def decoded_input_data(%Transaction{to_address: nil}, _, _, _, _), do: {:error, :no_to_address}
+
+defp decode_input_data_with_fallback(data, abi, input, hash, skip_sig_provider?, options, methods_map, abi_map) do
+  ...
+end
+
+def decoded_input_data(%Transaction{to_address: %NotLoaded{}}, _, _, _, _), do: {:error, :contract_not_verified, []}
+```
+
+This splits the `decoded_input_data/5` clause group and makes the function harder to scan.
+
+## Preferred Pattern
+
+```elixir
+def decoded_input_data(%Transaction{to_address: nil}, _, _, _, _), do: {:error, :no_to_address}
+
+def decoded_input_data(%Transaction{to_address: %NotLoaded{}}, _, _, _, _), do: {:error, :contract_not_verified, []}
+
+def decoded_input_data(%Transaction{to_address: %{smart_contract: smart_contract}} = transaction, skip_sig_provider?, options, methods_map, abi_map) do
+  ...
+end
+
+defp decode_input_data_with_fallback(data, abi, input, hash, skip_sig_provider?, options, methods_map, abi_map) do
+  ...
+end
+```
+
+## Refactoring Checklist
+
+1. Identify every clause of the function being edited.
+2. Keep those clauses adjacent to each other.
+3. Extract shared logic only after the full clause group.
+4. Re-check that no unrelated `def` or `defp` appears inside the group.
+5. Run formatting after the refactor.
+
+## Notes
+
+- This applies to both public and private multi-clause functions.
+- If a helper is only used by one clause group, place it immediately after that group.
+- Preserving clause grouping is preferred even when the extracted helper is small.

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -27,8 +27,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   import Explorer.Helper, only: [safe_parse_non_negative_integer: 1]
 
-  import Ecto.Query, only: [from: 2]
-
   import Explorer.MicroserviceInterfaces.BENS, only: [maybe_preload_ens: 1, maybe_preload_ens_to_address: 1]
   import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
   import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
@@ -45,7 +43,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   alias BlockScoutWeb.Schemas.Helper, as: SchemasHelper
   alias Explorer.{Chain, Market, PagingOptions}
-  alias Explorer.Chain.{Address, Beacon.Deposit, Block, Hash, SmartContract, Token, Transaction}
+  alias Explorer.Chain.{Address, Beacon.Deposit, Block, Hash, Token, Transaction}
   alias Explorer.Chain.Address.{CoinBalance, Counters}
 
   alias Explorer.Chain.Token.Instance
@@ -453,7 +451,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         created_contract_address: [
           :scam_badge,
           :names,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional,
@@ -461,7 +458,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         from_address: [
           :scam_badge,
           :names,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional,
@@ -469,19 +465,12 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         to_address: [
           :scam_badge,
           :names,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional,
       :block => :optional
     }
     |> Map.merge(@chain_type_transaction_necessity_by_association)
-  end
-
-  defp transaction_smart_contract_preload_query do
-    from(smart_contract in SmartContract,
-      select: struct(smart_contract, [:address_hash])
-    )
   end
 
   operation :token_transfers,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -27,6 +27,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   import Explorer.Helper, only: [safe_parse_non_negative_integer: 1]
 
+  import Ecto.Query, only: [from: 2]
+
   import Explorer.MicroserviceInterfaces.BENS, only: [maybe_preload_ens: 1, maybe_preload_ens_to_address: 1]
   import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
   import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
@@ -43,7 +45,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   alias BlockScoutWeb.Schemas.Helper, as: SchemasHelper
   alias Explorer.{Chain, Market, PagingOptions}
-  alias Explorer.Chain.{Address, Beacon.Deposit, Block, Hash, Token, Transaction}
+  alias Explorer.Chain.{Address, Beacon.Deposit, Block, Hash, SmartContract, Token, Transaction}
   alias Explorer.Chain.Address.{CoinBalance, Counters}
 
   alias Explorer.Chain.Token.Instance
@@ -65,19 +67,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     _ ->
       @chain_type_transaction_necessity_by_association %{}
   end
-
-  @transaction_necessity_by_association [
-    necessity_by_association:
-      %{
-        [created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] =>
-          :optional,
-        [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-        [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-        :block => :optional
-      }
-      |> Map.merge(@chain_type_transaction_necessity_by_association),
-    api?: true
-  ]
 
   @token_transfer_necessity_by_association [
     necessity_by_association: %{
@@ -420,7 +409,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
         {:ok, _address} ->
           options =
-            @transaction_necessity_by_association
+            [necessity_by_association: address_transactions_necessity_by_association()]
+            |> Keyword.merge(@api_true)
             |> Keyword.merge(paging_options(params))
             |> Keyword.merge(current_filter(params))
             |> Keyword.merge(address_transactions_sorting(params))
@@ -455,6 +445,43 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           })
       end
     end
+  end
+
+  defp address_transactions_necessity_by_association do
+    %{
+      [
+        created_contract_address: [
+          :scam_badge,
+          :names,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional,
+      [
+        from_address: [
+          :scam_badge,
+          :names,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional,
+      [
+        to_address: [
+          :scam_badge,
+          :names,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional,
+      :block => :optional
+    }
+    |> Map.merge(@chain_type_transaction_necessity_by_association)
+  end
+
+  defp transaction_smart_contract_preload_query do
+    from(smart_contract in SmartContract,
+      select: struct(smart_contract, [:address_hash])
+    )
   end
 
   operation :token_transfers,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -7,6 +7,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
   use OpenApiSpex.ControllerSpecs
 
+  import Ecto.Query, only: [from: 2]
+
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
@@ -42,7 +44,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias Explorer.Chain
   alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
   alias Explorer.Chain.Beacon.Deposit
-  alias Explorer.Chain.{Block, InternalTransaction}
+  alias Explorer.Chain.{Block, InternalTransaction, SmartContract}
   alias Explorer.Chain.Cache.{BlockNumber, Counters.AverageBlockTime}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
@@ -100,18 +102,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       @chain_type_transaction_necessity_by_association %{}
       @chain_type_block_necessity_by_association %{}
   end
-
-  @transaction_necessity_by_association [
-    necessity_by_association:
-      %{
-        [created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] =>
-          :optional,
-        [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-        [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-        :block => :optional
-      }
-      |> Map.merge(@chain_type_transaction_necessity_by_association)
-  ]
 
   @internal_transaction_address_preloads [
     address_preloads: [
@@ -403,7 +393,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   def transactions(conn, %{block_hash_or_number_param: block_hash_or_number} = params) do
     with {:ok, block} <- block_param_to_block(block_hash_or_number) do
       full_options =
-        @transaction_necessity_by_association
+        transaction_necessity_by_association()
         |> Keyword.merge(put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true))
         |> Keyword.merge(type_filter_options(params))
         |> Keyword.merge(@api_true)
@@ -683,6 +673,48 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         next_page_params: next_page_params
       })
     end
+  end
+
+  defp transaction_necessity_by_association do
+    [
+      necessity_by_association:
+        Map.merge(
+          %{
+            [
+              created_contract_address: [
+                :scam_badge,
+                :names,
+                {:smart_contract, transaction_smart_contract_preload_query()},
+                proxy_implementations_association()
+              ]
+            ] => :optional,
+            [
+              from_address: [
+                :scam_badge,
+                :names,
+                {:smart_contract, transaction_smart_contract_preload_query()},
+                proxy_implementations_association()
+              ]
+            ] => :optional,
+            [
+              to_address: [
+                :scam_badge,
+                :names,
+                {:smart_contract, transaction_smart_contract_preload_query()},
+                proxy_implementations_association()
+              ]
+            ] => :optional,
+            :block => :optional
+          },
+          @chain_type_transaction_necessity_by_association
+        )
+    ]
+  end
+
+  defp transaction_smart_contract_preload_query do
+    from(smart_contract in SmartContract,
+      select: struct(smart_contract, [:address_hash])
+    )
   end
 
   defp block_param_to_block(block_hash_or_number, options \\ @api_true) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -7,8 +7,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
   use OpenApiSpex.ControllerSpecs
 
-  import Ecto.Query, only: [from: 2]
-
   import BlockScoutWeb.Chain,
     only: [
       next_page_params: 3,
@@ -44,7 +42,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias Explorer.Chain
   alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
   alias Explorer.Chain.Beacon.Deposit
-  alias Explorer.Chain.{Block, InternalTransaction, SmartContract}
+  alias Explorer.Chain.{Block, InternalTransaction}
   alias Explorer.Chain.Cache.{BlockNumber, Counters.AverageBlockTime}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
@@ -684,7 +682,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
               created_contract_address: [
                 :scam_badge,
                 :names,
-                {:smart_contract, transaction_smart_contract_preload_query()},
                 proxy_implementations_association()
               ]
             ] => :optional,
@@ -692,7 +689,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
               from_address: [
                 :scam_badge,
                 :names,
-                {:smart_contract, transaction_smart_contract_preload_query()},
                 proxy_implementations_association()
               ]
             ] => :optional,
@@ -700,7 +696,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
               to_address: [
                 :scam_badge,
                 :names,
-                {:smart_contract, transaction_smart_contract_preload_query()},
                 proxy_implementations_association()
               ]
             ] => :optional,
@@ -709,12 +704,6 @@ defmodule BlockScoutWeb.API.V2.BlockController do
           @chain_type_transaction_necessity_by_association
         )
     ]
-  end
-
-  defp transaction_smart_contract_preload_query do
-    from(smart_contract in SmartContract,
-      select: struct(smart_contract, [:address_hash])
-    )
   end
 
   defp block_param_to_block(block_hash_or_number, options \\ @api_true) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -39,7 +39,6 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
   import Ecto.Query,
     only: [
-      from: 2,
       preload: 2
     ]
 
@@ -56,8 +55,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
   alias Explorer.Chain.Beacon.Reader, as: BeaconReader
   alias Explorer.Chain.Cache.Counters.{NewPendingTransactionsCount, Transactions24hCount}
-  alias Explorer.Chain.FheOperation
-  alias Explorer.Chain.{Hash, SmartContract, Transaction}
+  alias Explorer.Chain.{FheOperation, Hash, Transaction}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
   alias Explorer.Chain.Token.Instance
@@ -267,7 +265,6 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
           :scam_badge,
           :names,
           :token,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional,
@@ -275,7 +272,6 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         from_address: [
           :scam_badge,
           :names,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional,
@@ -283,18 +279,11 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         to_address: [
           :scam_badge,
           :names,
-          {:smart_contract, transaction_smart_contract_preload_query()},
           proxy_implementations_association()
         ]
       ] => :optional
     }
     |> Map.merge(@chain_type_transaction_necessity_by_association)
-  end
-
-  defp transaction_smart_contract_preload_query do
-    from(smart_contract in SmartContract,
-      select: struct(smart_contract, [:address_hash])
-    )
   end
 
   operation :zksync_batch,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -39,6 +39,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
   import Ecto.Query,
     only: [
+      from: 2,
       preload: 2
     ]
 
@@ -56,7 +57,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias Explorer.Chain.Beacon.Reader, as: BeaconReader
   alias Explorer.Chain.Cache.Counters.{NewPendingTransactionsCount, Transactions24hCount}
   alias Explorer.Chain.FheOperation
-  alias Explorer.Chain.{Hash, Transaction}
+  alias Explorer.Chain.{Hash, SmartContract, Transaction}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
   alias Explorer.Chain.Token.Instance
@@ -237,7 +238,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
     full_options =
       [
-        necessity_by_association: @transaction_necessity_by_association
+        necessity_by_association: transactions_necessity_by_association()
       ]
       |> Keyword.merge(paging_options(params, filter_options))
       |> Keyword.merge(method_filter_options(params))
@@ -256,6 +257,44 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       transactions: transactions |> maybe_preload_ens() |> maybe_preload_metadata(),
       next_page_params: next_page_params
     })
+  end
+
+  defp transactions_necessity_by_association do
+    %{
+      :block => :optional,
+      [
+        created_contract_address: [
+          :scam_badge,
+          :names,
+          :token,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional,
+      [
+        from_address: [
+          :scam_badge,
+          :names,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional,
+      [
+        to_address: [
+          :scam_badge,
+          :names,
+          {:smart_contract, transaction_smart_contract_preload_query()},
+          proxy_implementations_association()
+        ]
+      ] => :optional
+    }
+    |> Map.merge(@chain_type_transaction_necessity_by_association)
+  end
+
+  defp transaction_smart_contract_preload_query do
+    from(smart_contract in SmartContract,
+      select: struct(smart_contract, [:address_hash])
+    )
   end
 
   operation :zksync_batch,
@@ -457,7 +496,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
           end
 
         query
-        |> Chain.join_associations(@transaction_necessity_by_association)
+        |> Chain.join_associations(transactions_necessity_by_association())
         |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
         |> Repo.replica().all()
       end
@@ -491,7 +530,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   defp handle_batch_transactions(conn, %{batch_number_param: batch_number} = params, batch_transactions_fun) do
     full_options =
       [
-        necessity_by_association: @transaction_necessity_by_association
+        necessity_by_association: transactions_necessity_by_association()
       ]
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(@api_true)
@@ -544,7 +583,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def execution_node(conn, %{execution_node_hash_param: execution_node_hash_string} = params) do
     with {:format, {:ok, execution_node_hash}} <- {:format, Chain.string_to_address_hash(execution_node_hash_string)} do
       full_options =
-        [necessity_by_association: @transaction_necessity_by_association]
+        [necessity_by_association: transactions_necessity_by_association()]
         |> Keyword.merge(put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true))
         |> Keyword.merge(@api_true)
 
@@ -901,7 +940,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     with {:auth, %{watchlist_id: watchlist_id}} <- {:auth, current_user(conn)} do
       full_options =
         [
-          necessity_by_association: @transaction_necessity_by_association
+          necessity_by_association: transactions_necessity_by_association()
         ]
         |> Keyword.merge(paging_options(params, [:validated]))
         |> Keyword.merge(@api_true)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Ecto.Association.NotLoaded
-  alias Explorer.Chain.{Address, Address.Reputation, SmartContract}
+  alias Explorer.Chain.{Address, Address.Reputation}
   alias Explorer.Chain.SmartContract.Proxy
   alias Explorer.Chain.Transaction.History.TransactionStats
 
@@ -187,11 +187,10 @@ defmodule BlockScoutWeb.API.V2.Helper do
     - `false` if the smart contract is `NotLoaded`.
     - `true` if the smart contract is present and does not have metadata from a verified bytecode twin.
   """
-  @spec smart_contract_verified?(Address.t()) :: boolean()
-  def smart_contract_verified?(%Address{smart_contract: nil}), do: false
-  def smart_contract_verified?(%Address{smart_contract: %{metadata_from_verified_bytecode_twin: true}}), do: false
-  def smart_contract_verified?(%Address{smart_contract: %NotLoaded{}}), do: nil
-  def smart_contract_verified?(%Address{smart_contract: %SmartContract{}}), do: true
+  @spec smart_contract_verified?(Address.t()) :: boolean() | nil
+  def smart_contract_verified?(%Address{verified: verified}) when is_boolean(verified), do: verified
+  def smart_contract_verified?(%Address{verified: nil}), do: nil
+  def smart_contract_verified?(_), do: false
 
   def market_cap(:standard, %{
         available_supply: available_supply,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -382,7 +382,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     end
 
     test "get Resolved Delegate Proxy contract info", %{conn: conn} do
-      proxy_address = insert(:address, contract_code: @resolved_delegate_proxy)
+      proxy_address = insert(:address, contract_code: @resolved_delegate_proxy, verified: true)
       proxy_smart_contract = insert(:smart_contract, address_hash: proxy_address.hash)
 
       transaction =
@@ -3806,8 +3806,11 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(address, address_json)
     end
 
-    test "check smart contract preload", %{conn: conn} do
-      smart_contract = insert(:smart_contract, address_hash: insert(:contract_address, fetched_coin_balance: 1).hash)
+    test "check smart contract properties", %{conn: conn} do
+      smart_contract =
+        insert(:smart_contract,
+          address_hash: insert(:contract_address, fetched_coin_balance: 1, verified: true).hash
+        )
 
       request = get(conn, "/api/v2/addresses")
       response = json_response(request, 200)

--- a/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/address_view_test.exs
@@ -341,7 +341,7 @@ defmodule BlockScoutWeb.AddressViewTest do
   describe "address_page_title/1" do
     test "uses the Smart Contract name when the contract is verified" do
       smart_contract = build(:smart_contract, name: "POA")
-      address = build(:address, smart_contract: smart_contract)
+      address = build(:address, smart_contract: smart_contract, verified: true)
 
       assert AddressView.address_page_title(address) == "POA (#{address})"
     end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -458,34 +458,38 @@ defmodule Explorer.Chain do
   defp batch_load_proxy_implementations_for_contracts(addresses, proxy_preloads, options) when is_list(addresses) do
     address_hashes = Enum.map(addresses, & &1.hash)
 
-    # Build proxy preload spec based on what was requested
-    proxy_spec = build_proxy_preload_spec(proxy_preloads)
-
-    # Fetch proxy implementations for these contract addresses
     proxy_implementations =
-      Implementation
-      |> where([impl], impl.proxy_address_hash in ^address_hashes)
-      |> preload(^proxy_spec)
-      |> select_repo(options).all()
+      address_hashes
+      |> Implementation.get_proxy_implementations_for_multiple_proxies(options)
+      |> maybe_preload_proxy_implementation_nested(proxy_preloads, options)
 
     # Group proxy implementations by proxy_address_hash for efficient lookup
-    proxy_by_address = Enum.group_by(proxy_implementations, & &1.proxy_address_hash)
+    proxy_by_address = Map.new(proxy_implementations, &{&1.proxy_address_hash, &1})
 
     # Attach proxy data to addresses
     Enum.map(addresses, fn address ->
-      proxy_list = Map.get(proxy_by_address, address.hash, [])
-      Map.put(address, :proxy_implementations, proxy_list)
+      Map.put(address, :proxy_implementations, Map.get(proxy_by_address, address.hash))
     end)
   end
 
-  # Build the preload specification for proxy implementations
+  defp maybe_preload_proxy_implementation_nested(proxy_implementations, proxy_preloads, options)
+       when is_list(proxy_implementations) and is_list(proxy_preloads) do
+    case build_proxy_preload_spec(proxy_preloads) do
+      [] ->
+        proxy_implementations
+
+      proxy_spec ->
+        select_repo(options).preload(proxy_implementations, proxy_spec)
+    end
+  end
+
+  # Build the nested preload specification for implementation structs.
   defp build_proxy_preload_spec(proxy_preloads) when is_list(proxy_preloads) do
-    # Find the nested preload spec if one exists
     Enum.find_value(proxy_preloads, fn
-      :proxy_implementations -> [:addresses, :conflicting_addresses, :smart_contracts]
+      :proxy_implementations -> Implementation.proxy_implementations_addresses_association()
       [{:proxy_implementations, nested}] -> nested
       _ -> nil
-    end) || [:addresses, :conflicting_addresses]
+    end) || []
   end
 
   defp association_with_nested_preloads({association, _necessity}) when is_atom(association),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -419,6 +419,7 @@ defmodule Explorer.Chain do
     |> where([address], address.hash in ^hashes)
     |> maybe_preload_address_nested(address_nested_preloads)
     |> select_repo(options).all()
+    |> strip_smart_contract_large_fields()
     |> Map.new(&{&1.hash, &1})
   end
 
@@ -434,6 +435,29 @@ defmodule Explorer.Chain do
 
   defp maybe_preload_address_nested(query, []), do: query
   defp maybe_preload_address_nested(query, nested_preloads), do: preload(query, ^nested_preloads)
+
+  @doc """
+  Post-processes loaded addresses to remove large SmartContract fields to reduce memory usage
+  and deserialization overhead for transaction listings.
+
+  Removes:
+  - contract_source_code (can be hundreds of KB)
+  - abi (can be hundreds of KB)
+  - constructor_arguments (potentially large)
+  """
+  defp strip_smart_contract_large_fields(addresses) when is_list(addresses) do
+    Enum.map(addresses, fn address ->
+      if Map.has_key?(address, :smart_contract) && address.smart_contract do
+        filtered_contract =
+          address.smart_contract
+          |> Map.drop([:contract_source_code, :abi, :constructor_arguments])
+
+        Map.put(address, :smart_contract, filtered_contract)
+      else
+        address
+      end
+    end)
+  end
 
   defp address_hash_field_for_association(:from_address), do: :from_address_hash
   defp address_hash_field_for_association(:to_address), do: :to_address_hash

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -93,7 +93,7 @@ defmodule Explorer.Chain do
   # Geth-like node
   @revert_msg_prefix_5 "execution reverted: "
   @revert_msg_prefix_6_empty "execution reverted"
-
+  @deduplicated_optional_address_associations [:from_address, :to_address, :created_contract_address]
   @typedoc """
   The name of an association on the `t:Ecto.Schema.t/0`
   """
@@ -328,6 +328,10 @@ defmodule Explorer.Chain do
           ]
   def block_to_transactions(block_hash, options \\ [], old_ui? \\ true) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+
+    {optional_address_associations, other_necessity_by_association} =
+      split_optional_address_associations(necessity_by_association)
+
     type_filter = Keyword.get(options, :type)
 
     options
@@ -335,11 +339,105 @@ defmodule Explorer.Chain do
     |> fetch_transactions_in_ascending_order_by_index()
     |> where([transaction], transaction.block_hash == ^block_hash)
     |> Transaction.apply_filter_by_type_to_transactions(type_filter)
-    |> join_associations(necessity_by_association)
+    |> join_associations(other_necessity_by_association)
     |> Transaction.put_has_token_transfers_to_transaction(old_ui?)
     |> (&if(old_ui?, do: preload(&1, [{:token_transfers, [:token, :from_address, :to_address]}]), else: &1)).()
     |> select_repo(options).all()
+    |> preload_optional_address_associations(optional_address_associations, options)
   end
+
+  defp split_optional_address_associations(necessity_by_association) when is_map(necessity_by_association) do
+    {optional, other} =
+      Enum.split_with(necessity_by_association, fn {association, necessity} ->
+        necessity == :optional and address_association_key?(association)
+      end)
+
+    {optional, Map.new(other)}
+  end
+
+  defp address_association_key?(association) when is_atom(association),
+    do: association in @deduplicated_optional_address_associations
+
+  defp address_association_key?([{association, _nested_preloads}]),
+    do: association in @deduplicated_optional_address_associations
+
+  defp address_association_key?(_), do: false
+
+  defp preload_optional_address_associations([], _optional_address_associations, _options), do: []
+
+  defp preload_optional_address_associations(entities, [], _options) when is_list(entities), do: entities
+
+  defp preload_optional_address_associations(entities, optional_address_associations, options)
+       when is_list(entities) and is_list(optional_address_associations) do
+    associations_and_nested_preloads =
+      Enum.map(optional_address_associations, &association_with_nested_preloads/1)
+
+    associations =
+      associations_and_nested_preloads
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.uniq()
+
+    address_nested_preloads =
+      associations_and_nested_preloads
+      |> Enum.flat_map(&normalize_nested_preloads(elem(&1, 1)))
+      |> Enum.uniq()
+
+    hashes =
+      entities
+      |> Enum.flat_map(fn entity ->
+        Enum.flat_map(associations, fn association ->
+          association
+          |> address_hash_field_for_association()
+          |> then(&Map.get(entity, &1))
+          |> hash_to_list()
+        end)
+      end)
+      |> Enum.uniq()
+
+    addresses_by_hash = fetch_addresses_by_hash(hashes, address_nested_preloads, options)
+
+    Enum.map(entities, fn entity ->
+      Enum.reduce(associations, entity, fn association, acc_entity ->
+        address =
+          association
+          |> address_hash_field_for_association()
+          |> then(&Map.get(acc_entity, &1))
+          |> then(&Map.get(addresses_by_hash, &1))
+
+        Map.put(acc_entity, association, address)
+      end)
+    end)
+  end
+
+  defp hash_to_list(nil), do: []
+  defp hash_to_list(hash), do: [hash]
+
+  defp fetch_addresses_by_hash([], _address_nested_preloads, _options), do: %{}
+
+  defp fetch_addresses_by_hash(hashes, address_nested_preloads, options) do
+    Address
+    |> where([address], address.hash in ^hashes)
+    |> maybe_preload_address_nested(address_nested_preloads)
+    |> select_repo(options).all()
+    |> Map.new(&{&1.hash, &1})
+  end
+
+  defp association_with_nested_preloads({association, _necessity}) when is_atom(association),
+    do: {association, []}
+
+  defp association_with_nested_preloads({[{association, nested_preloads}], _necessity}),
+    do: {association, nested_preloads}
+
+  defp normalize_nested_preloads(nil), do: []
+  defp normalize_nested_preloads(nested_preload) when is_atom(nested_preload), do: [nested_preload]
+  defp normalize_nested_preloads(nested_preloads) when is_list(nested_preloads), do: nested_preloads
+
+  defp maybe_preload_address_nested(query, []), do: query
+  defp maybe_preload_address_nested(query, nested_preloads), do: preload(query, ^nested_preloads)
+
+  defp address_hash_field_for_association(:from_address), do: :from_address_hash
+  defp address_hash_field_for_association(:to_address), do: :to_address_hash
+  defp address_hash_field_for_association(:created_contract_address), do: :created_contract_address_hash
 
   @spec execution_node_to_transactions(Hash.Address.t(), [paging_options | necessity_by_association_option | api?()]) ::
           [Transaction.t()]
@@ -2015,9 +2113,20 @@ defmodule Explorer.Chain do
   """
   @spec join_associations(atom() | Ecto.Query.t(), %{any() => :optional | :required}) :: Ecto.Query.t()
   def join_associations(query, necessity_by_association) when is_map(necessity_by_association) do
-    Enum.reduce(necessity_by_association, query, fn {association, join}, acc_query ->
-      join_association(acc_query, association, join)
-    end)
+    {optional_associations, required_associations} =
+      Enum.split_with(necessity_by_association, fn {_association, join} -> join == :optional end)
+
+    query_with_required_joins =
+      Enum.reduce(required_associations, query, fn {association, _join}, acc_query ->
+        join_association(acc_query, association, :required)
+      end)
+
+    optional_preloads = Enum.map(optional_associations, fn {association, _join} -> association end)
+
+    case optional_preloads do
+      [] -> query_with_required_joins
+      _ -> preload(query_with_required_joins, ^optional_preloads)
+    end
   end
 
   def page_blocks(query, %PagingOptions{key: nil}), do: query

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -438,9 +438,10 @@ defmodule Explorer.Chain do
     Map.new(addresses_with_proxy, &{&1.hash, &1})
   end
 
-  # Check if an address is a contract or has proxy_implementations
-  defp proxy_applicable?(%Address{smart_contract: nil}), do: false
-  defp proxy_applicable?(_), do: true
+  # Check if an address can have proxy implementations.
+  # Address.smart_contract?/1 relies on contract code presence, so this also covers EIP-7702 addresses.
+  defp proxy_applicable?(%Address{} = address), do: Address.smart_contract?(address)
+  defp proxy_applicable?(_), do: false
 
   # Split proxy-related preloads from other nested preloads
   defp split_proxy_preloads(nested_preloads) when is_list(nested_preloads) do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -415,12 +415,77 @@ defmodule Explorer.Chain do
   defp fetch_addresses_by_hash([], _address_nested_preloads, _options), do: %{}
 
   defp fetch_addresses_by_hash(hashes, address_nested_preloads, options) do
-    Address
-    |> where([address], address.hash in ^hashes)
-    |> maybe_preload_address_nested(address_nested_preloads)
-    |> select_repo(options).all()
-    |> strip_smart_contract_large_fields()
-    |> Map.new(&{&1.hash, &1})
+    # Split nested preloads into proxy and non-proxy preloads
+    # This allows us to load proxy implementations conditionally only for contract addresses
+    {proxy_preloads, non_proxy_preloads} = split_proxy_preloads(address_nested_preloads)
+
+    addresses =
+      Address
+      |> where([address], address.hash in ^hashes)
+      |> maybe_preload_address_nested(non_proxy_preloads)
+      |> select_repo(options).all()
+      |> strip_smart_contract_large_fields()
+
+    # Only fetch proxy implementations for contract addresses (where smart_contract exists)
+    addresses_with_proxy =
+      if Enum.any?(proxy_preloads) and Enum.any?(addresses, &proxy_applicable?/1) do
+        contract_addresses = Enum.filter(addresses, &proxy_applicable?/1)
+        batch_load_proxy_implementations_for_contracts(contract_addresses, proxy_preloads, options)
+      else
+        addresses
+      end
+
+    Map.new(addresses_with_proxy, &{&1.hash, &1})
+  end
+
+  # Check if an address is a contract or has proxy_implementations
+  defp proxy_applicable?(%Address{smart_contract: nil}), do: false
+  defp proxy_applicable?(_), do: true
+
+  # Split proxy-related preloads from other nested preloads
+  defp split_proxy_preloads(nested_preloads) when is_list(nested_preloads) do
+    {proxy, non_proxy} =
+      Enum.split_with(nested_preloads, fn
+        :proxy_implementations -> true
+        [{:proxy_implementations, _}] -> true
+        _ -> false
+      end)
+
+    {proxy, non_proxy}
+  end
+
+  # Batch load proxy implementations for contract addresses and attach to originating addresses
+  defp batch_load_proxy_implementations_for_contracts(addresses, proxy_preloads, options) when is_list(addresses) do
+    address_hashes = Enum.map(addresses, & &1.hash)
+
+    # Build proxy preload spec based on what was requested
+    proxy_spec = build_proxy_preload_spec(proxy_preloads)
+
+    # Fetch proxy implementations for these contract addresses
+    proxy_implementations =
+      Implementation
+      |> where([impl], impl.proxy_address_hash in ^address_hashes)
+      |> preload(^proxy_spec)
+      |> select_repo(options).all()
+
+    # Group proxy implementations by proxy_address_hash for efficient lookup
+    proxy_by_address = Enum.group_by(proxy_implementations, & &1.proxy_address_hash)
+
+    # Attach proxy data to addresses
+    Enum.map(addresses, fn address ->
+      proxy_list = Map.get(proxy_by_address, address.hash, [])
+      Map.put(address, :proxy_implementations, proxy_list)
+    end)
+  end
+
+  # Build the preload specification for proxy implementations
+  defp build_proxy_preload_spec(proxy_preloads) when is_list(proxy_preloads) do
+    # Find the nested preload spec if one exists
+    Enum.find_value(proxy_preloads, fn
+      :proxy_implementations -> [:addresses, :conflicting_addresses, :smart_contracts]
+      [{:proxy_implementations, nested}] -> nested
+      _ -> nil
+    end) || [:addresses, :conflicting_addresses]
   end
 
   defp association_with_nested_preloads({association, _necessity}) when is_atom(association),
@@ -436,15 +501,13 @@ defmodule Explorer.Chain do
   defp maybe_preload_address_nested(query, []), do: query
   defp maybe_preload_address_nested(query, nested_preloads), do: preload(query, ^nested_preloads)
 
-  @doc """
-  Post-processes loaded addresses to remove large SmartContract fields to reduce memory usage
-  and deserialization overhead for transaction listings.
+  # Post-processes loaded addresses to remove large SmartContract fields to reduce memory usage
+  # and deserialization overhead for transaction listings.
 
-  Removes:
-  - contract_source_code (can be hundreds of KB)
-  - abi (can be hundreds of KB)
-  - constructor_arguments (potentially large)
-  """
+  # Removes:
+  # - contract_source_code (can be hundreds of KB)
+  # - abi (can be hundreds of KB)
+  # - constructor_arguments (potentially large)
   defp strip_smart_contract_large_fields(addresses) when is_list(addresses) do
     Enum.map(addresses, fn address ->
       if Map.has_key?(address, :smart_contract) && address.smart_contract do

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -515,7 +515,8 @@ defmodule Explorer.Chain do
   # - constructor_arguments (potentially large)
   defp strip_smart_contract_large_fields(addresses) when is_list(addresses) do
     Enum.map(addresses, fn address ->
-      if Map.has_key?(address, :smart_contract) && address.smart_contract do
+      if Map.has_key?(address, :smart_contract) && address.smart_contract &&
+           !is_struct(address.smart_contract, Ecto.Association.NotLoaded) do
         filtered_contract =
           address.smart_contract
           |> Map.drop([:contract_source_code, :abi, :constructor_arguments])

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -852,6 +852,33 @@ defmodule Explorer.Chain.Transaction do
         do: {:error, :not_a_contract_call}
   end
 
+  # if to_address is a verified contract but smart_contract is not preloaded,
+  # decode using the pre-built smart_contract_full_abi_map (keyed by address hash)
+  def decoded_input_data(
+        %__MODULE__{
+          input: %{bytes: data} = input,
+          to_address: %Address{verified: true, hash: to_address_hash, smart_contract: %NotLoaded{}},
+          hash: hash
+        },
+        skip_sig_provider?,
+        options,
+        methods_map,
+        smart_contract_full_abi_map
+      ) do
+    full_abi = Map.get(smart_contract_full_abi_map, to_address_hash, [])
+
+    decode_input_data_with_fallback(
+      data,
+      full_abi,
+      input,
+      hash,
+      skip_sig_provider?,
+      options,
+      methods_map,
+      smart_contract_full_abi_map
+    )
+  end
+
   # if to_address's smart_contract is nil reduce to the case when to_address is not loaded
   def decoded_input_data(
         %__MODULE__{
@@ -958,6 +985,37 @@ defmodule Explorer.Chain.Transaction do
       ) do
     full_abi = check_full_abi_cache(smart_contract, smart_contract_full_abi_map, options)
 
+    decode_input_data_with_fallback(
+      data,
+      full_abi,
+      input,
+      hash,
+      skip_sig_provider?,
+      options,
+      methods_map,
+      smart_contract_full_abi_map
+    )
+  end
+
+  def decoded_input_data(
+        %__MODULE__{to_address: %{metadata: _, ens_domain_name: _}},
+        _,
+        _,
+        _,
+        _
+      ),
+      do: {:error, :no_to_address}
+
+  defp decode_input_data_with_fallback(
+         data,
+         full_abi,
+         input,
+         hash,
+         skip_sig_provider?,
+         options,
+         methods_map,
+         smart_contract_full_abi_map
+       ) do
     case do_decoded_input_data(data, full_abi, hash) do
       # In some cases transactions use methods of some unpredictable contracts, so we can try to look up for method in a whole DB
       {:error, error} when error in [:could_not_decode, :no_matching_function] ->
@@ -986,15 +1044,6 @@ defmodule Explorer.Chain.Transaction do
         output
     end
   end
-
-  def decoded_input_data(
-        %__MODULE__{to_address: %{metadata: _, ens_domain_name: _}},
-        _,
-        _,
-        _,
-        _
-      ),
-      do: {:error, :no_to_address}
 
   defp decode_function_call_via_sig_provider_wrapper(input, hash, skip_sig_provider?) do
     case decode_function_call_via_sig_provider(input, hash, skip_sig_provider?) do


### PR DESCRIPTION
## Motivation

Improve API v2 transaction-related endpoint performance by reducing redundant address association preloads and avoiding heavy smart-contract/proxy loading when it is not needed.

## Changelog

### Enhancements

- Reworked optional address-association loading to deduplicate `from_address`, `to_address`, and `created_contract_address` preloads through a single batched address fetch.
- Updated transaction list flows in API v2 (address transactions, block transactions, generic transactions, batch-related transaction endpoints, execution-node transactions, and watchlist transactions) to use the optimized optional preload strategy.
- Changed association handling so required associations are joined, while optional ones are preloaded, reducing query complexity on hot paths.
- Added conditional proxy implementation loading so proxy preloads are fetched only for contract-capable addresses (including EIP-7702 cases).
- Reduced payload/memory overhead by trimming large smart contract fields (`contract_source_code`, `abi`, `constructor_arguments`) from list-view preload objects.
- Switched contract verification rendering helper to rely on `Address.verified`, removing the need to preload full smart contract records for this check.

The same technique can be spread in the future to the address preloads for other items list, e.g. internal transactions and token transfers.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transaction loading now builds association requirements at runtime, deduplicates certain address associations, and preloads some address data after queries to reduce heavy joins and improve performance.
  * Conditional proxy/contract-related loading optimized and large smart-contract payloads trimmed during address preloads.

* **Bug Fixes**
  * Smart contract verification now derives directly from address verification and may return true/false or nil.

* **Tests**
  * Fixtures and tests updated to cover verified contract scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->