### PR TITLE
chore: Add Autoscout promo in the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Add Autoscout promo in the logs ([#14234](https://github.com/blockscout/blockscout/pull/14234))
 - Improve internal transactions migrations ([#14233](https://github.com/blockscout/blockscout/pull/14233))
 - Remove unused Explorer.Chain.Address.find_contract_addresses/2 function ([#14220](https://github.com/blockscout/blockscout/pull/14220))
 - Prevent deadlocks in IT fields removing migration ([#14215](https://github.com/blockscout/blockscout/pull/14215))

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -104,7 +104,8 @@ defmodule Explorer.Application do
         recv_timeout: 60_000,
         timeout: 60_000,
         max_connections: Application.get_env(:explorer, :hackney_default_pool_size)
-      )
+      ),
+      Explorer.Promo.Autoscout
     ]
 
     children = base_children ++ configurable_children()

--- a/apps/explorer/lib/explorer/promo/autoscout.ex
+++ b/apps/explorer/lib/explorer/promo/autoscout.ex
@@ -26,7 +26,6 @@ defmodule Explorer.Promo.Autoscout do
 
   @impl GenServer
   def init(_) do
-    Logger.info(@autoscout_promo)
     Process.send_after(self(), :promo, :timer.seconds(10))
 
     {:ok, %{}}

--- a/apps/explorer/lib/explorer/promo/autoscout.ex
+++ b/apps/explorer/lib/explorer/promo/autoscout.ex
@@ -1,0 +1,43 @@
+defmodule Explorer.Promo.Autoscout do
+  @moduledoc """
+  Module responsible for logging the Autoscout promo message on application startup.
+  """
+
+  require Logger
+
+  use GenServer
+
+  @autoscout_promo """
+
+
+   █   █     ███  █   █ █████  ███   ████  ████  ███  █   █ █████
+  █     █   █   █ █   █   █   █   █ █     █     █   █ █   █   █
+  █  █  █   █████ █   █   █   █   █  ███  █     █   █ █   █   █
+  █  █  █   █   █ █   █   █   █   █     █ █     █   █ █   █   █
+  █     █   █   █  ███    █    ███  ████   ████  ███   ███    █
+
+  Deploy Blockscout explorer in 5 minutes at deploy.blockscout.com
+  """
+
+  def start_link(_) do
+    Logger.info(@autoscout_promo)
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    Process.send_after(self(), :promo, :timer.seconds(10))
+
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_info(:promo, state) do
+    promo()
+    {:noreply, state}
+  end
+
+  defp promo do
+    Logger.info(@autoscout_promo)
+  end
+end

--- a/apps/explorer/lib/explorer/promo/autoscout.ex
+++ b/apps/explorer/lib/explorer/promo/autoscout.ex
@@ -20,12 +20,12 @@ defmodule Explorer.Promo.Autoscout do
   """
 
   def start_link(_) do
-    Logger.info(@autoscout_promo)
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
   @impl GenServer
   def init(_) do
+    Logger.info(@autoscout_promo)
     Process.send_after(self(), :promo, :timer.seconds(10))
 
     {:ok, %{}}

--- a/apps/explorer/lib/explorer/promo/autoscout.ex
+++ b/apps/explorer/lib/explorer/promo/autoscout.ex
@@ -1,6 +1,7 @@
 defmodule Explorer.Promo.Autoscout do
   @moduledoc """
-  Module responsible for logging the Autoscout promo message on application startup.
+  Module responsible for logging the Autoscout promo message on application startup
+  and once again 10 seconds after initialization.
   """
 
   require Logger

--- a/apps/explorer/test/explorer/promo/autoscout_test.exs
+++ b/apps/explorer/test/explorer/promo/autoscout_test.exs
@@ -1,0 +1,47 @@
+defmodule Explorer.Promo.AutoscoutTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog, only: [capture_log: 1]
+
+  alias Explorer.Promo.Autoscout
+
+  @promo_line "Deploy Blockscout explorer in 5 minutes at deploy.blockscout.com"
+
+  @moduletag :capture_log
+
+  describe "init/1" do
+    test "logs promo and returns the initial state" do
+      parent = self()
+
+      log =
+        capture_log(fn ->
+          pid =
+            spawn(fn ->
+              send(parent, {:init_result, Autoscout.init(nil)})
+
+              receive do
+                :stop -> :ok
+              end
+            end)
+
+          assert_receive {:init_result, {:ok, %{}}}
+          send(pid, :stop)
+        end)
+
+      assert log =~ @promo_line
+    end
+  end
+
+  describe "handle_info/2" do
+    test "logs promo and keeps state unchanged" do
+      state = %{example: :state}
+
+      log =
+        capture_log(fn ->
+          assert {:noreply, ^state} = Autoscout.handle_info(:promo, state)
+        end)
+
+      assert log =~ @promo_line
+    end
+  end
+end

--- a/apps/explorer/test/explorer/promo/autoscout_test.exs
+++ b/apps/explorer/test/explorer/promo/autoscout_test.exs
@@ -10,25 +10,20 @@ defmodule Explorer.Promo.AutoscoutTest do
   @moduletag :capture_log
 
   describe "init/1" do
-    test "logs promo and returns the initial state" do
+    test "returns the initial state" do
       parent = self()
 
-      log =
-        capture_log(fn ->
-          pid =
-            spawn(fn ->
-              send(parent, {:init_result, Autoscout.init(nil)})
+      pid =
+        spawn(fn ->
+          send(parent, {:init_result, Autoscout.init(nil)})
 
-              receive do
-                :stop -> :ok
-              end
-            end)
-
-          assert_receive {:init_result, {:ok, %{}}}
-          send(pid, :stop)
+          receive do
+            :stop -> :ok
+          end
         end)
 
-      assert log =~ @promo_line
+      assert_receive {:init_result, {:ok, %{}}}
+      send(pid, :stop)
     end
   end
 

--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
         "autodetecttrue",
         "Autonity",
         "autoplay",
+        "Autoscout",
         "Averify",
         "awesomplete",
         "Backfiller",


### PR DESCRIPTION
## Motivation

Add Autoscout promo in the application logs for every mode.

## Changelog

This pull request introduces a new module to display a promotional message for Autoscout on application startup. The main changes involve registering and implementing the `Explorer.Promo.Autoscout` GenServer, which handles the logging of the promo message.

**New Autoscout Promo Feature:**

* Added `Explorer.Promo.Autoscout` GenServer module that logs an ASCII art promotional message for Autoscout after 10 seconds of application startup.
* Registered `Explorer.Promo.Autoscout` as a child process in the application's supervision tree in `explorer/application.ex`.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an Autoscout promotional banner that is logged shortly after application start.
* **Tests**
  * Adds tests ensuring the promo message is emitted and does not alter state.
* **Chores**
  * Adds "Autoscout" to the spelling dictionary to avoid false positives.
* **Documentation**
  * Adds a CHANGELOG entry noting the new Autoscout promo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->