### PR TITLE
fix: normalize Tesla timeout middleware exceptions

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -16,7 +16,7 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
 
     Instrumenter.json_rpc_requests(method)
 
-    case Tesla.post(TeslaHelper.client(options), url, json, headers: headers, opts: TeslaHelper.request_opts(options)) do
+    case do_post(url, json, headers, options) do
       {:ok, %Tesla.Env{body: body, status: status_code, headers: headers}} ->
         with {:ok, decoded_body} <- Jason.decode(body),
              true <- Helper.response_body_has_error?(decoded_body) do
@@ -33,4 +33,26 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
   end
 
   def json_rpc(url, _json, _headers, _options) when is_nil(url), do: {:error, "URL is nil"}
+
+  defp do_post(url, json, headers, options) do
+    Tesla.post(TeslaHelper.client(options), url, json, headers: headers, opts: TeslaHelper.request_opts(options))
+  rescue
+    error ->
+      if timeout_middleware_exception?(__STACKTRACE__) do
+        {:error, :timeout}
+      else
+        {:error, error}
+      end
+  catch
+    :exit, {:timeout, _} ->
+      {:error, :timeout}
+  end
+
+  defp timeout_middleware_exception?(stacktrace) do
+    Enum.any?(stacktrace, fn
+      {Tesla.Middleware.Timeout, :call, 3, _} -> true
+      {Tesla.Middleware.Timeout, :repass_error, 1, _} -> true
+      _ -> false
+    end)
+  end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -3,6 +3,8 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
   Uses `Tesla.Mint` for `EthereumJSONRPC.HTTP`
   """
 
+  require Logger
+
   alias EthereumJSONRPC.HTTP
   alias EthereumJSONRPC.HTTP.Helper
   alias EthereumJSONRPC.Prometheus.Instrumenter
@@ -39,12 +41,14 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
   rescue
     error ->
       if timeout_middleware_exception?(__STACKTRACE__) do
+        log_normalized_timeout(:rescue, url, headers, options)
         {:error, :timeout}
       else
         {:error, error}
       end
   catch
     :exit, {:timeout, _} ->
+      log_normalized_timeout(:exit, url, headers, options)
       {:error, :timeout}
   end
 
@@ -54,5 +58,11 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
       {Tesla.Middleware.Timeout, :repass_error, 1, _} -> true
       _ -> false
     end)
+  end
+
+  defp log_normalized_timeout(source, url, headers, options) do
+    Logger.warning(
+      "Normalized timeout in do_post/4 source=#{source} url=#{inspect(url)} timeout=#{inspect(options[:timeout])} recv_timeout=#{inspect(options[:recv_timeout])} headers_count=#{length(headers)}"
+    )
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14059

## Motivation

Prevent indexer crashes during initial indexing when the JSON-RPC HTTP timeout path raises from Tesla middleware instead of returning a timeout tuple.

## Changelog

### Enhancements

- Added defensive handling in Ethereum JSON-RPC Tesla transport to classify timeout-middleware exception stack traces and normalize them to timeout errors.
- Preserved existing error instrumentation flow so transport failures continue to be counted and observed.

### Bug Fixes

- Fixed a crash path where Tesla timeout middleware exceptions could escape the transport layer and terminate indexer GenServer processes.
- Transport now returns timeout error tuples for timeout middleware failures, allowing upstream retry/backoff logic to handle the condition gracefully.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for Ethereum JSON-RPC HTTP requests: timeouts coming from exceptions or system exits are now detected and normalized to a consistent timeout error, and a structured warning is logged with the source, request URL, timeout values, and header count to aid diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->