### PR TITLE
fix: Fix timeouts for API v1 tokentx endpoint

### DIFF
--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -650,17 +650,7 @@ defmodule Explorer.Etherscan do
   end
 
   defp list_erc1155_token_transfers(address_hash, contract_address_hash, options) do
-    base_query =
-      TokenTransfer.only_consensus_transfers_query()
-      |> TokenTransfer.maybe_filter_by_token_type("ERC-1155")
-      |> where_contract_address_match(contract_address_hash)
-      |> where_address_match_token_transfer(address_hash)
-      |> where_start_block_match_tt(options)
-      |> where_end_block_match_tt(options)
-      |> order_by([tt], [
-        {^options.order_by_direction, tt.block_number},
-        {^options.order_by_direction, tt.log_index}
-      ])
+    base_query = build_erc1155_base_query(address_hash, contract_address_hash, options)
 
     from(tt in {"base", TokenTransfer})
     |> with_cte("base", as: ^base_query, materialized: true)
@@ -693,6 +683,36 @@ defmodule Explorer.Etherscan do
     |> Repo.replica().all()
   end
 
+  defp build_erc1155_base_query(nil, contract_address_hash, options) do
+    TokenTransfer.only_consensus_transfers_query()
+    |> TokenTransfer.maybe_filter_by_token_type("ERC-1155")
+    |> where_contract_address_match(contract_address_hash)
+    |> where_start_block_match_tt(options)
+    |> where_end_block_match_tt(options)
+    |> order_by([tt], [
+      {^options.order_by_direction, tt.block_number},
+      {^options.order_by_direction, tt.log_index}
+    ])
+  end
+
+  defp build_erc1155_base_query(address_hash, contract_address_hash, options) do
+    inner =
+      TokenTransfer.only_consensus_transfers_query()
+      |> TokenTransfer.maybe_filter_by_token_type("ERC-1155")
+      |> where_contract_address_match(contract_address_hash)
+      |> where_start_block_match_tt(options)
+      |> where_end_block_match_tt(options)
+
+    union(
+      where(inner, [tt], tt.from_address_hash == ^address_hash),
+      ^where(inner, [tt], tt.to_address_hash == ^address_hash)
+    )
+    |> order_by([], [
+      {^options.order_by_direction, fragment("block_number")},
+      {^options.order_by_direction, fragment("log_index")}
+    ])
+  end
+
   defp list_erc404_token_transfers(address_hash, contract_address_hash, options) do
     "ERC-404"
     |> base_token_transfers_query(address_hash, contract_address_hash, options)
@@ -705,17 +725,37 @@ defmodule Explorer.Etherscan do
     |> Repo.replica().all()
   end
 
-  defp base_token_transfers_query(transfers_type, address_hash, contract_address_hash, options) do
+  defp base_token_transfers_query(transfers_type, nil, contract_address_hash, options) do
     TokenTransfer.only_consensus_transfers_query()
     |> TokenTransfer.maybe_filter_by_token_type(transfers_type)
     |> where_contract_address_match(contract_address_hash)
-    |> where_address_match_token_transfer(address_hash)
+    |> where_start_block_match_tt(options)
+    |> where_end_block_match_tt(options)
     |> order_by([tt], [
       {^options.order_by_direction, tt.block_number},
       {^options.order_by_direction, tt.log_index}
     ])
-    |> where_start_block_match_tt(options)
-    |> where_end_block_match_tt(options)
+    |> limit(^options.page_size)
+    |> offset(^options_to_offset(options))
+    |> maybe_preload_entities()
+  end
+
+  defp base_token_transfers_query(transfers_type, address_hash, contract_address_hash, options) do
+    inner_query =
+      TokenTransfer.only_consensus_transfers_query()
+      |> TokenTransfer.maybe_filter_by_token_type(transfers_type)
+      |> where_contract_address_match(contract_address_hash)
+      |> where_start_block_match_tt(options)
+      |> where_end_block_match_tt(options)
+
+    union(
+      where(inner_query, [tt], tt.from_address_hash == ^address_hash),
+      ^where(inner_query, [tt], tt.to_address_hash == ^address_hash)
+    )
+    |> order_by([], [
+      {^options.order_by_direction, fragment("block_number")},
+      {^options.order_by_direction, fragment("log_index")}
+    ])
     |> limit(^options.page_size)
     |> offset(^options_to_offset(options))
     |> maybe_preload_entities()
@@ -811,12 +851,6 @@ defmodule Explorer.Etherscan do
 
   defp where_contract_address_match(query, contract_address_hash) do
     where(query, [tt], tt.token_contract_address_hash == ^contract_address_hash)
