### PR TITLE
fix: scope missing_current_token_balances_count indexer metric to configured block ranges

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
@@ -114,25 +114,55 @@ defmodule Explorer.Chain.Metrics.Queries.IndexerMetrics do
   # sobelow_skip ["SQL"]
   @spec missing_current_token_balances_count() :: integer()
   def missing_current_token_balances_count do
-    sql_string =
-      """
+    block_ranges = RangesHelper.get_block_ranges()
+
+    if block_ranges == [] do
+      0
+    else
+      {range_conditions, params} =
+        Enum.reduce(block_ranges, {[], []}, fn
+          first..last//_, {conditions, acc_params} ->
+            from = min(first, last)
+            to = max(first, last)
+            param_index_from = length(acc_params) + 1
+            param_index_to = length(acc_params) + 2
+
+            condition =
+              "(ctb.block_number >= $#{param_index_from}::bigint AND ctb.block_number <= $#{param_index_to}::bigint)"
+
+            {[condition | conditions], [to, from | acc_params]}
+
+          start_from, {conditions, acc_params} ->
+            param_index = length(acc_params) + 1
+            condition = "ctb.block_number >= $#{param_index}::bigint"
+            {[condition | conditions], [start_from | acc_params]}
+        end)
+
+      range_filter =
+        range_conditions
+        |> Enum.reverse()
+        |> Enum.join(" OR ")
+
+      sql_string = """
       SELECT COUNT(1) as missing_current_token_balances_count
       FROM address_current_token_balances ctb
       WHERE (ctb.value_fetched_at is NULL OR ctb.value is NULL)
-      AND ctb.token_type != 'ERC-7984';
+      AND ctb.token_type != 'ERC-7984'
+      AND (#{range_filter});
       """
 
-    case SQL.query(Repo, sql_string, [], timeout: :infinity) do
-      {:ok,
-       %Postgrex.Result{
-         command: :select,
-         columns: ["missing_current_token_balances_count"],
-         rows: [[missing_current_token_balances_count]]
-       }} ->
-        missing_current_token_balances_count
+      case SQL.query(Repo, sql_string, Enum.reverse(params), timeout: :infinity) do
+        {:ok,
+         %Postgrex.Result{
+           command: :select,
+           columns: ["missing_current_token_balances_count"],
+           rows: [[missing_current_token_balances_count]]
+         }} ->
+          missing_current_token_balances_count
 
-      _ ->
-        0
+        _ ->
+          0
+      end
     end
   end
 


### PR DESCRIPTION
## Motivation

`missing_current_token_balances_count` was counting all token balances with missing values across the entire chain history, regardless of which block ranges the indexer is actually configured to index. This led to inflated metrics on instances that only index a subset of blocks. The metric should only reflect gaps within the configured block ranges, consistent with how `missing_blocks_count` already works.

## Changelog

### Bug Fixes

- `missing_current_token_balances_count` indexer health metric now filters `address_current_token_balances` by the block ranges returned from `RangesHelper.get_block_ranges()`, matching the scoping logic used in `missing_blocks_count`. Returns `0` when no block ranges are configured.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of token balance metrics by restricting queries to relevant block ranges, ensuring more precise data calculations in the indexer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->