### PR TITLE
fix: handle partial errors in ContractCode fetch_codes

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -196,7 +196,16 @@ defmodule Indexer.Fetcher.ContractCode do
         {:ok, code_addresses_params}
 
       {:ok, %{params_list: params, errors: errors}} ->
-        unique_errors = errors |> Enum.map(& &1.message) |> Enum.uniq()
+        unique_errors =
+          errors
+          |> Enum.map(fn
+            %{message: message} ->
+              message
+
+            error ->
+              inspect(error)
+          end)
+          |> Enum.uniq()
 
         Logger.error(fn -> ["failed to fetch some contract codes: ", inspect(unique_errors)] end)
 

--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -195,6 +195,14 @@ defmodule Indexer.Fetcher.ContractCode do
         code_addresses_params = Addresses.extract_addresses(%{codes: params})
         {:ok, code_addresses_params}
 
+      {:ok, %{params_list: params, errors: errors}} ->
+        unique_errors = errors |> Enum.map(& &1.message) |> Enum.uniq()
+
+        Logger.error(fn -> ["failed to fetch some contract codes: ", inspect(unique_errors)] end)
+
+        code_addresses_params = Addresses.extract_addresses(%{codes: params})
+        {:ok, code_addresses_params}
+
       error ->
         error
     end


### PR DESCRIPTION
## Motivation

`EthereumJSONRPC.fetch_codes/2` can return a `{:ok, %FetchedCodes{params_list: [], errors: [...]}}` response when the node rejects batch requests with an error like "Batch of more than 3 requests are not allowed on free tier". The previous `case` clause in `fetch_contract_codes/2` only matched `errors: []` and fell through to the catch-all `error ->` clause, which passed the raw `%FetchedCodes{}` struct back as a success value. This caused an `ArgumentError` crash in `:erlang.++` when the struct was later concatenated with a list in `run/2`.

Related log error:
`
{"message":"Task #PID<0.70060101.0> started from Indexer.Fetcher.ContractCode terminating\n** (ArgumentError) argument error\n    :erlang.++(%EthereumJSONRPC.FetchedCodes{params_list: [], errors: [%{code: 31, data: %{address: \"0x00017fc15d5857403689e23c2dabe4bc7d3ea637\", block_quantity: \"0x8E0996\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x00018396d3e94f4cfa2e9add9052c1245d10b69b\", block_quantity: \"0x8BF51A\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x000185d6c4506831cfb5225c6efac49f155f596d\", block_quantity: \"0x4240DB\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x000187e9c14d8d0d074237372443f7df5dd42ced\", block_quantity: \"0x98F3A4\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x00018d8ccb232c09fa84a35f5b538bcde05c1162\", block_quantity: \"0x82B2DB\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x00019170d8d0163c1199d11f46531476ed52acc4\", block_quantity: \"0x891E1F\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x000198623e4501b6213e668a43aebc801e109bc0\", block_quantity: \"0x8BB5A4\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x00019cffad93399cb680deb3cb044192d488966e\", block_quantity: \"0x84C4B3\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x0001a63adb1ab2af87d432dce2fbc018553ce5dd\", block_quantity: \"0x9875A1\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}, %{code: 31, data: %{address: \"0x0001a9fe3bcf0354c72fd6bc975069e13f815b19\", block_quantity: \"0x5CB16B\"}, message: \"Batch of more than 3 requests are not allowed on free tier, to use this feature register paid account at drpc.org\"}]}, [%{hash: \"0x00017fc15d5857403689e23c2dabe4bc7d3ea637\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 9308566}, %{hash: \"0x00018396d3e94f4cfa2e9add9052c1245d10b69b\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 9172250}, %{hash: \"0x000185d6c4506831cfb5225c6efac49f155f596d\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 4341979}, %{hash: \"0x000187e9c14d8d0d074237372443f7df5dd42ced\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 10023844}, %{hash: \"0x00018d8ccb232c09fa84a35f5b538bcde05c1162\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 8565467}, %{hash: \"0x00019170d8d0163c1199d11f46531476ed52acc4\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 8986143}, %{hash: \"0x000198623e4501b6213e668a43aebc801e109bc0\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 9156004}, %{hash: \"0x00019cffad93399cb680deb3cb044192d488966e\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 8701107}, %{hash: \"0x0001a63adb1ab2af87d432dce2fbc018553ce5dd\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 9991585}, %{hash: \"0x0001a9fe3bcf0354c72fd6bc975069e13f815b19\", fetched_coin_balance: 0, fetched_coin_balance_block_number: 6074731}])\n    (indexer 11.0.0) lib/indexer/fetcher/contract_code.ex:164: Indexer.Fetcher.ContractCode.run/2\n    (elixir 1.19.4) lib/task/supervised.ex:105: Task.Supervised.invoke_mfa/2\n    (elixir 1.19.4) lib/task/supervised.ex:40: Task.Supervised.reply/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [fetcher: :code], callback_module: Indexer.Fetcher.ContractCode, batch: [%Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<61, 152, 176, 86, 228, 148, 227, 161, 4, 25, 179, 38, 244, 98, 110, 218, 9, 105, 141, 40, 189, 46, 137, 156, 137, 166, 43, 222, 233, 253, 130, 67>>}, block_number: 9308566, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: :ok, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 2, has_error_in_internal_transactions: nil, fhe_operations_count: nil, has_token_transfers: nil, internal_transactions: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, created_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<0, 1, 127, 193, 93, 88, 87, 64, 54, 137, 226, 60, 45, 171, ...>>}, ...}, ...], ...}]","time":"2026-04-09T05:30:01.458Z","metadata":{"fetcher":"code"},"severity":"error"}
`

## Changelog

### Bug Fixes

- `Indexer.Fetcher.ContractCode`: handle `{:ok, %FetchedCodes{errors: [_ | _]}}` responses from `fetch_codes/2`. Previously this case fell through to the `error ->` clause and returned the raw struct, causing a crash in `run/2` when it was used in a list concatenation (`++`). Now, partial successes are handled gracefully: the available `params_list` is processed normally and the deduplicated error messages are logged.

### Incompatible Changes

_None._

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved contract code indexing to handle partial failures gracefully by logging encountered errors and continuing to extract available contract addresses instead of treating incomplete responses as total failures.
  * Deduplicated and surfaced error messages for clearer diagnostics while preserving successful data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->