### PR TITLE
chore: openapi - simplify using primitive leafs in schemas

### DIFF
--- a/.agents/skills/openapi-spec/references/schema-conventions.md
+++ b/.agents/skills/openapi-spec/references/schema-conventions.md
@@ -244,34 +244,58 @@ OpenApiSpex.schema(
 
 The pattern is: base schema -> extend with metadata -> apply chain-type fields.
 
-### Helper.extend_schema/2
+### Helper.extend_schema/2 — define a new schema by extending another
 
-Located at `schemas/helper.ex`. Merges `:properties`, `:required`, `:title`, `:description`, `:nullable`, and `:enum` into an existing schema map:
-- Properties are merged (new keys added, existing overwritten)
-- Required lists are concatenated
-- Scalar fields (title, description, nullable) are replaced
+Located at `schemas/helper.ex`. Merges `:properties`, `:required`, `:title`, `:description`, `:nullable`, `:enum` into a base schema. Properties are merged, required lists concatenated, scalars replaced.
+
+**Use only inside an outer `OpenApiSpex.schema(…)` macro** that re-establishes a new component identity (fresh `:title` + `x-struct`). Examples: `AddressNullable` (extends `Address` with `nullable: true`), `Arbitrum.Message` (extends `MinimalMessage`), `*Response` wrappers.
 
 ```elixir
-schema_map
-|> Helper.extend_schema(
-  title: "ExtendedSchema",
-  properties: %{new_field: %Schema{type: :string}},
-  required: [:new_field]
+OpenApiSpex.schema(
+  Base.schema()
+  |> Helper.extend_schema(
+    title: "Extended",                  # REQUIRED on every extend — see "Schema reuse and naming"
+    properties: %{new_field: ...},
+    required: [:new_field]
+  )
 )
 ```
 
-**Reusing a leaf primitive with a per-property override.** When you want the type/format/nullable of a `general/` leaf (`Timestamp`, `IntegerString`, `FullHash`, …) *and* a per-property field like `description:`, `example:`, or a flipped `nullable:`, use `Helper.extend_schema` at the property position:
+**Do not use at a property position** to overlay attributes on a `general/` leaf (`Timestamp`, `IntegerString`, `FullHash`, …). The result keeps the leaf's `:title` and `x-struct`, so `OpenApiSpex.resolve_schema_modules/1` re-registers it as `components.schemas.<Title>` (last-encounter wins). The overlay leaks onto the global component and every `$ref` to it across the spec.
+
+### Helper.describe_inline/2 — per-property description overlay on a primitive leaf
+
+Use at a property position when you want a leaf's exact type/format/nullable plus a per-property `description:`. Strips `:title` and `x-struct` (sets both to `nil`) so the result renders inline at the call site and the global component is untouched.
 
 ```elixir
 timestamp:
-  Helper.extend_schema(General.Timestamp.schema(),
-    description: "Block timestamp of the parent transaction."
+  Helper.describe_inline(
+    General.Timestamp.schema(),
+    "Block timestamp of the parent transaction."
   )
 ```
 
-This inlines the leaf's shape and overlays the description, no `allOf` casting layer involved.
+**Intentionally narrow — description only.** If a property needs a different `pattern:`, flipped `nullable:`, or any other constraint, define a new primitive in `schemas/api/v2/general/` and reference it. Do not reach for `extend_schema` at the property position to bend a leaf.
 
-Avoid `%Schema{allOf: [Leaf], description: "..."}` as the overlay mechanism. `allOf` is for *object* composition: it works fine for object leaves like `Address` (and `advanced_filter.ex` does this for `from`/`to`/`created_contract`), but for primitive leaves with a non-trivial `format:` cast — `Timestamp`'s `format: :"date-time"` casts strings to `%DateTime{}`, `Decimal`-typed leaves cast to `%Decimal{}` — `OpenApiSpex.Cast.AllOf` enumerates the per-branch results as maps and fails on non-Enumerable structs. The `extend_schema` form sidesteps the cast composition entirely.
+### Picking the right per-property overlay
+
+Two leaf shapes exist; treat them separately:
+
+- **Primitive leaf** — `type: :string` / `:integer` / `:number` / `:boolean`. Examples: `General.Timestamp`, `General.IntegerString`, `General.FullHash`, `General.AddressHash`. The schema body is 1–3 fields; inlining is cheap.
+- **Object leaf** — `type: :object` with its own `properties`. Examples: `Address`, `Token`, `Arbitrum.MinimalMessage`. The schema body is many fields; inlining duplicates the entire structure at every call site and breaks `$ref` dedup.
+
+| Goal | Mechanism | Why |
+|---|---|---|
+| Description on a primitive leaf | `Helper.describe_inline(Leaf.schema(), "…")` | Inlines 1–3 fields cheaply; `$ref` dedup not meaningful at that size. `allOf` would crash at runtime when the leaf has a `format:` cast (`Timestamp` → `%DateTime{}`, `Decimal` → `%Decimal{}`) because `OpenApiSpex.Cast.AllOf` enumerates per-branch results as maps and fails on non-Enumerable structs. |
+| Description (and/or `nullable:` flip) on an object leaf | `%Schema{allOf: [Leaf], description: "…", nullable: true}` | Keeps `$ref: '#/components/schemas/<Leaf>'`, so the object's properties stay deduplicated across the spec. No runtime crash because object branches all cast to maps. See `advanced_filter.ex` `from`/`to`/`created_contract`. |
+| Any per-property override beyond description on either leaf shape (pattern, enum, narrower bounds, …) | Define a new primitive in `general/`, then reference it | Pushes `general/` to grow as a real library of reusable primitives instead of every domain bending a leaf locally. |
+| Derived schema with its own component identity (response wrapper, nullable variant of an object, …) | `OpenApiSpex.schema(Base.schema() \|> Helper.extend_schema(title: …, …))` | The outer macro re-establishes `:title` + `x-struct`, so the result is a new registered component, not a property-position overlay. |
+
+**Anti-patterns — do not use:**
+
+- `Helper.extend_schema(Leaf.schema(), description: "…")` at a property position → leaks the description onto `components.schemas.<Leaf>` (last-encounter wins) and pollutes every `$ref` to that leaf across the spec.
+- `Helper.describe_inline(ObjectLeaf.schema(), "…")` at a property position → technically works, but inlines the entire object structure at every call site and kills `$ref` dedup; tests still pass, so the bloat goes unnoticed in review.
+- `%Schema{allOf: [PrimitiveLeaf], description: "…"}` at a property position → crashes at runtime on primitive leaves with `format:` casts.
 
 ### Schema reuse and naming for related schemas
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/legacy/get_block_number_by_time_result.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/legacy/get_block_number_by_time_result.ex
@@ -3,15 +3,12 @@ defmodule BlockScoutWeb.Schemas.API.Legacy.GetBlockNumberByTimeResult do
   @moduledoc false
   require OpenApiSpex
   alias BlockScoutWeb.Schemas.API.V2.General
-  alias OpenApiSpex.Schema
+  alias BlockScoutWeb.Schemas.Helper
 
   OpenApiSpex.schema(%{
     type: :object,
     properties: %{
-      blockNumber: %Schema{
-        description: "Decimal-string block number.",
-        allOf: [General.IntegerString]
-      }
+      blockNumber: Helper.describe_inline(General.IntegerString.schema(), "Decimal-string block number.")
     },
     required: [:blockNumber],
     additionalProperties: false,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/advanced_filter.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/advanced_filter.ex
@@ -86,8 +86,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.AdvancedFilter do
         description: "Token contract metadata. Populated only for token-transfer items; `null` otherwise."
       },
       timestamp:
-        Helper.extend_schema(General.Timestamp.schema(),
-          description: "Block timestamp of the parent transaction."
+        Helper.describe_inline(
+          General.Timestamp.schema(),
+          "Block timestamp of the parent transaction."
         ),
       block_number: %Schema{
         type: :integer,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/batch.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/batch.ex
@@ -8,6 +8,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.Batch do
   alias BlockScoutWeb.Schemas.API.V2.Arbitrum.CommitmentTransaction
   alias BlockScoutWeb.Schemas.API.V2.Arbitrum.DataAvailability
   alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -30,18 +31,18 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.Batch do
         minimum: 0,
         description: "Last Rollup block included in the batch."
       },
-      before_acc_hash: %Schema{
-        allOf: [General.FullHash],
-        description:
+      before_acc_hash:
+        Helper.describe_inline(
+          General.FullHash.schema(),
           "Accumulator hash of the sequencer inbox before this batch was appended. " <>
             "Forms a hash chain: must equal `after_acc_hash` of the previous batch."
-      },
-      after_acc_hash: %Schema{
-        allOf: [General.FullHash],
-        description:
+        ),
+      after_acc_hash:
+        Helper.describe_inline(
+          General.FullHash.schema(),
           "Accumulator hash of the sequencer inbox after this batch was appended. " <>
             "Must equal `before_acc_hash` of the next batch."
-      },
+        ),
       commitment_transaction: CommitmentTransaction,
       data_availability: %Schema{
         oneOf: [

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/claim_message.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/claim_message.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.ClaimMessage do
   @moduledoc "Schema for Arbitrum claim message response."
 
   alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   require OpenApiSpex
@@ -14,11 +15,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.ClaimMessage do
     required: [:calldata, :outbox_address_hash],
     properties: %{
       calldata: %Schema{type: :string, description: "ABI-encoded calldata for the executeTransaction call."},
-      outbox_address_hash: %Schema{
-        allOf: [General.AddressHash],
-        description:
+      outbox_address_hash:
+        Helper.describe_inline(
+          General.AddressHash.schema(),
           "Address of the Arbitrum Outbox contract on the Parent chain through which the withdrawal is executed."
-      }
+        )
     },
     additionalProperties: false
   })

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/message.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/message.ex
@@ -24,10 +24,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.Message do
           minimum: 0,
           description: "Unique cross-chain message identifier assigned by the protocol."
         },
-        origination_address_hash: %Schema{
-          allOf: [General.AddressHashNullable],
-          description: "Address that initiated the message on the originating chain."
-        },
+        origination_address_hash:
+          Helper.describe_inline(
+            General.AddressHashNullable.schema(),
+            "Address that initiated the message on the originating chain."
+          ),
         # Enum values must be kept in sync with Explorer.Chain.Arbitrum.Message :status field.
         status: %Schema{
           type: :string,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/minimal_message.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/minimal_message.ex
@@ -6,16 +6,18 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.MinimalMessage do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
     description: "Minimal Arbitrum cross-chain message with origination and completion fields.",
     type: :object,
     properties: %{
-      origination_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the transaction on the originating chain that initiated this message."
-      },
+      origination_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the transaction on the originating chain that initiated this message."
+        ),
       origination_timestamp: General.TimestampNullable,
       origination_transaction_block_number: %Schema{
         type: :integer,
@@ -23,10 +25,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.MinimalMessage do
         nullable: true,
         description: "Block number on the originating chain containing the initiation transaction."
       },
-      completion_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the transaction on the destination chain that executed this message."
-      }
+      completion_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the transaction on the destination chain that executed this message."
+        )
     },
     required: [
       :origination_transaction_hash,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/arbitrum/withdrawal.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.Withdrawal do
   require OpenApiSpex
 
   alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -36,45 +37,51 @@ defmodule BlockScoutWeb.Schemas.API.V2.Arbitrum.Withdrawal do
             "and `confirmed` (RBlock confirmed on Parent chain) to `relayed` (executed on Parent chain). " <>
             "`unknown` indicates the status could not be determined, e.g. when the Parent chain RPC is unavailable."
       },
