### PR TITLE
feat: add pending status to v2 internal transaction APIs

### DIFF
--- a/.agents/skills/alphabetically-ordered-aliases/SKILL.md
+++ b/.agents/skills/alphabetically-ordered-aliases/SKILL.md
@@ -13,6 +13,8 @@ Elixir code style conventions prefer that module aliases are alphabetically orde
 - When organizing module aliases at the top of a file
 - When multiple aliases from related modules are defined together
 - When refactoring code to improve consistency and readability
+- When adding a new alias into an existing `alias ...{...}` grouped block
+- When touching files that already have `Credo.Check.Readability.AliasOrder` warnings
 
 ## Anti-Patterns (Avoid These)
 
@@ -75,6 +77,15 @@ For modules with the same prefix like:
 
 Sort by the last component: `Create...` < `Drop...` < `Helper`
 
+For grouped aliases like:
+
+```elixir
+alias BlockScoutWeb.API.V2.{ApiView, Helper, InternalTransactionView, TokenView}
+```
+
+sort entries exactly as Credo expects by module name order within the group.
+When two names share a long prefix (for example `InternalTransaction...`), compare the next character and keep strict lexical order.
+
 ### Step 3: Reorder in code
 
 Rearrange the alias statements to match the alphabetical order determined in Step 2.
@@ -86,6 +97,26 @@ Run Credo to ensure no warnings remain:
 ```bash
 mix credo --strict
 ```
+
+If you changed only a few files, prefer targeted checks first:
+
+```bash
+mix credo --strict --files path/to/file1.ex,path/to/file2.ex
+```
+
+## Trigger Cues
+
+- Credo output includes: `The alias ... is not alphabetically ordered among its group`
+- A diff adds/reorders aliases near module top
+- A grouped alias block contains names that are visually close (`InternalTransaction...` vs `InternalTransactions...`)
+
+## Reliable Checklist
+
+1. Re-read every alias group in the touched file after edits.
+2. Re-sort grouped aliases (inside `{...}`) and standalone aliases.
+3. Ensure new aliases are inserted in-place, not appended.
+4. Run `mix format` after edits.
+5. Run Credo (targeted or full) and confirm no alias-order warnings remain.
 
 ## Example Violations and Fixes
 

--- a/.agents/skills/elixir-clause-grouping/SKILL.md
+++ b/.agents/skills/elixir-clause-grouping/SKILL.md
@@ -7,6 +7,8 @@ description: Use when refactoring Elixir multi-clause functions, extracting help
 
 In Elixir modules, all clauses of the same function should stay together. Inserting a `defp` helper between clauses of a `def` or `defp` makes the function harder to read and can trigger Credo readability warnings. When shared logic needs to be extracted, keep the original clause group contiguous and place the helper after the full group.
 
+This also applies to Phoenix view modules that define many `render/2` clauses with different templates: all `render/2` clauses still belong to the same function and must be contiguous.
+
 ## When to Use
 
 - When refactoring a multi-clause `def` or `defp`
@@ -14,12 +16,17 @@ In Elixir modules, all clauses of the same function should stay together. Insert
 - When addressing Credo warnings about clause grouping or readability
 - When editing controller, view, or context modules with several clauses of the same function
 - During review when a helper was added in the middle of another function's clauses
+- When editing Phoenix `render/2` clauses and introducing helper functions nearby
+- When adding any `defp` between two definitions that share the same function name/arity
+- When you see compiler output like: `clauses with the same name and arity ... should be grouped together`
 
 ## Core Rule
 
 - Keep all clauses of the same function contiguous
 - Do not place `defp` helpers between clauses of another function
 - Extract shared logic into a helper placed after the full clause group
+- Before finishing edits, scan up/down around each new helper and verify no same-name/same-arity clauses are split
+- In view modules, keep all `render/2` clauses contiguous even if clause heads match different template strings
 
 ## Anti-Pattern
 
@@ -58,6 +65,14 @@ end
 3. Extract shared logic only after the full clause group.
 4. Re-check that no unrelated `def` or `defp` appears inside the group.
 5. Run formatting after the refactor.
+6. For Phoenix views, explicitly verify all `render/2` clauses are contiguous (not only clauses for the same template).
+7. If you add a helper used by `render/2`, place it after the last `render/2` clause in the module.
+
+## Trigger Cues
+
+- Compiler warning: `clauses with the same name and arity ... should be grouped together`
+- Credo warning about grouping/splitting function clauses
+- A diff that inserts `defp` between two `def render(` declarations
 
 ## Notes
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -44,6 +44,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     BlockView,
     Ethereum.DepositController,
     Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper,
     TransactionView,
     WithdrawalView
   }
@@ -596,6 +597,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         {"All internal transactions for the specified address.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "block_number" => 22_530_770,
              "index" => 8,
@@ -641,6 +643,9 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           results_plus_one = address_to_internal_transactions(address_hash, full_options)
           {internal_transactions, next_page} = split_list_by_page(results_plus_one)
 
+          pending_status? =
+            InternalTransactionsPendingStatusHelper.address_internal_transactions_pending?(internal_transactions)
+
           next_page_params =
             next_page |> next_page_params(internal_transactions, params)
 
@@ -649,16 +654,20 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           |> put_view(TransactionView)
           |> render(:internal_transactions, %{
             internal_transactions: internal_transactions |> maybe_preload_ens() |> maybe_preload_metadata(),
-            next_page_params: next_page_params
+            next_page_params: next_page_params,
+            pending_status?: pending_status?
           })
 
         _ ->
+          pending_status? = InternalTransactionsPendingStatusHelper.address_internal_transactions_pending?([])
+
           conn
           |> put_status(200)
           |> put_view(TransactionView)
           |> render(:internal_transactions, %{
             internal_transactions: [],
-            next_page_params: nil
+            next_page_params: nil,
+            pending_status?: pending_status?
           })
       end
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -45,6 +45,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     BlockView,
     Ethereum.DepositController,
     Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper,
     TransactionView,
     WithdrawalView
   }
@@ -616,6 +617,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         {"All internal transactions for the specified address.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "block_number" => 22_530_770,
              "index" => 8,
@@ -662,21 +664,28 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           {internal_transactions, next_page_params} =
             paginate_list(results_plus_one, params, full_options[:paging_options])
 
+          pending_status? =
+            InternalTransactionsPendingStatusHelper.address_internal_transactions_pending?(internal_transactions)
+
           conn
           |> put_status(200)
           |> put_view(TransactionView)
           |> render(:internal_transactions, %{
             internal_transactions: internal_transactions |> maybe_preload_ens() |> maybe_preload_metadata(),
-            next_page_params: next_page_params
+            next_page_params: next_page_params,
+            pending_status?: pending_status?
           })
 
         _ ->
+          pending_status? = InternalTransactionsPendingStatusHelper.address_internal_transactions_pending?([])
+
           conn
           |> put_status(200)
           |> put_view(TransactionView)
           |> render(:internal_transactions, %{
             internal_transactions: [],
-            next_page_params: nil
+            next_page_params: nil,
+            pending_status?: pending_status?
           })
       end
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -34,6 +34,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias BlockScoutWeb.API.V2.{
     Ethereum.DepositController,
     Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper,
     TransactionView,
     WithdrawalView
   }
@@ -427,6 +428,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         {"Internal transactions in the specified block.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "transaction_index" => 3,
              "index" => 8,
@@ -461,6 +463,12 @@ defmodule BlockScoutWeb.API.V2.BlockController do
 
       {internal_transactions, next_page} = split_list_by_page(internal_transactions_plus_one)
 
+      pending_status? =
+        InternalTransactionsPendingStatusHelper.block_internal_transactions_pending?(
+          internal_transactions,
+          block.number
+        )
+
       next_page_params =
         next_page
         |> next_page_params(
@@ -476,7 +484,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions,
         next_page_params: next_page_params,
-        block: block
+        block: block,
+        pending_status?: pending_status?
       })
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -36,6 +36,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   alias BlockScoutWeb.API.V2.{
     Ethereum.DepositController,
     Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper,
     TransactionView,
     WithdrawalView
   }
@@ -425,6 +426,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         {"Internal transactions in the specified block.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "transaction_index" => 3,
              "index" => 8
@@ -461,13 +463,20 @@ defmodule BlockScoutWeb.API.V2.BlockController do
           paging_function: &InternalTransaction.internal_transaction_to_block_paging_options/1
         )
 
+      pending_status? =
+        InternalTransactionsPendingStatusHelper.block_internal_transactions_pending?(
+          internal_transactions,
+          block.number
+        )
+
       conn
       |> put_status(200)
       |> put_view(TransactionView)
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions,
         next_page_params: next_page_params,
-        block: block
+        block: block,
+        pending_status?: pending_status?
       })
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -4,6 +4,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
 
   alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.{Chain, PagingOptions}
