### PR TITLE
fix: Insert AddressIdToAddressHash via safe_insert_all

### DIFF
--- a/apps/explorer/lib/explorer/utility/address_id_to_address_hash.ex
+++ b/apps/explorer/lib/explorer/utility/address_id_to_address_hash.ex
@@ -76,7 +76,7 @@ defmodule Explorer.Utility.AddressIdToAddressHash do
       end)
       |> Enum.sort()
 
-    Repo.insert_all(
+    Repo.safe_insert_all(
       __MODULE__,
       Enum.map(filtered_address_hashes, &%{address_hash: &1}),
       on_conflict: :nothing


### PR DESCRIPTION
## Motivation

Avoid `postgresql protocol can not handle N parameters` errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced reliability of address mapping operations through improved database transaction handling for bulk inserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->