### PR TITLE
fix: Force search for contract creator if internal transactions module is disabled

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -19,7 +19,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     BlockNumberHelper,
     DenormalizationHelper,
     Import,
-    PendingBlockOperation,
     PendingOperationsHelper,
     SmartContract,
     Token,
@@ -104,16 +103,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :address_referencing,
         :blocks,
         :blocks
-      )
-    end)
-    |> Multi.run(:new_pending_block_operations, fn repo, %{blocks: blocks} ->
-      Instrumenter.block_import_stage_runner(
-        fn ->
-          new_pending_block_operations(repo, blocks, insert_options)
-        end,
-        :address_referencing,
-        :blocks,
-        :new_pending_block_operations
       )
     end)
     |> Multi.run(:uncle_fetched_block_second_degree_relations, fn repo, _ ->
@@ -693,44 +682,6 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         }
 
     lose_consensus(repo, blocks_changes, opts)
-  end
-
-  defp new_pending_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
-    case PendingOperationsHelper.pending_operations_type() do
-      "blocks" ->
-        traceable_consensus_blocks =
-          inserted_blocks
-          |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
-          |> Enum.filter(& &1.consensus)
-
-        traceable_consensus_block_numbers = Enum.map(traceable_consensus_blocks, & &1.number)
-        block_numbers_with_priorities = MissingBlockRange.find_priority_by_numbers(traceable_consensus_block_numbers)
-
-        sorted_pending_ops =
-          traceable_consensus_blocks
-          |> Enum.map(
-            &%{
-              block_hash: &1.hash,
-              block_number: &1.number,
-              priority: Map.get(block_numbers_with_priorities, &1.number)
-            }
-          )
-          |> Enum.sort()
-
-        Import.insert_changes_list(
-          repo,
-          sorted_pending_ops,
-          conflict_target: :block_hash,
-          on_conflict: :nothing,
-          for: PendingBlockOperation,
-          returning: true,
-          timeout: timeout,
-          timestamps: timestamps
-        )
-
-      _other_type ->
-        {:ok, []}
-    end
   end
 
   defp delete_address_coin_balances(_repo, [], _options), do: {:ok, []}

--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -698,11 +698,23 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp new_pending_block_operations(repo, inserted_blocks, %{timeout: timeout, timestamps: timestamps}) do
     case PendingOperationsHelper.pending_operations_type() do
       "blocks" ->
-        sorted_pending_ops =
+        traceable_consensus_blocks =
           inserted_blocks
           |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.number))
           |> Enum.filter(& &1.consensus)
-          |> Enum.map(&%{block_hash: &1.hash, block_number: &1.number})
+
+        traceable_consensus_block_numbers = Enum.map(traceable_consensus_blocks, & &1.number)
+        block_numbers_with_priorities = MissingBlockRange.find_priority_by_numbers(traceable_consensus_block_numbers)
+
+        sorted_pending_ops =
+          traceable_consensus_blocks
+          |> Enum.map(
+            &%{
+              block_hash: &1.hash,
+              block_number: &1.number,
+              priority: Map.get(block_numbers_with_priorities, &1.number)
+            }
+          )
           |> Enum.sort()
 
         Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -122,12 +122,18 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
   defp new_pending_transaction_operations(repo, inserted_transactions, %{timeout: timeout, timestamps: timestamps}) do
     case PendingOperationsHelper.pending_operations_type() do
       "transactions" ->
-        sorted_pending_ops =
+        traceable_consensus_transactions =
           inserted_transactions
           |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
           |> Transaction.filter_non_traceable_transactions()
+
+        traceable_consensus_block_numbers = Enum.map(traceable_consensus_transactions, & &1.block_number) |> Enum.uniq()
+        block_numbers_with_priorities = MissingBlockRange.find_priority_by_numbers(traceable_consensus_block_numbers)
+
+        sorted_pending_ops =
+          traceable_consensus_transactions
           |> Enum.reject(&is_nil(&1.block_number))
-          |> Enum.map(&%{transaction_hash: &1.hash})
+          |> Enum.map(&%{transaction_hash: &1.hash, priority: Map.get(block_numbers_with_priorities, &1.block_number)})
           |> Enum.sort()
 
         Import.insert_changes_list(

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -10,7 +10,17 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
 
   alias Ecto.{Multi, Repo}
   alias EthereumJSONRPC.Utility.RangesHelper
-  alias Explorer.Chain.{Block, Hash, Import, PendingOperationsHelper, PendingTransactionOperation, Transaction}
+
+  alias Explorer.Chain.{
+    Block,
+    Hash,
+    Import,
+    PendingBlockOperation,
+    PendingOperationsHelper,
+    PendingTransactionOperation,
+    Transaction
+  }
+
   alias Explorer.Chain.Import.Runner.TokenTransfers
   alias Explorer.Prometheus.Instrumenter
   alias Explorer.Utility.MissingBlockRange
@@ -66,14 +76,14 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
         :transactions
       )
     end)
