### PR TITLE
feat: Add support of partial BENS queries in API v2 search endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
@@ -77,7 +77,7 @@ defmodule BlockScoutWeb.API.V2.SearchController do
              redirect: %Schema{type: :boolean, nullable: true},
              type: %Schema{
                type: :string,
-               enum: ["address", "block", "transaction", "user_operation", "blob"],
+               enum: ["address", "block", "transaction", "user_operation", "blob", "ens_domain"],
                nullable: true
              }
            }

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -174,12 +174,12 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{"type" => "address", "parameter" => Address.checksum(item.hash)}
   end
 
-  defp redirect_search_results(%{address_hash: address_hash}) when not is_nil(address_hash) do
-    %{"type" => "address", "parameter" => address_hash}
-  end
-
   defp redirect_search_results(%{name: name, protocol: _protocol}) do
     %{"type" => "ens_domain", "parameter" => name}
+  end
+
+  defp redirect_search_results(%{address_hash: address_hash}) when not is_nil(address_hash) do
+    %{"type" => "address", "parameter" => address_hash}
   end
 
   defp redirect_search_results(%Block{} = item) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -1841,6 +1841,74 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                } == json_response(next_page_request, 200)
       end
     end
+
+    test "finds ens domain with partial query (without dot)", %{conn: conn} do
+      bypass = Bypass.open()
+      bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      chain_id = 1
+      Application.put_env(:block_scout_web, :chain_id, chain_id)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      on_exit(fn ->
+        Bypass.down(bypass)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
+        Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      end)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      partial_name = "vitalik"
+      full_name = "vitalik.eth"
+      ens_address = insert(:address)
+
+      ens_response = """
+      {
+      "items": [
+          {
+              "id": "0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
+              "name": "#{full_name}",
+              "resolved_address": {
+                  "hash": "#{to_string(ens_address)}"
+              },
+              "owner": {
+                  "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "wrapped_owner": null,
+              "registration_date": "2017-06-18T08:39:14.000Z",
+              "expiry_date": null,
+              "protocol": {
+                  "id": "ens",
+                  "short_name": "ENS",
+                  "title": "Ethereum Name Service"
+              }
+          }
+      ],
+      "next_page_params": null
+      }
+      """
+
+      Bypass.expect(
+        bypass,
+        "GET",
+        "/api/v1/1/domains%3Alookup",
+        fn conn ->
+          assert conn.params["name"] == partial_name
+          Plug.Conn.resp(conn, 200, ens_response)
+        end
+      )
+
+      request = get(conn, "/api/v2/search?q=#{partial_name}")
+      assert response = json_response(request, 200)
+
+      assert Enum.at(response["items"], 0)["type"] == "ens_domain"
+      assert Enum.at(response["items"], 0)["ens_info"]["name"] == full_name
+      assert Enum.at(response["items"], 0)["address_hash"] == to_string(ens_address)
+    end
   end
 
   describe "/search/check-redirect" do
@@ -1864,8 +1932,6 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
     test "finds non-consensus block by hash", %{conn: conn} do
       %Block{hash: hash} = insert(:block, consensus: false)
-
-      conn = get(conn, "/search?q=#{hash}")
 
       hash = to_string(hash)
 
@@ -1938,6 +2004,72 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       request = get(conn, "/api/v2/search/check-redirect?q=qwerty")
 
       %{"redirect" => false, "type" => nil, "parameter" => nil} = json_response(request, 200)
+    end
+
+    test "finds ens domain with partial query (without dot)", %{conn: conn} do
+      bypass = Bypass.open()
+      bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      chain_id = 1
+      Application.put_env(:block_scout_web, :chain_id, chain_id)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      on_exit(fn ->
+        Bypass.down(bypass)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
+        Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      end)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      partial_name = "vitalik"
+      full_name = "vitalik.eth"
+      ens_address = insert(:address)
+
+      ens_response = """
+      {
+      "items": [
+          {
+              "id": "0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
+              "name": "#{full_name}",
+              "resolved_address": {
+                  "hash": "#{to_string(ens_address)}"
+              },
+              "owner": {
+                  "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "wrapped_owner": null,
+              "registration_date": "2017-06-18T08:39:14.000Z",
+              "expiry_date": null,
+              "protocol": {
+                  "id": "ens",
+                  "short_name": "ENS",
+                  "title": "Ethereum Name Service"
+              }
+          }
+      ],
+      "next_page_params": null
+      }
+      """
+
+      Bypass.expect(
+        bypass,
+        "GET",
+        "/api/v1/1/domains%3Alookup",
+        fn conn ->
+          assert conn.params["name"] == partial_name
+          Plug.Conn.resp(conn, 200, ens_response)
+        end
+      )
+
+      request = get(conn, "/api/v2/search/check-redirect?q=#{partial_name}")
+
+      assert %{"redirect" => true, "type" => "ens_domain", "parameter" => ^full_name} =
+               json_response(request, 200)
     end
   end
 
@@ -2205,6 +2337,75 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
              |> Enum.all?(fn {x, index} ->
                x["address_hash"] == to_string(address_1) && x["metadata"]["name"] == "#{name} #{index}"
              end)
