### PR TITLE
chore: Add Block.full_refetch

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/ranges_helper.ex
@@ -139,6 +139,41 @@ defmodule EthereumJSONRPC.Utility.RangesHelper do
   end
 
   @doc """
+  Parses a block ranges string into a flat list of block numbers.
+
+  This function expands each parsed range into individual block numbers and returns
+  all resulting numbers as a single list. The input must contain only finite ranges.
+  If the parsed result includes a standalone integer such as a `latest` marker,
+  the function raises.
+
+  ## Parameters
+
+    - `block_ranges_string`: A string representing block ranges.
+
+  ## Returns
+
+    - A list of block numbers as integers.
+
+  ## Examples
+
+      iex> parse_block_ranges_to_numbers("1..3,5..6")
+      [1, 2, 3, 5, 6]
+
+      iex> parse_block_ranges_to_numbers("10..12")
+      [10, 11, 12]
+
+  """
+  @spec parse_block_ranges_to_numbers(binary()) :: [integer()]
+  def parse_block_ranges_to_numbers(block_ranges_string) do
+    block_ranges_string
+    |> parse_block_ranges()
+    |> Enum.flat_map(fn
+      %Range{} = range -> Range.to_list(range)
+      _number -> raise "Invalid ranges string"
+    end)
+  end
+
+  @doc """
   Extracts the minimum block number from a given block ranges string.
 
   ## Parameters

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -220,6 +220,8 @@ defmodule Explorer.Chain.Block do
   use Utils.RuntimeEnvHelper,
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
+  alias EthereumJSONRPC.Utility.RangesHelper
+
   alias Explorer.Chain.{
     Block,
     DenormalizationHelper,
@@ -233,6 +235,7 @@ defmodule Explorer.Chain.Block do
 
   alias Explorer.{Chain, Helper, PagingOptions, Repo}
   alias Explorer.Chain.Block.{EmissionReward, Reward, SecondDegreeRelation}
+  alias Explorer.Chain.InternalTransaction.DeleteQueue, as: InternalTransactionDeleteQueue
   alias Explorer.Utility.MissingBlockRange
 
   @optional_attrs ~w(size refetch_needed total_difficulty difficulty base_fee_per_gas)a
@@ -618,6 +621,56 @@ defmodule Explorer.Chain.Block do
     |> Decimal.div_int(gas_target)
     |> Decimal.div_int(base_fee_max_change_denominator)
   end
+
+  @doc """
+  Queues blocks for a full refetch and marks them as needing refetch.
+
+  This function accepts either a block ranges string, a list of block numbers,
+  or a single block number. When given a ranges string, it parses the string into
+  individual block numbers. It then enqueues the blocks for internal transaction
+  cleanup and marks the corresponding blocks with `refetch_needed: true` inside a
+  single database transaction.
+
+  ## Parameters
+
+    - `block_ranges_string_or_numbers`: A block ranges string, a list of block numbers, or a single block number.
+
+  ## Returns
+
+    - The result of `Repo.transaction/2` for range strings and lists.
+    - The delegated result for a single block number.
+
+  ## Examples
+
+      iex> full_refetch("1..3,5..6")
+      {:ok, _}
+
+      iex> full_refetch([10, 11, 12])
+      {:ok, _}
+
+      iex> full_refetch(15)
+      {:ok, _}
+
+  """
+  @spec full_refetch(binary() | [integer()] | integer()) :: {:ok, any()} | {:error, any()}
+  def full_refetch(block_ranges_string) when is_binary(block_ranges_string) do
+    block_ranges_string
+    |> RangesHelper.parse_block_ranges_to_numbers()
+    |> full_refetch()
+  end
+
+  def full_refetch(block_numbers) when is_list(block_numbers) do
+    Repo.transaction(
+      fn ->
+        # TODO: delete other crucial entities as well
+        InternalTransactionDeleteQueue.batch_insert(block_numbers)
+        set_refetch_needed(block_numbers)
+      end,
+      timeout: :infinity
+    )
+  end
+
+  def full_refetch(block_number), do: full_refetch([block_number])
 
   @spec set_refetch_needed(integer | [integer]) :: :ok
   def set_refetch_needed(block_numbers) when is_list(block_numbers) do

--- a/apps/explorer/lib/explorer/chain/internal_transaction/delete_queue.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction/delete_queue.ex
@@ -5,6 +5,7 @@ defmodule Explorer.Chain.InternalTransaction.DeleteQueue do
 
   use Explorer.Schema
   import Ecto.Query
+  alias Explorer.Chain.{Block, Import}
   alias Explorer.Repo
 
   @primary_key false
@@ -33,9 +34,43 @@ defmodule Explorer.Chain.InternalTransaction.DeleteQueue do
         when accumulator: term()
   def stream_data(initial, reducer, threshold \\ 600_000) when is_function(reducer, 2) do
     __MODULE__
+    |> join(:inner, [dq], b in Block, on: dq.block_number == b.number and b.refetch_needed == false)
     |> where([dq], dq.updated_at < ago(^threshold, "millisecond"))
     |> order_by([dq], desc: :block_number)
     |> select([dq], dq.block_number)
+    |> distinct(true)
     |> Repo.stream_reduce(initial, reducer)
+  end
+
+  @doc """
+  Inserts block numbers into the internal transactions delete queue.
+
+  This function builds queue entries for the given block numbers, adds shared
+  insert and update timestamps, and performs a bulk insert. Existing entries are
+  ignored because conflicts on the primary key are handled with `:nothing`.
+
+  ## Parameters
+
+    - `block_numbers`: A list of block numbers to enqueue for internal transaction deletion and refetch.
+
+  ## Returns
+
+    - The result of `Repo.safe_insert_all/3`.
+
+  ## Examples
+
+      iex> batch_insert([100, 101, 102])
+      {3, nil}
+
+      iex> batch_insert([100, 100])
+      {1, nil}
+
+  """
+  @spec batch_insert([integer()]) :: {non_neg_integer(), nil | [term()]}
+  def batch_insert(block_numbers) do
+    timestamps = Import.timestamps()
+    params = Enum.map(block_numbers, &Map.put(timestamps, :block_number, &1))
+
+    Repo.safe_insert_all(__MODULE__, params, timeout: :infinity, on_conflict: :nothing)
   end
 end

--- a/apps/explorer/test/explorer/chain/block_test.exs
+++ b/apps/explorer/test/explorer/chain/block_test.exs
@@ -3,6 +3,7 @@ defmodule Explorer.Chain.BlockTest do
 
   alias Ecto.Changeset
   alias Explorer.Chain.{Address, Block, PendingBlockOperation, Wei}
+  alias Explorer.Chain.InternalTransaction.DeleteQueue, as: InternalTransactionDeleteQueue
   alias Explorer.PagingOptions
 
   describe "changeset/2" do
@@ -397,6 +398,66 @@ defmodule Explorer.Chain.BlockTest do
       assert Block.gas_payment_by_block_hash([consensus_block_hash]) == %{
                consensus_block_hash => %Wei{value: Decimal.new(14)}
              }
+    end
+  end
+
+  describe "full_refetch/1" do
+    test "with block numbers" do
+      Enum.each(1..5, fn _i ->
+        insert(:block)
+      end)
+
+      blocks = Repo.all(Block)
+
+      assert Enum.all?(blocks, &(&1.refetch_needed == false))
+      assert [] = Repo.all(InternalTransactionDeleteQueue)
+
+      block_numbers = Enum.map(blocks, & &1.number)
+
+      Block.full_refetch(block_numbers)
+
+      assert Enum.all?(Repo.all(Block), &(&1.refetch_needed == true))
+
+      delete_queue_entries = Repo.all(InternalTransactionDeleteQueue)
+
+      assert Enum.count(delete_queue_entries) == 5
+      assert Enum.map(delete_queue_entries, & &1.block_number) -- block_numbers == []
+    end
+
+    test "with block ranges" do
+      Enum.each(1..5, fn i ->
+        insert(:block, number: i)
+      end)
+
+      blocks = Repo.all(Block)
+
+      assert Enum.all?(blocks, &(&1.refetch_needed == false))
+      assert [] = Repo.all(InternalTransactionDeleteQueue)
+
+      Block.full_refetch("1..5")
+
+      assert Enum.all?(Repo.all(Block), &(&1.refetch_needed == true))
+
+      delete_queue_entries = Repo.all(InternalTransactionDeleteQueue)
+
+      assert Enum.count(delete_queue_entries) == 5
+      assert Enum.map(delete_queue_entries, & &1.block_number) -- Enum.to_list(1..5) == []
+    end
+
+    test "with single block number" do
+      insert(:block)
+
+      [block] = Repo.all(Block)
+      block_number = block.number
+
+      assert block.refetch_needed == false
+      assert [] = Repo.all(InternalTransactionDeleteQueue)
+
+      Block.full_refetch(block.number)
+
+      assert Repo.one(Block).refetch_needed == true
+
+      assert [%{block_number: ^block_number}] = Repo.all(InternalTransactionDeleteQueue)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13859

## Changelog

Added `full_refetch` function for blocks for manual usage. It sets `refetch_needed: true` for provided blocks and adds them to `internal_transactions_delete_queue`. It allows to refetch blocks along with internal transactions. Internal transactions for blocks marked with `refetch_needed` won't be deleted immediately, since `DeleteQueue.stream_data` now has inner join with blocks by `refetch_needed == false` condition. This way, only when block will be actually refetched, its internal transactions will be deleted and refetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refetch blocks using range strings, lists, or single block numbers; accepts flexible input formats.

* **Refactor**
  * Block refetch now enqueues internal deletion tasks and marks blocks for refetch in a single transaction; queue insertion is batched and deduplicated to avoid duplicates.

* **Tests**
  * Added tests covering list, range-string, and single-number refetch flows and queue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->