### PR TITLE
feat: preload ENS and metadata for a single NFT instance owner

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -38,9 +38,10 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     ]
 
   import Explorer.MicroserviceInterfaces.BENS,
-    only: [maybe_preload_ens: 1, maybe_preload_ens_for_token_transfers: 1]
+    only: [maybe_preload_ens: 1, maybe_preload_ens_for_token_transfers: 1, maybe_preload_ens_to_instance: 1]
 
-  import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
+  import Explorer.MicroserviceInterfaces.Metadata,
+    only: [maybe_preload_metadata: 1, maybe_preload_metadata_to_instance: 1]
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -383,7 +384,8 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       conn
       |> put_status(200)
       |> render(:token_instance, %{
-        token_instance: updated_token_instance,
+        token_instance:
+          updated_token_instance |> maybe_preload_ens_to_instance() |> maybe_preload_metadata_to_instance(),
         token: token
       })
     end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1319,20 +1319,28 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       bypass = Bypass.open()
 
+      old_tesla_adapter = Application.get_env(:tesla, :adapter)
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      old_env_bens = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+      old_env_metadata = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
+
+      on_exit(fn ->
+        Application.put_env(:tesla, :adapter, old_tesla_adapter)
+        Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
+        Bypass.down(bypass)
+      end)
+
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
-      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
       chain_id = 1
       Application.put_env(:block_scout_web, :chain_id, chain_id)
-
-      old_env_bens = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
         service_url: "http://localhost:#{bypass.port}",
         enabled: true
       )
-
-      old_env_metadata = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
 
       Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
         service_url: "http://localhost:#{bypass.port}",
@@ -1387,12 +1395,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
                  }
                ]
              }
-
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
-      Application.put_env(:block_scout_web, :chain_id, old_chain_id)
-      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
-      Bypass.down(bypass)
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1305,6 +1305,95 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       assert instance.error == "blacklist"
       assert instance.skip_metadata_url == false
     end
+
+    test "preloads ENS and metadata for owner address", %{conn: conn} do
+      owner = insert(:address)
+      token = insert(:token, type: "ERC-721")
+
+      insert(:token_instance,
+        token_id: 0,
+        token_contract_address_hash: token.contract_address_hash,
+        owner_address_hash: owner.hash,
+        skip_metadata_url: true
+      )
+
+      bypass = Bypass.open()
+
+      Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+      old_chain_id = Application.get_env(:block_scout_web, :chain_id)
+      chain_id = 1
+      Application.put_env(:block_scout_web, :chain_id, chain_id)
+
+      old_env_bens = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      old_env_metadata = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata)
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata,
+        service_url: "http://localhost:#{bypass.port}",
+        enabled: true
+      )
+
+      owner_hash_string = Address.checksum(owner.hash)
+
+      Bypass.expect_once(bypass, "POST", "api/v1/#{chain_id}/addresses:batch_resolve_names", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{"names" => %{owner_hash_string => "owner.eth"}})
+        )
+      end)
+
+      Bypass.expect_once(bypass, "GET", "api/v1/metadata", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "addresses" => %{
+              owner_hash_string => %{
+                "tags" => [
+                  %{
+                    "name" => "Known Address",
+                    "ordinal" => 0,
+                    "slug" => "known-address",
+                    "tagType" => "generic",
+                    "meta" => "{}"
+                  }
+                ]
+              }
+            }
+          })
+        )
+      end)
+
+      request = get(conn, "/api/v2/tokens/#{token.contract_address.hash}/instances/0")
+
+      assert data = json_response(request, 200)
+      assert data["owner"]["ens_domain_name"] == "owner.eth"
+
+      assert data["owner"]["metadata"] == %{
+               "tags" => [
+                 %{
+                   "name" => "Known Address",
+                   "ordinal" => 0,
+                   "slug" => "known-address",
+                   "tagType" => "generic",
+                   "meta" => %{}
+                 }
+               ]
+             }
+
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_env_bens)
+      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_env_metadata)
+      Application.put_env(:block_scout_web, :chain_id, old_chain_id)
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      Bypass.down(bypass)
+    end
   end
 
   describe "/tokens/{address_hash}/instances/{token_id}/transfers" do

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -26,6 +26,7 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
           | Block.t()
           | CurrentTokenBalance.t()
           | InternalTransaction.t()
+          | Instance.t()
           | Log.t()
           | TokenTransfer.t()
           | Transaction.t()
@@ -130,6 +131,24 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
   def preload_metadata_to_block(block) do
     [block_with_metadata] = preload_metadata_to_list([block])
     block_with_metadata
