### PR TITLE
chore: Add swagger generation for Arc and Suave chain types

### DIFF
--- a/.github/workflows/generate-swagger.yml
+++ b/.github/workflows/generate-swagger.yml
@@ -34,9 +34,11 @@ jobs:
             const chainTypes = [
               "default",
               "arbitrum",
+              "arc",
               "blackfort",
               "ethereum",
               "filecoin",
+              "neon",
               "optimism",
               "optimism-celo",
               "polygon_zkevm",
@@ -44,10 +46,10 @@ jobs:
               "scroll",
               "shibarium",
               "stability",
+              "suave",
               "zetachain",
               "zilliqa",
-              "zksync",
-              "neon"
+              "zksync"
             ];
 
             const matrix = { "chain-type": ${{ 'chainTypes' }} };


### PR DESCRIPTION
## Motivation

Missing API swagger files for Arc and Suave chain types.

## Changelog

This pull request updates the list of supported chain types in the Swagger generation workflow. The main changes are the addition of new chains and reordering for consistency.

**Chain type updates:**

* Added new chain types: `arc`, `suave` to the `chainTypes` array.
* Reordered the `chainTypes` array and fixed the placement of `neon` and `zksync` for better organization.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended OpenAPI specification generation to support additional blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->