### PR TITLE
perf: Optimize token1155tx API v1 endpoint

### DIFF
--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -662,17 +662,17 @@ defmodule Explorer.Etherscan do
         {^options.order_by_direction, tt.log_index}
       ])
 
-    from(t in {"base", TokenTransfer})
+    from(tt in {"base", TokenTransfer})
     |> with_cte("base", as: ^base_query, materialized: true)
     |> join(
       :inner,
-      [t],
+      [tt],
       unnest in fragment(
         "LATERAL (SELECT unnest(?) AS token_id, unnest(COALESCE(?, ARRAY[?])) AS amount, GENERATE_SERIES(0, COALESCE(ARRAY_LENGTH(?, 1), 0) - 1) AS index_in_batch)",
-        t.token_ids,
-        t.amounts,
-        t.amount,
-        t.amounts
+        tt.token_ids,
+        tt.amounts,
+        tt.amount,
+        tt.amounts
       ),
       as: :unnest,
       on: true
@@ -682,9 +682,9 @@ defmodule Explorer.Etherscan do
       amount: fragment("?::numeric", unnest.amount),
       index_in_batch: fragment("?::integer", unnest.index_in_batch)
     })
-    |> order_by([t, unnest: unnest], [
-      {^options.order_by_direction, t.block_number},
-      {^options.order_by_direction, t.log_index},
+    |> order_by([tt, unnest: unnest], [
+      {^options.order_by_direction, tt.block_number},
+      {^options.order_by_direction, tt.log_index},
       {^options.order_by_direction, unnest.index_in_batch}
     ])
     |> limit(^options.page_size)

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -650,17 +650,29 @@ defmodule Explorer.Etherscan do
   end
 
   defp list_erc1155_token_transfers(address_hash, contract_address_hash, options) do
-    "ERC-1155"
-    |> base_token_transfers_query(address_hash, contract_address_hash, options)
+    base_query =
+      TokenTransfer.only_consensus_transfers_query()
+      |> TokenTransfer.maybe_filter_by_token_type("ERC-1155")
+      |> where_contract_address_match(contract_address_hash)
+      |> where_address_match_token_transfer(address_hash)
+      |> where_start_block_match_tt(options)
+      |> where_end_block_match_tt(options)
+      |> order_by([tt], [
+        {^options.order_by_direction, tt.block_number},
+        {^options.order_by_direction, tt.log_index}
+      ])
+
+    from(t in {"base", TokenTransfer})
+    |> with_cte("base", as: ^base_query, materialized: true)
     |> join(
       :inner,
-      [token_transfer],
+      [t],
       unnest in fragment(
-        "LATERAL (SELECT unnest(?) AS token_id, unnest(COALESCE(?, ARRAY[?])) AS amount, GENERATE_SERIES(0, COALESCE(ARRAY_LENGTH(?, 1), 0) - 1) as index_in_batch)",
-        token_transfer.token_ids,
-        token_transfer.amounts,
-        token_transfer.amount,
-        token_transfer.amounts
+        "LATERAL (SELECT unnest(?) AS token_id, unnest(COALESCE(?, ARRAY[?])) AS amount, GENERATE_SERIES(0, COALESCE(ARRAY_LENGTH(?, 1), 0) - 1) AS index_in_batch)",
+        t.token_ids,
+        t.amounts,
+        t.amount,
+        t.amounts
       ),
       as: :unnest,
       on: true
@@ -670,10 +682,14 @@ defmodule Explorer.Etherscan do
       amount: fragment("?::numeric", unnest.amount),
       index_in_batch: fragment("?::integer", unnest.index_in_batch)
     })
-    |> order_by(
-      [unnest: unnest],
+    |> order_by([t, unnest: unnest], [
+      {^options.order_by_direction, t.block_number},
+      {^options.order_by_direction, t.log_index},
       {^options.order_by_direction, unnest.index_in_batch}
-    )
+    ])
+    |> limit(^options.page_size)
+    |> offset(^options_to_offset(options))
+    |> maybe_preload_entities()
     |> Repo.replica().all()
   end
 


### PR DESCRIPTION
Closes #14184

## Changelog
- rewrite query with a materialized cte
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved ERC‑1155 token transfer retrieval: more reliable ordering, consistent pagination, and preloading for faster, more accurate results when viewing transfer lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->