+  alias Explorer.Chain.PendingOperationsHelper
 
   alias Explorer.Chain.Cache.BackgroundMigrations
 
@@ -70,7 +71,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       {internal_transactions, next_page} = result
 
       pending_status? =
-        InternalTransactionsPendingStatusHelper.internal_transactions_pending?(internal_transactions, transaction_hash)
+        pending_status?(internal_transactions, transaction_hash)
 
       next_page_params =
         next_page |> next_page_params(internal_transactions, params)
@@ -89,8 +90,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   end
 
   defp empty_response(conn, transaction_hash) do
-    pending_status? =
-      InternalTransactionsPendingStatusHelper.internal_transactions_pending?([], transaction_hash)
+    pending_status? = pending_status?([], transaction_hash)
 
     conn
     |> put_status(200)
@@ -122,5 +122,11 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       nil -> nil
       :error -> :invalid
     end
+  end
+
+  defp pending_status?([], nil), do: PendingOperationsHelper.any_pending_operations?()
+
+  defp pending_status?(internal_transactions, transaction_hash) do
+    InternalTransactionsPendingStatusHelper.internal_transactions_pending?(internal_transactions, transaction_hash)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   use BlockScoutWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.{Chain, PagingOptions}
 
   alias Explorer.Chain.Cache.BackgroundMigrations
@@ -37,6 +38,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
         {"List of internal transactions with pagination information.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "index" => 50,
              "transaction_index" => 68,
@@ -66,6 +68,9 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
 
       {internal_transactions, next_page} = result
 
+      pending_status? =
+        InternalTransactionsPendingStatusHelper.internal_transactions_pending?(internal_transactions, transaction_hash)
+
       next_page_params =
         next_page |> next_page_params(internal_transactions, params)
 
@@ -73,20 +78,25 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       |> put_status(200)
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions,
-        next_page_params: next_page_params
+        next_page_params: next_page_params,
+        pending_status?: pending_status?
       })
     else
       _ ->
-        empty_response(conn)
+        empty_response(conn, nil)
     end
   end
 
-  defp empty_response(conn) do
+  defp empty_response(conn, transaction_hash) do
+    pending_status? =
+      InternalTransactionsPendingStatusHelper.internal_transactions_pending?([], transaction_hash)
+
     conn
     |> put_status(200)
     |> render(:internal_transactions, %{
       internal_transactions: [],
-      next_page_params: nil
+      next_page_params: nil,
+      pending_status?: pending_status?
     })
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -54,9 +54,10 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   """
   @spec internal_transactions(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def internal_transactions(conn, params) do
+    transaction_hash = transaction_hash_from_params(params)
+
     with true <-
            BackgroundMigrations.get_heavy_indexes_create_internal_transactions_block_number_desc_transaction_index_desc_index_desc_index_finished(),
-         transaction_hash = transaction_hash_from_params(params),
          false <- transaction_hash == :invalid do
       paging_options = paging_options(params)
       options = options(paging_options, %{transaction_hash: transaction_hash, limit: params[:limit]})
@@ -83,7 +84,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       })
     else
       _ ->
-        empty_response(conn, nil)
+        empty_response(conn, if(transaction_hash == :invalid, do: nil, else: transaction_hash))
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -3,7 +3,9 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   use BlockScoutWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.Chain
+  alias Explorer.Chain.PendingOperationsHelper
 
   alias Explorer.Chain.Cache.BackgroundMigrations
 
@@ -35,6 +37,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
         {"List of internal transactions with pagination information.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "index" => 50,
              "transaction_index" => 68,
@@ -49,9 +52,10 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
   """
   @spec internal_transactions(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def internal_transactions(conn, params) do
+    transaction_hash = transaction_hash_from_params(params)
+
     with true <-
            BackgroundMigrations.get_heavy_indexes_create_internal_transactions_block_number_desc_transaction_index_desc_index_desc_index_finished(),
-         transaction_hash = transaction_hash_from_params(params),
          false <- transaction_hash == :invalid do
       paging_options = paging_options(params)
       options = options(paging_options, %{transaction_hash: transaction_hash, limit: params[:limit]})
@@ -61,24 +65,31 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
         |> fetch_internal_transactions()
         |> paginate_list(params, options[:paging_options])
 
+      pending_status? =
+        pending_status?(internal_transactions, transaction_hash)
+
       conn
       |> put_status(200)
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions,
-        next_page_params: next_page_params
+        next_page_params: next_page_params,
+        pending_status?: pending_status?
       })
     else
       _ ->
-        empty_response(conn)
+        empty_response(conn, if(transaction_hash == :invalid, do: nil, else: transaction_hash))
     end
   end
 
-  defp empty_response(conn) do
+  defp empty_response(conn, transaction_hash) do
+    pending_status? = pending_status?([], transaction_hash)
+
     conn
     |> put_status(200)
     |> render(:internal_transactions, %{
       internal_transactions: [],
-      next_page_params: nil
+      next_page_params: nil,
+      pending_status?: pending_status?
     })
   end
 
@@ -97,5 +108,11 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       nil -> nil
       :error -> :invalid
     end
+  end
+
+  defp pending_status?([], nil), do: PendingOperationsHelper.any_pending_operations?()
+
+  defp pending_status?(internal_transactions, transaction_hash) do
+    InternalTransactionsPendingStatusHelper.internal_transactions_pending?(internal_transactions, transaction_hash)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -5,7 +5,6 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
 
   alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.Chain
-  alias Explorer.Chain.PendingOperationsHelper
 
   alias Explorer.Chain.Cache.BackgroundMigrations
 
@@ -109,8 +108,6 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       :error -> :invalid
     end
   end
-
-  defp pending_status?([], nil), do: PendingOperationsHelper.any_pending_operations?()
 
   defp pending_status?(internal_transactions, transaction_hash) do
     InternalTransactionsPendingStatusHelper.internal_transactions_pending?(internal_transactions, transaction_hash)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -15,9 +15,6 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
 
   @doc """
   Checks whether the global internal-transactions endpoint scope contains pending operations.
-
-  If `internal_transactions` is empty and no explicit `transaction_hash` is provided,
-  it falls back to checking whether any pending internal-transaction processing exists.
   """
   @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
   def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
