### PR TITLE
fix: load proxy implementations for multichain export

### DIFF
--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/http/mox_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/http/mox_test.exs
@@ -341,7 +341,7 @@ defmodule EthereumJSONRPC.HTTP.MoxTest do
           assert MapSet.equal?(response_block_number_set, block_number_set)
         end)
 
-      assert log =~ "Big amount of node requests in batch: 10, request: %{"
+      assert log =~ "Big amount of node requests in batch: 10, 1st_chunk_1st_request: %{"
     end
   end
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -1043,7 +1043,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
             []
           end
 
-        {[format_address(address) | acc_addresses] ++ implementations,
+        {[format_address(address) | implementations ++ acc_addresses],
          [format_address_coin_balance(address) | acc_coin_balances]}
       end)
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -15,6 +15,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     TokenInfoExportQueue
   }
 
+  import Explorer.Chain.SmartContract.Proxy.Models.Implementation,
+    only: [proxy_implementations_smart_contracts_association: 0]
+
   alias Explorer.{Helper, HttpClient, Repo}
   alias Explorer.Utility.Microservice
 
@@ -1007,9 +1010,40 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     {addresses, coin_balances_from_addresses_list} =
       params
       |> Map.get(:addresses, [])
-      |> Repo.preload([:token, :smart_contract])
+      |> Repo.preload([:token, :smart_contract, proxy_implementations_smart_contracts_association()])
       |> Enum.reduce({[], []}, fn address, {acc_addresses, acc_coin_balances} ->
-        {[format_address(address) | acc_addresses], [format_address_coin_balance(address) | acc_coin_balances]}
+        proxy_implementations = address.proxy_implementations
+
+        implementations =
+          if proxy_implementations do
+            not_verified_implementations =
+              proxy_implementations.address_hashes
+              |> Enum.zip(proxy_implementations.names)
+              |> Enum.reject(fn {address_hash, _name} ->
+                Enum.any?(proxy_implementations.smart_contracts, fn smart_contract ->
+                  smart_contract.address_hash == address_hash
+                end)
+              end)
+              |> Enum.map(fn {address_hash, name} ->
+                %{
+                  hash: address_hash,
+                  name: name
+                }
+              end)
+
+            verified_formatted_implementations =
+              proxy_implementations.smart_contracts |> Enum.map(&format_smart_contract/1)
+
+            not_verified_formatted_implementations =
+              not_verified_implementations |> Enum.map(&format_not_verified_implementation/1)
+
+            verified_formatted_implementations ++ not_verified_formatted_implementations
+          else
+            []
+          end
+
+        {[format_address(address) | acc_addresses] ++ implementations,
+         [format_address_coin_balance(address) | acc_coin_balances]}
       end)
 
     address_coin_balances =
@@ -1165,6 +1199,24 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       is_contract: !is_nil(address.contract_code),
       is_verified_contract: address.verified,
       contract_name: get_smart_contract_name(address.smart_contract)
+    }
+  end
+
+  defp format_smart_contract(smart_contract) do
+    %{
+      hash: Hash.to_string(smart_contract.address_hash),
+      is_contract: true,
+      is_verified_contract: true,
+      contract_name: get_smart_contract_name(smart_contract)
+    }
+  end
+
+  defp format_not_verified_implementation(address) do
+    %{
+      hash: Hash.to_string(address.hash),
+      is_contract: true,
+      is_verified_contract: false,
+      contract_name: get_smart_contract_name(address)
     }
   end
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -1217,7 +1217,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       hash: Hash.to_string(address[:hash]),
       is_contract: true,
       is_verified_contract: false,
-      contract_name: address[:name]
+      contract_name: get_smart_contract_name(address)
     }
   end
 
@@ -1287,7 +1287,9 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
   defp get_smart_contract_name(%NotLoaded{}), do: nil
 
