### PR TITLE
fix: Fix internal transactions address dynamic condition

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -638,7 +638,7 @@ defmodule Explorer.Chain.InternalTransaction do
     address_id_field = String.to_existing_atom("#{address_field}_id")
 
     cond do
-      address_id_or_ids in [[], nil] or not address_ids_indexes_exists?() ->
+      not address_ids_indexes_exists?() ->
         dynamic([it], field(it, ^address_hash_field) in ^address_hashes)
 
       address_ids_filled?() ->


### PR DESCRIPTION
## Motivation

When querying `InternalTransaction.where_address_match` by address hash, address may not be in `address_ids_to_address_hashes` table just because it wasn't mentioned in any internal transaction. In this case we will use filter by `*_address_hash` even if there is already no index on that field.

## Changelog

Decide whether to use `*_address_hash` field or `*_address_id` field only on the basis of the completion of the relevant migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal transaction query logic for more consistent and reliable address filtering behavior across different lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->