### PR TITLE
fix: guard missing ETS table in contract creator fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug Fixes
 
+- Guard missing ETS table in contract creator fetcher ([#14241](https://github.com/blockscout/blockscout/pull/14241))
 - Address ids usage improvements ([#14240](https://github.com/blockscout/blockscout/pull/14240))
 - Fix timeouts for API v1 tokentx endpoint ([#14185](https://github.com/blockscout/blockscout/issues/14185))
 - Remove internal transaction error field references ([#14213](https://github.com/blockscout/blockscout/pull/14213))

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -45,6 +45,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
     with false <- is_nil(address.contract_code),
          true <- is_nil(creator_hash),
          false <- Address.eoa_with_code?(address),
+         true <- table_exists?(),
          {:address_lookup, [{_, contract_creation_block_number}]} <-
            {:address_lookup, :ets.lookup(@table_name, address_cache_name(address.hash))},
          {:pending_blocks_lookup, [{@pending_blocks_cache_key, blocks}]} <-
@@ -235,7 +236,17 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
 
   # - `[{String.t(), [map()]}]`: A list of tuples containing block identifiers and their associated data.
   @spec pending_blocks_cache() :: [{String.t(), [map()]}]
-  defp pending_blocks_cache, do: :ets.lookup(@table_name, @pending_blocks_cache_key)
+  defp pending_blocks_cache do
+    if table_exists?() do
+      :ets.lookup(@table_name, @pending_blocks_cache_key)
+    else
+      []
+    end
+  end
+
+  defp table_exists? do
+    :ets.whereis(@table_name) != :undefined
+  end
 
   @doc """
   Asynchronously updates value of ETS cache :contract_creator_lookup for key "pending_blocks":

--- a/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
@@ -117,6 +117,20 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                )
     end
 
+    test "does not crash when ETS table is unavailable" do
+      contract_address =
+        insert(:address, contract_code: "0x1234")
+
+      :ets.delete(:contract_creator_lookup)
+
+      assert :ignore =
+               ContractCreatorOnDemand.trigger_fetch(
+                 contract_address
+                 |> Repo.preload([:contract_creation_transaction])
+                 |> Address.preload_contract_creation_internal_transaction()
+               )
+    end
+
     test "initiates fetch if address has contract code but no creator hash (target block is right from the middle)" do
       contract_address =
         insert(:address, contract_code: "0x1234")


### PR DESCRIPTION
## Motivation
Prevent API request crashes when the on-demand contract creator ETS table is temporarily unavailable. In production, `trigger_fetch` can be called during startup or restart windows before the ETS table exists, which previously raised ArgumentError and terminated the request process.

## Changelog

### Enhancements
- Added a regression test that verifies trigger_fetch returns ignore and does not crash when the ETS table is missing.
- Kept behavior backward-compatible by safely skipping on-demand contract creator fetch logic while cache state is unavailable.

### Bug Fixes
- Added a table existence guard in trigger_fetch before ETS lookups.
- Made pending_blocks_cache return an empty list when the ETS table does not exist, avoiding runtime ETS lookup exceptions.
- Fixed the concrete crash path causing API v2 address endpoint failures due to missing ETS table.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
- [ ] General docs: submitted PR to docs repository.
- [ ] ENV vars: updated env vars list and set version parameter to master.
- [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked that they are not redundant, with PGHero or other tools.
- [ ] If I added or removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience so operations now safely ignore missing internal lookup data instead of crashing.

* **Tests**
  * Added coverage for the edge case where internal lookup data is removed, ensuring graceful handling.

* **Documentation**
  * Changelog updated to note the fix for guarded lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->