### PR TITLE
fix: Fix Celo epochs list pagination

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
@@ -31,7 +31,8 @@ defmodule BlockScoutWeb.API.V2.CeloController do
     parameters:
       base_params() ++
         define_paging_params([
-          "number"
+          "number",
+          "items_count"
         ]),
     responses: [
       ok:
@@ -39,7 +40,8 @@ defmodule BlockScoutWeb.API.V2.CeloController do
          paginated_response(
            items: Schemas.Celo.Epoch,
            next_page_params_example: %{
-             "number" => 100
+             "number" => 100,
+             "items_count" => 50
            },
            title_prefix: "CeloEpochs"
          )},
@@ -162,7 +164,8 @@ defmodule BlockScoutWeb.API.V2.CeloController do
         define_paging_params([
           "amount",
           "account_address_hash",
-          "associated_account_address_hash"
+          "associated_account_address_hash",
+          "items_count"
         ]),
     responses: [
       ok:
@@ -172,7 +175,8 @@ defmodule BlockScoutWeb.API.V2.CeloController do
            next_page_params_example: %{
              "amount" => "1000000000000000000",
              "account_address_hash" => "0x1234567890123456789012345678901234567890",
-             "associated_account_address_hash" => "0x0987654321098765432109876543210987654321"
+             "associated_account_address_hash" => "0x0987654321098765432109876543210987654321",
+             "items_count" => 50
            },
            title_prefix: "CeloEpochElectionRewards"
          )},
@@ -266,14 +270,19 @@ defmodule BlockScoutWeb.API.V2.CeloController do
     end
   end
 
-  @spec parse_epoch_number(String.t()) ::
+  @spec parse_epoch_number(non_neg_integer() | String.t()) ::
           {:ok, non_neg_integer()} | {:error, {:invalid, :number}}
-  defp parse_epoch_number(number) do
+  defp parse_epoch_number(epoch_number) when is_integer(epoch_number) and epoch_number >= 0 and epoch_number < 32_768,
+    do: {:ok, epoch_number}
+
+  defp parse_epoch_number(number) when is_binary(number) do
     case safe_parse_non_negative_integer(number) do
       {:ok, epoch_number} when epoch_number < 32_768 -> {:ok, epoch_number}
       _ -> {:error, {:invalid, :number}}
     end
   end
+
+  defp parse_epoch_number(_), do: {:error, {:invalid, :number}}
 
   # Parses a reward type value produced by CastAndValidate.
   #


### PR DESCRIPTION
## Motivation

`/api/v2/celo/epochs?number=190&items_count=50`

```
{
    "errors": [
        {
            "title": "Invalid value",
            "source": {
                "pointer": "/items_count"
            },
            "detail": "Unexpected field: items_count"
        }
    ]
}
```

The issue introduced in https://github.com/blockscout/blockscout/pull/14197.

## Changelog

This pull request updates the `CeloController` API to improve its pagination capabilities and input validation. The main changes are the addition of an `items_count` parameter to relevant endpoints and enhanced validation for the `epoch_number` parameter.

**API Enhancements:**

* Added support for the `items_count` query parameter in the paging parameters for both the Celo epochs and Celo epoch election rewards endpoints, allowing clients to specify how many items to return per page. [[1]](diffhunk://#diff-85116e263703855eb4435ecd4b0f60054d458e2109d4efadc688cc55ccf15ef0L34-R44) [[2]](diffhunk://#diff-85116e263703855eb4435ecd4b0f60054d458e2109d4efadc688cc55ccf15ef0L165-R168)
* Updated the OpenAPI response examples to include the new `items_count` parameter, making the documentation more accurate and helpful for API consumers. [[1]](diffhunk://#diff-85116e263703855eb4435ecd4b0f60054d458e2109d4efadc688cc55ccf15ef0L34-R44) [[2]](diffhunk://#diff-85116e263703855eb4435ecd4b0f60054d458e2109d4efadc688cc55ccf15ef0L175-R179)

**Input Validation Improvements:**

* Improved the `parse_epoch_number/1` function to accept both integers and strings, and to return an error for any other type or invalid value, increasing robustness and input flexibility.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `items_count` parameter to API documentation and examples for epochs and election rewards operations, providing better visibility into result set sizes for paginated API responses and improving documentation clarity for developers.

* **Bug Fixes**
  * Enhanced epoch number validation to properly accept and handle both integer and string input formats, with stricter validation ranges and improved error messages that better inform users of validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->