-    |> Multi.run(:new_pending_transaction_operations, fn repo, %{transactions: transactions} ->
+    |> Multi.run(:new_pending_operations, fn repo, %{transactions: transactions} ->
       Instrumenter.block_import_stage_runner(
         fn ->
-          new_pending_transaction_operations(repo, transactions, insert_options)
+          new_pending_operations(repo, transactions, insert_options)
         end,
         :block_referencing,
         :transactions,
-        :new_pending_transaction_operations
+        :new_pending_operations
       )
     end)
   end
@@ -119,17 +129,17 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
     )
   end
 
-  defp new_pending_transaction_operations(repo, inserted_transactions, %{timeout: timeout, timestamps: timestamps}) do
+  defp new_pending_operations(repo, inserted_transactions, %{timeout: timeout, timestamps: timestamps}) do
+    traceable_consensus_transactions =
+      inserted_transactions
+      |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
+      |> Transaction.filter_non_traceable_transactions()
+
+    traceable_consensus_block_numbers = Enum.map(traceable_consensus_transactions, & &1.block_number) |> Enum.uniq()
+    block_numbers_with_priorities = MissingBlockRange.find_priority_by_numbers(traceable_consensus_block_numbers)
+
     case PendingOperationsHelper.pending_operations_type() do
       "transactions" ->
-        traceable_consensus_transactions =
-          inserted_transactions
-          |> RangesHelper.filter_by_height_range(&RangesHelper.traceable_block_number?(&1.block_number))
-          |> Transaction.filter_non_traceable_transactions()
-
-        traceable_consensus_block_numbers = Enum.map(traceable_consensus_transactions, & &1.block_number) |> Enum.uniq()
-        block_numbers_with_priorities = MissingBlockRange.find_priority_by_numbers(traceable_consensus_block_numbers)
-
         sorted_pending_ops =
           traceable_consensus_transactions
           |> Enum.reject(&is_nil(&1.block_number))
@@ -147,8 +157,29 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
           timestamps: timestamps
         )
 
-      _other_type ->
-        {:ok, []}
+      "blocks" ->
+        sorted_pending_ops =
+          traceable_consensus_transactions
+          |> Enum.reject(&is_nil(&1.block_number))
+          |> Enum.map(
+            &%{
+              block_hash: &1.block_hash,
+              block_number: &1.block_number,
+              priority: Map.get(block_numbers_with_priorities, &1.block_number)
+            }
+          )
+          |> Enum.sort()
+
+        Import.insert_changes_list(
+          repo,
+          sorted_pending_ops,
+          conflict_target: :block_hash,
+          on_conflict: :nothing,
+          for: PendingBlockOperation,
+          returning: true,
+          timeout: timeout,
+          timestamps: timestamps
+        )
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/pending_block_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_block_operation.ex
@@ -28,6 +28,8 @@ defmodule Explorer.Chain.PendingBlockOperation do
       type: Hash.Full,
       null: false
     )
+
+    field(:priority, :integer)
   end
 
   def changeset(%__MODULE__{} = pending_ops, attrs) do
@@ -80,7 +82,7 @@ defmodule Explorer.Chain.PendingBlockOperation do
           limited? :: boolean()
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_blocks_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
+  def stream_blocks_with_unfetched_internal_transactions(initial, reducer, limited? \\ false, with_priority? \\ false)
       when is_function(reducer, 2) do
     direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
 
@@ -93,7 +95,16 @@ defmodule Explorer.Chain.PendingBlockOperation do
       )
 
     query
+    |> maybe_add_priority_filter(with_priority?)
     |> add_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
+  end
+
+  defp maybe_add_priority_filter(query, false), do: query
+
+  defp maybe_add_priority_filter(query, true) do
+    from(pbo in query,
+      where: not is_nil(pbo.priority)
+    )
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
+++ b/apps/explorer/lib/explorer/chain/pending_operations_helper.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
 
   import Ecto.Query
 
