### PR TITLE
fix: gate address tabs counters by chain identity/type

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -148,6 +148,36 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     }
   ]
 
+  @base_counter_name_to_json_field_name %{
+    validations: :validations_count,
+    transactions: :transactions_count,
+    token_transfers: :token_transfers_count,
+    token_balances: :token_balances_count,
+    logs: :logs_count,
+    withdrawals: :withdrawals_count,
+    internal_transactions: :internal_transactions_count
+  }
+
+  case @chain_identity do
+    {:optimism, :celo} ->
+      @chain_identity_counter_name_to_json_field_name %{celo_election_rewards: :celo_election_rewards_count}
+
+    _ ->
+      @chain_identity_counter_name_to_json_field_name %{}
+  end
+
+  case @chain_type do
+    :ethereum ->
+      @chain_type_counter_name_to_json_field_name %{beacon_deposits: :beacon_deposits_count}
+
+    _ ->
+      @chain_type_counter_name_to_json_field_name %{}
+  end
+
+  @counter_name_to_json_field_name @base_counter_name_to_json_field_name
+                                   |> Map.merge(@chain_identity_counter_name_to_json_field_name)
+                                   |> Map.merge(@chain_type_counter_name_to_json_field_name)
+
   @spec include_internal_transaction_association?() :: boolean()
   defp include_internal_transaction_association? do
     !Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false)
@@ -1170,25 +1200,13 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec tabs_counters(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def tabs_counters(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      counter_name_to_json_field_name = %{
-        validations: :validations_count,
-        transactions: :transactions_count,
-        token_transfers: :token_transfers_count,
-        token_balances: :token_balances_count,
-        logs: :logs_count,
-        withdrawals: :withdrawals_count,
-        internal_transactions: :internal_transactions_count,
-        celo_election_rewards: :celo_election_rewards_count,
-        beacon_deposits: :beacon_deposits_count
-      }
-
       case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
         {:ok, _address} ->
           counters_json =
             address_hash
             |> Counters.address_limited_counters(@api_true)
             |> Enum.reduce(%{}, fn {counter_name, counter_value}, acc ->
-              counter_name_to_json_field_name
+              @counter_name_to_json_field_name
               |> Map.fetch(counter_name)
               # credo:disable-for-next-line
               |> case do
@@ -1206,7 +1224,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
         _ ->
           counters_json =
-            counter_name_to_json_field_name
+            @counter_name_to_json_field_name
             |> Enum.reduce(%{}, fn {_counter_type, json_field}, acc ->
               Map.put(acc, json_field, 0)
             end)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -150,6 +150,50 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     }
   ]
 
+  @base_counter_name_to_json_field_name %{
+    validations: :validations_count,
+    transactions: :transactions_count,
+    token_transfers: :token_transfers_count,
+    token_balances: :token_balances_count,
+    logs: :logs_count,
+    withdrawals: :withdrawals_count,
+    internal_transactions: :internal_transactions_count
+  }
+
+  case @chain_identity do
+    {:optimism, :celo} ->
+      @chain_identity_counter_name_to_json_field_name %{celo_election_rewards: :celo_election_rewards_count}
+
+    _ ->
+      @chain_identity_counter_name_to_json_field_name %{}
+  end
+
+  case @chain_type do
+    :ethereum ->
+      @chain_type_counter_name_to_json_field_name %{beacon_deposits: :beacon_deposits_count}
+
+    _ ->
+      @chain_type_counter_name_to_json_field_name %{}
+  end
+
+  @counter_name_to_json_field_name @base_counter_name_to_json_field_name
+                                   |> Map.merge(@chain_identity_counter_name_to_json_field_name)
+                                   |> Map.merge(@chain_type_counter_name_to_json_field_name)
+
+  @spec include_internal_transaction_association?() :: boolean()
+  defp include_internal_transaction_association? do
+    !Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false)
+  end
+
+  @spec hash_to_address_options(keyword()) :: keyword()
+  defp hash_to_address_options(options) do
+    Keyword.put(
+      options,
+      :include_internal_transaction_association?,
+      include_internal_transaction_association?()
+    )
+  end
+
   @spec contract_address_preloads() :: [keyword()]
   defp contract_address_preloads do
     chain_type_associations =
