### PR TITLE
feat: support ECTO_SSL_MODE for Postgres SSL modes

### DIFF
--- a/apps/explorer/config/prod.exs
+++ b/apps/explorer/config/prod.exs
@@ -4,8 +4,7 @@ import Config
 config :explorer, Explorer.Repo,
   prepare: :unnamed,
   timeout: :timer.seconds(60),
-  migration_lock: nil,
-  ssl_opts: [verify: :verify_none]
+  migration_lock: nil
 
 for repo <- [
       # Configures API the database
@@ -37,8 +36,7 @@ for repo <- [
     ] do
   config :explorer, repo,
     prepare: :unnamed,
-    timeout: :timer.seconds(60),
-    ssl_opts: [verify: :verify_none]
+    timeout: :timer.seconds(60)
 end
 
 config :explorer, Explorer.Tracer, env: "production", disabled?: true

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -18,6 +18,8 @@ defmodule Explorer.Repo.ConfigHelper do
     database: "PGDATABASE"
   ]
 
+  @ecto_ssl_modes ~w(disable allow prefer require verify-ca verify-full)
+
   def get_db_config(opts) do
     url_encoded = opts[:url]
     url = url_encoded && URI.decode(url_encoded)
@@ -64,7 +66,42 @@ defmodule Explorer.Repo.ConfigHelper do
     {:ok, opts |> Keyword.put(:url, remove_search_path(db_url)) |> Keyword.merge(Keyword.take(merged, [:search_path]))}
   end
 
-  def ssl_enabled?, do: String.equivalent?(System.get_env("ECTO_USE_SSL") || "true", "true")
+  def ecto_ssl_mode(database_url \\ nil), do: ecto_ssl_mode(database_url, &System.get_env/1)
+
+  def ecto_ssl_mode(database_url, env_function) do
+    mode =
+      env_function.("ECTO_SSL_MODE") ||
+        ssl_mode_from_database_url(database_url) ||
+        "require"
+
+    normalize_ssl_mode!(mode)
+  end
+
+  def ssl_options(database_url \\ nil), do: ssl_options(database_url, &System.get_env/1)
+
+  def ssl_options(database_url, env_function) do
+    case ecto_ssl_mode(database_url, env_function) do
+      "disable" ->
+        [ssl: false]
+
+      # Postgrex cannot emulate allow/prefer fallback semantics exactly,
+      # so both modes are mapped to encrypted, non-verified transport.
+      mode when mode in ["allow", "prefer", "require"] ->
+        [ssl: [verify: :verify_none]]
+
+      "verify-ca" ->
+        [
+          ssl: [
+            cacerts: :public_key.cacerts_get(),
+            verify: :verify_peer,
+            server_name_indication: :disable
+          ]
+        ]
+
+      "verify-full" ->
+        [ssl: true]
+    end
+  end
 
   def extract_parameters(empty) when empty == nil or empty == "", do: []
 
@@ -118,6 +155,33 @@ defmodule Explorer.Repo.ConfigHelper do
         env_value -> Keyword.put(opts, name, env_value)
       end
     end)
+  end
+
+  defp ssl_mode_from_database_url(nil), do: nil
+  defp ssl_mode_from_database_url(""), do: nil
+
+  defp ssl_mode_from_database_url(database_url) do
+    case URI.parse(database_url) do
+      %{query: nil} ->
+        nil
+
+      %{query: query} ->
+        query
+        |> URI.decode_query()
+        |> Map.get("sslmode")
+    end
+  end
+
+  defp normalize_ssl_mode!(mode) when is_binary(mode) do
+    normalized_mode = mode |> String.trim() |> String.downcase()
+
+    if normalized_mode in @ecto_ssl_modes do
+      normalized_mode
+    else
+      raise ArgumentError,
+            "Unsupported ECTO_SSL_MODE value: #{inspect(mode)}. " <>
+              "Supported values: #{Enum.join(@ecto_ssl_modes, ", ")}."
+    end
   end
 
   def network_path do

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -73,21 +73,26 @@ defmodule Explorer.Repo.ConfigHelper do
   @spec ecto_ssl_mode(database_url :: String.t() | nil) :: String.t()
   def ecto_ssl_mode(database_url \\ nil), do: ecto_ssl_mode(database_url, &System.get_env/1)
 
