### PR TITLE
fix: Celo epoch OpenAPI schema issues and missing test coverage

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
@@ -17,6 +17,8 @@ defmodule BlockScoutWeb.API.V2.CeloController do
   alias Explorer.Chain.Hash
   alias Explorer.PagingOptions
 
+  @celo_reward_types ElectionReward.types()
+
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
   plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
@@ -273,9 +275,13 @@ defmodule BlockScoutWeb.API.V2.CeloController do
     end
   end
 
-  @spec parse_celo_reward_type(String.t()) ::
+  @spec parse_celo_reward_type(atom() | String.t()) ::
           {:ok, ElectionReward.type()} | {:error, {:invalid, :celo_election_reward_type}}
-  defp parse_celo_reward_type(reward_type_string) do
+  defp parse_celo_reward_type(reward_type) when reward_type in @celo_reward_types do
+    {:ok, reward_type}
+  end
+
+  defp parse_celo_reward_type(reward_type_string) when is_binary(reward_type_string) do
     reward_type_string
     |> ElectionReward.type_from_url_string()
     |> case do
@@ -283,4 +289,6 @@ defmodule BlockScoutWeb.API.V2.CeloController do
       :error -> {:error, {:invalid, :celo_election_reward_type}}
     end
   end
+
+  defp parse_celo_reward_type(_), do: {:error, {:invalid, :celo_election_reward_type}}
 end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
@@ -275,6 +275,21 @@ defmodule BlockScoutWeb.API.V2.CeloController do
     end
   end
 
+  # Parses a reward type value produced by CastAndValidate.
+  #
+  # The OpenAPI schema enum (see `ElectionReward.type_enum_with_legacy/0`)
+  # contains both atoms (:voter, :validator, :group, :delegated_payment)
+  # and a legacy hyphenated string ("delegated-payment"). CastAndValidate
+  # returns an atom when the URL segment matches `to_string(atom)`, but
+  # passes "delegated-payment" through as a string because
+  # `to_string(:delegated_payment)` is "delegated_payment" (underscore),
+  # which does not match the hyphenated URL form.
+  #
+  # The atom clause handles the canonical types; the string clause handles
+  # the legacy "delegated-payment" form via `type_from_url_string/1`.
+  #
+  # Once the legacy form is removed from the enum, the string clause and
+  # catch-all can be deleted.
   @spec parse_celo_reward_type(atom() | String.t()) ::
           {:ok, ElectionReward.type()} | {:error, {:invalid, :celo_election_reward_type}}
   defp parse_celo_reward_type(reward_type) when reward_type in @celo_reward_types do

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward/type.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward/type.ex
@@ -4,5 +4,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward.Type do
 
   alias Explorer.Chain.Celo.ElectionReward
 
