### PR TITLE
chore: publish OpenAPI specs on dev branch pushes

### DIFF
--- a/.github/workflows/generate-swagger.yml
+++ b/.github/workflows/generate-swagger.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - np-integrate-open-api-spex
+      - dev
     paths-ignore:
       - "CHANGELOG.md"
       - "**/README.md"
@@ -248,7 +248,7 @@ jobs:
 
       - name: Create specs directory structure
         run: |
-          VERSION=${{ github.event_name == 'release' && env.RELEASE_VERSION || 'master' }}
+          VERSION=${{ github.event_name == 'release' && env.RELEASE_VERSION || (github.ref_name == 'dev' && 'dev' || 'master') }}
 
           for SPEC_FILE in temp-specs/*; do
             if [ -f "$SPEC_FILE" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Publish OpenAPI specs on dev branch pushes ([#14391](https://github.com/blockscout/blockscout/pull/14391))
 - Add MIGRATION_FILL_INTERNAL_TRANSACTIONS_ADDRESS_IDS_CONCURRENCY ([#14390](https://github.com/blockscout/blockscout/pull/14390))
 - Close linked issues when PRs merge into dev ([#14384](https://github.com/blockscout/blockscout/pull/14384), [#14385](https://github.com/blockscout/blockscout/pull/14385))
 - Add SPDX attribution ([#14360](https://github.com/blockscout/blockscout/issues/14360))


### PR DESCRIPTION
## Motivation

Keep generated OpenAPI specs in sync with the `dev` branch without relying on the temporary `np-integrate-open-api-spex` trigger branch. Pushes to `dev` should update the `blockscout/dev` folder in the [swaggers](https://github.com/blockscout/swaggers) repository, while `master` continues to update `blockscout/master`.

## Changelog

### Enhancements

- Trigger `generate-swagger` workflow on push to `dev` (replacing `np-integrate-open-api-spex`).
- Map specs from `dev` branch pushes to `blockscout/dev/{chain-type}/` in the swaggers repo (release and `master` behavior unchanged).

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to handle development-branch builds while retaining proper release deployments.
  * OpenAPI/API specs publishing enabled for development-branch pushes and still published for release events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->