### PR TITLE
refactor: Move preload contract creation internal transaction under runtime toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🚜 Refactor
 
-- Move contract creation internal tx association flag to Chain.hash_to_address ([#14279](https://github.com/blockscout/blockscout/issues/14279))
+- Move preload contract creation internal transaction under runtime toggle ([#14279](https://github.com/blockscout/blockscout/issues/14279), ([#14287](https://github.com/blockscout/blockscout/pull/14287)))
 
 ### ⚙️ Miscellaneous Tasks
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -879,11 +879,7 @@ defmodule Explorer.Chain do
     query
     |> join_associations(necessity_by_association)
     |> select_repo(options).one()
-    |> then(fn address ->
-      if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false),
-        do: address,
-        else: Address.preload_contract_creation_internal_transaction(address, select_repo(options))
-    end)
+    |> Address.maybe_preload_contract_creation_internal_transaction(select_repo(options))
     |> SmartContract.compose_address_for_unverified_smart_contract(hash, options)
     |> case do
       nil -> {:error, :not_found}

--- a/apps/explorer/lib/explorer/chain/address.ex
+++ b/apps/explorer/lib/explorer/chain/address.ex
@@ -479,15 +479,6 @@ defmodule Explorer.Chain.Address do
     |> maybe_preload_contract_creation_internal_transaction(repo)
   end
 
-  @spec maybe_preload_contract_creation_internal_transaction(__MODULE__.t(), module()) :: __MODULE__.t()
-  defp maybe_preload_contract_creation_internal_transaction(address, repo) do
-    if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false) do
-      address
-    else
-      preload_contract_creation_internal_transaction(address, repo)
-    end
-  end
-
   @doc """
   Counts all the addresses where the `fetched_coin_balance` is > 0.
   """
@@ -866,30 +857,38 @@ defmodule Explorer.Chain.Address do
     - A single address with `:contract_creation_internal_transaction`
       populated when the input is a single struct
   """
-  @spec preload_contract_creation_internal_transaction([__MODULE__.t()] | __MODULE__.t() | nil, module()) ::
+  @spec maybe_preload_contract_creation_internal_transaction([__MODULE__.t()] | __MODULE__.t() | nil, module()) ::
           [__MODULE__.t()] | __MODULE__.t() | nil
-  def preload_contract_creation_internal_transaction(addresses, repo \\ Repo)
+  def maybe_preload_contract_creation_internal_transaction(addresses, repo \\ Repo)
 
-  def preload_contract_creation_internal_transaction([], _repo), do: []
-  def preload_contract_creation_internal_transaction(nil, _repo), do: nil
+  def maybe_preload_contract_creation_internal_transaction([], _repo), do: []
+  def maybe_preload_contract_creation_internal_transaction(nil, _repo), do: nil
 
-  def preload_contract_creation_internal_transaction(addresses, repo) when is_list(addresses) do
-    address_hashes = Enum.map(addresses, & &1.hash)
+  def maybe_preload_contract_creation_internal_transaction(addresses, repo) when is_list(addresses) do
+    if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false) do
+      addresses
+    else
+      address_hashes = Enum.map(addresses, & &1.hash)
 
-    internal_transactions_map =
-      contract_creation_internal_transaction_preload_query()
-      |> InternalTransaction.where_address_match(:created_contract_address, address_hashes)
-      |> repo.all()
-      |> InternalTransaction.preload_addresses([], repo)
-      |> Map.new(&{&1.created_contract_address_hash, &1})
+      internal_transactions_map =
+        contract_creation_internal_transaction_preload_query()
+        |> InternalTransaction.where_address_match(:created_contract_address, address_hashes)
+        |> repo.all()
+        |> InternalTransaction.preload_addresses([], repo)
+        |> Map.new(&{&1.created_contract_address_hash, &1})
 
-    Enum.map(addresses, &%{&1 | contract_creation_internal_transaction: internal_transactions_map[&1.hash]})
+      Enum.map(addresses, &%{&1 | contract_creation_internal_transaction: internal_transactions_map[&1.hash]})
+    end
   end
 
-  def preload_contract_creation_internal_transaction(address, repo) do
-    [address]
-    |> preload_contract_creation_internal_transaction(repo)
-    |> List.first()
+  def maybe_preload_contract_creation_internal_transaction(address, repo) do
+    if Application.get_env(:explorer, :api_disable_contract_creation_internal_transaction_association, false) do
+      address
+    else
+      [address]
+      |> maybe_preload_contract_creation_internal_transaction(repo)
+      |> List.first()
+    end
   end
 
   @doc """
@@ -1058,7 +1057,7 @@ defmodule Explorer.Chain.Address do
     |> Chain.select_repo(options).one()
     |> then(fn address ->
       if Keyword.get(options, :preload_contract_creation_internal_transaction, false) do
-        Address.preload_contract_creation_internal_transaction(address)
+        Address.maybe_preload_contract_creation_internal_transaction(address)
       else
         address
       end

--- a/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/contract_creator_test.exs
@@ -66,7 +66,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
       assert :ignore =
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
     end
 
@@ -80,7 +80,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
                  |> Repo.preload([:contract_creation_transaction])
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
     end
 
@@ -94,7 +94,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
                  |> Repo.preload([:contract_creation_transaction])
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
     end
 
@@ -113,7 +113,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
                  |> Repo.preload([:contract_creation_transaction])
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
     end
 
@@ -127,7 +127,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
                  |> Repo.preload([:contract_creation_transaction])
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
     end
 
@@ -153,7 +153,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
                ContractCreatorOnDemand.trigger_fetch(
                  contract_address
                  |> Repo.preload([:contract_creation_transaction])
-                 |> Address.preload_contract_creation_internal_transaction()
+                 |> Address.maybe_preload_contract_creation_internal_transaction()
                )
 
       :timer.sleep(300)
@@ -196,7 +196,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(300)
@@ -231,7 +231,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(300)
@@ -268,7 +268,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(1200)
@@ -300,7 +300,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(5400)
@@ -336,7 +336,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(300)
@@ -381,7 +381,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreatorTest do
              ContractCreatorOnDemand.trigger_fetch(
                contract_address
                |> Repo.preload([:contract_creation_transaction])
-               |> Address.preload_contract_creation_internal_transaction()
+               |> Address.maybe_preload_contract_creation_internal_transaction()
              )
 
     :timer.sleep(300)


### PR DESCRIPTION
## Motivation

Preload contract creation internal transaction ignores `API_DISABLE_CONTRACT_CREATION_INTERNAL_TRANSACTION_ASSOCIATION` flag in some edge cases.

## Changelog

This pull request refactors the way contract creation internal transactions are preloaded for addresses, consolidating and renaming the relevant function to improve clarity and ensure consistent behavior across the codebase. The main change is the replacement of `preload_contract_creation_internal_transaction` with `maybe_preload_contract_creation_internal_transaction`, which now handles both conditional logic and preloading. All usages and tests have been updated accordingly.

### Refactoring and API Changes

* Renamed and consolidated the function `preload_contract_creation_internal_transaction` to `maybe_preload_contract_creation_internal_transaction` in `Explorer.Chain.Address`, and updated its logic to always check the `:api_disable_contract_creation_internal_transaction_association` application environment variable before preloading. [[1]](diffhunk://#diff-569b19f44f40533f0dfeca3db3908345bdb9eb375b3cd862640d98ea49e82afbL869-R870) [[2]](diffhunk://#diff-569b19f44f40533f0dfeca3db3908345bdb9eb375b3cd862640d98ea49e82afbR882-R892)
* Removed the old private version of `maybe_preload_contract_creation_internal_transaction` and ensured all conditional logic is now handled in the new unified function.

### Code Usage Updates

* Updated all usages in the codebase and tests to call `maybe_preload_contract_creation_internal_transaction` instead of the old function, including in `Explorer.Chain`, `Explorer.Chain.Address`, and `Indexer.Fetcher.OnDemand.ContractCreatorTest`. [[1]](diffhunk://#diff-3fce0f082a5cb927aa738ef8f7d582824df91d08957971d36a0873efacd88816L882-R882) [[2]](diffhunk://#diff-569b19f44f40533f0dfeca3db3908345bdb9eb375b3cd862640d98ea49e82afbL1061-R1060) [[3]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L69-R69) [[4]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L83-R83) [[5]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L97-R97) [[6]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L116-R116) [[7]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L130-R130) [[8]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L156-R156) [[9]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L199-R199) [[10]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L234-R234) [[11]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L271-R271) [[12]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L303-R303) [[13]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L339-R339) [[14]](diffhunk://#diff-33963e0e30ef3863e699fee47a107d71d36a52920efbf7ea879bb8712e7e24b4L384-R384)

### Consistency and Maintainability

* Ensured consistent behavior and naming for preloading contract creation internal transactions, reducing confusion and the risk of incorrect usage. [[1]](diffhunk://#diff-569b19f44f40533f0dfeca3db3908345bdb9eb375b3cd862640d98ea49e82afbL869-R870) [[2]](diffhunk://#diff-569b19f44f40533f0dfeca3db3908345bdb9eb375b3cd862640d98ea49e82afbR882-R892)

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of contract creation transaction data through a runtime toggle configuration.

* **Tests**
  * Updated tests for contract creator fetching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->