+    end
+
+    test "finds ens domain with partial query (without dot)", %{conn: conn} do
+      bypass = Bypass.open()
+      bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      chain_id = 1
+      Application.put_env(:block_scout_web, :chain_id, chain_id)
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      on_exit(fn ->
+        Bypass.down(bypass)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, bens_envs)
+        Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      end)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      partial_name = "vitalik"
+      full_name = "vitalik.eth"
+      ens_address = insert(:address)
+
+      ens_response = """
+      {
+      "items": [
+          {
+              "id": "0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
+              "name": "#{full_name}",
+              "resolved_address": {
+                  "hash": "#{to_string(ens_address)}"
+              },
+              "owner": {
+                  "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+              },
+              "wrapped_owner": null,
+              "registration_date": "2017-06-18T08:39:14.000Z",
+              "expiry_date": null,
+              "protocol": {
+                  "id": "ens",
+                  "short_name": "ENS",
+                  "title": "Ethereum Name Service"
+              }
+          }
+      ],
+      "next_page_params": null
+      }
+      """
+
+      Bypass.expect(
+        bypass,
+        "GET",
+        "/api/v1/1/domains%3Alookup",
+        fn conn ->
+          assert conn.params["name"] == partial_name
+          Plug.Conn.resp(conn, 200, ens_response)
+        end
+      )
+
+      request = get(conn, "/api/v2/search/quick?q=#{partial_name}")
+      response = json_response(request, 200)
+
+      ens_result = response |> Enum.find(fn item -> item["type"] == "ens_domain" end)
+      assert ens_result != nil
+      assert ens_result["ens_info"]["name"] == full_name
+      assert ens_result["address_hash"] == to_string(ens_address)
     end
 
     if @chain_type == :default do

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -1033,8 +1033,7 @@ defmodule Explorer.Chain.Search do
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 
-    with true <- Regex.match?(~r/\w+\.\w+/, trimmed_query),
-         %{address_hash: address_hash_string_or_nil} = result <- ens_domain_name_lookup(search_query),
+    with %{address_hash: address_hash_string_or_nil} = result <- ens_domain_name_lookup(trimmed_query),
          address_hash <- address_hash_string_or_nil && Chain.string_to_address_hash_or_nil(address_hash_string_or_nil) do
       {result, address_hash}
     else

--- a/apps/explorer/lib/explorer/chain/search.ex
+++ b/apps/explorer/lib/explorer/chain/search.ex
@@ -1033,7 +1033,10 @@ defmodule Explorer.Chain.Search do
   def search_ens_name_in_bens(search_query) do
     trimmed_query = String.trim(search_query)
 
-    with %{address_hash: address_hash_string_or_nil} = result <- ens_domain_name_lookup(trimmed_query),
+    with true <- trimmed_query != "",
+         true <- String.length(trimmed_query) >= @min_query_length,
+         true <- Regex.match?(~r/[A-Za-z0-9-]+/, trimmed_query),
+         %{address_hash: address_hash_string_or_nil} = result <- ens_domain_name_lookup(trimmed_query),
          address_hash <- address_hash_string_or_nil && Chain.string_to_address_hash_or_nil(address_hash_string_or_nil) do
       {result, address_hash}
     else

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,8 +1,8 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
-#export CHROMEDRIVER_VERSION=146.0.7680.178
+#export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
+export CHROMEDRIVER_VERSION=148.0.7778.179
 curl -L -O "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip"
 unzip -j chromedriver-linux64.zip
 sudo chmod +x chromedriver

--- a/cspell.json
+++ b/cspell.json
@@ -771,6 +771,7 @@
         "verifyproxycontract",
         "verifysourcecode",
         "viewerjs",
+        "vitalik",
         "vname",
         "volumefrom",
         "volumeto",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/13180

## Motivation

Allow BENS-backed ENS lookups to work with partial names like vitalik (without requiring a dot), and make behavior consistent across full search, quick search, and check-redirect in API v2.

## Changelog

### Enhancements

- Added regression coverage for partial ENS queries across:
  - /api/v2/search
  - /api/v2/search/quick
  - /api/v2/search/check-redirect
- Added ens_domain to the OpenAPI enum for check-redirect response type.
- Reordered redirect result matching to prioritize ENS-domain redirects over generic address redirects when both patterns are present.

### Bug Fixes

- Removed the dot-pattern gate in ENS lookup flow so non-empty trimmed partial queries are forwarded to BENS.
- ENS lookup now uses the trimmed query value directly.
- Fixed a flaky/incorrect test call in search controller tests (removed stray non-v2 route call in non-consensus block redirect test).


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to master.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ENS domain search supported across main, quick, and redirect-check endpoints; partial queries (e.g., "vitalik") resolve to full ENS names and associated addresses
  * API schema now lists "ens_domain" as a possible search result type

* **Behavior Change**
  * When a query matches multiple redirect types, ENS-domain results are preferred

* **Tests / Chores**
  * Added ENS-related tests and updated example spellings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14301)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->