+  @spec ecto_ssl_mode(database_url :: String.t() | nil, env_function :: (String.t() -> String.t() | nil)) :: String.t()
   def ecto_ssl_mode(database_url, env_function) do
     mode =
-      env_function.("ECTO_SSL_MODE") ||
+      blank_to_nil(env_function.("ECTO_SSL_MODE")) ||
         ssl_mode_from_database_url(database_url) ||
         "require"
 
     normalize_ssl_mode!(mode)
   end
 
+  defp blank_to_nil(value) when value in [nil, ""], do: nil
+  defp blank_to_nil(value), do: value
+
   @doc """
-  Returns SSL options for Postgrex based on the ECTO_SSL_MODE environment variable or ssl
+  Returns SSL options for Postgrex based on the ECTO_SSL_MODE environment variable or ssl mode parameter in the database URL.
   """
   @spec ssl_options(database_url :: String.t() | nil) :: Keyword.t()
   def ssl_options(database_url \\ nil), do: ssl_options(database_url, &System.get_env/1)
 
+  @spec ssl_options(database_url :: String.t() | nil, env_function :: (String.t() -> String.t() | nil)) :: Keyword.t()
   def ssl_options(database_url, env_function) do
     case ecto_ssl_mode(database_url, env_function) do
       "disable" ->

--- a/apps/explorer/lib/explorer/repo/config_helper.ex
+++ b/apps/explorer/lib/explorer/repo/config_helper.ex
@@ -66,6 +66,11 @@ defmodule Explorer.Repo.ConfigHelper do
     {:ok, opts |> Keyword.put(:url, remove_search_path(db_url)) |> Keyword.merge(Keyword.take(merged, [:search_path]))}
   end
 
+  @doc """
+  Determines the Ecto SSL mode based on the ECTO_SSL_MODE environment variable, the
+  sslmode parameter in the database URL, or defaults to "require" if neither is set.
+  """
+  @spec ecto_ssl_mode(database_url :: String.t() | nil) :: String.t()
   def ecto_ssl_mode(database_url \\ nil), do: ecto_ssl_mode(database_url, &System.get_env/1)
 
   def ecto_ssl_mode(database_url, env_function) do
@@ -77,6 +82,10 @@ defmodule Explorer.Repo.ConfigHelper do
     normalize_ssl_mode!(mode)
   end
 
+  @doc """
+  Returns SSL options for Postgrex based on the ECTO_SSL_MODE environment variable or ssl
+  """
+  @spec ssl_options(database_url :: String.t() | nil) :: Keyword.t()
   def ssl_options(database_url \\ nil), do: ssl_options(database_url, &System.get_env/1)
 
   def ssl_options(database_url, env_function) do

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -128,4 +128,98 @@ defmodule Explorer.Repo.ConfigHelperTest do
       assert result[:database] == "test_database"
     end
   end
