### PR TITLE
fix: Update OnDemand.InternalTransaction etherscan fields

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2498,6 +2498,80 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert response["message"] == "OK"
       assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
     end
+
+    test "via on-demand fetcher", %{conn: conn} do
+      original_config = Application.get_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions)
+
+      Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions,
+        enabled: true,
+        storage_period: 0
+      )
+
+      transaction = :transaction |> insert() |> with_block()
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
+        [%{id: id, params: _}], _ ->
+          {:ok,
+           [
+             %{
+               id: id,
+               result: %{
+                 "type" => "create",
+                 "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
+                 "to" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
+                 "value" => "0x0",
+                 "gas" => "0x106f5",
+                 "gasUsed" => "0x106f5",
+                 "input" =>
+                   "0x608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033",
+                 "output" =>
+                   "0x608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033"
+               }
+             }
+           ]}
+      end)
+
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, tracer: "call_tracer", debug_trace_timeout: "5s")
+
+      expected_result = [
+        %{
+          "blockNumber" => "#{transaction.block_number}",
+          "callType" => "",
+          "contractAddress" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
+          "errCode" => "",
+          "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
+          "gas" => "67317",
+          "gasUsed" => "67317",
+          "index" => "0",
+          "input" => "",
+          "isError" => "0",
+          "timeStamp" => "#{DateTime.to_unix(transaction.block.timestamp)}",
+          "to" => "",
+          "transactionHash" => "#{transaction.hash}",
+          "type" => "create",
+          "value" => "0"
+        }
+      ]
+
+      params = %{
+        "module" => "account",
+        "action" => "txlistinternal",
+        "txhash" => "#{transaction.hash}",
+        "include_zero_value" => "true"
+      }
+
+      assert response =
+               conn
+               |> get("/api/v1", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
+
+      Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions, original_config)
+    end
   end
 
   describe "txlistinternal with address" do

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -774,8 +774,12 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   end
 
   defp etherscan_serialize(internal_transaction) do
+    internal_transaction_fields =
+      Etherscan.internal_transaction_fields() ++
+        [:transaction_hash, :from_address_hash, :to_address_hash, :created_contract_address_hash]
+
     internal_transaction
-    |> Map.take(Etherscan.internal_transaction_fields())
+    |> Map.take(internal_transaction_fields)
     |> Map.put(:block_timestamp, internal_transaction.block.timestamp)
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -776,7 +776,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   defp etherscan_serialize(internal_transaction) do
     internal_transaction_fields =
       Etherscan.internal_transaction_fields() ++
-        [:transaction_hash, :from_address_hash, :to_address_hash, :created_contract_address_hash]
+        [:transaction_hash, :from_address_hash, :to_address_hash, :created_contract_address_hash, :error]
 
     internal_transaction
     |> Map.take(internal_transaction_fields)

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -474,7 +474,8 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
                from_address_hash: from_address_hash,
                to_address_hash: nil,
                block_timestamp: ^block_timestamp,
-               transaction_hash: ^transaction_hash
+               transaction_hash: ^transaction_hash,
+               error: nil
              }
            ] = InternalTransactionOnDemand.etherscan_fetch_by_transaction(transaction, %{})
 

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -438,4 +438,47 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
 
     assert [] = InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
   end
+
+  test "etherscan_fetch_by_transaction/2" do
+    transaction = :transaction |> insert() |> with_block()
+    block_timestamp = transaction.block.timestamp
+    transaction_hash = transaction.hash
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
+      [%{id: id, params: _}], _ ->
+        {:ok,
+         [
+           %{
+             id: id,
+             result: %{
+               "type" => "create",
+               "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
+               "to" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
+               "value" => "0x0",
+               "gas" => "0x106f5",
+               "gasUsed" => "0x106f5",
+               "input" =>
+                 "0x608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033",
+               "output" =>
+                 "0x608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033"
+             }
+           }
+         ]}
+    end)
+
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, tracer: "call_tracer", debug_trace_timeout: "5s")
+
+    assert [
+             %{
+               created_contract_address_hash: created_contract_address_hash,
+               from_address_hash: from_address_hash,
+               to_address_hash: nil,
+               block_timestamp: ^block_timestamp,
+               transaction_hash: ^transaction_hash
+             }
+           ] = InternalTransactionOnDemand.etherscan_fetch_by_transaction(transaction, %{})
+
+    assert to_string(created_contract_address_hash) == "0x205a6b72ce16736c9d87172568a9c0cb9304de0d"
+    assert to_string(from_address_hash) == "0x117b358218da5a4f647072ddb50ded038ed63d17"
+  end
 end


### PR DESCRIPTION
## Motivation

`Explorer.Etherscan` internal transaction struct contains not only `@internal_transaction_fields` but also `transaction_hash, from_address_hash, to_address_hash, created_contract_address_hash`. However, they are not included in `Indexer.Fetcher.OnDemand.InternalTransaction.etherscan_serialize/1` which means that internal transactions struct came from DB differs from struct came from on-demand fetcher.

## Changelog

Added missing fields to `etherscan_serialize/1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal transaction handling now preserves additional address and transaction identifiers (including created-contract and error fields) and continues to reliably retain block timestamps during processing.
* **Tests**
  * Added unit and integration tests covering on-demand internal-transaction fetching and the RPC/internal-transactions API path to verify identifiers, timestamps, and response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->