@@ -31,17 +28,13 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
       |> extract_transaction_hashes()
       |> maybe_prepend_hash(transaction_hash)
 
-    if is_nil(block_range_bounds) and transaction_hashes == [] do
-      PendingOperationsHelper.any_pending_operations?()
-    else
-      {min_block_number, max_block_number} = block_range_bounds || {nil, nil}
+    {min_block_number, max_block_number} = block_range_bounds || {nil, nil}
 
-      PendingOperationsHelper.pending_operations_for_block_range_or_transactions?(
-        min_block_number,
-        max_block_number,
-        transaction_hashes
-      )
-    end
+    PendingOperationsHelper.pending_operations_for_block_range_or_transactions?(
+      min_block_number,
+      max_block_number,
+      transaction_hashes
+    )
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -1,0 +1,114 @@
+defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
+  @moduledoc """
+  Helpers for calculating whether internal-transactions API v2 responses should
+  include the pending-processing status metadata.
+  """
+
+  alias Explorer.Chain.PendingOperationsHelper
+
+  @pending_message "Some internal transactions within this block range have not yet been processed"
+
+  @doc """
+  Returns the standard message used when internal transactions are still pending processing.
+  """
+  def pending_message, do: @pending_message
+
+  @doc """
+  Checks whether the global internal-transactions endpoint scope contains pending operations.
+  """
+  @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
+  def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
+    block_range_bounds =
+      internal_transactions
+      |> extract_block_numbers()
+      |> expand_block_range()
+
+    transaction_hashes =
+      internal_transactions
+      |> extract_transaction_hashes()
+      |> maybe_prepend_hash(transaction_hash)
+
+    {min_block_number, max_block_number} = block_range_bounds || {nil, nil}
+
+    PendingOperationsHelper.pending_operations_for_block_range_or_transactions?(
+      min_block_number,
+      max_block_number,
+      transaction_hashes
+    )
+  end
+
+  @doc """
+  Checks whether the address internal-transactions endpoint scope contains pending operations.
+  """
+  @spec address_internal_transactions_pending?(list()) :: boolean()
+  def address_internal_transactions_pending?(internal_transactions) do
+    internal_transactions_pending?(internal_transactions)
+  end
+
+  @doc """
+  Checks whether the block internal-transactions endpoint scope contains pending operations.
+
+  It verifies both pending block operations for the block number itself and pending
+  transaction operations associated with that block.
+  """
+  @spec block_internal_transactions_pending?(list(), non_neg_integer()) :: boolean()
+  def block_internal_transactions_pending?(internal_transactions, block_number) do
+    transaction_hashes = extract_transaction_hashes(internal_transactions)
+
+    PendingOperationsHelper.pending_operations_for_blocks_or_transactions?([block_number], transaction_hashes) ||
+      PendingOperationsHelper.transactions_pending_in_block_range?(block_number, block_number)
+  end
+
+  @doc """
+  Checks whether the transaction internal-transactions endpoint scope contains pending operations.
+
+  The check includes the requested transaction hash and block number together with
+  hashes and block numbers extracted from the returned internal transactions.
+  """
+  @spec transaction_internal_transactions_pending?(list(), any(), non_neg_integer() | nil) :: boolean()
+  def transaction_internal_transactions_pending?(internal_transactions, transaction_hash, block_number) do
+    transaction_hashes =
+      internal_transactions
+      |> extract_transaction_hashes()
+      |> maybe_prepend_hash(transaction_hash)
+
+    block_numbers =
+      internal_transactions
+      |> extract_block_numbers()
+      |> maybe_prepend_block_number(block_number)
+
+    PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes)
+  end
+
+  defp maybe_prepend_hash(transaction_hashes, nil), do: transaction_hashes
+
+  defp maybe_prepend_hash(transaction_hashes, transaction_hash) do
+    [transaction_hash | transaction_hashes] |> Enum.uniq()
+  end
+
+  defp maybe_prepend_block_number(block_numbers, nil), do: block_numbers
+
+  defp maybe_prepend_block_number(block_numbers, block_number) do
+    [block_number | block_numbers] |> Enum.uniq()
+  end
+
+  defp extract_block_numbers(internal_transactions) do
+    internal_transactions
+    |> Enum.map(& &1.block_number)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp extract_transaction_hashes(internal_transactions) do
+    internal_transactions
+    |> Enum.map(& &1.transaction_hash)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp expand_block_range([]), do: nil
+
+  defp expand_block_range(block_numbers) do
+    Enum.min_max(block_numbers)
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -21,7 +21,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
   """
   @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
   def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
-    block_range =
+    block_range_bounds =
       internal_transactions
       |> extract_block_numbers()
       |> expand_block_range()
@@ -31,10 +31,16 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
       |> extract_transaction_hashes()
       |> maybe_prepend_hash(transaction_hash)
 
-    if block_range == [] and transaction_hashes == [] do
+    if is_nil(block_range_bounds) and transaction_hashes == [] do
       PendingOperationsHelper.any_pending_operations?()
     else
-      PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_range, transaction_hashes)
+      {min_block_number, max_block_number} = block_range_bounds || {nil, nil}
+
+      PendingOperationsHelper.pending_operations_for_block_range_or_transactions?(
+        min_block_number,
+        max_block_number,
+        transaction_hashes
+      )
     end
   end
 
@@ -107,10 +113,9 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
     |> Enum.uniq()
   end
 
-  defp expand_block_range([]), do: []
+  defp expand_block_range([]), do: nil
 
   defp expand_block_range(block_numbers) do
-    {min_block, max_block} = Enum.min_max(block_numbers)
-    Enum.to_list(min_block..max_block)
+    Enum.min_max(block_numbers)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -21,17 +21,20 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
   """
   @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
   def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
-    block_numbers = extract_block_numbers(internal_transactions)
+    block_range =
+      internal_transactions
+      |> extract_block_numbers()
+      |> expand_block_range()
 
     transaction_hashes =
       internal_transactions
       |> extract_transaction_hashes()
       |> maybe_prepend_hash(transaction_hash)
 
-    if block_numbers == [] and transaction_hashes == [] do
+    if block_range == [] and transaction_hashes == [] do
       PendingOperationsHelper.any_pending_operations?()
     else
-      PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes)
+      PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_range, transaction_hashes)
     end
   end
 
@@ -102,5 +105,12 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
     |> Enum.map(& &1.transaction_hash)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
