### PR TITLE
fix: Remove internal transaction error field references

### DIFF
--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -903,7 +903,7 @@ defmodule Explorer.Chain.Address do
     |> InternalTransaction.join_transaction_query()
     |> where([it], it.index > 0)
     |> order_by([it],
-      asc_nulls_first: coalesce(it.error, type(it.error_id, :string)),
+      asc_nulls_first: it.error_id,
       desc: it.block_number,
       desc: it.transaction_index,
       desc: it.index

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -321,8 +321,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
         internal_transaction.type in ~w(call create create2 selfdestruct)a and
         (is_nil(coalesce(type(internal_transaction.call_type_enum, :string), internal_transaction.call_type)) or
            coalesce(type(internal_transaction.call_type_enum, :string), internal_transaction.call_type) == ^"call") and
-        internal_transaction.value > ^0 and is_nil(internal_transaction.error) and
-        is_nil(internal_transaction.error_id) and
+        internal_transaction.value > ^0 and is_nil(internal_transaction.error_id) and
         (internal_transaction.to_address_hash == ^balance.address_hash or
            as(:to_address_mapping).address_hash == ^balance.address_hash or
            internal_transaction.from_address_hash == ^balance.address_hash or


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14099

## Motivation

`error` field is no longer present in `internal_transactions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal transaction filtering and ordering logic to improve query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->