### PR TITLE
fix: Adapt maybe_reject_zero_value for empty blocks

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -558,8 +558,9 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
          border_number when is_integer(border_number) <- DeleteZeroValueInternalTransactions.border_number() do
       Enum.reject(
         internal_transactions,
-        &(&1.block_number <= border_number and &1.type == :call and
-            (is_nil(Map.get(&1, :value)) || Decimal.eq?(&1.value.value, 0)))
+        &(Map.has_key?(&1, :type) and
+            (&1.block_number <= border_number and &1.type == :call and
+               (is_nil(Map.get(&1, :value)) || Decimal.eq?(&1.value.value, 0))))
       )
     else
       _ -> internal_transactions


### PR DESCRIPTION
## Motivation

Internal transactions params may contain only `block_number` if they were processed with `blockless_changeset`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of internal transaction import to correctly handle transactions lacking type information, preventing processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->