### PR TITLE
fix: Adapt maybe_reject_zero_value for pre-changeset values

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -557,12 +557,21 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
   defp maybe_reject_zero_value(internal_transactions) do
     with true <- Application.get_env(:explorer, DeleteZeroValueInternalTransactions)[:enabled],
          border_number when is_integer(border_number) <- DeleteZeroValueInternalTransactions.border_number() do
-      Enum.reject(
-        internal_transactions,
-        &(Map.has_key?(&1, :type) and
-            (&1.block_number <= border_number and &1.type == :call and
-               (is_nil(Map.get(&1, :value)) || Decimal.eq?(&1.value.value, 0))))
-      )
+      Enum.reject(internal_transactions, fn
+        %{type: type, block_number: block_number} = internal_transaction ->
+          # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
+          value =
+            case Map.get(internal_transaction, :value) do
+              %{value: decimal_value} -> decimal_value
+              integer_value when is_integer(integer_value) -> integer_value
+              nil -> 0
+            end
+
+          block_number <= border_number and type in [:call, "call"] and Decimal.eq?(value, 0)
+
+        _ ->
+          false
+      end)
     else
       _ -> internal_transactions
     end

--- a/apps/explorer/priv/repo/migrations/20260602073932_reset_delete_zero_value_internal_transactions_migration.exs
+++ b/apps/explorer/priv/repo/migrations/20260602073932_reset_delete_zero_value_internal_transactions_migration.exs
@@ -1,0 +1,7 @@
+defmodule Explorer.Repo.Migrations.ResetDeleteZeroValueInternalTransactionsMigration do
+  use Ecto.Migration
+
+  def change do
+    execute("DELETE FROM migrations_status WHERE migration_name = 'delete_zero_value_internal_transactions'")
+  end
+end

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -5,6 +5,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
   alias Ecto.Multi
   alias Explorer.Chain.{Block, Data, Wei, PendingBlockOperation, Transaction, InternalTransaction}
   alias Explorer.Chain.Import.Runner.InternalTransactions
+  alias Explorer.Migrator.DeleteZeroValueInternalTransactions
 
   setup do
     config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
@@ -592,6 +593,126 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
       # Should not raise an error
       assert {:ok, _} = run_internal_transactions([selfdestruct_changes])
+    end
+  end
+
+  describe "prepare_data/1 zero value filtering" do
+    setup do
+      original_config = Application.get_env(:explorer, DeleteZeroValueInternalTransactions)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, DeleteZeroValueInternalTransactions, original_config)
+      end)
+
+      :ok
+    end
+
+    test "removes zero-value call internal transactions before border block" do
+      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
+      block = insert(:block)
+
+      params = [
+        %{
+          type: :call,
+          block_number: block.number - 1,
+          value: Wei.from(Decimal.new(0), :wei)
+        },
+        %{
+          type: :call,
+          block_number: block.number - 1,
+          value: Wei.from(Decimal.new(1), :wei)
+        },
+        %{
+          type: "call",
+          block_number: block.number - 1,
+          value: 0
+        }
+      ]
+
+      result = InternalTransactions.prepare_data(params)
+
+      assert length(result) == 1
+      assert hd(result).value.value == Decimal.new(1)
+    end
+
+    test "does not remove zero-value calls after border block" do
+      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
+      block = insert(:block)
+
+      params = [
+        %{
+          type: :call,
+          block_number: block.number + 1,
+          value: Wei.from(Decimal.new(0), :wei)
+        },
+        %{
+          type: "call",
+          block_number: block.number + 1,
+          value: 0
+        }
+      ]
+
+      assert [_, _] = InternalTransactions.prepare_data(params)
+    end
+
+    test "does not remove non-call internal transactions" do
+      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
+      block = insert(:block)
+
+      params = [
+        %{
+          type: :create,
+          block_number: block.number - 1,
+          value: Wei.from(Decimal.new(0), :wei)
+        },
+        %{
+          type: "create",
+          block_number: block.number - 1,
+          value: 0
+        }
+      ]
+
+      assert [_, _] = InternalTransactions.prepare_data(params)
+    end
+
+    test "treats nil value as zero" do
+      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
+      block = insert(:block)
+
+      params = [
+        %{
+          type: :call,
+          block_number: block.number - 1,
+          value: nil
+        },
+        %{
+          type: "call",
+          block_number: block.number - 1,
+          value: nil
+        }
+      ]
+
+      assert [] == InternalTransactions.prepare_data(params)
+    end
+
+    test "does not filter anything when feature is disabled" do
+      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: false, storage_period: 0)
+      block = insert(:block)
+
+      params = [
+        %{
+          type: :call,
+          block_number: block.number - 1,
+          value: Wei.from(Decimal.new(0), :wei)
+        },
+        %{
+          type: "call",
+          block_number: block.number - 1,
+          value: 0
+        }
+      ]
+
+      assert [_, _] = InternalTransactions.prepare_data(params)
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/13921

## Motivation

`maybe_reject_zero_value/1` is executed before the changeset function is applied on import so the `type` and `value` field values may have the string and integer types respectively.

## Changelog

- Adapt `maybe_reject_zero_value/1` to operate with different possible data types
- Add tests with different data types
- Reset `delete_zero_value_internal_transactions` migration