-  alias Explorer.Chain.{Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
+  alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.{Helper, Repo}
 
   defp transactions_batch_size,
@@ -81,7 +81,7 @@ defmodule Explorer.Chain.PendingOperationsHelper do
       from(
         pto in PendingTransactionOperation,
         join: t in assoc(pto, :transaction),
-        select: %{block_hash: t.block_hash, block_number: t.block_number},
+        select: %{block_hash: t.block_hash, block_number: t.block_number, priority: pto.priority},
         limit: ^batch_size
       )
 
@@ -245,5 +245,83 @@ defmodule Explorer.Chain.PendingOperationsHelper do
     min_block_number
     |> block_range_in_query(max_block_number)
     |> Repo.exists?()
+  end
+
+  @doc """
+    Inserts pending operations for the given block numbers.
+  """
+  @spec insert_pending_operations([integer()], integer() | nil) :: {[integer()], [Explorer.Chain.Transaction.t()]}
+  def insert_pending_operations(block_numbers, priority \\ nil) do
+    case pending_operations_type() do
+      "transactions" ->
+        default_on_conflict = default_pto_on_conflict()
+        transactions = Transaction.get_transactions_of_block_numbers(block_numbers)
+
+        pto_params =
+          transactions
+          |> Transaction.filter_non_traceable_transactions()
+          |> Enum.map(&%{transaction_hash: &1.hash, priority: priority})
+          |> Helper.add_timestamps()
+
+        Repo.insert_all(PendingTransactionOperation, pto_params,
+          on_conflict: default_on_conflict,
+          conflict_target: [:transaction_hash]
+        )
+
+        {[], transactions}
+
+      "blocks" ->
+        default_on_conflict = default_pbo_on_conflict()
+
+        pbo_params =
+          Block
+          |> where([b], b.number in ^block_numbers)
+          |> where([b], b.consensus == true)
+          |> select([b], %{block_hash: b.hash, block_number: b.number})
+          |> Repo.all()
+          |> add_priority(priority)
+          |> Helper.add_timestamps()
+
+        {_total, inserted} =
+          Repo.insert_all(PendingBlockOperation, pbo_params,
+            on_conflict: default_on_conflict,
+            conflict_target: [:block_hash],
+            returning: [:block_number]
+          )
+
+        {Enum.map(inserted, & &1.block_number), []}
+    end
+  end
+
+  defp default_pbo_on_conflict do
+    from(
+      pending_block_operation in PendingBlockOperation,
+      update: [
+        set: [
+          priority: fragment("EXCLUDED.priority"),
+          inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", pending_block_operation.inserted_at),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", pending_block_operation.updated_at)
+        ]
+      ],
+      where: is_nil(pending_block_operation.priority) and fragment("EXCLUDED.priority IS NOT NULL")
+    )
+  end
+
+  defp default_pto_on_conflict do
+    from(
+      pending_transaction_operation in PendingTransactionOperation,
+      update: [
+        set: [
+          priority: fragment("EXCLUDED.priority"),
+          inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", pending_transaction_operation.inserted_at),
+          updated_at: fragment("GREATEST(?, EXCLUDED.updated_at)", pending_transaction_operation.updated_at)
+        ]
+      ],
+      where: is_nil(pending_transaction_operation.priority) and fragment("EXCLUDED.priority IS NOT NULL")
+    )
+  end
+
+  defp add_priority(params, priority) do
+    Enum.map(params, &Map.merge(&1, %{priority: priority}))
   end
 end

--- a/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
+++ b/apps/explorer/lib/explorer/chain/pending_transaction_operation.ex
@@ -26,6 +26,8 @@ defmodule Explorer.Chain.PendingTransactionOperation do
       type: Hash.Full,
       null: false
     )
+
+    field(:priority, :integer)
   end
 
   def changeset(%__MODULE__{} = pending_ops, attrs) do
