### PR TITLE
refactor: use Hash.Address for token info export queue

### DIFF
--- a/apps/explorer/lib/explorer/chain/multichain_search_db/token_info_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/token_info_export_queue.ex
@@ -7,6 +7,7 @@ defmodule Explorer.Chain.MultichainSearchDb.TokenInfoExportQueue do
 
   import Ecto.Query
 
+  alias Explorer.Chain.Hash
   alias Explorer.Repo
 
   @required_attrs ~w(address_hash data_type data)a
@@ -15,7 +16,7 @@ defmodule Explorer.Chain.MultichainSearchDb.TokenInfoExportQueue do
 
   @primary_key false
   typed_schema "multichain_search_db_export_token_info_queue" do
-    field(:address_hash, :binary, null: false, primary_key: true)
+    field(:address_hash, Hash.Address, null: false, primary_key: true)
 
     field(:data_type, Ecto.Enum,
       values: [
@@ -86,7 +87,8 @@ defmodule Explorer.Chain.MultichainSearchDb.TokenInfoExportQueue do
     ## Returns
     - An `Ecto.Query` struct containing the delete operation.
   """
-  @spec delete_query(%{:address_hash => binary(), :data_type => atom(), optional(:data) => map()}) :: Ecto.Query.t()
+  @spec delete_query(%{:address_hash => Hash.Address.t(), :data_type => atom(), optional(:data) => map()}) ::
+          Ecto.Query.t()
   def delete_query(queue_item) do
     from(q in __MODULE__,
       where: q.address_hash == ^queue_item.address_hash and q.data_type == ^queue_item.data_type

--- a/apps/explorer/lib/explorer/chain/multichain_search_db/token_info_export_queue.ex
+++ b/apps/explorer/lib/explorer/chain/multichain_search_db/token_info_export_queue.ex
@@ -87,7 +87,7 @@ defmodule Explorer.Chain.MultichainSearchDb.TokenInfoExportQueue do
     ## Returns
     - An `Ecto.Query` struct containing the delete operation.
   """
-  @spec delete_query(%{:address_hash => Hash.Address.t(), :data_type => atom(), optional(:data) => map()}) ::
+  @spec delete_query(%{:address_hash => Hash.Address.t() | binary(), :data_type => atom(), optional(:data) => map()}) ::
           Ecto.Query.t()
   def delete_query(queue_item) do
     from(q in __MODULE__,

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -140,7 +140,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   """
   @spec batch_export_token_info([
           %{
-            :address_hash => binary(),
+            :address_hash => Hash.Address.t() | binary(),
             :data_type => :metadata | :total_supply | :counters | :market_data,
             :data => map()
           }
@@ -430,7 +430,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     - A map ready to send to Multichain service via HTTP.
   """
   @spec token_info_queue_item_to_http_item(%{
-          :address_hash => binary(),
+          :address_hash => Hash.Address.t() | binary(),
           :data_type => :metadata | :total_supply | :counters | :market_data,
           :data => map()
         }) ::
@@ -438,7 +438,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
           | %{:address_hash => String.t(), :counters => map()}
           | %{:address_hash => String.t(), :price_data => map()}
   def token_info_queue_item_to_http_item(item_from_db_queue) do
-    token = %{address_hash: "0x" <> Base.encode16(item_from_db_queue.address_hash, case: :lower)}
+    token = %{address_hash: item_from_db_queue.address_hash |> cast_address_hash!() |> Hash.to_string()}
 
     case item_from_db_queue.data_type do
       :metadata -> Map.put(token, :metadata, item_from_db_queue.data)
@@ -463,12 +463,12 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
           | %{:address_hash => String.t(), :counters => map()}
           | %{:address_hash => String.t(), :price_data => map()}
         ) :: %{
-          :address_hash => binary(),
+          :address_hash => Hash.Address.t(),
           :data_type => :metadata | :total_supply | :counters | :market_data,
           :data => map()
         }
   def token_info_http_item_to_queue_item(%{address_hash: "0x" <> address_string} = http_item) do
-    {:ok, address_hash} = Base.decode16(address_string, case: :mixed)
+    address_hash = cast_address_hash!("0x" <> address_string)
 
     metadata = Map.get(http_item, :metadata)
 
@@ -746,7 +746,10 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     # - `:ok` if the data is accepted for insertion.
     # - `:ignore` if the Multichain service is not used.
   """
-  @spec send_token_info_to_queue(%{binary() => map()}, :metadata | :total_supply | :counters | :market_data) ::
+  @spec send_token_info_to_queue(
+          %{(Hash.Address.t() | binary()) => map()},
+          :metadata | :total_supply | :counters | :market_data
+        ) ::
           :ok | :ignore
   def send_token_info_to_queue(entries, entries_type) do
     if enabled?() do
@@ -768,19 +771,26 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   end
 
   @spec extract_token_info_entries_into_chunks(
-          %{binary() => map()},
+          %{(Hash.Address.t() | binary()) => map()},
           :metadata | :total_supply | :counters | :market_data
         ) :: list()
   defp extract_token_info_entries_into_chunks(entries, entries_type) do
     entries
     |> Enum.map(fn {address_hash, data} ->
       %{
-        address_hash: address_hash,
+        address_hash: cast_address_hash!(address_hash),
         data_type: entries_type,
         data: data
       }
     end)
     |> Enum.chunk_every(token_info_chunk_size())
+  end
+
+  defp cast_address_hash!(address_hash) do
+    case Hash.Address.cast(address_hash) do
+      {:ok, cast_address_hash} -> cast_address_hash
+      :error -> raise ArgumentError, "invalid token info address_hash: #{inspect(address_hash)}"
+    end
   end
 
   @doc """

--- a/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
+++ b/apps/explorer/test/explorer/microservice_interfaces/multichain_search_test.exs
@@ -5,7 +5,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
   alias Explorer.Chain.Cache.ChainId
   alias Explorer.Chain.MultichainSearchDb.{MainExportQueue, TokenInfoExportQueue}
-  alias Explorer.Chain.{Token, Wei}
+  alias Explorer.Chain.{Hash, Token, Wei}
   alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.{Repo, TestHelper}
   alias Plug.Conn
@@ -667,13 +667,13 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
   describe "token_info_http_item_to_queue_item/1" do
     test "returns correct map to add to queue" do
       address_hash_string = "0x000102030405060708090a0b0c0d0e0f10111213"
-      address_hash_binary = Base.decode16!("000102030405060708090a0b0c0d0e0f10111213", case: :mixed)
+      {:ok, address_hash} = Hash.Address.cast(address_hash_string)
 
       assert MultichainSearch.token_info_http_item_to_queue_item(%{
                address_hash: address_hash_string,
                metadata: %{token_type: "ERC-20", name: "TestToken", symbol: "TEST", decimals: 18, total_supply: "1000"}
              }) == %{
-               address_hash: address_hash_binary,
+               address_hash: address_hash,
                data_type: :metadata,
                data: %{token_type: "ERC-20", name: "TestToken", symbol: "TEST", decimals: 18, total_supply: "1000"}
              }
@@ -682,7 +682,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                address_hash: address_hash_string,
                metadata: %{token_type: "ERC-20"}
              }) == %{
-               address_hash: address_hash_binary,
+               address_hash: address_hash,
                data_type: :metadata,
                data: %{token_type: "ERC-20"}
              }