-      caller_address_hash: %Schema{
-        allOf: [General.AddressHash],
-        description: "Address of the account that initiated the withdrawal on the Rollup."
-      },
-      destination_address_hash: %Schema{
-        allOf: [General.AddressHash],
-        description: "Recipient address on the Parent chain that will receive funds when the withdrawal is executed."
-      },
+      caller_address_hash:
+        Helper.describe_inline(
+          General.AddressHash.schema(),
+          "Address of the account that initiated the withdrawal on the Rollup."
+        ),
+      destination_address_hash:
+        Helper.describe_inline(
+          General.AddressHash.schema(),
+          "Recipient address on the Parent chain that will receive funds when the withdrawal is executed."
+        ),
       arb_block_number: %Schema{type: :integer, minimum: 0, description: "Rollup block number."},
       eth_block_number: %Schema{type: :integer, minimum: 0, description: "Parent chain block number."},
       l2_timestamp: %Schema{type: :integer, minimum: 0, description: "Unix timestamp of the originating transaction."},
-      callvalue: %Schema{
-        allOf: [General.IntegerString],
-        description: "Native coin amount in wei attached to the withdrawal message."
-      },
-      data: %Schema{
-        allOf: [General.HexString],
-        description:
+      callvalue:
+        Helper.describe_inline(
+          General.IntegerString.schema(),
+          "Native coin amount in wei attached to the withdrawal message."
+        ),
+      data:
+        Helper.describe_inline(
+          General.HexString.schema(),
           "ABI-encoded calldata passed to the destination address when the withdrawal is executed on the Parent chain. " <>
             "Empty (`0x`) for plain native coin transfers."
-      },
+        ),
       token: %Schema{
         type: :object,
         nullable: true,
         description:
           "Token withdrawal details. Present when the withdrawal is for a bridged token, null for native coin.",
         properties: %{
-          address_hash: %Schema{
-            allOf: [General.AddressHashNullable],
-            description: "Token contract address on the Parent chain."
-          },
-          destination_address_hash: %Schema{
-            allOf: [General.AddressHashNullable],
-            description: "Token recipient address on the Parent chain."
-          },
-          amount: %Schema{
-            allOf: [General.IntegerString],
-            description: "Token amount in the token's smallest unit."
-          },
+          address_hash:
+            Helper.describe_inline(
+              General.AddressHashNullable.schema(),
+              "Token contract address on the Parent chain."
+            ),
+          destination_address_hash:
+            Helper.describe_inline(
+              General.AddressHashNullable.schema(),
+              "Token recipient address on the Parent chain."
+            ),
+          amount:
+            Helper.describe_inline(
+              General.IntegerString.schema(),
+              "Token amount in the token's smallest unit."
+            ),
           decimals: %Schema{type: :integer, minimum: 0, nullable: true},
           name: %Schema{type: :string, nullable: true},
           symbol: %Schema{type: :string, nullable: true}

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -316,6 +316,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Common do
   This module defines common schema fields for block.
   """
   alias BlockScoutWeb.Schemas.API.V2.{Address, General}
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   @required_fields [
@@ -445,34 +446,38 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Common do
         },
         hash: General.FullHash,
         parent_hash: General.FullHash,
-        difficulty: %Schema{
-          allOf: [General.IntegerStringNullable],
-          description: "Proof-of-work difficulty of this block. Zero on proof-of-stake chains."
-        },
-        total_difficulty: %Schema{
-          allOf: [General.IntegerStringNullable],
-          description:
+        difficulty:
+          Helper.describe_inline(
+            General.IntegerStringNullable.schema(),
+            "Proof-of-work difficulty of this block. Zero on proof-of-stake chains."
+          ),
+        total_difficulty:
+          Helper.describe_inline(
+            General.IntegerStringNullable.schema(),
             "Cumulative chain difficulty through this block (sum of `difficulty` of this block and all ancestors)."
-        },
+          ),
         gas_used: General.IntegerString,
         gas_limit: General.IntegerString,
-        nonce: %Schema{
-          allOf: [General.HexString],
-          description: "Proof-of-work nonce used to satisfy the difficulty target. Zero on proof-of-stake chains."
-        },
-        base_fee_per_gas: %Schema{
-          allOf: [General.IntegerStringNullable],
-          description:
+        nonce:
+          Helper.describe_inline(
+            General.HexString.schema(),
+            "Proof-of-work nonce used to satisfy the difficulty target. Zero on proof-of-stake chains."
+          ),
+        base_fee_per_gas:
+          Helper.describe_inline(
+            General.IntegerStringNullable.schema(),
             "EIP-1559 base fee per gas, in wei. Null on blocks produced before EIP-1559 activation or on chains that do not implement EIP-1559."
-        },
-        burnt_fees: %Schema{
-          allOf: [General.IntegerStringNullable],
-          description: "Sum of EIP-1559 base fees burned by transactions in this block, in wei."
-        },
-        priority_fee: %Schema{
-          allOf: [General.IntegerStringNullable],
-          description: "Sum of validator tips (EIP-1559 priority fees) paid by transactions in this block, in wei."
-        },
+          ),
+        burnt_fees:
+          Helper.describe_inline(
+            General.IntegerStringNullable.schema(),
+            "Sum of EIP-1559 base fees burned by transactions in this block, in wei."
+          ),
+        priority_fee:
+          Helper.describe_inline(
+            General.IntegerStringNullable.schema(),
+            "Sum of validator tips (EIP-1559 priority fees) paid by transactions in this block, in wei."
+          ),
         uncles_hashes: %Schema{
           type: :array,
           description: "Hashes of ommer (uncle) blocks referenced by this block.",
@@ -512,10 +517,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Common do
           description:
             "Block classification: `block` = main-chain consensus block; `uncle` = ommer (valid but not in main chain); `reorg` = former main-chain block lost to reorganization."
         },
-        transaction_fees: %Schema{
-          allOf: [General.IntegerString],
-          description: "Sum of transaction fees (gas price × gas used) paid by transactions in this block, in wei."
-        },
+        transaction_fees:
+          Helper.describe_inline(
+            General.IntegerString.schema(),
+            "Sum of transaction fees (gas price × gas used) paid by transactions in this block, in wei."
+          ),
         withdrawals_count: %Schema{
           type: :integer,
           minimum: 0,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/deposit.ex
@@ -19,22 +19,25 @@ defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Deposit do
         minimum: 0,
         description: "Parent chain block in which the deposit was initiated."
       },
-      l1_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the parent chain transaction that initiates the deposit."
-      },
-      l2_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the Shibarium transaction that completes the deposit."
-      },
+      l1_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the parent chain transaction that initiates the deposit."
+        ),
+      l2_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the Shibarium transaction that completes the deposit."
+        ),
       user: %Schema{
         allOf: [Address],
         description:
           "Address of the user that initiated the deposit on the parent chain; the same address acts as the recipient on Shibarium."
       },
       timestamp:
-        Helper.extend_schema(General.TimestampNullable.schema(),
-          description: "Timestamp of the parent chain block that contains the deposit transaction."
+        Helper.describe_inline(
+          General.TimestampNullable.schema(),
+          "Timestamp of the parent chain block that contains the deposit transaction."
         )
     },
     required: [

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/shibarium/withdrawal.ex
@@ -19,22 +19,25 @@ defmodule BlockScoutWeb.Schemas.API.V2.Shibarium.Withdrawal do
         minimum: 0,
         description: "Shibarium block in which the withdrawal was initiated."
       },
-      l2_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the Shibarium transaction that initiates the withdrawal."
-      },
-      l1_transaction_hash: %Schema{
-        allOf: [General.FullHashNullable],
-        description: "Hash of the parent chain transaction that completes the withdrawal."
-      },
+      l2_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the Shibarium transaction that initiates the withdrawal."
+        ),
+      l1_transaction_hash:
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the parent chain transaction that completes the withdrawal."
+        ),
       user: %Schema{
         allOf: [Address],
         description:
           "Address of the user that initiated the withdrawal on Shibarium; the same address acts as the recipient on the parent chain."
       },
       timestamp:
-        Helper.extend_schema(General.TimestampNullable.schema(),
-          description: "Timestamp of the Shibarium block that contains the withdrawal transaction."
+        Helper.describe_inline(
+          General.TimestampNullable.schema(),
+          "Timestamp of the Shibarium block that contains the withdrawal transaction."
         )
     },
     required: [

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/stability/counters.ex
@@ -15,16 +15,19 @@ defmodule BlockScoutWeb.Schemas.API.V2.Stability.Counters do
     type: :object,
     properties: %{
       validators_count:
-        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
-          description: "Total number of validators known on the Stability chain across all operational states."
+        Helper.describe_inline(
+          General.NonNegativeIntegerString.schema(),
+          "Total number of validators known on the Stability chain across all operational states."
         ),
       new_validators_count_24h:
-        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
-          description: "Number of validators that joined the set within the last 24 hours."
+        Helper.describe_inline(
+          General.NonNegativeIntegerString.schema(),
+          "Number of validators that joined the set within the last 24 hours."
         ),
       active_validators_count:
-        Helper.extend_schema(General.NonNegativeIntegerString.schema(),
-          description: "Number of validators currently in the `active` operational state."
+        Helper.describe_inline(
+          General.NonNegativeIntegerString.schema(),
+          "Number of validators currently in the `active` operational state."
         ),
       active_validators_percentage: %Schema{
         type: :number,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/helper.ex
@@ -6,6 +6,27 @@ defmodule BlockScoutWeb.Schemas.Helper do
 
   @doc """
   Extends a schema with additional properties and required fields.
+
+  Designed for use **inside an outer `OpenApiSpex.schema(…)` macro** that
+  re-establishes a new component identity (a fresh `:title` and `x-struct`)
+  for the extended result — for example, when defining
+  `AddressNullable` by extending `Address.schema()` with `nullable: true`.
+
+  Do **not** use this helper at a property position to overlay attributes
+  (`description:`, `nullable:`, `pattern:`, …) on a leaf primitive such as
+  `General.Timestamp`, `General.IntegerString`, or `General.HexString`. The
+  returned struct retains the leaf's `:title` and `x-struct`, so
+  `OpenApiSpex.resolve_schema_modules/1` registers it as
+  `components.schemas.<Title>` on a last-encounter-wins basis. The overlay
+  leaks onto the global component and every `$ref` pointing at it across
+  the spec inherits the property-specific value.
+
+  For per-property description overlays on a leaf primitive, use
+  `describe_inline/2` instead — it strips `:title` and `x-struct` so the
+  result is rendered inline at the call site and the global component
+  stays pristine. For other per-property overrides (different `pattern:`,
+  flipped `nullable:`, etc.), define a new primitive in
+  `schemas/api/v2/general/` and reference that.
   """
   @spec extend_schema(Schema.t() | map(), Keyword.t()) :: Schema.t() | map()
   def extend_schema(schema, options) do
@@ -46,5 +67,27 @@ defmodule BlockScoutWeb.Schemas.Helper do
         else: updated_schema_with_nullable
 
     updated_schema_with_enum
+  end
+
+  @doc """
+  Attaches a per-property description to a leaf schema for use at a property position.
+
+  The result is rendered inline at the call site: `x-struct` and `title` are
+  stripped from the input so `OpenApiSpex.resolve_schema_modules/1` does not
+  register the result as the named OpenAPI component. The global
+  `components.schemas.<Title>` entry stays untouched.
+
+  This function is intentionally narrow — it only attaches a description. If
+  a property needs a different `pattern:`, `nullable:`, or other constraint
+  than the leaf provides, define a new primitive in
+  `schemas/api/v2/general/` and describe that. This pushes the codebase
+  toward a clean library of reusable primitives.
+  """
+  @spec describe_inline(Schema.t() | map(), String.t()) :: Schema.t() | map()
+  def describe_inline(schema, description) do
+    schema
+    |> Map.put(:description, description)
+    |> Map.put(:"x-struct", nil)
+    |> Map.put(:title, nil)
   end
 end


### PR DESCRIPTION
Closes #14367

## Summary

- **Fixes #14367** — adds `BlockScoutWeb.Schemas.Helper.describe_inline/2` for safe per-property description overlays on primitive-leaf schemas (Timestamp, IntegerString, FullHash, …) and migrates the 6 existing call sites that were using `Helper.extend_schema/2` at property position (which silently rewrote global `components.schemas.<Title>` entries). Extends `extend_schema/2`'s docstring to document its intended use and limitations.
- **Skill update** — rewrites `.agents/skills/openapi-spec/references/schema-conventions.md` with primitive-leaf vs object-leaf definitions, a decision table for picking the right overlay mechanism (`describe_inline` / `allOf` / `extend_schema`) with reasoning ($ref dedup, runtime crash), and explicit anti-patterns.
- **Codebase aligned with the new guidance** — migrates 25 additional sites across 9 schema files from `%Schema{allOf: [<PrimitiveLeaf>], description: "…"}` to `Helper.describe_inline(<PrimitiveLeaf>.schema(), "…")`, matching the convention the skill now recommends.

## Test plan

- [x] `generate-spec.sh` succeeds and `oastools validate` passes for `default`, `arbitrum`, `shibarium`
- [x] Global components `FullHashNullable`, `IntegerStringNullable`, etc. remain pristine (no leaked per-property descriptions)
- [x] Migrated properties render inline with their per-property `description` + inherited `type`/`pattern`/`nullable`
- [x] `mix compile` clean for `default`, `arbitrum`, `shibarium`
- [x] `mix format`, `credo`, `cspell` pass on changed files

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated schema conventions with clearer guidance on per-field overlays, description usage, and anti-patterns to prevent schema registration leaks.

* **Refactor**
  * Standardized API schema construction across many endpoints to produce consistent inline field descriptions and preserved behavior of responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->