### PR TITLE
fix: exclude scam tokens from address tabs counters

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -1181,7 +1181,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         {:ok, _address} ->
           counters_json =
             address_hash
-            |> Counters.address_limited_counters(@api_true)
+            |> Counters.address_limited_counters(@api_true |> fetch_scam_token_toggle(conn))
             |> Enum.reduce(%{}, fn {counter_name, counter_value}, acc ->
               @counter_name_to_json_field_name
               |> Map.fetch(counter_name)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3937,7 +3937,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(tokens_response["items"]) == 1
 
       assert List.first(tokens_response["items"])["token"]["address_hash"] ==
-               to_string(legit_balance.token_contract_address_hash)
+               Address.checksum(legit_balance.token_contract_address_hash)
     end
 
     test "get 200 on non existing address", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3899,6 +3899,47 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   end
 
   describe "/addresses/{address_hash}/tabs-counters" do
+    test "token_balances_count excludes scam tokens when hide_scam_addresses is true", %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      address = insert(:address)
+
+      legit_balance =
+        insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+          address: address,
+          token_type: "ERC-20",
+          token_id: Enum.random(1..100_000)
+        )
+
+      scam_balance =
+        insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+          address: address,
+          token_type: "ERC-20",
+          token_id: Enum.random(1..100_000)
+        )
+
+      insert(:scam_badge_to_address, address_hash: scam_balance.token_contract_address_hash)
+
+      response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/tabs-counters")
+        |> json_response(200)
+
+      assert response["token_balances_count"] == 1
+
+      tokens_response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/tokens?type=ERC-20")
+        |> json_response(200)
+
+      assert Enum.count(tokens_response["items"]) == 1
+
+      assert List.first(tokens_response["items"])["token"]["address_hash"] ==
+               to_string(legit_balance.token_contract_address_hash)
+    end
+
     test "get 200 on non existing address", %{conn: conn} do
       address = build(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3994,6 +3994,74 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                Address.checksum(legit_transfer.token_contract_address_hash)
     end
 
+    test "token_balances_count includes scam tokens when show_scam_tokens cookie is true even if hide_scam_addresses is true",
+         %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      address = insert(:address)
+
+      insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+        address: address,
+        token_type: "ERC-20",
+        token_id: Enum.random(1..100_000)
+      )
+
+      scam_balance =
+        insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+          address: address,
+          token_type: "ERC-20",
+          token_id: Enum.random(1..100_000)
+        )
+
+      insert(:scam_badge_to_address, address_hash: scam_balance.token_contract_address_hash)
+
+      response =
+        conn
+        |> put_req_cookie("show_scam_tokens", "true")
+        |> get("/api/v2/addresses/#{address.hash}/tabs-counters")
+        |> json_response(200)
+
+      assert response["token_balances_count"] == 2
+    end
+
+    test "token_transfers_count includes scam tokens when show_scam_tokens cookie is true even if hide_scam_addresses is true",
+         %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      address = insert(:address)
+
+      transaction = insert(:transaction) |> with_block()
+
+      insert(:token_transfer,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        to_address: address
+      )
+
+      scam_transfer =
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          to_address: address
+        )
+
+      insert(:scam_badge_to_address, address_hash: scam_transfer.token_contract_address_hash)
+
+      response =
+        conn
+        |> put_req_cookie("show_scam_tokens", "true")
+        |> get("/api/v2/addresses/#{address.hash}/tabs-counters")
+        |> json_response(200)
+
+      assert response["token_transfers_count"] == 2
+    end
+
     test "get 200 on non existing address", %{conn: conn} do
       address = build(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3908,6 +3908,47 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   end
 
   describe "/addresses/{address_hash}/tabs-counters" do
+    test "token_balances_count excludes scam tokens when hide_scam_addresses is true", %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      address = insert(:address)
+
+      legit_balance =
+        insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+          address: address,
+          token_type: "ERC-20",
+          token_id: Enum.random(1..100_000)
+        )
+
+      scam_balance =
+        insert(:address_current_token_balance_with_token_id_and_fixed_token_type,
+          address: address,
+          token_type: "ERC-20",
+          token_id: Enum.random(1..100_000)
+        )
+
+      insert(:scam_badge_to_address, address_hash: scam_balance.token_contract_address_hash)
+
+      response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/tabs-counters")
+        |> json_response(200)
+
+      assert response["token_balances_count"] == 1
+
+      tokens_response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/tokens?type=ERC-20")
+        |> json_response(200)
+
+      assert Enum.count(tokens_response["items"]) == 1
+
+      assert List.first(tokens_response["items"])["token"]["address_hash"] ==
+               to_string(legit_balance.token_contract_address_hash)
+    end
+
     test "get 200 on non existing address", %{conn: conn} do
       address = build(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3946,7 +3946,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(tokens_response["items"]) == 1
 
       assert List.first(tokens_response["items"])["token"]["address_hash"] ==
-               to_string(legit_balance.token_contract_address_hash)
+               Address.checksum(legit_balance.token_contract_address_hash)
     end
 
     test "get 200 on non existing address", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3949,6 +3949,51 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                Address.checksum(legit_balance.token_contract_address_hash)
     end
 
+    test "token_transfers_count excludes scam tokens when hide_scam_addresses is true", %{conn: conn} do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      address = insert(:address)
+
+      transaction = insert(:transaction) |> with_block()
+
+      legit_transfer =
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          to_address: address
+        )
+
+      scam_transfer =
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number,
+          to_address: address
+        )
+
+      insert(:scam_badge_to_address, address_hash: scam_transfer.token_contract_address_hash)
+
+      response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/tabs-counters")
+        |> json_response(200)
+
+      assert response["token_transfers_count"] == 1
+
+      token_transfers_response =
+        conn
+        |> get("/api/v2/addresses/#{address.hash}/token-transfers")
+        |> json_response(200)
+
+      assert Enum.count(token_transfers_response["items"]) == 1
+
+      assert List.first(token_transfers_response["items"])["token"]["address_hash"] ==
+               Address.checksum(legit_transfer.token_contract_address_hash)
+    end
+
     test "get 200 on non existing address", %{conn: conn} do
       address = build(:address)
 

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -34,6 +34,8 @@ defmodule Explorer.Chain.Address.Counters do
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
   alias Explorer.Chain.Celo.ElectionReward, as: CeloElectionReward
 