+
+  describe "ecto_ssl_mode/2" do
+    test "defaults to require when mode is not set" do
+      assert ConfigHelper.ecto_ssl_mode(nil, fn _ -> nil end) == "require"
+    end
+
+    test "reads sslmode from database url" do
+      database_url = "postgresql://test:test@localhost:5432/test_db?sslmode=verify-full"
+
+      assert ConfigHelper.ecto_ssl_mode(database_url, fn _ -> nil end) == "verify-full"
+    end
+
+    test "ECTO_SSL_MODE has precedence over database url sslmode" do
+      database_url = "postgresql://test:test@localhost:5432/test_db?sslmode=disable"
+
+      env_func = fn
+        "ECTO_SSL_MODE" -> "verify-ca"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ecto_ssl_mode(database_url, env_func) == "verify-ca"
+    end
+
+    test "raises on invalid ssl mode" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "invalid-mode"
+        _ -> nil
+      end
+
+      assert_raise ArgumentError, ~r/Unsupported ECTO_SSL_MODE value/, fn ->
+        ConfigHelper.ecto_ssl_mode(nil, env_func)
+      end
+    end
+  end
+
+  describe "ssl_options/2" do
+    test "maps disable to ssl false" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "disable"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ssl_options(nil, env_func) == [ssl: false]
+    end
+
+    test "maps allow to verify_none SSL" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "allow"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ssl_options(nil, env_func) == [ssl: [verify: :verify_none]]
+    end
+
+    test "maps prefer to verify_none SSL" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "prefer"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ssl_options(nil, env_func) == [ssl: [verify: :verify_none]]
+    end
+
+    test "maps require to verify_none SSL" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "require"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ssl_options(nil, env_func) == [ssl: [verify: :verify_none]]
+    end
+
+    test "maps verify-ca to peer verification without SNI" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "verify-ca"
+        _ -> nil
+      end
+
+      ssl_options = ConfigHelper.ssl_options(nil, env_func)[:ssl]
+
+      assert ssl_options[:verify] == :verify_peer
+      assert ssl_options[:server_name_indication] == :disable
+      assert ssl_options[:cacerts] == :public_key.cacerts_get()
+    end
+
+    test "maps verify-full to secure Postgrex defaults" do
+      env_func = fn
+        "ECTO_SSL_MODE" -> "verify-full"
+        _ -> nil
+      end
+
+      assert ConfigHelper.ssl_options(nil, env_func) == [ssl: true]
+    end
+  end
 end

--- a/apps/explorer/test/explorer/repo/config_helper_test.exs
+++ b/apps/explorer/test/explorer/repo/config_helper_test.exs
@@ -164,6 +164,10 @@ defmodule Explorer.Repo.ConfigHelperTest do
   end
 
   describe "ssl_options/2" do
+    test "defaults to require (verify_none) when mode is not set" do
+      assert ConfigHelper.ssl_options(nil, fn _ -> nil end) == [ssl: [verify: :verify_none]]
+    end
+
     test "maps disable to ssl false" do
       env_func = fn
         "ECTO_SSL_MODE" -> "disable"

--- a/bin/deployment/migrate
+++ b/bin/deployment/migrate
@@ -11,7 +11,7 @@ source /etc/environment
 
 export DATABASE_URL
 export POOL_SIZE
-export ECTO_USE_SSL
+export ECTO_SSL_MODE
 
 mix ecto.create
 mix ecto.migrate

--- a/config/runtime/prod.exs
+++ b/config/runtime/prod.exs
@@ -39,46 +39,75 @@ config :block_scout_web, BlockScoutWeb.HealthEndpoint,
 
 pool_size = ConfigHelper.parse_integer_env_var("POOL_SIZE", 50)
 queue_target = ConfigHelper.parse_integer_env_var("DATABASE_QUEUE_TARGET", 50)
+database_url = ConfigHelper.parse_url_env_var("DATABASE_URL")
 
 # Configures the database
-config :explorer, Explorer.Repo,
-  url: ConfigHelper.parse_url_env_var("DATABASE_URL"),
-  pool_size: pool_size,
-  ssl: ExplorerConfigHelper.ssl_enabled?(),
-  queue_target: queue_target
+config :explorer,
+       Explorer.Repo,
+       [
+         url: database_url,
+         pool_size: pool_size,
+         queue_target: queue_target
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(database_url))
+
+api_db_url = ExplorerConfigHelper.get_api_db_url()
 
 # Configures API the database
