### PR TITLE
perf: use tuple-based comparison to utlize index

### DIFF
--- a/apps/explorer/lib/explorer/chain/scroll/reader.ex
+++ b/apps/explorer/lib/explorer/chain/scroll/reader.ex
@@ -300,8 +300,7 @@ defmodule Explorer.Chain.Scroll.Reader do
             base_query,
             [p],
             p.name == ^name and
-              (p.block_number < ^transaction.block_number or
-                 (p.block_number == ^transaction.block_number and p.transaction_index < ^transaction.index))
+              {p.block_number, p.transaction_index} < {^transaction.block_number, ^transaction.index}
           )
       end
 


### PR DESCRIPTION
One of the most demanding queries on scroll mainnet:
```
SELECT s0."value" FROM "scroll_l1_fee_params" AS s0 WHERE ((s0."name" = 'l1_base_fee') AND ((s0."block_number" < 100000) OR ((s0."block_number" = 100000) AND (s0."transaction_index" < 10)))) ORDER BY s0."block_number" DESC, s0."transaction_index" DESC LIMIT 1

                                                                                   QUERY PLAN                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..26.82 rows=1 width=20) (actual time=1520.066..1520.068 rows=1 loops=1)
   ->  Index Scan Backward using scroll_l1_fee_params_pkey on scroll_l1_fee_params s0  (cost=0.43..132760.54 rows=5031 width=20) (actual time=1520.064..1520.064 rows=1 loops=1)
         Index Cond: (name = 'l1_base_fee'::scroll_l1_fee_param_names)
         Filter: ((block_number < 100000) OR ((block_number = 100000) AND (transaction_index < 10)))
         Rows Removed by Filter: 2538601
 Planning Time: 1.093 ms
 Execution Time: 1520.140 ms
```
Now:
```
SELECT s0."value" FROM "scroll_l1_fee_params" AS s0 WHERE s0."name" = 'l1_base_fee' AND (s0."block_number", s0."transaction_index") < (100000, 10) ORDER BY s0."block_number" DESC, s0."transaction_index" DESC LIMIT 1

                                                                               QUERY PLAN                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..0.95 rows=1 width=20) (actual time=0.386..0.386 rows=1 loops=1)
   ->  Index Scan Backward using scroll_l1_fee_params_pkey on scroll_l1_fee_params s0  (cost=0.43..2626.76 rows=5030 width=20) (actual time=0.379..0.379 rows=1 loops=1)
         Index Cond: ((ROW(block_number, transaction_index) < ROW(100000, 10)) AND (name = 'l1_base_fee'::scroll_l1_fee_param_names))
 Planning Time: 0.335 ms
 Execution Time: 0.479 ms
```

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transaction fee parameter retrieval for improved efficiency on the Scroll chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->