### PR TITLE
chore: Disable flaky contract code compiler doctest

### DIFF
--- a/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/code_compiler_test.exs
@@ -4,7 +4,8 @@ defmodule Explorer.SmartContract.Solidity.CodeCompilerTest do
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   if @chain_type == :default do
-    doctest Explorer.SmartContract.Solidity.CodeCompiler
+    # This doctest is often flaky
+    # doctest Explorer.SmartContract.Solidity.CodeCompiler
 
     @moduletag timeout: :infinity
 


### PR DESCRIPTION
## Motivation

`Explorer.SmartContract.Solidity.CodeCompiler` doctest is often fails.

## Changelog

Disable that doctest in CI since the smart-contract code compilation functionality has been moved to the verifier micro service.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by addressing a flaky test condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->