### PR TITLE
fix: Internal transactions on-demand fetcher: check existence of deleted internal transactions address placeholders

### DIFF
--- a/apps/explorer/lib/explorer/utility/internal_transactions_address_placeholder.ex
+++ b/apps/explorer/lib/explorer/utility/internal_transactions_address_placeholder.ex
@@ -6,6 +6,8 @@ defmodule Explorer.Utility.InternalTransactionsAddressPlaceholder do
 
   use Explorer.Schema
 
+  alias Explorer.Repo
+
   @primary_key false
   typed_schema "deleted_internal_transactions_address_placeholders" do
     field(:address_id, :integer, primary_key: true)
@@ -17,5 +19,10 @@ defmodule Explorer.Utility.InternalTransactionsAddressPlaceholder do
   @doc false
   def changeset(placeholder \\ %__MODULE__{}, params) do
     cast(placeholder, params, [:address_id, :block_number, :count_tos, :count_froms])
+  end
+
+  @spec empty?() :: boolean()
+  def empty? do
+    not Repo.exists?(__MODULE__)
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -37,7 +37,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
          true <- InternalTransaction.present_in_db?(min_block_number) do
       false
     else
-      _ -> true
+      _ -> not InternalTransactionsAddressPlaceholder.empty?()
     end
   end
 


### PR DESCRIPTION
## Motivation

If the `deleted_internal_transactions_address_placeholders` table is empty and the number of internal transactions in the database is below the page limit for the view, we should not make additional on-demand calls to the node to fetch more transactions. Instead, we should return the results already available in the database.

## Changelog

This pull request introduces a mechanism to check if the `deleted_internal_transactions_address_placeholders` table is empty and updates the logic for determining the presence of internal transactions accordingly. The main changes are grouped into utility module enhancements and fetcher logic updates.

**Utility module enhancements:**

* Added a new function `empty?/0` to the `Explorer.Utility.InternalTransactionsAddressPlaceholder` module, which returns `true` if the `deleted_internal_transactions_address_placeholders` table is empty, using `Repo.exists?/1` for the check. [[1]](diffhunk://#diff-c6a8c492f9d6171e4018b56073424c7885c642996bc29376cefd42116b6335bcR9-R10) [[2]](diffhunk://#diff-c6a8c492f9d6171e4018b56073424c7885c642996bc29376cefd42116b6335bcR23-R27)

**Fetcher logic updates:**

* Updated the fallback logic in `Indexer.Fetcher.OnDemand.InternalTransaction` to use the new `empty?/0` function, so the presence check now depends on whether the address placeholder table is empty.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced on-demand internal transaction fetching by implementing a data availability check before processing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->