### PR TITLE
fix: do not return partial internal transactions when blocks are pending

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/address_controller.ex
@@ -232,7 +232,7 @@ defmodule BlockScoutWeb.API.RPC.AddressController do
     if PendingOperationsHelper.blocks_pending?(start_block_number, end_block_number) do
       render(conn, :pending_internal_transaction,
         message: @block_range_not_yet_processed_message,
-        data: internal_transactions
+        data: []
       )
     else
       render(conn, :txlistinternal, %{internal_transactions: internal_transactions})

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2866,6 +2866,46 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
     end
+
+    test "returns status = 2 and empty result when blocks are pending, even if partial data exists", %{conn: conn} do
+      address = insert(:address)
+      address_2 = insert(:address)
+
+      block = insert(:block)
+      insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
+
+      transaction =
+        :transaction
+        |> insert(from_address: address, to_address: address_2)
+        |> with_block(block)
+
+      :internal_transaction
+      |> insert(
+        transaction: transaction,
+        transaction_index: transaction.index,
+        index: 0,
+        value: 1,
+        from_address: address,
+        to_address: address_2,
+        block_number: block.number
+      )
+
+      params = %{
+        "module" => "account",
+        "action" => "txlistinternal",
+        "address" => "#{address.hash}"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == []
+      assert response["status"] == "2"
+      assert response["message"] == "Some internal transactions within this block range have not yet been processed"
+      assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
+    end
   end
 
   describe "tokentx" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -1879,7 +1879,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
     end
 
-    test "returns status = 2 for internal transactions not yet processed", %{conn: conn, params: params} do
+    test "returns status = 2 and empty result when blocks are pending, even if partial data exists", %{conn: conn, params: params} do
       address = insert(:address)
       address_2 = insert(:address)
 
@@ -1902,44 +1902,23 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
         block_number: block.number
       )
 
-      internal_transaction =
-        :internal_transaction
-        |> insert(
-          transaction: transaction,
-          transaction_index: transaction.index,
-          index: 1,
-          value: 2,
-          from_address: address,
-          to_address: address_2,
-          block_number: block.number
-        )
-
-      expected_result = [
-        %{
-          "blockNumber" => "#{transaction.block_number}",
-          "timeStamp" => "#{DateTime.to_unix(block.timestamp)}",
-          "from" => "#{AddressIdToAddressHash.id_to_hash(internal_transaction.from_address_id)}",
-          "to" => "#{AddressIdToAddressHash.id_to_hash(internal_transaction.to_address_id)}",
-          "value" => "#{internal_transaction.value.value}",
-          "contractAddress" => "",
-          "input" => "#{internal_transaction.input}",
-          "type" => "#{internal_transaction.type}",
-          "callType" => "#{internal_transaction.call_type}",
-          "gas" => "#{internal_transaction.gas}",
-          "gasUsed" => "#{internal_transaction.gas_used}",
-          "index" => "#{internal_transaction.index}",
-          "transactionHash" => "#{transaction.hash}",
-          "isError" => "0",
-          "errCode" => "#{internal_transaction.error}"
-        }
-      ]
+      :internal_transaction
+      |> insert(
+        transaction: transaction,
+        transaction_index: transaction.index,
+        index: 1,
+        value: 2,
+        from_address: address,
+        to_address: address_2,
+        block_number: block.number
+      )
 
       assert response =
                conn
                |> get("/api/v1", params)
                |> json_response(200)
 
-      assert response["result"] == expected_result
+      assert response["result"] == []
       assert response["status"] == "2"
       assert response["message"] == "Some internal transactions within this block range have not yet been processed"
       assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)


### PR DESCRIPTION
Closes #14276

## Motivation

When some blocks in the requested range have not yet been indexed, `txlistinternal` was returning the rows it had already fetched alongside `status: "2"` and a warning message. Etherscan-compatible clients (ethers.js, web3.js, custom scripts) treat any status other than `"1"` as an error and discard the entire payload, causing valid transactions to be silently lost.

## Changelog

### Enhancements

- Added regression test for `txlistinternal` with address parameter when blocks are pending but partial data exists in the database.

### Bug Fixes

- `txlistinternal`: when any block in the requested range is still pending, the response now always contains an empty `result` array with `status: "2"`, instead of a partial set of rows. Clients receive either a complete dataset (`status: "1"`) or a clear signal to retry later (`status: "2"`, `result: []`) — never silent partial data.

### Incompatible Changes

_None. The response schema is unchanged. Clients that were already handling `status: "2"` will continue to receive an empty array as before; the only change is that partial rows are no longer included._

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Internal transactions endpoint now returns an empty result array for pending blocks instead of potentially incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->