### PR TITLE
chore: Drop internal transactions address hashes

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
@@ -425,7 +425,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert response = json_response(request, 200)
 
       assert Enum.all?(response["items"], fn item ->
-               is_nil(item["to"]) and not is_nil(item["created_contract"])
+               not is_nil(item["created_contract"])
              end)
 
       request_2nd_page =
@@ -440,7 +440,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert Enum.count(response_2nd_page["items"]) == 12
 
       assert Enum.all?(response_2nd_page["items"], fn item ->
-               is_nil(item["to"]) and not is_nil(item["created_contract"])
+               not is_nil(item["created_contract"])
              end)
 
       check_paginated_response(

--- a/apps/block_scout_web/test/block_scout_web/graphql/schema/query/transaction_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/graphql/schema/query/transaction_test.exs
@@ -211,7 +211,7 @@ defmodule BlockScoutWeb.GraphQL.Schema.Query.TransactionTest do
                            "created_contract_address_hash" =>
                              to_string(internal_transaction.created_contract_address_hash),
                            "from_address_hash" => to_string(internal_transaction.from_address_hash),
-                           "to_address_hash" => nil,
+                           "to_address_hash" => to_string(internal_transaction.created_contract_address_hash),
                            "transaction_hash" => to_string(internal_transaction.transaction.hash)
                          }
                        }

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -193,6 +193,7 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsCreatedContractAddressIdIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberCreatedContractAddressIdPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError,
+      Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsAddressHashes,
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesHashContractCodeNotNullIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockNumberCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -122,6 +122,7 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsCreatedContractAddressIdIndex,
       Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberCreatedContractAddressIdPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError,
+      Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsAddressHashes,
       Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesHashContractCodeNotNullIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockNumberCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -411,6 +411,10 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsAddressHashes,
+          :indexer
+        ),
+        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockNumberCreatedContractAddressHashIndex,
           :indexer
         ),

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -350,11 +350,8 @@ defmodule Explorer.Chain.Address.CoinBalance do
         (is_nil(coalesce(type(internal_transaction.call_type_enum, :string), internal_transaction.call_type)) or
            coalesce(type(internal_transaction.call_type_enum, :string), internal_transaction.call_type) == ^"call") and
         internal_transaction.value > ^0 and is_nil(internal_transaction.error_id) and
-        (internal_transaction.to_address_hash == ^balance.address_hash or
-           as(:to_address_mapping).address_hash == ^balance.address_hash or
-           internal_transaction.from_address_hash == ^balance.address_hash or
+        (as(:to_address_mapping).address_hash == ^balance.address_hash or
            as(:from_address_mapping).address_hash == ^balance.address_hash or
-           internal_transaction.created_contract_address_hash == ^balance.address_hash or
            as(:created_contract_address_mapping).address_hash == ^balance.address_hash)
     )
     |> select([_internal_transaction, transaction], transaction.hash)

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -888,7 +888,7 @@ defmodule Explorer.Chain.AdvancedFilter do
         end)
 
       query =
-        if "CONTRACT_INTERACTION" in types or "CONTRACT_CREATION" in types do
+        if "CONTRACT_INTERACTION" in types do
           InternalTransaction.join_address_query(query, :to_address)
         else
           query
@@ -915,11 +915,10 @@ defmodule Explorer.Chain.AdvancedFilter do
     do: dynamic([t], is_nil(t.to_address_hash) or ^dynamic_condition)
 
   defp filter_internal_transaction_by_type("CONTRACT_CREATION", nil),
-    do: dynamic([it], is_nil(as(:to_address_mapping).address_hash) and is_nil(it.to_address_hash))
+    do: dynamic([it], not is_nil(it.created_contract_address_id))
 
   defp filter_internal_transaction_by_type("CONTRACT_CREATION", dynamic_condition),
-    do:
-      dynamic([it], (is_nil(as(:to_address_mapping).address_hash) and is_nil(it.to_address_hash)) or ^dynamic_condition)
+    do: dynamic([it], not is_nil(it.created_contract_address_id) or ^dynamic_condition)
 
   defp filter_internal_transaction_by_type(type, dynamic_condition),
     do: filter_transaction_by_type(type, dynamic_condition)
@@ -1296,13 +1295,9 @@ defmodule Explorer.Chain.AdvancedFilter do
   defp do_filter_internal_transactions_by_address(query, {:exclude, addresses}, binding, order_by) do
     address_ids = AddressIdToAddressHash.hashes_to_ids(addresses)
     address_id_field = String.to_existing_atom("#{binding}_id")
