### PR TITLE
fix: Add missing internal transactions address preload

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -1229,7 +1229,8 @@ defmodule Explorer.Chain.InternalTransaction do
           Keyword.merge(options,
             address_preloads: [
               from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-              to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
+              to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
+              created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
             ]
           )
 


### PR DESCRIPTION
## Motivation

Internal transaction `created_contract_address` is used in view with its preloads as well as the other addresses


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized data loading performance for internal transaction queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->