### PR TITLE
chore: Perceive "out of gas" error as contract failure

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc.ex
@@ -969,6 +969,7 @@ defmodule EthereumJSONRPC do
   formats. The function identifies two types of contract failures:
   1. Errors with the atom `:unable_to_decode`
   2. Binary errors containing the pattern "execution" followed by "revert"
+  3. Binary errors containing the pattern "out of gas"
 
   ## Parameters
   - `error`: The error to check. Can be a map with an `:error` key, a tuple
@@ -980,8 +981,14 @@ defmodule EthereumJSONRPC do
   """
   @spec contract_failure?(any()) :: boolean()
   def contract_failure?(%{error: :unable_to_decode}), do: true
-  def contract_failure?(%{error: error}) when is_binary(error), do: String.match?(error, ~r/execution.*revert/)
+
+  def contract_failure?(%{error: error}) when is_binary(error),
+    do: String.match?(error, ~r/execution.*revert/) or String.match?(error, ~r/out of gas/)
+
   def contract_failure?({:error, :unable_to_decode}), do: true
-  def contract_failure?({:error, error}) when is_binary(error), do: String.match?(error, ~r/execution.*revert/)
+
+  def contract_failure?({:error, error}) when is_binary(error),
+    do: String.match?(error, ~r/execution.*revert/) or String.match?(error, ~r/out of gas/)
+
   def contract_failure?(_), do: false
 end


### PR DESCRIPTION
## Changelog

Add `out of gas` error to `EthereumJSONRPC.contract_failure?/1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract failure detection to recognize "out of gas" errors in addition to revert-style execution errors, across different error response formats.
* **Documentation**
  * Updated docs to note that binary errors containing "out of gas" are now classified as contract execution failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->