### PR TITLE
fix: Add fallback for empty "to" in Geth selfdestruct

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -413,17 +413,23 @@ defmodule EthereumJSONRPC.Geth do
     end
   end
 
-  defp parse_call_tracer_calls(calls, acc, trace_address, inner? \\ true)
-  defp parse_call_tracer_calls([], acc, _trace_address, _inner?), do: acc
-  defp parse_call_tracer_calls({%{"type" => 0}, _}, acc, _trace_address, _inner?), do: acc
+  defp parse_call_tracer_calls(calls, acc, trace_address, inner?, parent \\ nil)
+  defp parse_call_tracer_calls([], acc, _trace_address, _inner?, _parent), do: acc
+  defp parse_call_tracer_calls({%{"type" => 0}, _}, acc, _trace_address, _inner?, _parent), do: acc
 
-  defp parse_call_tracer_calls({%{"type" => type}, _}, [last | acc], _trace_address, _inner?)
+  defp parse_call_tracer_calls({%{"type" => type}, _}, [last | acc], _trace_address, _inner?, _parent)
        when type in ["STOP", "stop"] do
     [Map.put(last, "error", "execution stopped") | acc]
   end
 
   # credo:disable-for-next-line /Complexity/
-  defp parse_call_tracer_calls({%{"type" => upcase_type, "from" => from} = call, index}, acc, trace_address, inner?) do
+  defp parse_call_tracer_calls(
+         {%{"type" => upcase_type, "from" => from} = call, index},
+         acc,
+         trace_address,
+         inner?,
+         parent
+       ) do
     case String.downcase(upcase_type) do
       type when type in ~w(call callcode delegatecall staticcall create create2 selfdestruct revert stop invalid) ->
         new_trace_address = [index | trace_address]
@@ -432,7 +438,7 @@ defmodule EthereumJSONRPC.Geth do
           "type" => if(type in ~w(call callcode delegatecall staticcall), do: "call", else: type),
           "callType" => type,
           "from" => from,
-          "to" => Map.get(call, "to", "0x"),
+          "to" => Map.get(call, "to", if(type == "selfdestruct", do: parent["to"], else: "0x")),
           "createdContractAddressHash" => Map.get(call, "to", "0x"),
           "value" => Map.get(call, "value", "0x0"),
           "gas" => Map.get(call, "gas", "0x0"),
@@ -448,7 +454,9 @@ defmodule EthereumJSONRPC.Geth do
         parse_call_tracer_calls(
           Map.get(call, "calls", []),
           [formatted_call | acc],
-          if(inner?, do: new_trace_address, else: [])
+          if(inner?, do: new_trace_address, else: []),
+          true,
+          call
         )
 
       "" ->
@@ -461,15 +469,15 @@ defmodule EthereumJSONRPC.Geth do
     end
   end
 
-  defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?) do
+  defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?, _parent) do
     if !allow_empty_traces?(), do: log_unknown_type(call)
     acc
   end
 
-  defp parse_call_tracer_calls(calls, acc, trace_address, _inner) when is_list(calls) do
+  defp parse_call_tracer_calls(calls, acc, trace_address, inner?, parent) when is_list(calls) do
     calls
     |> Stream.with_index()
-    |> Enum.reduce(acc, &parse_call_tracer_calls(&1, &2, trace_address))
+    |> Enum.reduce(acc, &parse_call_tracer_calls(&1, &2, trace_address, inner?, parent))
   end
 
   defp log_unknown_type(call) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -413,17 +413,23 @@ defmodule EthereumJSONRPC.Geth do
     end
   end
 
-  defp parse_call_tracer_calls(calls, acc, trace_address, inner? \\ true)
-  defp parse_call_tracer_calls([], acc, _trace_address, _inner?), do: acc
-  defp parse_call_tracer_calls({%{"type" => 0}, _}, acc, _trace_address, _inner?), do: acc
+  defp parse_call_tracer_calls(calls, acc, trace_address, inner?, parent \\ nil)
+  defp parse_call_tracer_calls([], acc, _trace_address, _inner?, _parent), do: acc
+  defp parse_call_tracer_calls({%{"type" => 0}, _}, acc, _trace_address, _inner?, _parent), do: acc
 
-  defp parse_call_tracer_calls({%{"type" => type}, _}, [last | acc], _trace_address, _inner?)
+  defp parse_call_tracer_calls({%{"type" => type}, _}, [last | acc], _trace_address, _inner?, _parent)
        when type in ["STOP", "stop"] do
     [Map.put(last, "error", "execution stopped") | acc]
   end
 
   # credo:disable-for-next-line /Complexity/
-  defp parse_call_tracer_calls({%{"type" => upcase_type, "from" => from} = call, index}, acc, trace_address, inner?) do
+  defp parse_call_tracer_calls(
+         {%{"type" => upcase_type, "from" => from} = call, index},
+         acc,
+         trace_address,
+         inner?,
+         parent
+       ) do
     case String.downcase(upcase_type) do
       type when type in ~w(call callcode delegatecall staticcall create create2 selfdestruct revert stop invalid) ->
         new_trace_address = [index | trace_address]
@@ -432,7 +438,7 @@ defmodule EthereumJSONRPC.Geth do
           "type" => if(type in ~w(call callcode delegatecall staticcall), do: "call", else: type),
           "callType" => type,
           "from" => from,
-          "to" => Map.get(call, "to", "0x"),
+          "to" => Map.get(call, "to", if(type == "selfdestruct", do: parent["to"])),
           "createdContractAddressHash" => Map.get(call, "to", "0x"),
           "value" => Map.get(call, "value", "0x0"),
           "gas" => Map.get(call, "gas", "0x0"),