-  OpenApiSpex.schema(%{type: :string, nullable: false, enum: ElectionReward.types(), title: "CeloElectionRewardType"})
+  # Uses `type_enum_with_legacy/0` instead of `types/0` so that
+  # CastAndValidate accepts both the canonical underscore form
+  # ("delegated_payment") and the legacy hyphenated URL form
+  # ("delegated-payment"). See `ElectionReward.type_enum_with_legacy/0`
+  # for details.
+  OpenApiSpex.schema(%{
+    type: :string,
+    nullable: false,
+    enum: ElectionReward.type_enum_with_legacy(),
+    title: "CeloElectionRewardType"
+  })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/epoch/detailed.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/epoch/detailed.ex
@@ -11,6 +11,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.Epoch.Detailed do
   OpenApiSpex.schema(
     Epoch.schema()
     |> Helper.extend_schema(
+      title: "CeloEpochDetailed",
       nullable: false,
       properties: %{
         start_processing_block_hash: General.FullHashNullable,
@@ -21,19 +22,15 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.Epoch.Detailed do
           type: :object,
           nullable: true,
           additionalProperties: %Schema{
-            anyOf: [
-              %Schema{
-                type: :object,
-                properties: %{
-                  total: General.IntegerString,
-                  count: %Schema{type: :integer, nullable: false, minimum: 0},
-                  token: %Schema{type: :object, nullable: true, additionalProperties: true}
-                },
-                required: [:total, :count, :token],
-                additionalProperties: false
-              },
-              %Schema{type: :null}
-            ]
+            type: :object,
+            nullable: true,
+            properties: %{
+              total: General.IntegerString,
+              count: %Schema{type: :integer, nullable: false, minimum: 0},
+              token: %Schema{type: :object, nullable: true, additionalProperties: true}
+            },
+            required: [:total, :count, :token],
+            additionalProperties: false
           }
         },
         distribution: %Schema{type: :object, nullable: true, additionalProperties: true}

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
@@ -181,6 +181,14 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
         request = get(conn, "/api/v2/celo/epochs/invalid/election-rewards/voter")
         assert %{"errors" => [_]} = json_response(request, 422)
       end
+
+      test "accepts both hyphenated and underscored delegated_payment type in URL", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs/1/election-rewards/delegated-payment")
+        assert %{"items" => []} = json_response(request, 200)
+
+        request = get(conn, "/api/v2/celo/epochs/1/election-rewards/delegated_payment")
+        assert %{"items" => []} = json_response(request, 200)
+      end
     end
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
@@ -6,9 +6,14 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
     chain_identity: [:explorer, :chain_identity]
 
   if @chain_identity == {:optimism, :celo} do
+    alias Explorer.Chain.Celo.ElectionReward
+
     setup do
       celo_token = insert(:token)
       usd_token = insert(:token)
+
+      original_core_contracts_config =
+        Application.get_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts)
 
       Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts,
         contracts: %{
@@ -35,7 +40,12 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
       original_celo_config = Application.get_env(:explorer, :celo)
 
       on_exit(fn ->
-        Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts, contracts: %{})
+        Application.put_env(
+          :explorer,
+          Explorer.Chain.Cache.CeloCoreContracts,
+          original_core_contracts_config
+        )
+
         Application.put_env(:explorer, :celo, original_celo_config)
       end)
 
@@ -103,7 +113,7 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
           end_block_number: 17_279
         )
 
-        for type <- [:voter, :validator, :group, :delegated_payment] do
+        for type <- ElectionReward.types() do
           insert(:celo_aggregated_election_reward,
             epoch_number: 1,
             type: type,
@@ -120,8 +130,8 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
         rewards = response["aggregated_election_rewards"]
         assert is_map(rewards)
 
-        for type <- ["voter", "validator", "group", "delegated_payment"] do
-          assert %{"total" => _, "count" => 5, "token" => _} = rewards[type]
+        for type <- ElectionReward.types() do
+          assert %{"total" => _, "count" => 5, "token" => _} = rewards[to_string(type)]
         end
       end
 
@@ -137,7 +147,7 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
           end_block_number: 34_559
         )
 
