### PR TITLE
chore: Remove unused Explorer.Chain.Address.find_contract_addresses/2 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Remove unused Explorer.Chain.Address.find_contract_addresses/2 function ([#14220](https://github.com/blockscout/blockscout/pull/14220))
 - Prevent deadlocks in IT fields removing migration ([#14215](https://github.com/blockscout/blockscout/pull/14215))
 - Filter blocks by BLOCK_RANGES in add_ranges_by_block_numbers ([#13875](https://github.com/blockscout/blockscout/pull/13875))
 - FillInternalTransactionsAddressIds improvements ([#14208](https://github.com/blockscout/blockscout/pull/14208))

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -969,50 +969,6 @@ defmodule Explorer.Chain.Address do
     ]
   end
 
-  @doc """
-  Finds contract addresses from a list of hashes.
-
-  ## Parameters
-
-    - `hashes`: A list of hashes to search for contract addresses.
-    - `options`: An optional keyword list of options.
-
-  ## Options
-
-    - `:necessity_by_association`: A map of associations with their necessity (default: `%{}`).
-
-  ## Returns
-
-    - `{:ok, addresses}`: A tuple with `:ok` and a list of found addresses.
-    - `{:error, :not_found}`: A tuple with `:error` and `:not_found` if no addresses are found.
-
-  """
-  @spec find_contract_addresses([Hash.Address.t()], [Chain.necessity_by_association_option() | Chain.api?()]) ::
-          {:ok, [__MODULE__.t()]} | {:error, :not_found}
-  def find_contract_addresses(
-        hashes,
-        options \\ []
-      ) do
-    necessity_by_association =
-      options
-      |> Keyword.get(:necessity_by_association, %{})
-      |> Map.merge(%{
-        Implementation.proxy_implementations_association() => :optional
-      })
-
-    hashes
-    |> addresses_with_bytecode_query()
-    |> Chain.join_associations(necessity_by_association)
-    |> Chain.select_repo(options).all()
-    |> Enum.map(fn address_result ->
-      update_address_result(address_result, options, true)
-    end)
-    |> case do
-      [] -> {:error, :not_found}
-      addresses -> {:ok, addresses}
-    end
-  end
-
   @spec update_address_result(
           map() | nil,
           [Chain.necessity_by_association_option() | Chain.api?() | Chain.ip()],


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12133

## Motivation

Remove unused Explorer.Chain.Address.find_contract_addresses/2 function
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a deprecated internal batch contract-address retrieval API (no replacement).
  * Added a changelog entry noting the removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->