-    address_hash_field = String.to_existing_atom("#{binding}_hash")
 
     query
-    |> where(
-      [it],
-      field(it, ^address_id_field) not in ^address_ids and field(it, ^address_hash_field) not in ^addresses
-    )
+    |> where([it], is_nil(field(it, ^address_id_field)) or field(it, ^address_id_field) not in ^address_ids)
     |> order_by.()
   end
 
@@ -1470,7 +1465,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> Enum.map(fn from_address ->
         query
         |> InternalTransaction.where_address_match(:from_address, from_address)
-        |> where([it], it.to_address_id not in ^to_address_ids and it.to_address_hash not in ^to)
+        |> where([it], is_nil(it.to_address_id) or it.to_address_id not in ^to_address_ids)
         |> order_by.()
       end)
       |> map_first(&subquery/1)
@@ -1487,7 +1482,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> Enum.map(fn from_address ->
         query
         |> InternalTransaction.where_address_match(:from_address, from_address)
-        |> or_where([it], it.to_address_id not in ^to_address_ids and it.to_address_hash not in ^to)
+        |> or_where([it], is_nil(it.to_address_id) or it.to_address_id not in ^to_address_ids)
         |> order_by.()
       end)
       |> map_first(&subquery/1)
@@ -1504,7 +1499,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> Enum.map(fn to_address ->
         query
         |> InternalTransaction.where_address_match(:to_address, to_address)
-        |> where([it], it.from_address_id not in ^from_address_ids and it.from_address_hash not in ^from)
+        |> where([it], is_nil(it.from_address_id) or it.from_address_id not in ^from_address_ids)
         |> order_by.()
       end)
       |> map_first(&subquery/1)
@@ -1521,7 +1516,7 @@ defmodule Explorer.Chain.AdvancedFilter do
       |> Enum.map(fn to_address ->
         query
         |> InternalTransaction.where_address_match(:to_address, to_address)
-        |> or_where([it], it.from_address_id not in ^from_address_ids and it.from_address_hash not in ^from)
+        |> or_where([it], is_nil(it.from_address_id) or it.from_address_id not in ^from_address_ids)
         |> order_by.()
       end)
       |> map_first(&subquery/1)
@@ -1535,8 +1530,8 @@ defmodule Explorer.Chain.AdvancedFilter do
     to_address_ids = AddressIdToAddressHash.hashes_to_ids(to)
 
     query
-    |> where([it], it.from_address_id not in ^from_address_ids and it.from_address_hash not in ^from)
-    |> where([it], it.to_address_id not in ^to_address_ids and it.to_address_hash not in ^to)
+    |> where([it], is_nil(it.from_address_id) or it.from_address_id not in ^from_address_ids)
+    |> where([it], is_nil(it.to_address_id) or it.to_address_id not in ^to_address_ids)
     |> order_by.()
   end
 
@@ -1548,8 +1543,8 @@ defmodule Explorer.Chain.AdvancedFilter do
     |> where(as(:from_address).hash not in ^from or as(:to_address).hash not in ^to)
     |> where(
       [it],
-      (it.from_address_id not in ^from_address_ids and it.from_address_hash not in ^from) or
-        (it.to_address_id not in ^to_address_ids and it.to_address_hash not in ^to)
+      is_nil(it.from_address_id) or it.from_address_id not in ^from_address_ids or is_nil(it.to_address_id) or
+        it.to_address_id not in ^to_address_ids
     )
     |> order_by.()
   end

--- a/apps/explorer/lib/explorer/chain/bridged_token.ex
+++ b/apps/explorer/lib/explorer/chain/bridged_token.ex
@@ -300,8 +300,7 @@ defmodule Explorer.Chain.BridgedToken do
         |> where([it], it.transaction_index == ^transaction_index)
         |> where(
           [it],
-          it.to_address_hash == ^omni_bridge_mediator_hash or
-            as(:to_address_mapping).address_hash == ^omni_bridge_mediator_hash
+          as(:to_address_mapping).address_hash == ^omni_bridge_mediator_hash
         )
 
       created_by_amb_mediator =

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -75,6 +75,9 @@ defmodule Explorer.Chain.InternalTransaction do
 
     field(:transaction, :map, virtual: true)
     field(:transaction_hash, Hash.Full, virtual: true)
+    field(:created_contract_address_hash, Hash.Address, virtual: true)
+    field(:from_address_hash, Hash.Address, virtual: true)
+    field(:to_address_hash, Hash.Address, virtual: true)
 
     timestamps()
 
