### PR TITLE
chore: openapi specification for Shibarium endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -1083,6 +1083,18 @@ defmodule BlockScoutWeb.Chain do
     %{"number" => number}
   end
 
+  # Shibarium Deposits — must precede the Optimism Deposits clause since the
+  # Shibarium reader map also contains :l1_block_number and :l2_transaction_hash;
+  # :user is present only in the Shibarium-shaped map.
+  defp paging_params(%{l1_block_number: block_number, user: _}) do
+    %{block_number: block_number}
+  end
+
+  # Shibarium Withdrawals — kept next to deposits for symmetry; :user is the discriminator.
+  defp paging_params(%{l2_block_number: block_number, user: _}) do
+    %{block_number: block_number}
+  end
+
   # clause for Optimism Deposits
   defp paging_params(%{l1_block_number: l1_block_number, l2_transaction_hash: l2_transaction_hash}) do
     %{l1_block_number: l1_block_number, transaction_hash: l2_transaction_hash}
@@ -1091,16 +1103,6 @@ defmodule BlockScoutWeb.Chain do
   # clause for Optimism Withdrawals
   defp paging_params(%{msg_nonce: nonce}) do
     %{nonce: nonce}
-  end
-
-  # clause for Shibarium Deposits
-  defp paging_params(%{l1_block_number: block_number}) do
-    %{"block_number" => block_number}
-  end
-
-  # clause for Shibarium Withdrawals
-  defp paging_params(%{l2_block_number: block_number}) do
-    %{"block_number" => block_number}
   end
 
   @spec paging_params_with_fiat_value(CurrentTokenBalance.t()) :: %{

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/celo_controller.ex
@@ -43,8 +43,7 @@ defmodule BlockScoutWeb.API.V2.CeloController do
            next_page_params_example: %{
              "number" => 100,
              "items_count" => 50
-           },
-           title_prefix: "CeloEpochs"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -178,8 +177,7 @@ defmodule BlockScoutWeb.API.V2.CeloController do
              "account_address_hash" => "0x1234567890123456789012345678901234567890",
              "associated_account_address_hash" => "0x0987654321098765432109876543210987654321",
              "items_count" => 50
-           },
-           title_prefix: "CeloEpochElectionRewards"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/mud_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/mud_controller.ex
@@ -44,8 +44,7 @@ defmodule BlockScoutWeb.API.V2.MudController do
            next_page_params_example: %{
              "world" => "0x82cb040ff4463bff3395d52b558fd77c61583b27",
              "items_count" => 50
-           },
-           title_prefix: "Worlds"
+           }
          )}
     ]
 
@@ -127,8 +126,7 @@ defmodule BlockScoutWeb.API.V2.MudController do
            next_page_params_example: %{
              "table_id" => "0x746243484553545f5641554c5400000043686573744163636573730000000000",
              "items_count" => 50
-           },
-           title_prefix: "Tables"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -257,8 +255,7 @@ defmodule BlockScoutWeb.API.V2.MudController do
                "key_bytes" => "0x73796269746c7900000000000000000043686573743332000000000000000000",
                "key0" => "0x73796269746c7900000000000000000043686573743332000000000000000000",
                "items_count" => 50
-             },
-             title_prefix: "Records"
+             }
            ),
            properties: %{
              table: Schemas.MUD.Table,

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/optimism_controller.ex
@@ -58,8 +58,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
            next_page_params_example: %{
              "id" => 394_591,
              "items_count" => 50
-           },
-           title_prefix: "Batches"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -241,8 +240,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
            next_page_params_example: %{
              "index" => 8829,
              "items_count" => 50
-           },
-           title_prefix: "OutputRoots"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -303,8 +301,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
            next_page_params_example: %{
              "index" => 12967,
              "items_count" => 50
-           },
-           title_prefix: "Games"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -371,8 +368,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
              "items_count" => 50,
              "l1_block_number" => 23_937_283,
              "transaction_hash" => "0x5dc155c382d95353c5876e735d675d284e3b29b1379e5859dc35cfd4a1dd5188"
-           },
-           title_prefix: "Deposits"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -597,8 +593,7 @@ defmodule BlockScoutWeb.API.V2.OptimismController do
            next_page_params_example: %{
              "items_count" => 50,
              "nonce" => "1766847064778384329583297500742918515827483896875618958121606201292650102"
-           },
-           title_prefix: "Withdrawals"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/scroll_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/scroll_controller.ex
@@ -81,8 +81,7 @@ defmodule BlockScoutWeb.API.V2.ScrollController do
            next_page_params_example: %{
              "items_count" => 50,
              "number" => 502_655
-           },
-           title_prefix: "Batches"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -145,8 +144,7 @@ defmodule BlockScoutWeb.API.V2.ScrollController do
            next_page_params_example: %{
              "items_count" => 50,
              "id" => 986_043
-           },
-           title_prefix: "Deposits"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]
@@ -212,8 +210,7 @@ defmodule BlockScoutWeb.API.V2.ScrollController do
            next_page_params_example: %{
              "items_count" => 50,
              "id" => 220_243
-           },
-           title_prefix: "Withdrawals"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
@@ -74,7 +74,19 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     })
   end
 
