### PR TITLE
fix: add ENS preload to single token instance endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -386,7 +386,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       conn
       |> put_status(200)
       |> render(:token_instance, %{
-        token_instance: updated_token_instance,
+        token_instance: updated_token_instance |> maybe_preload_ens() |> maybe_preload_metadata(),
         token: token
       })
     end


### PR DESCRIPTION
## Motivation

The `GET /api/v2/tokens/:address_hash/instances/:token_id` endpoint does not call `maybe_preload_ens()` on the token instance before rendering, so the owner's `ens_domain_name` is always `null`.

The list endpoint (`instances/0` at line 334) already calls `maybe_preload_ens()`. The single-instance endpoint (`instance/2` at line 389) does not — this is the inconsistency.

**Reproduction:**
1. Enable BENS microservice
2. `GET /api/v2/tokens/<nft>/instances/<id>` where the owner has a resolved ENS/domain name
3. Observe `owner.ens_domain_name` is `null`
4. `GET /api/v2/addresses/<same_owner>` — `ens_domain_name` is populated correctly

## Changelog

### Bug Fixes

- Add missing `maybe_preload_ens()` and `maybe_preload_metadata()` calls to the single token instance endpoint, matching the existing list endpoint behavior.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - _Note: No regression test added — the fix is a one-liner matching the existing pattern at line 334. Adding a proper test would require mocking the BENS microservice._
- [x] I updated documentation if needed: N/A
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly: N/A (response shape unchanged, field was already present but null)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Token instance API endpoint responses now include preloaded ENS and metadata information, providing more comprehensive data in a single request.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->