+  end
+
+  defp expand_block_range([]), do: []
+
+  defp expand_block_range(block_numbers) do
+    {min_block, max_block} = Enum.min_max(block_numbers)
+    Enum.to_list(min_block..max_block)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -1,0 +1,106 @@
+defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
+  @moduledoc """
+  Helpers for calculating whether internal-transactions API v2 responses should
+  include the pending-processing status metadata.
+  """
+
+  alias Explorer.Chain.PendingOperationsHelper
+
+  @pending_message "Some internal transactions within this block range have not yet been processed"
+
+  @doc """
+  Returns the standard message used when internal transactions are still pending processing.
+  """
+  def pending_message, do: @pending_message
+
+  @doc """
+  Checks whether the global internal-transactions endpoint scope contains pending operations.
+
+  If `internal_transactions` is empty and no explicit `transaction_hash` is provided,
+  it falls back to checking whether any pending internal-transaction processing exists.
+  """
+  @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
+  def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
+    block_numbers = extract_block_numbers(internal_transactions)
+
+    transaction_hashes =
+      internal_transactions
+      |> extract_transaction_hashes()
+      |> maybe_prepend_hash(transaction_hash)
+
+    if block_numbers == [] and transaction_hashes == [] do
+      PendingOperationsHelper.any_pending_operations?()
+    else
+      PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes)
+    end
+  end
+
+  @doc """
+  Checks whether the address internal-transactions endpoint scope contains pending operations.
+  """
+  @spec address_internal_transactions_pending?(list()) :: boolean()
+  def address_internal_transactions_pending?(internal_transactions) do
+    internal_transactions_pending?(internal_transactions)
+  end
+
+  @doc """
+  Checks whether the block internal-transactions endpoint scope contains pending operations.
+
+  It verifies both pending block operations for the block number itself and pending
+  transaction operations associated with that block.
+  """
+  @spec block_internal_transactions_pending?(list(), non_neg_integer()) :: boolean()
+  def block_internal_transactions_pending?(internal_transactions, block_number) do
+    transaction_hashes = extract_transaction_hashes(internal_transactions)
+
+    PendingOperationsHelper.pending_operations_for_blocks_or_transactions?([block_number], transaction_hashes) ||
+      PendingOperationsHelper.transactions_pending_in_block_range?(block_number, block_number)
+  end
+
+  @doc """
+  Checks whether the transaction internal-transactions endpoint scope contains pending operations.
+
+  The check includes the requested transaction hash and block number together with
+  hashes and block numbers extracted from the returned internal transactions.
+  """
+  @spec transaction_internal_transactions_pending?(list(), any(), non_neg_integer() | nil) :: boolean()
+  def transaction_internal_transactions_pending?(internal_transactions, transaction_hash, block_number) do
+    transaction_hashes =
+      internal_transactions
+      |> extract_transaction_hashes()
+      |> maybe_prepend_hash(transaction_hash)
+
+    block_numbers =
+      internal_transactions
+      |> extract_block_numbers()
+      |> maybe_prepend_block_number(block_number)
+
+    PendingOperationsHelper.pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes)
+  end
+
+  defp maybe_prepend_hash(transaction_hashes, nil), do: transaction_hashes
+
+  defp maybe_prepend_hash(transaction_hashes, transaction_hash) do
+    [transaction_hash | transaction_hashes] |> Enum.uniq()
+  end
+
+  defp maybe_prepend_block_number(block_numbers, nil), do: block_numbers
+
+  defp maybe_prepend_block_number(block_numbers, block_number) do
+    [block_number | block_numbers] |> Enum.uniq()
+  end
+
+  defp extract_block_numbers(internal_transactions) do
+    internal_transactions
+    |> Enum.map(& &1.block_number)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp extract_transaction_hashes(internal_transactions) do
+    internal_transactions
+    |> Enum.map(& &1.transaction_hash)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
   @moduledoc """
   Helpers for calculating whether internal-transactions API v2 responses should
@@ -39,10 +40,20 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
 
   @doc """
   Checks whether the address internal-transactions endpoint scope contains pending operations.
+
+  Only checks block-range pending operations — tx-hash checking is not meaningful here
+  because internal transactions are imported atomically per transaction: if any internal
+  transaction exists for a given tx_hash, all of them are already imported.
   """
   @spec address_internal_transactions_pending?(list()) :: boolean()
   def address_internal_transactions_pending?(internal_transactions) do
-    internal_transactions_pending?(internal_transactions)
+    {min_block_number, max_block_number} =
+      internal_transactions
+      |> extract_block_numbers()
+      |> expand_block_range()
+      |> then(&(&1 || {nil, nil}))
+
+    PendingOperationsHelper.pending_operations_in_block_range?(min_block_number, max_block_number)
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transactions_pending_status_helper.ex
@@ -19,22 +19,21 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
   """
   @spec internal_transactions_pending?(list(), any() | nil) :: boolean()
   def internal_transactions_pending?(internal_transactions, transaction_hash \\ nil) do
-    block_range_bounds =
+    {min_block_number, max_block_number} =
       internal_transactions
       |> extract_block_numbers()
       |> expand_block_range()
+      |> then(&(&1 || {nil, nil}))
 
-    transaction_hashes =
-      internal_transactions
-      |> extract_transaction_hashes()
-      |> maybe_prepend_hash(transaction_hash)
-
-    {min_block_number, max_block_number} = block_range_bounds || {nil, nil}
-
+    # Tx hashes extracted from the fetched page are already within the page's block range, so
+    # they are covered by the block-range PTO check inside
+    # pending_operations_for_block_range_or_transactions?/3.
+    # Only the explicit transaction_hash (which may fall outside the page's range) is passed
+    # separately so it is still checked even when the block range wouldn't cover it.
     PendingOperationsHelper.pending_operations_for_block_range_or_transactions?(
       min_block_number,
       max_block_number,
-      transaction_hashes
+      maybe_prepend_hash([], transaction_hash)
     )
   end
 
