### PR TITLE
chore: Add PG statement_timeout for import transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -4,7 +4,7 @@ defmodule Explorer.Chain.Import do
   Bulk importing of data into `Explorer.Repo`
   """
 
-  alias Ecto.Changeset
+  alias Ecto.{Changeset, Multi}
   alias Explorer.Account.Notify
   alias Explorer.Chain.{Block, Import}
   alias Explorer.Chain.Events.Publisher
@@ -436,10 +436,26 @@ defmodule Explorer.Chain.Import do
   end
 
   defp import_transaction(multi, options) when is_map(options) do
-    Repo.logged_transaction(multi, timeout: Map.get(options, :timeout, @transaction_timeout))
+    timeout = Map.get(options, :timeout, @transaction_timeout)
+
+    multi
+    |> add_statement_timeout(timeout)
+    |> Repo.logged_transaction(timeout: timeout)
   rescue
     exception -> {:exception, exception, __STACKTRACE__}
   end
+
+  defp add_statement_timeout(multi, timeout) when is_integer(timeout) do
+    prefix_multi =
+      Multi.run(Multi.new(), :set_statement_timeout, fn repo, _ ->
+        repo.query!("SET LOCAL statement_timeout = #{timeout}")
+        {:ok, :done}
+      end)
+
+    Multi.prepend(multi, prefix_multi)
+  end
+
+  defp add_statement_timeout(multi, _timeout), do: multi
 
   defp handle_task_results(task_results, acc_changes) do
     Enum.reduce_while(task_results, {:ok, acc_changes}, fn task_result, {:ok, acc_changes_inner} ->

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -493,7 +493,7 @@ defmodule Explorer.Chain.ImportTest do
     end
 
     test "with empty map" do
-      assert {:ok, %{}} == Import.all(%{})
+      assert {:ok, %{set_statement_timeout: :done}} == Import.all(%{})
     end
 
     test "with invalid data" do
@@ -1848,7 +1848,7 @@ defmodule Explorer.Chain.ImportTest do
                blocks: %{
                  params: []
                }
-             }) == {:ok, %{}}
+             }) == {:ok, %{set_statement_timeout: :done}}
     end
 
     # https://github.com/poanetwork/blockscout/issues/868 regression test


### PR DESCRIPTION
## Motivation

If the application is launched with an external pooler as an interlayer between app and DB, the `:timeout` option in `Repo.transaction` may not affect the long-running queries. It means that some long-running import queries may continue to run in the DB even when they have already timed out in the application.

## Changelog

Add `LOCAL statement_timeout` to every import transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk import transaction timeout handling: timeouts are now derived from options (with sensible defaults) and applied at the database level to better control long-running imports.
* **Tests**
  * Updated tests to reflect the new behavior where a statement-timeout step is recorded during import transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->