@@ -86,15 +89,6 @@ defmodule Explorer.Chain.InternalTransaction do
 
     has_one(:created_contract_address, through: [:created_contract_address_mapping, :address])
 
-    # TODO: remove after migration to address ids is done
-    belongs_to(
-      :created_contract_address_by_hash,
-      Address,
-      foreign_key: :created_contract_address_hash,
-      references: :hash,
-      type: Hash.Address
-    )
-
     belongs_to(:from_address_mapping, AddressIdToAddressHash,
       foreign_key: :from_address_id,
       references: :address_id,
@@ -103,15 +97,6 @@ defmodule Explorer.Chain.InternalTransaction do
 
     has_one(:from_address, through: [:from_address_mapping, :address])
 
-    # TODO: remove after migration to address ids is done
-    belongs_to(
-      :from_address_by_hash,
-      Address,
-      foreign_key: :from_address_hash,
-      references: :hash,
-      type: Hash.Address
-    )
-
     belongs_to(:to_address_mapping, AddressIdToAddressHash,
       foreign_key: :to_address_id,
       references: :address_id,
@@ -119,15 +104,6 @@ defmodule Explorer.Chain.InternalTransaction do
     )
 
     has_one(:to_address, through: [:to_address_mapping, :address])
-
-    # TODO: remove after migration to address ids is done
-    belongs_to(
-      :to_address_by_hash,
-      Address,
-      foreign_key: :to_address_hash,
-      references: :hash,
-      type: Hash.Address
-    )
 
     belongs_to(:block, Block,
       foreign_key: :block_number,
@@ -512,43 +488,12 @@ defmodule Explorer.Chain.InternalTransaction do
     address_id = AddressIdToAddressHash.hash_to_id(address_hash)
 
     case direction do
-      :to ->
-        if BackgroundMigrations.get_empty_internal_transactions_data_finished() do
-          where_address_match(query, :to_address, address_hash, address_id)
-        else
-          where(
-            query,
-            [it],
-            ^to_direction_match_dynamic(address_hash, address_id)
-          )
-        end
-
-      :from ->
-        where_address_match(query, :from_address, address_hash, address_id)
-
-      :to_address_hash ->
-        if BackgroundMigrations.get_empty_internal_transactions_data_finished() do
-          where(
-            query,
-            [it],
-            ^to_address_hash_match_dynamic(address_hash, address_id)
-          )
-        else
-          where_address_match(query, :to_address, address_hash, address_id)
-        end
-
-      :from_address_hash ->
-        where_address_match(query, :from_address, address_hash, address_id)
-
-      :created_contract_address_hash ->
-        where_address_match(query, :created_contract_address, address_hash, address_id)
-
-      _ ->
-        where(
-          query,
-          [it],
-          ^all_address_fields_match_dynamic(address_hash, address_id)
-        )
+      :to -> do_where_address_match(query, :to_address, address_id)
+      :from -> do_where_address_match(query, :from_address, address_id)
+      :to_address_hash -> where(query, [it], ^to_address_hash_match_dynamic(address_id))
+      :from_address_hash -> do_where_address_match(query, :from_address, address_id)
+      :created_contract_address_hash -> do_where_address_match(query, :created_contract_address, address_id)
+      _ -> where(query, [it], ^all_address_fields_match_dynamic(address_id))
     end
   end
 
@@ -582,87 +527,53 @@ defmodule Explorer.Chain.InternalTransaction do
           Hash.Address.t() | [Hash.Address.t()]
         ) :: Ecto.Query.t()
   def where_address_match(query, address_field, address_hash_or_hashes) do
-    address_hashes = List.wrap(address_hash_or_hashes)
-    address_ids = AddressIdToAddressHash.hashes_to_ids(address_hashes)
+    address_ids =
+      address_hash_or_hashes
+      |> List.wrap()
+      |> AddressIdToAddressHash.hashes_to_ids()
 
-    where_address_match(query, address_field, address_hashes, address_ids)
+    where(query, [it], ^address_match_dynamic(address_field, address_ids))
   end
 
-  @spec where_address_match(
-          Ecto.Query.t() | module(),
-          :from_address | :to_address | :created_contract_address,
-          Hash.Address.t() | [Hash.Address.t()],
-          integer() | [integer()] | nil
-        ) :: Ecto.Query.t()
-  def where_address_match(query, address_field, address_hash_or_hashes, address_id_or_ids) do
-    address_hashes = List.wrap(address_hash_or_hashes)
-    address_ids = List.wrap(address_id_or_ids)
-
-    where(query, [it], ^address_match_dynamic(address_field, address_hashes, address_ids))
+  defp do_where_address_match(query, address_field, address_ids) when is_list(address_ids) do
+    where(query, [it], ^address_match_dynamic(address_field, address_ids))
   end
 
-  defp to_direction_match_dynamic(address_hash, address_id) do
-    to_match = address_match_dynamic(:to_address, address_hash, address_id)
-    created_contract_match = address_match_dynamic(:created_contract_address, address_hash, address_id)
+  defp do_where_address_match(query, address_field, address_id) do
+    address_ids =
+      address_id
+      |> List.wrap()
+      |> Enum.reject(&is_nil/1)
 
+    do_where_address_match(query, address_field, address_ids)
+  end
+
+  defp to_address_hash_match_dynamic(nil), do: dynamic(false)
+
+  defp to_address_hash_match_dynamic(address_id) do
+    dynamic([it], it.to_address_id == ^address_id and is_nil(it.created_contract_address_id))
+  end
+
+  defp all_address_fields_match_dynamic(nil), do: dynamic(false)
+
+  defp all_address_fields_match_dynamic(address_id) do
     dynamic(
       [it],
-      (^to_match and is_nil(it.created_contract_address_hash) and is_nil(it.created_contract_address_id)) or
-        (is_nil(it.to_address_hash) and is_nil(it.to_address_id) and ^created_contract_match)
+      it.to_address_id == ^address_id or it.from_address_id == ^address_id or
+        it.created_contract_address_id == ^address_id
     )
   end
 
-  defp to_address_hash_match_dynamic(address_hash, address_id) do
-    to_match = address_match_dynamic(:to_address, address_hash, address_id)
+  defp address_match_dynamic(_address_field, []), do: dynamic(false)
 
-    dynamic(
-      [it],
-      ^to_match and is_nil(it.created_contract_address_hash) and is_nil(it.created_contract_address_id)
-    )
-  end
-
-  defp all_address_fields_match_dynamic(address_hash, address_id) do
-    to_match = address_match_dynamic(:to_address, address_hash, address_id)
-    from_match = address_match_dynamic(:from_address, address_hash, address_id)
-    created_contract_match = address_match_dynamic(:created_contract_address, address_hash, address_id)
-
-    dynamic(
-      [it],
-      ^to_match or ^from_match or ^created_contract_match
-    )
-  end
-
-  defp address_match_dynamic(address_field, address_hash_or_hashes, address_id_or_ids) do
-    address_hashes = List.wrap(address_hash_or_hashes)
-    address_hash_field = String.to_existing_atom("#{address_field}_hash")
-    address_ids = List.wrap(address_id_or_ids)
+  defp address_match_dynamic(address_field, address_ids) do
     address_id_field = String.to_existing_atom("#{address_field}_id")
 
-    cond do
-      not address_ids_indexes_exists?() ->
-        adjust_address_match_dynamic(address_hash_field, address_hashes)
-
-      address_ids_filled?() ->
-        adjust_address_match_dynamic(address_id_field, address_ids)
-
-      true ->
-        dynamic(
-          [it],
-          field(it, ^address_id_field) in ^address_ids or field(it, ^address_hash_field) in ^address_hashes
-        )
-    end
+    adjust_address_match_dynamic(address_id_field, address_ids)
   end
 
   defp adjust_address_match_dynamic(field, [value]), do: dynamic([it], field(it, ^field) == ^value)
   defp adjust_address_match_dynamic(field, values), do: dynamic([it], field(it, ^field) in ^values)
-
-  defp address_ids_indexes_exists? do
-    BackgroundMigrations.get_heavy_indexes_create_address_ids_internal_transactions_indexes_finished()
-  end
-
-  defp address_ids_filled? do
-    BackgroundMigrations.get_fill_internal_transactions_address_ids_finished()
-  end
 
   def where_is_different_from_parent_transaction(query) do
     where(
@@ -1004,7 +915,6 @@ defmodule Explorer.Chain.InternalTransaction do
     mapping_binding = String.to_existing_atom("#{address_field}_mapping")
     address_binding = address_field
     address_id_field = String.to_existing_atom("#{address_field}_id")
-    address_hash_field = String.to_existing_atom("#{address_field}_hash")
 
     query
     |> with_named_binding(mapping_binding, fn query, binding ->
@@ -1016,9 +926,7 @@ defmodule Explorer.Chain.InternalTransaction do
     |> with_named_binding(address_binding, fn query, binding ->
       join(query, join_type, [it], a in Address,
         as: ^binding,
-        on:
-          a.hash == as(^mapping_binding).address_hash or
-            (is_nil(as(^mapping_binding).address_hash) and a.hash == field(it, ^address_hash_field))
+        on: a.hash == as(^mapping_binding).address_hash
       )
     end)
   end
@@ -1594,72 +1502,6 @@ defmodule Explorer.Chain.InternalTransaction do
     preloads = Keyword.merge(@default_address_preloads, Keyword.get(options, :address_preloads, []))
     repo = repo || Chain.select_repo(options)
 
-    indexed_transactions = Enum.with_index(internal_transactions)
-
-    {migrated_indexed, not_migrated_indexed} =
-      Enum.split_with(
-        indexed_transactions,
-        fn {it, _idx} ->
-          is_nil(it.from_address_hash) and is_nil(it.to_address_hash) and is_nil(it.created_contract_address_hash)
-        end
-      )
-
-    migrated = Enum.map(migrated_indexed, &elem(&1, 0))
-    not_migrated = Enum.map(not_migrated_indexed, &elem(&1, 0))
-
-    not_migrated_preloaded = preload_addresses_for_not_migrated_internal_transactions(not_migrated, preloads, repo)
-    migrated_preloaded = preload_addresses_for_migrated_internal_transactions(migrated, preloads, repo)
-
-    migrated_with_idx = Enum.zip(migrated_preloaded, Enum.map(migrated_indexed, &elem(&1, 1)))
-    not_migrated_with_idx = Enum.zip(not_migrated_preloaded, Enum.map(not_migrated_indexed, &elem(&1, 1)))
-
-    (migrated_with_idx ++ not_migrated_with_idx)
-    |> Enum.sort_by(&elem(&1, 1))
-    |> Enum.map(&elem(&1, 0))
-  end
-
-  def preload_addresses(internal_transaction, options, repo) do
-    [internal_transaction]
-    |> preload_addresses(options, repo)
-    |> List.first()
-  end
-
-  defp preload_addresses_for_not_migrated_internal_transactions([], _preloads, _repo), do: []
-
-  defp preload_addresses_for_not_migrated_internal_transactions(internal_transactions, preloads, repo) do
-    unified_preloads =
-      preloads
-      |> List.wrap()
-      |> Enum.map(fn
-        preload when is_atom(preload) -> {String.to_existing_atom("#{preload}_by_hash"), []}
-        {preload, fields} -> {String.to_existing_atom("#{preload}_by_hash"), fields}
-      end)
-
-    internal_transactions
-    |> repo.preload(unified_preloads)
-    |> Enum.map(fn internal_transaction ->
-      Enum.reduce(
-        [
-          {:from_address_by_hash, :from_address_hash, :from_address},
-          {:to_address_by_hash, :to_address_hash, :to_address},
-          {:created_contract_address_by_hash, :created_contract_address_hash, :created_contract_address}
-        ],
-        internal_transaction,
-        fn {source_field, hash_field, address_field}, acc ->
-          corresponding_address = Map.get(acc, source_field)
-
-          Map.merge(acc, %{
-            hash_field => (corresponding_address && corresponding_address.hash) || Map.get(acc, hash_field),
-            address_field => corresponding_address
-          })
-        end
-      )
-    end)
-  end
-
-  defp preload_addresses_for_migrated_internal_transactions([], _preloads, _repo), do: []
-
-  defp preload_addresses_for_migrated_internal_transactions(internal_transactions, preloads, repo) do
     internal_transactions
     |> repo.preload(preloads)
     |> Enum.map(fn internal_transaction ->
@@ -1672,9 +1514,15 @@ defmodule Explorer.Chain.InternalTransaction do
         internal_transaction,
         fn {hash_field, address_field}, acc ->
           corresponding_address = Map.get(acc, address_field)
-          Map.put(acc, hash_field, corresponding_address && corresponding_address.hash)
+          Map.put(acc, hash_field, Map.get(acc, hash_field) || (corresponding_address && corresponding_address.hash))
         end
       )
     end)
+  end
+
+  def preload_addresses(internal_transaction, options, repo) do
+    [internal_transaction]
+    |> preload_addresses(options, repo)
+    |> List.first()
   end
 end

--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -11,7 +11,6 @@ defmodule Explorer.Etherscan do
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{Address, Block, DenormalizationHelper, Hash, InternalTransaction, TokenTransfer, Transaction}
   alias Explorer.Chain.Address.{CurrentTokenBalance, TokenBalance}
-  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.Transaction.History.TransactionStats
   alias Explorer.Etherscan.Logs
 
@@ -139,10 +138,9 @@ defmodule Explorer.Etherscan do
           merge(map(it, ^@internal_transaction_fields), %{
             block_timestamp: as(:transaction).block_timestamp,
             transaction_hash: as(:transaction).hash,
-            from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
-            to_address_hash: coalesce(it.to_address_hash, as(:to_address_mapping).address_hash),
-            created_contract_address_hash:
-              coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+            from_address_hash: as(:from_address_mapping).address_hash,
+            to_address_hash: as(:to_address_mapping).address_hash,
+            created_contract_address_hash: as(:created_contract_address_mapping).address_hash
           })
         )
       else
@@ -159,10 +157,9 @@ defmodule Explorer.Etherscan do
           merge(map(it, ^@internal_transaction_fields), %{
             block_timestamp: as(:block).timestamp,
             transaction_hash: as(:transaction).hash,
-            from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
-            to_address_hash: coalesce(it.to_address_hash, as(:to_address_mapping).address_hash),
-            created_contract_address_hash:
-              coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+            from_address_hash: as(:from_address_mapping).address_hash,
+            to_address_hash: as(:to_address_mapping).address_hash,
+            created_contract_address_hash: as(:created_contract_address_mapping).address_hash
           })
         )
       end