@@ -63,11 +62,12 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper do
   transaction operations associated with that block.
   """
   @spec block_internal_transactions_pending?(list(), non_neg_integer()) :: boolean()
-  def block_internal_transactions_pending?(internal_transactions, block_number) do
-    transaction_hashes = extract_transaction_hashes(internal_transactions)
-
-    PendingOperationsHelper.pending_operations_for_blocks_or_transactions?([block_number], transaction_hashes) ||
-      PendingOperationsHelper.transactions_pending_in_block_range?(block_number, block_number)
+  def block_internal_transactions_pending?(_internal_transactions, block_number) do
+    # pending_operations_in_block_range?/2 checks both PBO (block pending) and PTO (any
+    # transaction in that block still pending). Checking tx hashes individually would be
+    # redundant — all fetched internal-tx hashes belong to that block and are already
+    # covered by the PTO block-range check.
+    PendingOperationsHelper.pending_operations_in_block_range?(block_number, block_number)
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -51,7 +51,14 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   require Logger
 
   alias BlockScoutWeb.AccessHelper
-  alias BlockScoutWeb.API.V2.{BlobView, Ethereum.DepositController, Ethereum.DepositView}
+
+  alias BlockScoutWeb.API.V2.{
+    BlobView,
+    Ethereum.DepositController,
+    Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper
+  }
+
   alias BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation, as: TransactionInterpretationService
   alias BlockScoutWeb.Models.TransactionStateHelper
   alias BlockScoutWeb.Schemas.API.V2.ErrorResponses.{ForbiddenResponse, NotFoundResponse}
@@ -722,6 +729,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         {"Internal transactions for the specified transaction, with pagination.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "index" => 50,
              "block_number" => 22_133_247,
@@ -748,6 +756,13 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
       {internal_transactions, next_page} = split_list_by_page(internal_transactions_plus_one)
 
+      pending_status? =
+        InternalTransactionsPendingStatusHelper.transaction_internal_transactions_pending?(
+          internal_transactions,
+          transaction.hash,
+          transaction.block_number
+        )
+
       next_page_params =
         next_page
         |> next_page_params(internal_transactions, params)
@@ -756,7 +771,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       |> put_status(200)
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions |> maybe_preload_ens() |> maybe_preload_metadata(),
-        next_page_params: next_page_params
+        next_page_params: next_page_params,
+        pending_status?: pending_status?
       })
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -51,7 +51,14 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   require Logger
 
   alias BlockScoutWeb.AccessHelper
-  alias BlockScoutWeb.API.V2.{BlobView, Ethereum.DepositController, Ethereum.DepositView}
+
+  alias BlockScoutWeb.API.V2.{
+    BlobView,
+    Ethereum.DepositController,
+    Ethereum.DepositView,
+    InternalTransactionsPendingStatusHelper
+  }
+
   alias BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation, as: TransactionInterpretationService
   alias BlockScoutWeb.Models.TransactionStateHelper
   alias BlockScoutWeb.Schemas.API.V2.ErrorResponses.{ForbiddenResponse, NotFoundResponse}
@@ -705,6 +712,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         {"Internal transactions for the specified transaction, with pagination.", "application/json",
          paginated_response(
            items: Schemas.InternalTransaction,
+           include_pending_status?: true,
            next_page_params_example: %{
              "index" => 50,
              "block_number" => 22_133_247,
@@ -731,11 +739,19 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       {internal_transactions, next_page_params} =
         paginate_list(internal_transactions_plus_one, params, full_options[:paging_options])
 
+      pending_status? =
+        InternalTransactionsPendingStatusHelper.transaction_internal_transactions_pending?(
+          internal_transactions,
+          transaction.hash,
+          transaction.block_number
+        )
+
       conn
       |> put_status(200)
       |> render(:internal_transactions, %{
         internal_transactions: internal_transactions |> maybe_preload_ens() |> maybe_preload_metadata(),
-        next_page_params: next_page_params
+        next_page_params: next_page_params,
+        pending_status?: pending_status?
       })
     end
   end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -1001,17 +1001,30 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   def paginated_response(options) do
     items_schema = Keyword.fetch!(options, :items)
     next_page_params_example = Keyword.fetch!(options, :next_page_params_example)
+    include_pending_status? = Keyword.get(options, :include_pending_status?, false)
+
+    properties = %{
+      items: %Schema{type: :array, items: items_schema, nullable: false},
+      next_page_params: %Schema{
+        type: :object,
+        nullable: true,
+        example: next_page_params_example
+      }
+    }
+
+    properties =
+      if include_pending_status? do
+        Map.merge(properties, %{
+          status: %Schema{type: :integer, enum: [2]},
+          message: %Schema{type: :string}
+        })
+      else
+        properties
+      end
 
     %Schema{
       type: :object,
-      properties: %{
-        items: %Schema{type: :array, items: items_schema, nullable: false},
-        next_page_params: %Schema{
-          type: :object,
-          nullable: true,
-          example: next_page_params_example
-        }
-      },
+      properties: properties,
       required: [:items, :next_page_params],
       nullable: false,
       additionalProperties: false

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -1052,20 +1052,27 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
       }
     }
 
-    properties =
+    {properties, required} =
       if include_pending_status? do
-        Map.merge(properties, %{
-          status: %Schema{type: :integer, enum: [2]},
-          message: %Schema{type: :string}
-        })
+        meta_schema = %Schema{
+          type: :object,
+          nullable: false,
+          properties: %{
+            status: %Schema{type: :integer, enum: [1, 2]},
+            message: %Schema{type: :string, nullable: true}
+          },
+          required: [:status, :message]
+        }
+
+        {Map.put(properties, :meta, meta_schema), [:items, :next_page_params, :meta]}
       else
-        properties
+        {properties, [:items, :next_page_params]}
       end
 
     %Schema{
       type: :object,
       properties: properties,
-      required: [:items, :next_page_params],
+      required: required,
       nullable: false,
       additionalProperties: false
     }

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -1041,17 +1041,30 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   def paginated_response(options) do
     items_schema = Keyword.fetch!(options, :items)
     next_page_params_example = Keyword.fetch!(options, :next_page_params_example)
+    include_pending_status? = Keyword.get(options, :include_pending_status?, false)
+
+    properties = %{
+      items: %Schema{type: :array, items: items_schema, nullable: false},
+      next_page_params: %Schema{
+        type: :object,
+        nullable: true,
+        example: next_page_params_example
+      }
+    }
+
+    properties =
+      if include_pending_status? do
+        Map.merge(properties, %{
+          status: %Schema{type: :integer, enum: [2]},
+          message: %Schema{type: :string}
+        })
+      else
+        properties
+      end
 
     %Schema{
       type: :object,
-      properties: %{
-        items: %Schema{type: :array, items: items_schema, nullable: false},
-        next_page_params: %Schema{
-          type: :object,
-          nullable: true,
-          example: next_page_params_example
-        }
-      },
+      properties: properties,
       required: [:items, :next_page_params],
       nullable: false,
       additionalProperties: false

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
@@ -2,6 +2,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.API.V2.Helper
+  alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.Chain.{Block, InternalTransaction, Wei}
 
   def render("internal_transaction.json", %{internal_transaction: nil}) do
@@ -15,14 +16,18 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
     prepare_internal_transaction(internal_transaction, block)
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &prepare_internal_transaction(&1, &1.block)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   @doc """
@@ -53,5 +58,13 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
       "index" => internal_transaction.index,
       "gas_limit" => internal_transaction.gas || Decimal.new(0)
     }
+  end
+
+  defp maybe_put_pending_status(response, false), do: response
+
+  defp maybe_put_pending_status(response, true) do
+    response
+    |> Map.put("status", 2)
+    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
   use BlockScoutWeb, :view
 
   alias BlockScoutWeb.API.V2.Helper
+  alias BlockScoutWeb.API.V2.InternalTransactionsPendingStatusHelper
   alias Explorer.Chain.{Block, InternalTransaction, Wei}
 
   def render("internal_transaction.json", %{internal_transaction: nil}) do
@@ -16,14 +17,18 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
     prepare_internal_transaction(internal_transaction, block)
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &prepare_internal_transaction(&1, &1.block)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   @doc """
@@ -54,5 +59,13 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
       "index" => internal_transaction.index,
       "gas_limit" => internal_transaction.gas || Decimal.new(0)
     }
+  end
+
+  defp maybe_put_pending_status(response, false), do: response
+
+  defp maybe_put_pending_status(response, true) do
+    response
+    |> Map.put("status", 2)
+    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/internal_transaction_view.ex
@@ -28,7 +28,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
       "items" => Enum.map(internal_transactions, &prepare_internal_transaction(&1, &1.block)),
       "next_page_params" => next_page_params
     }
-    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
+    |> put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   @doc """
@@ -61,11 +61,11 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionView do
     }
   end
 
-  defp maybe_put_pending_status(response, false), do: response
+  defp put_pending_status(response, true) do
+    Map.put(response, "meta", %{"status" => 2, "message" => InternalTransactionsPendingStatusHelper.pending_message()})
+  end
 
-  defp maybe_put_pending_status(response, true) do
-    response
-    |> Map.put("status", 2)
-    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
+  defp put_pending_status(response, _) do
+    Map.put(response, "meta", %{"status" => 1, "message" => nil})
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -6,7 +6,14 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     chain_identity: [:explorer, :chain_identity],
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
-  alias BlockScoutWeb.API.V2.{ApiView, Helper, InternalTransactionView, TokenTransferView, TokenView}
+  alias BlockScoutWeb.API.V2.{
+    ApiView,
+    Helper,
+    InternalTransactionsPendingStatusHelper,
+    InternalTransactionView,
+    TokenTransferView,
+    TokenView
+  }
 
   alias BlockScoutWeb.Models.GetTransactionTags
   alias BlockScoutWeb.{TransactionStateView, TransactionView}
