### PR TITLE
fix: Fix filecoin view error

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
@@ -39,7 +39,10 @@ defmodule BlockScoutWeb.API.V2.FilecoinView do
           _ -> nil
         end
 
-      put_filecoin_robust_address(result, Map.put(params, :address, address))
+      params
+      |> Map.put_new(:field_prefix, nil)
+      |> Map.put(:address, address)
+      |> then(&put_filecoin_robust_address(result, &1))
     end
 
     def preload_and_put_filecoin_robust_address(result, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/filecoin_view.ex
@@ -33,7 +33,11 @@ defmodule BlockScoutWeb.API.V2.FilecoinView do
           }) ::
             map()
     def preload_and_put_filecoin_robust_address(result, %{address_hash: address_hash} = params) do
-      address = address_hash && Address.get(address_hash, @api_true)
+      address =
+        case address_hash do
+          hash when is_binary(hash) and hash != "" -> Address.get(hash, @api_true)
+          _ -> nil
+        end
 
       put_filecoin_robust_address(result, Map.put(params, :address, address))
     end


### PR DESCRIPTION
## Motivation

Fix test on `filecoin` chain type:

`  1) test /smart-contracts/{address_hash} get an eip1967 proxy contract (BlockScoutWeb.API.V2.SmartContractControllerTest)
Error:      test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs:137
     ** (Ecto.Query.CastError) /home/runner/work/blockscout/blockscout/apps/explorer/lib/explorer/chain/address.ex:355: value `""` in `where` cannot be cast to type Explorer.Chain.Hash.Address in query:

     from a0 in Explorer.Chain.Address,
       where: a0.hash == ^"",
       select: a0

     stacktrace:
       (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (elixir 1.19.4) lib/enum.ex:1814: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto 3.13.5) lib/ecto/repo/queryable.ex:223: Ecto.Repo.Queryable.execute/4
       (ecto 3.13.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
       (ecto 3.13.5) lib/ecto/repo/queryable.ex:163: Ecto.Repo.Queryable.one/3
       (block_scout_web 11.0.0) lib/block_scout_web/views/api/v2/filecoin_view.ex:36: BlockScoutWeb.API.V2.FilecoinView.preload_and_put_filecoin_robust_address/2
       (phoenix_view 2.0.4) lib/phoenix_view.ex:577: Phoenix.View.render_to_iodata/3
       (phoenix 1.6.16) lib/phoenix/controller.ex:772: Phoenix.Controller.render_and_send/4
       (block_scout_web 11.0.0) lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex:1: BlockScoutWeb.API.V2.SmartContractController.action/2`


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Filecoin address handling: empty or non-binary address inputs are no longer sent to lookup, preventing unnecessary lookups and errors. Ensures address-related parameters include a default field prefix when absent, making address resolution more robust and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->