@@ -69,10 +71,17 @@ defmodule Explorer.Chain.PendingTransactionOperation do
   """
   @spec stream_transactions_with_unfetched_internal_transactions(
           initial :: accumulator,
-          reducer :: (entry :: term(), accumulator -> accumulator)
+          reducer :: (entry :: term(), accumulator -> accumulator),
+          limited? :: boolean(),
+          with_priority? :: boolean()
         ) :: {:ok, accumulator}
         when accumulator: term()
-  def stream_transactions_with_unfetched_internal_transactions(initial, reducer, limited? \\ false)
+  def stream_transactions_with_unfetched_internal_transactions(
+        initial,
+        reducer,
+        limited? \\ false,
+        with_priority? \\ false
+      )
       when is_function(reducer, 2) do
     direction = Application.get_env(:indexer, :internal_transactions_fetch_order)
 
@@ -85,7 +94,16 @@ defmodule Explorer.Chain.PendingTransactionOperation do
       )
 
     query
+    |> maybe_add_priority_filter(with_priority?)
     |> add_fetcher_limit(limited?)
     |> Repo.stream_reduce(initial, reducer)
+  end
+
+  defp maybe_add_priority_filter(query, false), do: query
+
+  defp maybe_add_priority_filter(query, true) do
+    from(pto in query,
+      where: not is_nil(pto.priority)
+    )
   end
 end

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -732,7 +732,7 @@ defmodule Explorer.Utility.MissingBlockRange do
     query =
       from(i in fragment("SELECT unnest(?::int[]) AS number", ^numbers),
         left_join: m in __MODULE__,
-        on: fragment("? BETWEEN ? AND ?", i.number, m.from_number, m.to_number),
+        on: fragment("? BETWEEN ? AND ?", i.number, m.to_number, m.from_number),
         select: {i.number, m.priority}
       )
 

--- a/apps/explorer/lib/explorer/utility/missing_block_range.ex
+++ b/apps/explorer/lib/explorer/utility/missing_block_range.ex
@@ -711,4 +711,33 @@ defmodule Explorer.Utility.MissingBlockRange do
       fn range -> {:cont, range, nil} end
     )
   end
+
+  @doc """
+    Finds the priority of missing block ranges for a list of block numbers.
+
+    This function takes a list of block numbers and checks which missing block ranges
+    they fall into, returning a list of maps with the block number and its associated
+    priority (if any).
+
+    ## Parameters
+    - `numbers`: A list of block numbers to check against the missing block ranges.
+
+    ## Returns
+    - A list of tuples, each containing:
+      - `:number`: The block number from the input list.
+      - `:priority`: The priority of the range that includes the block number.
+  """
+  @spec find_priority_by_numbers([Block.block_number()]) :: %{Block.block_number() => integer() | nil}
+  def find_priority_by_numbers(numbers) do
+    query =
+      from(i in fragment("SELECT unnest(?::int[]) AS number", ^numbers),
+        left_join: m in __MODULE__,
+        on: fragment("? BETWEEN ? AND ?", i.number, m.from_number, m.to_number),
+        select: {i.number, m.priority}
+      )
+
+    query
+    |> Repo.all()
+    |> Enum.into(%{})
+  end
 end

--- a/apps/explorer/priv/repo/migrations/20260506124737_add_priority_to_pending_operations.exs
+++ b/apps/explorer/priv/repo/migrations/20260506124737_add_priority_to_pending_operations.exs
@@ -1,0 +1,16 @@
+defmodule Explorer.Repo.Migrations.AddPriorityToPendingOperations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:pending_block_operations) do
+      add(:priority, :smallint)
+    end
+
+    alter table(:pending_transaction_operations) do
+      add(:priority, :smallint)
+    end
+
+    create(index(:pending_block_operations, :priority))
+    create(index(:pending_transaction_operations, :priority))
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -539,50 +539,6 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       assert %{from_number: ^block_number, to_number: ^block_number} = Repo.one(MissingBlockRange)
     end
 
-    test "inserts pending_block_operations only for consensus blocks",
-         %{consensus_block: %{miner_hash: miner_hash}, options: options} do
-      %{number: number, hash: hash} = new_block = params_for(:block, miner_hash: miner_hash, consensus: true)
-      new_block1 = params_for(:block, miner_hash: miner_hash, consensus: false)
-
-      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, new_block)
-      %Ecto.Changeset{valid?: true, changes: block_changes1} = Block.changeset(%Block{}, new_block1)
-
-      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
-      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
-
-      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
-
-      Multi.new()
-      |> Blocks.run([block_changes, block_changes1], options)
-      |> Repo.transaction()
-
-      assert %{block_number: ^number, block_hash: ^hash} = Repo.one(PendingBlockOperation)
-    end
-
-    test "inserts pending_block_operations only for actually inserted blocks",
-         %{consensus_block: %{miner_hash: miner_hash}, options: options} do
-      %{number: number, hash: hash} = new_block = params_for(:block, miner_hash: miner_hash, consensus: true)
-      new_block1 = params_for(:block, miner_hash: miner_hash, consensus: true)
-
-      miner = Repo.get_by(Address, hash: miner_hash)
-
-      insert(:block, Map.put(new_block1, :miner, miner))
-
-      %Ecto.Changeset{valid?: true, changes: block_changes} = Block.changeset(%Block{}, new_block)
-      %Ecto.Changeset{valid?: true, changes: block_changes1} = Block.changeset(%Block{}, new_block1)
-
-      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
-      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :block_traceable?, true))
-
-      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
-
-      Multi.new()
-      |> Blocks.run([block_changes, block_changes1], options)
-      |> Repo.transaction()
-
-      assert %{block_number: ^number, block_hash: ^hash} = Repo.one(PendingBlockOperation)
-    end
-
     test "change instance owner if was token transfer in older blocks",
          %{consensus_block: %{hash: block_hash, miner_hash: miner_hash, number: block_number}, options: options} do
       block_number = block_number + 2

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -585,10 +585,12 @@ defmodule Indexer.Block.Fetcher do
 
   def async_import_created_contract_codes(_, _), do: :ok
 
+  def async_import_internal_transactions(_imported, _realtime?)
+
   def async_import_internal_transactions(%{blocks: blocks} = imported, realtime?) do
     blocks
     |> Enum.map(fn %Block{number: block_number} -> block_number end)
-    |> InternalTransaction.async_fetch(Map.get(imported, :transactions, []), realtime?, 10_000)
+    |> InternalTransaction.async_fetch(Map.get(imported, :transactions, []), realtime?, false, 10_000)
   end
 
   def async_import_internal_transactions(_, _), do: :ok

--- a/apps/indexer/lib/indexer/fetcher/filecoin/address_info.ex
+++ b/apps/indexer/lib/indexer/fetcher/filecoin/address_info.ex
@@ -118,7 +118,7 @@ defmodule Indexer.Fetcher.Filecoin.AddressInfo do
   @impl BufferedTask
   @decorate trace(
               name: "fetch",
-              resource: "Indexer.Fetcher.InternalTransaction.run/2",
+              resource: "Indexer.Fetcher.Filecoin.AddressInfo.run/2",
               service: :indexer,
               tracer: Tracer
             )

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -475,7 +475,7 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
   def defaults do
     [
-      poll: false,
+      poll: true,
       flush_interval: :timer.seconds(3),
       max_concurrency: Application.get_env(:indexer, __MODULE__)[:concurrency] || @default_max_concurrency,
       max_batch_size: Application.get_env(:indexer, __MODULE__)[:batch_size] || @default_max_batch_size,

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -25,7 +25,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
   alias Explorer.Chain.{Block, Hash, PendingBlockOperation, PendingTransactionOperation, Transaction}
   alias Explorer.Chain.Cache.{Accounts, Blocks}
   alias Indexer.{BufferedTask, Tracer}
-  alias Indexer.Fetcher.InternalTransaction.Supervisor, as: InternalTransactionSupervisor
   alias Indexer.Transform.{AddressCoinBalances, Addresses, AddressTokenBalances}
   alias Indexer.Transform.Celo.TransactionTokenTransfers, as: CeloTransactionTokenTransfers
 
@@ -50,9 +49,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
   *Note*: The internal transactions for individual transactions cannot be paginated,
   so the total number of internal transactions that could be produced is unknown.
   """