@@ -162,25 +169,33 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     TokenTransferView.prepare_token_transfer(token_transfer, conn, decoded_transaction)
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params,
-        block: block
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params,
+          block: block
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1, block)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   def render("logs.json", %{logs: logs, next_page_params: next_page_params, transaction_hash: transaction_hash}) do
@@ -260,6 +275,14 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "max_depth_hcu" => max_depth_hcu,
       "operation_count" => operation_count
     }
+  end
+
+  defp maybe_put_pending_status(response, false), do: response
+
+  defp maybe_put_pending_status(response, true) do
+    response
+    |> Map.put("status", 2)
+    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -7,7 +7,14 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     chain_identity: [:explorer, :chain_identity],
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
-  alias BlockScoutWeb.API.V2.{ApiView, Helper, InternalTransactionView, TokenTransferView, TokenView}
+  alias BlockScoutWeb.API.V2.{
+    ApiView,
+    Helper,
+    InternalTransactionsPendingStatusHelper,
+    InternalTransactionView,
+    TokenTransferView,
+    TokenView
+  }
 
   alias BlockScoutWeb.Models.GetTransactionTags
   alias BlockScoutWeb.{TransactionStateView, TransactionView}
@@ -163,25 +170,33 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     TokenTransferView.prepare_token_transfer(token_transfer, conn, decoded_transaction)
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params,
-        block: block
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params,
+          block: block
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1, block)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
-  def render("internal_transactions.json", %{
-        internal_transactions: internal_transactions,
-        next_page_params: next_page_params
-      }) do
+  def render(
+        "internal_transactions.json",
+        %{
+          internal_transactions: internal_transactions,
+          next_page_params: next_page_params
+        } = assigns
+      ) do
     %{
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1)),
       "next_page_params" => next_page_params
     }
+    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   def render("logs.json", %{logs: logs, next_page_params: next_page_params, transaction_hash: transaction_hash}) do
@@ -261,6 +276,14 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "max_depth_hcu" => max_depth_hcu,
       "operation_count" => operation_count
     }
+  end
+
+  defp maybe_put_pending_status(response, false), do: response
+
+  defp maybe_put_pending_status(response, true) do
+    response
+    |> Map.put("status", 2)
+    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
   end
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -182,7 +182,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1, block)),
       "next_page_params" => next_page_params
     }
-    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
+    |> put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   def render(
@@ -196,7 +196,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "items" => Enum.map(internal_transactions, &InternalTransactionView.prepare_internal_transaction(&1)),
       "next_page_params" => next_page_params
     }
-    |> maybe_put_pending_status(Map.get(assigns, :pending_status?, false))
+    |> put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
   def render("logs.json", %{logs: logs, next_page_params: next_page_params, transaction_hash: transaction_hash}) do
@@ -278,12 +278,12 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     }
   end
 
-  defp maybe_put_pending_status(response, false), do: response
+  defp put_pending_status(response, true) do
+    Map.put(response, "meta", %{"status" => 2, "message" => InternalTransactionsPendingStatusHelper.pending_message()})
+  end
 
-  defp maybe_put_pending_status(response, true) do
-    response
-    |> Map.put("status", 2)
-    |> Map.put("message", InternalTransactionsPendingStatusHelper.pending_message())
+  defp put_pending_status(response, _) do
+    Map.put(response, "meta", %{"status" => 1, "message" => nil})
   end
 
   @doc """

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2275,7 +2275,11 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       address = insert(:address)
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
-      assert %{"items" => []} = json_response(request, 200)
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
 
       block = insert(:block)
       insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
@@ -2302,8 +2306,16 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         index: 1,
         block_number: transaction.block_number,
         transaction_index: transaction.index,
-        from_address: address
+        from_address: insert(:address)
       )
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
 
       insert(:pending_transaction_operation, transaction_hash: transaction.hash)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2271,6 +2271,49 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(internal_transaction_to, Enum.at(response["items"], 0))
     end
 
+    test "returns pending status when scope includes pending operations", %{conn: conn} do
+      address = insert(:address)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+      assert %{"items" => []} = json_response(request, 200)
+
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status for pending transaction operation", %{conn: conn} do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        from_address: address
+      )
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
     test "returns gas_limit as 0 for selfdestruct without gas", %{conn: conn} do
       address = insert(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2275,6 +2275,61 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(internal_transaction_to, Enum.at(response["items"], 0))
     end
 
+    test "returns pending status when scope includes pending operations", %{conn: conn} do
+      address = insert(:address)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status for pending transaction operation", %{conn: conn} do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        from_address: insert(:address)
+      )
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
     test "returns gas_limit as 0 for selfdestruct without gas", %{conn: conn} do
       address = insert(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2282,8 +2282,8 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      refute Map.has_key?(response, "status")
-      refute Map.has_key?(response, "message")
+      assert response["meta"]["status"] == 1
+      assert is_nil(response["meta"]["message"])
 
       block = insert(:block)
       insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
@@ -2293,8 +2293,10 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "returns pending status for pending transaction operation", %{conn: conn} do
@@ -2318,16 +2320,18 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      refute Map.has_key?(response, "status")
-      refute Map.has_key?(response, "message")
+      assert response["meta"]["status"] == 1
+      assert is_nil(response["meta"]["message"])
 
       insert(:pending_transaction_operation, transaction_hash: transaction.hash)
 
       request = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
 
       assert response = json_response(request, 200)
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "returns gas_limit as 0 for selfdestruct without gas", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -910,6 +910,15 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
     test "returns pending status when block is in pending_block_operations", %{conn: conn} do
       block = insert(:block)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
       insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
       request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
@@ -924,11 +933,22 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
     test "returns pending status when block has pending transaction operations", %{conn: conn} do
       block = insert(:block)
       transaction = insert(:transaction) |> with_block(block)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
       insert(:pending_transaction_operation, transaction_hash: transaction.hash)
 
       request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
 
       assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
       assert response["status"] == 2
       assert response["message"] == "Some internal transactions within this block range have not yet been processed"
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -907,6 +907,31 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
       check_paginated_response(response, response_2nd_page, internal_transactions)
     end
+
+    test "returns pending status when block is in pending_block_operations", %{conn: conn} do
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when block has pending transaction operations", %{conn: conn} do
+      block = insert(:block)
+      transaction = insert(:transaction) |> with_block(block)
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
   end
 
   if @chain_type == :ethereum do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -931,8 +931,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      refute Map.has_key?(response, "status")
-      refute Map.has_key?(response, "message")
+      assert response["meta"]["status"] == 1
+      assert is_nil(response["meta"]["message"])
 
       insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 
@@ -941,8 +941,10 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "returns pending status when block has pending transaction operations", %{conn: conn} do
@@ -954,8 +956,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      refute Map.has_key?(response, "status")
-      refute Map.has_key?(response, "message")
+      assert response["meta"]["status"] == 1
+      assert is_nil(response["meta"]["message"])
 
       insert(:pending_transaction_operation, transaction_hash: transaction.hash)
 
@@ -964,8 +966,10 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -922,6 +922,51 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
       check_paginated_response(response, response_2nd_page, internal_transactions)
     end
+
+    test "returns pending status when block is in pending_block_operations", %{conn: conn} do
+      block = insert(:block)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when block has pending transaction operations", %{conn: conn} do
+      block = insert(:block)
+      transaction = insert(:transaction) |> with_block(block)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      refute Map.has_key?(response, "status")
+      refute Map.has_key?(response, "message")
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
   end
 
   if @chain_type == :ethereum do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
@@ -21,6 +21,38 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
       assert response["next_page_params"] == nil
     end
 
+    test "returns pending status when internal transaction scope is pending", %{conn: conn} do
+      request = get(conn, "/api/v2/internal-transactions")
+      assert %{"items" => []} = json_response(request, 200)
+
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when transaction hash is in pending_transaction_operations", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/internal-transactions", %{"transaction_hash" => to_string(transaction.hash)})
+
+      assert response = json_response(request, 200)
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
     test "non empty list", %{conn: conn} do
       tx =
         :transaction

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
@@ -34,8 +34,10 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "returns pending status when transaction hash is in pending_transaction_operations", %{conn: conn} do
@@ -50,8 +52,10 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
 
       assert response = json_response(request, 200)
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "non empty list", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
@@ -22,6 +22,38 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
       assert response["next_page_params"] == nil
     end
 
+    test "returns pending status when internal transaction scope is pending", %{conn: conn} do
+      request = get(conn, "/api/v2/internal-transactions")
+      assert %{"items" => []} = json_response(request, 200)
+
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      request = get(conn, "/api/v2/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when transaction hash is in pending_transaction_operations", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/internal-transactions", %{"transaction_hash" => to_string(transaction.hash)})
+
+      assert response = json_response(request, 200)
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
     test "non empty list", %{conn: conn} do
       tx =
         :transaction

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -679,6 +679,40 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       check_paginated_response(response, response_2nd_page, internal_transactions)
     end
+
+    test "returns pending status when transaction block is pending", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when transaction is in pending_transaction_operations", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
   end
 
   describe "/transactions/{transaction_hash}/logs" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -739,8 +739,10 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
 
     test "returns pending status when transaction is in pending_transaction_operations", %{conn: conn} do
@@ -756,8 +758,10 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       assert response = json_response(request, 200)
       assert response["items"] == []
       assert response["next_page_params"] == nil
-      assert response["status"] == 2
-      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert response["meta"]["status"] == 2
+
+      assert response["meta"]["message"] ==
+               "Some internal transactions within this block range have not yet been processed"
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -725,6 +725,40 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       check_paginated_response(response, response_2nd_page, internal_transactions)
     end
+
+    test "returns pending status when transaction block is pending", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "returns pending status when transaction is in pending_transaction_operations", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:pending_transaction_operation, transaction_hash: transaction.hash)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
+      assert response["next_page_params"] == nil
+      assert response["status"] == 2
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+    end
   end
 
   describe "/transactions/{transaction_hash}/logs" do

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -189,6 +189,28 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   end
 
   @doc """
