### PR TITLE
fix: declare missing OpenAPI params for advanced-filters endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -183,6 +183,30 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
         "Comma-separated list of token contract address hashes to exclude. Use the literal `native` to also " <>
           "exclude native coin transfers. Each list (include and exclude) is capped to 20 entries separately.",
       example: "0x0000000000000000000000000000000000000000"
+    },
+    %OpenApiSpex.Parameter{
+      name: :methods_names,
+      in: :query,
+      schema: %OpenApiSpex.Schema{type: :string, nullable: true},
+      required: false,
+      description: "Comma-separated list of human-readable method names corresponding to the `methods` selectors.",
+      example: "transfer,approve"
+    },
+    %OpenApiSpex.Parameter{
+      name: :token_contract_symbols_to_include,
+      in: :query,
+      schema: %OpenApiSpex.Schema{type: :string, nullable: true},
+      required: false,
+      description: "Comma-separated list of token symbols to include.",
+      example: "USDT,USDC"
+    },
+    %OpenApiSpex.Parameter{
+      name: :token_contract_symbols_to_exclude,
+      in: :query,
+      schema: %OpenApiSpex.Schema{type: :string, nullable: true},
+      required: false,
+      description: "Comma-separated list of token symbols to exclude.",
+      example: "USDT,USDC"
     }
   ]
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -505,9 +505,29 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
   end
 
   defp extract_filters(params) do
+    address_token_hashes =
+      params[:token_contract_address_hashes_to_include]
+      |> prepare_include_exclude_address_hashes(
+        params[:token_contract_address_hashes_to_exclude],
+        &prepare_token_address_hash/1
+      )
+
+    symbol_token_hashes =
+      prepare_include_exclude_address_hashes_from_symbols(
+        params[:token_contract_symbols_to_include],
+        params[:token_contract_symbols_to_exclude]
+      )
+
+    token_contract_address_hashes =
+      merge_token_hashes(address_token_hashes, symbol_token_hashes)
+      |> Enum.map(fn
+        {key, value} when is_list(value) -> {key, Enum.take(value, @tokens_filter_limit)}
+        key_value -> key_value
+      end)
+
     [
       transaction_types: prepare_transaction_types(params[:transaction_types]),
-      methods: params[:methods] |> prepare_methods(),
+      methods: merge_methods(prepare_methods(params[:methods]), prepare_methods_from_names(params[:methods_names])),
       age: prepare_age(params[:age_from], params[:age_to]),
       from_address_hashes:
         prepare_include_exclude_address_hashes(
@@ -523,16 +543,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
         ),
       address_relation: prepare_address_relation(params[:address_relation]),
       amount: prepare_amount(params[:amount_from], params[:amount_to]),
-      token_contract_address_hashes:
-        params[:token_contract_address_hashes_to_include]
-        |> prepare_include_exclude_address_hashes(
-          params[:token_contract_address_hashes_to_exclude],
-          &prepare_token_address_hash/1
-        )
-        |> Enum.map(fn
-          {key, value} when is_list(value) -> {key, Enum.take(value, @tokens_filter_limit)}
-          key_value -> key_value
-        end)
+      token_contract_address_hashes: token_contract_address_hashes
     ]
   end
 
@@ -575,6 +586,28 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
 
   defp prepare_methods(_), do: nil
 
+  defp prepare_methods_from_names(names) when is_binary(names) do
+    names
+    |> String.split(",")
+    |> Enum.map(&(String.trim(&1) |> String.downcase()))
+    |> Enum.flat_map(fn name -> List.wrap(Map.get(@methods_name_to_id_map, name)) end)
+    |> Enum.uniq()
+  end
+
+  defp prepare_methods_from_names(_), do: nil
+
+  defp merge_methods(nil, nil), do: nil
+
+  defp merge_methods(a, b) do
+    (List.wrap(a) ++ List.wrap(b))
+    |> Enum.uniq()
+    |> Enum.take(@methods_filter_limit)
+    |> case do
+      [] -> nil
+      list -> list
+    end
+  end
+
   defp prepare_age(from, to), do: [from: parse_date(from), to: parse_date(to)]
 
   defp parse_date(string_date) do
@@ -605,6 +638,42 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
       "native" -> ["native"]
       _ -> prepare_address_hash(token_address_hash)
     end