-  @spec async_fetch([Block.block_number()], [Transaction.t()], boolean()) :: :ok
-  def async_fetch(block_numbers, transactions, realtime?, timeout \\ 5000) when is_list(block_numbers) do
-    if InternalTransactionSupervisor.disabled?() do
+  @spec async_fetch([Block.block_number()], [Transaction.t()], boolean(), boolean(), integer()) :: :ok
+  def async_fetch(block_numbers, transactions, realtime?, for_contract_creator? \\ false, timeout \\ 5000)
+      when is_list(block_numbers) do
+    if disabled?() && !for_contract_creator? do
       :ok
     else
       data =
@@ -95,16 +95,42 @@ defmodule Indexer.Fetcher.InternalTransaction do
   def init(initial, reducer, json_rpc_named_arguments) do
     stream_reducer = RangesHelper.stream_reducer_traceable(reducer)
 
-    {:ok, final} =
-      case queue_data_type(json_rpc_named_arguments) do
-        :block_number ->
-          PendingBlockOperation.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
+    if disabled?() do
+      {:ok, final} =
+        case queue_data_type(json_rpc_named_arguments) do
+          :block_number ->
+            PendingBlockOperation.stream_blocks_with_unfetched_internal_transactions(
+              initial,
+              stream_reducer,
+              false,
+              true
+            )
 
-        :transaction_params ->
-          PendingTransactionOperation.stream_transactions_with_unfetched_internal_transactions(initial, stream_reducer)
-      end
+          :transaction_params ->
+            PendingTransactionOperation.stream_transactions_with_unfetched_internal_transactions(
+              initial,
+              stream_reducer,
+              false,
+              true
+            )
+        end
 
-    final
+      final
+    else
+      {:ok, final} =
+        case queue_data_type(json_rpc_named_arguments) do
+          :block_number ->
+            PendingBlockOperation.stream_blocks_with_unfetched_internal_transactions(initial, stream_reducer)
+
+          :transaction_params ->
+            PendingTransactionOperation.stream_transactions_with_unfetched_internal_transactions(
+              initial,
+              stream_reducer
+            )
+        end
+
+      final
+    end
   end
 
   defp params(%{block_number: block_number, hash: hash, index: index}) when is_integer(block_number) do
@@ -482,5 +508,15 @@ defmodule Indexer.Fetcher.InternalTransaction do
     else
       error -> Logger.error("Failed to cast string to hash: #{inspect(error)}")
     end
+  end
+
+  @doc """
+  Returns whether the internal transaction fetcher is disabled.
+
+   This can be used to conditionally disable fetching internal transactions, for example, in a staging environment where the load on the JSON-RPC should be minimized.
+  """
+  @spec disabled? :: boolean()
+  def disabled? do
+    Application.get_env(:indexer, __MODULE__, [])[:disabled?] == true
   end
 end

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction/delete_queue.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction/delete_queue.ex
@@ -11,17 +11,9 @@ defmodule Indexer.Fetcher.InternalTransaction.DeleteQueue do
 
   alias Explorer.Repo
 
-  alias Explorer.Chain.{
-    Block,
-    InternalTransaction,
-    PendingBlockOperation,
-    PendingOperationsHelper,
-    PendingTransactionOperation,
-    Transaction
-  }
+  alias Explorer.Chain.{InternalTransaction, PendingOperationsHelper}
 
   alias Explorer.Chain.InternalTransaction.DeleteQueue
-  alias Explorer.Helper, as: ExplorerHelper
   alias Indexer.BufferedTask
   alias Indexer.Fetcher.InternalTransaction, as: InternalTransactionFetcher
   alias Indexer.Helper, as: IndexerHelper