+  end
+
+  @doc """
+  Preloads ENS name to Instance.t()
+  """
+  @spec preload_ens_to_instance(Instance.t()) :: Instance.t()
+  def preload_ens_to_instance(instance) do
+    [instance_with_ens] = preload_ens_to_list([instance])
+    instance_with_ens
+  end
+
+  @doc """
+  Preloads metadata to Instance.t()
+  """
+  @spec preload_metadata_to_instance(Instance.t()) :: Instance.t()
+  def preload_metadata_to_instance(instance) do
+    [instance_with_metadata] = preload_metadata_to_list([instance])
+    instance_with_metadata
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/bens.ex
@@ -7,7 +7,7 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   alias Explorer.{Chain, HttpClient}
   alias Explorer.Chain.Address.MetadataPreloader
 
-  alias Explorer.Chain.{Address, Block, Transaction}
+  alias Explorer.Chain.{Address, Block, Token.Instance, Transaction}
 
   alias Explorer.Utility.Microservice
 
@@ -338,6 +338,14 @@ defmodule Explorer.MicroserviceInterfaces.BENS do
   @spec maybe_preload_ens_to_block(Block.t()) :: Block.t()
   def maybe_preload_ens_to_block(block) do
     maybe_preload_meta(block, __MODULE__, &MetadataPreloader.preload_ens_to_block/1)
+  end
+
+  @doc """
+  Preloads ENS data to the NFT instance if BENS is enabled
+  """
+  @spec maybe_preload_ens_to_instance(Instance.t()) :: Instance.t()
+  def maybe_preload_ens_to_instance(instance) do
+    maybe_preload_meta(instance, __MODULE__, &MetadataPreloader.preload_ens_to_instance/1)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/metadata.ex
@@ -5,7 +5,7 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
   """
 
   alias Explorer.{Chain, HttpClient}
-  alias Explorer.Chain.{Address.MetadataPreloader, Block, Transaction}
+  alias Explorer.Chain.{Address.MetadataPreloader, Block, Token.Instance, Transaction}
   alias Explorer.Utility.Microservice
 
   import Explorer.MicroserviceInterfaces.BENS, only: [maybe_preload_ens: 1]
@@ -189,6 +189,14 @@ defmodule Explorer.MicroserviceInterfaces.Metadata do
   @spec maybe_preload_metadata_to_block(Block.t()) :: Block.t()
   def maybe_preload_metadata_to_block(block) do
     maybe_preload_meta(block, __MODULE__, &MetadataPreloader.preload_metadata_to_block/1)
+  end
+
+  @doc """
+  Preloads metadata to NFT instance if Metadata microservice is enabled
+  """
+  @spec maybe_preload_metadata_to_instance(Instance.t()) :: Instance.t()
+  def maybe_preload_metadata_to_instance(instance) do
+    maybe_preload_meta(instance, __MODULE__, &MetadataPreloader.preload_metadata_to_instance/1)
   end
 
   defp decode_meta({:ok, %{"addresses" => addresses} = result}) do


### PR DESCRIPTION
## Motivation

The `/api/v2/tokens/:address_hash/instances/:token_id` endpoint was not enriching the NFT instance owner address with ENS domain names or Metadata microservice tags, unlike other endpoints that return address data. This PR adds that enrichment in a Dialyzer-safe way.

## Changelog

### Enhancements

- Add `Instance.t()` to `MetadataPreloader.supported_types` so the type system correctly covers NFT instances passed to ENS/metadata preload functions.
- Add `preload_ens_to_instance/1` and `preload_metadata_to_instance/1` single-item helpers to `Explorer.Chain.Address.MetadataPreloader`, following the existing Transaction/Block pattern.
- Add `maybe_preload_ens_to_instance/1` to `Explorer.MicroserviceInterfaces.BENS`.
- Add `maybe_preload_metadata_to_instance/1` to `Explorer.MicroserviceInterfaces.Metadata`.
- Apply the new preloads to the `instance` action in `BlockScoutWeb.API.V2.TokenController` so the response owner field is enriched with `ens_domain_name` and `metadata` when the respective microservices are enabled.
- Add unit test covering ENS and metadata preload for the instance endpoint using Bypass to mock both microservices.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token instance API responses now include owner ENS domain names and rich metadata for token instances, giving more contextual information when fetching instance details.

* **Tests**
  * Added controller tests verifying ENS names and metadata are correctly returned for token instance owners.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blockscout/blockscout/pull/14428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->