### PR TITLE
fix: use describe_inline for leaf-type properties in ZkSync batch schemas

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/zksync/batch.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/zksync/batch.ex
@@ -23,8 +23,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.ZkSync.Batch do
           "with the corresponding parent-chain lifecycle data.",
       properties: %{
         root_hash:
-          Helper.extend_schema(General.FullHash.schema(),
-            description: "State root hash committed for this batch on the parent chain."
+          Helper.describe_inline(
+            General.FullHash.schema(),
+            "State root hash committed for this batch on the parent chain."
           ),
         l1_transactions_count: %Schema{
           type: :integer,
@@ -37,12 +38,14 @@ defmodule BlockScoutWeb.Schemas.API.V2.ZkSync.Batch do
           description: "Number of transactions in the batch originating on the rollup."
         },
         l1_gas_price:
-          Helper.extend_schema(General.NonNegativeIntegerString.schema(),
-            description: "Parent-chain gas price observed for this batch, in wei."
+          Helper.describe_inline(
+            General.NonNegativeIntegerString.schema(),
+            "Parent-chain gas price observed for this batch, in wei."
           ),
         l2_fair_gas_price:
-          Helper.extend_schema(General.NonNegativeIntegerString.schema(),
-            description: "Rollup fair gas price for this batch, in wei."
+          Helper.describe_inline(
+            General.NonNegativeIntegerString.schema(),
+            "Rollup fair gas price for this batch, in wei."
           ),
         start_block_number: %Schema{
           type: :integer,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/zksync/minimal_batch.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/zksync/minimal_batch.ex
@@ -22,8 +22,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.ZkSync.MinimalBatch do
     properties: %{
       number: %Schema{type: :integer, minimum: 0, description: "Batch number on the rollup."},
       timestamp:
-        Helper.extend_schema(General.Timestamp.schema(),
-          description: "Timestamp when the batch was sealed on the rollup."
+        Helper.describe_inline(
+          General.Timestamp.schema(),
+          "Timestamp when the batch was sealed on the rollup."
         ),
       status: %Schema{
         type: :string,
@@ -37,40 +38,40 @@ defmodule BlockScoutWeb.Schemas.API.V2.ZkSync.MinimalBatch do
         """
       },
       commit_transaction_hash:
-        Helper.extend_schema(General.FullHashNullable.schema(),
-          description:
-            "Hash of the parent-chain transaction that committed this batch. " <>
-              "`null` until the commit transaction is observed."
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the parent-chain transaction that committed this batch. " <>
+            "`null` until the commit transaction is observed."
         ),
       commit_transaction_timestamp:
-        Helper.extend_schema(General.TimestampNullable.schema(),
-          description:
-            "Timestamp of the parent-chain transaction that committed this batch. " <>
-              "`null` until the commit transaction is observed."
+        Helper.describe_inline(
+          General.TimestampNullable.schema(),
+          "Timestamp of the parent-chain transaction that committed this batch. " <>
+            "`null` until the commit transaction is observed."
         ),
       prove_transaction_hash:
-        Helper.extend_schema(General.FullHashNullable.schema(),
-          description:
-            "Hash of the parent-chain transaction that proved this batch. " <>
-              "`null` until the prove transaction is observed."
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the parent-chain transaction that proved this batch. " <>
+            "`null` until the prove transaction is observed."
         ),
       prove_transaction_timestamp:
-        Helper.extend_schema(General.TimestampNullable.schema(),
-          description:
-            "Timestamp of the parent-chain transaction that proved this batch. " <>
-              "`null` until the prove transaction is observed."
+        Helper.describe_inline(
+          General.TimestampNullable.schema(),
+          "Timestamp of the parent-chain transaction that proved this batch. " <>
+            "`null` until the prove transaction is observed."
         ),
       execute_transaction_hash:
-        Helper.extend_schema(General.FullHashNullable.schema(),
-          description:
-            "Hash of the parent-chain transaction that executed this batch. " <>
-              "`null` until the execute transaction is observed."
+        Helper.describe_inline(
+          General.FullHashNullable.schema(),
+          "Hash of the parent-chain transaction that executed this batch. " <>
+            "`null` until the execute transaction is observed."
         ),
       execute_transaction_timestamp:
-        Helper.extend_schema(General.TimestampNullable.schema(),
-          description:
-            "Timestamp of the parent-chain transaction that executed this batch. " <>
-              "`null` until the execute transaction is observed."
+        Helper.describe_inline(
+          General.TimestampNullable.schema(),
+          "Timestamp of the parent-chain transaction that executed this batch. " <>
+            "`null` until the execute transaction is observed."
         )
     },
     required: [


### PR DESCRIPTION
## Summary

ZkSync batch schemas (`MinimalBatch`, `Batch`) used `Helper.extend_schema/2` at property positions where only a `description:` overlay was needed. This caused the property-specific description to leak into the corresponding global `components.schemas` entry (e.g. `Timestamp`, `FullHash`, `FullHashNullable`, `TimestampNullable`, `NonNegativeIntegerString`), overwriting the component description for every `\$ref` pointing at it across the spec.

Fixed by replacing those calls with `Helper.describe_inline/2`, which strips `:title` and `x-struct` so the result is rendered inline at the call site and the global component stays pristine.

## Why this wasn't caught earlier

The ZkSync OpenAPI spec was introduced in #14364, while `Helper.describe_inline/2` was introduced in #14369 — created and merged after #14364. Both PRs were merged nearly simultaneously, leaving no window to adapt the ZkSync schemas to the new helper. In addition, #14364 was missing a follow-up note that the ZkSync spec would need to be updated to use `describe_inline` once #14369 landed.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ZkSync API schema field descriptions for improved consistency and maintainability. No changes to user-facing functionality or API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->