### PR TITLE
chore: Optimize internal transactions address_match_dynamic

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -639,10 +639,10 @@ defmodule Explorer.Chain.InternalTransaction do
 
     cond do
       not address_ids_indexes_exists?() ->
-        dynamic([it], field(it, ^address_hash_field) in ^address_hashes)
+        adjust_address_match_dynamic(address_hash_field, address_hashes)
 
       address_ids_filled?() ->
-        dynamic([it], field(it, ^address_id_field) in ^address_ids)
+        adjust_address_match_dynamic(address_id_field, address_ids)
 
       true ->
         dynamic(
@@ -651,6 +651,9 @@ defmodule Explorer.Chain.InternalTransaction do
         )
     end
   end
+
+  defp adjust_address_match_dynamic(field, [value]), do: dynamic([it], field(it, ^field) == ^value)
+  defp adjust_address_match_dynamic(field, values), do: dynamic([it], field(it, ^field) in ^values)
 
   defp address_ids_indexes_exists? do
     BackgroundMigrations.get_heavy_indexes_create_address_ids_internal_transactions_indexes_finished()


### PR DESCRIPTION
## Changelog

Avoid `= ANY()` queries in case when there is only one address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to consolidate query construction logic, improving code maintainability with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->