### PR TITLE
feat: add include_zero_value param to v2 internal-tx endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -1278,6 +1278,7 @@ defmodule BlockScoutWeb.Chain do
   def fetch_internal_transactions(options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
     transaction_hash = Keyword.get(options, :transaction_hash)
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
 
     necessity_by_association = %{block: :optional}
 
@@ -1306,6 +1307,7 @@ defmodule BlockScoutWeb.Chain do
         end
 
       match?(%PagingOptions{key: {_, _, _}}, paging_options) and
+        include_zero_value? and
           not InternalTransaction.present_in_db?(elem(paging_options.key, 0)) ->
         InternalTransactionOnDemand.fetch_latest(options_with_necessity)
 
@@ -1313,7 +1315,7 @@ defmodule BlockScoutWeb.Chain do
         from_db = InternalTransaction.fetch(options_with_necessity)
 
         from_node =
-          if InternalTransactionOnDemand.should_fetch?(from_db, paging_options.page_size) do
+          if include_zero_value? and InternalTransactionOnDemand.should_fetch?(from_db, paging_options.page_size) do
             InternalTransactionOnDemand.fetch_latest(options_with_necessity)
           else
             []
@@ -1345,7 +1347,9 @@ defmodule BlockScoutWeb.Chain do
   """
   @spec transaction_to_internal_transactions(Transaction.t(), Keyword.t()) :: [InternalTransaction.t()]
   def transaction_to_internal_transactions(transaction, options \\ []) do
-    if InternalTransaction.present_in_db?(transaction.block_number) do
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
+
+    if InternalTransaction.present_in_db?(transaction.block_number) or not include_zero_value? do
       InternalTransaction.transaction_to_internal_transactions(transaction.hash, options)
     else
       InternalTransactionOnDemand.fetch_by_transaction(transaction, options)
@@ -1374,7 +1378,9 @@ defmodule BlockScoutWeb.Chain do
   """
   @spec block_to_internal_transactions(Block.t(), Keyword.t()) :: [InternalTransaction.t()]
   def block_to_internal_transactions(block, options \\ []) do
-    if InternalTransaction.present_in_db?(block.number) do
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
+
+    if InternalTransaction.present_in_db?(block.number) or not include_zero_value? do
       InternalTransaction.block_to_internal_transactions(block.number, options)
     else
       InternalTransactionOnDemand.fetch_by_block(block, options)
@@ -1407,10 +1413,12 @@ defmodule BlockScoutWeb.Chain do
         []
 
       _ ->
+        include_zero_value? = Keyword.get(options, :include_zero_value, true)
+
         from_db = InternalTransaction.fetch_from_db_by_address(address_hash, options)
 
         from_node =
-          if InternalTransactionOnDemand.should_fetch?(from_db, paging_options.page_size) do
+          if include_zero_value? and InternalTransactionOnDemand.should_fetch?(from_db, paging_options.page_size) do
             InternalTransactionOnDemand.fetch_by_address(address_hash, options)
           else
             []

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -610,7 +610,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
       "Retrieves all internal transactions involving a specific address, with optional filtering for internal transactions sent from or to the address.",
     parameters:
       base_params() ++
-        [address_hash_param(), direction_filter_param()] ++
+        [address_hash_param(), direction_filter_param(), include_zero_value_param()] ++
         define_paging_params(["block_number", "index", "transaction_index"]),
     responses: [
       ok:
@@ -658,6 +658,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
             |> Keyword.merge(paging_options(params))
             |> Keyword.merge(current_filter(params))
             |> Keyword.merge(@api_true)
+            |> Keyword.put(:include_zero_value, Map.get(params, :include_zero_value, true))
 
           results_plus_one = address_to_internal_transactions(address_hash, full_options)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -419,7 +419,12 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       "Retrieves internal transactions included in a specific block with optional filtering by type and call type.",
     parameters:
       base_params() ++
-        [block_hash_or_number_param(), internal_transaction_type_param(), internal_transaction_call_type_param()] ++
+        [
+          block_hash_or_number_param(),
+          internal_transaction_type_param(),
+          internal_transaction_call_type_param(),
+          include_zero_value_param()
+        ] ++
         define_paging_params(["transaction_index", "index"]),
     responses: [
       ok:
@@ -455,6 +460,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
         |> Keyword.merge(@api_true)
         |> Keyword.merge(internal_transaction_type_options(params))
         |> Keyword.merge(internal_transaction_call_type_options(params))
+        |> Keyword.put(:include_zero_value, Map.get(params, :include_zero_value, true))
 
       internal_transactions_plus_one = block_to_internal_transactions(block, full_options)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       "Retrieves a paginated list of internal transactions. Internal transactions are generated during contract execution and not directly recorded on the blockchain.",
     parameters:
       base_params() ++
-        [query_transaction_hash_param(), limit_param()] ++
+        [query_transaction_hash_param(), limit_param(), include_zero_value_param()] ++
         define_paging_params(["index", "block_number", "transaction_index"]),
     responses: [
       ok:
@@ -57,7 +57,13 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
            BackgroundMigrations.get_heavy_indexes_create_internal_transactions_block_number_desc_transaction_index_desc_index_desc_index_finished(),
          false <- transaction_hash == :invalid do
       paging_options = paging_options(params)
-      options = options(paging_options, %{transaction_hash: transaction_hash, limit: params[:limit]})
+
+      options =
+        options(paging_options, %{
+          transaction_hash: transaction_hash,
+          limit: params[:limit],
+          include_zero_value: Map.get(params, :include_zero_value, true)
+        })
 
       {internal_transactions, next_page_params} =
         options
@@ -96,6 +102,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
     paging_options
     |> Keyword.put(:transaction_hash, params.transaction_hash)
     |> Keyword.put(:exclude_origin_internal_transaction, true)
+    |> Keyword.put(:include_zero_value, Map.get(params, :include_zero_value, true))
     |> Keyword.merge(@api_true)
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -706,6 +706,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       "Retrieves internal transactions generated during the execution of a specific transaction. Useful for analyzing contract interactions and debugging failed transactions.",
     parameters:
       [transaction_hash_param() | base_params()] ++
+        [include_zero_value_param()] ++
         define_paging_params(["index", "block_number", "transaction_index"]),
     responses: [
       ok:
@@ -733,6 +734,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
         @internal_transaction_address_preloads
         |> Keyword.merge(paging_options(params))
         |> Keyword.merge(@api_true)
+        |> Keyword.put(:include_zero_value, Map.get(params, :include_zero_value, true))
 
       internal_transactions_plus_one = transaction_to_internal_transactions(transaction, full_options)
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -333,6 +333,17 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
     }
   end
 
+  @spec include_zero_value_param() :: Parameter.t()
+  def include_zero_value_param do
+    %Parameter{
+      name: :include_zero_value,
+      in: :query,
+      schema: %Schema{type: :boolean, default: true},
+      required: false,
+      description: "If `false`, zero-value call-type internal transactions are excluded from results."
+    }
+  end
+
   @doc """
   Returns a reusable OpenApiSpex.RequestBody for audit report submission.
   """

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -2433,6 +2433,46 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
 
       check_paginated_response(response, response_2nd_page, internal_transactions_from)
     end
+
+    test "include_zero_value=false excludes zero-value call internal transactions", %{conn: conn} do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        to_address: address,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        to_address: address,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      request =
+        get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions", %{"include_zero_value" => "false"})
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 1
+      assert List.first(response["items"])["index"] == 2
+
+      request_default = get(conn, "/api/v2/addresses/#{address.hash}/internal-transactions")
+      assert response_default = json_response(request_default, 200)
+      assert Enum.count(response_default["items"]) == 2
+    end
   end
 
   describe "/addresses/{address_hash}/blocks-validated" do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -971,6 +971,44 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       assert response["meta"]["message"] ==
                "Some internal transactions within this block range have not yet been processed"
     end
+
+    test "include_zero_value=false excludes zero-value call internal transactions", %{conn: conn} do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      request =
+        get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions", %{"include_zero_value" => "false"})
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 1
+      assert List.first(response["items"])["index"] == 2
+
+      request_default = get(conn, "/api/v2/blocks/#{block.hash}/internal-transactions")
+      assert response_default = json_response(request_default, 200)
+      assert Enum.count(response_default["items"]) == 2
+    end
   end
 
   if @chain_type == :ethereum do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/internal_transaction_controller_test.exs
@@ -204,6 +204,40 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionControllerTest do
       assert Enum.count(response_2nd_page["items"]) == 1
       assert response_2nd_page["next_page_params"] == nil
     end
+
+    test "include_zero_value=false excludes zero-value call internal transactions", %{conn: conn} do
+      tx =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: tx,
+        transaction_index: tx.index,
+        block_number: tx.block_number,
+        index: 1,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: tx,
+        transaction_index: tx.index,
+        block_number: tx.block_number,
+        index: 2,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      request = get(conn, "/api/v2/internal-transactions", %{"include_zero_value" => "false"})
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 1
+      assert List.first(response["items"])["index"] == 2
+
+      request_default = get(conn, "/api/v2/internal-transactions")
+      assert response_default = json_response(request_default, 200)
+      assert Enum.count(response_default["items"]) == 2
+    end
   end
 
   defp compare_item(%InternalTransaction{} = internal_transaction, json) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -727,11 +727,6 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     end
 
     test "returns pending status when transaction block is pending", %{conn: conn} do
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block()
-
       insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
@@ -762,6 +757,53 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       assert response["meta"]["message"] ==
                "Some internal transactions within this block range have not yet been processed"
+    end
+
+    test "include_zero_value=false excludes zero-value call internal transactions", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 0,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      request =
+        get(
+          conn,
+          "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions",
+          %{"include_zero_value" => "false"}
+        )
+
+      assert response = json_response(request, 200)
+      assert Enum.count(response["items"]) == 1
+      assert List.first(response["items"])["index"] == 2
+
+      request_default = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")
+      assert response_default = json_response(request_default, 200)
+      assert Enum.count(response_default["items"]) == 2
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -727,6 +727,11 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     end
 
     test "returns pending status when transaction block is pending", %{conn: conn} do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
       insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
 
       request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/internal-transactions")

--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -743,12 +743,14 @@ defmodule Explorer.Chain.InternalTransaction do
   def transaction_to_internal_transactions(hash, options \\ []) when is_list(options) do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
 
     __MODULE__
     |> for_parent_transaction(hash)
     |> Chain.join_associations(necessity_by_association)
     |> where_is_different_from_parent_transaction()
     |> where_nonpending_operation()
+    |> include_zero_value(include_zero_value?)
     |> page_internal_transaction(paging_options)
     |> limit(^paging_options.page_size)
     |> order_by([internal_transaction], asc: internal_transaction.index)
@@ -770,12 +772,14 @@ defmodule Explorer.Chain.InternalTransaction do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
     type_filter = Keyword.get(options, :type, [])
     call_type_filter = Keyword.get(options, :call_type, [])
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
 
     __MODULE__
     |> where([internal_transaction], internal_transaction.block_number == ^block_number)
     |> Chain.join_associations(necessity_by_association)
     |> where_is_different_from_parent_transaction()
     |> where_nonpending_operation()
+    |> include_zero_value(include_zero_value?)
     |> page_block_internal_transaction(paging_options)
     |> filter_by_type(type_filter, call_type_filter)
     |> filter_by_call_type(call_type_filter)
@@ -882,6 +886,7 @@ defmodule Explorer.Chain.InternalTransaction do
     necessity_by_association = Keyword.get(options, :necessity_by_association, %{})
     direction = Keyword.get(options, :direction)
     timeout = Keyword.get(options, :timeout)
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
 
     from_block = Chain.from_block(options)
     to_block = Chain.to_block(options)
@@ -895,6 +900,7 @@ defmodule Explorer.Chain.InternalTransaction do
         |> where_address_fields_match(hash, :to)
         |> BlockReaderGeneral.where_block_number_in_period(from_block, to_block)
         |> where_is_different_from_parent_transaction()
+        |> include_zero_value(include_zero_value?)
         |> common_where_limit_order(paging_options)
         |> Chain.wrapped_union_subquery()
 
@@ -904,6 +910,7 @@ defmodule Explorer.Chain.InternalTransaction do
         |> where_address_fields_match(hash, :from_address_hash)
         |> BlockReaderGeneral.where_block_number_in_period(from_block, to_block)
         |> where_is_different_from_parent_transaction()
+        |> include_zero_value(include_zero_value?)
         |> common_where_limit_order(paging_options)
         |> Chain.wrapped_union_subquery()
 
@@ -924,6 +931,7 @@ defmodule Explorer.Chain.InternalTransaction do
       |> where_address_fields_match(hash, direction)
       |> BlockReaderGeneral.where_block_number_in_period(from_block, to_block)
       |> where_is_different_from_parent_transaction()
+      |> include_zero_value(include_zero_value?)
       |> common_where_limit_order(paging_options)
       |> preload(:block)
       |> Chain.join_associations(necessity_by_association)
@@ -1220,6 +1228,7 @@ defmodule Explorer.Chain.InternalTransaction do
   def fetch(options) do
     paging_options = Keyword.get(options, :paging_options, @default_paging_options)
     exclude_zero_index_internal_transaction = Keyword.get(options, :exclude_origin_internal_transaction, false)
+    include_zero_value? = Keyword.get(options, :include_zero_value, true)
 
     case paging_options do
       %PagingOptions{key: {0, 0}} ->
@@ -1238,6 +1247,7 @@ defmodule Explorer.Chain.InternalTransaction do
         __MODULE__
         |> where_nonpending_operation()
         |> maybe_filter_origin_transaction(exclude_zero_index_internal_transaction)
+        |> include_zero_value(include_zero_value?)
         |> page_internal_transaction(paging_options, %{index_internal_transaction_desc_order: true})
         |> where_internal_transactions_by_transaction_hash(Keyword.get(options, :transaction_hash))
         |> order_by([internal_transaction],

--- a/apps/explorer/test/explorer/chain/internal_transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/internal_transaction_test.exs
@@ -321,6 +321,70 @@ defmodule Explorer.Chain.InternalTransactionTest do
                )
                |> Enum.map(&{&1.transaction_index, &1.index})
     end
+
+    test "excludes zero-value call internal transactions when include_zero_value: false" do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      %InternalTransaction{transaction_index: t_index, index: kept_index} =
+        insert(:internal_transaction,
+          transaction: transaction,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index,
+          type: :call,
+          value: Decimal.new(1)
+        )
+
+      result =
+        transaction.hash
+        |> InternalTransaction.transaction_to_internal_transactions(include_zero_value: false)
+        |> Enum.map(&{&1.transaction_index, &1.index})
+
+      assert result == [{t_index, kept_index}]
+    end
+
+    test "includes zero-value call internal transactions by default" do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      assert length(InternalTransaction.transaction_to_internal_transactions(transaction.hash)) == 2
+    end
   end
 
   describe "all_transaction_to_internal_transactions/1" do
@@ -994,6 +1058,142 @@ defmodule Explorer.Chain.InternalTransactionTest do
       assert {actual.block_number, actual.transaction_index, actual.index} ==
                {expected.block_number, expected.transaction_index, expected.index}
     end
+
+    test "excludes zero-value call internal transactions when include_zero_value: false" do
+      address = insert(:address)
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        to_address: address,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      %InternalTransaction{transaction_index: t_index, index: kept_index} =
+        insert(:internal_transaction,
+          transaction: transaction,
+          to_address: address,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index,
+          type: :call,
+          value: Decimal.new(1)
+        )
+
+      result =
+        address.hash
+        |> InternalTransaction.address_to_internal_transactions(include_zero_value: false)
+        |> Enum.map(&{&1.transaction_index, &1.index})
+
+      assert result == [{t_index, kept_index}]
+    end
+
+    test "includes zero-value call internal transactions by default" do
+      address = insert(:address)
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        to_address: address,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        to_address: address,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      assert length(InternalTransaction.address_to_internal_transactions(address.hash)) == 2
+    end
+  end
+
+  describe "block_to_internal_transactions/1" do
+    test "excludes zero-value call internal transactions when include_zero_value: false" do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      %InternalTransaction{transaction_index: t_index, index: kept_index} =
+        insert(:internal_transaction,
+          transaction: transaction,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index,
+          type: :call,
+          value: Decimal.new(1)
+        )
+
+      result =
+        block.number
+        |> InternalTransaction.block_to_internal_transactions(include_zero_value: false)
+        |> Enum.map(&{&1.transaction_index, &1.index})
+
+      assert result == [{t_index, kept_index}]
+    end
+
+    test "includes zero-value call internal transactions by default" do
+      block = insert(:block)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block(block)
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      assert length(InternalTransaction.block_to_internal_transactions(block.number)) == 2
+    end
   end
 
   describe "fetch/1" do
@@ -1032,6 +1232,66 @@ defmodule Explorer.Chain.InternalTransactionTest do
     #              |> InternalTransaction.fetch()
     #              |> Enum.map(&{&1.transaction_hash, &1.index, &1.block_hash})
     #   end
+
+    test "excludes zero-value call internal transactions when include_zero_value: false" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      %InternalTransaction{transaction_index: t_index, index: kept_index} =
+        insert(:internal_transaction,
+          transaction: transaction,
+          index: 2,
+          block_number: transaction.block_number,
+          transaction_index: transaction.index,
+          type: :call,
+          value: Decimal.new(1)
+        )
+
+      result =
+        [include_zero_value: false, exclude_origin_internal_transaction: false]
+        |> InternalTransaction.fetch()
+        |> Enum.map(&{&1.transaction_index, &1.index})
+
+      assert result == [{t_index, kept_index}]
+    end
+
+    test "includes zero-value call internal transactions by default" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 1,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(0)
+      )
+
+      insert(:internal_transaction,
+        transaction: transaction,
+        index: 2,
+        block_number: transaction.block_number,
+        transaction_index: transaction.index,
+        type: :call,
+        value: Decimal.new(1)
+      )
+
+      assert length(InternalTransaction.fetch(exclude_origin_internal_transaction: false)) == 2
+    end
   end
 
   describe "fetch_first_trace/2" do


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/14400

## Motivation

The Etherscan-compatible RPC API already supports filtering zero-value internal transactions via `include_zero_value`. This change exposes the same flag as a boolean query parameter on the four V2 REST endpoints that return internal transactions, giving REST API consumers the same filtering capability without changing default behavior.

## Changelog

### Enhancements

- Add `include_zero_value` boolean query parameter to `GET /api/v2/internal-transactions`, `GET /api/v2/addresses/:hash/internal-transactions`, `GET /api/v2/transactions/:hash/internal-transactions`, and `GET /api/v2/blocks/:hash/internal-transactions`. When set to `false`, call-type internal transactions with a value of 0 are excluded from results. Default is `true` (existing behavior preserved).

### Bug Fixes

### Incompatible Changes

## Upgrading

No migration or configuration changes required.

## Checklist

- [x] I have added tests
- [x] I have updated OpenAPI/Swagger specs (parameter added via `include_zero_value_param/0` in `BlockScoutWeb.Schemas.API.V2.General`)
- [ ] I have updated the documentation
- [ ] I have added an entry to the `CHANGELOG.md`
- [ ] I have added an env variable to `docker-compose/envs/common-blockscout.env` if applicable
- [ ] I have added DB indices
- [ ] I have verified that this change works on the following chain types: Ethereum/EVM-compatible, Filecoin/FVM-compatible, Cosmos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional include_zero_value query parameter to internal-transaction endpoints (default: true). Set to false to exclude zero-value call-type internal transactions.
* **Documentation**
  * API parameter added to OpenAPI schemas and documented behavior.
* **Behavior**
  * Internal-transaction fetch paths now respect include_zero_value when selecting results and routing fetches.
* **Tests**
  * New tests covering include/exclude behavior across endpoints and internal fetch logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->