### PR TITLE
chore: Close linked issues when PRs merge into dev

### DIFF
--- a/.github/workflows/close-issues-on-dev-merge.yml
+++ b/.github/workflows/close-issues-on-dev-merge.yml
@@ -1,0 +1,123 @@
+name: Close issues on dev merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues linked via closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ISSUE_REF_PATTERN =
+              /(?:^|[\s(])(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+((?:[\w.-]+\/[\w.-]+)?#\d+(?:\s*(?:,\s*|\s+and\s+)(?:[\w.-]+\/[\w.-]+)?#\d+)*)/gi;
+
+            const parseIssueNumbers = (text, { owner, repo }) => {
+              if (!text) return [];
+
+              const issueNumbers = new Set();
+              let match;
+
+              ISSUE_REF_PATTERN.lastIndex = 0;
+
+              while ((match = ISSUE_REF_PATTERN.exec(text)) !== null) {
+                const refs = match[1];
+                const refPattern = /(?:(?<repo>[\w.-]+\/[\w.-]+))?#(?<number>\d+)/g;
+                let refMatch;
+
+                while ((refMatch = refPattern.exec(refs)) !== null) {
+                  const { repo: refRepo, number } = refMatch.groups;
+
+                  if (refRepo && refRepo.toLowerCase() !== `${owner}/${repo}`.toLowerCase()) {
+                    continue;
+                  }
+
+                  issueNumbers.add(Number(number));
+                }
+              }
+
+              return [...issueNumbers];
+            };
+
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const pr = context.payload.pull_request;
+
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner, repo, pull_number }
+            );
+
+            const commitMessages = commits
+              .map((commit) => commit.commit.message)
+              .join("\n");
+
+            const texts = [pr.title, pr.body, commitMessages].filter(Boolean);
+            const repoContext = { owner, repo };
+            const issueNumbers = [
+              ...new Set(
+                texts.flatMap((text) => parseIssueNumbers(text, repoContext))
+              ),
+            ];
+
+            if (issueNumbers.length === 0) {
+              core.info("No issues to close (no closing keywords found).");
+              return;
+            }
+
+            core.info(`Closing issues: ${issueNumbers.join(", ")}`);
+
+            for (const issue_number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number,
+                });
+
+                if (issue.state === "closed") {
+                  core.info(`Issue #${issue_number} is already closed.`);
+                  continue;
+                }
+
+                if (issue.pull_request) {
+                  core.info(`Skipping #${issue_number}: not an issue.`);
+                  continue;
+                }
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number,
+                  state: "closed",
+                  state_reason: "completed",
+                });
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body:
+                    `Closed by merge of #${pull_number} into \`dev\`.\n\n` +
+                    `GitHub closes linked issues automatically only when merging into the default branch. ` +
+                    `This comment was added by the [\`close-issues-on-dev-merge\`](${context.serverUrl}/${owner}/${repo}/actions/workflows/close-issues-on-dev-merge.yml) workflow.`,
+                });
+
+                core.info(`Closed issue #${issue_number}.`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.warning(`Issue #${issue_number} not found in ${owner}/${repo}.`);
+                } else {
+                  core.setFailed(`Failed to close issue #${issue_number}: ${error.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
## Motivation

GitHub automatically closes linked issues only when a PR is merged into the default branch (`master`). PRs merged into `dev` do not trigger that behavior, so issues referenced with standard closing keywords in PR titles, descriptions, or commit messages stay open.

This PR adds a workflow that closes those issues when a PR targeting `dev` is merged.

## Changelog

### Enhancements

- Add `close-issues-on-dev-merge` GitHub Actions workflow that runs when a PR into `dev` is merged.
- Parse case-insensitive closing keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
- Scan PR title, PR description, and all PR commit messages for linked issue references (e.g. `Closes #123`, `Fixes #10, #12`, `Resolves owner/repo#123`).
- Close matching open issues in the same repository and leave a comment explaining the closure.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: N/A (CI workflow only).
  - [x] ENV vars: N/A.
  - [x] Deprecated vars: N/A.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description. N/A
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools. N/A
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly. N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to automatically close linked issues when pull requests are merged into the dev branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->