### PR TITLE
fix: expose delete-zero migration status for API gating

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -68,7 +68,8 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_a_finished,
     key: :heavy_indexes_create_addresses_hash_contract_code_not_null_index_finished,
     key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished,
-    key: :fill_internal_transactions_address_ids_finished
+    key: :fill_internal_transactions_address_ids_finished,
+    key: :delete_zero_value_internal_transactions_finished
 
   @dialyzer :no_match
 
@@ -77,6 +78,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     AddressTokenBalanceTokenType,
     ArbitrumDaRecordsNormalization,
     BackfillMultichainSearchDB,
+    DeleteZeroValueInternalTransactions,
     EmptyInternalTransactionsData,
     FillInternalTransactionsAddressIds,
     SanitizeDuplicatedLogIndexLogs,
@@ -411,6 +413,13 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     set_and_return_migration_status(
       FillInternalTransactionsAddressIds,
       &set_fill_internal_transactions_address_ids_finished/1
+    )
+  end
+
+  defp handle_fallback(:delete_zero_value_internal_transactions_finished) do
+    set_and_return_migration_status(
+      DeleteZeroValueInternalTransactions,
+      &set_delete_zero_value_internal_transactions_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -1297,11 +1297,15 @@ defmodule Explorer.Chain.InternalTransaction do
   def include_zero_value(query, true), do: query
 
   def include_zero_value(query, false) do
-    where(
-      query,
-      [internal_transaction],
-      (internal_transaction.type == :call and internal_transaction.value > ^0) or internal_transaction.type != :call
-    )
+    if BackgroundMigrations.get_delete_zero_value_internal_transactions_finished() do
+      query
+    else
+      where(
+        query,
+        [internal_transaction],
+        (internal_transaction.type == :call and internal_transaction.value > ^0) or internal_transaction.type != :call
+      )
+    end
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -35,6 +35,14 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
   @spec border_number() :: non_neg_integer() | nil
   def border_number, do: get_border_number()
 
+  @doc """
+  Checks if this migration has completed.
+  """
+  @spec migration_finished?() :: boolean()
+  def migration_finished? do
+    MigrationStatus.get_status(@migration_name) == "completed"
+  end
+
   @impl true
   def init(_) do
     {:ok, %{}, {:continue, :ok}}


### PR DESCRIPTION
## Motivation

Expose a stable boolean status for the `DeleteZeroValueInternalTransactions` background migration and use it in internal transaction filtering logic. This lets API code safely switch behavior once zero-value internal transactions are physically deleted by migration, instead of relying only on config/runtime assumptions.

## Changelog

### Enhancements

- Added `migration_finished?/0` to `Explorer.Migrator.DeleteZeroValueInternalTransactions`.
- Extended `Explorer.Chain.Cache.BackgroundMigrations` with a new cached key:
  - `:delete_zero_value_internal_transactions_finished`
- Added fallback resolution in `BackgroundMigrations` for that key via migration status lookup.

### Bug Fixes

- Updated `Explorer.Chain.InternalTransaction.include_zero_value/2`:
  - when `include_zero` is `false` and migration is finished, returns query unchanged;
  - otherwise keeps existing zero-value exclusion `where` clause.
- This prevents unnecessary zero-value filtering after data has already been deleted by migration.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added background migration completion tracking for transaction data management. The system now intelligently monitors migration status and dynamically adjusts transaction processing rules. This improves data consistency and ensures proper transaction handling throughout the migration lifecycle, providing better stability and system reliability while maintaining accurate records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->