@@ -448,7 +454,9 @@ defmodule EthereumJSONRPC.Geth do
         parse_call_tracer_calls(
           Map.get(call, "calls", []),
           [formatted_call | acc],
-          if(inner?, do: new_trace_address, else: [])
+          if(inner?, do: new_trace_address, else: []),
+          true,
+          call
         )
 
       "" ->
@@ -461,15 +469,15 @@ defmodule EthereumJSONRPC.Geth do
     end
   end
 
-  defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?) do
+  defp parse_call_tracer_calls({%{} = call, _}, acc, _trace_address, _inner?, _parent) do
     if !allow_empty_traces?(), do: log_unknown_type(call)
     acc
   end
 
-  defp parse_call_tracer_calls(calls, acc, trace_address, _inner) when is_list(calls) do
+  defp parse_call_tracer_calls(calls, acc, trace_address, inner?, parent) when is_list(calls) do
     calls
     |> Stream.with_index()
-    |> Enum.reduce(acc, &parse_call_tracer_calls(&1, &2, trace_address))
+    |> Enum.reduce(acc, &parse_call_tracer_calls(&1, &2, trace_address, inner?, parent))
   end
 
   defp log_unknown_type(call) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth/call.ex
@@ -306,9 +306,8 @@ defmodule EthereumJSONRPC.Geth.Call do
 
   defp entry_to_elixir({"error", nil} = entry), do: entry
 
-  defp entry_to_elixir({key, value} = entry)
-       when key in ~w(callType createdContractAddressHash createdContractCode error from init input output to transactionHash type) and
-              is_binary(value),
+  defp entry_to_elixir({key, _value} = entry)
+       when key in ~w(callType createdContractAddressHash createdContractCode error from init input output to transactionHash type),
        do: entry
 
   defp entry_to_elixir({key, value} = entry) when key in ~w(blockNumber index transactionIndex) and is_integer(value),

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/geth_test.exs
@@ -554,6 +554,109 @@ defmodule EthereumJSONRPC.GethTest do
 
       assert uppercase_result == lowercase_result
     end
+
+    test "fallback 'to' field to the parent object for selfdestruct", %{
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      transaction_hash = "0xb342cafc6ac552c3be2090561453204c8784caf025ac8267320834e4cd163d96"
+      block_number = 3_287_375
+      transaction_index = 13
+
+      transaction_params = %{
+        block_number: block_number,
+        transaction_index: transaction_index,
+        hash_data: transaction_hash
+      }
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
+        [%{id: id, params: [^transaction_hash, %{"tracer" => "callTracer"}]}], _ ->
+          {:ok,
+           [
+             %{
+               id: id,
+               result: %{
+                 "calls" => [
+                   %{
+                     "from" => "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+                     "gas" => "0x12816",
+                     "gasUsed" => "0x229e",
+                     "input" => "0x",
+                     "output" => "0x",
+                     "to" => "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                     "type" => "CALL",
+                     "value" => "0x0"
+                   },
+                   %{
+                     "from" => "0x0000000000000000000000000000000000000000",
+                     "gas" => "0x0",
+                     "gasUsed" => "0x0",
+                     "input" => "0x",
+                     "type" => "SELFDESTRUCT"
+                   }
+                 ],
+                 "from" => "0xd2ca697bb0114ca4f6a2ed28a5896d280a46d61b",
+                 "gas" => "0x6799",
+                 "gasUsed" => "0x6642",
+                 "input" => "0x092a5cce",
+                 "to" => "0x97f09972913935c098096d364a286c7b941070b3",
+                 "type" => "CALL",
+                 "value" => "0x0"
+               }
+             }
+           ]}
+      end)
+
+      Application.put_env(:ethereum_jsonrpc, Geth, tracer: "call_tracer", debug_trace_timeout: "5s")
+
+      assert {:ok,
+              [
+                %{
+                  index: 0,
+                  input: "0x092a5cce",
+                  output: "0x",
+                  type: "call",
+                  value: nil,
+                  call_type: "call",
+                  block_number: ^block_number,
+                  gas_used: 26178,
+                  transaction_hash: ^transaction_hash,
+                  transaction_index: 13,
+                  gas: 26521,
+                  from_address_hash: "0xd2ca697bb0114ca4f6a2ed28a5896d280a46d61b",
+                  to_address_hash: "0x97f09972913935c098096d364a286c7b941070b3",
+                  trace_address: []
+                },
+                %{
+                  index: 1,
+                  input: "0x",
+                  output: "0x",
+                  type: "call",
+                  value: nil,
+                  call_type: "call",
+                  block_number: ^block_number,
+                  gas_used: 8862,
+                  transaction_hash: ^transaction_hash,
+                  transaction_index: 13,
+                  gas: 75798,
+                  from_address_hash: "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640",
+                  to_address_hash: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                  trace_address: [0]
+                },
+                %{
+                  index: 2,
+                  type: "selfdestruct",
+                  value: nil,
+                  block_number: ^block_number,
+                  gas_used: 0,
+                  transaction_hash: ^transaction_hash,
+                  transaction_index: 13,
+                  gas: 0,
+                  from_address_hash: "0x0000000000000000000000000000000000000000",
+                  to_address_hash: "0x97f09972913935c098096d364a286c7b941070b3",
+                  trace_address: [1]
+                }
+              ]} = Geth.fetch_internal_transactions([transaction_params], json_rpc_named_arguments)
+    end
   end
 
   describe "fetch_block_internal_transactions/1" do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Self-destruct traces now inherit the recipient address from their parent when the recipient is missing.
  * Nested trace address handling corrected so inner traces record indices consistently.

* **Tests**
  * Added a test validating nested call traces, flattened entries, trace-address positions, and the self-destruct recipient fallback.

* **Chores**
  * Relaxed input handling to avoid failures when trace fields are non-text values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->