### PR TITLE
chore: Don't lock tables if foreign keys are already dropped

### DIFF
--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
@@ -109,22 +109,10 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
 
   # sobelow_skip ["SQL"]
   defp drop_blocks_foreign_key do
-    dropped? =
-      case Repo.query("""
-           SELECT EXISTS (
-             SELECT 1
-             FROM pg_constraint
-             WHERE conname = 'internal_transactions_block_hash_fkey'
-           );
-           """) do
-        {:ok, %Postgrex.Result{rows: [[false]]}} -> true
-        {:ok, %Postgrex.Result{rows: [[true]]}} -> false
-      end
-
-    if dropped? do
-      {:ok, :dropped}
-    else
+    if foreign_key_exists?("internal_transactions_block_hash_fkey") do
       do_drop_blocks_foreign_key()
+    else
+      {:ok, :dropped}
     end
   end
 
@@ -146,22 +134,10 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
 
   # sobelow_skip ["SQL"]
   defp drop_transactions_foreign_key do
-    dropped? =
-      case Repo.query("""
-           SELECT EXISTS (
-             SELECT 1
-             FROM pg_constraint
-             WHERE conname = 'internal_transactions_transaction_hash_fkey'
-           );
-           """) do
-        {:ok, %Postgrex.Result{rows: [[false]]}} -> true
-        {:ok, %Postgrex.Result{rows: [[true]]}} -> false
-      end
-
-    if dropped? do
-      {:ok, :dropped}
-    else
+    if foreign_key_exists?("internal_transactions_transaction_hash_fkey") do
       do_drop_transactions_foreign_key()
+    else
+      {:ok, :dropped}
     end
   end
 
@@ -183,6 +159,20 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
       end,
       timeout: :infinity
     )
+  end
+
+  # sobelow_skip ["SQL"]
+  defp foreign_key_exists?(foreign_key_name) do
+    {:ok, %Postgrex.Result{rows: [[exists?]]}} =
+      Repo.query("""
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = '#{foreign_key_name}'
+      );
+      """)
+
+    exists?
   end
 
   defp lock_blocks_query_string do

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
@@ -109,6 +109,27 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
 
   # sobelow_skip ["SQL"]
   defp drop_blocks_foreign_key do
+    dropped? =
+      case Repo.query("""
+           SELECT EXISTS (
+             SELECT 1
+             FROM pg_constraint
+             WHERE conname = 'internal_transactions_block_hash_fkey'
+           );
+           """) do
+        {:ok, %Postgrex.Result{rows: [[false]]}} -> true
+        {:ok, %Postgrex.Result{rows: [[true]]}} -> false
+      end
+
+    if dropped? do
+      {:ok, :dropped}
+    else
+      do_drop_blocks_foreign_key()
+    end
+  end
+
+  # sobelow_skip ["SQL"]
+  defp do_drop_blocks_foreign_key do
     Repo.transaction(
       fn ->
         with {:ok, _} <- Repo.query(lock_blocks_query_string(), [], timeout: :infinity),
@@ -125,6 +146,27 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
 
   # sobelow_skip ["SQL"]
   defp drop_transactions_foreign_key do
+    dropped? =
+      case Repo.query("""
+           SELECT EXISTS (
+             SELECT 1
+             FROM pg_constraint
+             WHERE conname = 'internal_transactions_transaction_hash_fkey'
+           );
+           """) do
+        {:ok, %Postgrex.Result{rows: [[false]]}} -> true
+        {:ok, %Postgrex.Result{rows: [[true]]}} -> false
+      end
+
+    if dropped? do
+      {:ok, :dropped}
+    else
+      do_drop_transactions_foreign_key()
+    end
+  end
+
+  # sobelow_skip ["SQL"]
+  defp do_drop_transactions_foreign_key do
     Repo.transaction(
       fn ->
         with {:ok, _} <- Repo.query(lock_transactions_query_string(), [], timeout: :infinity),

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_block_hash_transaction_hash_block_index_error.ex
@@ -169,7 +169,8 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
   defp do_drop_transactions_foreign_key do
     Repo.transaction(
       fn ->
-        with {:ok, _} <- Repo.query(lock_transactions_query_string(), [], timeout: :infinity),
+        with {:ok, _} <- Repo.query(lock_internal_transactions_query_string(), [], timeout: :infinity),
+             {:ok, _} <- Repo.query(lock_transactions_query_string(), [], timeout: :infinity),
              {:ok, _} <- Repo.query(drop_transactions_foreign_key_query_string(), [], timeout: :infinity) do
           Logger.info(
             "Migration RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError finished transactions"
@@ -193,6 +194,12 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBloc
   defp lock_transactions_query_string do
     """
     LOCK TABLE transactions IN ACCESS EXCLUSIVE MODE;
+    """
+  end
+
+  defp lock_internal_transactions_query_string do
+    """
+    LOCK TABLE internal_transactions IN ACCESS EXCLUSIVE MODE;
     """
   end
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14099

## Motivation

In case when migration failed but foreign keys were already deleted, there is no point in locking tables again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database migrations for removing constraints are now safe to run multiple times, avoiding errors from redundant executions.
  * Migrations now check whether a constraint exists before attempting removal, reducing failure risk.
  * Stronger locking applied when removing transaction-related constraints to ensure consistent, safe schema changes.
  * Overall migration behavior and dropped columns remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->