-        for type <- [:voter, :validator, :group, :delegated_payment] do
+        for type <- ElectionReward.types() do
           insert(:celo_aggregated_election_reward,
             epoch_number: 2,
             type: type,
@@ -153,8 +163,8 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
         rewards = response["aggregated_election_rewards"]
         assert rewards["delegated_payment"] == nil
 
-        for type <- ["voter", "validator", "group"] do
-          assert %{"total" => _, "count" => 5, "token" => _} = rewards[type]
+        for type <- ElectionReward.types() -- [:delegated_payment] do
+          assert %{"total" => _, "count" => 5, "token" => _} = rewards[to_string(type)]
         end
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
@@ -1,0 +1,176 @@
+defmodule BlockScoutWeb.API.V2.CeloControllerTest do
+  use BlockScoutWeb.ConnCase
+
+  use Utils.CompileTimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
+
+  if @chain_identity == {:optimism, :celo} do
+    setup do
+      celo_token = insert(:token)
+      usd_token = insert(:token)
+
+      Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts,
+        contracts: %{
+          "addresses" => %{
+            "Accounts" => [],
+            "Election" => [],
+            "EpochRewards" => [],
+            "FeeHandler" => [],
+            "GasPriceMinimum" => [],
+            "GoldToken" => [
+              %{"address" => to_string(celo_token.contract_address_hash), "updated_at_block_number" => 0}
+            ],
+            "Governance" => [],
+            "LockedGold" => [],
+            "Reserve" => [],
+            "StableToken" => [
+              %{"address" => to_string(usd_token.contract_address_hash), "updated_at_block_number" => 0}
+            ],
+            "Validators" => []
+          }
+        }
+      )
+
+      original_celo_config = Application.get_env(:explorer, :celo)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts, contracts: %{})
+        Application.put_env(:explorer, :celo, original_celo_config)
+      end)
+
+      {:ok, %{celo_token: celo_token, usd_token: usd_token}}
+    end
+
+    describe "/api/v2/celo/epochs" do
+      test "returns empty list", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs")
+        assert response = json_response(request, 200)
+        assert response["items"] == []
+        assert response["next_page_params"] == nil
+      end
+
+      test "returns epochs", %{conn: conn} do
+        epoch =
+          insert(:celo_epoch,
+            number: 1,
+            fetched?: true,
+            start_block_number: 0,
+            end_block_number: 17_279
+          )
+
+        request = get(conn, "/api/v2/celo/epochs")
+        assert response = json_response(request, 200)
+        assert [item] = response["items"]
+        assert item["number"] == epoch.number
+        assert item["start_block_number"] == epoch.start_block_number
+        assert item["end_block_number"] == epoch.end_block_number
+        assert item["is_finalized"] == true
+      end
+    end
+
+    describe "/api/v2/celo/epochs/:number" do
+      test "returns 404 for non-existing epoch", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs/100")
+        assert %{"message" => "Not found"} = json_response(request, 404)
+      end
+
+      test "returns 422 for invalid epoch number", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs/invalid")
+        assert %{"errors" => [_]} = json_response(request, 422)
+      end
+
+      test "returns unfetched epoch with null aggregated rewards", %{conn: conn} do
+        insert(:celo_epoch,
+          number: 1,
+          fetched?: false,
+          start_block_number: 0,
+          end_block_number: 17_279
+        )
+
+        request = get(conn, "/api/v2/celo/epochs/1")
+        assert response = json_response(request, 200)
+        assert response["number"] == 1
+        assert response["is_finalized"] == false
+        assert response["aggregated_election_rewards"] == nil
+      end
+
+      test "returns fetched epoch with aggregated rewards", %{conn: conn} do
+        insert(:celo_epoch,
+          number: 1,
+          fetched?: true,
+          start_block_number: 0,
+          end_block_number: 17_279
+        )
+
+        for type <- [:voter, :validator, :group, :delegated_payment] do
+          insert(:celo_aggregated_election_reward,
+            epoch_number: 1,
+            type: type,
+            sum: 1000,
+            count: 5
+          )
+        end
+
+        request = get(conn, "/api/v2/celo/epochs/1")
+        assert response = json_response(request, 200)
+        assert response["number"] == 1
+        assert response["is_finalized"] == true
+
+        rewards = response["aggregated_election_rewards"]
+        assert is_map(rewards)
+
+        for type <- ["voter", "validator", "group", "delegated_payment"] do
+          assert %{"total" => _, "count" => 5, "token" => _} = rewards[type]
+        end
+      end
+
+      test "returns L2 epoch with null delegated_payment in aggregated rewards", %{conn: conn} do
+        # Epoch 2 starts at block 17280. Setting l2_migration_block to 17280
+        # makes epoch 2 an L2 epoch (epoch_number >= migration epoch number).
+        Application.put_env(:explorer, :celo, l2_migration_block: 17_280)
+
+        insert(:celo_epoch,
+          number: 2,
+          fetched?: true,
+          start_block_number: 17_280,
+          end_block_number: 34_559
+        )
+
+        for type <- [:voter, :validator, :group, :delegated_payment] do
+          insert(:celo_aggregated_election_reward,
+            epoch_number: 2,
+            type: type,
+            sum: 1000,
+            count: 5
+          )
+        end
+
+        request = get(conn, "/api/v2/celo/epochs/2")
+        assert response = json_response(request, 200)
+        assert response["type"] == "L2"
+
+        rewards = response["aggregated_election_rewards"]
+        assert rewards["delegated_payment"] == nil
+
+        for type <- ["voter", "validator", "group"] do
+          assert %{"total" => _, "count" => 5, "token" => _} = rewards[type]
+        end
+      end
+    end
+
+    describe "/api/v2/celo/epochs/:number/election-rewards/:type" do
+      test "returns empty list", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs/1/election-rewards/voter")
+        assert response = json_response(request, 200)
+        assert response["items"] == []
+        assert response["next_page_params"] == nil
+      end
+
+      test "returns 422 for invalid epoch number", %{conn: conn} do
+        request = get(conn, "/api/v2/celo/epochs/invalid/election-rewards/voter")
+        assert %{"errors" => [_]} = json_response(request, 422)
+      end
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/celo/election_reward.ex
+++ b/apps/explorer/lib/explorer/chain/celo/election_reward.ex
@@ -38,6 +38,16 @@ defmodule Explorer.Chain.Celo.ElectionReward do
   @type type :: :voter | :validator | :group | :delegated_payment
   @types_enum ~w(voter validator group delegated_payment)a
 