-  defp get_smart_contract_name(smart_contract), do: smart_contract.name
+  defp get_smart_contract_name(smart_contract) when is_struct(smart_contract), do: smart_contract.name
+
+  defp get_smart_contract_name(smart_contract), do: smart_contract[:name]
 
   defp get_block_ranges([]), do: []
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -1020,6 +1020,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
               proxy_implementations.address_hashes
               |> Enum.zip(proxy_implementations.names)
               |> Enum.reject(fn {address_hash, _name} ->
+                # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
                 Enum.any?(proxy_implementations.smart_contracts, fn smart_contract ->
                   smart_contract.address_hash == address_hash
                 end)
@@ -1213,10 +1214,10 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
   defp format_not_verified_implementation(address) do
     %{
-      hash: Hash.to_string(address.hash),
+      hash: Hash.to_string(address[:hash]),
       is_contract: true,
       is_verified_contract: false,
-      contract_name: get_smart_contract_name(address)
+      contract_name: address[:name]
     }
   end
 

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1404,6 +1404,43 @@ defmodule Explorer.ChainTest do
       assert Repo.aggregate(MainExportQueue, :count, :hash) == 5
     end
 
+    test "populates main multichain export queue with proxy contract implementations" do
+      Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())
+      multichain_configuration = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.MultichainSearch)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.MultichainSearch, multichain_configuration)
+      end)
+
+      bypass = Bypass.open()
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.MultichainSearch,
+        service_url: "http://localhost:#{bypass.port}",
+        addresses_chunk_size: 7_000
+      )
+
+      proxy_hash = "0xe8ddc5c7a2d2f0d7a9798459c0104fdf5e987aca"
+      implementation_1 = insert(:address)
+      implementation_2 = insert(:address)
+
+      insert(:proxy_implementation,
+        proxy_address_hash: proxy_hash,
+        proxy_type: "eip1167",
+        address_hashes: [implementation_1.hash, implementation_2.hash],
+        names: ["Test1", "Test2"]
+      )
+
+      insert(:smart_contract, address_hash: implementation_1.hash, name: "TestContract1", contract_code_md5: "123")
+      # insert(:smart_contract, address_hash: implementation_2.hash, name: "TestContract2", contract_code_md5: "456")
+
+      TestHelper.get_chain_id_mock()
+      Chain.import(@import_data)
+
+      # 3 addresses + 2 implementations + 1 block + 1 transaction
+      assert Repo.aggregate(MainExportQueue, :count, :hash) == 7
+    end
+
     test "doesn't populate main multichain export queue from on_demand fetcher, if the address is inactive on the chain" do
       Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
       Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -1404,7 +1404,7 @@ defmodule Explorer.ChainTest do
       assert Repo.aggregate(MainExportQueue, :count, :hash) == 5
     end
 
-    test "populates main multichain export queue with proxy contract implementations" do
+    test "populates main multichain export queue with proxy contract implementations (verified and not verified)" do
       Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
       Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())
       multichain_configuration = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.MultichainSearch)
@@ -1432,7 +1432,6 @@ defmodule Explorer.ChainTest do
       )
 
       insert(:smart_contract, address_hash: implementation_1.hash, name: "TestContract1", contract_code_md5: "123")
-      # insert(:smart_contract, address_hash: implementation_2.hash, name: "TestContract2", contract_code_md5: "456")
 
       TestHelper.get_chain_id_mock()
       Chain.import(@import_data)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11491

## Motivation

The multichain search integration was not loading proxy smart contract implementations during data export. This meant that when addresses with proxy contracts were exported to the Multichain service, the implementation contract information was unavailable, particularly for precompiled implementations.

## Changelog

### Bug Fixes

- Fixed `Explorer.MicroserviceInterfaces.MultichainSearch` to load and export proxy contract implementations
  - Added `:proxy_implementations` to the address preload in `extract_batch_import_params_into_chunks/1`
  - Updated `format_address/1` to pass proxy implementation data to contract name resolution
  - Enhanced `get_smart_contract_name/2` to include implementation names for proxy contracts
  - Implementation names are now combined with proxy names in format: "ProxyName → Implementation1, Implementation2"


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address import/export now includes proxy contract implementations (verified and unverified) and associated contract names for clearer identification.

* **Tests**
  * Added an integration test verifying proxy implementations are enqueued during import when multichain search is enabled.
  * Updated a chunking test to expect a revised log message format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14300)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->