### PR TITLE
fix: MissingBalanceOfToken fixes

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -17,6 +17,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   alias Explorer.Chain.{Address, Block, Hash, Token}
   alias Explorer.Chain.Address.TokenBalance
   alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Utility.MissingBalanceOfToken
 
   @default_paging_options %PagingOptions{page_size: 50}
 
@@ -350,6 +351,7 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
         when accumulator: term()
   def stream_unfetched_current_token_balances(initial, reducer, limited? \\ false) when is_function(reducer, 2) do
     unfetched_current_token_balances()
+    |> MissingBalanceOfToken.filter_token_balances_query()
     |> TokenBalance.add_token_balances_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
   end

--- a/apps/explorer/lib/explorer/chain/address/token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/token_balance.ex
@@ -10,10 +10,12 @@ defmodule Explorer.Chain.Address.TokenBalance do
   use Explorer.Schema
 
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+  import Explorer.QueryHelper, only: [select_ctid: 1, join_on_ctid: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Address, Block, Hash, Token}
   alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Utility.MissingBalanceOfToken
 
   @typedoc """
    *  `address` - The `t:Explorer.Chain.Address.t/0` that is the balance's owner.
@@ -142,11 +144,34 @@ defmodule Explorer.Chain.Address.TokenBalance do
   @spec delete_token_balance_placeholders_below(atom(), Hash.Address.t(), Block.block_number()) ::
           {non_neg_integer(), nil | [term()]}
   def delete_token_balance_placeholders_below(module, token_contract_address_hash, block_number) do
-    module
-    |> where([tb], tb.token_contract_address_hash == ^token_contract_address_hash)
-    |> where([tb], tb.block_number <= ^block_number)
-    |> where([tb], is_nil(tb.value_fetched_at) or is_nil(tb.value))
-    |> Repo.delete_all()
+    {:ok, result} =
+      Repo.transaction(fn ->
+        ordered_query =
+          from(tb in module,
+            where: tb.token_contract_address_hash == ^token_contract_address_hash,
+            where: tb.block_number <= ^block_number,
+            where: is_nil(tb.value_fetched_at) or is_nil(tb.value),
+            select: select_ctid(tb),
+            # Enforce TokenBalance ShareLocks order (see docs: sharelocks.md)
+            order_by: [
+              tb.token_contract_address_hash,
+              tb.token_id,
+              tb.address_hash,
+              tb.block_number
+            ],
+            lock: "FOR UPDATE"
+          )
+
+        query =
+          from(tb in module,
+            inner_join: ordered_address_token_balance in subquery(ordered_query),
+            on: join_on_ctid(tb, ordered_address_token_balance)
+          )
+
+        Repo.delete_all(query)
+      end)
+
+    result
   end
 
   @doc """
@@ -160,6 +185,7 @@ defmodule Explorer.Chain.Address.TokenBalance do
         when accumulator: term()
   def stream_unfetched_token_balances(initial, reducer, limited? \\ false) when is_function(reducer, 2) do
     __MODULE__.unfetched_token_balances()
+    |> MissingBalanceOfToken.filter_token_balances_query()
     |> add_token_balances_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
   end

--- a/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
+++ b/apps/explorer/lib/explorer/utility/missing_balance_of_token.ex
@@ -55,6 +55,25 @@ defmodule Explorer.Utility.MissingBalanceOfToken do
   end
 
   @doc """
+  Filters provided token balances query by presence of record with the same `token_contract_address_hash`
+  and above or equal `block_number` in `missing_balance_of_tokens`.
+  """
+  @spec filter_token_balances_query(Ecto.Query.t()) :: Ecto.Query.t()
+  def filter_token_balances_query(query) do
+    query
+    |> join(:left, [tb], mbot in __MODULE__,
+      on: tb.token_contract_address_hash == mbot.token_contract_address_hash,
+      as: :mbot
+    )
+    |> where(
+      [tb],
+      is_nil(as(:mbot).token_contract_address_hash) or
+        (as(:mbot).currently_implemented == true and tb.block_number > as(:mbot).block_number) or
+        tb.block_number > as(:mbot).block_number + ^missing_balance_of_window()
+    )
+  end
+
+  @doc """
   Filters provided token balances params by presence of record with the same `token_contract_address_hash`
   and above or equal `block_number` in `missing_balance_of_tokens`.
   """


### PR DESCRIPTION
## Changelog

- Added filter by missing balanceOf token presence for token balance fetchers
- Fixed deadlocks on deleting token balances placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate token balance results by filtering out balances that are superseded or covered by historical "missing balance" records during streaming/fetching.
  * Safer cleanup of obsolete token balance placeholders using a transactional, row-locked delete to avoid race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->