### PR TITLE
fix: missing transaction links in Arc coin balance history

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2608,35 +2608,37 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(acb, acb_json)
     end
 
-    test "get coin balance with internal transaction", %{conn: conn} do
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block()
+    if @chain_type != :arc do
+      test "get coin balance with internal transaction", %{conn: conn} do
+        transaction =
+          :transaction
+          |> insert()
+          |> with_block()
 
-      address = insert(:address)
+        address = insert(:address)
 
-      insert(:internal_transaction,
-        type: "call",
-        call_type: "call",
-        transaction: transaction,
-        transaction_index: transaction.index,
-        block: transaction.block,
-        to_address: address,
-        value: 123,
-        block_number: transaction.block_number,
-        index: 1
-      )
+        insert(:internal_transaction,
+          type: "call",
+          call_type: "call",
+          transaction: transaction,
+          transaction_index: transaction.index,
+          block: transaction.block,
+          to_address: address,
+          value: 123,
+          block_number: transaction.block_number,
+          index: 1
+        )
 
-      insert(:address_coin_balance)
-      acb = insert(:address_coin_balance, address: address, block_number: transaction.block_number)
+        insert(:address_coin_balance)
+        acb = insert(:address_coin_balance, address: address, block_number: transaction.block_number)
 
-      request = get(conn, "/api/v2/addresses/#{address.hash}/coin-balance-history")
+        request = get(conn, "/api/v2/addresses/#{address.hash}/coin-balance-history")
 
-      assert %{"items" => [acb_json], "next_page_params" => nil} = json_response(request, 200)
-      assert acb_json["transaction_hash"] == to_string(transaction.hash)
+        assert %{"items" => [acb_json], "next_page_params" => nil} = json_response(request, 200)
+        assert acb_json["transaction_hash"] == to_string(transaction.hash)
 
-      compare_item(acb, acb_json)
+        compare_item(acb, acb_json)
+      end
     end
 
     test "coin balance history can paginate", %{conn: conn} do

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -7,6 +7,10 @@ defmodule Explorer.Chain.Address.CoinBalance do
 
   use Explorer.Schema
 
+  use Utils.RuntimeEnvHelper,
+    chain_type: [:explorer, :chain_type],
+    arc_native_token_address: [:indexer, [:arc, :arc_native_token_address]]
+
   alias Explorer.{Chain, PagingOptions, Repo}
   alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, TokenTransfer, Transaction, Wei}
   alias Explorer.Chain.Address.CoinBalance
@@ -288,7 +292,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
       |> Chain.select_repo(options).one()
 
     if is_nil(transaction_hash) do
-      if Application.get_env(:explorer, :chain_type) == :arc do
+      if chain_type() == :arc do
         balance
         |> preload_arc_native_token_transfer_query()
         |> Chain.select_repo(options).one()
@@ -306,8 +310,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
   # don't show up in transaction `value` or internal transactions; the indexer
   # normalizes them into `TokenTransfer` rows under the synthetic native token.
   defp preload_arc_native_token_transfer_query(balance) do
-    native_token_address_hash_string = Application.get_env(:indexer, :arc)[:arc_native_token_address]
-    {:ok, native_token_address_hash} = Chain.string_to_address_hash(native_token_address_hash_string)
+    {:ok, native_token_address_hash} = Chain.string_to_address_hash(arc_native_token_address())
 
     TokenTransfer
     |> where(

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Chain.Address.CoinBalance do
   use Explorer.Schema
 
   alias Explorer.{Chain, PagingOptions, Repo}
-  alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, Transaction, Wei}
+  alias Explorer.Chain.{Address, Block, Hash, InternalTransaction, TokenTransfer, Transaction, Wei}
   alias Explorer.Chain.Address.CoinBalance
 
   @optional_fields ~w(value value_fetched_at)a
@@ -288,12 +288,36 @@ defmodule Explorer.Chain.Address.CoinBalance do
       |> Chain.select_repo(options).one()
 
     if is_nil(transaction_hash) do
