### PR TITLE
fix: Run background migrations immediately on green install

### DIFF
--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -223,11 +223,11 @@ defmodule Explorer.Application do
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesVerifiedIndex,
           :indexer
         ),
-        configure_mode_dependent_process(Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.DropLogsBlockNumberAscIndexAscIndex,
           :indexer
         ),
+        configure_mode_dependent_process(Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashBlockNumberDescIndexDescIndex,
           :indexer
@@ -382,10 +382,6 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError,
-          :indexer
-        ),
-        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsFromAddressIdPartialIndex,
           :indexer
         ),
@@ -399,6 +395,10 @@ defmodule Explorer.Application do
         ),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateInternalTransactionsBlockNumberCreatedContractAddressIdPartialIndex,
+          :indexer
+        ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.RemoveInternalTransactionsBlockHashTransactionHashBlockIndexError,
           :indexer
         ),
         configure_mode_dependent_process(

--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -171,6 +171,7 @@ defmodule Explorer.Migrator.FillingMigration do
 
       import Ecto.Query
 
+      alias Explorer.Chain.Block
       alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
       alias Explorer.Migrator.MigrationStatus
       alias Explorer.Repo
@@ -195,7 +196,13 @@ defmodule Explorer.Migrator.FillingMigration do
 
       @impl true
       def init(_) do
-        {:ok, %{}, {:continue, :ok}}
+        if Repo.exists?(Block) do
+          {:ok, %{}, {:continue, :ok}}
+        else
+          MigrationStatus.set_status(migration_name(), "completed")
+          update_cache()
+          :ignore
+        end
       end
 
       # Called once when the GenServer starts to initialize the migration process by checking its

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
@@ -130,6 +130,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
       import Ecto.Query
 
       alias Ecto.Adapters.SQL
+      alias Explorer.Chain.Block
       alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
       alias Explorer.Migrator.MigrationStatus
       alias Explorer.Repo
@@ -152,7 +153,22 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
 
       @impl true
       def init(_) do
-        {:ok, %{}, {:continue, :ok}}
+        with {:green_install?, true} <- {:green_install?, not Repo.exists?(Block)},
+             {:migration_finished?, false} <- {:migration_finished?, migration_finished?()},
+             {:dependent_from_migrations_completed?, true} <-
+               {:dependent_from_migrations_completed?, dependent_from_migrations_completed?()},
+             {:db_index_operation, :ok} <- {:db_index_operation, db_index_operation()} do
+          MigrationStatus.set_status(migration_name(), "completed")
+          update_cache()
+          :ignore
+        else
+          {:migration_finished?, true} ->
+            update_cache()
+            :ignore
+
+          _ ->
+            {:ok, %{}, {:continue, :ok}}
+        end
       end
 
       @impl true
@@ -226,16 +242,20 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
         if running_other_heavy_migration_exists?(migration_name()) do
           false
         else
-          if Enum.empty?(dependent_from_migrations()) do
-            true
-          else
-            all_statuses =
-              MigrationStatus.fetch_migration_statuses(dependent_from_migrations())
+          dependent_from_migrations_completed?()
+        end
+      end
 
-            all_statuses_completed? = not Enum.empty?(all_statuses) && all_statuses |> Enum.all?(&(&1 == "completed"))
+      defp dependent_from_migrations_completed? do
+        if Enum.empty?(dependent_from_migrations()) do
+          true
+        else
+          all_statuses =
+            MigrationStatus.fetch_migration_statuses(dependent_from_migrations())
 
-            all_statuses_completed? && Enum.count(all_statuses) == Enum.count(dependent_from_migrations())
-          end
+          all_statuses_completed? = not Enum.empty?(all_statuses) && all_statuses |> Enum.all?(&(&1 == "completed"))
+
+          all_statuses_completed? && Enum.count(all_statuses) == Enum.count(dependent_from_migrations())
         end
       end
 

--- a/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_current_token_balance_token_type_test.exs
@@ -9,6 +9,8 @@ defmodule Explorer.Migrator.AddressCurrentTokenBalanceTokenTypeTest do
 
   describe "Migrate current token balances" do
     test "Set token_type for not processed current token balances" do
+      insert(:block)
+
       Enum.each(0..10, fn _x ->
         current_token_balance = insert(:address_current_token_balance, token_type: nil)
         assert %{token_type: nil} = current_token_balance

--- a/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
+++ b/apps/explorer/test/explorer/migrator/address_token_balance_token_type_test.exs
@@ -9,6 +9,8 @@ defmodule Explorer.Migrator.AddressTokenBalanceTokenTypeTest do
 
   describe "Migrate token balances" do
     test "Set token_type for not processed token balances" do
+      insert(:block)
+
       Enum.each(0..10, fn _x ->
         token_balance = insert(:token_balance, token_type: nil)
         assert %{token_type: nil} = token_balance

--- a/apps/explorer/test/explorer/migrator/backfill_metadata_url_test.exs
+++ b/apps/explorer/test/explorer/migrator/backfill_metadata_url_test.exs
@@ -31,6 +31,7 @@ defmodule Explorer.Migrator.BackfillMetadataURLTest do
 
   describe "BackfillMetadataURL" do
     test "complete migration" do
+      insert(:block)
       token = insert(:token, type: "ERC-721")
 
       insert(:token_instance,
@@ -127,6 +128,7 @@ defmodule Explorer.Migrator.BackfillMetadataURLTest do
     end
 
     test "Resolve domain" do
+      insert(:block)
       token = insert(:token, type: "ERC-721")
       env = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Helper)
       Application.put_env(:explorer, Explorer.Migrator.BackfillMetadataURL, batch_size: 1, concurrency: 1)
@@ -279,6 +281,7 @@ defmodule Explorer.Migrator.BackfillMetadataURLTest do
     end
 
     test "drop metadata on invalid token uri response" do
+      insert(:block)
       token = insert(:token, type: "ERC-1155")
       env = Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Helper)
       Application.put_env(:explorer, Explorer.Migrator.BackfillMetadataURL, batch_size: 1, concurrency: 1)
@@ -349,6 +352,7 @@ defmodule Explorer.Migrator.BackfillMetadataURLTest do
     end
 
     test "regression for https://github.com/blockscout/blockscout/issues/12389" do
+      insert(:block)
       token = insert(:token, type: "ERC-721")
 
       insert(:token_instance,

--- a/apps/explorer/test/explorer/migrator/merge_adjacent_missing_block_ranges_test.exs
+++ b/apps/explorer/test/explorer/migrator/merge_adjacent_missing_block_ranges_test.exs
@@ -7,6 +7,8 @@ defmodule Explorer.Migrator.MergeAdjacentMissingBlockRangesTest do
   alias Explorer.Utility.MissingBlockRange
 
   test "Merges adjacent ranges" do
+    insert(:block)
+
     Repo.delete_all(MissingBlockRange)
 
     insert(:missing_block_range, from_number: 100, to_number: 70, priority: nil)

--- a/apps/explorer/test/explorer/migrator/sanitize_duplicate_smart_contract_additional_sources_test.exs
+++ b/apps/explorer/test/explorer/migrator/sanitize_duplicate_smart_contract_additional_sources_test.exs
@@ -10,6 +10,8 @@ defmodule Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSourcesTest 
 
   describe "sanitize duplicates in smart_contracts_additional_sources" do
     test "removes duplicate rows keeping a single record per (address_hash, file_name)" do
+      insert(:block)
+
       sc1 = insert(:smart_contract)
       sc2 = insert(:smart_contract)
 
@@ -53,6 +55,7 @@ defmodule Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSourcesTest 
     end
 
     test "completes gracefully when there are no duplicates" do
+      insert(:block)
       sc = insert(:smart_contract)
 
       %SmartContractAdditionalSource{}

--- a/apps/explorer/test/explorer/migrator/sanitize_missing_token_balances_test.exs
+++ b/apps/explorer/test/explorer/migrator/sanitize_missing_token_balances_test.exs
@@ -8,6 +8,8 @@ defmodule Explorer.Migrator.SanitizeMissingTokenBalancesTest do
 
   describe "Migrate token balances" do
     test "Unset value and value_fetched_at for token balances related to not processed current token balances" do
+      insert(:block)
+
       Enum.each(0..10, fn _x ->
         token_balance = insert(:token_balance)
 

--- a/apps/explorer/test/explorer/migrator/unescape_ampersands_in_tokens_test.exs
+++ b/apps/explorer/test/explorer/migrator/unescape_ampersands_in_tokens_test.exs
@@ -6,6 +6,8 @@ defmodule Explorer.Migrator.UnescapeAmpersandsInTokensTest do
   alias Explorer.Repo
 
   test "Unescapes ampersands in tokens" do
+    insert(:block)
+
     escaped_name_token = insert(:token, name: "Rock &amp; Roll")
     escaped_symbol_token = insert(:token, symbol: "R&amp;R")
     escaped_both_token = insert(:token, name: "Tom &amp; Jerry", symbol: "T&amp;J")

--- a/apps/explorer/test/explorer/migrator/unescape_quotes_in_tokens_test.exs
+++ b/apps/explorer/test/explorer/migrator/unescape_quotes_in_tokens_test.exs
@@ -6,6 +6,8 @@ defmodule Explorer.Migrator.UnescapeQuotesInTokensTest do
   alias Explorer.Repo
 
   test "Unescapes quotes in tokens" do
+    insert(:block)
+
     escaped_name_token = insert(:token, name: "Smth&#39;s")
     escaped_symbol_token = insert(:token, symbol: "&quot;Double quoted&quot;")
     escaped_both_token = insert(:token, name: "Smth&#39;s", symbol: "&quot;Double quoted&quot;")


### PR DESCRIPTION
## Motivation

There is no need to wait between background migration in case when DB is empty. Also it causes an issue if the second launch after green install happens before all the necessary for current version migrations were completed.

## Changelog

Run background migrations immediately on start if DB is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Startup now skips unnecessary index work on fresh installs, reducing startup time.
  * Migration checks are stricter: dependent migrations must be completed before running heavy index steps, and migrations already marked completed are not re-run.
  * Initialization better synchronizes cache and marks completed migrations reliably to avoid repeated operations.
  * Job scheduling order adjusted and a redundant migration task removed to streamline startup sequencing.

* **Tests**
  * Various migrator tests now include required block setup to ensure reliable test contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->