### PR TITLE
fix: restrict minimal proxy detection to bytecode ≤ 100 bytes

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy/minimal_proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy/minimal_proxy.ex
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule Explorer.Chain.SmartContract.Proxy.MinimalProxy do
-  @moduledoc """
-  Module for fetching proxy implementation from minimal proxy contracts where the EIP-1167-like
-  bytecode sequence is embedded somewhere in the middle of the contract bytecode rather than at
-  the start.
+  @max_bytecode_byte_size 100
 
-  The pattern `3D3D3D3D363D3D37363D73` is located anywhere in the bytecode, and the 20 bytes
+  @moduledoc """
+  Fetches the implementation address from minimal proxy contracts where the EIP-1167-like
+  bytecode sequence is embedded in the middle of the contract bytecode rather than at the start.
+
+  The pattern `3D3D3D3D363D3D37363D73` is searched anywhere in the bytecode; the 20 bytes
   immediately following it are the implementation address.
+
+  Only bytecode up to #{@max_bytecode_byte_size} bytes is considered. Standard minimal proxies are
+  well below that size; longer bytecode is treated as a different contract shape and skipped to
+  avoid false positives from incidental pattern matches in large contracts.
   """
 
   alias Explorer.Chain.Hash
@@ -19,7 +24,7 @@ defmodule Explorer.Chain.SmartContract.Proxy.MinimalProxy do
   @impl true
   def quick_resolve_implementations(proxy_address, _proxy_type) do
     case proxy_address.contract_code && proxy_address.contract_code.bytes do
-      bytes when is_binary(bytes) ->
+      bytes when is_binary(bytes) and byte_size(bytes) <= @max_bytecode_byte_size ->
         case :binary.match(bytes, @pattern) do
           {pos, len} when byte_size(bytes) >= pos + len + 20 ->
             template_address = binary_part(bytes, pos + len, 20)

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy/minimal_proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy/minimal_proxy_test.exs
@@ -36,6 +36,23 @@ defmodule Explorer.Chain.SmartContract.Proxy.MinimalProxyTest do
       assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
     end
 
+    test "returns nil when bytecode exceeds 100 bytes" do
+      impl_address = "AABBCCDDEE112233445566778899001122334455"
+      # over 100 bytes total: 60 bytes prefix + 11 bytes pattern + 20 bytes address + suffix
+      padding = String.duplicate("AA", 60)
+
+      bytecode =
+        "0x" <>
+          padding <>
+          "3D3D3D3D363D3D37363D73" <>
+          impl_address <>
+          "5AF43D3D93803E605757FD5BF3DEADBEEF"
+
+      proxy_address = insert(:address, contract_code: bytecode)
+
+      assert MinimalProxy.quick_resolve_implementations(proxy_address, :minimal_proxy) == nil
+    end
+
     test "returns nil when pattern is found but there are fewer than 20 bytes following it" do
       # pattern (11 bytes) + only 10 bytes after it — not enough for an address
       short_bytecode =


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14426

## Motivation

The `MinimalProxy` resolver searches for an EIP-1167-like pattern anywhere in the contract bytecode. Without a size bound, large contracts with an incidental match would be misidentified as proxies. Capping detection at 100 bytes constrains the resolver to contracts that are structurally consistent with the minimal proxy shape and eliminates false positives from unrelated large contracts.

## Changelog

### Enhancements

- `MinimalProxy.quick_resolve_implementations/2` now skips bytecode larger than 100 bytes (enforced via a `byte_size/1` guard and the named module attribute `@max_bytecode_byte_size`).
- Added a unit test asserting that a contract whose bytecode exceeds 100 bytes — even if it contains the matching pattern — returns `nil`.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minimal proxy implementation detection now limited to bytecode of 100 bytes or less; larger bytecode is skipped.

* **Tests**
  * Added test case verifying bytecode size limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->