### PR TITLE
feat: support for EIP-7708 on arc

### DIFF
--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -173,6 +173,9 @@ defmodule Explorer.Chain.TokenTransfer do
   @arc_native_coin_burned_event "0xaaf1ef013644e67c5cea90217acdf0accd334f8437fc9a89a53cfc9b25fb5c25"
   @erc7984_transfer_event "0x67500e8d0ed826d2194f514dd0d8124f35648ab6e3fb5e6ed867134cffe661e9"
 
+  # EIP-7708: log `address` for protocol-emitted ETH/native transfer logs
+  @eip7708_system_address "0xfffffffffffffffffffffffffffffffffffffffe"
+
   @transfer_function_signature "0xa9059cbb"
 
   @typedoc """
@@ -247,6 +250,11 @@ defmodule Explorer.Chain.TokenTransfer do
   def arc_native_coin_burned_event, do: @arc_native_coin_burned_event
 
   def erc7984_transfer_event, do: @erc7984_transfer_event
+
+  @doc """
+  EIP-7708 [`SYSTEM_ADDRESS`](https://eips.ethereum.org/EIPS/eip-7708) — log emitter for protocol `Transfer` events.
+  """
+  def eip7708_system_address, do: @eip7708_system_address
 
   @doc """
   ERC 20's transfer(address,uint256) function signature

--- a/apps/indexer/lib/indexer/transform/address_coin_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances.ex
@@ -10,6 +10,9 @@ defmodule Indexer.Transform.AddressCoinBalances do
     arc_native_token_system_address: [:indexer, [:arc, :arc_native_token_system_address]]
 
   import Explorer.Helper, only: [truncate_address_hash: 1]
+  import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
+
+  @burn_address_hash_string burn_address_hash_string()
 
   alias Explorer.Chain.TokenTransfer
 
@@ -52,7 +55,7 @@ defmodule Indexer.Transform.AddressCoinBalances do
       end)
       |> Enum.reject(fn val -> is_nil(val) end)
 
-    # for :arc chain type we also need to parse the `NativeCoinTransferred`, `NativeCoinMinted`, `NativeCoinBurned` events
+    # for :arc chain type we also need to parse the `NativeCoinTransferred`, `NativeCoinMinted`, `NativeCoinBurned`, EIP-7708 events
     filtered_arc_logs =
       if chain_type() == :arc do
         handle_arc_transfer_logs(logs_params)
@@ -100,6 +103,8 @@ defmodule Indexer.Transform.AddressCoinBalances do
     arc_native_coin_minted_event = TokenTransfer.arc_native_coin_minted_event()
     arc_native_coin_burned_event = TokenTransfer.arc_native_coin_burned_event()
     arc_native_token_system_address = arc_native_token_system_address()
+    eip7708_transfer_topic = TokenTransfer.constant()
+    eip7708_system_address = TokenTransfer.eip7708_system_address()
 
     logs_params
     |> Enum.flat_map(fn
@@ -107,6 +112,20 @@ defmodule Indexer.Transform.AddressCoinBalances do
         type: "pending"
       } ->
         []