@@ -691,7 +691,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                address_hash: address_hash_string,
                metadata: %{total_supply: "1000"}
              }) == %{
-               address_hash: address_hash_binary,
+               address_hash: address_hash,
                data_type: :total_supply,
                data: %{total_supply: "1000"}
              }
@@ -700,7 +700,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                address_hash: address_hash_string,
                counters: %{holders_count: "123", transfers_count: "456"}
              }) == %{
-               address_hash: address_hash_binary,
+               address_hash: address_hash,
                data_type: :counters,
                data: %{holders_count: "123", transfers_count: "456"}
              }
@@ -709,7 +709,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                address_hash: address_hash_string,
                price_data: %{fiat_value: "123.456", circulating_market_cap: "1000.0001"}
              }) == %{
-               address_hash: address_hash_binary,
+               address_hash: address_hash,
                data_type: :market_data,
                data: %{fiat_value: "123.456", circulating_market_cap: "1000.0001"}
              }
@@ -940,8 +940,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                :ok
 
       [record] = Repo.all(TokenInfoExportQueue)
+      {:ok, address_hash} = Hash.Address.cast(address_hash_binary)
 
-      assert record.address_hash == address_hash_binary && record.data_type == :total_supply &&
+      assert record.address_hash == address_hash && record.data_type == :total_supply &&
                record.data == %{"total_supply" => "123"}
     end
 
@@ -972,15 +973,19 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
       assert MultichainSearch.send_token_info_to_queue(entries, :total_supply) == :ok
 
       records = Repo.all(TokenInfoExportQueue)
