### PR TITLE
fix: Fix compilation warning in OP chain types

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -26,8 +26,8 @@ defmodule EthereumJSONRPC.Receipt do
                              l1_fee_scalar: non_neg_integer(),
                              l1_gas_price: non_neg_integer(),
                              l1_gas_used: non_neg_integer(),
-                             operator_fee_scalar: non_neg_integer(),
-                             operator_fee_constant: non_neg_integer(),
+                             operator_fee_scalar: non_neg_integer() | nil,
+                             operator_fee_constant: non_neg_integer() | nil,
                              da_footprint_gas_scalar: non_neg_integer() | nil
                            ]
                          )
@@ -132,8 +132,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: 0,\
-          operator_fee_constant: 0,\
+          operator_fee_scalar: nil,\
+          operator_fee_constant: nil,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """
@@ -187,8 +187,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: 0,\
-          operator_fee_constant: 0,\
+          operator_fee_scalar: nil,\
+          operator_fee_constant: nil,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -132,8 +132,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: nil,\
-          operator_fee_constant: nil,\
+          operator_fee_scalar: 0,\
+          operator_fee_constant: 0,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """
@@ -187,8 +187,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: nil,\
-          operator_fee_constant: nil,\
+          operator_fee_scalar: 0,\
+          operator_fee_constant: 0,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -26,8 +26,8 @@ defmodule EthereumJSONRPC.Receipt do
                              l1_fee_scalar: non_neg_integer(),
                              l1_gas_price: non_neg_integer(),
                              l1_gas_used: non_neg_integer(),
-                             operator_fee_scalar: non_neg_integer() | nil,
-                             operator_fee_constant: non_neg_integer() | nil,
+                             operator_fee_scalar: non_neg_integer(),
+                             operator_fee_constant: non_neg_integer(),
                              da_footprint_gas_scalar: non_neg_integer() | nil
                            ]
                          )
@@ -132,8 +132,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: nil,\
-          operator_fee_constant: nil,\
+          operator_fee_scalar: 0,\
+          operator_fee_constant: 0,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """
@@ -187,8 +187,8 @@ defmodule EthereumJSONRPC.Receipt do
           l1_fee_scalar: 0,\
           l1_gas_price: 0,\
           l1_gas_used: 0,\
-          operator_fee_scalar: nil,\
-          operator_fee_constant: nil,\
+          operator_fee_scalar: 0,\
+          operator_fee_constant: 0,\
           da_footprint_gas_scalar: nil\
       """
     :scroll -> """
@@ -252,24 +252,15 @@ defmodule EthereumJSONRPC.Receipt do
       end
 
     :optimism ->
-      alias Explorer.Chain.Optimism.SuperchainConfig
-
       defp chain_type_fields(params, elixir) do
-        {operator_fee_scalar_default, operator_fee_constant_default} =
-          if is_nil(SuperchainConfig.isthmus_timestamp_l2()) do
-            {nil, nil}
-          else
-            {0, 0}
-          end
-
         params
         |> Map.merge(%{
           l1_fee: Map.get(elixir, "l1Fee", 0),
           l1_fee_scalar: Map.get(elixir, "l1FeeScalar", 0),
           l1_gas_price: Map.get(elixir, "l1GasPrice", 0),
           l1_gas_used: Map.get(elixir, "l1GasUsed", 0),
-          operator_fee_scalar: Map.get(elixir, "operatorFeeScalar", operator_fee_scalar_default),
-          operator_fee_constant: Map.get(elixir, "operatorFeeConstant", operator_fee_constant_default),
+          operator_fee_scalar: Map.get(elixir, "operatorFeeScalar", 0),
+          operator_fee_constant: Map.get(elixir, "operatorFeeConstant", 0),
           da_footprint_gas_scalar: Map.get(elixir, "daFootprintGasScalar")
         })
       end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
@@ -113,8 +113,8 @@ defmodule EthereumJSONRPC.Receipts do
         l1_fee_scalar: 0,\
         l1_gas_price: 0,\
         l1_gas_used: 0,\
-        operator_fee_scalar: 0,\
-        operator_fee_constant: 0,\
+        operator_fee_scalar: nil,\
+        operator_fee_constant: nil,\
         da_footprint_gas_scalar: nil\
       """
     :scroll -> """

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipts.ex
@@ -113,8 +113,8 @@ defmodule EthereumJSONRPC.Receipts do
         l1_fee_scalar: 0,\
         l1_gas_price: 0,\
         l1_gas_used: 0,\
-        operator_fee_scalar: nil,\
-        operator_fee_constant: nil,\
+        operator_fee_scalar: 0,\
+        operator_fee_constant: 0,\
         da_footprint_gas_scalar: nil\
       """
     :scroll -> """


### PR DESCRIPTION
## Motivation

Fix compilation warning in `optimism` and `optimism-celo` chain types after merging https://github.com/blockscout/blockscout/pull/14237.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent defaults for Optimism receipt fee fields: operator fee parameters now reliably default to zero when absent, ensuring consistent transaction data.

* **Documentation**
  * Updated example outputs and doctests to reflect the new default values for Optimism fee fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14363)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14363)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->