-      balance
-      |> preload_internal_transaction_query()
-      |> Chain.select_repo(options).one()
+      if Application.get_env(:explorer, :chain_type) == :arc do
+        balance
+        |> preload_arc_native_token_transfer_query()
+        |> Chain.select_repo(options).one()
+      else
+        balance
+        |> preload_internal_transaction_query()
+        |> Chain.select_repo(options).one()
+      end
     else
       transaction_hash
     end
+  end
+
+  # On Arc, native-coin movement is emitted via EIP-7708 / NativeCoin* logs that
+  # don't show up in transaction `value` or internal transactions; the indexer
+  # normalizes them into `TokenTransfer` rows under the synthetic native token.
+  defp preload_arc_native_token_transfer_query(balance) do
+    native_token_address_hash_string = Application.get_env(:indexer, :arc)[:arc_native_token_address]
+    {:ok, native_token_address_hash} = Chain.string_to_address_hash(native_token_address_hash_string)
+
+    TokenTransfer
+    |> where(
+      [tt],
+      tt.block_number == ^balance.block_number and
+        tt.token_contract_address_hash == ^native_token_address_hash and
+        (tt.from_address_hash == ^balance.address_hash or tt.to_address_hash == ^balance.address_hash)
+    )
+    |> select([tt], tt.transaction_hash)
+    |> limit(1)
   end
 
   defp preload_transaction_query(balance) do

--- a/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
+++ b/apps/explorer/test/explorer/chain/address/coin_balance_test.exs
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Chain.Address.CoinBalanceTest do
   use Explorer.DataCase
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Ecto.Changeset
   alias Explorer.Chain.Address.CoinBalance
@@ -297,6 +298,151 @@ defmodule Explorer.Chain.Address.CoinBalanceTest do
       value = result |> List.first() |> Map.get(:value)
 
       assert(value == Wei.from(Decimal.new(2000), :wei))
