### PR TITLE
fix: prevent ETS crash in ContractCreator on GenServer restart

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -41,6 +41,10 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
   @spec trigger_fetch(Address.t()) :: :ok | :ignore
   def trigger_fetch(address) do
     if :ets.whereis(@table_name) == :undefined do
+      Logger.warning(
+        "ContractCreator ETS table is not available, skipping on-demand fetch for address #{to_string(address.hash)}"
+      )
+
       :ignore
     else
       do_trigger_fetch(address)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -25,19 +25,30 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
   @max_json_rpc_retries 5
 
   def start_link(_) do
-    :ets.new(@table_name, [
-      :set,
-      :named_table,
-      :public,
-      read_concurrency: true,
-      write_concurrency: true
-    ])
+    if :ets.whereis(@table_name) == :undefined do
+      :ets.new(@table_name, [
+        :set,
+        :named_table,
+        :public,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+    end
 
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   @spec trigger_fetch(Address.t()) :: :ok | :ignore
   def trigger_fetch(address) do
+    if :ets.whereis(@table_name) == :undefined do
+      :ignore
+    else
+      do_trigger_fetch(address)
+    end
+  end
+
+  @spec do_trigger_fetch(Address.t()) :: :ok | :ignore
+  defp do_trigger_fetch(address) do
     # we expect here, that address has 'contract_creation_internal_transaction' and 'contract_creation_transaction' preloads
     creation_transaction = Address.creation_transaction(address)
     creator_hash = creation_transaction && creation_transaction.from_address_hash

--- a/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
@@ -150,6 +150,14 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                {"pending_blocks", [%{block_number: 3, address_hash_string: contract_address_hash}]}
              ]
     end
+
+    test "returns :ignore when ETS table does not exist (GenServer not started)" do
+      :ets.delete(:contract_creator_lookup)
+
+      address = insert(:address, contract_code: "0x1234")
+
+      assert :ignore = ContractCreatorOnDemand.trigger_fetch(address)
+    end
   end
 
   test "initiates fetch if address has contract code but no creator hash (target block is in the middle)" do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14170

## Motivation

`Indexer.Fetcher.OnDemand.ContractCreator` crashes time to time during fetch attempts. On restart, `start_link/1` calls `:ets.new/2` with `:named_table` on a table that is already owned by the supervisor process — causing a second `ArgumentError`. OTP counts this as another failed start, and after hitting the restart intensity limit the supervisor itself shuts down, destroying the ETS table. During the window before the supervisor is recreated, any call to `trigger_fetch/1` hits `:ets.lookup/2` on a non-existent table and raises an `ArgumentError` that crashes the HTTP request process, returning a 500 to callers of `GET /api/v2/addresses/:address_hash`.

## Changelog

### Bug Fixes

- `Indexer.Fetcher.OnDemand.ContractCreator`: guard `:ets.new/2` in `start_link/1` with `:ets.whereis/1` so the named table is only created when it does not already exist, making GenServer restarts idempotent and preventing the supervisor from exhausting its restart budget.
- `Indexer.Fetcher.OnDemand.ContractCreator`: guard `trigger_fetch/1` with `:ets.whereis/1` to return `:ignore` immediately when the ETS table is absent, preventing `ArgumentError` from propagating into HTTP request processes during any remaining unavailability window.

### Incompatible Changes

_None._

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of the contract-creator service: initialization now checks for the presence of its lookup table and will emit a warning and ignore requests if the table is missing, preventing errors when the service isn't started.

* **Tests**
  * Added test coverage for the missing lookup-table edge case to ensure correct ignore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->