+  Generates a query to find pending block operations that match any of the given block numbers.
+  """
+  @spec block_number_in_query([non_neg_integer()]) :: Ecto.Query.t()
+  def block_number_in_query(block_numbers) do
+    from(
+      pending_ops in PendingBlockOperation,
+      where: pending_ops.block_number in ^block_numbers
+    )
+  end
+
+  @doc """
+  Generates a query to find pending transaction operations that match any of the given transaction hashes.
+  """
+  @spec transaction_hash_in_query([Hash.Full.t()]) :: Ecto.Query.t()
+  def transaction_hash_in_query(transaction_hashes) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      where: pending_ops.transaction_hash in ^transaction_hashes
+    )
+  end
+
+  @doc """
   Checks if a block with the given hash is pending.
   A block is considered pending if there exists a corresponding entry in the `PendingBlockOperation` table.
   """
@@ -196,6 +218,30 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   def block_pending?(block_hash) do
     [block_hash]
     |> block_hash_in_query()
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if at least one block number from the provided list is pending.
+  """
+  @spec block_numbers_pending?([non_neg_integer()]) :: boolean()
+  def block_numbers_pending?([]), do: false
+
+  def block_numbers_pending?(block_numbers) do
+    block_numbers
+    |> block_number_in_query()
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if at least one transaction hash from the provided list is pending.
+  """
+  @spec transaction_hashes_pending?([Hash.Full.t()]) :: boolean()
+  def transaction_hashes_pending?([]), do: false
+
+  def transaction_hashes_pending?(transaction_hashes) do
+    transaction_hashes
+    |> transaction_hash_in_query()
     |> Repo.exists?()
   end
 
@@ -228,6 +274,37 @@ defmodule Explorer.Chain.PendingOperationsHelper do
     )
   end
 
+  @spec transaction_block_range_in_query(non_neg_integer() | nil, non_neg_integer() | nil) :: Ecto.Query.t()
+  defp transaction_block_range_in_query(min_block_number, max_block_number)
+       when is_integer(min_block_number) and is_integer(max_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number >= ^min_block_number and t.block_number <= ^max_block_number
+    )
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number)
+       when is_nil(min_block_number) and is_nil(max_block_number) do
+    from(pending_ops in PendingTransactionOperation)
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number) when is_nil(min_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number <= ^max_block_number
+    )
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number) when is_nil(max_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number >= ^min_block_number
+    )
+  end
+
   @doc """
   Checks if there are any pending blocks within the specified range of block numbers.
   A block is considered pending if there exists a corresponding entry in the `PendingBlockOperation`
@@ -238,5 +315,49 @@ defmodule Explorer.Chain.PendingOperationsHelper do
     min_block_number
     |> block_range_in_query(max_block_number)
     |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if there are any pending transactions within the specified block range.
+  """
+  @spec transactions_pending_in_block_range?(non_neg_integer() | nil, non_neg_integer() | nil) :: boolean()
+  def transactions_pending_in_block_range?(min_block_number, max_block_number) do
+    min_block_number
+    |> transaction_block_range_in_query(max_block_number)
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if there are any pending block or transaction operations within the specified block range.
+  """
+  @spec pending_operations_in_block_range?(non_neg_integer() | nil, non_neg_integer() | nil) :: boolean()
+  def pending_operations_in_block_range?(min_block_number, max_block_number) do
+    blocks_pending?(min_block_number, max_block_number) ||
+      transactions_pending_in_block_range?(min_block_number, max_block_number)
+  end
+
+  @doc """
+  Checks if there are any pending block or transaction operations in the system.
+  """
+  @spec any_pending_operations?() :: boolean()
+  def any_pending_operations? do
+    Repo.exists?(PendingBlockOperation) || Repo.exists?(PendingTransactionOperation)
+  end
+
+  @doc """
+  Checks if there are pending operations for any of the provided block numbers or transaction hashes.
+  """
+  @spec pending_operations_for_blocks_or_transactions?([non_neg_integer()], [Hash.Full.t()]) :: boolean()
+  def pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes) do
+    block_numbers_pending?(block_numbers) || transaction_hashes_pending?(transaction_hashes)
+  end
+
+  @doc """
+  Checks if there are pending operations for a single transaction scope.
+  """
+  @spec pending_operations_for_transaction?(Hash.Full.t(), non_neg_integer() | nil) :: boolean()
+  def pending_operations_for_transaction?(transaction_hash, block_number \\ nil) do
+    transaction_hashes_pending?([transaction_hash]) ||
+      if(is_nil(block_number), do: false, else: blocks_pending?(block_number, block_number))
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -353,6 +353,19 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   end
 
   @doc """
+  Checks if there are pending operations in a block-number range or among provided transaction hashes.
+  """
+  @spec pending_operations_for_block_range_or_transactions?(
+          non_neg_integer() | nil,
+          non_neg_integer() | nil,
+          [Hash.Full.t()]
+        ) :: boolean()
+  def pending_operations_for_block_range_or_transactions?(min_block_number, max_block_number, transaction_hashes) do
+    pending_operations_in_block_range?(min_block_number, max_block_number) ||
+      transaction_hashes_pending?(transaction_hashes)
+  end
+
+  @doc """
   Checks if there are pending operations for a single transaction scope.
   """
   @spec pending_operations_for_transaction?(Hash.Full.t(), non_neg_integer() | nil) :: boolean()

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -197,6 +197,28 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   end
 
   @doc """
+  Generates a query to find pending block operations that match any of the given block numbers.
+  """
+  @spec block_number_in_query([non_neg_integer()]) :: Ecto.Query.t()
+  def block_number_in_query(block_numbers) do
+    from(
+      pending_ops in PendingBlockOperation,
+      where: pending_ops.block_number in ^block_numbers
+    )
+  end
+
+  @doc """
+  Generates a query to find pending transaction operations that match any of the given transaction hashes.
+  """
+  @spec transaction_hash_in_query([Hash.Full.t()]) :: Ecto.Query.t()
+  def transaction_hash_in_query(transaction_hashes) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      where: pending_ops.transaction_hash in ^transaction_hashes
+    )
+  end
+
+  @doc """
   Checks if a block with the given hash is pending.
   A block is considered pending if there exists a corresponding entry in the `PendingBlockOperation` table.
   """
