### PR TITLE
fix: Update transaction from receipt in PendingTransactionsSanitizer

### DIFF
--- a/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
+++ b/apps/indexer/lib/indexer/pending_transactions_sanitizer.ex
@@ -61,7 +61,7 @@ defmodule Indexer.PendingTransactionsSanitizer do
     {:noreply, state}
   end
 
-  defp sanitize_pending_transactions(json_rpc_named_arguments) do
+  def sanitize_pending_transactions(json_rpc_named_arguments) do
     receipts_batch_size = Application.get_env(:indexer, :receipts_batch_size)
     pending_transactions_list_from_db = Transaction.pending_transactions_list()
     id_to_params = id_to_params(pending_transactions_list_from_db)
@@ -169,24 +169,31 @@ defmodule Indexer.PendingTransactionsSanitizer do
   end
 
   defp invalidate_block(block, pending_transaction, transaction) do
+    transaction_info = to_elixir(transaction)
+
+    pending_transaction
+    |> Transaction.changeset()
+    |> Changeset.put_change(:cumulative_gas_used, transaction_info["cumulativeGasUsed"])
+    |> Changeset.put_change(:gas_used, transaction_info["gasUsed"])
+    |> Changeset.put_change(:index, transaction_info["transactionIndex"])
+    |> Changeset.put_change(:status, transaction_info["status"])
+    |> Changeset.put_change(:created_contract_address_hash, transaction_info["contractAddress"])
+    |> Changeset.put_change(:block_number, block.number)
+    |> Changeset.put_change(:block_hash, block.hash)
+    |> Changeset.put_change(:block_timestamp, block.timestamp)
+    |> Changeset.put_change(:block_consensus, block.consensus)
+    |> Repo.update()
+    |> case do
+      {:ok, _result} ->
+        :ok
+
+      {:error, error} ->
+        Logger.error("Failed to update pending transaction with hash #{pending_transaction.hash}: #{inspect(error)}")
+    end
+
     if block.consensus do
       Block.set_refetch_needed(block.number)
     else
-      transaction_info = to_elixir(transaction)
-
-      changeset =
-        pending_transaction
-        |> Transaction.changeset()
-        |> Changeset.put_change(:cumulative_gas_used, transaction_info["cumulativeGasUsed"])
-        |> Changeset.put_change(:gas_used, transaction_info["gasUsed"])
-        |> Changeset.put_change(:index, transaction_info["transactionIndex"])
-        |> Changeset.put_change(:block_number, block.number)
-        |> Changeset.put_change(:block_hash, block.hash)
-        |> Changeset.put_change(:block_timestamp, block.timestamp)
-        |> Changeset.put_change(:block_consensus, false)
-
-      Repo.update(changeset)
-
       Logger.debug(
         "Pending transaction with hash #{pending_transaction.hash} assigned to block ##{block.number} with hash #{block.hash}"
       )

--- a/apps/indexer/test/indexer/pending_transactions_sanitizer_test.exs
+++ b/apps/indexer/test/indexer/pending_transactions_sanitizer_test.exs
@@ -1,0 +1,119 @@
+defmodule Indexer.PendingTransactionsSanitizerTest do
+  use EthereumJSONRPC.Case
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Explorer.Chain.Transaction
+  alias Explorer.Repo
+  alias Indexer.PendingTransactionsSanitizer
+
+  describe "sanitize_pending_transactions/1" do
+    test "with included transaction", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      pending_transaction = insert(:transaction, inserted_at: Timex.shift(Timex.now(), days: -2))
+      block = insert(:block, consensus: true, refetch_needed: false)
+
+      EthereumJSONRPC.Mox
+      |> expect(
+        :json_rpc,
+        fn _json, _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: %{
+                 "transactionHash" => to_string(pending_transaction.hash),
+                 "blockHash" => to_string(block.hash),
+                 "cumulativeGasUsed" => "0x5208",
+                 "gasUsed" => "0x5208",
+                 "status" => "0x1",
+                 "transactionIndex" => "0x0"
+               }
+             }
+           ]}
+        end
+      )
+
+      PendingTransactionsSanitizer.sanitize_pending_transactions(json_rpc_named_arguments)
+
+      updated_block = Repo.reload(block)
+      assert updated_block.refetch_needed == true
+
+      assert [transaction] = Repo.all(Transaction)
+
+      assert transaction.cumulative_gas_used == Decimal.new("21000")
+      assert transaction.gas_used == Decimal.new("21000")
+      assert transaction.block_hash == block.hash
+      assert transaction.status == :ok
+      assert transaction.index == 0
+    end
+
+    test "with empty result", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      insert(:transaction, inserted_at: Timex.shift(Timex.now(), days: -2))
+      block = insert(:block, consensus: true, refetch_needed: false)
+
+      EthereumJSONRPC.Mox
+      |> expect(
+        :json_rpc,
+        fn _json, _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: nil
+             }
+           ]}
+        end
+      )
+
+      PendingTransactionsSanitizer.sanitize_pending_transactions(json_rpc_named_arguments)
+
+      updated_block = Repo.reload(block)
+      assert updated_block.refetch_needed == false
+
+      assert [] = Repo.all(Transaction)
+    end
+
+    test "with non-consensus block", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      pending_transaction = insert(:transaction, inserted_at: Timex.shift(Timex.now(), days: -2))
+      block = insert(:block, consensus: false, refetch_needed: false)
+
+      EthereumJSONRPC.Mox
+      |> expect(
+        :json_rpc,
+        fn _json, _options ->
+          {:ok,
+           [
+             %{
+               id: 0,
+               jsonrpc: "2.0",
+               result: %{
+                 "transactionHash" => to_string(pending_transaction.hash),
+                 "blockHash" => to_string(block.hash),
+                 "cumulativeGasUsed" => "0x5208",
+                 "gasUsed" => "0x5208",
+                 "status" => "0x1",
+                 "transactionIndex" => "0x0"
+               }
+             }
+           ]}
+        end
+      )
+
+      PendingTransactionsSanitizer.sanitize_pending_transactions(json_rpc_named_arguments)
+
+      updated_block = Repo.reload(block)
+      assert updated_block.refetch_needed == false
+
+      assert [transaction] = Repo.all(Transaction)
+
+      assert transaction.cumulative_gas_used == Decimal.new("21000")
+      assert transaction.gas_used == Decimal.new("21000")
+      assert transaction.block_hash == block.hash
+      assert transaction.status == :ok
+      assert transaction.index == 0
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14176

## Changelog
Update pending transaction in both cases, in case when block has `consensus: true` as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending transaction records are now updated consistently regardless of block consensus, ensuring transaction status, gas usage, index, and related block metadata are persisted.
  * Improved error logging when updating pending transactions to include the transaction identifier and detailed error info, aiding troubleshooting.

* **Tests**
  * Added tests validating sanitizer behavior for consensus, non-consensus, and empty-result scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->