@@ -68,7 +60,7 @@ defmodule Indexer.Fetcher.InternalTransaction.DeleteQueue do
         |> where([it], it.block_number in ^block_numbers)
         |> Repo.delete_all(timeout: :infinity)
 
-        insert_pending_operations(block_numbers)
+        PendingOperationsHelper.insert_pending_operations(block_numbers)
       end)
 
     case result do
@@ -82,36 +74,6 @@ defmodule Indexer.Fetcher.InternalTransaction.DeleteQueue do
       {:error, error} ->
         Logger.error("Unable to clean internal transactions for reorg: #{inspect(error)}")
         {:retry, block_numbers}
-    end
-  end
-
-  defp insert_pending_operations(block_numbers) do
-    case PendingOperationsHelper.pending_operations_type() do
-      "transactions" ->
-        transactions = Transaction.get_transactions_of_block_numbers(block_numbers)
-
-        pto_params =
-          transactions
-          |> Transaction.filter_non_traceable_transactions()
-          |> Enum.map(&%{transaction_hash: &1.hash})
-          |> ExplorerHelper.add_timestamps()
-
-        Repo.insert_all(PendingTransactionOperation, pto_params, on_conflict: :nothing)
-        {[], transactions}
-
-      "blocks" ->
-        pbo_params =
-          Block
-          |> where([b], b.number in ^block_numbers)
-          |> where([b], b.consensus == true)
-          |> select([b], %{block_hash: b.hash, block_number: b.number})
-          |> Repo.all()
-          |> ExplorerHelper.add_timestamps()
-
-        {_total, inserted} =
-          Repo.insert_all(PendingBlockOperation, pbo_params, on_conflict: :nothing, returning: [:block_number])
-
-        {Enum.map(inserted, & &1.block_number), []}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -11,6 +11,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
   import EthereumJSONRPC, only: [id_to_params: 1, integer_to_quantity: 1, json_rpc: 2]
 
   alias EthereumJSONRPC.Nonce
+  alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain.{Address, Block, PendingOperationsHelper}
   alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Utility.MissingBlockRange
@@ -207,10 +208,13 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
 
     if InternalTransaction.disabled?() do
       if Block.indexed?(contract_creation_block_number) do
-        {block_numbers, transactions} =
-          PendingOperationsHelper.insert_pending_operations([contract_creation_block_number], priority)
+        # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
+        if RangesHelper.traceable_block_number?(contract_creation_block_number) do
+          {block_numbers, transactions} =
+            PendingOperationsHelper.insert_pending_operations([contract_creation_block_number], priority)
 
-        InternalTransaction.async_fetch(block_numbers, transactions, false, true, 10_000)
+          InternalTransaction.async_fetch(block_numbers, transactions, false, true, 10_000)
+        end
       else
         MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], priority)
       end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -14,11 +14,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
   alias Explorer.Chain.{Address, Block}
   alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Utility.MissingBlockRange
-
-  import Indexer.Block.Fetcher,
-    only: [
-      async_import_internal_transactions: 2
-    ]
+  alias Indexer.Fetcher.InternalTransaction
 
   @table_name :contract_creator_lookup
   @pending_blocks_cache_key "pending_blocks"
@@ -176,7 +172,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
     address_hash = address.hash
     :ets.insert(@table_name, {address_cache_name(address_hash), :in_progress})
 
-    Task.Supervisor.start_child(Indexer.TaskSupervisor, fn ->
+    Task.start(fn ->
       result = fetch_contract_creator_address_hash(address_hash)
       GenServer.cast(__MODULE__, {:fetch_result, address_hash, result})
     end)
@@ -206,7 +202,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
     :ets.insert(@table_name, {address_cache_name(address_hash), contract_creation_block_number})
     :ets.insert(@table_name, {@pending_blocks_cache_key, updated_pending_blocks})
 
-    unless Block.indexed?(contract_creation_block_number) do
+    if InternalTransaction.disabled?() or not Block.indexed?(contract_creation_block_number) do
       # Change `1` to specific label when `priority` field becomes `Ecto.Enum`.
       MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], 1)
     end
@@ -294,8 +290,8 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
           contract_creation_block =
             find_contract_creation_block_in_imported(imported, pending_block.block_number)
 
-          internal_transactions_import_params = [%{blocks: [contract_creation_block]}]
-          async_import_internal_transactions(internal_transactions_import_params, true)
+          [contract_creation_block.number]
+          |> InternalTransaction.async_fetch([], true, true, 10_000)
 
           # todo: emit event that contract creator updated for the contract. This was the purpose keeping address_hash_string in that cache key.
           :ets.delete(@table_name, pending_block.address_hash_string)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -11,7 +11,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
   import EthereumJSONRPC, only: [id_to_params: 1, integer_to_quantity: 1, json_rpc: 2]
 
   alias EthereumJSONRPC.Nonce
