### PR TITLE
chore: Add /api prefix to endpoints in swagger

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/specs/private.ex
+++ b/apps/block_scout_web/lib/block_scout_web/specs/private.ex
@@ -14,7 +14,7 @@ defmodule BlockScoutWeb.Specs.Private do
   def spec do
     %OpenApi{
       servers: [
-        %Server{url: to_string(Helper.instance_url() |> URI.append_path("/api"))}
+        %Server{url: to_string(Helper.instance_url())}
       ],
       info: %Info{
         title: "Blockscout Private API",
@@ -23,7 +23,7 @@ defmodule BlockScoutWeb.Specs.Private do
           email: "info@blockscout.com"
         }
       },
-      paths: Paths.from_routes(Specs.routes_with_prefix(AccountRouter, "/account")),
+      paths: Paths.from_routes(Specs.routes_with_prefix(AccountRouter, "/api/account")),
       components: %Components{
         securitySchemes: %{"dynamic_jwt" => %SecurityScheme{type: "http", scheme: "bearer", bearerFormat: "JWT"}}
       }

--- a/apps/block_scout_web/lib/block_scout_web/specs/public.ex
+++ b/apps/block_scout_web/lib/block_scout_web/specs/public.ex
@@ -65,7 +65,7 @@ defmodule BlockScoutWeb.Specs.Public do
   def spec do
     %OpenApi{
       servers: [
-        %Server{url: to_string(Helper.instance_url() |> URI.append_path("/api"))}
+        %Server{url: to_string(Helper.instance_url())}
       ],
       info: %Info{
         title: "Blockscout",
@@ -76,9 +76,10 @@ defmodule BlockScoutWeb.Specs.Public do
       },
       paths:
         ApiRouter
-        |> Paths.from_router()
-        |> Map.merge(Paths.from_routes(Specs.routes_with_prefix(TokensApiV2Router, "/v2/tokens")))
-        |> Map.merge(Paths.from_routes(Specs.routes_with_prefix(SmartContractsApiV2Router, "/v2/smart-contracts"))),
+        |> Specs.routes_with_prefix("/api")
+        |> Paths.from_routes()
+        |> Map.merge(Paths.from_routes(Specs.routes_with_prefix(TokensApiV2Router, "/api/v2/tokens")))
+        |> Map.merge(Paths.from_routes(Specs.routes_with_prefix(SmartContractsApiV2Router, "/api/v2/smart-contracts"))),
       tags:
         Enum.map(@default_api_categories, fn category -> %Tag{name: category} end) ++
           chain_type_category_tags() ++ [%Tag{name: "legacy"}]

--- a/apps/block_scout_web/test/block_scout_web/specs/public_legacy_tag_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/specs/public_legacy_tag_test.exs
@@ -2,9 +2,9 @@ defmodule BlockScoutWeb.Specs.PublicLegacyTagTest do
   use ExUnit.Case, async: true
 
   @legacy_paths [
-    "/legacy/logs/get-logs",
-    "/legacy/block/get-block-number-by-time",
-    "/legacy/block/eth-block-number"
+    "/api/legacy/logs/get-logs",
+    "/api/legacy/block/get-block-number-by-time",
+    "/api/legacy/block/eth-block-number"
   ]
 
   setup_all do

--- a/apps/block_scout_web/test/support/api_schema_assertions.ex
+++ b/apps/block_scout_web/test/support/api_schema_assertions.ex
@@ -51,18 +51,13 @@ defmodule BlockScoutWeb.TestApiSchemaAssertions do
   defp maybe_assert_schema(_conn, _status_code, _json), do: :ok
 
   defp find_path_item(specs, request_path) do
-    api_relative = strip_api_prefix(request_path)
-
     Enum.reduce_while(specs, :error, fn %{paths: paths} = spec, acc ->
-      case match_template_path(paths, api_relative) do
+      case match_template_path(paths, request_path) do
         {:ok, {_, path_item}} -> {:halt, {:ok, spec, path_item}}
         _ -> {:cont, acc}
       end
     end)
   end
-
-  defp strip_api_prefix("/api" <> rest), do: rest
-  defp strip_api_prefix(path), do: path
 
   defp match_template_path(paths_map, actual_path) do
     actual_segments = split_path(actual_path)


### PR DESCRIPTION
## Motivation
`/api` prefix was attached to base url of the server, that is not quite correct
## Changelog
- Add `/api` prefix to each endpoint in swagger
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated API documentation configuration so the OpenAPI server base and endpoint paths consistently include the /api prefix (e.g., /api/v2/...), ensuring documented endpoints match actual routes.

* **Tests**
  * Adjusted test expectations to validate legacy and versioned endpoints under the new /api-prefixed paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->