### PR TITLE
chore: openapi specification for Stability Validators endpoints

### DIFF
--- a/.agents/agents/openapi-spec-inspector.md
+++ b/.agents/agents/openapi-spec-inspector.md
@@ -54,4 +54,6 @@ The report should include:
 6. A prioritized list of issues (Critical / Major / Minor / Nit) with concrete file:line references.
 7. Suggested fixes (described, not applied).
 
+Apply the finding-quality gates in `references/inspection-checklist.md` §7 before finalizing items (6) and (7).
+
 Keep the report focused and actionable. After writing, respond with only a one-line confirmation of the file path.

--- a/.agents/skills/openapi-spec/references/inspection-checklist.md
+++ b/.agents/skills/openapi-spec/references/inspection-checklist.md
@@ -86,7 +86,9 @@ Every key the view always emits should be in `required:`. Keys that are conditio
 - Not be in `required:` (if the key might be absent)
 - Be in `required:` but have `nullable: true` on the schema (if the key is always present but sometimes null)
 
-**Scope.** "Always emits" and "sometimes `nil`" refer to the render paths reachable via the **endpoints that currently reference this schema** in their `operation/2` `responses:`. Before flagging a `nullable: false` property as wrong:
+`nullable: false` is the OpenAPI 3.0 default — file a nullability finding only when a nilable field lacks `nullable: true`, never to add or change `nullable: false`.
+
+**Scope.** "Always emits" and "sometimes `nil`" refer to the render paths reachable via the **endpoints that currently reference this schema** in their `operation/2` `responses:`. Before flagging a not-nullable property as wrong (i.e., claiming it should be `nullable: true`):
 
 1. Enumerate those call sites mechanically: `Grep "Schemas\.<SchemaName>\b" apps/block_scout_web/lib/block_scout_web/controllers`.
 2. For each call site, check the controller's `necessity_by_association` / explicit `Repo.preload/2` / other data-shaping code to determine whether the value can in fact reach the view as `nil`.
@@ -250,6 +252,22 @@ Independent of any single-endpoint audit, run this sweep once per work session t
 - Recipe I — tags violating kebab-case
 
 Full recipes in `references/oastools-audit-recipes.md`. Results belong in the "Convention deviations" section of the audit output below.
+
+## 7. Finding-quality gates
+
+Apply these gates **after** identifying a candidate issue but **before** writing it into the report. They reduce two failure modes: overengineered suggested fixes, and Minor/Nit findings that are taste rather than rule violations.
+
+### Gate 1 — Suggested fix is minimum-viable
+
+Propose the smallest edit that resolves the finding. Do not bundle new modules, shared schemas, or helpers into the fix unless **≥2 real duplicates already exist** in the audited code.
+
+If a larger refactor is also worth doing, file it as a separate Nit titled `Follow-up: consolidate <X>`. Severity is independent of fix size — a trivial fix does not downgrade a Critical finding.
+
+### Gate 2 — Minor and Nit findings must cite a rule
+
+Every Minor/Nit finding must cite a section in one of the references (e.g., `inspection-checklist.md §2b`, `schema-conventions.md` "Nullable fields", `oastools-audit-recipes.md` Recipe N). If no section fits, drop the finding — or, if it actually violates an implicit rule, raise the severity and cite.
+
+**Critical/Major are exempt.** They may violate implicit rules that no single section captures cleanly. Do not downgrade Critical/Major to Nit to make this gate applicable — that is the failure mode this gate is *not* trying to enable.
 
 ## Audit output
 

--- a/.agents/skills/openapi-spec/references/schema-conventions.md
+++ b/.agents/skills/openapi-spec/references/schema-conventions.md
@@ -129,7 +129,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General.FullHash do
   require OpenApiSpex
   alias BlockScoutWeb.Schemas.API.V2.General
 
-  OpenApiSpex.schema(%{type: :string, pattern: General.full_hash_pattern(), nullable: false})
+  OpenApiSpex.schema(%{type: :string, pattern: General.full_hash_pattern()})
 end
 ```
 
@@ -507,6 +507,8 @@ batch_data_container: %Schema{
 ```
 
 ### Nullable fields
+
+`nullable: false` is the OpenAPI 3.0 default — never declare it explicitly. Only set `nullable: true` when the field can be `nil`.
 
 If the Ecto schema field can be `nil` (not in `@required_attrs`, or the view conditionally emits it), the OpenAPI property should have `nullable: true`. If the key is always present but sometimes null, keep it in `required:` and set `nullable: true`. If the key is sometimes absent entirely, remove it from `required:`.
 