@@ -192,8 +189,7 @@ defmodule Explorer.Etherscan do
     options
     |> options_to_directions()
     |> then(fn directions ->
-      if BackgroundMigrations.get_empty_internal_transactions_data_finished() and
-           Enum.member?(directions, :to_address_hash) do
+      if Enum.member?(directions, :to_address_hash) do
         directions
         |> Kernel.--([:created_contract_address_hash, :to_address_hash])
         |> Enum.concat([:to])
@@ -274,10 +270,9 @@ defmodule Explorer.Etherscan do
         merge(map(it, ^@internal_transaction_fields), %{
           block_timestamp: transaction.block_timestamp,
           transaction_hash: transaction.hash,
-          from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
-          to_address_hash: coalesce(it.to_address_hash, as(:to_address_mapping).address_hash),
-          created_contract_address_hash:
-            coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+          from_address_hash: as(:from_address_mapping).address_hash,
+          to_address_hash: as(:to_address_mapping).address_hash,
+          created_contract_address_hash: as(:created_contract_address_mapping).address_hash
         })
       )
     else
@@ -303,10 +298,9 @@ defmodule Explorer.Etherscan do
         merge(map(it, ^@internal_transaction_fields), %{
           block_timestamp: as(:block).timestamp,
           transaction_hash: as(:transaction).hash,
-          from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
-          to_address_hash: coalesce(it.to_address_hash, as(:to_address_mapping).address_hash),
-          created_contract_address_hash:
-            coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+          from_address_hash: as(:from_address_mapping).address_hash,
+          to_address_hash: as(:to_address_mapping).address_hash,
+          created_contract_address_hash: as(:created_contract_address_mapping).address_hash
         })
       )
     end
