### PR TITLE
fix: Process empty list of changes on fetching contract codes

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/contract_code.ex
+++ b/apps/indexer/lib/indexer/fetcher/contract_code.ex
@@ -258,6 +258,9 @@ defmodule Indexer.Fetcher.ContractCode do
         Accounts.drop(addresses)
         {:ok, addresses}
 
+      {:ok, _} ->
+        {:ok, []}
+
       {:error, step, reason, _changes_so_far} ->
         Logger.error(
           fn ->


### PR DESCRIPTION
## Motivation

Processing of this  error:

`{"message":"Task #PID<0.2853015.0> started from Indexer.Fetcher.ContractCode terminating\n** (CaseClauseError) no case clause matching:\n\n    {:ok, %{}}\n\n    (indexer 11.0.1) lib/indexer/fetcher/contract_code.ex:253: Indexer.Fetcher.ContractCode.import_addresses/1\n    (indexer 11.0.1) lib/indexer/fetcher/contract_code.ex:165: Indexer.Fetcher.ContractCode.run/2\n    (elixir 1.19.4) lib/task/supervised.ex:105: Task.Supervised.invoke_mfa/2\n    (elixir 1.19.4) lib/task/supervised.ex:40: Task.Supervised.reply/4\nFunction: &Indexer.BufferedTask.log_run/1\n    Args: [%{metadata: [fetcher: :code], callback_module: Indexer.Fetcher.ContractCode, batch: [%Explorer.Chain.Transaction{__meta__: #Ecto.Schema.Metadata<:loaded, \"transactions\">, hash: %Explorer.Chain.Hash{byte_count: 32, bytes: <<36, 135, 189, 134, 79, 203, 191, 59, 231, 203, 244, 74, 92, 86, 23, 170, 11, 25, 222, 146, 97, 43, 191, 64, 108, 105, 91, 168, 48, 238, 136, 23>>}, block_number: 8901232, block_consensus: nil, block_timestamp: nil, cumulative_gas_used: nil, earliest_processing_start: nil, error: nil, gas: nil, gas_price: nil, gas_used: nil, index: nil, created_contract_code_indexed_at: nil, input: nil, nonce: nil, r: nil, s: nil, status: :ok, v: nil, value: nil, revert_reason: nil, max_priority_fee_per_gas: nil, max_fee_per_gas: nil, type: 0, has_error_in_internal_transactions: nil, fhe_operations_count: nil, has_token_transfers: nil, internal_transactions: nil, transaction_fee_log: nil, transaction_fee_token: nil, old_block_hash: nil, inserted_at: nil, updated_at: nil, block_hash: nil, block: #Ecto.Association.NotLoaded<association :block is not loaded>, forks: #Ecto.Association.NotLoaded<association :forks is not loaded>, from_address_hash: nil, from_address: #Ecto.Association.NotLoaded<association :from_address is not loaded>, logs: #Ecto.Association.NotLoaded<association :logs is not loaded>, token_transfers: #Ecto.Association.NotLoaded<association :token_transfers is not loaded>, to_address_hash: nil, to_address: #Ecto.Association.NotLoaded<association :to_address is not loaded>, uncles: #Ecto.Association.NotLoaded<association :uncles is not loaded>, created_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<2, 201, 91, 15, 248, 157, 230, 246, 88, 90, 3, 21, 22, 214, ...>>}, ...}, ...], ...}]","time":"2026-05-04T14:30:02.237Z","metadata":{"fetcher":"code"},"severity":"error"} `

## Changelog

Add missing function clause in `Indexer.Fetcher.ContractCode.import_addresses/1` function.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract code import process to handle additional response formats from the system, enhancing stability when processing imports without address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->