+  end
+
+  defp prepare_include_exclude_address_hashes_from_symbols(include_symbols, exclude_symbols) do
+    [
+      include: resolve_symbols_to_address_hashes(include_symbols),
+      exclude: resolve_symbols_to_address_hashes(exclude_symbols)
+    ]
+  end
+
+  defp resolve_symbols_to_address_hashes(symbols_str) when is_binary(symbols_str) do
+    case symbols_str |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == "")) do
+      [] ->
+        nil
+
+      symbols ->
+        symbols
+        |> Token.get_by_symbols(@api_true)
+        |> Enum.map(& &1.contract_address_hash)
+    end
+  end
+
+  defp resolve_symbols_to_address_hashes(_), do: nil
+
+  defp merge_token_hashes(address_based, symbol_based) do
+    [:include, :exclude]
+    |> Enum.map(fn key ->
+      merged =
+        case {address_based[key], symbol_based[key]} do
+          {nil, nil} -> nil
+          {a, nil} -> a
+          {nil, b} -> b
+          {a, b} -> Enum.uniq(a ++ b)
+        end
+
+      {key, merged}
+    end)
   end
 
   defp prepare_address_relation(relation) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
@@ -559,6 +559,143 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert Enum.count(response["items"]) == 21
     end
 
+    test "filter by methods_names alone", %{conn: conn} do
+      contract_address = insert(:contract_address)
+      transfer_selector = "0xa9059cbb"
+      mint_selector = "0xa0712d68"
+      {:ok, transfer_input} = Data.cast(transfer_selector <> "ab0ba0")
+      {:ok, mint_input} = Data.cast(mint_selector <> "ab0ba0")
+
+      3
+      |> insert_list(:transaction,
+        to_address: contract_address,
+        to_address_hash: contract_address.hash,
+        input: transfer_input
+      )
+      |> with_block()
+
+      5
+      |> insert_list(:transaction,
+        to_address: contract_address,
+        to_address_hash: contract_address.hash,
+        input: mint_input
+      )
+      |> with_block()
+
+      request = get(conn, "/api/v2/advanced-filters", %{"methods_names" => "transfer"})
+      assert response = json_response(request, 200)
+
+      assert Enum.count(response["items"]) == 3
+      assert Enum.all?(response["items"], fn item ->
+               String.slice(item["method"], 0..9) == transfer_selector
+             end)
+    end
+
+    test "filter by methods_names merges with methods param", %{conn: conn} do
+      contract_address = insert(:contract_address)
+      transfer_selector = "0xa9059cbb"
+      mint_selector = "0xa0712d68"
+      {:ok, transfer_input} = Data.cast(transfer_selector <> "ab0ba0")
+      {:ok, mint_input} = Data.cast(mint_selector <> "ab0ba0")
+
+      3
+      |> insert_list(:transaction,
+        to_address: contract_address,
+        to_address_hash: contract_address.hash,
+        input: transfer_input
+      )
+      |> with_block()
+
+      5
+      |> insert_list(:transaction,
+        to_address: contract_address,
+        to_address_hash: contract_address.hash,
+        input: mint_input
+      )
+      |> with_block()
+
+      2 |> insert_list(:transaction) |> with_block()
+
+      request =
+        get(conn, "/api/v2/advanced-filters", %{
+          "methods_names" => "transfer",
+          "methods" => mint_selector
+        })
+
+      assert response = json_response(request, 200)
+
+      assert Enum.count(response["items"]) == 8
+      assert Enum.all?(response["items"], fn item ->
+               String.slice(item["method"], 0..9) in [transfer_selector, mint_selector]
+             end)
+    end
+
+    test "filter by token_contract_symbols_to_include", %{conn: conn} do
+      token_a = insert(:token, symbol: "SYMINCL_A")
+      token_b = insert(:token, symbol: "SYMINCL_B")
+      token_c = insert(:token, symbol: "SYMINCL_C")
+
+      transaction = :transaction |> insert() |> with_block()
+
+      [token_a, token_b, token_c, token_a, token_b, token_c]
+      |> Enum.with_index()
+      |> Enum.each(fn {token, i} ->
+        insert(:token_transfer,
+          token_contract_address: token.contract_address,
+          transaction: transaction,
+          block_number: transaction.block_number,
+          log_index: i
+        )
+      end)
+
+      request =
+        get(conn, "/api/v2/advanced-filters", %{
+          "token_contract_symbols_to_include" => "SYMINCL_A,SYMINCL_B"
+        })
+
+      assert response = json_response(request, 200)
+
+      # Include filter: only token transfers whose contract matches — the parent
+      # transaction itself has no token contract so it is excluded.
+      assert Enum.count(response["items"]) == 4
+      assert Enum.all?(response["items"], fn item ->
+               item["token"]["symbol"] in ["SYMINCL_A", "SYMINCL_B"]
+             end)
+    end
+
+    test "filter by token_contract_symbols_to_exclude", %{conn: conn} do
+      token_a = insert(:token, symbol: "SYMEXCL_A")
+      token_b = insert(:token, symbol: "SYMEXCL_B")
+      token_c = insert(:token, symbol: "SYMEXCL_C")
+
+      transaction = :transaction |> insert() |> with_block()
+
+      [token_a, token_b, token_c, token_a, token_b, token_c]
+      |> Enum.with_index()
+      |> Enum.each(fn {token, i} ->
+        insert(:token_transfer,
+          token_contract_address: token.contract_address,
+          transaction: transaction,
+          block_number: transaction.block_number,
+          log_index: i
+        )
+      end)
+
+      request =
+        get(conn, "/api/v2/advanced-filters", %{
+          "token_contract_symbols_to_exclude" => "SYMEXCL_C"
+        })
+
+      assert response = json_response(request, 200)
+
+      # Exclude filter: 4 token transfers (A×2 + B×2) plus the parent transaction
+      # itself (which has no token contract and is therefore not excluded).
+      assert Enum.count(response["items"]) == 5
+      assert Enum.all?(response["items"], fn item ->
+               is_nil(item["token"]) or item["token"]["symbol"] != "SYMEXCL_C"
+             end)
+    end
+
     test "filter by age", %{conn: conn} do
       [_, transaction_a, _, transaction_b, _] =
         for i <- 0..4 do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