+  # Legacy URL forms that differ from `to_string(atom)`.
+  # The URL path uses "delegated-payment" (hyphen), but the canonical atom
+  # is :delegated_payment (underscore). OpenApiSpex.Plug.CastAndValidate
+  # matches enum values via `to_string(atom) == binary`, so
+  # "delegated-payment" does not match :delegated_payment. Including the
+  # hyphenated string in the enum lets CastAndValidate accept both forms
+  # during a migration period, after which the hyphenated form can be
+  # removed.
+  @legacy_type_url_strings ["delegated-payment"]
+
   @reward_type_url_string_to_atom %{
     "voter" => :voter,
     "validator" => :validator,
@@ -123,6 +133,21 @@ defmodule Explorer.Chain.Celo.ElectionReward do
   """
   @spec types() :: [type]
   def types, do: @types_enum
+
+  @doc """
+  Returns the list of election reward types extended with legacy hyphenated
+  URL strings (e.g. `"delegated-payment"`).
+
+  Intended for use as the `enum` in OpenApiSpex schemas so that
+  `CastAndValidate` accepts both the canonical atom forms (`voter`,
+  `validator`, `group`, `delegated_payment`) and the legacy hyphenated URL
+  form (`delegated-payment`).
+
+  Once the migration period ends and `"delegated-payment"` is no longer
+  accepted, replace usages with `types/0` and remove `@legacy_type_url_strings`.
+  """
+  @spec type_enum_with_legacy() :: [type | String.t()]
+  def type_enum_with_legacy, do: @types_enum ++ @legacy_type_url_strings
 
   @doc """
   Converts a reward type url string to its corresponding atom.

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -1674,7 +1674,7 @@ defmodule Explorer.Factory do
   def celo_aggregated_election_reward_factory do
     %CeloAggregatedElectionReward{
       epoch_number: sequence("celo_aggregated_election_reward_epoch_number", & &1),
-      type: Enum.random([:voter, :validator, :group, :delegated_payment]),
+      type: Enum.random(CeloElectionReward.types()),
       sum: Enum.random(1..100_000),
       count: Enum.random(0..100)
     }
@@ -1683,7 +1683,7 @@ defmodule Explorer.Factory do
   def celo_election_reward_factory do
     %CeloElectionReward{
       amount: Enum.random(1..100_000),
-      type: Enum.random([:voter, :validator, :group, :delegated_payment]),
+      type: Enum.random(CeloElectionReward.types()),
       epoch_number: sequence("celo_election_reward_epoch_number", & &1),
       account_address_hash: insert(:address).hash,
       associated_account_address_hash: insert(:address).hash

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -67,6 +67,7 @@ defmodule Explorer.Factory do
 
   alias Explorer.Chain.Optimism.Deposit, as: OptimismDeposit
 
+  alias Explorer.Chain.Celo.AggregatedElectionReward, as: CeloAggregatedElectionReward
   alias Explorer.Chain.Celo.ElectionReward, as: CeloElectionReward
   alias Explorer.Chain.Celo.Epoch, as: CeloEpoch
 
@@ -1667,6 +1668,15 @@ defmodule Explorer.Factory do
       end_block_number: nil,
       start_processing_block_hash: nil,
       end_processing_block_hash: nil
+    }
+  end
+
+  def celo_aggregated_election_reward_factory do
+    %CeloAggregatedElectionReward{
+      epoch_number: sequence("celo_aggregated_election_reward_epoch_number", & &1),
+      type: Enum.random([:voter, :validator, :group, :delegated_payment]),
+      sum: Enum.random(1..100_000),
+      count: Enum.random(0..100)
     }
   end
 


### PR DESCRIPTION
## Problem

The `Celo.Epoch.Detailed` OpenAPI schema had three issues, none of which were caught because no controller tests existed for the Celo epoch endpoints.

**1. Invalid `%Schema{type: :null}` in `additionalProperties`**

The `aggregated_election_rewards` property used an `anyOf` with `%Schema{type: :null}` to express nullable map values:

```elixir
additionalProperties: %Schema{
  anyOf: [
    %Schema{type: :object, ...},
    %Schema{type: :null}
  ]
}
```

`:null` is not a valid type in OpenAPI 3.0 or in the `open_api_spex` library (the valid types are `:string | :number | :integer | :boolean | :array | :object` per `schema.ex:266`). It compiled without errors because Elixir `@type` specs are not enforced at compile time, and it never failed at runtime because the `anyOf` validator short-circuits when the first branch matches -- so the `:null` branch was never evaluated.

**2. Schema title collision between `Epoch` and `Epoch.Detailed`**

`Epoch.Detailed` extends the base `Epoch` schema via `Helper.extend_schema/2`, which preserves the base schema's title. Both modules ended up with the title `"Epoch"`, causing `Detailed` to overwrite the base `Epoch` component when the OpenAPI spec was resolved. As a result, the list endpoint (`/api/v2/celo/epochs`) validated its items against the Detailed schema (which requires fields like `aggregated_election_rewards` that the list view does not emit).

**3. `parse_celo_reward_type/1` incompatible with CastAndValidate**

The `ElectionReward.Type` schema declares its enum using atoms from `ElectionReward.types()` (e.g., `[:voter, :validator, ...]`). When CastAndValidate processes a path parameter against this enum, `open_api_spex`'s `Cast.Enum` module returns the matched atom value (not the original string). However, `parse_celo_reward_type/1` only accepted strings and passed them to `type_from_url_string/1`, which uses string keys. This would cause all valid requests to the election-rewards endpoint to return 422 once the OpenAPI specs (from #14197) are deployed.

The bug was introduced in #14197 (merged Apr 6) but has not yet reached production. Verified via MCP against the live Celo Blockscout instance (chain_id 42220): a request to `/api/v2/celo/epochs/2167/election-rewards/voter` currently returns 200 with data, and an invalid type returns the controller's own error message (`"Invalid Celo reward type, allowed types are: ..."`) rather than an OpenApiSpex validation error -- confirming CastAndValidate is not active on the deployed version. Once #14197 is deployed, the endpoint would break without this fix.

## Changes

- **`Celo.Epoch.Detailed` schema** -- replaced `anyOf: [..., %Schema{type: :null}]` with `nullable: true` on the object schema (the standard OpenAPI 3.0 mechanism). Added `title: "CeloEpochDetailed"` to `extend_schema` to prevent title collision with the base `Epoch` schema.

- **`CeloController.parse_celo_reward_type/1`** -- added a clause that accepts atom values directly (as produced by CastAndValidate), preserving the existing string clause for backward compatibility.

- **`celo_aggregated_election_reward` factory** -- new factory in `Explorer.Factory` for `AggregatedElectionReward` records, needed by the detailed epoch tests.

- **`CeloControllerTest`** -- new test file with 9 tests covering all three Celo epoch endpoints:
  - `/api/v2/celo/epochs` -- empty list, returns epochs
  - `/api/v2/celo/epochs/:number` -- not found, invalid number, unfetched epoch (null aggregated rewards), fetched epoch with rewards, L2 epoch with null `delegated_payment`
  - `/api/v2/celo/epochs/:number/election-rewards/:type` -- empty list, invalid number

  The L2 epoch test specifically exercises the `nullable: true` fix by validating that `delegated_payment: null` passes OpenAPI schema validation.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive tests for Celo API v2 epochs and election-reward endpoints covering list/detail views, error cases, L2 classification, null handling, URL forms, and pagination.

* **Improvements**
  * Standardized aggregated election rewards schema for consistent API responses.
  * Enhanced reward-type handling to accept both atom and string inputs and to accept legacy hyphenated URL forms.
  * Updated test factories to generate election reward types dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->