-config :explorer, Explorer.Repo.Replica1,
-  url: ExplorerConfigHelper.get_api_db_url(),
-  pool_size: ConfigHelper.parse_integer_env_var("POOL_SIZE_API", 50),
-  ssl: ExplorerConfigHelper.ssl_enabled?(),
-  queue_target: queue_target
+config :explorer,
+       Explorer.Repo.Replica1,
+       [
+         url: api_db_url,
+         pool_size: ConfigHelper.parse_integer_env_var("POOL_SIZE_API", 50),
+         queue_target: queue_target
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(api_db_url))
+
+account_db_url = ExplorerConfigHelper.get_account_db_url()
 
 # Configures Account database
-config :explorer, Explorer.Repo.Account,
-  url: ExplorerConfigHelper.get_account_db_url(),
-  pool_size: ConfigHelper.parse_integer_env_var("ACCOUNT_POOL_SIZE", 50),
-  ssl: ExplorerConfigHelper.ssl_enabled?(),
-  queue_target: queue_target
+config :explorer,
+       Explorer.Repo.Account,
+       [
+         url: account_db_url,
+         pool_size: ConfigHelper.parse_integer_env_var("ACCOUNT_POOL_SIZE", 50),
+         queue_target: queue_target
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(account_db_url))
+
+mud_db_url = ExplorerConfigHelper.get_mud_db_url()
 
 # Configures Mud database
-config :explorer, Explorer.Repo.Mud,
-  url: ExplorerConfigHelper.get_mud_db_url(),
-  pool_size: ConfigHelper.parse_integer_env_var("MUD_POOL_SIZE", 50),
-  ssl: ExplorerConfigHelper.ssl_enabled?(),
-  queue_target: queue_target
+config :explorer,
+       Explorer.Repo.Mud,
+       [
+         url: mud_db_url,
+         pool_size: ConfigHelper.parse_integer_env_var("MUD_POOL_SIZE", 50),
+         queue_target: queue_target
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(mud_db_url))
+
+suave_db_url = ExplorerConfigHelper.get_suave_db_url()
 
 # Configures Suave database
-config :explorer, Explorer.Repo.Suave,
-  url: ExplorerConfigHelper.get_suave_db_url(),
-  pool_size: 1,
-  ssl: ExplorerConfigHelper.ssl_enabled?()
+config :explorer,
+       Explorer.Repo.Suave,
+       [
+         url: suave_db_url,
+         pool_size: 1
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(suave_db_url))
 
-config :explorer, Explorer.Repo.EventNotifications,
-  url: ExplorerConfigHelper.get_event_notification_db_url(),
-  pool_size: ConfigHelper.parse_integer_env_var("DATABASE_EVENT_POOL_SIZE", 10),
-  ssl: ExplorerConfigHelper.ssl_enabled?(),
-  queue_target: queue_target
+event_notification_db_url = ExplorerConfigHelper.get_event_notification_db_url()
+
+config :explorer,
+       Explorer.Repo.EventNotifications,
+       [
+         url: event_notification_db_url,
+         pool_size: ConfigHelper.parse_integer_env_var("DATABASE_EVENT_POOL_SIZE", 10),
+         queue_target: queue_target
+       ]
+       |> Keyword.merge(ExplorerConfigHelper.ssl_options(event_notification_db_url))
 
 # Actually the following repos are not started, and its pool size remains
 # unused. Separating repos for different chain type or feature flag is
@@ -105,10 +134,13 @@ for repo <- [
       Explorer.Repo.ZkSync,
       Explorer.Repo.Neon
     ] do
-  config :explorer, repo,
-    url: ConfigHelper.parse_url_env_var("DATABASE_URL"),
-    pool_size: 1,
-    ssl: ExplorerConfigHelper.ssl_enabled?()
+  config :explorer,
+         repo,
+         [
+           url: database_url,
+           pool_size: 1
+         ]
+         |> Keyword.merge(ExplorerConfigHelper.ssl_options(database_url))
 end
 
 variant = Variant.get()

