### PR TITLE
fix: Fix OnDemand.InternalTransaction fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -455,6 +455,21 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
       |> windows([q], w: [order_by: [{^order, :block_number}]])
       |> select([q], %{
         block_number: q.block_number,
+        value:
+          fragment(
+            """
+            CASE ?
+              WHEN 'froms' THEN ?
+              WHEN 'tos'   THEN ?
+              ELSE ? + ?
+            END
+            """,
+            ^sum_mode,
+            q.count_froms,
+            q.count_tos,
+            q.count_froms,
+            q.count_tos
+          ),
         running_sum:
           fragment(
             """
@@ -478,6 +493,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
       from(r in subquery(ranked_query),
         select: %{
           block_number: r.block_number,
+          value: r.value,
           running_sum: r.running_sum,
           cutoff_block:
             fragment(
@@ -491,8 +507,8 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
 
     condition =
       case order do
-        :desc -> dynamic([c], is_nil(c.cutoff_block) or c.block_number >= c.cutoff_block)
-        :asc -> dynamic([c], is_nil(c.cutoff_block) or c.block_number <= c.cutoff_block)
+        :desc -> dynamic([c], c.value > 0 and (is_nil(c.cutoff_block) or c.block_number >= c.cutoff_block))
+        :asc -> dynamic([c], c.value > 0 and (is_nil(c.cutoff_block) or c.block_number <= c.cutoff_block))
       end
 
     final_query =

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -350,4 +350,44 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
     assert result |> Enum.filter(&(&1.block_number == 3)) |> Enum.count() == 3
     assert result |> Enum.filter(&(&1.block_number == 2)) |> Enum.count() == 1
   end
+
+  test "fetch_by_address/2 (no suitable placeholders)" do
+    address = insert(:address)
+    address_hash_str = to_string(address.hash)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 1,
+      count_tos: 0,
+      count_froms: 1
+    )
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 2,
+      count_tos: 0,
+      count_froms: 2
+    )
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 3,
+      count_tos: 0,
+      count_froms: 3
+    )
+
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth,
+      tracer: "call_tracer",
+      debug_trace_timeout: "5s",
+      block_traceable?: true
+    )
+
+    opts = [
+      direction: :to_address_hash,
+      paging_options: %PagingOptions{page_size: 4}
+    ]
+
+    assert [] = InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
+  end
 end


### PR DESCRIPTION
## Motivation

In case when there is no suitable by direction address placeholders, `get_block_numbers_for_address/6` would return all the blocks that contains internal transactions for address even if all of them doesn't match query direction. It causes unnecessary node requests.

## Changelog

Fix placeholders filtering logic to count only those placeholders that match the provided direction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination accuracy for internal transaction address queries through enhanced boundary condition validation.
  * Enhanced handling of edge cases when processing deleted transaction records with insufficient transaction data.

* **Tests**
  * Added test coverage to verify correct behavior when internal transaction queries yield no results due to insufficient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->