@@ -204,6 +226,30 @@ defmodule Explorer.Chain.PendingOperationsHelper do
   def block_pending?(block_hash) do
     [block_hash]
     |> block_hash_in_query()
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if at least one block number from the provided list is pending.
+  """
+  @spec block_numbers_pending?([non_neg_integer()]) :: boolean()
+  def block_numbers_pending?([]), do: false
+
+  def block_numbers_pending?(block_numbers) do
+    block_numbers
+    |> block_number_in_query()
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if at least one transaction hash from the provided list is pending.
+  """
+  @spec transaction_hashes_pending?([Hash.Full.t()]) :: boolean()
+  def transaction_hashes_pending?([]), do: false
+
+  def transaction_hashes_pending?(transaction_hashes) do
+    transaction_hashes
+    |> transaction_hash_in_query()
     |> Repo.exists?()
   end
 
@@ -233,6 +279,37 @@ defmodule Explorer.Chain.PendingOperationsHelper do
     from(
       pending_ops in PendingBlockOperation,
       where: pending_ops.block_number >= ^min_block_number
+    )
+  end
+
+  @spec transaction_block_range_in_query(non_neg_integer() | nil, non_neg_integer() | nil) :: Ecto.Query.t()
+  defp transaction_block_range_in_query(min_block_number, max_block_number)
+       when is_integer(min_block_number) and is_integer(max_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number >= ^min_block_number and t.block_number <= ^max_block_number
+    )
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number)
+       when is_nil(min_block_number) and is_nil(max_block_number) do
+    from(pending_ops in PendingTransactionOperation)
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number) when is_nil(min_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number <= ^max_block_number
+    )
+  end
+
+  defp transaction_block_range_in_query(min_block_number, max_block_number) when is_nil(max_block_number) do
+    from(
+      pending_ops in PendingTransactionOperation,
+      join: t in assoc(pending_ops, :transaction),
+      where: t.block_number >= ^min_block_number
     )
   end
 
@@ -324,5 +401,62 @@ defmodule Explorer.Chain.PendingOperationsHelper do
 
   defp add_priority(params, priority) do
     Enum.map(params, &Map.merge(&1, %{priority: priority}))
+  end
+
+  @doc """
+  Checks if there are any pending transactions within the specified block range.
+  """
+  @spec transactions_pending_in_block_range?(non_neg_integer() | nil, non_neg_integer() | nil) :: boolean()
+  def transactions_pending_in_block_range?(min_block_number, max_block_number) do
+    min_block_number
+    |> transaction_block_range_in_query(max_block_number)
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Checks if there are any pending block or transaction operations within the specified block range.
+  """
+  @spec pending_operations_in_block_range?(non_neg_integer() | nil, non_neg_integer() | nil) :: boolean()
+  def pending_operations_in_block_range?(min_block_number, max_block_number) do
+    blocks_pending?(min_block_number, max_block_number) ||
+      transactions_pending_in_block_range?(min_block_number, max_block_number)
+  end
+
+  @doc """
+  Checks if there are any pending block or transaction operations in the system.
+  """
+  @spec any_pending_operations?() :: boolean()
+  def any_pending_operations? do
+    Repo.exists?(PendingBlockOperation) || Repo.exists?(PendingTransactionOperation)
+  end
+
+  @doc """
+  Checks if there are pending operations for any of the provided block numbers or transaction hashes.
+  """
+  @spec pending_operations_for_blocks_or_transactions?([non_neg_integer()], [Hash.Full.t()]) :: boolean()
+  def pending_operations_for_blocks_or_transactions?(block_numbers, transaction_hashes) do
+    block_numbers_pending?(block_numbers) || transaction_hashes_pending?(transaction_hashes)
+  end
+
+  @doc """
+  Checks if there are pending operations in a block-number range or among provided transaction hashes.
+  """
+  @spec pending_operations_for_block_range_or_transactions?(
+          non_neg_integer() | nil,
+          non_neg_integer() | nil,
+          [Hash.Full.t()]
+        ) :: boolean()
+  def pending_operations_for_block_range_or_transactions?(min_block_number, max_block_number, transaction_hashes) do
+    pending_operations_in_block_range?(min_block_number, max_block_number) ||
+      transaction_hashes_pending?(transaction_hashes)
+  end
+
+  @doc """
+  Checks if there are pending operations for a single transaction scope.
+  """
+  @spec pending_operations_for_transaction?(Hash.Full.t(), non_neg_integer() | nil) :: boolean()
+  def pending_operations_for_transaction?(transaction_hash, block_number \\ nil) do
+    transaction_hashes_pending?([transaction_hash]) ||
+      if(is_nil(block_number), do: false, else: blocks_pending?(block_number, block_number))
   end
 end


### PR DESCRIPTION
Related to #13758

## Motivation

Expose pending internal-transaction processing state in the REST API, matching the recently added Etherscan-like `txlistinternal` behavior. This lets clients distinguish between a truly complete empty result and a response where some internal transactions have not been processed yet.

## Changelog

### Enhancements

- Added shared helpers to detect pending internal-transaction processing from both `pending_block_operations` and `pending_transaction_operations`.
- Added a dedicated V2 helper to compute pending status for internal-transactions REST responses.
- Extended paginated OpenAPI schema generation to optionally include top-level `status` and `message` fields for affected endpoints.
- Added regression coverage for pending status responses across the affected V2 internal-transactions endpoints.
- Improved local Copilot skills documentation for Elixir clause grouping and alphabetically ordered aliases to better catch Credo/compiler issues during edits.

### Bug Fixes

- Added top-level `status: 2` and `message: "Some internal transactions within this block range have not yet been processed"` to these endpoints when pending internal-transaction processing is detected:
  - `/api/v2/internal-transactions`
  - `/api/v2/addresses/:hash/internal-transactions`
  - `/api/v2/blocks/:hash/internal-transactions`
  - `/api/v2/transactions/:hash/internal-transactions`
- Ensured pending status is returned when the relevant scope is pending even if `"items"` is empty.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internal-transactions endpoints (address, block, transaction, paginated) can include a pending-processing status (status + message); responses and schemas updated to opt into this flag.
  * Centralized pending-status detection added to drive the new response behavior.

* **Documentation**
  * Skill guides expanded with alias-ordering and clause-grouping examples, checklists, and verification cues.

* **Tests**
  * New controller and integration tests validating pending-status responses across internal-transactions endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->