### PR TITLE
fix: Properly start VersionUpgrade on application launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### ⚙️ Miscellaneous Tasks
 
+- Add SPDX license identifier to Elixir source and test files ([#14393](https://github.com/blockscout/blockscout/pull/14393))
 - Publish OpenAPI specs on dev branch pushes ([#14391](https://github.com/blockscout/blockscout/pull/14391))
 - Add MIGRATION_FILL_INTERNAL_TRANSACTIONS_ADDRESS_IDS_CONCURRENCY ([#14390](https://github.com/blockscout/blockscout/pull/14390))
 - Close linked issues when PRs merge into dev ([#14384](https://github.com/blockscout/blockscout/pull/14384), [#14385](https://github.com/blockscout/blockscout/pull/14385))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug Fixes
 
+- Properly start VersionUpgrade on application launch ([#14396](https://github.com/blockscout/blockscout/pull/14396))
 - MissingBalanceOfToken fixes ([#14267](https://github.com/blockscout/blockscout/pull/14267))
 - Improvements of OpenAPI specification for `/v2/blocks` ([#14251](https://github.com/blockscout/blockscout/issues/14251))
 - Normalize Tesla timeout middleware exceptions ([#14059](https://github.com/blockscout/blockscout/issues/14059))

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -114,6 +114,8 @@ config :explorer, Explorer.Chain.Mud, enabled: ConfigHelper.parse_bool_env_var("
 
 config :explorer, Explorer.Utility.VersionConstantsUpdater, enabled: true
 
+config :explorer, Explorer.Utility.VersionUpgrade, enabled: true
+
 for migrator <- [
       # Background migrations
       Explorer.Migrator.TransactionsDenormalization,

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -104,5 +104,6 @@ config :logger, :explorer, path: Path.absname("logs/test/explorer.log")
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: false
 config :explorer, Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand, enabled: false
 config :explorer, Explorer.Tags.AddressTag.Cataloger, enabled: false
+config :explorer, Explorer.Utility.VersionUpgrade, enabled: false
 
 config :tesla, adapter: Explorer.Mock.TeslaAdapter

--- a/apps/explorer/lib/explorer/utility/version_upgrade.ex
+++ b/apps/explorer/lib/explorer/utility/version_upgrade.ex
@@ -24,6 +24,8 @@ defmodule Explorer.Utility.VersionUpgrade do
   If no rule matches the target version, the upgrade is allowed by default.
   """
 
+  use GenServer
+
   alias Explorer.Application.Constants
   alias Explorer.Chain.Block
   alias Explorer.Migrator.HeavyDbIndexOperation.UpdateInternalTransactionsPrimaryKey
@@ -37,6 +39,16 @@ defmodule Explorer.Utility.VersionUpgrade do
       required_completed_migrations: [UpdateInternalTransactionsPrimaryKey.migration_name()]
     }
   ]
+
+  @spec start_link(term()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(_) do
+    validate_current_upgrade()
+    :ignore
+  end
 
   def validate_current_upgrade do
     previous_version = Constants.get_previous_backend_version()

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,8 +1,8 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
-#export CHROMEDRIVER_VERSION=146.0.7680.178
+#export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
+export CHROMEDRIVER_VERSION=148.0.7778.179
 curl -L -O "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip"
 unzip -j chromedriver-linux64.zip
 sudo chmod +x chromedriver


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version upgrade checker is enabled in the application and starts during launch to validate compatibility.

* **Bug Fixes**
  * Upgrade validation now runs at app startup to detect issues earlier in runtime.

* **Chores**
  * Environment configs updated to enable/disable the upgrade checker per environment.
  * Headless browser installer now pins a specific ChromeDriver version for consistent setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->