@@ -335,10 +329,9 @@ defmodule Explorer.Etherscan do
       merge(map(it, ^@internal_transaction_fields), %{
         block_timestamp: as(:block).timestamp,
         transaction_hash: as(:transaction).hash,
-        from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
-        to_address_hash: coalesce(it.to_address_hash, as(:to_address_mapping).address_hash),
-        created_contract_address_hash:
-          coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+        from_address_hash: as(:from_address_mapping).address_hash,
+        to_address_hash: as(:to_address_mapping).address_hash,
+        created_contract_address_hash: as(:created_contract_address_mapping).address_hash
       })
     )
   end

--- a/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_zero_value_internal_transactions.ex
@@ -14,7 +14,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
   alias Explorer.Chain.Cache.Counters.AverageBlockTime
   alias Explorer.Migrator.MigrationStatus
   alias Explorer.Repo
-  alias Explorer.Utility.{AddressIdToAddressHash, InternalTransactionsAddressPlaceholder}
+  alias Explorer.Utility.InternalTransactionsAddressPlaceholder
   alias Timex.Duration
 
   @migration_name "delete_zero_value_internal_transactions"
@@ -128,9 +128,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
             inner_join: locked_it in subquery(locked_internal_transactions_to_delete_query),
             on: join_on_ctid(it, locked_it),
             select: %{
-              from_address_hash: it.from_address_hash,
               from_address_id: it.from_address_id,
-              to_address_hash: it.to_address_hash,
               to_address_id: it.to_address_id,
               block_number: it.block_number,
               index: it.index
@@ -138,23 +136,6 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
           )
 
         {_count, deleted_internal_transactions} = Repo.delete_all(delete_query, timeout: :infinity)
