### PR TITLE
chore: Expand action of API_DISABLE_CONTRACT_CREATION_INTERNAL_TRANSACTION_ASSOCIATION flag to preload smart-contract associations

### DIFF
--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -472,9 +472,20 @@ defmodule Explorer.Chain.Address do
     do: address
 
   def maybe_preload_smart_contract_associations(%__MODULE__{contract_code: _} = address, associations, options) do
+    repo = Chain.select_repo(options)
+
     address
-    |> Chain.select_repo(options).preload(associations)
-    |> preload_contract_creation_internal_transaction(Chain.select_repo(options))
+    |> repo.preload(associations)
+    |> maybe_preload_contract_creation_internal_transaction(repo)
+  end
+
+  @spec maybe_preload_contract_creation_internal_transaction(__MODULE__.t(), module()) :: __MODULE__.t()
+  defp maybe_preload_contract_creation_internal_transaction(address, repo) do
+    if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false) do
+      address
+    else
+      preload_contract_creation_internal_transaction(address, repo)
+    end
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

`API_DISABLE_CONTRACT_CREATION_INTERNAL_TRANSACTION_ASSOCIATION` was already honoured in the API v2 address controller when deciding whether to set the preload option, but the `Address.maybe_preload_smart_contract_associations/3` code path always called `preload_contract_creation_internal_transaction/2` unconditionally. This meant callers that went through `maybe_preload_smart_contract_associations/3` could not be opted out of the expensive internal-transaction query via the flag.

## Changelog

### Enhancements

- Extended the effect of `API_DISABLE_CONTRACT_CREATION_INTERNAL_TRANSACTION_ASSOCIATION=true` to also suppress the `preload_contract_creation_internal_transaction/2` call inside `Address.maybe_preload_smart_contract_associations/3`.


## Upgrading

No database or configuration changes required. The env var `API_DISABLE_CONTRACT_CREATION_INTERNAL_TRANSACTION_ASSOCIATION` already exists and defaults to `false`, preserving current behaviour for all existing deployments.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.