### PR TITLE
fix: ignore unknown fields in ethereum_jsonrpc JSON response parsing

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/besu/trace.ex
@@ -44,4 +44,5 @@ defmodule EthereumJSONRPC.Besu.Trace do
   end
 
   defp entry_to_elixir({"transactionIndex", index} = entry) when is_integer(index), do: entry
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
@@ -324,6 +324,8 @@ defmodule EthereumJSONRPC.Geth.Call do
     entry
   end
 
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
+
   defp elixir_to_internal_transaction_params(
          %{
            "blockNumber" => block_number,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace.ex
@@ -484,4 +484,5 @@ defmodule EthereumJSONRPC.Nethermind.Trace do
   end
 
   defp entry_to_elixir({"transactionIndex", index} = entry) when is_integer(index), do: entry
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace/action.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace/action.ex
@@ -51,4 +51,6 @@ defmodule EthereumJSONRPC.Nethermind.Trace.Action do
   defp entry_to_elixir({key, quantity}) when key in ~w(balance gas value) do
     {key, quantity_to_integer(quantity)}
   end
+
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace/result.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/nethermind/trace/result.ex
@@ -39,4 +39,6 @@ defmodule EthereumJSONRPC.Nethermind.Trace.Result do
   defp entry_to_elixir({key, quantity}) when key in ~w(gasUsed) do
     {key, quantity_to_integer(quantity)}
   end
+
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawal.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/withdrawal.ex
@@ -98,4 +98,5 @@ defmodule EthereumJSONRPC.Withdrawal do
 
   defp entry_to_elixir({key, value}) when key in ~w(index validatorIndex amount), do: {key, quantity_to_integer(value)}
   defp entry_to_elixir({key, value}) when key in ~w(address), do: {key, value}
+  defp entry_to_elixir({_, _}), do: {:ignore, :ignore}
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/10334

## Motivation

Several modules in `apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/` would crash with a `FunctionClauseError` when a node returned an unexpected or newly introduced JSON field in its response. `EthereumJSONRPC.Receipt` already handled this correctly by having a catch-all `entry_to_elixir` clause that silently ignores unknown keys. The same pattern was missing from six other modules.

## Changelog

### Bug Fixes

- Added a catch-all `defp entry_to_elixir({_, _}), do: {:ignore, :ignore}` clause to the following modules to silently ignore unexpected fields returned by the node, matching the existing behavior in `EthereumJSONRPC.Receipt`:
  - `EthereumJSONRPC.Withdrawal`
  - `EthereumJSONRPC.Nethermind.Trace`
  - `EthereumJSONRPC.Nethermind.Trace.Result`
  - `EthereumJSONRPC.Nethermind.Trace.Action`
  - `EthereumJSONRPC.Besu.Trace`
  - `EthereumJSONRPC.Geth.Call`


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience across JSON-RPC response processors to gracefully handle unexpected or unrecognized fields, ensuring the system continues functioning correctly when receiving data with additional properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->