### PR TITLE
fix: map optimism-celo to celo OpenAPI folder

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -54,7 +54,7 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
         "mud"
 
       chain_identity() == {:optimism, :celo} ->
-        "celo"
+        "optimism-celo"
 
       true ->
         chain_type() || "default"

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/config_controller.ex
@@ -2,7 +2,9 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
   use BlockScoutWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  use Utils.RuntimeEnvHelper, chain_type: [:explorer, :chain_type]
+  use Utils.RuntimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    chain_identity: [:explorer, :chain_identity]
 
   alias Explorer.Chain.CsvExport.Helper, as: CsvHelper
   alias Explorer.Chain.SmartContract
@@ -47,10 +49,15 @@ defmodule BlockScoutWeb.API.V2.ConfigController do
 
   @spec chain_type_translate_to_openapi_spec_folder_name() :: String.t()
   defp chain_type_translate_to_openapi_spec_folder_name do
-    if Application.get_env(:explorer, Explorer.Chain.Mud)[:enabled] do
-      "mud"
-    else
-      chain_type() || "default"
+    cond do
+      Application.get_env(:explorer, Explorer.Chain.Mud)[:enabled] ->
+        "mud"
+
+      chain_identity() == {:optimism, :celo} ->
+        "celo"
+
+      true ->
+        chain_type() || "default"
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.API.V2.ConfigControllerTest do
           request = get(conn, "/api/v2/config/backend")
           response = json_response(request, 200)
 
-          assert %{"openapi_spec_folder_name" => "celo"} = response
+          assert %{"openapi_spec_folder_name" => "optimism-celo"} = response
         end
 
       _ ->

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/config_controller_test.exs
@@ -22,6 +22,27 @@ defmodule BlockScoutWeb.API.V2.ConfigControllerTest do
       expected_chain_type = if is_atom(@chain_type), do: Atom.to_string(@chain_type), else: @chain_type
       assert chain_type == expected_chain_type
     end
+
+    test "returns openapi spec folder name", %{conn: conn} do
+      request = get(conn, "/api/v2/config/backend")
+      response = json_response(request, 200)
+
+      assert %{"openapi_spec_folder_name" => openapi_spec_folder_name} = response
+      assert is_binary(openapi_spec_folder_name)
+    end
+
+    case Application.compile_env(:explorer, :chain_identity) do
+      {:optimism, :celo} ->
+        test "translates optimism-celo chain identity to celo openapi folder", %{conn: conn} do
+          request = get(conn, "/api/v2/config/backend")
+          response = json_response(request, 200)
+
+          assert %{"openapi_spec_folder_name" => "celo"} = response
+        end
+
+      _ ->
+        :ok
+    end
   end
 
   describe "/config/backend-version" do


### PR DESCRIPTION
## Motivation

The backend config endpoint returned `openapi_spec_folder_name` based on `chain_type`, which produced `optimism` for the `{:optimism, :celo}` chain identity.  
For OpenAPI spec selection, this identity must resolve to the `optimism-celo` folder.

## Changelog

### Enhancements

- Added regression coverage for `/api/v2/config/backend`:
  - verifies `openapi_spec_folder_name` is returned
  - verifies `{:optimism, :celo}` resolves to `"optimism-celo"`

### Bug Fixes

- Updated backend config translation logic to map `{:optimism, :celo}` chain identity to `"optimism-celo"` for `openapi_spec_folder_name`.
- Kept existing precedence for MUD (`"mud"`), then chain-identity mapping, then default chain-type fallback.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added openapi_spec_folder_name field to the API configuration response.

* **Improvements**
  * Updated chain identity handling to improve selection of OpenAPI spec folders, including a specific mapping for Optimism+Celo and a clearer fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->