### PR TITLE
Fixed the issue where /api/v2/blocks in the API documentation was not…

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -609,8 +609,8 @@ config :explorer, Explorer.Chain.Cache.BlockNumber,
   global_ttl: ConfigHelper.cache_global_ttl(disable_indexer?)
 
 config :explorer, Explorer.Chain.Cache.Blocks,
-  ttl_check_interval: false,
-  global_ttl: nil
+  ttl_check_interval: ConfigHelper.cache_ttl_check_interval(disable_indexer?),
+  global_ttl: ConfigHelper.cache_global_ttl(disable_indexer?)
 
 config :explorer, Explorer.Chain.Cache.Transactions,
   ttl_check_interval: false,


### PR DESCRIPTION
outputting the latest block. #14166


## Motivation

Revert to this code to fix the issue where /api/v2/blocks could not retrieve the latest block. #14166

## Changelog

Revert to this code


### Bug Fixes

Revert to this code to fix the issue where /api/v2/blocks could not retrieve the latest block.

This bug originates here: https://github.com/blockscout/blockscout/pull/13698



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated cache configuration settings to dynamically adjust based on operational modes, improving system performance and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->