### PR TITLE
fix: make "sort_param" description endpoint-agnostic in OpenAPI spec

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -528,8 +528,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   defp sort_description(sort_fields) do
     field_descriptions =
       sort_fields
-      |> Enum.map(fn field -> "* #{field} - #{sort_field_description(field)}" end)
-      |> Enum.join("\n")
+      |> Enum.map_join("\n", fn field -> "* #{field} - #{sort_field_description(field)}" end)
 
     """
     Sort results by:

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -492,10 +492,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @doc """
-  Returns a parameter definition for sorting transactions by specified fields.
+  Returns a parameter definition for sorting by specified fields.
   """
   @spec sort_param([String.t()]) :: Parameter.t()
   def sort_param(sort_fields) do
+    description = sort_description(sort_fields)
+
     %Parameter{
       name: :sort,
       in: :query,
@@ -504,20 +506,39 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
         enum: sort_fields
       },
       required: false,
-      description: """
-      Sort transactions by:
-      * block_number - Sort by block number
-      * value - Sort by transaction value
-      * fee - Sort by transaction fee
-      * balance - Sort by account balance
-      * transactions_count - Sort by number of transactions on address
-      * fiat_value - Sort by fiat value of the token transfer
-      * holders_count - Sort by number of token holders
-      * circulating_market_cap - Sort by circulating market cap of the token
-      Should be used together with `order` parameter.
-      """
+      description: description
     }
   end
+
+  @sort_field_descriptions %{
+    "balance" => "Sort by account balance",
+    "block_number" => "Sort by block number",
+    "circulating_market_cap" => "Sort by circulating market cap of the token",
+    "fee" => "Sort by transaction fee",
+    "fiat_value" => "Sort by fiat value",
+    "holders_count" => "Sort by number of token holders",
+    "key0" => "Sort by MUD record key0",
+    "key1" => "Sort by MUD record key1",
+    "key_bytes" => "Sort by MUD record key_bytes",
+    "total_gas_used" => "Sort by total gas used",
+    "transactions_count" => "Sort by number of transactions",
+    "value" => "Sort by transaction value"
+  }
+
+  defp sort_description(sort_fields) do
+    field_descriptions =
+      sort_fields
+      |> Enum.map(fn field -> "* #{field} - #{sort_field_description(field)}" end)
+      |> Enum.join("\n")
+
+    """
+    Sort results by:
+    #{field_descriptions}
+    Should be used together with `order` parameter.
+    """
+  end
+
+  defp sort_field_description(field), do: Map.get(@sort_field_descriptions, field, "Sort by #{field}")
 
   @doc """
   Returns a parameter definition for sorting order (asc/desc).


### PR DESCRIPTION
## Motivation

The current sort parameter description is hardcoded for transactions, but the same helper is reused by non-transaction endpoints such as tokens, MUD, and stats. This change makes Swagger docs accurate per endpoint by generating sort field descriptions from the actual fields passed into sort_param.

## Changelog

### Enhancements

- Made API sort parameter documentation dynamic based on sort_fields.
- Added reusable sort field description mapping with safe fallback text for unknown fields.
- Updated sort_param docs wording to be generic and endpoint-agnostic.

### Bug Fixes

- Fixed incorrect Swagger/OpenAPI wording that described all sort options as transaction-specific even when used by other resources.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API docs for the sort parameter now generate a dynamic, user-friendly "Sort results by" list with readable per-field labels and a sensible fallback for unknown fields; wording simplified while preserving the note to use it with the order parameter.

* **Refactor**
  * Improved description generation for better maintainability and future extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->