@@ -586,6 +586,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert response = json_response(request, 200)
 
       assert Enum.count(response["items"]) == 3
+
       assert Enum.all?(response["items"], fn item ->
                String.slice(item["method"], 0..9) == transfer_selector
              end)
@@ -625,6 +626,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert response = json_response(request, 200)
 
       assert Enum.count(response["items"]) == 8
+
       assert Enum.all?(response["items"], fn item ->
                String.slice(item["method"], 0..9) in [transfer_selector, mint_selector]
              end)
@@ -658,6 +660,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       # Include filter: only token transfers whose contract matches — the parent
       # transaction itself has no token contract so it is excluded.
       assert Enum.count(response["items"]) == 4
+
       assert Enum.all?(response["items"], fn item ->
                item["token"]["symbol"] in ["SYMINCL_A", "SYMINCL_B"]
              end)
@@ -691,6 +694,7 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       # Exclude filter: 4 token transfers (A×2 + B×2) plus the parent transaction
       # itself (which has no token contract and is therefore not excluded).
       assert Enum.count(response["items"]) == 5
+
       assert Enum.all?(response["items"], fn item ->
                is_nil(item["token"]) or item["token"]["symbol"] != "SYMEXCL_C"
              end)

--- a/apps/explorer/lib/explorer/chain/token.ex
+++ b/apps/explorer/lib/explorer/chain/token.ex
@@ -469,6 +469,16 @@ defmodule Explorer.Chain.Token do
   end
 
   @doc """
+    Gets tokens whose symbol matches any of the given symbols (case-sensitive).
+  """
+  @spec get_by_symbols([String.t()], [Chain.api?()]) :: [__MODULE__.t()]
+  def get_by_symbols(symbols, options) do
+    __MODULE__
+    |> where([t], t.symbol in ^symbols)
+    |> Chain.select_repo(options).all()
+  end
+
+  @doc """
     For usage in Indexer.Fetcher.TokenInstance.SanitizeERC721
   """
   @spec ordered_erc_721_token_address_hashes_list_query(integer(), Hash.Address.t() | nil) :: Ecto.Query.t()

--- a/cspell.json
+++ b/cspell.json
@@ -680,6 +680,8 @@
         "sushiswap",
         "swal",
         "sweetalert",
+        "SYMEXCL",
+        "SYMINCL",
         "Synthereum",
         "tabindex",
         "tablist",


### PR DESCRIPTION
## Motivation

Requests to `/api/v2/advanced-filters` that included `methods_names`, `token_contract_symbols_to_include`, or `token_contract_symbols_to_exclude` query parameters were rejected by `OpenApiSpex.Plug.CastAndValidate` with `422 Unprocessable Entity` / `"Unexpected field"` errors, because these parameters were absent from the endpoint's OpenAPI spec definition.

Example failing requests:
- `?methods=0xa9059cbb&methods_names=transfer&address_relation=and&from_address_hashes_to_include=0xEAf...`
- `?address_relation=or&token_contract_symbols_to_include=VanityTron.io&token_contract_symbols_to_exclude=`

## Changelog

### Bug Fixes

- Declared `methods_names`, `token_contract_symbols_to_include`, and `token_contract_symbols_to_exclude` as accepted query parameters in `@advanced_filter_query_params` so the `CastAndValidate` plug no longer rejects requests that include them.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced filter API gains three query parameters: methods_names, token_contract_symbols_to_include, and token_contract_symbols_to_exclude — filter by method names and include/exclude token symbols, merged with existing filters.

* **Tests**
  * Added controller tests for method-name filtering, merging with existing method filters, and token-symbol include/exclude behavior.

* **Chores**
  * Added token-symbol lookup support and updated spell-check allowlist for new symbol keys.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->