### PR TITLE
chore: Change "coinsupply" RPC API response to fit JSON RPC requirements

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/rpc_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/rpc_view.ex
@@ -9,14 +9,6 @@ defmodule BlockScoutWeb.API.RPC.RPCView do
     }
   end
 
-  def render("show_value.json", %{data: data}) do
-    {value, _} =
-      data
-      |> Float.parse()
-
-    value
-  end
-
   def render("pending_internal_transaction.json", %{data: data, message: message}) do
     %{
       "status" => "2",

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/stats_view.ex
@@ -16,7 +16,7 @@ defmodule BlockScoutWeb.API.RPC.StatsView do
   end
 
   def render("coinsupply.json", %{total_supply: total_supply}) do
-    RPCView.render("show_value.json", data: total_supply)
+    RPCView.render("show.json", data: total_supply)
   end
 
   def render("ethprice.json", %{rates: rates}) do


### PR DESCRIPTION
## Motivation

JSON RPC requires response to be a JSON object. However, "coinsupply" RPC API endpoint returns plain text.

## Changelog

Make the response structure of the "coinsupply" RPC API endpoint the same as "ethsupply":
```
{
    "message": "OK",
    "result": "187814944243970369897937286",
    "status": "1"
}
```

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated RPC API response formatting by streamlining the coin supply endpoint to use a standardized response template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->