-  alias Explorer.Chain.{Address, Block}
+  alias Explorer.Chain.{Address, Block, PendingOperationsHelper}
   alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Utility.MissingBlockRange
   alias Indexer.Fetcher.InternalTransaction
@@ -202,9 +202,22 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
     :ets.insert(@table_name, {address_cache_name(address_hash), contract_creation_block_number})
     :ets.insert(@table_name, {@pending_blocks_cache_key, updated_pending_blocks})
 
-    if InternalTransaction.disabled?() or not Block.indexed?(contract_creation_block_number) do
-      # Change `1` to specific label when `priority` field becomes `Ecto.Enum`.
-      MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], 1)
+    # Change `1` to specific label when `priority` field becomes `Ecto.Enum`.
+    priority = 1
+
+    if InternalTransaction.disabled?() do
+      if Block.indexed?(contract_creation_block_number) do
+        {block_numbers, transactions} =
+          PendingOperationsHelper.insert_pending_operations([contract_creation_block_number], priority)
+
+        InternalTransaction.async_fetch(block_numbers, transactions, false, true, 10_000)
+      else
+        MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], priority)
+      end
+    else
+      unless Block.indexed?(contract_creation_block_number) do
+        MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], priority)
+      end
     end
 
     {:noreply, state}
@@ -228,7 +241,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
       |> Map.get(:blocks, [])
       |> Enum.map(&Map.get(&1, :number))
 
-    maybe_update_pending_contract_creator_cache(imported, imported_block_numbers)
+    maybe_update_pending_contract_creator_cache(imported_block_numbers)
 
     {:noreply, state}
   end
@@ -269,30 +282,24 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
     :ok
   end
 
-  defp maybe_update_pending_contract_creator_cache(_imported, []), do: :ok
+  defp maybe_update_pending_contract_creator_cache([]), do: :ok
 
-  defp maybe_update_pending_contract_creator_cache(imported, imported_block_numbers) do
+  defp maybe_update_pending_contract_creator_cache(imported_block_numbers) do
     case pending_blocks_cache() do
       [{@pending_blocks_cache_key, pending_blocks}] ->
-        update_pending_contract_creator_blocks(pending_blocks, imported_block_numbers, imported)
+        update_pending_contract_creator_blocks(pending_blocks, imported_block_numbers)
 
       [] ->
         :ok
     end
   end
 
-  defp update_pending_contract_creator_blocks([], _imported_block_numbers, _imported), do: []
+  defp update_pending_contract_creator_blocks([], _imported_block_numbers), do: []
 
-  defp update_pending_contract_creator_blocks(pending_blocks, imported_block_numbers, imported) do
+  defp update_pending_contract_creator_blocks(pending_blocks, imported_block_numbers) do
     updated_pending_block_numbers =
       Enum.filter(pending_blocks, fn pending_block ->
         if Enum.member?(imported_block_numbers, pending_block.block_number) do
-          contract_creation_block =
-            find_contract_creation_block_in_imported(imported, pending_block.block_number)
-
-          [contract_creation_block.number]
-          |> InternalTransaction.async_fetch([], true, true, 10_000)
-
           # todo: emit event that contract creator updated for the contract. This was the purpose keeping address_hash_string in that cache key.
           :ets.delete(@table_name, pending_block.address_hash_string)
           false
@@ -305,11 +312,5 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
       @table_name,
       {@pending_blocks_cache_key, updated_pending_block_numbers}
     )
-  end
-
-  defp find_contract_creation_block_in_imported(imported, contract_creation_block_number) do
-    Enum.find(imported[:blocks], fn %Explorer.Chain.Block{number: block_number} ->
-      block_number == contract_creation_block_number
-    end)
   end
 end

--- a/apps/indexer/test/indexer/block/fetcher_test.exs
+++ b/apps/indexer/test/indexer/block/fetcher_test.exs
@@ -298,6 +298,13 @@ defmodule Indexer.Block.FetcherTest do
     test "can import range with all synchronous imported schemas", %{
       block_fetcher: %Fetcher{json_rpc_named_arguments: json_rpc_named_arguments} = block_fetcher
     } do
+      initial_env = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction)
+
+      on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction, initial_env)
+      end)
+
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction, disabled?: false)
       block_number = @first_full_block_number
 
       if Application.get_env(:explorer, :chain_type) == :filecoin do

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -134,9 +134,18 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
   end
 
   describe "init/2" do
+    setup do
+      initial_env = Application.get_env(:indexer, Indexer.Fetcher.InternalTransaction)
+
+      on_exit(fn ->
+        Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction, initial_env)
+      end)
+    end
+
     test "buffers blocks with unfetched internal transactions", %{
       json_rpc_named_arguments: json_rpc_named_arguments
     } do
+      Application.put_env(:indexer, Indexer.Fetcher.InternalTransaction, disabled?: false)
       block = insert(:block)
       insert(:pending_block_operation, block_hash: block.hash, block_number: block.number)
 

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -341,41 +341,6 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
     end
   end
 