-
-        address_hashes =
-          deleted_internal_transactions
-          |> Enum.flat_map(&[&1.from_address_hash, &1.to_address_hash])
-          |> Enum.uniq()
-          |> Enum.reject(&is_nil/1)
-
-        id_to_address_params = Enum.map(address_hashes, &%{address_hash: &1})
-
-        Repo.insert_all(AddressIdToAddressHash, id_to_address_params, on_conflict: :nothing)
-
-        address_to_id_map =
-          AddressIdToAddressHash
-          |> where([a], a.address_hash in ^address_hashes)
-          |> select([a], {a.address_hash, a.address_id})
-          |> Repo.all()
-          |> Map.new()
 
         placeholders_params =
           deleted_internal_transactions
@@ -166,11 +147,8 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactions do
                 inner_acc
 
               internal_transaction, inner_acc ->
-                from_address_id =
-                  internal_transaction.from_address_id || address_to_id_map[internal_transaction.from_address_hash]
-
-                to_address_id =
-                  internal_transaction.to_address_id || address_to_id_map[internal_transaction.to_address_hash]
+                from_address_id = internal_transaction.from_address_id
+                to_address_id = internal_transaction.to_address_id
 
                 inner_acc
                 |> Map.update(

--- a/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
+++ b/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
@@ -74,7 +74,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
         |> where([it], it.type == :selfdestruct)
         |> select([it], %{
           transaction_index: it.transaction_index,
-          from_address_hash: coalesce(it.from_address_hash, as(:from_address_mapping).address_hash),
+          from_address_hash: as(:from_address_mapping).address_hash,
           block_number: it.block_number
         })
 
@@ -98,8 +98,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
           |> select([it], %{
             block_number: it.block_number,
             transaction_index: it.transaction_index,
-            created_contract_address_hash:
-              coalesce(it.created_contract_address_hash, as(:created_contract_address_mapping).address_hash)
+            created_contract_address_hash: as(:created_contract_address_mapping).address_hash
           })
 
         created_contracts = Repo.all(create_query, timeout: :infinity)

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_address_hashes.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/remove_internal_transactions_address_hashes.ex
@@ -1,0 +1,103 @@
+defmodule Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsAddressHashes do
+  @moduledoc """
+  Removes `from_address_hash`, `to_address_hash`, `created_contract_address_hash` columns from `internal_transactions`
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  require Logger
+
+  alias Explorer.Migrator.{FillInternalTransactionsAddressIds, HeavyDbIndexOperation, MigrationStatus}
+
+  alias Explorer.Repo
+
+  @table_name :internal_transactions
+  @index_name "internal_transactions_remove_address_hashes"
+  @operation_type :create
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations,
+    do: [
+      FillInternalTransactionsAddressIds.migration_name()
+    ]
+
+  @impl HeavyDbIndexOperation
+  # sobelow_skip ["SQL"]
+  def db_index_operation do
+    Logger.info("Migration RemoveInternalTransactionsAddressHashes started")
+
+    case Repo.query(drop_columns_query_string(), [], timeout: :infinity) do
+      {:ok, _} ->
+        Logger.info("Migration RemoveInternalTransactionsAddressHashes finished")
+        :ok
+
+      {:error, error} ->
+        Logger.error("Migration RemoveInternalTransactionsAddressHashes failed: #{inspect(error)}")
+
+        :error
+    end
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, drop_columns_query_string())
+  end
+
+  @impl HeavyDbIndexOperation
+  # credo:disable-for-next-line /Complexity/
+  def db_index_operation_status do
+    completed? =
+      case Repo.query("""
+           SELECT COUNT(*) = 0
+           FROM information_schema.columns
+           WHERE table_name = '#{@table_name}' AND column_name IN ('from_address_hash', 'to_address_hash', 'created_contract_address_hash');
+           """) do
+        {:ok, %Postgrex.Result{rows: [[completed]]}} -> completed
+        _ -> nil
+      end
+
+    started? =
+      case check_db_index_operation_progress() do
+        :in_progress -> true
+        :finished_or_not_started -> false
+        _ -> nil
+      end
+
+    cond do
+      completed? == true -> :completed
+      started? == true -> :not_completed
+      is_nil(completed?) or is_nil(started?) -> :unknown
+      true -> :not_initialized
+    end
+  end
+
+  @impl HeavyDbIndexOperation
+  # sobelow_skip ["SQL"]
+  def restart_db_index_operation, do: db_index_operation()
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache, do: :ok
+
+  defp drop_columns_query_string do
+    """
+    ALTER TABLE #{@table_name}
+    DROP COLUMN IF EXISTS from_address_hash,
+    DROP COLUMN IF EXISTS to_address_hash,
+    DROP COLUMN IF EXISTS created_contract_address_hash;
+    """
+  end
+end

--- a/apps/explorer/lib/explorer/utility/version_upgrade.ex
+++ b/apps/explorer/lib/explorer/utility/version_upgrade.ex
@@ -28,8 +28,8 @@ defmodule Explorer.Utility.VersionUpgrade do
 
   alias Explorer.Application.Constants
   alias Explorer.Chain.Block
+  alias Explorer.Migrator.{FillInternalTransactionsAddressIds, MigrationStatus}
   alias Explorer.Migrator.HeavyDbIndexOperation.UpdateInternalTransactionsPrimaryKey
-  alias Explorer.Migrator.MigrationStatus
   alias Explorer.Repo
 
   @upgrade_rules [
@@ -37,6 +37,11 @@ defmodule Explorer.Utility.VersionUpgrade do
       since: "11.0.0",
       min_from: "10.2.3",
       required_completed_migrations: [UpdateInternalTransactionsPrimaryKey.migration_name()]
+    },
+    %{
+      since: "12.0.0",
+      min_from: "11.0.2",
+      required_completed_migrations: [FillInternalTransactionsAddressIds.migration_name()]
     }
   ]
 

--- a/apps/explorer/test/explorer/migrator/delete_zero_value_internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/migrator/delete_zero_value_internal_transactions_test.exs
@@ -28,7 +28,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
 
     block = insert(:block, timestamp: Timex.shift(Timex.now(), days: -40))
 
-    Enum.map(1..3, fn i ->
+    Enum.map(1..3, fn _i ->
       transaction =
         :transaction
         |> insert()
@@ -46,7 +46,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
       )
     end)
 
-    Enum.map(1..4, fn i ->
+    Enum.map(1..4, fn _i ->
       transaction =
         :transaction
         |> insert()
@@ -64,7 +64,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
       )
     end)
 
-    Enum.map(1..5, fn i ->
+    Enum.map(1..5, fn _i ->
       transaction =
         :transaction
         |> insert()
@@ -82,7 +82,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
       )
     end)
 
-    Enum.map(1..4, fn i ->
+    Enum.map(1..4, fn _i ->
       transaction =
         :transaction
         |> insert()
@@ -98,7 +98,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
       )
     end)
 
-    Enum.map(1..5, fn i ->
+    Enum.map(1..5, fn _i ->
       transaction =
         :transaction
         |> insert()
@@ -113,7 +113,7 @@ defmodule Explorer.Migrator.DeleteZeroValueInternalTransactionsTest do
       )
     end)
 
-    Enum.map(1..6, fn i ->
+    Enum.map(1..6, fn _i ->
       transaction =
         :transaction
         |> insert()

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -878,7 +878,13 @@ defmodule Explorer.Factory do
 
     all_attrs =
       attrs
-      |> adjust_internal_transaction_addresses_attrs([:from_address, :created_contract_address], contract_code)
+      |> then(fn attrs ->
+        Map.put(attrs, :to_address, Map.get(attrs, :to_address) || Map.get(attrs, :created_contract_address))
+      end)
+      |> adjust_internal_transaction_addresses_attrs(
+        [:from_address, :created_contract_address, :to_address],
+        contract_code
+      )
       |> adjust_internal_transaction_error_attr()
 
     %InternalTransaction{


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Shifted internal-transaction address handling to mapping-driven joins for more consistent address resolution and query behavior.
  * Added a disabled maintenance operation to remove redundant address-hash columns; can be run to reduce storage.
  * Updated runtime/config and upgrade rules to coordinate the staged migration and ensure safe upgrades.

* **User-facing behavior**
  * Internal-transaction queries and filters now return more consistent address fields (affects API/query results).

* **Tests**
  * Expanded test data to cover more zero-value internal-transaction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->