@@ -1158,25 +1202,13 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec tabs_counters(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def tabs_counters(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      counter_name_to_json_field_name = %{
-        validations: :validations_count,
-        transactions: :transactions_count,
-        token_transfers: :token_transfers_count,
-        token_balances: :token_balances_count,
-        logs: :logs_count,
-        withdrawals: :withdrawals_count,
-        internal_transactions: :internal_transactions_count,
-        celo_election_rewards: :celo_election_rewards_count,
-        beacon_deposits: :beacon_deposits_count
-      }
-
-      case Chain.hash_to_address(address_hash, @address_options) do
+      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
         {:ok, _address} ->
           counters_json =
             address_hash
             |> Counters.address_limited_counters(@api_true)
             |> Enum.reduce(%{}, fn {counter_name, counter_value}, acc ->
-              counter_name_to_json_field_name
+              @counter_name_to_json_field_name
               |> Map.fetch(counter_name)
               # credo:disable-for-next-line
               |> case do
@@ -1194,7 +1226,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
         _ ->
           counters_json =
-            counter_name_to_json_field_name
+            @counter_name_to_json_field_name
             |> Enum.reduce(%{}, fn {_counter_type, json_field}, acc ->
               Map.put(acc, json_field, 0)
             end)

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
@@ -4,23 +4,47 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TabsCounters do
   """
   require OpenApiSpex
 
+  use Utils.CompileTimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
+
   alias OpenApiSpex.Schema
+
+  @base_properties %{
+    transactions_count: %Schema{type: :integer, nullable: false},
+    token_transfers_count: %Schema{type: :integer, nullable: false},
+    token_balances_count: %Schema{type: :integer, nullable: false},
+    logs_count: %Schema{type: :integer, nullable: false},
+    withdrawals_count: %Schema{type: :integer, nullable: false},
+    internal_transactions_count: %Schema{type: :integer, nullable: false},
+    validations_count: %Schema{type: :integer, nullable: false}
+  }
+
+  case @chain_identity do
+    {:optimism, :celo} ->
+      @chain_identity_properties %{celo_election_rewards_count: %Schema{type: :integer, nullable: false}}
+
+    _ ->
+      @chain_identity_properties %{}
+  end
+
+  case @chain_type do
+    :ethereum ->
+      @chain_type_properties %{beacon_deposits_count: %Schema{type: :integer, nullable: false}}
+
+    _ ->
+      @chain_type_properties %{}
+  end
+
+  @properties @base_properties
+              |> Map.merge(@chain_identity_properties)
+              |> Map.merge(@chain_type_properties)
 
   OpenApiSpex.schema(%{
     title: "AddressTabsCounters",
     description: "Counters for address tabs",
     type: :object,
-    properties: %{
-      transactions_count: %Schema{type: :integer, nullable: false},
-      token_transfers_count: %Schema{type: :integer, nullable: false},
-      token_balances_count: %Schema{type: :integer, nullable: false},
-      logs_count: %Schema{type: :integer, nullable: false},
-      withdrawals_count: %Schema{type: :integer, nullable: false},
-      internal_transactions_count: %Schema{type: :integer, nullable: false},
-      validations_count: %Schema{type: :integer, nullable: false},
-      celo_election_rewards_count: %Schema{type: :integer, nullable: false},
-      beacon_deposits_count: %Schema{type: :integer, nullable: false}
-    },
+    properties: @properties,
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/address/tabs_counters.ex
@@ -5,23 +5,47 @@ defmodule BlockScoutWeb.Schemas.API.V2.Address.TabsCounters do
   """
   require OpenApiSpex
 
+  use Utils.CompileTimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
+
   alias OpenApiSpex.Schema
+
+  @base_properties %{
+    transactions_count: %Schema{type: :integer, nullable: false},
+    token_transfers_count: %Schema{type: :integer, nullable: false},
+    token_balances_count: %Schema{type: :integer, nullable: false},
+    logs_count: %Schema{type: :integer, nullable: false},
+    withdrawals_count: %Schema{type: :integer, nullable: false},
+    internal_transactions_count: %Schema{type: :integer, nullable: false},
+    validations_count: %Schema{type: :integer, nullable: false}
+  }
+
+  case @chain_identity do
+    {:optimism, :celo} ->
+      @chain_identity_properties %{celo_election_rewards_count: %Schema{type: :integer, nullable: false}}
+
+    _ ->
+      @chain_identity_properties %{}
+  end
+
+  case @chain_type do
+    :ethereum ->
+      @chain_type_properties %{beacon_deposits_count: %Schema{type: :integer, nullable: false}}
+
+    _ ->
+      @chain_type_properties %{}
+  end
+
+  @properties @base_properties
+              |> Map.merge(@chain_identity_properties)
+              |> Map.merge(@chain_type_properties)
 
   OpenApiSpex.schema(%{
     title: "AddressTabsCounters",
     description: "Counters for address tabs",
     type: :object,
-    properties: %{
-      transactions_count: %Schema{type: :integer, nullable: false},
-      token_transfers_count: %Schema{type: :integer, nullable: false},
-      token_balances_count: %Schema{type: :integer, nullable: false},
-      logs_count: %Schema{type: :integer, nullable: false},
-      withdrawals_count: %Schema{type: :integer, nullable: false},
-      internal_transactions_count: %Schema{type: :integer, nullable: false},
-      validations_count: %Schema{type: :integer, nullable: false},
-      celo_election_rewards_count: %Schema{type: :integer, nullable: false},
-      beacon_deposits_count: %Schema{type: :integer, nullable: false}
-    },
+    properties: @properties,
     additionalProperties: false
   })
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2,7 +2,10 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   use BlockScoutWeb.ConnCase
   use EthereumJSONRPC.Case, async: false
   use BlockScoutWeb.ChannelCase
-  use Utils.CompileTimeEnvHelper, chain_identity: [:explorer, :chain_identity]
+
+  use Utils.CompileTimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
 
   alias ABI.{TypeDecoder, TypeEncoder}
   alias Explorer.{Chain, Repo, TestHelper}
@@ -3905,16 +3908,31 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/tabs-counters")
       response = json_response(request, 200)
 
-      assert %{
-               "validations_count" => 0,
-               "transactions_count" => 0,
-               "token_transfers_count" => 0,
-               "token_balances_count" => 0,
-               "logs_count" => 0,
-               "withdrawals_count" => 0,
-               "internal_transactions_count" => 0,
-               "celo_election_rewards_count" => 0
-             } = response
+      expected_response =
+        %{
+          "validations_count" => 0,
+          "transactions_count" => 0,
+          "token_transfers_count" => 0,
+          "token_balances_count" => 0,
+          "logs_count" => 0,
+          "withdrawals_count" => 0,
+          "internal_transactions_count" => 0
+        }
+        |> then(fn expected_response ->
+          case @chain_identity do
+            {:optimism, :celo} -> Map.put(expected_response, "celo_election_rewards_count", 0)
+            _ -> expected_response
+          end
+        end)
+        |> then(fn expected_response ->
+          if @chain_type == :ethereum do
+            Map.put(expected_response, "beacon_deposits_count", 0)
+          else
+            expected_response
+          end
+        end)
+
+      assert expected_response == response
     end
 
     test "get 422 on invalid address", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3,7 +3,10 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
   use BlockScoutWeb.ConnCase
   use EthereumJSONRPC.Case, async: false
   use BlockScoutWeb.ChannelCase
-  use Utils.CompileTimeEnvHelper, chain_identity: [:explorer, :chain_identity]
+
+  use Utils.CompileTimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
 
   alias ABI.{TypeDecoder, TypeEncoder}
   alias Explorer.{Chain, Repo, TestHelper}
@@ -3909,16 +3912,31 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       request = get(conn, "/api/v2/addresses/#{address.hash}/tabs-counters")
       response = json_response(request, 200)
 
-      assert %{
-               "validations_count" => 0,
-               "transactions_count" => 0,
-               "token_transfers_count" => 0,
-               "token_balances_count" => 0,
-               "logs_count" => 0,
-               "withdrawals_count" => 0,
-               "internal_transactions_count" => 0,
-               "celo_election_rewards_count" => 0
-             } = response
+      expected_response =
+        %{
+          "validations_count" => 0,
+          "transactions_count" => 0,
+          "token_transfers_count" => 0,
+          "token_balances_count" => 0,
+          "logs_count" => 0,
+          "withdrawals_count" => 0,
+          "internal_transactions_count" => 0
+        }
+        |> then(fn expected_response ->
+          case @chain_identity do
+            {:optimism, :celo} -> Map.put(expected_response, "celo_election_rewards_count", 0)
+            _ -> expected_response
+          end
+        end)
+        |> then(fn expected_response ->
+          if @chain_type == :ethereum do
+            Map.put(expected_response, "beacon_deposits_count", 0)
+          else
+            expected_response
+          end
+        end)
+
+      assert expected_response == response
     end
 
     test "get 422 on invalid address", %{conn: conn} do


### PR DESCRIPTION
## Motivation

Ensure the address tabs counters contract is chain-aware and consistent between runtime responses and OpenAPI schemas.

Previously, `celo_election_rewards_count` and `beacon_deposits_count` were exposed unconditionally in the tabs counters schema and could appear in responses where they are not applicable. This change restricts them to the intended networks:
- `celo_election_rewards_count` only for `optimism-celo`
- `beacon_deposits_count` only for `ethereum` chain type

## Changelog

### Enhancements

- Updated Address tabs counters OpenAPI schema to build properties from:
  - a shared base set
  - chain identity specific additions
  - chain type specific additions
- Updated tabs counters controller mapping to use the same chain-conditional rules as the schema.
- Updated address controller test to assert the chain-conditional response shape.

### Bug Fixes

- Fixed mismatch between intended chain-specific counters behavior and the actual API contract.
- Fixed API/schema drift by aligning tabs-counters runtime JSON keys with OpenAPI exposure rules.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to master.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Address tabs-counters API now returns only the blockchain-relevant counter fields (e.g., election rewards for Optimism Celo, beacon deposits for Ethereum) and provides sensible defaults for non-existing addresses.
* **Tests**
  * API tests updated to assert the conditional presence and defaulting of these counter fields based on the configured chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->