+  alias Explorer.Helper, as: ExplorerHelper
+
   require Logger
 
   @typep counter :: non_neg_integer() | nil
@@ -73,7 +75,7 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def check_if_tokens_at_address(address_hash, options \\ []) do
-    select_repo(options).exists?(address_hash_to_token_balances_query(address_hash))
+    select_repo(options).exists?(address_hash_to_token_balances_query(address_hash, options))
   end
 
   @spec check_if_withdrawals_at_address(Hash.Address.t()) :: boolean()
@@ -176,12 +178,13 @@ defmodule Explorer.Chain.Address.Counters do
     Repo.aggregate(query, :count, timeout: :infinity)
   end
 
-  def address_hash_to_token_balances_query(address_hash) do
+  def address_hash_to_token_balances_query(address_hash, options \\ []) do
     from(
       tb in CurrentTokenBalance,
       where: tb.address_hash == ^address_hash,
       where: tb.value > 0 or tb.token_type == "ERC-7984"
     )
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
   end
 
   @doc """
@@ -414,7 +417,7 @@ defmodule Explorer.Chain.Address.Counters do
       configure_task(
         :token_balances,
         cached_counters,
-        address_hash_to_token_balances_query(address_hash),
+        address_hash_to_token_balances_query(address_hash, options),
         address_hash,
         options
       )

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -164,12 +164,13 @@ defmodule Explorer.Chain.Address.Counters do
     Repo.aggregate(to_address_query, :sum, :gas_used, timeout: :infinity)
   end
 
-  def address_to_token_transfer_count_query(address_hash) do
+  def address_to_token_transfer_count_query(address_hash, options \\ []) do
     from(
       token_transfer in TokenTransfer,
       where: token_transfer.to_address_hash == ^address_hash,
       or_where: token_transfer.from_address_hash == ^address_hash
     )
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
   end
 
   @spec address_to_token_transfer_count(Address.t()) :: non_neg_integer()
@@ -409,7 +410,7 @@ defmodule Explorer.Chain.Address.Counters do
       configure_task(
         :token_transfers,
         cached_counters,
-        address_to_token_transfer_count_query(address_hash),
+        address_to_token_transfer_count_query(address_hash, options),
         address_hash,
         options
       )

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -35,6 +35,8 @@ defmodule Explorer.Chain.Address.Counters do
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
   alias Explorer.Chain.Celo.ElectionReward, as: CeloElectionReward
 
+  alias Explorer.Helper, as: ExplorerHelper
+
   require Logger
 
   @typep counter :: non_neg_integer() | nil
@@ -74,7 +76,7 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def check_if_tokens_at_address(address_hash, options \\ []) do
-    select_repo(options).exists?(address_hash_to_token_balances_query(address_hash))
+    select_repo(options).exists?(address_hash_to_token_balances_query(address_hash, options))
   end
 
   @spec check_if_withdrawals_at_address(Hash.Address.t()) :: boolean()
@@ -177,12 +179,13 @@ defmodule Explorer.Chain.Address.Counters do
     Repo.aggregate(query, :count, timeout: :infinity)
   end
 
-  def address_hash_to_token_balances_query(address_hash) do
+  def address_hash_to_token_balances_query(address_hash, options \\ []) do
     from(
       tb in CurrentTokenBalance,
       where: tb.address_hash == ^address_hash,
       where: tb.value > 0 or tb.token_type == "ERC-7984"
     )
+    |> ExplorerHelper.maybe_hide_scam_addresses(:token_contract_address_hash, options)
   end
 
   @doc """
