### PR TITLE
chore: Add SPDX license identifier to Elixir source and test files

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/legacy_paging_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/legacy_paging_helper.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.LegacyPagingHelper do
   @moduledoc """
   Legacy pagination helpers for old UI controllers.

--- a/apps/block_scout_web/test/block_scout_web/paging_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/paging_helper_test.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.PagingHelperTest do
   use ExUnit.Case, async: true
 

--- a/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db_current_token_balances.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db_current_token_balances.ex
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Migrator.BackfillMultichainSearchDbCurrentTokenBalances do
   @moduledoc """
   Backfills current token balances from Blockscout DB to Multichain Search DB.

--- a/apps/explorer/priv/repo/migrations/20260511153825_reset_nfts_skip_metadata.exs
+++ b/apps/explorer/priv/repo/migrations/20260511153825_reset_nfts_skip_metadata.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Repo.Migrations.ResetNftsSkipMetadata do
   use Ecto.Migration
 

--- a/apps/explorer/test/explorer/eth_rpc_test.exs
+++ b/apps/explorer/test/explorer/eth_rpc_test.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.EthRPCTest do
   use Explorer.DataCase, async: false
 

--- a/apps/explorer/test/explorer/migrator/backfill_multichain_search_db_current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/migrator/backfill_multichain_search_db_current_token_balances_test.exs
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Migrator.BackfillMultichainSearchDbCurrentTokenBalancesTest do
   use Explorer.DataCase, async: false
 


### PR DESCRIPTION
## Motivation

Adds SPDX license identifier headers to Elixir source files, test files, and migrations that were missing them, ensuring consistent license attribution across the codebase.

## Changelog

### Enhancements

- Added `# SPDX-License-Identifier: LicenseRef-Blockscout` header to 6 Elixir files:
  - Source file: `apps/block_scout_web/lib/block_scout_web/legacy_paging_helper.ex`
  - Source file: `apps/explorer/lib/explorer/migrator/backfill_multichain_search_db_current_token_balances.ex`
  - Test files: `apps/block_scout_web/test/block_scout_web/paging_helper_test.exs`, `apps/explorer/test/explorer/eth_rpc_test.exs`, `apps/explorer/test/explorer/migrator/backfill_multichain_search_db_current_token_balances_test.exs`
  - Migration: `apps/explorer/priv/repo/migrations/20260511153825_reset_nfts_skip_metadata.exs`


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly.
- [x] If I added new DB indices, I checked that they are not redundant.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added SPDX license identifiers to multiple source and test files for compliance tracking.

* **Database**
  * Added a migration that resets NFT metadata flags by clearing skip_metadata for ERC-721 tokens that have name and symbol set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->