### PR TITLE
chore: add coverage for core API v2 views

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/address_view_test.exs
@@ -1,0 +1,67 @@
+defmodule BlockScoutWeb.API.V2.AddressViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.AddressView
+  alias Explorer.Chain.Wei
+
+  describe "prepare_coin_balance_history_entry/1" do
+    test "returns map with expected keys and values" do
+      block_timestamp = ~U[2023-01-01 00:00:00Z]
+      delta = Decimal.new(100)
+      value = Decimal.new(200)
+
+      coin_balance = %{
+        transaction_hash: nil,
+        block_number: 10,
+        delta: delta,
+        value: value,
+        block_timestamp: block_timestamp
+      }
+
+      result = AddressView.prepare_coin_balance_history_entry(coin_balance)
+
+      assert result["transaction_hash"] == nil
+      assert result["block_number"] == 10
+      assert Decimal.equal?(result["delta"], delta)
+      assert Decimal.equal?(result["value"], value)
+      assert result["block_timestamp"] == block_timestamp
+    end
+  end
+
+  describe "prepare_coin_balance_history_by_day_entry/1" do
+    test "returns date and value" do
+      value = Decimal.new(500)
+      coin_balance_by_day = %{date: ~D[2023-01-01], value: value}
+
+      result = AddressView.prepare_coin_balance_history_by_day_entry(coin_balance_by_day)
+
+      assert result["date"] == ~D[2023-01-01]
+      assert Decimal.equal?(result["value"], value)
+    end
+  end
+
+  describe "prepare_address_for_list/1" do
+    test "includes coin balance and transaction count" do
+      address =
+        build(:address,
+          fetched_coin_balance: %Wei{value: Decimal.new(100)},
+          transactions_count: 5
+        )
+
+      result = AddressView.prepare_address_for_list(address)
+
+      assert Decimal.equal?(result[:coin_balance], Decimal.new(100))
+      assert result[:transactions_count] == "5"
+      assert Map.has_key?(result, "hash")
+    end
+
+    test "sets coin balance to nil when fetched coin balance is missing" do
+      address = build(:address, fetched_coin_balance: nil, transactions_count: 3)
+
+      result = AddressView.prepare_address_for_list(address)
+
+      assert result[:coin_balance] == nil
+      assert result[:transactions_count] == "3"
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/api_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/api_view_test.exs
@@ -1,0 +1,25 @@
+defmodule BlockScoutWeb.API.V2.ApiViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.ApiView
+
+  describe "render/2" do
+    test "renders message.json" do
+      assert %{"message" => "ok"} = ApiView.render("message.json", %{message: "ok"})
+    end
+
+    test "renders smart_contract_audit_report_changeset_errors.json" do
+      changeset =
+        {%{}, %{audit_report_url: :string}}
+        |> Ecto.Changeset.cast(%{}, [])
+        |> Ecto.Changeset.add_error(:audit_report_url, "can't be blank")
+
+      result =
+        ApiView.render("smart_contract_audit_report_changeset_errors.json", %{changeset: changeset})
+
+      assert result["message"] == "Error on inserting audit report"
+      assert is_map(result["errors"])
+      assert map_size(result["errors"]) > 0
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/block_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/block_view_test.exs
@@ -1,0 +1,59 @@
+defmodule BlockScoutWeb.API.V2.BlockViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.BlockView
+  alias Explorer.Repo
+
+  describe "burnt_fees_percentage/2" do
+    test "returns nil when transaction fees are zero" do
+      assert BlockView.burnt_fees_percentage(Decimal.new(50), Decimal.new(0)) == nil
+    end
+
+    test "returns nil when transaction fees are nil" do
+      assert BlockView.burnt_fees_percentage(Decimal.new(50), nil) == nil
+    end
+
+    test "returns nil when burnt fees are nil" do
+      assert BlockView.burnt_fees_percentage(nil, Decimal.new(100)) == nil
+    end
+
+    test "returns percentage for valid values" do
+      assert BlockView.burnt_fees_percentage(Decimal.new(50), Decimal.new(100)) == 50.0
+    end
+  end
+
+  describe "render/2" do
+    test "renders block_countdown.json" do
+      result =
+        BlockView.render("block_countdown.json", %{
+          current_block: 100,
+          countdown_block: 200,
+          remaining_blocks: 100,
+          estimated_time_in_sec: 1200
+        })
+
+      assert result.current_block_number == 100
+      assert result.countdown_block_number == 200
+      assert result.remaining_blocks_count == 100
+      assert result.estimated_time_in_seconds == "1200"
+    end
+  end
+
+  describe "prepare_block/3" do
+    test "returns expected block fields" do
+      block =
+        insert(:block)
+        |> Repo.preload([:miner, :uncle_relations, :rewards, :withdrawals, :internal_transactions, :transactions])
+
+      result = BlockView.prepare_block(block, nil)
+
+      assert result["height"] == block.number
+      assert result["hash"] == block.hash
+      assert result["transactions_count"] == 0
+      assert result["uncles_hashes"] == []
+      assert result["rewards"] == []
+      assert result["withdrawals_count"] == 0
+      assert is_map(result["miner"])
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/config_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/config_view_test.exs
@@ -1,0 +1,11 @@
+defmodule BlockScoutWeb.API.V2.ConfigViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.ConfigView
+
+  test "renders backend_version.json" do
+    result = ConfigView.render("backend_version.json", %{version: "1.2.3"})
+
+    assert result == %{"backend_version" => "1.2.3"}
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/internal_transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/internal_transaction_view_test.exs
@@ -1,0 +1,101 @@
+defmodule BlockScoutWeb.API.V2.InternalTransactionViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.InternalTransactionView
+  alias Explorer.Chain.{InternalTransaction, Wei}
+
+  describe "prepare_internal_transaction/2" do
+    test "returns expected fields for a successful call" do
+      from_address = build(:address)
+      to_address = build(:address)
+
+      internal_transaction = %InternalTransaction{
+        error: nil,
+        type: :call,
+        call_type: :call,
+        transaction_hash: nil,
+        transaction_index: 0,
+        from_address: from_address,
+        from_address_hash: from_address.hash,
+        to_address: to_address,
+        to_address_hash: to_address.hash,
+        created_contract_address: nil,
+        created_contract_address_hash: nil,
+        value: Wei.zero(),
+        block_number: 10,
+        block: nil,
+        index: 0,
+        gas: Decimal.new(21_000)
+      }
+
+      result = InternalTransactionView.prepare_internal_transaction(internal_transaction, nil)
+
+      assert result["success"] == true
+      assert result["error"] == nil
+      assert result["type"] in [:call, "call"]
+      assert result["block_number"] == 10
+      assert result["index"] == 0
+      assert Decimal.equal?(result["gas_limit"], Decimal.new(21_000))
+      assert is_map(result["from"])
+      assert is_map(result["to"])
+    end
+
+    test "returns success false when error is present" do
+      from_address = build(:address)
+      to_address = build(:address)
+
+      internal_transaction = %InternalTransaction{
+        error: "reverted",
+        type: :call,
+        call_type: :call,
+        transaction_hash: nil,
+        transaction_index: 1,
+        from_address: from_address,
+        from_address_hash: from_address.hash,
+        to_address: to_address,
+        to_address_hash: to_address.hash,
+        created_contract_address: nil,
+        created_contract_address_hash: nil,
+        value: Wei.zero(),
+        block_number: 11,
+        block: nil,
+        index: 1,
+        gas: Decimal.new(22_000)
+      }
+
+      result = InternalTransactionView.prepare_internal_transaction(internal_transaction, nil)
+
+      assert result["success"] == false
+      assert result["error"] == "reverted"
+    end
+
+    test "uses provided block timestamp when block is passed" do
+      from_address = build(:address)
+      to_address = build(:address)
+      block = build(:block)
+
+      internal_transaction = %InternalTransaction{
+        error: nil,
+        type: :call,
+        call_type: :call,
+        transaction_hash: nil,
+        transaction_index: 2,
+        from_address: from_address,
+        from_address_hash: from_address.hash,
+        to_address: to_address,
+        to_address_hash: to_address.hash,
+        created_contract_address: nil,
+        created_contract_address_hash: nil,
+        value: Wei.zero(),
+        block_number: 12,
+        block: nil,
+        index: 2,
+        gas: Decimal.new(23_000)
+      }
+
+      result = InternalTransactionView.prepare_internal_transaction(internal_transaction, block)
+
+      assert result["timestamp"] == block.timestamp
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/internal_transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/internal_transaction_view_test.exs
@@ -29,10 +29,11 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionViewTest do
       }
 
       result = InternalTransactionView.prepare_internal_transaction(internal_transaction, nil)