+      {:ok, address1_hash} = Hash.Address.cast(address1_hash_binary)
+      {:ok, address2_hash} = Hash.Address.cast(address2_hash_binary)
+      {:ok, address3_hash} = Hash.Address.cast(address3_hash_binary)
+      {:ok, address4_hash} = Hash.Address.cast(address4_hash_binary)
 
       assert Enum.all?(records, fn record ->
-               (record.address_hash == address1_hash_binary && record.data_type == :total_supply &&
+               (record.address_hash == address1_hash && record.data_type == :total_supply &&
                   record.data == %{"total_supply" => "123"}) ||
-                 (record.address_hash == address2_hash_binary && record.data_type == :total_supply &&
+                 (record.address_hash == address2_hash && record.data_type == :total_supply &&
                     record.data == %{"total_supply" => "124"}) ||
-                 (record.address_hash == address3_hash_binary && record.data_type == :total_supply &&
+                 (record.address_hash == address3_hash && record.data_type == :total_supply &&
                     record.data == %{"total_supply" => "125"}) ||
-                 (record.address_hash == address4_hash_binary && record.data_type == :total_supply &&
+                 (record.address_hash == address4_hash && record.data_type == :total_supply &&
                     record.data == %{"total_supply" => "126"})
              end)
     end
@@ -1004,8 +1009,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
                :ok
 
       [record] = Repo.all(TokenInfoExportQueue)
+      {:ok, address_hash} = Hash.Address.cast(address_hash_binary)
 
-      assert record.address_hash == address_hash_binary && record.data_type == :total_supply &&
+      assert record.address_hash == address_hash && record.data_type == :total_supply &&
                record.data == %{"total_supply" => "123"}
 
       assert MultichainSearch.send_token_info_to_queue(%{address_hash_binary => %{total_supply: "124"}}, :total_supply) ==
@@ -1013,7 +1019,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearchTest do
 
       [record_new] = Repo.all(TokenInfoExportQueue)
 
-      assert record_new.address_hash == address_hash_binary && record_new.data_type == :total_supply &&
+      assert record_new.address_hash == address_hash && record_new.data_type == :total_supply &&
                record_new.data == %{"total_supply" => "124"} &&
                DateTime.compare(record_new.updated_at, record.updated_at) == :gt
     end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -321,7 +321,7 @@ defmodule Explorer.Factory do
       end
 
     %MultichainSearchDb.TokenInfoExportQueue{
-      address_hash: address_hash().bytes,
+      address_hash: address_hash(),
       data_type: data_type,
       data: data
     }

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -326,7 +326,7 @@ defmodule Explorer.Factory do
       end
 
     %MultichainSearchDb.TokenInfoExportQueue{
-      address_hash: address_hash().bytes,
+      address_hash: address_hash(),
       data_type: data_type,
       data: data
     }

--- a/apps/indexer/test/indexer/fetcher/multichain_search_db/token_info_export_queue_test.exs
+++ b/apps/indexer/test/indexer/fetcher/multichain_search_db/token_info_export_queue_test.exs
@@ -4,6 +4,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.TokenInfoExportQueueTest do
 
   import ExUnit.CaptureLog, only: [capture_log: 1]
 
+  alias Explorer.Chain.Hash
   alias Explorer.Chain.MultichainSearchDb.TokenInfoExportQueue
   alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.TestHelper
@@ -140,7 +141,7 @@ defmodule Indexer.Fetcher.MultichainSearchDb.TokenInfoExportQueueTest do
       token_info_item_2 = insert(:multichain_search_db_export_token_info_queue)
       token_info_item_3 = insert(:multichain_search_db_export_token_info_queue)
       token_info_item_4 = insert(:multichain_search_db_export_token_info_queue)
-      token_info_item_4_address_hash_string = "0x" <> Base.encode16(token_info_item_4.address_hash, case: :lower)
+      token_info_item_4_address_hash_string = Hash.to_string(token_info_item_4.address_hash)
       token_info_item_5 = insert(:multichain_search_db_export_token_info_queue)
 
       export_data = [


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12894

## Motivation

Align token info export queue address typing with the rest of the codebase by using `Hash.Address` instead of raw binary for `address_hash`.  
This improves consistency and convenience when reading, comparing, serializing, and testing queue items.

## Changelog

### Enhancements

- Added explicit address hash casting in token info queue conversion and queue insertion paths to support both binary and Hash.Address inputs safely.
- Updated tests and factories to use `Hash.Address`-aware expectations and fixtures.

### Bug Fixes

- Changed `TokenInfoExportQueue.address_hash` type from binary to Hash.Address.
- Fixed token info HTTP serialization/deserialization paths to correctly handle Hash.Address values.
- Prevented potential runtime issues in insert_all flows by normalizing address hash input before queue inserts.

### Incompatible Changes

- Internal queue item shape now uses Hash.Address for address_hash where values are loaded from the schema.
- No database migration is required because storage remains bytea-compatible through Ecto type dump/load.

## Upgrading

No database reset or reindex required.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to master.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved address-hash handling across token export, queueing and HTTP conversion for more consistent, robust processing of token info.
* **Tests**
  * Updated test fixtures and assertions to use the canonical address representation and validate the revised handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14236)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->