### PR TITLE
fix: Address ids usage improvements

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -67,7 +67,8 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_create_transactions_created_contract_address_hash_w_pending_index_finished,
     key: :heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_a_finished,
     key: :heavy_indexes_create_addresses_hash_contract_code_not_null_index_finished,
-    key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished
+    key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished,
+    key: :fill_internal_transactions_address_ids_finished
 
   @dialyzer :no_match
 
@@ -77,6 +78,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     ArbitrumDaRecordsNormalization,
     BackfillMultichainSearchDB,
     EmptyInternalTransactionsData,
+    FillInternalTransactionsAddressIds,
     SanitizeDuplicatedLogIndexLogs,
     TokenTransferTokenType,
     TransactionsDenormalization
@@ -402,6 +404,13 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     set_and_return_migration_status(
       EmptyInternalTransactionsData,
       &set_empty_internal_transactions_data_finished/1
+    )
+  end
+
+  defp handle_fallback(:fill_internal_transactions_address_ids_finished) do
+    set_and_return_migration_status(
+      FillInternalTransactionsAddressIds,
+      &set_fill_internal_transactions_address_ids_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -634,22 +634,30 @@ defmodule Explorer.Chain.InternalTransaction do
   defp address_match_dynamic(address_field, address_hash_or_hashes, address_id_or_ids) do
     address_hashes = List.wrap(address_hash_or_hashes)
     address_hash_field = String.to_existing_atom("#{address_field}_hash")
+    address_ids = List.wrap(address_id_or_ids)
+    address_id_field = String.to_existing_atom("#{address_field}_id")
 
-    if address_id_or_ids in [[], nil] or not address_ids_indexes_exists?() do
-      dynamic([it], field(it, ^address_hash_field) in ^address_hashes)
-    else
-      address_ids = List.wrap(address_id_or_ids)
-      address_id_field = String.to_existing_atom("#{address_field}_id")
+    cond do
+      address_id_or_ids in [[], nil] or not address_ids_indexes_exists?() ->
+        dynamic([it], field(it, ^address_hash_field) in ^address_hashes)
 
-      dynamic(
-        [it],
-        field(it, ^address_id_field) in ^address_ids or field(it, ^address_hash_field) in ^address_hashes
-      )
+      address_ids_filled?() ->
+        dynamic([it], field(it, ^address_id_field) in ^address_ids)
+
+      true ->
+        dynamic(
+          [it],
+          field(it, ^address_id_field) in ^address_ids or field(it, ^address_hash_field) in ^address_hashes
+        )
     end
   end
 
   defp address_ids_indexes_exists? do
     BackgroundMigrations.get_heavy_indexes_create_address_ids_internal_transactions_indexes_finished()
+  end
+
+  defp address_ids_filled? do
+    BackgroundMigrations.get_fill_internal_transactions_address_ids_finished()
   end
 
   def where_is_different_from_parent_transaction(query) do

--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -110,7 +110,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
   defp do_clear_internal_transactions(dynamic_condition) do
     Repo.transaction(
       fn ->
-        condition = dynamic([it], ^dynamic_condition and it.type == ^:call and it.value == ^0)
+        condition = dynamic([it], ^dynamic_condition and it.type == ^:call and (is_nil(it.value) or it.value == ^0))
 
         locked_internal_transactions_to_delete_query =
           from(
@@ -122,18 +122,19 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
           )
 
         delete_query =
-          InternalTransaction
-          |> join(:inner, [it], locked_it in subquery(locked_internal_transactions_to_delete_query),
-            on: join_on_ctid(it, locked_it)
+          from(
+            it in InternalTransaction,
+            inner_join: locked_it in subquery(locked_internal_transactions_to_delete_query),
+            on: join_on_ctid(it, locked_it),
+            select: %{
+              from_address_hash: it.from_address_hash,
+              from_address_id: it.from_address_id,
+              to_address_hash: it.to_address_hash,
+              to_address_id: it.to_address_id,
+              block_number: it.block_number,
+              index: it.index
+            }
           )
-          |> InternalTransaction.join_address_query(:from_address, :inner)
-          |> InternalTransaction.join_address_query(:to_address, :inner)
-          |> select([it], %{
-            from_address_hash: as(:from_address).hash,
-            to_address_hash: as(:to_address).hash,
-            block_number: it.block_number,
-            index: it.index
-          })
 
         {_count, deleted_internal_transactions} = Repo.delete_all(delete_query, timeout: :infinity)
 
@@ -164,14 +165,17 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
                 inner_acc
 
               internal_transaction, inner_acc ->
-                from_address_hash = internal_transaction.from_address_hash
-                to_address_hash = internal_transaction.to_address_hash
+                from_address_id =
+                  internal_transaction.from_address_id || address_to_id_map[internal_transaction.from_address_hash]
+
+                to_address_id =
+                  internal_transaction.to_address_id || address_to_id_map[internal_transaction.to_address_hash]
 
                 inner_acc
                 |> Map.update(
-                  from_address_hash,
+                  from_address_id,
                   %{
-                    address_id: address_to_id_map[from_address_hash],
+                    address_id: from_address_id,
                     block_number: block_number,
                     count_tos: 0,
                     count_froms: 1
@@ -181,9 +185,9 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
                   end
                 )
                 |> Map.update(
-                  to_address_hash,
+                  to_address_id,
                   %{
-                    address_id: address_to_id_map[to_address_hash],
+                    address_id: to_address_id,
                     block_number: block_number,
                     count_tos: 1,
                     count_froms: 0

--- a/apps/explorer/lib/explorer/migrator/fill_internal_transactions_address_ids.ex
+++ b/apps/explorer/lib/explorer/migrator/fill_internal_transactions_address_ids.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Migrator.FillInternalTransactionsAddressIds do
   import Ecto.Query
   import Explorer.QueryHelper, only: [select_ctid: 1, join_on_ctid: 2]
 
+  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.InternalTransaction
   alias Explorer.Migrator.FillingMigration
   alias Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError
@@ -137,5 +138,7 @@ defmodule Explorer.Migrator.FillInternalTransactionsAddressIds do
   end
 
   @impl FillingMigration
-  def update_cache, do: :ok
+  def update_cache do
+    BackgroundMigrations.set_fill_internal_transactions_address_ids_finished(true)
+  end
 end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14099

## Changelog

- Remove address hashes from internal transactions queries after filling address ids migration in completed
- Remove unnecessary addresses join from `DeleteZeroValueInternalTransactions` migration
- Updated zero value definition in `DeleteZeroValueInternalTransactions` according to `EmptyInternalTransactionsData`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Queries now prefer indexed address identifiers when backfill is ready, improving internal-transaction lookup speed.

* **Bug Fixes**
  * Deletion logic corrected to treat null-value and zero-value internal transactions equivalently.

* **Improvements**
  * Background migration state tracking enhanced to reliably gate ID-based optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->