+    end
+  end
+
+  if @chain_type == :arc do
+    describe "address_to_coin_balances/2 on Arc" do
+      @arc_native_token "0x3600000000000000000000000000000000000000"
+
+      setup do
+        original_arc = Application.get_env(:indexer, :arc) || []
+
+        Application.put_env(
+          :indexer,
+          :arc,
+          Keyword.merge(original_arc, arc_native_token_address: @arc_native_token)
+        )
+
+        on_exit(fn ->
+          Application.put_env(:indexer, :arc, original_arc)
+        end)
+
+        :ok
+      end
+
+      test "falls back to the synthetic native-token transfer when no regular tx involves the address" do
+        {:ok, native_token_address_hash} = Explorer.Chain.string_to_address_hash(@arc_native_token)
+        native_token_address = insert(:address, hash: native_token_address_hash)
+        insert(:token, contract_address: native_token_address)
+
+        address = insert(:address)
+        block = insert(:block)
+
+        transfer_transaction =
+          :transaction
+          |> insert()
+          |> with_block(block)
+
+        token_transfer =
+          insert(:token_transfer,
+            from_address: address,
+            token_contract_address: native_token_address,
+            transaction: transfer_transaction,
+            block: block,
+            block_number: block.number
+          )
+
+        insert(:fetched_balance, address_hash: address.hash, value: 100, block_number: block.number)
+
+        [coin_balance] =
+          CoinBalance.address_to_coin_balances(address, paging_options: %PagingOptions{page_size: 50})
+
+        assert coin_balance.transaction_hash == token_transfer.transaction_hash
+        assert coin_balance.transaction_hash == transfer_transaction.hash
+      end
+
+      test "prefers a regular transaction involving the address over the system token transfer" do
+        {:ok, native_token_address_hash} = Explorer.Chain.string_to_address_hash(@arc_native_token)
+        native_token_address = insert(:address, hash: native_token_address_hash)
+        insert(:token, contract_address: native_token_address)
+
+        address = insert(:address)
+        block = insert(:block)
+
+        regular_transaction =
+          :transaction
+          |> insert(from_address: address)
+          |> with_block(block)
+
+        transfer_transaction =
+          :transaction
+          |> insert()
+          |> with_block(block)
+
+        insert(:token_transfer,
+          from_address: address,
+          token_contract_address: native_token_address,
+          transaction: transfer_transaction,
+          block: block,
+          block_number: block.number
+        )
+
+        insert(:fetched_balance, address_hash: address.hash, value: 100, block_number: block.number)
+
+        [coin_balance] =
+          CoinBalance.address_to_coin_balances(address, paging_options: %PagingOptions{page_size: 50})
+
+        assert coin_balance.transaction_hash == regular_transaction.hash
+      end
+
+      test "returns nil transaction hash when neither a regular tx nor a system token transfer matches the balance" do
+        {:ok, native_token_address_hash} = Explorer.Chain.string_to_address_hash(@arc_native_token)
+        native_token_address = insert(:address, hash: native_token_address_hash)
+        insert(:token, contract_address: native_token_address)
+
+        address = insert(:address)
+        block = insert(:block)
+
+        unrelated_transaction =
+          :transaction
+          |> insert()
+          |> with_block(block)
+
+        insert(:token_transfer,
+          token_contract_address: native_token_address,
+          transaction: unrelated_transaction,
+          block: block,
+          block_number: block.number
+        )
+
+        insert(:fetched_balance, address_hash: address.hash, value: 100, block_number: block.number)
+
+        [coin_balance] =
+          CoinBalance.address_to_coin_balances(address, paging_options: %PagingOptions{page_size: 50})
+
+        assert is_nil(coin_balance.transaction_hash)
+      end
+
+      test "ignores token transfers on a different block" do
+        {:ok, native_token_address_hash} = Explorer.Chain.string_to_address_hash(@arc_native_token)
+        native_token_address = insert(:address, hash: native_token_address_hash)
+        insert(:token, contract_address: native_token_address)
+
+        address = insert(:address)
+        balance_block = insert(:block)
+        other_block = insert(:block)
+
+        other_transaction =
+          :transaction
+          |> insert()
+          |> with_block(other_block)
+
+        insert(:token_transfer,
+          from_address: address,
+          token_contract_address: native_token_address,
+          transaction: other_transaction,
+          block: other_block,
+          block_number: other_block.number
+        )
+
+        insert(:fetched_balance, address_hash: address.hash, value: 100, block_number: balance_block.number)
+
+        [coin_balance] =
+          CoinBalance.address_to_coin_balances(address, paging_options: %PagingOptions{page_size: 50})
+
+        assert is_nil(coin_balance.transaction_hash)
+      end
     end
   end
 

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Indexer.Transform.AddressCoinBalancesTest do
   use Explorer.DataCase, async: true
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Explorer.Factory
   alias Indexer.Transform.AddressCoinBalances
@@ -247,7 +248,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
     end
   end
 
-  if Application.compile_env(:explorer, :chain_type) == :arc do
+  if @chain_type == :arc do
     describe "params_set/1 logs_params on Arc chain" do
       test "with EIP-7708 Transfer queues non-burn from_address and to_address for coin balances" do
         from_address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Indexer.Transform.TokenTransfersTest do
   use Explorer.DataCase
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   import ExUnit.CaptureLog
 
@@ -641,7 +642,7 @@ defmodule Indexer.Transform.TokenTransfersTest do
     end
   end
 
-  if Application.compile_env(:explorer, :chain_type) == :arc do
+  if @chain_type == :arc do
     describe "parse/1 on Arc chain" do
       @arc_native_token "0x3600000000000000000000000000000000000000"
       @arc_system "0x1800000000000000000000000000000000000000"


### PR DESCRIPTION
## Changelog

* Fix missing transactions links for coin balance history on arc

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [X] If I added new functionality, I added tests covering it.
- [X] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Arc-chain coin-balance resolution: when a standard transaction lookup is missing, transaction hash will fall back to matching synthetic native-token transfers scoped to the correct block.

* **Tests**
  * Added and updated tests to cover Arc-specific coin-balance behavior, fallback selection, block scoping, and preference for regular transactions; tests now use a compile-time chain-type helper and run conditionally based on chain configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->