### PR TITLE
fix: disable on-demand internal tx fetch when corresponding flag is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐛 Bug Fixes
 
+- Disable on-demand internal tx fetch when corresponding flag is provided ([#14289](https://github.com/blockscout/blockscout/pull/14289))
 - Add fill IT addresses dependency into drop index migrations ([#14280](https://github.com/blockscout/blockscout/issues/14280))
 - Fix incorrect batch size in Indexer.Fetcher.OnDemand.TokenBalance ([#14265](https://github.com/blockscout/blockscout/issues/14265))
 - Prevent ETS crash in ContractCreator on GenServer restart ([#14221](https://github.com/blockscout/blockscout/issues/14221))

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -32,12 +32,16 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   def should_fetch?(_records, 0), do: false
 
   def should_fetch?(records_from_db, limit) do
-    with true <- Enum.count(records_from_db) >= limit,
-         %{block_number: min_block_number} <- Enum.min_by(records_from_db, & &1.block_number),
-         true <- InternalTransaction.present_in_db?(min_block_number) do
+    if internal_transactions_fetching_disabled?() do
       false
     else
-      _ -> not InternalTransactionsAddressPlaceholder.empty?()
+      with true <- Enum.count(records_from_db) >= limit,
+           %{block_number: min_block_number} <- Enum.min_by(records_from_db, & &1.block_number),
+           true <- InternalTransaction.present_in_db?(min_block_number) do
+        false
+      else
+        _ -> not InternalTransactionsAddressPlaceholder.empty?()
+      end
     end
   end
 
@@ -57,33 +61,37 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   """
   @spec fetch_latest(Keyword.t()) :: [InternalTransaction.t()]
   def fetch_latest(options) do
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+    if internal_transactions_fetching_disabled?() do
+      []
+    else
+      paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    from_block = Chain.from_block(options)
-    to_block = Chain.to_block(options)
+      from_block = Chain.from_block(options)
+      to_block = Chain.to_block(options)
 
-    to_block_number =
-      case {paging_options, to_block} do
-        {%PagingOptions{key: {block_number, _, _}}, _} -> block_number
-        {_, block_number} when is_integer(block_number) -> block_number
-        _ -> BlockNumber.get_max()
-      end
+      to_block_number =
+        case {paging_options, to_block} do
+          {%PagingOptions{key: {block_number, _, _}}, _} -> block_number
+          {_, block_number} when is_integer(block_number) -> block_number
+          _ -> BlockNumber.get_max()
+        end
 
-    sort_direction =
-      case Keyword.get(options, :sort_direction) do
-        :asc -> &<=/2
-        _ -> &>=/2
-      end
+      sort_direction =
+        case Keyword.get(options, :sort_direction) do
+          :asc -> &<=/2
+          _ -> &>=/2
+        end
 
-    index_internal_transaction_desc_order = Keyword.get(options, :index_internal_transaction_desc_order, true)
+      index_internal_transaction_desc_order = Keyword.get(options, :index_internal_transaction_desc_order, true)
 
-    to_block_number
-    |> fetch_enough(from_block || 0, paging_options.page_size, options)
-    |> Enum.sort_by(&{&1.block_number, &1.transaction_index, &1.index}, sort_direction)
-    |> page_internal_transaction(paging_options, %{
-      index_internal_transaction_desc_order: index_internal_transaction_desc_order
-    })
-    |> Enum.take(paging_options.page_size)
+      to_block_number
+      |> fetch_enough(from_block || 0, paging_options.page_size, options)
+      |> Enum.sort_by(&{&1.block_number, &1.transaction_index, &1.index}, sort_direction)
+      |> page_internal_transaction(paging_options, %{
+        index_internal_transaction_desc_order: index_internal_transaction_desc_order
+      })
+      |> Enum.take(paging_options.page_size)
+    end
   end
 
   @doc """
@@ -103,53 +111,57 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   """
   @spec fetch_by_transaction(Transaction.t(), Keyword.t()) :: [InternalTransaction.t()]
   def fetch_by_transaction(transaction, options \\ []) do
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+    if internal_transactions_fetching_disabled?() do
+      []
+    else
+      necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+      paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+      json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
-    params = [
-      %{
-        block_number: transaction.block_number,
-        hash_data: to_string(transaction.hash),
-        transaction_index: transaction.index
-      }
-    ]
+      params = [
+        %{
+          block_number: transaction.block_number,
+          hash_data: to_string(transaction.hash),
+          transaction_index: transaction.index
+        }
+      ]
 
-    case EthereumJSONRPC.fetch_internal_transactions(params, json_rpc_named_arguments) do
-      {:ok, internal_transactions_params} ->
-        internal_transactions_params
-        |> Enum.map(&serialize/1)
-        |> different_from_parent_transaction()
-        |> Enum.sort_by(& &1.index)
-        |> join_associations(necessity_by_association)
-        |> page_internal_transaction(paging_options)
-        |> Enum.take(paging_options.page_size)
-        |> Repo.preload(:block)
-        |> InternalTransaction.preload_error()
-        |> InternalTransaction.preload_transaction()
-        |> InternalTransaction.preload_addresses(options)
+      case EthereumJSONRPC.fetch_internal_transactions(params, json_rpc_named_arguments) do
+        {:ok, internal_transactions_params} ->
+          internal_transactions_params
+          |> Enum.map(&serialize/1)
+          |> different_from_parent_transaction()
+          |> Enum.sort_by(& &1.index)
+          |> join_associations(necessity_by_association)
+          |> page_internal_transaction(paging_options)
+          |> Enum.take(paging_options.page_size)
+          |> Repo.preload(:block)
+          |> InternalTransaction.preload_error()
+          |> InternalTransaction.preload_transaction()
+          |> InternalTransaction.preload_addresses(options)
 
-      :ignore ->
-        [transaction.block_number]
-        |> fetch_block_internal_transactions()
-        |> Enum.map(&serialize/1)
-        |> Enum.filter(&(&1.block_number == transaction.block_number and &1.transaction_index == transaction.index))
-        |> different_from_parent_transaction()
-        |> Enum.sort_by(& &1.index)
-        |> join_associations(necessity_by_association)
-        |> page_internal_transaction(paging_options)
-        |> Enum.take(paging_options.page_size)
-        |> Repo.preload(:block)
-        |> InternalTransaction.preload_error()
-        |> InternalTransaction.preload_transaction()
-        |> InternalTransaction.preload_addresses(options)
+        :ignore ->
+          [transaction.block_number]
+          |> fetch_block_internal_transactions()
+          |> Enum.map(&serialize/1)
+          |> Enum.filter(&(&1.block_number == transaction.block_number and &1.transaction_index == transaction.index))
+          |> different_from_parent_transaction()
+          |> Enum.sort_by(& &1.index)
+          |> join_associations(necessity_by_association)
+          |> page_internal_transaction(paging_options)
+          |> Enum.take(paging_options.page_size)
+          |> Repo.preload(:block)
+          |> InternalTransaction.preload_error()
+          |> InternalTransaction.preload_transaction()
+          |> InternalTransaction.preload_addresses(options)
 
-      error ->
-        Logger.error(
-          "Failed to fetch internal transactions for transaction #{inspect(transaction.hash)}: #{inspect(error)}"
-        )
+        error ->
+          Logger.error(
+            "Failed to fetch internal transactions for transaction #{inspect(transaction.hash)}: #{inspect(error)}"
+          )
 
-        []
+          []
+      end
     end
   end
 
@@ -178,24 +190,28 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   end
 
   def fetch_by_block(%Block{} = block, options) do
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
-    type_filter = Keyword.get(options, :type)
-    call_type_filter = Keyword.get(options, :call_type)
-    unlimited? = Keyword.get(options, :unlimited)
+    if internal_transactions_fetching_disabled?() do
+      []
+    else
+      necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+      paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+      type_filter = Keyword.get(options, :type)
+      call_type_filter = Keyword.get(options, :call_type)
+      unlimited? = Keyword.get(options, :unlimited)
 
-    [block.number]
-    |> fetch_block_internal_transactions()
-    |> Enum.map(&serialize/1)
-    |> different_from_parent_transaction()
-    |> filter_by_type(type_filter, call_type_filter)
-    |> filter_by_call_type(call_type_filter)
-    |> page_block_internal_transaction(paging_options)
-    |> Enum.sort_by(&{&1.transaction_index, &1.index})
-    |> then(&if unlimited?, do: &1, else: Enum.take(&1, paging_options.page_size))
-    |> join_associations(necessity_by_association)
-    |> InternalTransaction.preload_error()
-    |> InternalTransaction.preload_transaction()
+      [block.number]
+      |> fetch_block_internal_transactions()
+      |> Enum.map(&serialize/1)
+      |> different_from_parent_transaction()
+      |> filter_by_type(type_filter, call_type_filter)
+      |> filter_by_call_type(call_type_filter)
+      |> page_block_internal_transaction(paging_options)
+      |> Enum.sort_by(&{&1.transaction_index, &1.index})
+      |> then(&if unlimited?, do: &1, else: Enum.take(&1, paging_options.page_size))
+      |> join_associations(necessity_by_association)
+      |> InternalTransaction.preload_error()
+      |> InternalTransaction.preload_transaction()
+    end
   end
 
   @doc """
@@ -221,61 +237,65 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   """
   @spec fetch_by_address(Hash.Address.t(), Keyword.t()) :: [InternalTransaction.t()]
   def fetch_by_address(address_hash, options) do
-    necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
-    direction = Keyword.get(options, :direction)
+    if internal_transactions_fetching_disabled?() do
+      []
+    else
+      necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
+      direction = Keyword.get(options, :direction)
 
-    from_block = Chain.from_block(options)
-    to_block = Chain.to_block(options)
+      from_block = Chain.from_block(options)
+      to_block = Chain.to_block(options)
 
-    paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+      paging_options = Keyword.get(options, :paging_options, @default_paging_options)
 
-    address_id = AddressIdToAddressHash.hash_to_id(address_hash)
+      address_id = AddressIdToAddressHash.hash_to_id(address_hash)
 
-    block_number_from_paging_options =
-      case paging_options do
-        %{key: {block_number, _, _}} -> block_number
-        _ -> nil
-      end
+      block_number_from_paging_options =
+        case paging_options do
+          %{key: {block_number, _, _}} -> block_number
+          _ -> nil
+        end
 
-    max_block_number =
-      case {to_block, block_number_from_paging_options} do
-        {nil, nil} -> nil
-        {nil, key} -> key
-        {to, nil} -> to
-        {to, key} -> min(to, key)
-      end
+      max_block_number =
+        case {to_block, block_number_from_paging_options} do
+          {nil, nil} -> nil
+          {nil, key} -> key
+          {to, nil} -> to
+          {to, key} -> min(to, key)
+        end
 
-    sum_mode =
-      case direction do
-        d when d in [:to, :to_address_hash] -> "tos"
-        d when d in [:from, :from_address_hash] -> "froms"
-        _ -> "both"
-      end
+      sum_mode =
+        case direction do
+          d when d in [:to, :to_address_hash] -> "tos"
+          d when d in [:from, :from_address_hash] -> "froms"
+          _ -> "both"
+        end
 
-    sort_direction = Keyword.get(options, :sort_direction, :desc)
+      sort_direction = Keyword.get(options, :sort_direction, :desc)
 
-    sort_func =
-      case sort_direction do
-        :asc -> &<=/2
-        _ -> &>=/2
-      end
+      sort_func =
+        case sort_direction do
+          :asc -> &<=/2
+          _ -> &>=/2
+        end
 
-    index_internal_transaction_desc_order = Keyword.get(options, :index_internal_transaction_desc_order, true)
+      index_internal_transaction_desc_order = Keyword.get(options, :index_internal_transaction_desc_order, true)
 
-    address_id
-    |> do_fetch_for_address(max_block_number, from_block, paging_options.page_size, sum_mode, sort_direction)
-    |> Enum.map(&serialize/1)
-    |> filter_by_address(address_hash, direction)
-    |> different_from_parent_transaction()
-    |> page_internal_transaction(paging_options, %{
-      index_internal_transaction_desc_order: index_internal_transaction_desc_order
-    })
-    |> Enum.sort_by(&{&1.block_number, &1.transaction_index, &1.index}, sort_func)
-    |> Enum.take(paging_options.page_size)
-    |> join_associations(necessity_by_association)
-    |> Repo.preload(:block)
-    |> InternalTransaction.preload_error()
-    |> InternalTransaction.preload_transaction()
+      address_id
+      |> do_fetch_for_address(max_block_number, from_block, paging_options.page_size, sum_mode, sort_direction)
+      |> Enum.map(&serialize/1)
+      |> filter_by_address(address_hash, direction)
+      |> different_from_parent_transaction()
+      |> page_internal_transaction(paging_options, %{
+        index_internal_transaction_desc_order: index_internal_transaction_desc_order
+      })
+      |> Enum.sort_by(&{&1.block_number, &1.transaction_index, &1.index}, sort_func)
+      |> Enum.take(paging_options.page_size)
+      |> join_associations(necessity_by_association)
+      |> Repo.preload(:block)
+      |> InternalTransaction.preload_error()
+      |> InternalTransaction.preload_transaction()
+    end
   end
 
   defp do_fetch_for_address(address_id, to_block, from_block, limit, sum_mode, sort_direction, acc \\ [])
@@ -541,53 +561,66 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   defp fetch_block_internal_transactions([]), do: []
 
   defp fetch_block_internal_transactions(block_numbers) do
-    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
-    variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
-
-    if variant in InternalTransactionFetcher.block_traceable_variants() do
-      case EthereumJSONRPC.fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments) do
-        {:ok, result} ->
-          result
-
-        error ->
-          Logger.error("Failed to fetch internal transactions for blocks #{inspect(block_numbers)}: #{inspect(error)}")
-          []
-      end
+    if internal_transactions_fetching_disabled?() do
+      []
     else
-      Enum.reduce(block_numbers, [], fn block_number, acc_list ->
-        block_number
-        |> Transaction.get_transactions_of_block_number()
-        |> Transaction.filter_non_traceable_transactions()
-        |> Enum.map(
-          &%{
-            block_number: &1.block_number,
-            hash_data: to_string(&1.hash),
-            transaction_index: &1.index
-          }
-        )
-        |> case do
-          [] ->
-            {:ok, []}
+      json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+      variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
 
-          transactions ->
-            try do
-              EthereumJSONRPC.fetch_internal_transactions(transactions, json_rpc_named_arguments)
-            catch
-              :exit, error ->
-                {:error, error, __STACKTRACE__}
-            end
+      if variant in InternalTransactionFetcher.block_traceable_variants() do
+        case EthereumJSONRPC.fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments) do
+          {:ok, result} ->
+            result
+
+          error ->
+            Logger.error(
+              "Failed to fetch internal transactions for blocks #{inspect(block_numbers)}: #{inspect(error)}"
+            )
+
+            []
         end
-        |> case do
-          {:ok, internal_transactions} ->
-            internal_transactions ++ acc_list
+      else
+        Enum.reduce(block_numbers, [], fn block_number, acc_list ->
+          block_number
+          |> Transaction.get_transactions_of_block_number()
+          |> Transaction.filter_non_traceable_transactions()
+          |> Enum.map(
+            &%{
+              block_number: &1.block_number,
+              hash_data: to_string(&1.hash),
+              transaction_index: &1.index
+            }
+          )
+          |> case do
+            [] ->
+              {:ok, []}
 
-          error_or_ignore ->
-            Logger.error("Failed to fetch internal transactions for block #{block_number}: #{inspect(error_or_ignore)}")
+            transactions ->
+              try do
+                EthereumJSONRPC.fetch_internal_transactions(transactions, json_rpc_named_arguments)
+              catch
+                :exit, error ->
+                  {:error, error, __STACKTRACE__}
+              end
+          end
+          |> case do
+            {:ok, internal_transactions} ->
+              internal_transactions ++ acc_list
 
-            acc_list
-        end
-      end)
+            error_or_ignore ->
+              Logger.error(
+                "Failed to fetch internal transactions for block #{block_number}: #{inspect(error_or_ignore)}"
+              )
+
+              acc_list
+          end
+        end)
+      end
     end
+  end
+
+  defp internal_transactions_fetching_disabled? do
+    Application.get_env(:indexer, __MODULE__, [])[:disabled?] == true
   end
 
   defp page_internal_transaction(_, _, _ \\ %{index_internal_transaction_desc_order: false})

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -15,13 +15,87 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
   setup do
     initial_ethereum_jsonrpc_env = Application.get_all_env(:ethereum_jsonrpc)
     initial_json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+
+    initial_on_demand_internal_transaction_config =
+      Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+
     %{json_rpc_named_arguments: json_rpc_named_arguments} = EthereumJSONRPC.Case.Geth.Mox.setup()
     Application.put_env(:explorer, :json_rpc_named_arguments, json_rpc_named_arguments)
 
     on_exit(fn ->
       Application.put_all_env([{:ethereum_jsonrpc, initial_ethereum_jsonrpc_env}])
       Application.put_env(:explorer, :json_rpc_named_arguments, initial_json_rpc_named_arguments)
+
+      if is_nil(initial_on_demand_internal_transaction_config) do
+        Application.delete_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+      else
+        Application.put_env(
+          :indexer,
+          Indexer.Fetcher.OnDemand.InternalTransaction,
+          initial_on_demand_internal_transaction_config
+        )
+      end
     end)
+  end
+
+  test "returns empty results when internal transactions fetcher is disabled" do
+    initial_on_demand_internal_transaction_config =
+      Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+
+    on_exit(fn ->
+      if is_nil(initial_on_demand_internal_transaction_config) do
+        Application.delete_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+      else
+        Application.put_env(
+          :indexer,
+          Indexer.Fetcher.OnDemand.InternalTransaction,
+          initial_on_demand_internal_transaction_config
+        )
+      end
+    end)
+
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
+
+    transaction = :transaction |> insert() |> with_block()
+    block = transaction.block
+    address = insert(:address)
+    opts = [paging_options: %PagingOptions{page_size: 5}]
+
+    assert [] = InternalTransactionOnDemand.fetch_latest(opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_transaction(transaction, opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_block(block, opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
+  end
+
+  test "should_fetch?/2 returns false when internal transactions fetcher is disabled" do
+    initial_on_demand_internal_transaction_config =
+      Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+
+    on_exit(fn ->
+      if is_nil(initial_on_demand_internal_transaction_config) do
+        Application.delete_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
+      else
+        Application.put_env(
+          :indexer,
+          Indexer.Fetcher.OnDemand.InternalTransaction,
+          initial_on_demand_internal_transaction_config
+        )
+      end
+    end)
+
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
+
+    address = insert(:address)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 1,
+      count_tos: 1,
+      count_froms: 1
+    )
+
+    refute InternalTransactionOnDemand.should_fetch?([], 10)
   end
 
   test "fetch_by_transaction/2" do

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -13,14 +13,48 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
   setup :verify_on_exit!
 
   setup do
+    snapshot_env_restore()
+
+    %{json_rpc_named_arguments: json_rpc_named_arguments} = EthereumJSONRPC.Case.Geth.Mox.setup()
+    Application.put_env(:explorer, :json_rpc_named_arguments, json_rpc_named_arguments)
+  end
+
+  test "returns empty results when internal transactions fetcher is disabled" do
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
+
+    transaction = :transaction |> insert() |> with_block()
+    block = transaction.block
+    address = insert(:address)
+    opts = [paging_options: %PagingOptions{page_size: 5}]
+
+    assert [] = InternalTransactionOnDemand.fetch_latest(opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_transaction(transaction, opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_block(block, opts)
+    assert [] = InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
+  end
+
+  test "should_fetch?/2 returns false when internal transactions fetcher is disabled" do
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
+
+    address = insert(:address)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 1,
+      count_tos: 1,
+      count_froms: 1
+    )
+
+    refute InternalTransactionOnDemand.should_fetch?([], 10)
+  end
+
+  defp snapshot_env_restore do
     initial_ethereum_jsonrpc_env = Application.get_all_env(:ethereum_jsonrpc)
     initial_json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
 
     initial_on_demand_internal_transaction_config =
       Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
-
-    %{json_rpc_named_arguments: json_rpc_named_arguments} = EthereumJSONRPC.Case.Geth.Mox.setup()
-    Application.put_env(:explorer, :json_rpc_named_arguments, json_rpc_named_arguments)
 
     on_exit(fn ->
       Application.put_all_env([{:ethereum_jsonrpc, initial_ethereum_jsonrpc_env}])
@@ -36,66 +70,6 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
         )
       end
     end)
-  end
-
-  test "returns empty results when internal transactions fetcher is disabled" do
-    initial_on_demand_internal_transaction_config =
-      Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
-
-    on_exit(fn ->
-      if is_nil(initial_on_demand_internal_transaction_config) do
-        Application.delete_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
-      else
-        Application.put_env(
-          :indexer,
-          Indexer.Fetcher.OnDemand.InternalTransaction,
-          initial_on_demand_internal_transaction_config
-        )
-      end
-    end)
-
-    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
-
-    transaction = :transaction |> insert() |> with_block()
-    block = transaction.block
-    address = insert(:address)
-    opts = [paging_options: %PagingOptions{page_size: 5}]
-
-    assert [] = InternalTransactionOnDemand.fetch_latest(opts)
-    assert [] = InternalTransactionOnDemand.fetch_by_transaction(transaction, opts)
-    assert [] = InternalTransactionOnDemand.fetch_by_block(block, opts)
-    assert [] = InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
-  end
-
-  test "should_fetch?/2 returns false when internal transactions fetcher is disabled" do
-    initial_on_demand_internal_transaction_config =
-      Application.get_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
-
-    on_exit(fn ->
-      if is_nil(initial_on_demand_internal_transaction_config) do
-        Application.delete_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction)
-      else
-        Application.put_env(
-          :indexer,
-          Indexer.Fetcher.OnDemand.InternalTransaction,
-          initial_on_demand_internal_transaction_config
-        )
-      end
-    end)
-
-    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, disabled?: true)
-
-    address = insert(:address)
-    id_to_hash = insert(:address_id_to_address_hash, address: address)
-
-    insert(:deleted_internal_transactions_address_placeholder,
-      address_id: id_to_hash.address_id,
-      block_number: 1,
-      count_tos: 1,
-      count_froms: 1
-    )
-
-    refute InternalTransactionOnDemand.should_fetch?([], 10)
   end
 
   test "fetch_by_transaction/2" do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1141,6 +1141,9 @@ config :indexer, Indexer.Fetcher.BlockReward.Supervisor,
 config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor,
   disabled?: trace_url_missing? or ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
 
+config :indexer, Indexer.Fetcher.OnDemand.InternalTransaction,
+  disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
+
 disable_coin_balances_fetcher? = ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ADDRESS_COIN_BALANCE_FETCHER")
 
 config :indexer, Indexer.Fetcher.CoinBalance.Catchup.Supervisor, disabled?: disable_coin_balances_fetcher?


### PR DESCRIPTION
## Motivation

When `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER` is enabled, internal transaction fetching should be fully disabled.  
Before this change, on-demand paths could still call JSON-RPC and emit fetch errors, which was inconsistent with the expected behavior.

## Changelog

### Enhancements

- Added runtime config for Indexer.Fetcher.OnDemand.InternalTransaction disabled? flag, driven by `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER`.
- Added regression tests for disabled mode in on-demand internal transaction fetcher:
  - verifies empty results for latest, by transaction, by block, and by address paths
  - verifies `should_fetch?/2` returns false when disabled
- Added test setup/on_exit config isolation for on-demand fetcher env overrides.

### Bug Fixes

- Added a shared disabled gate in `Indexer.Fetcher.OnDemand.InternalTransaction` and applied it before on-demand RPC calls.
- Prevented `fetch_block_internal_transactions` from calling JSON-RPC when disabled.
- Prevented `should_fetch?/2` from requesting on-demand fetch behavior when disabled.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a config option to disable on‑demand internal-transaction fetching via environment variable.

* **Bug Fixes**
  * When disabled, on‑demand internal-transaction endpoints now consistently return no results, preventing downstream fetch and processing.

* **Tests**
  * Added tests to verify the disabled behavior across public fetch entry points and the fetch decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->