### PR TITLE
fix: Remove addresses preload in celo parse_internal_transactions

### DIFF
--- a/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
@@ -98,7 +98,6 @@ defmodule Indexer.Transform.Celo.TransactionTokenTransfers do
           (not Map.has_key?(internal_transaction, :call_type) || internal_transaction.call_type != "delegatecall")
       end)
       |> InternalTransaction.preload_transaction()
-      |> InternalTransaction.preload_addresses()
       |> Enum.map(fn internal_transaction ->
         to_address_hash =
           Map.get(internal_transaction, :to_address_hash) ||


### PR DESCRIPTION
## Motivation

`Indexer.Transform.Celo.TransactionTokenTransfers.parse_internal_transactions/2` receives internal transaction params which still contains address hashes because they weren't inserted yet, which means that addresses preloading is not necessary here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal transaction processing to improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->