+      expected_type = InternalTransaction.call_type(internal_transaction) || internal_transaction.type
 
       assert result["success"] == true
       assert result["error"] == nil
-      assert result["type"] in [:call, "call"]
+      assert result["type"] == expected_type
       assert result["block_number"] == 10
       assert result["index"] == 0
       assert Decimal.equal?(result["gas_limit"], Decimal.new(21_000))

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/search_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/search_view_test.exs
@@ -1,0 +1,78 @@
+defmodule BlockScoutWeb.API.V2.SearchViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.SearchView
+  alias Explorer.Chain.Address
+
+  describe "render search_results.json" do
+    test "renders search results list and encoded next_page_params" do
+      search_result = %{
+        type: "token",
+        name: "Token",
+        symbol: "TKN",
+        address_hash: "0x123",
+        icon_url: "https://example.com/token.png",
+        token_type: "ERC-20",
+        verified: true,
+        exchange_rate: Decimal.new("1.5"),
+        total_supply: Decimal.new("1000"),
+        circulating_market_cap: Decimal.new("1500"),
+        is_verified_via_admin_panel: false,
+        certified: nil,
+        priority: 1,
+        reputation: "ok",
+        is_smart_contract_address: true
+      }
+
+      result =
+        SearchView.render("search_results.json", %{
+          search_results: [search_result],
+          next_page_params: %{"q" => "token", "type" => ""}
+        })
+
+      assert [item] = result["items"]
+      assert item["type"] == "token"
+      assert item["name"] == "Token"
+      assert item["exchange_rate"] == "1.5"
+      assert item["certified"] == false
+      assert item["token_url"] =~ "/token/0x123"
+      assert item["address_url"] =~ "/address/0x123"
+
+      assert result["next_page_params"] == %{"q" => "token", "type" => nil}
+    end
+
+    test "renders redirect payload for successful lookup" do
+      address = build(:address)
+
+      result = SearchView.render("search_results.json", %{result: {:ok, address}})
+
+      assert result["redirect"] == true
+      assert result["type"] == "address"
+      assert result["parameter"] == Address.checksum(address.hash)
+    end
+
+    test "renders not found payload" do
+      assert SearchView.render("search_results.json", %{result: {:error, :not_found}}) ==
+               %{"redirect" => false, "type" => nil, "parameter" => nil}
+    end
+  end
+
+  describe "prepare_search_result/1" do
+    test "renders transaction search result" do
+      transaction = build(:transaction)
+
+      result =
+        SearchView.prepare_search_result(%{
+          type: "transaction",
+          transaction_hash: transaction.hash,
+          timestamp: ~U[2024-01-01 00:00:00Z],
+          priority: 2
+        })
+
+      assert result["type"] == "transaction"
+      assert result["transaction_hash"] == to_string(transaction.hash)
+      assert result["url"] =~ "/tx/"
+      assert result["priority"] == 2
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/stats_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/stats_view_test.exs
@@ -1,0 +1,33 @@
+defmodule BlockScoutWeb.API.V2.StatsViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.StatsView
+  alias Explorer.Chain.Wei
+
+  test "renders hot_smart_contracts.json" do
+    contract_address =
+      build(:address,
+        fetched_coin_balance: %Wei{value: Decimal.new(500)}
+      )
+
+    hot_contract = %{
+      contract_address: contract_address,
+      contract_address_hash: contract_address.hash,
+      transactions_count: 12,
+      total_gas_used: 34
+    }
+
+    result =
+      StatsView.render("hot_smart_contracts.json", %{
+        hot_smart_contracts: [hot_contract],
+        next_page_params: %{"items_count" => 50}
+      })
+
+    assert result.next_page_params == %{"items_count" => 50}
+    assert [item] = result.items
+    assert item.transactions_count == "12"
+    assert item.total_gas_used == "34"
+    assert Decimal.equal?(item.balance, Decimal.new(500))
+    assert is_map(item.contract_address)
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/token_transfer_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/token_transfer_view_test.exs
@@ -1,0 +1,64 @@
+defmodule BlockScoutWeb.API.V2.TokenTransferViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.TokenTransferView
+  alias Explorer.Chain.TokenTransfer
+
+  describe "prepare_token_transfer_total/1" do
+    test "returns value and decimals for ERC-20 transfer" do
+      token = build(:token, type: "ERC-20", decimals: 18)
+
+      token_transfer = %TokenTransfer{
+        token: token,
+        token_type: "ERC-20",
+        amount: Decimal.new(1000),
+        amounts: nil,
+        token_ids: nil,
+        token_instance: nil
+      }
+
+      result = TokenTransferView.prepare_token_transfer_total(token_transfer)
+
+      assert Decimal.equal?(result["value"], Decimal.new(1000))
+      assert result["decimals"] == 18
+    end
+
+    test "returns token_id for ERC-721 transfer" do
+      token = build(:token, type: "ERC-721")
+
+      token_transfer = %TokenTransfer{
+        token: token,
+        token_type: "ERC-721",
+        amount: nil,
+        amounts: nil,
+        token_ids: [42],
+        token_instance: nil
+      }
+
+      result = TokenTransferView.prepare_token_transfer_total(token_transfer)
+
+      assert result["token_id"] == 42
+      assert Map.has_key?(result, "token_instance")
+    end
+
+    test "returns token_id, value and decimals for ERC-1155 transfer" do
+      token = build(:token, type: "ERC-1155", decimals: 0)
+
+      token_transfer = %TokenTransfer{
+        token: token,
+        token_type: "ERC-1155",
+        amount: Decimal.new(5),
+        amounts: nil,
+        token_ids: [99],
+        token_instance: nil
+      }
+
+      result = TokenTransferView.prepare_token_transfer_total(token_transfer)
+
+      assert result["token_id"] == 99
+      assert Decimal.equal?(result["value"], Decimal.new(5))
+      assert result["decimals"] == 0
+      assert Map.has_key?(result, "token_instance")
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/token_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/token_view_test.exs
@@ -1,0 +1,33 @@
+defmodule BlockScoutWeb.API.V2.TokenViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.TokenView
+
+  describe "exchange_rate/1" do
+    test "returns string when fiat_value exists" do
+      assert TokenView.exchange_rate(%{fiat_value: Decimal.new("1.5")}) == "1.5"
+    end
+
+    test "returns nil when fiat_value is nil" do
+      assert TokenView.exchange_rate(%{fiat_value: nil}) == nil
+    end
+  end
+
+  describe "render token.json" do
+    test "renders token fields" do
+      token = insert(:token)
+      result = TokenView.render("token.json", %{token: token})
+
+      assert result["symbol"] == token.symbol
+      assert result["name"] == token.name
+      assert result["type"] == token.type
+      assert result["decimals"] == token.decimals
+      assert Map.has_key?(result, "address_hash")
+      assert Map.has_key?(result, "holders_count")
+    end
+
+    test "returns nil for nil token" do
+      assert TokenView.render("token.json", %{token: nil}) == nil
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/withdrawal_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/withdrawal_view_test.exs
@@ -1,0 +1,65 @@
+defmodule BlockScoutWeb.API.V2.WithdrawalViewTest do
+  use BlockScoutWeb.ConnCase, async: true
+
+  alias BlockScoutWeb.API.V2.WithdrawalView
+  alias Explorer.Chain.Withdrawal
+
+  describe "prepare_withdrawal/1" do
+    test "returns full map when block and address are loaded" do
+      withdrawal = build(:withdrawal)
+
+      result = WithdrawalView.prepare_withdrawal(withdrawal)
+
+      assert result["index"] == withdrawal.index
+      assert result["validator_index"] == withdrawal.validator_index
+      assert result["block_number"] == withdrawal.block.number
+      assert is_map(result["receiver"])
+      assert result["amount"] == withdrawal.amount
+      assert result["timestamp"] == withdrawal.block.timestamp
+    end
+
+    test "returns map without block fields when block is not loaded" do
+      address = build(:address)
+
+      withdrawal = %Withdrawal{
+        index: 1,
+        validator_index: 2,
+        amount: 100,
+        block: %Ecto.Association.NotLoaded{},
+        address: address,
+        address_hash: address.hash
+      }
+
+      result = WithdrawalView.prepare_withdrawal(withdrawal)
+
+      assert result["index"] == 1
+      assert result["validator_index"] == 2
+      assert is_map(result["receiver"])
+      refute Map.has_key?(result, "block_number")
+      refute Map.has_key?(result, "timestamp")
+    end
+
+    test "returns map without receiver when address is not loaded" do
+      block = build(:block)
+      address = build(:address)
+
+      withdrawal = %Withdrawal{
+        index: 3,
+        validator_index: 4,
+        amount: 200,
+        block: block,
+        block_hash: block.hash,
+        address: %Ecto.Association.NotLoaded{},
+        address_hash: address.hash
+      }
+
+      result = WithdrawalView.prepare_withdrawal(withdrawal)
+
+      assert result["index"] == 3
+      assert result["validator_index"] == 4
+      assert result["block_number"] == block.number
+      assert result["timestamp"] == block.timestamp
+      refute Map.has_key?(result, "receiver")
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/8928

## Motivation

Increase confidence in API v2 view serialization by adding focused tests for most core view modules in the API v2 views test folder. This improves regression protection for response shapes and branch behavior without changing runtime API logic.

## Changelog

### Enhancements

Added new API v2 view test modules and expanded coverage for core render and helper paths:

- Added tests for Address view rendering helpers.
- Added tests for Block view percentage/countdown/block mapping behavior.
- Added tests for Token view exchange rate and token rendering behavior.
- Added tests for TokenTransfer total preparation for ERC-20, ERC-721, and ERC-1155.
- Added tests for InternalTransaction view success/error/timestamp branches.
- Added tests for Withdrawal view loaded and NotLoaded association branches.
- Added tests for Api view message and audit report changeset error payloads.
- Added tests for Config view backend version payload.
- Added tests for Stats view hot smart contracts payload.
- Added tests for Search view list rendering, redirect/not_found behavior, next_page_params encoding, and transaction result preparation.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
- [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
- [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
- [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for API V2 view rendering and data mapping: address, block, config, internal transaction, search, stats, token, token transfer, and withdrawal views—validating JSON shapes, field types/formatting, pagination, redirects, and edge-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->