-  test "doesn't delete pending block operations after block import if no async process was requested", %{
-    json_rpc_named_arguments: json_rpc_named_arguments
-  } do
-    fetcher_options =
-      Keyword.merge([poll: true, json_rpc_named_arguments: json_rpc_named_arguments], InternalTransaction.defaults())
-
-    if fetcher_options[:poll] do
-      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id}], _options ->
-        {:ok, [%{id: id, result: []}]}
-      end)
-    end
-
-    InternalTransaction.Supervisor.Case.start_supervised!(fetcher_options)
-
-    %Ecto.Changeset{valid?: true, changes: block_changes} =
-      Block.changeset(%Block{}, params_for(:block, miner_hash: insert(:address).hash, number: 1))
-
-    changes_list = [block_changes]
-    timestamp = DateTime.utc_now()
-    options = %{timestamps: %{inserted_at: timestamp, updated_at: timestamp}}
-
-    assert [] = Repo.all(PendingBlockOperation)
-
-    {:ok, %{blocks: [%{number: block_number, hash: block_hash}]}} =
-      Multi.new()
-      |> Blocks.run(changes_list, options)
-      |> Repo.transaction()
-
-    assert %{block_number: ^block_number, block_hash: ^block_hash} = Repo.one(PendingBlockOperation)
-
-    Process.sleep(4000)
-
-    assert %{block_number: ^block_number, block_hash: ^block_hash} = Repo.one(PendingBlockOperation)
-  end
-
   if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     test "fetches internal transactions from Arbitrum", %{
       json_rpc_named_arguments: json_rpc_named_arguments

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,8 +1,8 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-#export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
-export CHROMEDRIVER_VERSION=146.0.7680.178
+export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
+#export CHROMEDRIVER_VERSION=146.0.7680.178
 curl -L -O "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip"
 unzip -j chromedriver-linux64.zip
 sudo chmod +x chromedriver

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1139,7 +1139,9 @@ config :indexer, Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch,
 config :indexer, Indexer.Fetcher.BlockReward.Supervisor,
   disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_BLOCK_REWARD_FETCHER")
 
-config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor,
+config :indexer, Indexer.Fetcher.InternalTransaction.Supervisor, disabled?: trace_url_missing?
+
+config :indexer, Indexer.Fetcher.InternalTransaction,
   disabled?: trace_url_missing? or ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
 
 config :indexer, Indexer.Fetcher.OnDemand.InternalTransaction,


### PR DESCRIPTION
## Motivation

On-demand search of contract creator assumes traces are available. However, when `INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER` is set to true, traces are not fetched via the on-demand fetcher, preventing contract creators created via internal transactions from being revealed. This PR enables force-fetching traces on-demand for contract creator lookups, bypassing the supervisor disabled state.

Additionally, this PR improves the handling of pending operations with a priority system to ensure critical operations are processed first, and updates ChromeDriver to use the latest stable version dynamically.

## Changelog

### Enhancements

- Thread `for_contract_creator?` flag through internal transaction fetching pipeline to allow contract creator searches to bypass the disabled internal transactions fetcher
- Add priority field to pending block and transaction operations to track which operations should be processed first based on missing block ranges
- Add `MissingBlockRange.find_priority_by_numbers/1` utility function to fetch priorities for specific block numbers
- Refactor `async_import_internal_transactions` to accept optional `for_contract_creator?` parameter (defaults to `false`)
- Update `Indexer.Fetcher.InternalTransaction.async_fetch` signature to accept `for_contract_creator?` and `timeout` parameters

### Bug Fixes

- Fix `Indexer.Fetcher.OnDemand.ContractCreator` binary search trigger by replacing `Task.Supervisor.start_child` with `Task.start` for immediate task execution

### Chores

- Update ChromeDriver installation script to dynamically fetch the latest stable version instead of using hard-coded version number
- Separate internal transaction fetcher configuration: supervisor-level vs. module-level settings for more granular control

### Incompatible Changes

- Rename `PendingBlockOperation.stream_blocks_with_unfetched_internal_transactions/3` to accept additional `with_priority?` parameter
- Rename `PendingTransactionOperation.stream_transactions_with_unfetched_internal_transactions/3` to accept additional `with_priority?` parameter
- Database schema change: added `priority` column to `pending_block_operations` and `pending_transaction_operations` tables (database reset and re-index required if upgrading from prior version and using these pending operations)


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added priority support for pending block and transaction operations (DB migration and APIs to persist/query priorities).

* **Improvements**
  * More flexible internal-transaction fetching with an optional flag for contract-creator cases and streamlined on‑demand fetch flow.
  * Pending operations and import flows now compute and honor per-block/transaction priorities.

* **Chores**
  * Headless ChromeDriver installer now fetches the latest stable version dynamically.

* **Tests**
  * Tests now save/restore fetcher runtime env to ensure deterministic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->