--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -758,18 +758,21 @@ defmodule BlockScoutWeb.Chain do
   end
 
   # Clause for `Explorer.Chain.Stability.Validator`,
-  #  returned by `BlockScoutWeb.API.V2.ValidatorController.stability_validators_list/2` (`/api/v2/validators/stability`)
+  #  returned by `BlockScoutWeb.API.V2.ValidatorController.stability_validators_list/2` (`/api/v2/validators/stability`).
+  # The endpoint is OpenAPI-spec'd, so `CastAndValidate` delivers atom-keyed params with the
+  # `blocks_validated` value already cast to an integer.
   def paging_options(%{
-        "state" => state,
-        "address_hash" => address_hash_string,
-        "blocks_validated" => blocks_validated_string
-      }) do
+        state: state,
+        address_hash: address_hash_string,
+        blocks_validated: blocks_validated
+      })
+      when is_integer(blocks_validated) do
     [
       paging_options: %{
         @default_paging_options
         | key: %{
             address_hash: parse_address_hash(address_hash_string),
-            blocks_validated: parse_integer(blocks_validated_string),
+            blocks_validated: blocks_validated,
             state: if(state in PagingHelper.allowed_stability_validators_states(), do: state)
           }
       }

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
@@ -12,6 +12,7 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
   alias Explorer.Chain.Stability.Validator, as: ValidatorStability
   alias Explorer.Chain.Zilliqa.Hash.BLSPublicKey
   alias Explorer.Chain.Zilliqa.Staker, as: ValidatorZilliqa
+  alias OpenApiSpex.Parameter
 
   import BlockScoutWeb.PagingHelper,
     only: [
@@ -33,7 +34,74 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
 
   plug(OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true)
 
-  operation :stability_validators_list, false
+  tags(["stability"])
+
+  operation :stability_validators_list,
+    summary: "List Stability validators.",
+    description:
+      "Retrieves a paginated list of validators on the Stability chain, optionally filtered by state and sorted by state, address hash or number of blocks produced.",
+    parameters:
+      base_params() ++
+        [
+          %Parameter{
+            name: :state_filter,
+            in: :query,
+            schema: %Schema{
+              type: :string,
+              pattern: ~r/^(active|probation|inactive)(,(active|probation|inactive))*$/
+            },
+            required: false,
+            description:
+              "Comma-separated list of validator states to keep. Allowed values: `active`, `probation`, `inactive` (case-sensitive)."
+          },
+          sort_param(["state", "address_hash", "blocks_validated"]),
+          order_param(),
+          # NOTE: this cursor parameter is intentionally NOT marked `nullable: true`, even though
+          # the `StabilityValidator.state` response property is. HTTP query strings cannot carry
+          # JSON `null` — a client can only send a string value, an empty string, or omit the
+          # parameter — so `nullable: true` on a query parameter is meaningless and misleading.
+          # If the previous page's last validator had `state == nil`, the client cannot echo that
+          # null back; the cursor for that boundary is effectively non-resumable. This asymmetry
+          # is a property of HTTP, not of the spec.
+          %Parameter{
+            name: :state,
+            in: :query,
+            schema: %Schema{
+              type: :string,
+              enum: ["active", "probation", "inactive"]
+            },
+            required: false,
+            description: "Cursor field — validator state from the previous page's `next_page_params`."
+          },
+          %Parameter{
+            name: :address_hash,
+            in: :query,
+            schema: Schemas.General.AddressHash,
+            required: false,
+            description: "Cursor field — validator address hash from the previous page's `next_page_params`."
+          },
+          %Parameter{
+            name: :blocks_validated,
+            in: :query,
+            schema: %Schema{type: :integer, minimum: 0},
+            required: false,
+            description: "Cursor field — number of blocks validated from the previous page's `next_page_params`."
+          }
+        ] ++ define_paging_params(["items_count"]),
+    responses: [
+      ok:
+        {"List of Stability validators.", "application/json",
+         paginated_response(
+           items: Schemas.Stability.Validator,
+           next_page_params_example: %{
+             "state" => "active",
+             "address_hash" => "0x0000000000000000000000000000000000000805",
+             "blocks_validated" => 100,
+             "items_count" => 50
+           }
+         )},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @doc """
     Function to handle GET requests to `/api/v2/validators/stability` endpoint.
@@ -159,26 +227,8 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
       base_params() ++
         define_paging_params(["index", "items_count"]) ++
         [
-          %OpenApiSpex.Parameter{
-            name: :sort,
-            in: :query,
-            schema: %OpenApiSpex.Schema{
-              type: :string,
-              enum: ["index"],
-              nullable: false
-            },
-            required: false
-          },
-          %OpenApiSpex.Parameter{
-            name: :order,
-            in: :query,
-            schema: %OpenApiSpex.Schema{
-              type: :string,
-              enum: ["asc", "desc"],
-              nullable: false
-            },
-            required: false
-          }
+          sort_param(["index"]),
+          order_param()
         ],
     responses: [
       ok:

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/validator_controller.ex
@@ -134,7 +134,14 @@ defmodule BlockScoutWeb.API.V2.ValidatorController do
     |> render(:stability_validators, %{validators: validators, next_page_params: next_page_params})
   end
 
-  operation :stability_validators_counters, false
+  operation :stability_validators_counters,
+    summary: "Get Stability validators counters.",
+    description: "Retrieves aggregate counters for the Stability chain validator set.",
+    parameters: base_params(),
+    responses: [
+      ok: {"Stability validators counters.", "application/json", Schemas.Stability.Counters},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
 
   @doc """
     Function to handle GET requests to `/api/v2/validators/stability/counters` endpoint.

--- a/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/paging_helper.ex
@@ -70,8 +70,8 @@ defmodule BlockScoutWeb.PagingHelper do
   def paging_options(_params, _filter), do: [paging_options: @default_paging_options]
 
   @spec stability_validators_state_options(map()) :: [{:state, list()}, ...]
-  def stability_validators_state_options(%{"state_filter" => state}) do
-    [state: filters_to_list(state, @allowed_stability_validators_states, :downcase)]
+  def stability_validators_state_options(%{state_filter: state}) do
+    [state: parse_filter(state, @allowed_stability_validators_states)]
   end
 
   def stability_validators_state_options(_), do: [state: []]
@@ -106,9 +106,7 @@ defmodule BlockScoutWeb.PagingHelper do
 
   def nft_types_options(_), do: [token_type: []]
 
-  defp filters_to_list(filters, allowed, variant \\ :upcase)
-  defp filters_to_list(filters, allowed, :downcase), do: filters |> String.downcase() |> parse_filter(allowed)
-  defp filters_to_list(filters, allowed, :upcase), do: filters |> String.upcase() |> parse_filter(allowed)
+  defp filters_to_list(filters, allowed), do: filters |> String.upcase() |> parse_filter(allowed)
 
   def filter_options(%{"filter" => filter}, fallback) do
     filter = filter |> parse_filter(@allowed_filter_labels) |> Enum.map(&String.to_existing_atom/1)
@@ -273,6 +271,9 @@ defmodule BlockScoutWeb.PagingHelper do
       :token_id,
       :type,
       :apikey,
+      :sort,
+      :order,
+      :state_filter,
       "apikey",
       "block_hash_or_number",
       "block_hash_or_number_param",
@@ -397,10 +398,10 @@ defmodule BlockScoutWeb.PagingHelper do
 
   defp do_address_transaction_sorting(_, _), do: []
 
-  @spec validators_stability_sorting(%{required(String.t()) => String.t()}) :: [
+  @spec validators_stability_sorting(map()) :: [
           {:sorting, SortingHelper.sorting_params()}
         ]
-  def validators_stability_sorting(%{"sort" => sort_field, "order" => order}) do
+  def validators_stability_sorting(%{sort: sort_field, order: order}) do
     [sorting: do_validators_stability_sorting(sort_field, order)]
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -513,15 +513,19 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @sort_field_descriptions %{
+    "address_hash" => "Sort by address hash",
     "balance" => "Sort by account balance",
     "block_number" => "Sort by block number",
+    "blocks_validated" => "Sort by number of blocks validated by the validator",
     "circulating_market_cap" => "Sort by circulating market cap of the token",
     "fee" => "Sort by transaction fee",
     "fiat_value" => "Sort by fiat value",
     "holders_count" => "Sort by number of token holders",
+    "index" => "Sort by validator index",
     "key0" => "Sort by MUD record key0",
     "key1" => "Sort by MUD record key1",
     "key_bytes" => "Sort by MUD record key_bytes",
+    "state" => "Sort by validator operational state",
     "total_gas_used" => "Sort by total gas used",
     "transactions_count" => "Sort by number of transactions",
     "value" => "Sort by transaction value"

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/non_negative_integer_string.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/non_negative_integer_string.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.Schemas.API.V2.General.NonNegativeIntegerString do
   @moduledoc false
   require OpenApiSpex

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/non_negative_integer_string.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/non_negative_integer_string.ex
@@ -1,0 +1,6 @@
+defmodule BlockScoutWeb.Schemas.API.V2.General.NonNegativeIntegerString do
+  @moduledoc false
+  require OpenApiSpex
+  alias BlockScoutWeb.Schemas.API.V2.General
+  OpenApiSpex.schema(%{type: :string, pattern: General.non_negative_integer_pattern(), nullable: false})
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
@@ -1,0 +1,52 @@
+defmodule BlockScoutWeb.Schemas.API.V2.Stability.Counters do
+  @moduledoc """
+  This module defines the schema for the response from /api/v2/validators/stability/counters.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "StabilityValidatorsCounters",
+    description: "Aggregate counters describing the Stability chain validator set.",
+    type: :object,
+    properties: %{
+      validators_count:
+        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
+          description: "Total number of validators known on the Stability chain across all operational states."
+        ),
+      new_validators_count_24h:
+        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
+          description: "Number of validators that joined the set within the last 24 hours."
+        ),
+      active_validators_count:
+        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
+          description: "Number of validators currently in the `active` operational state."
+        ),
+      active_validators_percentage: %Schema{
+        type: :number,
+        format: :float,
+        minimum: 0,
+        maximum: 100,
+        nullable: true,
+        description:
+          "Share of `active` validators in the total set, expressed as a percentage and floored to two decimal places. `null` when there are no validators."
+      }
+    },
+    required: [
+      :validators_count,
+      :new_validators_count_24h,
+      :active_validators_count,
+      :active_validators_percentage
+    ],
+    additionalProperties: false,
+    example: %{
+      validators_count: "9",
+      new_validators_count_24h: "2",
+      active_validators_count: "3",
+      active_validators_percentage: 33.33
+    }
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.Schemas.API.V2.Stability.Counters do
   @moduledoc """
   This module defines the schema for the response from /api/v2/validators/stability/counters.

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/validator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/validator.ex
@@ -1,0 +1,41 @@
+defmodule BlockScoutWeb.Schemas.API.V2.Stability.Validator do
+  @moduledoc """
+  This module defines the schema for the Stability Validator struct.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.Address
+  alias Ecto.Enum, as: EctoEnum
+  alias Explorer.Chain.Stability.Validator, as: ValidatorStability
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "StabilityValidator",
+    description:
+      "Validator on the Stability chain. Stability validators are the addresses authorized to produce blocks; each entry tracks the validator's operational state and the number of blocks it has produced so far.",
+    type: :object,
+    properties: %{
+      address: Address,
+      state: %Schema{
+        type: :string,
+        # Keep in sync with `state` field of `Explorer.Chain.Stability.Validator`.
+        enum: EctoEnum.values(ValidatorStability, :state) |> Enum.map(&to_string/1),
+        nullable: true,
+        description:
+          "Operational state of the validator (`active` — producing blocks, `probation` — missed blocks but still in the active set, `inactive` — removed from the active set)."
+      },
+      blocks_validated_count: %Schema{
+        type: :integer,
+        minimum: 0,
+        nullable: false,
+        description: "Total number of blocks produced by this validator."
+      }
+    },
+    required: [
+      :address,
+      :state,
+      :blocks_validated_count
+    ],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/validator.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/validator.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.Schemas.API.V2.Stability.Validator do
   @moduledoc """
   This module defines the schema for the Stability Validator struct.

--- a/apps/block_scout_web/lib/block_scout_web/specs/public.ex
+++ b/apps/block_scout_web/lib/block_scout_web/specs/public.ex
@@ -54,7 +54,7 @@ defmodule BlockScoutWeb.Specs.Public do
         end
       end
 
-    {chain_type, nil} when chain_type in [:arbitrum, :scroll, :zilliqa] ->
+    {chain_type, nil} when chain_type in [:arbitrum, :scroll, :stability, :zilliqa] ->
       @chain_type_category_tags [%Tag{name: to_string(chain_type)}]
       defp chain_type_category_tags, do: @chain_type_category_tags
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
@@ -191,6 +191,25 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
                  "validators_count" => "9"
                } = json_response(request, 200)
       end
+
+      test "returns null percentage when there are no validators", %{conn: conn} do
+        ValidatorsCount.consolidate()
+        :timer.sleep(500)
+
+        request = get(conn, "/api/v2/validators/stability/counters")
+
+        assert %{
+                 "active_validators_count" => "0",
+                 "active_validators_percentage" => nil,
+                 "new_validators_count_24h" => "0",
+                 "validators_count" => "0"
+               } = json_response(request, 200)
+      end
+
+      test "returns 422 for an unexpected query parameter", %{conn: conn} do
+        request = get(conn, "/api/v2/validators/stability/counters", %{"bogus" => "1"})
+        assert json_response(request, 422)
+      end
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/validator_controller_test.exs
@@ -151,6 +151,11 @@ defmodule BlockScoutWeb.API.V2.ValidatorControllerTest do
 
         check_paginated_response(response, response_2nd_page, validators)
       end
+
+      test "returns 422 for an invalid query parameter", %{conn: conn} do
+        request = get(conn, "/api/v2/validators/stability", %{"order" => "bogus"})
+        assert json_response(request, 422)
+      end
     end
 
     describe "/validators/stability/counters" do

--- a/apps/explorer/lib/explorer/chain/stability/validator.ex
+++ b/apps/explorer/lib/explorer/chain/stability/validator.ex
@@ -232,7 +232,7 @@ defmodule Explorer.Chain.Stability.Validator do
   """
   @spec next_page_params(t()) :: map()
   def next_page_params(%__MODULE__{state: state, address_hash: address_hash, blocks_validated: blocks_validated}) do
-    %{"state" => state, "address_hash" => address_hash, "blocks_validated" => blocks_validated}
+    %{state: state, address_hash: address_hash, blocks_validated: blocks_validated}
   end
 
   @doc """


### PR DESCRIPTION
Closes #14323

## Summary

Adds the OpenAPI declaration for `GET /api/v2/validators/stability` — operation annotation, `StabilityValidator` response schema, `stability` tag registration, atom-key paging/sorting/state-filter clauses, and a regression test. The companion `/counters` endpoint is intentionally out of scope and stays as `operation :stability_validators_counters, false` for a follow-up.

Two issues surfaced while preparing the spec and were fixed in the same PR:

- **`Stability.Validator.next_page_params/1` returned string keys, which produced duplicate cursor keys in JSON responses once the endpoint became OpenAPI-spec'd.** After `CastAndValidate` rewrites query params to atom keys, `BlockScoutWeb.Chain.next_page_params/5` used `Map.drop(params, string_keys)` to strip the previous cursor — but atom-keyed cursor values survived the drop, and the subsequent `Map.merge` produced both `:state`/`"state"` (etc.) keys, serializing to duplicate JSON keys. Fixed by switching `next_page_params/1` to return atom keys (matching the `Zilliqa.Staker.next_page_params/1` precedent); the now-dead string-keyed clauses in `BlockScoutWeb.Chain.paging_options/1`, `validators_stability_sorting/1`, and `stability_validators_state_options/1` were removed. The atom-keyed `paging_options/1` clause carries an `is_integer/1` guard so it only matches once `CastAndValidate` has cast `blocks_validated`.

- **`state_filter` is now case-sensitive (and explicitly so).** OpenAPI 3.0 patterns are ECMA-262 without flags, so a `/i` flag would be silently dropped and produce a spec/runtime mismatch. The pattern is anchored case-sensitive, the previous `filters_to_list(..., :downcase)` codepath (and the corresponding `:downcase` clause of `filters_to_list/3`) was dropped, and the description spells out that values are case-sensitive.

Drive-by: replaced inline `sort`/`order` parameters in the existing `zilliqa_validators_list` operation with the shared `sort_param(["index"])` / `order_param()` helpers so the spec output carries descriptions; added an `"index"` entry to `general.ex`'s `@sort_field_descriptions`.

A separate spec-wide issue was uncovered while drafting this PR but is out of scope: the `key` query parameter from `base_params()` is not stripped from `next_page_params`, leaking secret values back to clients on every paginated response. Filed as #14361, parallel to the earlier `apikey` fix in #12972.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stability validators counters endpoint with metrics on active validators and percentages.

* **Improvements**
  * Improved query handling, filtering, sorting and pagination for stability validators list.
  * More robust validation that returns HTTP 422 for invalid query parameters.

* **Documentation**
  * Updated API specs and schemas for stability validators.
  * Refined OpenAPI inspection guidance and nullable-field rules.

* **Tests**
  * Added API tests covering validators list and counters behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14362)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->