-  operation :deposits_count, false
+  # The `%Schema{type: :integer, ...}` body below is mirrored in :withdrawals_count. The shape is a
+  # one-line primitive, so the schema is inlined at each call site rather than extracted into a
+  # shared leaf module that would only be referenced twice within this controller.
+  operation :deposits_count,
+    summary: "Number of Shibarium deposits.",
+    description: "Retrieves the total count of completed Shibarium deposits.",
+    parameters: base_params(),
+    responses: [
+      ok:
+        {"Number of items in the deposits list.", "application/json",
+         %Schema{type: :integer, nullable: false, minimum: 0}},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @spec deposits_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def deposits_count(conn, _params) do
@@ -142,7 +154,19 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     })
   end
 
-  operation :withdrawals_count, false
+  # The `%Schema{type: :integer, ...}` body below is mirrored in :deposits_count. The shape is a
+  # one-line primitive, so the schema is inlined at each call site rather than extracted into a
+  # shared leaf module that would only be referenced twice within this controller.
+  operation :withdrawals_count,
+    summary: "Number of Shibarium withdrawals.",
+    description: "Retrieves the total count of completed Shibarium withdrawals.",
+    parameters: base_params(),
+    responses: [
+      ok:
+        {"Number of items in the withdrawals list.", "application/json",
+         %Schema{type: :integer, nullable: false, minimum: 0}},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @spec withdrawals_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals_count(conn, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
@@ -27,6 +27,9 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     Retrieves a paginated list of completed Shibarium deposits ordered by parent chain block number descending.
     A deposit is "completed" when both the parent-chain and Shibarium sides of the bridge have been observed.
     """,
+    # The `Enum.map` block below is mirrored in :withdrawals. The only delta is the `block_number`
+    # description, so the block is duplicated intentionally rather than hidden behind a helper for
+    # two call sites.
     parameters:
       base_params() ++
         Enum.map(
@@ -86,7 +89,39 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     |> render(:shibarium_items_count, %{count: count})
   end
 
-  operation :withdrawals, false
+  operation :withdrawals,
+    summary: "List Shibarium withdrawals.",
+    description: """
+    Retrieves a paginated list of completed Shibarium withdrawals ordered by Shibarium block number descending.
+    A withdrawal is "completed" when both the Shibarium and parent-chain sides of the bridge have been observed.
+    """,
+    # The `Enum.map` block below is mirrored in :deposits. The only delta is the `block_number`
+    # description, so the block is duplicated intentionally rather than hidden behind a helper for
+    # two call sites.
+    parameters:
+      base_params() ++
+        Enum.map(
+          define_paging_params(["items_count", "block_number"]),
+          fn
+            %OpenApiSpex.Parameter{name: :block_number} = param ->
+              %{param | description: "Shibarium block number for paging (cursor on `l2_block_number`)."}
+
+            param ->
+              param
+          end
+        ),
+    responses: [
+      ok:
+        {"List of Shibarium withdrawals.", "application/json",
+         paginated_response(
+           items: Schemas.Shibarium.Withdrawal,
+           next_page_params_example: %{
+             "items_count" => 50,
+             "block_number" => 5_000_000
+           }
+         )},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @spec withdrawals(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals(conn, params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/shibarium_controller.ex
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.API.V2.ShibariumController do
   use BlockScoutWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   import BlockScoutWeb.Chain,
     only: [
@@ -12,9 +13,44 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
   alias Explorer.Chain.Cache.Counters.Shibarium.DepositsAndWithdrawalsCount
   alias Explorer.Chain.Shibarium.Reader
 
+  plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
+
+  tags(["shibarium"])
+
   @api_true [api?: true]
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
+  operation :deposits,
+    summary: "List Shibarium deposits.",
+    description: """
+    Retrieves a paginated list of completed Shibarium deposits ordered by parent chain block number descending.
+    A deposit is "completed" when both the parent-chain and Shibarium sides of the bridge have been observed.
+    """,
+    parameters:
+      base_params() ++
+        Enum.map(
+          define_paging_params(["items_count", "block_number"]),
+          fn
+            %OpenApiSpex.Parameter{name: :block_number} = param ->
+              %{param | description: "Parent chain block number for paging (cursor on `l1_block_number`)."}
+
+            param ->
+              param
+          end
+        ),
+    responses: [
+      ok:
+        {"List of Shibarium deposits.", "application/json",
+         paginated_response(
+           items: Schemas.Shibarium.Deposit,
+           next_page_params_example: %{
+             "items_count" => 50,
+             "block_number" => 17_500_000
+           }
+         )},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @spec deposits(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def deposits(conn, params) do
@@ -35,6 +71,8 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     })
   end
 
+  operation :deposits_count, false
+
   @spec deposits_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def deposits_count(conn, _params) do
     count =
@@ -47,6 +85,8 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
     |> put_status(200)
     |> render(:shibarium_items_count, %{count: count})
   end
+
+  operation :withdrawals, false
 
   @spec withdrawals(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals(conn, params) do
@@ -66,6 +106,8 @@ defmodule BlockScoutWeb.API.V2.ShibariumController do
       next_page_params: next_page_params
     })
   end
+
+  operation :withdrawals_count, false
 
   @spec withdrawals_count(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def withdrawals_count(conn, _params) do

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
@@ -245,8 +245,7 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
            next_page_params_example: %{
              "index" => 55,
              "items_count" => 50
-           },
-           title_prefix: "Validators"
+           }
          )},
       unprocessable_entity: JsonErrorResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -344,7 +344,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     end
 
     scope "/shibarium" do
-      if @chain_type == :shibarium do
+      chain_scope :shibarium do
         get("/deposits", V2.ShibariumController, :deposits)
         get("/deposits/count", V2.ShibariumController, :deposits_count)
         get("/withdrawals", V2.ShibariumController, :withdrawals)
@@ -420,7 +420,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         end
       end
 
-      if @chain_type == :stability do
+      chain_scope :stability do
         scope "/stability" do
           get("/", V2.ValidatorController, :stability_validators_list)
           get("/counters", V2.ValidatorController, :stability_validators_counters)

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -344,7 +344,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     end
 
     scope "/shibarium" do
-      chain_scope :shibarium do
+      if @chain_type == :shibarium do
         get("/deposits", V2.ShibariumController, :deposits)
         get("/deposits/count", V2.ShibariumController, :deposits_count)
         get("/withdrawals", V2.ShibariumController, :withdrawals)
@@ -420,7 +420,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
         end
       end
 
-      chain_scope :stability do
+      if @chain_type == :stability do
         scope "/stability" do
           get("/", V2.ValidatorController, :stability_validators_list)
           get("/counters", V2.ValidatorController, :stability_validators_counters)

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
@@ -16,19 +16,20 @@ defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Deposit do
       l1_block_number: %Schema{
         type: :integer,
         minimum: 0,
-        description: "Number of the parent chain block that contains the deposit transaction."
+        description: "Parent chain block in which the deposit was initiated."
       },
       l1_transaction_hash: %Schema{
-        allOf: [General.FullHash],
+        allOf: [General.FullHashNullable],
         description: "Hash of the parent chain transaction that initiates the deposit."
       },
       l2_transaction_hash: %Schema{
-        allOf: [General.FullHash],
+        allOf: [General.FullHashNullable],
         description: "Hash of the Shibarium transaction that completes the deposit."
       },
       user: %Schema{
         allOf: [Address],
-        description: "Initiator of the deposit on the parent chain."
+        description:
+          "Address of the user that initiated the deposit on the parent chain; the same address acts as the recipient on Shibarium."
       },
       timestamp:
         Helper.extend_schema(General.TimestampNullable.schema(),

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Deposit do
   @moduledoc """
   This module defines the schema for the Shibarium Deposit struct.

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
@@ -1,0 +1,47 @@
+defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Deposit do
+  @moduledoc """
+  This module defines the schema for the Shibarium Deposit struct.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.{Address, General}
+  alias BlockScoutWeb.Schemas.Helper
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "ShibariumDeposit",
+    description: "Shibarium deposit item that bridges assets from the parent chain to Shibarium.",
+    type: :object,
+    properties: %{
+      l1_block_number: %Schema{
+        type: :integer,
+        minimum: 0,
+        description: "Number of the parent chain block that contains the deposit transaction."
+      },
+      l1_transaction_hash: %Schema{
+        allOf: [General.FullHash],
+        description: "Hash of the parent chain transaction that initiates the deposit."
+      },
+      l2_transaction_hash: %Schema{
+        allOf: [General.FullHash],
+        description: "Hash of the Shibarium transaction that completes the deposit."
+      },
+      user: %Schema{
+        allOf: [Address],
+        description: "Initiator of the deposit on the parent chain."
+      },
+      timestamp:
+        Helper.extend_schema(General.TimestampNullable.schema(),
+          description: "Timestamp of the parent chain block that contains the deposit transaction."
+        )
+    },
+    required: [
+      :l1_block_number,
+      :l1_transaction_hash,
+      :l2_transaction_hash,
+      :user,
+      :timestamp
+    ],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Withdrawal do
   @moduledoc """
   This module defines the schema for the Shibarium Withdrawal struct.

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
@@ -1,0 +1,48 @@
+defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Withdrawal do
+  @moduledoc """
+  This module defines the schema for the Shibarium Withdrawal struct.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.{Address, General}
+  alias BlockScoutWeb.Schemas.Helper
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "ShibariumWithdrawal",
+    description: "Shibarium withdrawal item that bridges assets from Shibarium to the parent chain.",
+    type: :object,
+    properties: %{
+      l2_block_number: %Schema{
+        type: :integer,
+        minimum: 0,
+        description: "Shibarium block in which the withdrawal was initiated."
+      },
+      l2_transaction_hash: %Schema{
+        allOf: [General.FullHashNullable],
+        description: "Hash of the Shibarium transaction that initiates the withdrawal."
+      },
+      l1_transaction_hash: %Schema{
+        allOf: [General.FullHashNullable],
+        description: "Hash of the parent chain transaction that completes the withdrawal."
+      },
+      user: %Schema{
+        allOf: [Address],
+        description:
+          "Address of the user that initiated the withdrawal on Shibarium; the same address acts as the recipient on the parent chain."
+      },
+      timestamp:
+        Helper.extend_schema(General.TimestampNullable.schema(),
+          description: "Timestamp of the Shibarium block that contains the withdrawal transaction."
+        )
+    },
+    required: [
+      :l2_block_number,
+      :l2_transaction_hash,
+      :l1_transaction_hash,
+      :user,
+      :timestamp
+    ],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/specs/public.ex
+++ b/apps/block_scout_web/lib/block_scout_web/specs/public.ex
@@ -54,7 +54,7 @@ defmodule BlockScoutWeb.Specs.Public do
         end
       end
 
-    {chain_type, nil} when chain_type in [:arbitrum, :scroll, :stability, :zilliqa] ->
+    {chain_type, nil} when chain_type in [:arbitrum, :scroll, :shibarium, :stability, :zilliqa] ->
       @chain_type_category_tags [%Tag{name: to_string(chain_type)}]
       defp chain_type_category_tags, do: @chain_type_category_tags
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/shibarium_view.ex
@@ -20,7 +20,7 @@ defmodule BlockScoutWeb.API.V2.ShibariumView do
             "l1_block_number" => deposit.l1_block_number,
             "l1_transaction_hash" => deposit.l1_transaction_hash,
             "l2_transaction_hash" => deposit.l2_transaction_hash,
-            "user" => Map.get(user_addresses, deposit.user, deposit.user),
+            "user" => resolve_user(user_addresses, deposit.user, conn),
             "timestamp" => deposit.timestamp
           }
         end),
@@ -42,7 +42,7 @@ defmodule BlockScoutWeb.API.V2.ShibariumView do
             "l2_block_number" => withdrawal.l2_block_number,
             "l2_transaction_hash" => withdrawal.l2_transaction_hash,
             "l1_transaction_hash" => withdrawal.l1_transaction_hash,
-            "user" => Map.get(user_addresses, withdrawal.user, withdrawal.user),
+            "user" => resolve_user(user_addresses, withdrawal.user, conn),
             "timestamp" => withdrawal.timestamp
           }
         end),
@@ -52,6 +52,12 @@ defmodule BlockScoutWeb.API.V2.ShibariumView do
 
   def render("shibarium_items_count.json", %{count: count}) do
     count
+  end
+
+  defp resolve_user(user_addresses, user_hash, conn) do
+    Map.get_lazy(user_addresses, user_hash, fn ->
+      Helper.address_with_info(conn, nil, user_hash, true)
+    end)
   end
 
   defp get_user_addresses(items, conn) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
@@ -54,6 +54,84 @@ defmodule BlockScoutWeb.API.V2.ShibariumControllerTest do
       end
     end
 
+    describe "/api/v2/shibarium/withdrawals" do
+      test "returns empty list when no withdrawals exist", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/withdrawals")
+        assert response = json_response(request, 200)
+
+        assert response["items"] == []
+        assert response["next_page_params"] == nil
+      end
+
+      test "returns withdrawals with next_page_params and paginates", %{conn: conn} do
+        withdrawals = insert_list(51, :address) |> Enum.map(&insert_shibarium_withdrawal(&1.hash))
+
+        request = get(conn, "/api/v2/shibarium/withdrawals")
+        assert response = json_response(request, 200)
+
+        assert Enum.count(response["items"]) == 50
+        assert response["next_page_params"] != nil
+        assert response["next_page_params"]["block_number"] != nil
+        assert response["next_page_params"]["items_count"] == 50
+
+        compare_withdrawal(Enum.at(withdrawals, 50), Enum.at(response["items"], 0))
+        compare_withdrawal(Enum.at(withdrawals, 1), Enum.at(response["items"], 49))
+
+        request_2nd_page = get(conn, "/api/v2/shibarium/withdrawals", response["next_page_params"])
+        assert response_2nd_page = json_response(request_2nd_page, 200)
+        assert Enum.count(response_2nd_page["items"]) == 1
+        assert response_2nd_page["next_page_params"] == nil
+
+        compare_withdrawal(Enum.at(withdrawals, 0), Enum.at(response_2nd_page["items"], 0))
+      end
+
+      test "renders user as Address even when no address row exists", %{conn: conn} do
+        orphan_hash = address_hash()
+        insert_shibarium_withdrawal(orphan_hash)
+
+        request = get(conn, "/api/v2/shibarium/withdrawals")
+        assert response = json_response(request, 200)
+
+        [item] = response["items"]
+        assert is_map(item["user"])
+        assert String.downcase(item["user"]["hash"]) == String.downcase(to_string(orphan_hash))
+      end
+
+      test "rejects malformed block_number with 422", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/withdrawals", %{"block_number" => "not-a-number"})
+        assert json_response(request, 422)
+      end
+    end
+
+    defp insert_shibarium_withdrawal(user_hash) do
+      l2_block_number = block_number()
+
+      {:ok, bridge} =
+        %Bridge{}
+        |> Bridge.changeset(%{
+          user: user_hash,
+          operation_hash: transaction_hash(),
+          operation_type: :withdrawal,
+          token_type: :bone,
+          l1_transaction_hash: transaction_hash(),
+          l1_block_number: block_number(),
+          l2_transaction_hash: transaction_hash(),
+          l2_block_number: l2_block_number,
+          timestamp: DateTime.utc_now()
+        })
+        |> Explorer.Repo.insert()
+
+      bridge
+    end
+
+    defp compare_withdrawal(%Bridge{} = item, json) do
+      assert item.l2_block_number == json["l2_block_number"]
+      assert to_string(item.l2_transaction_hash) == json["l2_transaction_hash"]
+      assert to_string(item.l1_transaction_hash) == json["l1_transaction_hash"]
+      assert to_string(item.user) == json["user"]["hash"] |> String.downcase()
+      assert DateTime.to_iso8601(item.timestamp) == json["timestamp"]
+    end
+
     defp insert_shibarium_deposit(user_hash) do
       l1_block_number = block_number()
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
@@ -54,6 +54,26 @@ defmodule BlockScoutWeb.API.V2.ShibariumControllerTest do
       end
     end
 
+    describe "/api/v2/shibarium/deposits/count" do
+      test "returns 0 when no deposits exist", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/deposits/count")
+        assert json_response(request, 200) == 0
+      end
+
+      test "returns deposits count", %{conn: conn} do
+        insert_list(3, :address) |> Enum.each(&insert_shibarium_deposit(&1.hash))
+
+        request = get(conn, "/api/v2/shibarium/deposits/count")
+        assert response = json_response(request, 200)
+        assert is_integer(response) and response >= 0
+      end
+
+      test "rejects unexpected query parameter with 422", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/deposits/count", %{"unknown" => "x"})
+        assert json_response(request, 422)
+      end
+    end
+
     describe "/api/v2/shibarium/withdrawals" do
       test "returns empty list when no withdrawals exist", %{conn: conn} do
         request = get(conn, "/api/v2/shibarium/withdrawals")
@@ -99,6 +119,26 @@ defmodule BlockScoutWeb.API.V2.ShibariumControllerTest do
 
       test "rejects malformed block_number with 422", %{conn: conn} do
         request = get(conn, "/api/v2/shibarium/withdrawals", %{"block_number" => "not-a-number"})
+        assert json_response(request, 422)
+      end
+    end
+
+    describe "/api/v2/shibarium/withdrawals/count" do
+      test "returns 0 when no withdrawals exist", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/withdrawals/count")
+        assert json_response(request, 200) == 0
+      end
+
+      test "returns withdrawals count", %{conn: conn} do
+        insert_list(3, :address) |> Enum.each(&insert_shibarium_withdrawal(&1.hash))
+
+        request = get(conn, "/api/v2/shibarium/withdrawals/count")
+        assert response = json_response(request, 200)
+        assert is_integer(response) and response >= 0
+      end
+
+      test "rejects unexpected query parameter with 422", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/withdrawals/count", %{"unknown" => "x"})
         assert json_response(request, 422)
       end
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.API.V2.ShibariumControllerTest do
   use BlockScoutWeb.ConnCase
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/shibarium_controller_test.exs
@@ -1,0 +1,86 @@
+defmodule BlockScoutWeb.API.V2.ShibariumControllerTest do
+  use BlockScoutWeb.ConnCase
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+
+  alias Explorer.Chain.Shibarium.Bridge
+
+  if @chain_type == :shibarium do
+    describe "/api/v2/shibarium/deposits" do
+      test "returns empty list when no deposits exist", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/deposits")
+        assert response = json_response(request, 200)
+
+        assert response["items"] == []
+        assert response["next_page_params"] == nil
+      end
+
+      test "returns deposits with next_page_params and paginates", %{conn: conn} do
+        deposits = insert_list(51, :address) |> Enum.map(&insert_shibarium_deposit(&1.hash))
+
+        request = get(conn, "/api/v2/shibarium/deposits")
+        assert response = json_response(request, 200)
+
+        assert Enum.count(response["items"]) == 50
+        assert response["next_page_params"] != nil
+        assert response["next_page_params"]["block_number"] != nil
+        assert response["next_page_params"]["items_count"] == 50
+
+        compare_deposit(Enum.at(deposits, 50), Enum.at(response["items"], 0))
+        compare_deposit(Enum.at(deposits, 1), Enum.at(response["items"], 49))
+
+        request_2nd_page = get(conn, "/api/v2/shibarium/deposits", response["next_page_params"])
+        assert response_2nd_page = json_response(request_2nd_page, 200)
+        assert Enum.count(response_2nd_page["items"]) == 1
+        assert response_2nd_page["next_page_params"] == nil
+
+        compare_deposit(Enum.at(deposits, 0), Enum.at(response_2nd_page["items"], 0))
+      end
+
+      test "renders user as Address even when no address row exists", %{conn: conn} do
+        orphan_hash = address_hash()
+        insert_shibarium_deposit(orphan_hash)
+
+        request = get(conn, "/api/v2/shibarium/deposits")
+        assert response = json_response(request, 200)
+
+        [item] = response["items"]
+        assert is_map(item["user"])
+        assert String.downcase(item["user"]["hash"]) == String.downcase(to_string(orphan_hash))
+      end
+
+      test "rejects malformed block_number with 422", %{conn: conn} do
+        request = get(conn, "/api/v2/shibarium/deposits", %{"block_number" => "not-a-number"})
+        assert json_response(request, 422)
+      end
+    end
+
+    defp insert_shibarium_deposit(user_hash) do
+      l1_block_number = block_number()
+
+      {:ok, bridge} =
+        %Bridge{}
+        |> Bridge.changeset(%{
+          user: user_hash,
+          operation_hash: transaction_hash(),
+          operation_type: :deposit,
+          token_type: :bone,
+          l1_transaction_hash: transaction_hash(),
+          l1_block_number: l1_block_number,
+          l2_transaction_hash: transaction_hash(),
+          l2_block_number: block_number(),
+          timestamp: DateTime.utc_now()
+        })
+        |> Explorer.Repo.insert()
+
+      bridge
+    end
+
+    defp compare_deposit(%Bridge{} = item, json) do
+      assert item.l1_block_number == json["l1_block_number"]
+      assert to_string(item.l1_transaction_hash) == json["l1_transaction_hash"]
+      assert to_string(item.l2_transaction_hash) == json["l2_transaction_hash"]
+      assert to_string(item.user) == json["user"]["hash"] |> String.downcase()
+      assert DateTime.to_iso8601(item.timestamp) == json["timestamp"]
+    end
+  end
+end


### PR DESCRIPTION
Closes #14322

## Summary

Adds OpenAPI declarations for `GET /api/v2/shibarium/deposits`, `GET /api/v2/shibarium/deposits/count`, `GET /api/v2/shibarium/withdrawals`, and `GET /api/v2/shibarium/withdrawals/count` (controller, view, schemas, test coverage, and tag registration).

While preparing the spec, two pre-existing issues surfaced and were fixed:

- **Shibarium deposits pagination was broken on page 2.** `paging_params/1` in `BlockScoutWeb.Chain` was matching the Shibarium reader map against the Optimism Deposits clause, producing a 2-tuple cursor that `Explorer.Chain.Shibarium.Reader.page_deposits/2` could not handle. Fixed by adding Shibarium-specific clauses (keyed on `:user`) ahead of the Optimism ones, so the cursor is just `block_number` again.
- **`title_prefix:` was dead code at every `paginated_response/1` call site.** `General.paginated_response/1` reads only `:items` and `:next_page_params_example` (via `Keyword.fetch!`), so the keyword had no effect on spec output — it signalled an unrealized "named wrapper component" intent that risked spreading. Stripped from all 14 call sites across the Celo, MUD, Optimism, Scroll, Shibarium, and Validator controllers.

Also, the view path that rendered the `user` field for Shibarium deposits and withdrawals could fall back to a raw `Hash.Address` struct when `hashes_to_addresses/2` returned no entry, which would violate the response schema. `ShibariumView` now routes every user hash through `Helper.address_with_info/5` so the response shape is uniform regardless of whether an `Address` row exists; a regression test covers the orphan case.

Schema notes:
- `l1_transaction_hash` / `l2_transaction_hash` are declared as `FullHashNullable` on both the Deposit and Withdrawal schemas — the reader's `WHERE` clause only requires the L1/L2 block numbers to be present, but the transaction-hash columns are in `Bridge`'s `@optional_attrs` and can be `nil` in a "completed" row.
- The two `*/count` endpoints render a bare JSON integer (e.g., `42`), not an object. Their 200 response is declared inline as `%Schema{type: :integer, minimum: 0, nullable: false}` rather than extracted into a leaf schema, since the shape is a one-line primitive used by only two call sites in this controller. `unprocessable_entity` is declared because `CastAndValidate` rejects any unknown query parameter with 422 even though `base_params()` itself (optional `apikey` / `key` strings) cannot fail validation; this branch is covered by a dedicated test on each endpoint.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Shibarium API endpoints for deposits and withdrawals with OpenAPI specs and new request/response schemas.

* **Documentation**
  * Improved and standardized OpenAPI examples and paginated response docs across Shibarium, Optimism, Scroll, Celo, MUD, and Zilliqa; updated pagination examples.

* **Refactor**
  * Shibarium responses now lazily resolve user address info; pagination parameter handling for Shibarium was adjusted.

* **Tests**
  * Added Shibarium API tests covering pagination, counts, user representation, and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14338)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->