### PR TITLE
fix: Fix some web tests

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/celo/election_reward.ex
@@ -23,8 +23,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Celo.ElectionReward do
     required: [
       :amount,
       :account,
-      :associated_account,
-      :epoch_number
+      :associated_account
     ],
     additionalProperties: false
   })

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/search_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/search_view_test.exs
@@ -10,7 +10,7 @@ defmodule BlockScoutWeb.API.V2.SearchViewTest do
         type: "token",
         name: "Token",
         symbol: "TKN",
-        address_hash: "0x123",
+        address_hash: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         icon_url: "https://example.com/token.png",
         token_type: "ERC-20",
         verified: true,
@@ -35,8 +35,8 @@ defmodule BlockScoutWeb.API.V2.SearchViewTest do
       assert item["name"] == "Token"
       assert item["exchange_rate"] == "1.5"
       assert item["certified"] == false
-      assert item["token_url"] =~ "/token/0x123"
-      assert item["address_url"] =~ "/address/0x123"
+      assert item["token_url"] =~ "/token/0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      assert item["address_url"] =~ "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7"
 
       assert result["next_page_params"] == %{"q" => "token", "type" => nil}
     end


### PR DESCRIPTION
## Motivation

Fix tests:

`  1) test render search_results.json renders search results list and encoded next_page_params (BlockScoutWeb.API.V2.SearchViewTest)
Error:      test/block_scout_web/views/api/v2/search_view_test.exs:8
     ** (Ecto.Query.CastError) /home/runner/work/blockscout/blockscout/apps/explorer/lib/explorer/chain.ex:984: value `["0x123"]` in `where` cannot be cast to type {:in, Explorer.Chain.Hash.Address} in query:

     from a0 in Explorer.Chain.Address,
       as: :address,
       where: a0.hash in ^["0x123"],
       order_by: [
       asc:
         fragment(
           "array_position(?, ?)",
           type(^["0x123"], {:array, Explorer.Chain.Hash.Address}),
           a0.hash
         )
     ],
       select: a0

     code: SearchView.render("search_results.json", %{
     stacktrace:
       (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (elixir 1.19.4) lib/enum.ex:1814: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
       (elixir 1.19.4) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ecto 3.13.5) lib/ecto/repo/queryable.ex:223: Ecto.Repo.Queryable.execute/4
       (ecto 3.13.5) lib/ecto/repo/queryable.ex:19: Ecto.Repo.Queryable.all/3
       (block_scout_web 11.0.2) lib/block_scout_web/views/api/v2/filecoin_view.ex:104: BlockScoutWeb.API.V2.FilecoinView.preload_and_put_filecoin_robust_address_to_search_results/1
       (block_scout_web 11.0.2) lib/block_scout_web/views/api/v2/search_view.ex:12: BlockScoutWeb.API.V2.SearchView.render/2
       test/block_scout_web/views/api/v2/search_view_test.exs:28: (test)`

`  2) test /api/v2/celo/epochs/:number/election-rewards/:type paginates election rewards across two pages (BlockScoutWeb.API.V2.CeloControllerTest)
Error:      test/block_scout_web/controllers/api/v2/celo_controller_test.exs:180
     Value does not conform to schema : Missing field: epoch_number at /items/0/epoch_number
     Missing field: epoch_number at /items/1/epoch_number
     Missing field: epoch_number at /items/2/epoch_number
     Missing field: epoch_number at /items/3/epoch_number
     Missing field: epoch_number at /items/4/epoch_number
     Missing field: epoch_number at /items/5/epoch_number
     Missing field: epoch_number at /items/6/epoch_number
     Missing field: epoch_number at /items/7/epoch_number
     Missing field: epoch_number at /items/8/epoch_number
     Missing field: epoch_number at /items/9/epoch_number
     Missing field: epoch_number at /items/10/epoch_number
     Missing field: epoch_number at /items/11/epoch_number
     Missing field: epoch_number at /items/12/epoch_number
     Missing field: epoch_number at /items/13/epoch_number
     Missing field: epoch_number at /items/14/epoch_number
     Missing field: epoch_number at /items/15/epoch_number
     Missing field: epoch_number at /items/16/epoch_number
     Missing field: epoch_number at /items/17/epoch_number
     Missing field: epoch_number at /items/18/epoch_number
     Missing field: epoch_number at /items/19/epoch_number
     Missing field: epoch_number at /items/20/epoch_number
     Missing field: epoch_number at /items/21/epoch_number
     Missing field: epoch_number at /items/22/epoch_number
     Missing field: epoch_number at /items/23/epoch_number
     Missing field: epoch_number at /items/24/epoch_number
     Missing field: epoch_number at /items/25/epoch_number
     Missing field: epoch_number at /items/26/epoch_number
     Missing field: epoch_number at /items/27/epoch_number
     Missing field: epoch_number at /items/28/epoch_number
     Missing field: epoch_number at /items/29/epoch_number
     Missing field: epoch_number at /items/30/epoch_number
     Missing field: epoch_number at /items/31/epoch_number
     Missing field: epoch_number at /items/32/epoch_number
     Missing field: epoch_number at /items/33/epoch_number
     Missing field: epoch_number at /items/34/epoch_number
     Missing field: epoch_number at /items/35/epoch_number
     Missing field: epoch_number at /items/36/epoch_number
     Missing field: epoch_number at /items/37/epoch_number
     Missing field: epoch_number at /items/38/epoch_number
     Missing field: epoch_number at /items/39/epoch_number
     Missing field: epoch_number at /items/40/epoch_number
     Missing field: epoch_number at /items/41/epoch_number
     Missing field: epoch_number at /items/42/epoch_number
     Missing field: epoch_number at /items/43/epoch_number
     Missing field: epoch_number at /items/44/epoch_number
     Missing field: epoch_number at /items/45/epoch_number
     Missing field: epoch_number at /items/46/epoch_number
     Missing field: epoch_number at /items/47/epoch_number
     Missing field: epoch_number at /items/48/epoch_number
     Missing field: epoch_number at /items/49/epoch_number
     %{"items" => [%{"account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003a87", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}, "amount" => "51", "associated_account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003B1e", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}}, %{"account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003a87", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}, "amount" => "50", "associated_account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003B1b", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}}, %{"account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003a87", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}, "amount" => "49", "associated_account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003B18", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}}, %{"account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003a87", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}, "amount" => "48", "associated_account" => %{"ens_domain_name" => nil, "hash" => "0x0000000000000000000000000000000000003B15", "implementations" => [], "is_contract" => false, "is_scam" => false, "is_verified" => false, "metadata" => nil, "name" => nil, "proxy_type" => nil, "reputation" => "ok"}}, %{"account" => %{"ens_domain_name" => nil, ...}, ...}, ...], ...}
     code: assert response = json_response(request, 200)
     stacktrace:
       (block_scout_web 11.0.2) test/support/api_schema_assertions.ex:18: BlockScoutWeb.TestApiSchemaAssertions.json_response/2
       test/block_scout_web/controllers/api/v2/celo_controller_test.exs:205: (test)`


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made `epoch_number` optional in Celo election reward API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->