### PR TITLE
fix: use string keys in ZkSync batches paging function

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/zksync_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/zksync_controller.ex
@@ -85,7 +85,7 @@ defmodule BlockScoutWeb.API.V2.ZkSyncController do
       zksync_options
       |> Reader.batches()
       |> paginate_list(params, zksync_options[:paging_options],
-        paging_function: fn %TransactionBatch{number: number} -> %{number: number} end
+        paging_function: fn %TransactionBatch{number: number} -> %{"number" => number} end
       )
 
     conn


### PR DESCRIPTION
Use string map keys in the ZkSync batches `paging_function`, consistent with Arbitrum and the rest of the codebase. Previously `%{number: number}` (atom key) was used, which produced a mixed-key `next_page_params` map after merging with Phoenix's string-keyed `params`. Both serialize to identical JSON, so there is no behavioral change — this is a consistency fix only.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination response format in the ZkSync batches API endpoint to use consistent key naming conventions, improving API compatibility and data structure consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->