### PR TITLE
fix: implementation address hash retrieval logic in the old UI

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/smart_contract_controller.ex
@@ -103,7 +103,7 @@ defmodule BlockScoutWeb.SmartContractController do
   defp implementation_address_hash(contract_type, address) do
     if contract_type == "proxy" do
       implementation = Implementation.get_implementation(address.smart_contract)
-      (implementation && implementation.address_hashes |> List.first()) || burn_address_hash_string()
+      (implementation && (implementation.address_hashes || []) |> List.first()) || burn_address_hash_string()
     else
       burn_address_hash_string()
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/smart_contract_controller_test.exs
@@ -143,6 +143,57 @@ defmodule BlockScoutWeb.SmartContractControllerTest do
       assert conn.status == 200
       assert conn.assigns.read_only_functions == []
     end
+
+    test "uses first implementation from address_hashes for proxy contract" do
+      proxy_address = insert(:contract_address)
+      implementation_address = insert(:contract_address)
+
+      insert(:smart_contract,
+        address_hash: proxy_address.hash,
+        contract_code_md5: "123"
+      )
+
+      insert(:smart_contract,
+        address_hash: implementation_address.hash,
+        abi: [
+          %{
+            "type" => "function",
+            "stateMutability" => "view",
+            "payable" => false,
+            "outputs" => [%{"type" => "uint256", "name" => ""}],
+            "name" => "get",
+            "inputs" => [],
+            "constant" => true
+          }
+        ],
+        contract_code_md5: "456"
+      )
+
+      insert(:proxy_implementation,
+        proxy_address_hash: proxy_address.hash,
+        proxy_type: "eip1967",
+        address_hashes: [implementation_address.hash],
+        names: ["implementation"]
+      )
+
+      blockchain_get_function_mock()
+
+      path =
+        smart_contract_path(BlockScoutWeb.Endpoint, :index,
+          hash: proxy_address.hash,
+          type: :proxy,
+          action: :read
+        )
+
+      conn =
+        build_conn()
+        |> put_req_header("x-requested-with", "xmlhttprequest")
+        |> get(path)
+
+      assert conn.status == 200
+      assert conn.assigns.implementation_address == implementation_address.hash
+      refute conn.assigns.read_only_functions == []
+    end
   end
 
   describe "GET show/3" do


### PR DESCRIPTION
## Motivation

Prevent proxy contract interaction pages from crashing or falling back incorrectly when a proxy implementation record exists but its address_hashes field is nil. This keeps implementation address resolution safe and deterministic.

## Changelog

### Enhancements

- Added a regression test for SmartContractController index proxy flow that verifies:
- The first implementation address from address_hashes is used.
- Read-only functions are loaded from the resolved implementation ABI.

### Bug Fixes

- Made proxy implementation address retrieval nil-safe in SmartContractController by handling nil address_hashes before taking the first element.
- Preserved fallback to burn address when no implementation address is available.

### Incompatible Changes

- None.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where proxy contracts did not properly display implementation contract addresses when implementation data was unavailable.

* **Tests**
  * Added test coverage for proxy contract implementation address display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->