+
+      %{
+        first_topic: ^eip7708_transfer_topic,
+        second_topic: second_topic,
+        third_topic: third_topic,
+        address_hash: ^eip7708_system_address,
+        block_number: block_number
+      }
+      when is_integer(block_number) and is_binary(second_topic) and is_binary(third_topic) ->
+        [
+          %{address_hash: truncate_address_hash(second_topic), block_number: block_number},
+          %{address_hash: truncate_address_hash(third_topic), block_number: block_number}
+        ]
+        |> Enum.filter(fn %{address_hash: address_hash} -> address_hash != @burn_address_hash_string end)
 
       %{
         first_topic: ^arc_native_coin_transferred_event,
@@ -204,10 +223,6 @@ defmodule Indexer.Transform.AddressCoinBalances do
   end
 
   if @chain_identity == {:optimism, :celo} do
-    import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
-
-    @burn_address_hash_string burn_address_hash_string()
-
     # todo: subject for deprecation, since celo transactions with
     # gatewayFeeRecipient are deprecated
     defp transactions_params_chain_type_fields_reducer(

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -243,7 +243,7 @@ defmodule Indexer.Transform.TokenTransfers do
        when not is_nil(second_topic) and not is_nil(third_topic) do
     if arc_native_token_transfer_event?(log) do
       # for :arc chain type we need to ignore ERC-20 Transfer events from the native token as there are
-      # NativeCoinTransferred, NativeCoinMinted, NativeCoinBurned events instead
+      # NativeCoinTransferred, NativeCoinMinted, NativeCoinBurned, EIP-7708 events instead
       nil
     else
       # handle the transfer for other cases
@@ -251,8 +251,9 @@ defmodule Indexer.Transform.TokenTransfers do
       decimal_amount = Decimal.new(decoded_amount || 0)
 
       {token_contract_address_hash, amount} =
-        if arc_native_coin_transferred_event?(log) do
-          # if this is NativeCoinTransferred event for Arc chain, there are 18 decimals for the native token, so we need to adjust the amount with the token decimals
+        if arc_native_coin_transferred_event?(log) or arc_eip7708_transfer_log?(log) do
+          # NativeCoinTransferred and EIP-7708 protocol Transfer use 18-decimal amounts on-chain;
+          # normalize to configured native token decimals
           {arc_native_token_address(), amount_18_decimals_to_n_decimals(decimal_amount, arc_native_token_decimals())}
         else
           {log.address_hash, decimal_amount}
@@ -553,6 +554,17 @@ defmodule Indexer.Transform.TokenTransfers do
     amount
     |> Decimal.mult(Integer.pow(10, new_decimals))
     |> Decimal.div_int(Integer.pow(10, 18))
+  end
+
+  # EIP-7708 protocol `Transfer` log (emitter is SYSTEM_ADDRESS, not the synthetic ERC-20).
+  @spec arc_eip7708_transfer_log?(%{
+          :first_topic => String.t(),
+          :address_hash => String.t(),
+          optional(any()) => any()
+        }) :: boolean()
+  defp arc_eip7708_transfer_log?(log) do
+    chain_type() == :arc and log.first_topic == TokenTransfer.constant() and
+      log.address_hash == TokenTransfer.eip7708_system_address()
   end
 
   # Determines if the given log is the NativeCoinTransferred event emitted by the native token system address on Arc chain.

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -245,4 +245,45 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
       assert MapSet.member?(params_set, %{address_hash: to_address_hash, block_number: block_number})
     end
   end
+
+  if Application.compile_env(:explorer, :chain_type) == :arc do
+    describe "params_set/1 logs_params on Arc chain" do
+      test "with EIP-7708 Transfer queues non-burn from_address and to_address for coin balances" do
+        from_address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        to_address = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        logs_params = [
+          %{
+            block_number: 100,
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            second_topic: "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            third_topic: "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            block_number: 101,
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            second_topic: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            third_topic: "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            block_number: 102,
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            second_topic: "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            third_topic: "0x0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        ]
+
+        params_set = AddressCoinBalances.params_set(%{logs_params: logs_params})
+
+        assert MapSet.member?(params_set, %{address_hash: from_address, block_number: 100})
+        assert MapSet.member?(params_set, %{address_hash: to_address, block_number: 100})
+        assert MapSet.member?(params_set, %{address_hash: to_address, block_number: 101})
+        assert MapSet.member?(params_set, %{address_hash: from_address, block_number: 102})
+        assert MapSet.size(params_set) == 4
+      end
+    end
+  end
 end

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -640,6 +640,316 @@ defmodule Indexer.Transform.TokenTransfersTest do
     end
   end
 
+  if Application.compile_env(:explorer, :chain_type) == :arc do
+    describe "parse/1 on Arc chain" do
+      @arc_native_token "0x3600000000000000000000000000000000000000"
+      @arc_system "0x1800000000000000000000000000000000000000"
+      @wei_1e18 "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+      @wei_1e6 "0x00000000000000000000000000000000000000000000000000000000000f4240"
+
+      setup do
+        original_indexer_arc = Application.get_env(:indexer, :arc)
+
+        on_exit(fn ->
+          Application.put_env(:indexer, :arc, original_indexer_arc)
+        end)
+
+        Application.put_env(:indexer, :arc,
+          arc_native_token_decimals: 6,
+          arc_native_token_address: @arc_native_token,
+          arc_native_token_system_address: @arc_system
+        )
+
+        :ok
+      end
+
+      test "ignores ERC-20 Transfer from synthetic native token contract" do
+        log = %{
+          address_hash: @arc_native_token,
+          block_number: 1,
+          block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          data: @wei_1e6,
+          first_topic: Explorer.Chain.TokenTransfer.constant(),
+          fourth_topic: nil,
+          index: 0,
+          second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+          third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+          transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+
+        assert %{tokens: [], token_transfers: []} = TokenTransfers.parse([log])
+      end
+
+      test "maps native EIP-7708 Transfer to synthetic native token with decimal normalization" do
+        log = %{
+          address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+          block_number: 1,
+          block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          data: @wei_1e18,
+          first_topic: Explorer.Chain.TokenTransfer.constant(),
+          fourth_topic: nil,
+          index: 0,
+          second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+          third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+          transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse([log])
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.to_address_hash == "0x2000000000000000000000000000000000000002"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps EIP-7708 + ERC-20 Transfer to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.to_address_hash == "0x2000000000000000000000000000000000000002"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps native legacy NativeCoinTransferred to synthetic native token with decimal normalization" do
+        log = %{
+          address_hash: @arc_system,
+          block_number: 1,
+          block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          data: @wei_1e18,
+          first_topic: Explorer.Chain.TokenTransfer.arc_native_coin_transferred_event(),
+          fourth_topic: nil,
+          index: 0,
+          second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+          third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+          transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse([log])
+        assert token.contract_address_hash == @arc_native_token
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps legacy NativeCoinTransferred + ERC-20 Transfer to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: @arc_system,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.arc_native_coin_transferred_event(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x2000000000000000000000000000000000000002"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token.contract_address_hash == @arc_native_token
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps EIP-7708 + ERC-20 Mint to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            third_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            third_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x0000000000000000000000000000000000000000"
+        assert tt.to_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps legacy NativeCoinMinted + ERC-20 Transfer to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: @arc_system,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.arc_native_coin_minted_event(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: nil,
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            third_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x0000000000000000000000000000000000000000"
+        assert tt.to_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps EIP-7708 + ERC-20 Burn to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: Explorer.Chain.TokenTransfer.eip7708_system_address(),
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.to_address_hash == "0x0000000000000000000000000000000000000000"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+
+      test "maps legacy NativeCoinBurned + ERC-20 Transfer to synthetic native token with decimal normalization" do
+        logs = [
+          %{
+            address_hash: @arc_system,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e18,
+            first_topic: Explorer.Chain.TokenTransfer.arc_native_coin_burned_event(),
+            fourth_topic: nil,
+            index: 0,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: nil,
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          },
+          %{
+            address_hash: @arc_native_token,
+            block_number: 1,
+            block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            data: @wei_1e6,
+            first_topic: Explorer.Chain.TokenTransfer.constant(),
+            fourth_topic: nil,
+            index: 1,
+            second_topic: topic_padded_address("0x1000000000000000000000000000000000000001"),
+            third_topic: topic_padded_address("0x0000000000000000000000000000000000000000"),
+            transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ]
+
+        assert %{tokens: [token], token_transfers: [tt]} = TokenTransfers.parse(logs)
+        assert token == %{contract_address_hash: @arc_native_token, type: "ERC-20"}
+        assert tt.from_address_hash == "0x1000000000000000000000000000000000000001"
+        assert tt.to_address_hash == "0x0000000000000000000000000000000000000000"
+        assert tt.token_contract_address_hash == @arc_native_token
+        assert tt.log_index == 0
+        assert tt.amount == Decimal.new(1_000_000)
+      end
+    end
+
+    defp topic_padded_address("0x" <> addr_hex) when byte_size(addr_hex) == 40 do
+      "0x000000000000000000000000#{addr_hex}"
+    end
+  end
+
   defp truncated_hash("0x000000000000000000000000" <> rest) do
     "0x" <> rest
   end


### PR DESCRIPTION
## Changelog

* Add a backward compatible support for new EIP-7708 native coin transfer events on Arc chain type, replacing existing custom `NativeCoin*` style events

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [X] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for EIP-7708 protocol transfers on the Arc chain.
  * Token transfer parsing now recognizes EIP-7708 synthetic transfer events and applies proper native-token decimal normalization.
  * Coin balance tracking now includes EIP-7708 transfer events.

* **Tests**
  * Added comprehensive Arc-specific tests covering EIP-7708 transfer parsing and coin-balance scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14336)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->