### PR TITLE
feat: add MinimalProxy detection for mid-bytecode EIP-1167-like pattern

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -25,6 +25,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     EIP7702,
     ERC7760,
     MasterCopy,
+    MinimalProxy,
     ResolvedDelegateProxy
   }
 
@@ -49,6 +50,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
     {ERC7760, :erc7760},
     {CloneWithImmutableArguments, :clone_with_immutable_arguments},
     {ResolvedDelegateProxy, :resolved_delegate_proxy},
+    {MinimalProxy, :minimal_proxy},
 
     # generic proxy types
     {EIP1967, :eip1967},

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/minimal_proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/minimal_proxy.ex
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.SmartContract.Proxy.MinimalProxy do
+  @moduledoc """
+  Module for fetching proxy implementation from minimal proxy contracts where the EIP-1167-like
+  bytecode sequence is embedded somewhere in the middle of the contract bytecode rather than at
+  the start.
+
+  The pattern `3D3D3D3D363D3D37363D73` is located anywhere in the bytecode, and the 20 bytes
+  immediately following it are the implementation address.
+  """
+
+  alias Explorer.Chain.Hash
+  alias Explorer.Chain.SmartContract.Proxy.ResolverBehaviour
+
+  @behaviour ResolverBehaviour
+
+  @pattern <<0x3D3D3D3D363D3D37363D73::11-unit(8)>>
+
+  @impl true
+  def quick_resolve_implementations(proxy_address, _proxy_type) do
+    case proxy_address.contract_code && proxy_address.contract_code.bytes do
+      bytes when is_binary(bytes) ->
+        case :binary.match(bytes, @pattern) do
+          {pos, len} when byte_size(bytes) >= pos + len + 20 ->
+            template_address = binary_part(bytes, pos + len, 20)
+            {:ok, template_address_hash} = Hash.Address.cast(template_address)
+            {:ok, [template_address_hash]}
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/models/implementation.ex
@@ -37,7 +37,8 @@ defmodule Explorer.Chain.SmartContract.Proxy.Models.Implementation do
     :clone_with_immutable_arguments,
     :eip7702,
     :resolved_delegate_proxy,
-    :erc7760
+    :erc7760,
+    :minimal_proxy
   ]
 
   @typedoc """

--- a/apps/explorer/priv/repo/migrations/20260602000000_add_minimal_proxy_to_proxy_type.exs
+++ b/apps/explorer/priv/repo/migrations/20260602000000_add_minimal_proxy_to_proxy_type.exs
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Repo.Migrations.AddMinimalProxyToProxyType do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TYPE proxy_type ADD VALUE 'minimal_proxy'")
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy/minimal_proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy/minimal_proxy_test.exs
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.SmartContract.Proxy.MinimalProxyTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.SmartContract.Proxy.MinimalProxy
+
+  # Deployed bytecode from a real minimal proxy contract where the EIP-1167-like sequence
+  # appears in the middle of the bytecode. Implementation address: 1e2086a7e84a32482ac03000d56925f607ccb708
+  @deployed_bytecode "0x36602c57343d527f9e4ac34f21c619cefc926c8bd93b54bf5a39c7ab2127a895af1cc0691d7e3dff593da1005b3d3d3d3d363d3d37363d731e2086a7e84a32482ac03000d56925f607ccb7085af43d3d93803e605757fd5bf3"
+  @expected_impl "0x1e2086a7e84a32482ac03000d56925f607ccb708"
+
+  describe "quick_resolve_implementations/2" do
+    test "detects implementation address when pattern is in the middle of bytecode" do
+      proxy_address = insert(:address, contract_code: @deployed_bytecode)
+      {:ok, expected_hash} = Explorer.Chain.Hash.Address.cast(@expected_impl)
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) ==
+               {:ok, [expected_hash]}
+    end
+
+    test "returns nil when pattern is absent" do
+      proxy_address = insert(:address, contract_code: "0x60806040526004361061")
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
+    end
+
+    test "returns nil for nil contract code" do
+      proxy_address = insert(:address, contract_code: nil)
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
+    end
+
+    test "returns nil for empty bytecode" do
+      proxy_address = insert(:address, contract_code: "0x")
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
+    end
+
+    test "returns nil when pattern is found but there are fewer than 20 bytes following it" do
+      # pattern (11 bytes) + only 10 bytes after it — not enough for an address
+      short_bytecode =
+        "0x" <>
+          "AABBCCDD" <>
+          "3D3D3D3D363D3D37363D73" <>
+          "1e2086a7e84a32482ac03000d56925f607cc"
+
+      proxy_address = insert(:address, contract_code: short_bytecode)
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
+    end
+
+    test "correctly extracts address when pattern appears after arbitrary leading bytes" do
+      impl_address = "AABBCCDDEE112233445566778899001122334455"
+
+      bytecode =
+        "0x" <>
+          "DEADBEEF00112233" <>
+          "3D3D3D3D363D3D37363D73" <>
+          impl_address <>
+          "5AF43D3D93803E605757FD5BF3"
+
+      proxy_address = insert(:address, contract_code: bytecode)
+      {:ok, expected_hash} = Explorer.Chain.Hash.Address.cast("0x" <> impl_address)
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) ==
+               {:ok, [expected_hash]}
+    end
+  end
+end

--- a/cspell.json
+++ b/cspell.json
@@ -30,6 +30,7 @@
     // words - list of words to be always considered correct
     "words": [
         "AABB",
+        "AABBCCDD",
         "aave",
         "absname",
         "acbs",


### PR DESCRIPTION
## Motivation

Some deployed proxy contracts embed the EIP-1167 pattern 2 sequence (`3D3D3D3D363D3D37363D73`) in the **middle** of their bytecode rather than at the start. These contracts are not detected by the existing EIP-1167 resolver, so they appear as non-proxy contracts in Blockscout. This PR introduces a new `MinimalProxy` proxy type that locates that sequence anywhere in the bytecode and extracts the implementation address that follows it.

## Changelog

### Enhancements

- Added new `minimal_proxy` proxy type to the `proxy_type` database enum (migration `20260602000000_add_minimal_proxy_to_proxy_type`).
- Added `Explorer.Chain.SmartContract.Proxy.MinimalProxy` resolver module that uses `:binary.match/2` to find the `3D3D3D3D363D3D37363D73` sequence anywhere in the contract bytecode and extracts the 20-byte implementation address that follows it.
- Registered `{MinimalProxy, :minimal_proxy}` in the proxy resolver pipeline (`proxy.ex`) after the other bytecode-matching resolvers.
- Added unit tests covering: real-world deployed bytecode detection, absent pattern, nil/empty contract code, truncated bytecode, and arbitrary leading bytes.


### Incompatible Changes

- New `minimal_proxy` value added to the `proxy_type` PostgreSQL enum. A database migration is required.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [[docs repository](https://github.com/blockscout/docs)](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [[env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables)](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [[deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables)](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and resolving Minimal Proxy (EIP-1167-like) smart contract implementations, enabling the platform to identify proxy contracts using the minimal proxy pattern and extract their implementation addresses.

* **Tests**
  * Comprehensive test coverage for Minimal Proxy pattern detection and implementation address extraction across various edge cases and bytecode scenarios.

* **Chores**
  * Updated database schema to support the new minimal proxy type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->