### PR TITLE
fix: Add transactions uniqueness before insert

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -105,7 +105,10 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
-    ordered_changes_list = Enum.sort_by(changes_list, & &1.hash)
+    ordered_changes_list =
+      changes_list
+      |> Enum.uniq_by(& &1.hash)
+      |> Enum.sort_by(& &1.hash)
 
     Import.insert_changes_list(
       repo,


### PR DESCRIPTION
## Motivation

In case of non-uniq transaction hash in a single block bug we should be able to process them anyway

Megaeth mainnet case: `eth_getBlockByNumber` request returns non-unique transaction hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Redis Sentinel support for improved connection availability and failover capabilities
  * Added SSL/TLS encryption option for Redis connections

* **Bug Fixes**
  * Fixed transaction deduplication to prevent duplicate transaction inserts

* **Chores**
  * Enhanced Auth0 integration security with encrypted token storage
  * Improved Redis configuration management with extended sentinel and SSL settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->