### PR TITLE
chore: Reset skip metadata flag for NFTs

### DIFF
--- a/apps/explorer/priv/repo/migrations/20260511153825_reset_nfts_skip_metadata.exs
+++ b/apps/explorer/priv/repo/migrations/20260511153825_reset_nfts_skip_metadata.exs
@@ -1,0 +1,9 @@
+defmodule Explorer.Repo.Migrations.ResetNftsSkipMetadata do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    UPDATE tokens SET skip_metadata = NULL WHERE skip_metadata = TRUE AND name IS NOT NULL AND symbol IS NOT NULL AND type='ERC-721';
+    """)
+  end
+end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13891

## Motivation

Reset `skip_metadata` flag for NFTs.

## Changelog

After fixing filling of `skip_metadata` flag, we need to reset it for NFTs.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied a database migration to reset NFT metadata handling: for ERC-721 tokens that already have name and symbol, the system will clear the flag that previously skipped metadata so metadata can be used/displayed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14337)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->