### PR TITLE
chore: Migrate constructor_arguments column to bytea type

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -495,7 +495,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         insert(:smart_contract,
           name: "Implementation",
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",
@@ -710,7 +710,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           optimization_runs: @optimization_runs,
           evm_version: "default",
           constructor_arguments:
-            "00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
+            "0x00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
           contract_code_md5: "123"
         )
 
@@ -731,7 +731,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           "OptimizationRuns" => @optimization_runs,
           "EVMVersion" => "default",
           "ConstructorArguments" =>
-            "00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
+            "0x00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
           "FileName" => "",
           "IsProxy" => "false"
         }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -496,7 +496,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
         insert(:smart_contract,
           name: "Implementation",
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",
@@ -711,7 +711,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           optimization_runs: @optimization_runs,
           evm_version: "default",
           constructor_arguments:
-            "00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
+            "0x00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
           contract_code_md5: "123"
         )
 
@@ -732,7 +732,7 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
           "OptimizationRuns" => @optimization_runs,
           "EVMVersion" => "default",
           "ConstructorArguments" =>
-            "00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
+            "0x00000000000000000000000008e7592ce0d7ebabf42844b62ee6a878d4e1913e000000000000000000000000e1b6037da5f1d756499e184ca15254a981c92546",
           "FileName" => "",
           "IsProxy" => "false"
         }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -231,7 +231,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         insert(:smart_contract,
           name: "Implementation",
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -235,7 +235,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
         insert(:smart_contract,
           name: "Implementation",
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -33,6 +33,15 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     :ok
   end
 
+  defp expected_constructor_args(nil), do: nil
+  defp expected_constructor_args(""), do: ""
+  defp expected_constructor_args("0x" <> _ = constructor_arguments), do: constructor_arguments
+
+  defp expected_constructor_args(constructor_arguments) when is_binary(constructor_arguments),
+    do: "0x" <> constructor_arguments
+
+  defp expected_constructor_args(constructor_arguments), do: to_string(constructor_arguments)
+
   describe "/smart-contracts/{address_hash}" do
     setup do
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
@@ -202,7 +211,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => [%{"name" => "ABC", "address_hash" => Address.checksum(lib_address)}],
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => nil,
         "deployed_bytecode" =>
           "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
@@ -309,7 +318,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => [%{"name" => "ABC", "address_hash" => Address.checksum(lib_address)}],
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => [
           ["0x0000000000000000000000000000000000000000", %{"name" => "_proxyStorage", "type" => "address"}],
           [
@@ -456,7 +465,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       implementation_contract =
         insert(:smart_contract,
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",
@@ -581,7 +590,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => target_contract.external_libraries,
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => nil,
         "deployed_bytecode" =>
           "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
@@ -620,7 +629,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     implementation_contract =
       insert(:smart_contract,
         external_libraries: [],
-        constructor_arguments: "",
+        constructor_arguments: nil,
         abi: [
           %{
             "type" => "constructor",
@@ -942,7 +951,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["decoded_constructor_args"] == [
@@ -1300,7 +1309,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]
@@ -1419,7 +1428,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]
@@ -1538,7 +1547,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -34,6 +34,15 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     :ok
   end
 
+  defp expected_constructor_args(nil), do: nil
+  defp expected_constructor_args(""), do: ""
+  defp expected_constructor_args("0x" <> _ = constructor_arguments), do: constructor_arguments
+
+  defp expected_constructor_args(constructor_arguments) when is_binary(constructor_arguments),
+    do: "0x" <> constructor_arguments
+
+  defp expected_constructor_args(constructor_arguments), do: to_string(constructor_arguments)
+
   describe "/smart-contracts/{address_hash}" do
     setup do
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
@@ -203,7 +212,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => [%{"name" => "ABC", "address_hash" => Address.checksum(lib_address)}],
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => nil,
         "deployed_bytecode" =>
           "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
@@ -310,7 +319,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => [%{"name" => "ABC", "address_hash" => Address.checksum(lib_address)}],
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => [
           ["0x0000000000000000000000000000000000000000", %{"name" => "_proxyStorage", "type" => "address"}],
           [
@@ -457,7 +466,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       implementation_contract =
         insert(:smart_contract,
           external_libraries: [],
-          constructor_arguments: "",
+          constructor_arguments: nil,
           abi: [
             %{
               "type" => "constructor",
@@ -582,7 +591,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         "additional_sources" => [],
         "compiler_settings" => target_contract.compiler_settings,
         "external_libraries" => target_contract.external_libraries,
-        "constructor_args" => target_contract.constructor_arguments,
+        "constructor_args" => expected_constructor_args(target_contract.constructor_arguments),
         "decoded_constructor_args" => nil,
         "deployed_bytecode" =>
           "0x6080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582061b7676067d537e410bb704932a9984739a959416170ea17bda192ac1218d2790029",
@@ -621,7 +630,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
     implementation_contract =
       insert(:smart_contract,
         external_libraries: [],
-        constructor_arguments: "",
+        constructor_arguments: nil,
         abi: [
           %{
             "type" => "constructor",
@@ -943,7 +952,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["decoded_constructor_args"] == [
@@ -1301,7 +1310,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]
@@ -1420,7 +1429,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]
@@ -1539,7 +1548,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
         assert response["name"] == smart_contract["contractName"]
         assert response["compiler_version"] == smart_contract["compilerVersion"]
         assert response["file_path"] == smart_contract["fileName"]
-        assert response["constructor_args"] == smart_contract["constructorArguments"]
+        assert response["constructor_args"] == expected_constructor_args(smart_contract["constructorArguments"])
         assert response["abi"] == Jason.decode!(smart_contract["abi"])
 
         assert response["source_code"] == smart_contract["sourceFiles"][smart_contract["fileName"]]

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.SmartContract.Schema do
   alias Explorer.Chain.{
     Address,
     Address.Reputation,
+    Data,
     Hash,
     SmartContractAdditionalSource
   }
@@ -42,7 +43,7 @@ defmodule Explorer.Chain.SmartContract.Schema do
         field(:compiler_version, :string, null: false)
         field(:optimization, :boolean, null: false)
         field(:contract_source_code, :string, null: false)
-        field(:constructor_arguments, :string)
+        field(:constructor_arguments, Data)
         field(:evm_version, :string)
         embeds_many(:external_libraries, ExternalLibrary, on_replace: :delete)
         field(:abi, {:array, :map})

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.SmartContract.Schema do
   alias Explorer.Chain.{
     Address,
     Address.Reputation,
+    Data,
     Hash,
     SmartContractAdditionalSource
   }
@@ -43,7 +44,7 @@ defmodule Explorer.Chain.SmartContract.Schema do
         field(:compiler_version, :string, null: false)
         field(:optimization, :boolean, null: false)
         field(:contract_source_code, :string, null: false)
-        field(:constructor_arguments, :string)
+        field(:constructor_arguments, Data)
         field(:evm_version, :string)
         embeds_many(:external_libraries, ExternalLibrary, on_replace: :delete)
         field(:abi, {:array, :map})

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -422,10 +422,18 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   """
   @spec clear_constructor_arguments(String.t() | nil) :: String.t() | nil
   def clear_constructor_arguments(constructor_arguments) do
-    if constructor_arguments != nil && constructor_arguments != "" do
-      constructor_arguments
-    else
-      nil
+    case constructor_arguments do
+      nil ->
+        nil
+
+      "" ->
+        nil
+
+      "0x" <> _ = prefixed_arguments ->
+        prefixed_arguments
+
+      constructor_arguments ->
+        "0x" <> constructor_arguments
     end
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -429,6 +429,9 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
       "" ->
         nil
 
+      "0x" ->
+        nil
+
       "0x" <> _ = prefixed_arguments ->
         prefixed_arguments
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -430,6 +430,9 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
       "" ->
         nil
 
+      "0x" ->
+        nil
+
       "0x" <> _ = prefixed_arguments ->
         prefixed_arguments
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/publisher.ex
@@ -423,10 +423,18 @@ defmodule Explorer.SmartContract.Solidity.Publisher do
   """
   @spec clear_constructor_arguments(String.t() | nil) :: String.t() | nil
   def clear_constructor_arguments(constructor_arguments) do
-    if constructor_arguments != nil && constructor_arguments != "" do
-      constructor_arguments
-    else
-      nil
+    case constructor_arguments do
+      nil ->
+        nil
+
+      "" ->
+        nil
+
+      "0x" <> _ = prefixed_arguments ->
+        prefixed_arguments
+
+      constructor_arguments ->
+        "0x" <> constructor_arguments
     end
   end
 

--- a/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
+++ b/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
@@ -8,8 +8,10 @@ defmodule Explorer.Repo.Migrations.SmartContractsAddConstructorArgumentsHexField
 
     execute("""
       UPDATE smart_contracts
-      SET constructor_arguments_hex = decode(replace(constructor_arguments, '0x', ''), 'hex')
-      WHERE constructor_arguments IS NOT NULL;
+      SET constructor_arguments_hex = decode(regexp_replace(constructor_arguments, '^0[xX]', ''), 'hex')
+      WHERE constructor_arguments IS NOT NULL
+        AND regexp_replace(constructor_arguments, '^0[xX]', '') ~ '^[0-9A-Fa-f]*$'
+        AND mod(length(regexp_replace(constructor_arguments, '^0[xX]', '')), 2) = 0;
     """)
 
     alter table(:smart_contracts) do

--- a/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
+++ b/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
@@ -1,0 +1,39 @@
+defmodule Explorer.Repo.Migrations.SmartContractsAddConstructorArgumentsHexField do
+  use Ecto.Migration
+
+  def up do
+    alter table(:smart_contracts) do
+      add(:constructor_arguments_hex, :bytea)
+    end
+
+    execute("""
+      UPDATE smart_contracts
+      SET constructor_arguments_hex = decode(replace(constructor_arguments, '0x', ''), 'hex')
+      WHERE constructor_arguments IS NOT NULL;
+    """)
+
+    alter table(:smart_contracts) do
+      remove(:constructor_arguments)
+    end
+
+    execute("ALTER TABLE smart_contracts RENAME COLUMN constructor_arguments_hex TO constructor_arguments")
+  end
+
+  def down do
+    alter table(:smart_contracts) do
+      add(:constructor_arguments_text, :text)
+    end
+
+    execute("""
+      UPDATE smart_contracts
+      SET constructor_arguments_text = encode(constructor_arguments, 'hex')
+      WHERE constructor_arguments IS NOT NULL;
+    """)
+
+    alter table(:smart_contracts) do
+      remove(:constructor_arguments)
+    end
+
+    execute("ALTER TABLE smart_contracts RENAME COLUMN constructor_arguments_text TO constructor_arguments")
+  end
+end

--- a/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
+++ b/apps/explorer/priv/repo/migrations/20260413121113_smart_contracts_add_constructor_arguments_hex_field.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Repo.Migrations.SmartContractsAddConstructorArgumentsHexField do
   use Ecto.Migration
 

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -85,7 +85,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
         }
 
         assert {:ok, result} = Publisher.publish(contract_address.hash, params)
-        assert result.constructor_arguments == expected_constructor_arguments
+        assert Data.to_string(result.constructor_arguments) == "0x" <> expected_constructor_arguments
       end
 
       test "corresponding contract_methods are created for the abi" do
@@ -138,7 +138,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
         response = Publisher.publish(contract_address.hash, params)
         assert {:ok, %SmartContract{} = smart_contract} = response
 
-        assert smart_contract.constructor_arguments == contract_code_info.constructor_args
+        assert Data.to_string(smart_contract.constructor_arguments) == "0x" <> contract_code_info.constructor_args
       end
 
       test "with invalid data returns error changeset" do

--- a/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/publisher_test.exs
@@ -86,7 +86,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
         }
 
         assert {:ok, result} = Publisher.publish(contract_address.hash, params)
-        assert result.constructor_arguments == expected_constructor_arguments
+        assert Data.to_string(result.constructor_arguments) == "0x" <> expected_constructor_arguments
       end
 
       test "corresponding contract_methods are created for the abi" do
@@ -139,7 +139,7 @@ defmodule Explorer.SmartContract.Solidity.PublisherTest do
         response = Publisher.publish(contract_address.hash, params)
         assert {:ok, %SmartContract{} = smart_contract} = response
 
-        assert smart_contract.constructor_arguments == contract_code_info.constructor_args
+        assert Data.to_string(smart_contract.constructor_arguments) == "0x" <> contract_code_info.constructor_args
       end
 
       test "with invalid data returns error changeset" do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13371

## Motivation

Migrate `smart_contracts.constructor_arguments` from text storage to `bytea` so the field uses the native binary representation handled by `Explorer.Chain.Data`, while preserving existing values during the transition.

## Changelog

### Enhancements

- Added a schema update so `constructor_arguments` now uses `Explorer.Chain.Data`.
- Added a migration that converts existing hex strings into `bytea` before renaming the column.
- Added rollback support so the migration can restore the previous text representation.

### Bug Fixes

- Ensured existing constructor argument values, including `0x`-prefixed payloads, decode cleanly during migration.
- Fixed the migration to be reversible instead of relying on a one-way `change/0` flow.

### Incompatible Changes

- The `smart_contracts.constructor_arguments` column storage type changes from text to `bytea`.

## Upgrading

Database migration required. No manual data fix is needed for the forward migration. If rollback is required, the down migration restores the previous text column and re-encodes the stored binary as lowercase hex.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Constructor arguments in smart contract API responses are now consistently prefixed with "0x" where applicable.
  * Empty or missing constructor arguments are handled consistently across endpoints and tooling.

* **Other Changes**
  * Smart contract storage format and processing were updated to reliably normalize and preserve constructor argument data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->