@@ -415,7 +418,7 @@ defmodule Explorer.Chain.Address.Counters do
       configure_task(
         :token_balances,
         cached_counters,
-        address_hash_to_token_balances_query(address_hash),
+        address_hash_to_token_balances_query(address_hash, options),
         address_hash,
         options
       )

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -308,10 +308,15 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   @spec address_limited_counters(Hash.t(), Keyword.t()) :: %{atom() => counter}
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def address_limited_counters(address_hash, options) do
+    show_scam_tokens? = options[:show_scam_tokens?] || false
+
     cached_counters =
       Enum.reduce(@types, %{}, fn type, acc ->
-        case AddressTabsElementsCount.get_counter(type, address_hash) do
+        scam_flag = if type in [:token_transfers, :token_balances], do: show_scam_tokens?, else: false
+
+        case AddressTabsElementsCount.get_counter(type, address_hash, scam_flag) do
           {_datetime, counter, status} ->
             Map.put(acc, type, {status, counter})
 
@@ -540,11 +545,24 @@ defmodule Explorer.Chain.Address.Counters do
     end
   end
 
+  defp run_or_ignore({ok, _counter}, _type, _address_hash, _show_scam_tokens?, _fun)
+       when ok in [:up_to_date, :limit_value],
+       do: nil
+
+  defp run_or_ignore(_, type, address_hash, show_scam_tokens?, fun) do
+    if !AddressTabsElementsCount.get_task(type, address_hash, show_scam_tokens?) do
+      AddressTabsElementsCount.set_task(type, address_hash, show_scam_tokens?)
+
+      Task.async(fun)
+    end
+  end
+
   defp configure_task(counter_type, cache, query, address_hash, options) do
     address_hash = to_string(address_hash)
+    show_scam_tokens? = options[:show_scam_tokens?] || false
     start = System.monotonic_time()
 
-    run_or_ignore(cache[counter_type], counter_type, address_hash, fn ->
+    run_or_ignore(cache[counter_type], counter_type, address_hash, show_scam_tokens?, fn ->
       result =
         query
         |> count(options, counter_type)
@@ -554,8 +572,8 @@ defmodule Explorer.Chain.Address.Counters do
 
       Logger.info("Time consumed for #{counter_type} counter task for #{address_hash} is #{diff}ms")
 
-      AddressTabsElementsCount.set_counter(counter_type, address_hash, result)
-      AddressTabsElementsCount.drop_task(counter_type, address_hash)
+      AddressTabsElementsCount.set_counter(counter_type, address_hash, result, show_scam_tokens?)
+      AddressTabsElementsCount.drop_task(counter_type, address_hash, show_scam_tokens?)
 
       {counter_type, result}
     end)

--- a/apps/explorer/lib/explorer/chain/cache/counters/address_tabs_elements_count.ex
+++ b/apps/explorer/lib/explorer/chain/cache/counters/address_tabs_elements_count.ex
@@ -23,31 +23,33 @@ defmodule Explorer.Chain.Cache.Counters.AddressTabsElementsCount do
            | :beacon_deposits
   @typep response_status :: :limit_value | :stale | :up_to_date
 
-  @spec get_counter(counter_type, String.t()) :: {DateTime.t(), non_neg_integer(), response_status} | nil
-  def get_counter(counter_type, address_hash) do
-    @cache_name |> fetch_from_ets_cache(address_hash |> cache_key(counter_type), nil) |> check_staleness()
+  @spec get_counter(counter_type, String.t(), boolean()) :: {DateTime.t(), non_neg_integer(), response_status} | nil
+  def get_counter(counter_type, address_hash, show_scam_tokens? \\ false) do
+    @cache_name
+    |> fetch_from_ets_cache(cache_key(address_hash, counter_type, show_scam_tokens?), nil)
+    |> check_staleness()
   end
 
-  @spec set_counter(counter_type, String.t(), non_neg_integer()) :: :ok
-  def set_counter(counter_type, address_hash, counter) do
-    :ets.insert(@cache_name, {cache_key(address_hash, counter_type), {DateTime.utc_now(), counter}})
+  @spec set_counter(counter_type, String.t(), non_neg_integer(), boolean()) :: :ok
+  def set_counter(counter_type, address_hash, counter, show_scam_tokens? \\ false) do
+    :ets.insert(@cache_name, {cache_key(address_hash, counter_type, show_scam_tokens?), {DateTime.utc_now(), counter}})
 
     :ok
   end
 
-  @spec set_task(atom, String.t()) :: true
-  def set_task(counter_type, address_hash) do
-    :ets.insert(@cache_name, {task_cache_key(address_hash, counter_type), true})
+  @spec set_task(atom, String.t(), boolean()) :: true
+  def set_task(counter_type, address_hash, show_scam_tokens? \\ false) do
+    :ets.insert(@cache_name, {task_cache_key(address_hash, counter_type, show_scam_tokens?), true})
   end
 
-  @spec drop_task(atom, String.t()) :: true
-  def drop_task(counter_type, address_hash) do
-    :ets.delete(@cache_name, task_cache_key(address_hash, counter_type))
+  @spec drop_task(atom, String.t(), boolean()) :: true
+  def drop_task(counter_type, address_hash, show_scam_tokens? \\ false) do
+    :ets.delete(@cache_name, task_cache_key(address_hash, counter_type, show_scam_tokens?))
   end
 
-  @spec get_task(atom, String.t()) :: true | nil
-  def get_task(counter_type, address_hash) do
-    @cache_name |> fetch_from_ets_cache(address_hash |> task_cache_key(counter_type), nil)
+  @spec get_task(atom, String.t(), boolean()) :: true | nil
+  def get_task(counter_type, address_hash, show_scam_tokens? \\ false) do
+    @cache_name |> fetch_from_ets_cache(task_cache_key(address_hash, counter_type, show_scam_tokens?), nil)
   end
 
   def save_transactions_counter_progress(address_hash, results) do
@@ -135,6 +137,9 @@ defmodule Explorer.Chain.Cache.Counters.AddressTabsElementsCount do
   defp ttl, do: Application.get_env(:explorer, Explorer.Chain.Cache.Counters.AddressTabsElementsCount)[:ttl]
   defp lowercased_string(str), do: str |> to_string() |> String.downcase()
 
-  defp cache_key(address_hash, counter_type), do: {lowercased_string(address_hash), counter_type}
-  defp task_cache_key(address_hash, counter_type), do: {:task, lowercased_string(address_hash), counter_type}
+  defp cache_key(address_hash, counter_type, show_scam_tokens?),
+    do: {lowercased_string(address_hash), counter_type, show_scam_tokens?}
+
+  defp task_cache_key(address_hash, counter_type, show_scam_tokens?),
+    do: {:task, lowercased_string(address_hash), counter_type, show_scam_tokens?}
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13944

## Motivation

When `hide_scam_addresses` is enabled, the address tabs counters endpoint counted scam tokens in `token_balances_count`, while the address tokens endpoint filtered them out. This produced inconsistent API results for the same address. This change aligns counter calculation with token list filtering logic.

## Changelog

### Enhancements

- Added a regression test for address tabs counters to ensure `token_balances_count` excludes scam tokens when hide_scam_addresses is enabled.
- Added an assertion that tabs-counters and tokens endpoints stay consistent for ERC-20 results in this scenario.

### Bug Fixes

- Updated token balances counter query construction to apply the same scam-address filtering used by token list queries.
- Passed request options through token balance counter query paths so hide_scam_addresses behavior is respected in counters and existence checks.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Counters and token listings now respect the scam-token toggle and the "show scam tokens" cookie; scam-flagged tokens are excluded or included accordingly.
  * Cached counters are separated by scam-visibility mode so counts remain consistent per setting.

* **Tests**
  * Added tests verifying counters and ERC-20 listings omit or include scam tokens depending on the toggle and cookie.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->