### PR TITLE
chore: Remove timeout for test for FillInternalTransactionsAddressIds

### DIFF
--- a/apps/explorer/test/explorer/migrator/fill_internal_transactions_address_ids_test.exs
+++ b/apps/explorer/test/explorer/migrator/fill_internal_transactions_address_ids_test.exs
@@ -45,6 +45,8 @@ defmodule Explorer.Migrator.FillInternalTransactionsAddressIdsTest do
 
     assert MigrationStatus.get_status("fill_internal_transactions_address_ids") == nil
 
+    Application.put_env(:explorer, FillInternalTransactionsAddressIds, batch_size: 100, timeout: 0)
+
     FillInternalTransactionsAddressIds.start_link([])
 
     wait_for_results(fn ->


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for the internal transactions address IDs migration process with explicit parameter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->