### PR TITLE
fix: trim contractaddresses in getcontractcreation

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/contract_controller.ex
@@ -45,7 +45,9 @@ defmodule BlockScoutWeb.API.RPC.ContractController do
   def getcontractcreation(conn, %{"contractaddresses" => contract_address_hash_strings} = params) do
     addresses =
       contract_address_hash_strings
-      |> String.split(",")
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
       |> Enum.take(@addresses_limit)
       |> Enum.map(fn address_hash_string ->
         case validate_address(address_hash_string, params) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/contract_controller_test.exs
@@ -1103,6 +1103,49 @@ defmodule BlockScoutWeb.API.RPC.ContractControllerTest do
       assert creation_bytecode == to_string(transaction.input)
     end
 
+    test "returns contract creation info for addresses separated by comma and whitespace", %{conn: conn, params: params} do
+      {:ok, block_timestamp, _} = DateTime.from_iso8601("2021-05-05T21:42:11.000000Z")
+
+      address = insert(:contract_address)
+      address_1 = insert(:contract_address)
+
+      transaction =
+        insert(:transaction,
+          created_contract_address: address,
+          block_timestamp: block_timestamp
+        )
+
+      transaction_1 =
+        insert(:transaction,
+          created_contract_address: address_1,
+          block_timestamp: block_timestamp
+        )
+
+      %{
+        "status" => "1",
+        "message" => "OK",
+        "result" => result
+      } =
+        conn
+        |> get(
+          "/api",
+          Map.put(params, "contractaddresses", "#{to_string(address)}, #{to_string(address_1)}")
+        )
+        |> json_response(200)
+
+      assert length(result) == 2
+
+      assert Enum.map(result, & &1["contractAddress"]) == [
+               to_string(address.hash),
+               to_string(address_1.hash)
+             ]
+
+      assert Enum.map(result, & &1["txHash"]) == [
+               to_string(transaction.hash),
+               to_string(transaction_1.hash)
+             ]
+    end
+
     test "get contract creation info via internal transaction", %{conn: conn, params: params} do
       {:ok, block_timestamp, _} = DateTime.from_iso8601("2021-05-05T21:42:11.000000Z")
       unix_timestamp = DateTime.to_unix(block_timestamp, :second)


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14305

## Motivation

Fix `getcontractcreation` behavior when `contractaddresses` includes whitespace after commas, for example "addr1, addr2". Previously, the second address could fail parsing and be silently omitted from the result list.

## Changelog

### Enhancements

- Added a regression test that covers comma plus whitespace separated contractaddresses and asserts both contracts are returned.

### Bug Fixes

- Normalized contractaddresses parsing in getcontractcreation by:
  - splitting with trim enabled
  - trimming each parsed address
  - rejecting empty tokens before validation
- This prevents valid addresses with leading or trailing whitespace from being dropped.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the contract address parameter parsing to properly handle multiple addresses separated by commas with additional whitespace.

* **Tests**
  * Added test coverage validating correct parsing of comma-separated contract addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->