### PR TITLE
fix: Parse GitHub issue URLs in dev-merge close workflow

### DIFF
--- a/.github/workflows/close-issues-on-dev-merge.yml
+++ b/.github/workflows/close-issues-on-dev-merge.yml
@@ -18,8 +18,26 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const ISSUE_REF_PATTERN =
-              /(?:^|[\s(])(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+((?:[\w.-]+\/[\w.-]+)?#\d+(?:\s*(?:,\s*|\s+and\s+)(?:[\w.-]+\/[\w.-]+)?#\d+)*)/gi;
+            const SINGLE_ISSUE_REF =
+              "(?:[\\w.-]+\\/[\\w.-]+)?#\\d+" +
+              "|https?:\\/\\/github\\.com\\/[\\w.-]+\\/[\\w.-]+\\/issues\\/\\d+";
+
+            const ISSUE_REF_PATTERN = new RegExp(
+              `(?:^|[\\s(])(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\\s+((?:${SINGLE_ISSUE_REF})(?:\\s*(?:,\\s*|\\s+and\\s+)(?:${SINGLE_ISSUE_REF}))*)`,
+              "gi"
+            );
+
+            const HASH_REF_PATTERN = /(?:(?<repo>[\w.-]+\/[\w.-]+))?#(?<number>\d+)/g;
+            const URL_REF_PATTERN =
+              /https?:\/\/github\.com\/(?<owner>[\w.-]+)\/(?<repoName>[\w.-]+)\/issues\/(?<number>\d+)/gi;
+
+            const addIssueFromRef = (issueNumbers, { refRepo, number }, { owner, repo }) => {
+              if (refRepo && refRepo.toLowerCase() !== `${owner}/${repo}`.toLowerCase()) {
+                return;
+              }
+
+              issueNumbers.add(Number(number));
+            };
 
             const parseIssueNumbers = (text, { owner, repo }) => {
               if (!text) return [];
@@ -31,17 +49,21 @@ jobs:
 
               while ((match = ISSUE_REF_PATTERN.exec(text)) !== null) {
                 const refs = match[1];
-                const refPattern = /(?:(?<repo>[\w.-]+\/[\w.-]+))?#(?<number>\d+)/g;
                 let refMatch;
 
-                while ((refMatch = refPattern.exec(refs)) !== null) {
-                  const { repo: refRepo, number } = refMatch.groups;
+                HASH_REF_PATTERN.lastIndex = 0;
 
-                  if (refRepo && refRepo.toLowerCase() !== `${owner}/${repo}`.toLowerCase()) {
-                    continue;
-                  }
+                while ((refMatch = HASH_REF_PATTERN.exec(refs)) !== null) {
+                  addIssueFromRef(issueNumbers, refMatch.groups, { owner, repo });
+                }
 
-                  issueNumbers.add(Number(number));
+                URL_REF_PATTERN.lastIndex = 0;
+
+                while ((refMatch = URL_REF_PATTERN.exec(refs)) !== null) {
+                  const { owner: refOwner, repoName, number } = refMatch.groups;
+                  const refRepo = `${refOwner}/${repoName}`;
+
+                  addIssueFromRef(issueNumbers, { refRepo, number }, { owner, repo });
                 }
               }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,13 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Close linked issues when PRs merge into dev ([#14384](https://github.com/blockscout/blockscout/pull/14384), [#14385](https://github.com/blockscout/blockscout/pull/14385))
 - Add SPDX attribution ([#14360](https://github.com/blockscout/blockscout/issues/14360))
 - Eliminate horizontal scroll in the main LICENSE file ([#14359](https://github.com/blockscout/blockscout/issues/14359))
 - Partial async import ([#14277](https://github.com/blockscout/blockscout/issues/14277))
 - OpenAPI specifications for all `/api/v2/advanced-filters` endpoints ([#14227](https://github.com/blockscout/blockscout/issues/14227))
 - OpenAPI spec for Arbitrum-related endpoints ([#14169](https://github.com/blockscout/blockscout/issues/14169))
-- Audit mode dependent processes ([#13925](https://github.com/blockscout/blockscout/issues/13925))
+- Audit mode dependent processes ([#13925](https://github.com/blockscout/blockscout/issues/13925), [#14383](https://github.com/blockscout/blockscout/pull/14383))
 - Delete fiat_value for token if it disappears in coingecko ([#8932](https://github.com/blockscout/blockscout/issues/8932))
 
 ## 11.0.3


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14384

## Motivation

The close-issues-on-dev-merge workflow only matched #123 refs, so PRs like "Resolves https://github.com/.../issues/13180" did not close linked issues.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the automated workflow that closes linked issues when pull requests merge into the development branch. The system now includes improved pattern detection for identifying issue references in pull request descriptions, with better support for cross-repository issue tracking and more accurate closure handling of related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->