### PR TITLE
refactor: move contract creation internal tx association flag to Chain.hash_to_address

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -149,20 +149,6 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     }
   ]
 
-  @spec include_internal_transaction_association?() :: boolean()
-  defp include_internal_transaction_association? do
-    !Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false)
-  end
-
-  @spec hash_to_address_options(keyword()) :: keyword()
-  defp hash_to_address_options(options) do
-    Keyword.put(
-      options,
-      :include_internal_transaction_association?,
-      include_internal_transaction_association?()
-    )
-  end
-
   @spec contract_address_preloads() :: [keyword()]
   defp contract_address_preloads do
     chain_type_associations =
@@ -200,7 +186,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, address} ->
           %Address{} =
             fully_preloaded_address =
@@ -268,7 +254,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def counters(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
       # TODO: check if @address_options is needed here
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, address} ->
           {validation_count} = Counters.address_counters(address, @api_true)
 
@@ -331,7 +317,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           token_balances =
             address_hash
@@ -412,7 +398,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           options =
             [necessity_by_association: address_transactions_necessity_by_association()]
@@ -536,7 +522,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, token_address_hash} <- validate_optional_address_hash(params[:token], params),
          token_address_exists <- (token_address_hash && Token.check_token_exists(token_address_hash)) || :ok do
-      case {Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)), token_address_exists} do
+      case {Chain.hash_to_address(address_hash, @address_options), token_address_exists} do
         {{:ok, _address}, :ok} ->
           paging_options = paging_options(params)
 
@@ -625,7 +611,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec internal_transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def internal_transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           full_options =
             [
@@ -700,7 +686,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def logs(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, topic} <- validate_optional_topic(params[:topic]) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@api_true)) do
+      case Chain.hash_to_address(address_hash, @api_true) do
         {:ok, _address} ->
           options =
             params
@@ -773,7 +759,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec blocks_validated(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def blocks_validated(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           full_options =
             [
@@ -840,7 +826,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec coin_balance_history(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def coin_balance_history(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, address} ->
           full_options = params |> paging_options() |> Keyword.merge(@api_true)
 
@@ -902,7 +888,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def coin_balance_history_by_day(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           balances_by_day =
             address_hash
@@ -963,7 +949,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           results_plus_one =
             address_hash
@@ -1035,7 +1021,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec withdrawals(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def withdrawals(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           options = @api_true |> Keyword.merge(paging_options(params))
           withdrawals_plus_one = address_hash |> Chain.address_hash_to_withdrawals(options)
@@ -1183,7 +1169,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         beacon_deposits: :beacon_deposits_count
       }
 
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           counters_json =
             address_hash
@@ -1260,7 +1246,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_list(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_list(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           results_plus_one =
             Instance.nft_list(
@@ -1336,7 +1322,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_collections(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_collections(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, hash_to_address_options(@address_options)) do
+      case Chain.hash_to_address(address_hash, @address_options) do
         {:ok, _address} ->
           results_plus_one =
             Instance.nft_collections(
@@ -1402,7 +1388,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec celo_election_rewards(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def celo_election_rewards(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
-         {:ok, _address} <- Chain.hash_to_address(address_hash, hash_to_address_options(api?: true)) do
+         {:ok, _address} <- Chain.hash_to_address(address_hash, api?: true) do
       full_options =
         @celo_election_rewards_options
         |> Keyword.put(

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -136,8 +136,6 @@ defmodule Explorer.Chain do
   @type paging_options :: {:paging_options, PagingOptions.t()}
   @typep balance_by_day :: %{date: String.t(), value: Wei.t()}
   @type api? :: {:api?, true | false}
-  @type include_internal_transaction_association? ::
-          {:include_internal_transaction_association?, true | false}
   @type ip :: {:ip, String.t()}
   @type show_scam_tokens? :: {:show_scam_tokens?, true | false}
   @type timeout_option :: {:timeout, timeout() | nil}
@@ -863,7 +861,7 @@ defmodule Explorer.Chain do
   """
   @spec hash_to_address(
           Hash.Address.t() | binary(),
-          [necessity_by_association_option | api? | include_internal_transaction_association?]
+          [necessity_by_association_option | api?]
         ) ::
           {:ok, Address.t()} | {:error, :not_found}
   def hash_to_address(
@@ -872,9 +870,6 @@ defmodule Explorer.Chain do
           necessity_by_association: default_hash_to_address_necessity_by_association()
         ]
       ) do
-    include_internal_transaction_association? =
-      Keyword.get(options, :include_internal_transaction_association?, true)
-
     necessity_by_association =
       options
       |> Keyword.get(:necessity_by_association, default_hash_to_address_necessity_by_association())
@@ -885,9 +880,9 @@ defmodule Explorer.Chain do
     |> join_associations(necessity_by_association)
     |> select_repo(options).one()
     |> then(fn address ->
-      if include_internal_transaction_association?,
-        do: Address.preload_contract_creation_internal_transaction(address, select_repo(options)),
-        else: address
+      if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false),
+        do: address,
+        else: Address.preload_contract_creation_internal_transaction(address, select_repo(options))
     end)
     |> SmartContract.compose_address_for_unverified_smart_contract(hash, options)
     |> case do


### PR DESCRIPTION
## Motivation

The `include_internal_transaction_association?` flag and its associated helper functions were duplicated across `AddressController` and `OptimismView`. The logic for reading the `api_disable_contract_creation_internal_transaction_association` env var belongs in `Explorer.Chain.hash_to_address/2`, which is the single place that acts on it.

## Changelog

### Enhancements

- Moved the `api_disable_contract_creation_internal_transaction_association` env var read directly into `Explorer.Chain.hash_to_address/2`, so the function automatically respects the flag without callers needing to pass `include_internal_transaction_association?` in options.
- Removed the now-redundant `include_internal_transaction_association?/0` and `hash_to_address_options/1` private helper functions from `BlockScoutWeb.API.V2.AddressController` and `BlockScoutWeb.API.V2.OptimismView`.
- Removed the `include_internal_transaction_association?` type and its corresponding `@spec` option from `Explorer.Chain`.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal transaction association configuration by consolidating control to environment-based settings, removing redundant configuration options while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->