-  end
-
-  defp where_address_match_token_transfer(query, nil), do: query
-
-  defp where_address_match_token_transfer(query, address_hash) do
-    where(query, [tt], tt.from_address_hash == ^address_hash or tt.to_address_hash == ^address_hash)
   end
 
   defp options_to_offset(options), do: (options.page_number - 1) * options.page_size

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -708,13 +708,14 @@ defmodule Explorer.Etherscan do
       ])
       |> limit(^options_to_limit_for_inner_query(options))
 
-    union(
-      where(inner, [tt], tt.from_address_hash == ^address_hash),
-      ^where(inner, [tt], tt.to_address_hash == ^address_hash)
-    )
-    |> order_by([], [
-      {^options.order_by_direction, fragment("block_number")},
-      {^options.order_by_direction, fragment("log_index")}
+    from_query = inner |> where([tt], tt.from_address_hash == ^address_hash) |> Chain.wrapped_union_subquery()
+    to_query = inner |> where([tt], tt.to_address_hash == ^address_hash) |> Chain.wrapped_union_subquery()
+
+    union(from_query, ^to_query)
+    |> Chain.wrapped_union_subquery()
+    |> order_by([q], [
+      {^options.order_by_direction, q.block_number},
+      {^options.order_by_direction, q.log_index}
     ])
   end
 
@@ -758,13 +759,14 @@ defmodule Explorer.Etherscan do
       ])
       |> limit(^options_to_limit_for_inner_query(options))
 
-    union(
-      where(inner_query, [tt], tt.from_address_hash == ^address_hash),
-      ^where(inner_query, [tt], tt.to_address_hash == ^address_hash)
-    )
-    |> order_by([], [
-      {^options.order_by_direction, fragment("block_number")},
-      {^options.order_by_direction, fragment("log_index")}
+    from_query = inner_query |> where([tt], tt.from_address_hash == ^address_hash) |> Chain.wrapped_union_subquery()
+    to_query = inner_query |> where([tt], tt.to_address_hash == ^address_hash) |> Chain.wrapped_union_subquery()
+
+    union(from_query, ^to_query)
+    |> Chain.wrapped_union_subquery()
+    |> order_by([q], [
+      {^options.order_by_direction, q.block_number},
+      {^options.order_by_direction, q.log_index}
     ])
     |> limit(^options.page_size)
     |> offset(^options_to_offset(options))

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -702,6 +702,11 @@ defmodule Explorer.Etherscan do
       |> where_contract_address_match(contract_address_hash)
       |> where_start_block_match_tt(options)
       |> where_end_block_match_tt(options)
+      |> order_by([tt], [
+        {^options.order_by_direction, tt.block_number},
+        {^options.order_by_direction, tt.log_index}
+      ])
+      |> limit(^options_to_limit_for_inner_query(options))
 
     union(
       where(inner, [tt], tt.from_address_hash == ^address_hash),
@@ -747,6 +752,11 @@ defmodule Explorer.Etherscan do
       |> where_contract_address_match(contract_address_hash)
       |> where_start_block_match_tt(options)
       |> where_end_block_match_tt(options)
+      |> order_by([tt], [
+        {^options.order_by_direction, tt.block_number},
+        {^options.order_by_direction, tt.log_index}
+      ])
+      |> limit(^options_to_limit_for_inner_query(options))
 
     union(
       where(inner_query, [tt], tt.from_address_hash == ^address_hash),

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1632,6 +1632,55 @@ defmodule Explorer.EtherscanTest do
 
       assert found_token_transfer.token_contract_address_hash == contract_address.hash
     end
+
+    test "does not duplicate erc20 transfers when address is both sender and receiver" do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:token_transfer,
+        from_address: address,
+        to_address: address,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number
+      )
+
+      result = Etherscan.list_token_transfers(:erc20, address.hash, nil, %{})
+
+      assert length(result) == 1
+    end
+
+    test "does not duplicate erc1155 transfers when address is both sender and receiver" do
+      address = insert(:address)
+
+      token_contract_address = insert(:contract_address)
+      insert(:token, contract_address: token_contract_address, type: "ERC-1155")
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:token_transfer,
+        from_address: address,
+        to_address: address,
+        token_contract_address: token_contract_address,
+        token_type: "ERC-1155",
+        token_ids: [Decimal.new(1)],
+        amounts: [Decimal.new(10)],
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number
+      )
+
+      result = Etherscan.list_token_transfers(:erc1155, address.hash, nil, %{})
+
+      assert length(result) == 1
+    end
   end
 
   describe "list_blocks/1" do


### PR DESCRIPTION
Closes #14185 

## Changelog
- Rewrite to union
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate token-transfer entries when an address is both sender and receiver.
  * Improved accuracy of token transfer filtering across ERC-20 and ERC-1155 queries.

* **Refactor**
  * Reworked token-transfer query construction to separate address/no-address paths and apply more precise ordering, limits, and pagination.

* **Tests**
  * Added tests ensuring no duplication when sender and receiver are the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->