--- a/cspell.json
+++ b/cspell.json
@@ -635,6 +635,7 @@
         "spex",
         "splitted",
         "srcset",
+        "sslmode",
         "stabletoken",
         "staker",
         "stakers",

--- a/cspell.json
+++ b/cspell.json
@@ -645,6 +645,7 @@
         "spex",
         "splitted",
         "srcset",
+        "sslmode",
         "stabletoken",
         "staker",
         "stakers",

--- a/docker-compose/envs/common-blockscout.env
+++ b/docker-compose/envs/common-blockscout.env
@@ -97,7 +97,8 @@ DISABLE_MARKET=true
 # MARKET_HISTORY_FIRST_FETCH_DAY_COUNT=
 POOL_SIZE=80
 POOL_SIZE_API=10
-ECTO_USE_SSL=false
+# Supported values: disable, allow, prefer, require, verify-ca, verify-full
+ECTO_SSL_MODE=disable
 # DATADOG_HOST=
 # DATADOG_PORT=
 # SPANDEX_BATCH_SIZE=

--- a/docker-compose/envs/common-blockscout.env
+++ b/docker-compose/envs/common-blockscout.env
@@ -99,7 +99,8 @@ DISABLE_MARKET=true
 # MARKET_HISTORY_FIRST_FETCH_DAY_COUNT=
 POOL_SIZE=80
 POOL_SIZE_API=10
-ECTO_USE_SSL=false
+# Supported values: disable, allow, prefer, require, verify-ca, verify-full
+ECTO_SSL_MODE=disable
 # DATADOG_HOST=
 # DATADOG_PORT=
 # SPANDEX_BATCH_SIZE=


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8818

## Motivation

Replace the boolean ECTO_USE_SSL toggle with a flexible ECTO_SSL_MODE configuration that supports all PostgreSQL SSL modes and allows maintainers to choose the required transport and verification level per deployment.

## Changelog

### Enhancements

- Added ECTO_SSL_MODE parsing and validation in Explorer repo config helper.
- Added support for all six SSL modes: disable, allow, prefer, require, verify-ca, verify-full.
- Added precedence rules for SSL mode resolution:
  - ECTO_SSL_MODE environment variable has highest priority.
  - DATABASE_URL sslmode query parameter is used as fallback.
  - Default mode is require when neither is set.
- Added SSL option mapping helper used by runtime repo configuration.
- Updated production runtime DB repo config to use mode-based SSL options for all Explorer repos.
- Added tests for:
  - defaulting behavior
  - env over URL precedence
  - invalid value validation
  - mapping for all six SSL modes
- Updated deployment and local env templates to use ECTO_SSL_MODE.

### Bug Fixes

- Removed static production ssl_opts defaults that could override dynamic SSL mode behavior and reduce flexibility.

### Incompatible Changes

- Renamed environment variable ECTO_USE_SSL to ECTO_SSL_MODE.
- ECTO_USE_SSL is no longer supported as a fallback.
- SSL configuration now expects one of the six explicit SSL mode values.

## Upgrading

- Replace ECTO_USE_SSL in your environment with ECTO_SSL_MODE.
- Use one of the supported values:
  - disable
  - allow
  - prefer
  - require
  - verify-ca
  - verify-full
- If no value is set, behavior defaults to require.
- If both ECTO_SSL_MODE and DATABASE_URL sslmode are set, ECTO_SSL_MODE takes precedence.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master. https://github.com/blockscout/docs/pull/107
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced granular SSL/TLS modes for DB connections: disable, allow, prefer, require, verify-ca, verify-full.

* **Configuration**
  * Replaced boolean env var with string-based ECTO_SSL_MODE; per-repo runtime config now derives SSL options from the selected mode and removed the prior global TLS-verification bypass.

* **Tests**
  * Added tests for SSL mode resolution and the resulting SSL option mappings.

* **Documentation**
  * Added sslmode to spelling allowlist and updated example env files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14200)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->