### PR TITLE
fix: parse celo reward cursor params for address pagination

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -53,6 +53,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   alias Explorer.Chain.{Address, Beacon.Deposit, Block, Hash, Token, Transaction}
   alias Explorer.Chain.Address.{CoinBalance, Counters}
 
+  alias Explorer.Chain.Token.FiatValue
   alias Explorer.Chain.Token.Instance
   alias Explorer.SmartContract.Helper, as: SmartContractHelper
 
@@ -1454,7 +1455,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
            fetch_key(params, ["associated_account_address_hash", :associated_account_address_hash]),
          {:ok, type_string} <- fetch_key(params, ["type", :type]),
          {:ok, epoch_number} <- parse_non_negative_integer_string(epoch_number_string),
-         {:ok, amount} <- parse_decimal_string(amount_string),
+         {:ok, amount} <- FiatValue.cast(amount_string),
          {:ok, associated_account_address_hash} <- Hash.Address.cast(associated_account_address_hash_string),
          {:ok, type} <- parse_celo_reward_type_string(type_string) do
       %{
@@ -1486,16 +1487,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     do: safe_parse_non_negative_integer(value)
 
   defp parse_non_negative_integer_string(_), do: :error
-
-  @spec parse_decimal_string(String.t()) :: {:ok, Decimal.t()} | :error
-  defp parse_decimal_string(value) when is_binary(value) do
-    case Decimal.parse(value) do
-      {amount, ""} -> {:ok, amount}
-      _ -> :error
-    end
-  end
-
-  defp parse_decimal_string(_), do: :error
 
   @spec parse_celo_reward_type_string(String.t() | atom()) :: {:ok, CeloElectionReward.type()} | :error
   defp parse_celo_reward_type_string(value) when is_atom(value) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -1448,26 +1448,15 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   @spec celo_election_rewards_paging_options(map()) :: PagingOptions.t()
   defp celo_election_rewards_paging_options(params) do
-    with %{
-           epoch_number: epoch_number_string,
-           amount: amount_string,
-           associated_account_address_hash: associated_account_address_hash_string,
-           type: type_string
-         }
-         when is_binary(epoch_number_string) and
-                is_binary(amount_string) and
-                is_binary(associated_account_address_hash_string) and
-                is_binary(type_string) <- params,
-         {:ok, epoch_number} <- safe_parse_non_negative_integer(epoch_number_string),
-         {amount, ""} <- Decimal.parse(amount_string),
-         {:ok, associated_account_address_hash} <-
-           Hash.Address.cast(associated_account_address_hash_string),
-         sanitized_type_string <-
-           type_string
-           |> String.trim()
-           |> String.downcase()
-           |> String.replace("-", "_"),
-         {:ok, type} <- CeloElectionReward.type_from_string(sanitized_type_string) do
+    with {:ok, epoch_number_string} <- fetch_key(params, ["epoch_number", :epoch_number]),
+         {:ok, amount_string} <- fetch_key(params, ["amount", :amount]),
+         {:ok, associated_account_address_hash_string} <-
+           fetch_key(params, ["associated_account_address_hash", :associated_account_address_hash]),
+         {:ok, type_string} <- fetch_key(params, ["type", :type]),
+         {:ok, epoch_number} <- parse_non_negative_integer_string(epoch_number_string),
+         {:ok, amount} <- parse_decimal_string(amount_string),
+         {:ok, associated_account_address_hash} <- Hash.Address.cast(associated_account_address_hash_string),
+         {:ok, type} <- parse_celo_reward_type_string(type_string) do
       %{
         PagingOptions.default_paging_options()
         | key: %{
@@ -1482,6 +1471,46 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         PagingOptions.default_paging_options()
     end
   end
+
+  defp fetch_key(map, keys) when is_list(keys) do
+    Enum.find_value(keys, :error, fn key ->
+      case Map.fetch(map, key) do
+        {:ok, value} -> {:ok, value}
+        :error -> nil
+      end
+    end)
+  end
+
+  @spec parse_non_negative_integer_string(String.t()) :: {:ok, non_neg_integer()} | :error
+  defp parse_non_negative_integer_string(value) when is_binary(value),
+    do: safe_parse_non_negative_integer(value)
+
+  defp parse_non_negative_integer_string(_), do: :error
+
+  @spec parse_decimal_string(String.t()) :: {:ok, Decimal.t()} | :error
+  defp parse_decimal_string(value) when is_binary(value) do
+    case Decimal.parse(value) do
+      {amount, ""} -> {:ok, amount}
+      _ -> :error
+    end
+  end
+
+  defp parse_decimal_string(_), do: :error
+
+  @spec parse_celo_reward_type_string(String.t() | atom()) :: {:ok, CeloElectionReward.type()} | :error
+  defp parse_celo_reward_type_string(value) when is_atom(value) do
+    if value in CeloElectionReward.types(), do: {:ok, value}, else: :error
+  end
+
+  defp parse_celo_reward_type_string(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace("-", "_")
+    |> CeloElectionReward.type_from_string()
+  end
+
+  defp parse_celo_reward_type_string(_), do: :error
 
   operation :beacon_deposits,
     summary: "List Beacon Deposits for a specific address",

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -5620,6 +5620,159 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
     end
   end
 
+  if @chain_identity == {:optimism, :celo} do
+    describe "/addresses/{address_hash}/election-rewards" do
+      setup do
+        celo_token = insert(:token)
+        usd_token = insert(:token)
+
+        original_core_contracts_config =
+          Application.get_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts)
+
+        Application.put_env(:explorer, Explorer.Chain.Cache.CeloCoreContracts,
+          contracts: %{
+            "addresses" => %{
+              "Accounts" => [],
+              "Election" => [],
+              "EpochRewards" => [],
+              "FeeHandler" => [],
+              "GasPriceMinimum" => [],
+              "GoldToken" => [
+                %{"address" => to_string(celo_token.contract_address_hash), "updated_at_block_number" => 0}
+              ],
+              "Governance" => [],
+              "LockedGold" => [],
+              "Reserve" => [],
+              "StableToken" => [
+                %{"address" => to_string(usd_token.contract_address_hash), "updated_at_block_number" => 0}
+              ],
+              "Validators" => []
+            }
+          }
+        )
+
+        original_celo_config = Application.get_env(:explorer, :celo)
+
+        on_exit(fn ->
+          Application.put_env(
+            :explorer,
+            Explorer.Chain.Cache.CeloCoreContracts,
+            original_core_contracts_config
+          )
+
+          Application.put_env(:explorer, :celo, original_celo_config)
+        end)
+
+        {:ok, %{celo_token: celo_token, usd_token: usd_token}}
+      end
+
+      test "get empty list on non-existing address", %{conn: conn} do
+        address = build(:address)
+
+        request = get(conn, "/api/v2/addresses/#{address.hash}/celo/election-rewards")
+        # The endpoint requires the address to exist in the database, returns 404 if not found
+        json_response(request, 404)
+      end
+
+      test "get 422 on invalid address", %{conn: conn} do
+        request = get(conn, "/api/v2/addresses/0x/celo/election-rewards")
+
+        assert %{
+                 "errors" => [
+                   %{
+                     "detail" => "Invalid format. Expected ~r/^0x([A-Fa-f0-9]{40})$/",
+                     "source" => %{"pointer" => "/address_hash_param"},
+                     "title" => "Invalid value"
+                   }
+                 ]
+               } = json_response(request, 422)
+      end
+
+      test "paginates election rewards across two pages", %{conn: conn} do
+        address = insert(:address)
+        end_processing_block = insert(:block)
+
+        epoch =
+          insert(:celo_epoch,
+            number: 1,
+            fetched?: true,
+            start_block_number: 0,
+            end_block_number: 17_279,
+            end_processing_block_hash: end_processing_block.hash
+          )
+
+        # Insert 51 rewards with distinct amounts 1..51 for the same address, epoch, and type.
+        # Default sort is desc:epoch_number, asc:type, desc:amount, so within a single epoch+type
+        # rewards are ordered by descending amount: 51, 50, ..., 1.
+        rewards =
+          1..51
+          |> Enum.map(fn i ->
+            insert(:celo_election_reward,
+              account_address_hash: address.hash,
+              epoch_number: epoch.number,
+              type: :voter,
+              amount: i
+            )
+          end)
+          |> Enum.sort_by(& &1.amount.value, :desc)
+
+        request = get(conn, "/api/v2/addresses/#{address.hash}/celo/election-rewards")
+        assert response = json_response(request, 200)
+
+        assert Enum.count(response["items"]) == 50
+        assert response["next_page_params"] != nil
+
+        assert Enum.at(response["items"], 0)["epoch_number"] == epoch.number
+        assert Enum.at(response["items"], 0)["type"] == "voter"
+
+        # First page: amounts 51 down to 2
+        assert Enum.at(response["items"], 0)["amount"] ==
+                 to_string(Enum.at(rewards, 0).amount.value)
+
+        assert Enum.at(response["items"], 49)["amount"] ==
+                 to_string(Enum.at(rewards, 49).amount.value)
+
+        request_2nd_page =
+          get(conn, "/api/v2/addresses/#{address.hash}/celo/election-rewards", response["next_page_params"])
+
+        assert response_2nd_page = json_response(request_2nd_page, 200)
+
+        assert Enum.count(response_2nd_page["items"]) == 1
+        assert response_2nd_page["next_page_params"] == nil
+
+        # Second page: the one reward with the lowest amount
+        assert Enum.at(response_2nd_page["items"], 0)["amount"] ==
+                 to_string(Enum.at(rewards, 50).amount.value)
+      end
+
+      test "rewards for different addresses do not appear in each other's results", %{conn: conn} do
+        address_a = insert(:address)
+        address_b = insert(:address)
+        end_processing_block = insert(:block)
+
+        epoch =
+          insert(:celo_epoch,
+            number: 1,
+            fetched?: true,
+            start_block_number: 0,
+            end_block_number: 17_279,
+            end_processing_block_hash: end_processing_block.hash
+          )
+
+        insert(:celo_election_reward, account_address_hash: address_a.hash, epoch_number: epoch.number, type: :voter)
+        insert(:celo_election_reward, account_address_hash: address_b.hash, epoch_number: epoch.number, type: :voter)
+
+        request_a = get(conn, "/api/v2/addresses/#{address_a.hash}/celo/election-rewards")
+        assert %{"items" => [item_a], "next_page_params" => nil} = json_response(request_a, 200)
+        assert item_a["account"]["hash"] == Address.checksum(address_a.hash)
+
+        request_b = get(conn, "/api/v2/addresses/#{address_b.hash}/celo/election-rewards")
+        assert %{"items" => [item_b], "next_page_params" => nil} = json_response(request_b, 200)
+        assert item_b["account"]["hash"] == Address.checksum(address_b.hash)
+      end
+    end
+  end
+
   if @chain_type == :ethereum do
     describe "/addresses/{address_hash}/beacon/deposits" do
       test "get empty list on non-existing address", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
@@ -172,9 +172,52 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
     describe "/api/v2/celo/epochs/:number/election-rewards/:type" do
       test "returns empty list", %{conn: conn} do
         request = get(conn, "/api/v2/celo/epochs/1/election-rewards/voter")
-        assert response = json_response(request, 200)
+        assert response = Phoenix.ConnTest.json_response(request, 200)
         assert response["items"] == []
         assert response["next_page_params"] == nil
+      end
+
+      test "paginates election rewards across two pages", %{conn: conn} do
+        epoch =
+          insert(:celo_epoch,
+            number: 1,
+            fetched?: true,
+            start_block_number: 0,
+            end_block_number: 17_279
+          )
+
+        account_address = insert(:address)
+
+        1..51
+        |> Enum.each(fn amount ->
+          associated_account_address = insert(:address)
+
+          insert(:celo_election_reward,
+            epoch_number: epoch.number,
+            type: :voter,
+            amount: amount,
+            account_address_hash: account_address.hash,
+            associated_account_address_hash: associated_account_address.hash
+          )
+        end)
+
+        request = get(conn, "/api/v2/celo/epochs/1/election-rewards/voter")
+        assert response = Phoenix.ConnTest.json_response(request, 200)
+
+        assert Enum.count(response["items"]) == 50
+        assert response["next_page_params"] != nil
+
+        assert Enum.at(response["items"], 0)["amount"] == "51"
+        assert Enum.at(response["items"], 49)["amount"] == "2"
+
+        request_2nd_page =
+          get(conn, "/api/v2/celo/epochs/1/election-rewards/voter", response["next_page_params"])
+
+        assert response_2nd_page = Phoenix.ConnTest.json_response(request_2nd_page, 200)
+
+        assert Enum.count(response_2nd_page["items"]) == 1
+        assert response_2nd_page["next_page_params"] == nil
+        assert Enum.at(response_2nd_page["items"], 0)["amount"] == "1"
       end
 
       test "returns 422 for invalid epoch number", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/celo_controller_test.exs
@@ -172,7 +172,7 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
     describe "/api/v2/celo/epochs/:number/election-rewards/:type" do
       test "returns empty list", %{conn: conn} do
         request = get(conn, "/api/v2/celo/epochs/1/election-rewards/voter")
-        assert response = Phoenix.ConnTest.json_response(request, 200)
+        assert response = json_response(request, 200)
         assert response["items"] == []
         assert response["next_page_params"] == nil
       end
@@ -202,7 +202,7 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
         end)
 
         request = get(conn, "/api/v2/celo/epochs/1/election-rewards/voter")
-        assert response = Phoenix.ConnTest.json_response(request, 200)
+        assert response = json_response(request, 200)
 
         assert Enum.count(response["items"]) == 50
         assert response["next_page_params"] != nil
@@ -213,7 +213,7 @@ defmodule BlockScoutWeb.API.V2.CeloControllerTest do
         request_2nd_page =
           get(conn, "/api/v2/celo/epochs/1/election-rewards/voter", response["next_page_params"])
 
-        assert response_2nd_page = Phoenix.ConnTest.json_response(request_2nd_page, 200)
+        assert response_2nd_page = json_response(request_2nd_page, 200)
 
         assert Enum.count(response_2nd_page["items"]) == 1
         assert response_2nd_page["next_page_params"] == nil


### PR DESCRIPTION
## Motivation

Address-level Celo election rewards pagination was not advancing to the next page after recent cursor-related changes.  
Cursor params from CastAndValidate could arrive with atom keys and/or atom `type` values, causing cursor parsing to fall back to default paging and repeatedly return the first page.

Also added coverage to verify pagination behavior in the epoch-level Celo endpoint and confirm the same issue is not present there.

## Changelog

### Enhancements

- Added controller tests for `/api/v2/addresses/:address_hash/celo/election-rewards`:
  - invalid address returns 422
  - non-existing address returns 404
  - cross-address isolation
  - 2-page pagination regression coverage
- Added pagination regression test for `/api/v2/celo/epochs/:number/election-rewards/:type`.
- In Celo controller tests, used `Phoenix.ConnTest.json_response/2` in the new pagination path to assert paging behavior directly.

### Bug Fixes

- Fixed cursor parsing for address-level Celo election rewards pagination by:
  - accepting both string and atom param keys for cursor fields
  - parsing `type` when provided as atom or string
  - parsing numeric cursor fields via dedicated helpers
- This prevents fallback to default paging when valid cursor params are present and allows second-page retrieval to work correctly.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Celo election-rewards API: more flexible parameter handling and parsing for address, amount, epoch, and reward type inputs, with robust pagination that preserves ordering and next-page tokens across requests.

* **Tests**
  * Added Celo-focused endpoint tests covering pagination across pages, deterministic ordering, error responses for missing/invalid addresses, and results scoped to the requested address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->