### PR TITLE
feat: Preload only listened entities before broadcast

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -113,6 +113,7 @@ defmodule BlockScoutWeb.Notifier do
 
     addresses
     |> Stream.reject(fn %Address{fetched_coin_balance: fetched_coin_balance} -> is_nil(fetched_coin_balance) end)
+    |> Stream.filter(fn %Address{hash: hash} -> address_has_subscribers?(hash) end)
     |> Enum.each(&broadcast_balance/1)
   end
 
@@ -120,12 +121,15 @@ defmodule BlockScoutWeb.Notifier do
       when type in [:realtime, :on_demand] do
     address_coin_balances
     |> Enum.reject(fn balance -> is_nil(balance[:value]) end)
+    |> Enum.filter(fn balance -> address_has_subscribers?(balance[:address_hash]) end)
     |> Enum.each(&broadcast_address_coin_balance/1)
   end
 
   def handle_event({:chain_event, :address_token_balances, type, address_token_balances})
       when type in [:realtime, :on_demand] do
-    Enum.each(address_token_balances, &broadcast_address_token_balance/1)
+    address_token_balances
+    |> Enum.filter(fn balance -> address_has_subscribers?(balance[:address_hash]) end)
+    |> Enum.each(&broadcast_address_token_balance/1)
   end
 
   def handle_event(
@@ -259,6 +263,10 @@ defmodule BlockScoutWeb.Notifier do
   # internal transactions broadcast disabled on the indexer level, therefore it out of scope of the refactoring within https://github.com/blockscout/blockscout/pull/7474
   def handle_event({:chain_event, :internal_transactions, :realtime, internal_transactions}) do
     internal_transactions
+    |> Stream.filter(fn it ->
+      address_has_subscribers?(it.from_address_hash) or
+        address_has_subscribers?(it.to_address_hash)
+    end)
     |> Stream.map(
       &(InternalTransaction.where_nonpending_operation()
         |> Repo.get_by(block_number: &1.block_number, transaction_index: &1.transaction_index, index: &1.index)
@@ -270,41 +278,46 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :token_transfers, :realtime, all_token_transfers}) do
-    all_token_transfers_full =
-      all_token_transfers
-      |> Repo.preload(
-        DenormalizationHelper.extend_transaction_preload([
-          [token: Reputation.reputation_association()],
-          :transaction,
-          from_address: [
-            :scam_badge,
-            :names,
-            :smart_contract,
-            proxy_implementations_association()
-          ],
-          to_address: [
-            :scam_badge,
-            :names,
-            :smart_contract,
-            proxy_implementations_association()
-          ]
-        ])
-      )
-      |> Instance.preload_nft(@api_true)
+    relevant_transfers = Enum.filter(all_token_transfers, &token_transfer_has_subscribers?/1)
 
-    transfers_by_token = Enum.group_by(all_token_transfers_full, fn tt -> to_string(tt.token_contract_address_hash) end)
+    if relevant_transfers != [] do
+      all_token_transfers_full =
+        relevant_transfers
+        |> Repo.preload(
+          DenormalizationHelper.extend_transaction_preload([
+            [token: Reputation.reputation_association()],
+            :transaction,
+            from_address: [
+              :scam_badge,
+              :names,
+              :smart_contract,
+              proxy_implementations_association()
+            ],
+            to_address: [
+              :scam_badge,
+              :names,
+              :smart_contract,
+              proxy_implementations_association()
+            ]
+          ])
+        )
+        |> Instance.preload_nft(@api_true)
 
-    broadcast_token_transfers_websocket_v2(all_token_transfers_full, transfers_by_token)
+      transfers_by_token =
+        Enum.group_by(all_token_transfers_full, fn tt -> to_string(tt.token_contract_address_hash) end)
 
-    for {token_contract_address_hash, token_transfers} <- transfers_by_token do
-      Subscription.publish(
-        Endpoint,
-        token_transfers,
-        token_transfers: token_contract_address_hash
-      )
+      broadcast_token_transfers_websocket_v2(all_token_transfers_full, transfers_by_token)
 
-      token_transfers
-      |> Enum.each(&broadcast_token_transfer/1)
+      for {token_contract_address_hash, token_transfers} <- transfers_by_token do
+        Subscription.publish(
+          Endpoint,
+          token_transfers,
+          token_transfers: token_contract_address_hash
+        )
+
+        token_transfers
+        |> Enum.each(&broadcast_token_transfer/1)
+      end
     end
   end
 
@@ -415,12 +428,14 @@ defmodule BlockScoutWeb.Notifier do
          %{address_current_token_balances: address_current_token_balances, address_hash: address_hash}}
       )
       when type in [:realtime, :on_demand] do
-    address_current_token_balances
-    |> Repo.preload(token: Reputation.reputation_association())
-    |> Enum.group_by(& &1.token_type)
-    |> Enum.each(fn {token_type, balances} ->
-      broadcast_token_balances(address_hash, token_type, balances)
-    end)
+    if address_has_subscribers?(address_hash) do
+      address_current_token_balances
+      |> Repo.preload(token: Reputation.reputation_association())
+      |> Enum.group_by(& &1.token_type)
+      |> Enum.each(fn {token_type, balances} ->
+        broadcast_token_balances(address_hash, token_type, balances)
+      end)
+    end
   end
 
   def handle_event({:chain_event, :address_current_token_balances, :realtime, _empty_balances_params}) do
@@ -780,13 +795,15 @@ defmodule BlockScoutWeb.Notifier do
       })
     end
 
+    relevant_transactions = Enum.filter(transactions, &transaction_has_subscribers?/1)
+
     prepared_transactions =
       TransactionView.render("transactions.json", %{
-        transactions: Repo.preload(transactions, @transaction_associations),
+        transactions: Repo.preload(relevant_transactions, @transaction_associations),
         conn: nil
       })
 
-    transactions
+    relevant_transactions
     |> Enum.zip(prepared_transactions)
     |> group_by_address_hashes_and_broadcast(event, :transactions, & &1["hash"])
   end
@@ -893,5 +910,39 @@ defmodule BlockScoutWeb.Notifier do
     # TODO: delete duplicated event when old UI becomes deprecated
     Endpoint.broadcast("addresses_old:#{to_string(address_hash)}", to_string(event), %{})
     Endpoint.broadcast("addresses:#{to_string(address_hash)}", to_string(event), %{})
+  end
+
+  defp has_subscribers?(topic) when is_binary(topic) do
+    Registry.lookup(BlockScoutWeb.PubSub, topic) != []
+  end
+
+  defp address_has_subscribers?(nil), do: false
+
+  defp address_has_subscribers?(address_hash) do
+    hash_string = to_string(address_hash)
+
+    has_subscribers?("addresses:" <> hash_string) or
+      has_subscribers?("addresses_old:" <> hash_string)
+  end
+
+  defp token_transfer_has_subscribers?(tt) do
+    address_has_subscribers?(tt.from_address_hash) or
+      address_has_subscribers?(tt.to_address_hash) or
+      token_has_subscribers?(tt.token_contract_address_hash)
+  end
+
+  defp token_has_subscribers?(nil), do: false
+
+  defp token_has_subscribers?(token_address_hash) do
+    hash_string = to_string(token_address_hash)
+
+    has_subscribers?("tokens:" <> hash_string) or
+      has_subscribers?("tokens_old:" <> hash_string)
+  end
+
+  defp transaction_has_subscribers?(transaction) do
+    address_has_subscribers?(transaction.from_address_hash) or
+      address_has_subscribers?(transaction.to_address_hash) or
+      address_has_subscribers?(transaction.created_contract_address_hash)
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -278,6 +278,17 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :token_transfers, :realtime, all_token_transfers}) do
+    all_transfers_by_token =
+      Enum.group_by(all_token_transfers, fn tt -> to_string(tt.token_contract_address_hash) end)
+
+    for {token_contract_address_hash, token_transfers} <- all_transfers_by_token do
+      Subscription.publish(
+        Endpoint,
+        token_transfers,
+        token_transfers: token_contract_address_hash
+      )
+    end
+
     relevant_transfers = Enum.filter(all_token_transfers, &token_transfer_has_subscribers?/1)
 
     if relevant_transfers != [] do
@@ -308,13 +319,7 @@ defmodule BlockScoutWeb.Notifier do
 
       broadcast_token_transfers_websocket_v2(all_token_transfers_full, transfers_by_token)
 
-      for {token_contract_address_hash, token_transfers} <- transfers_by_token do
-        Subscription.publish(
-          Endpoint,
-          token_transfers,
-          token_transfers: token_contract_address_hash
-        )
-
+      for {_token_contract_address_hash, token_transfers} <- transfers_by_token do
         token_transfers
         |> Enum.each(&broadcast_token_transfer/1)
       end

--- a/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
+  use BlockScoutWeb.ChannelCase,
+    async: false
+
+  alias BlockScoutWeb.Notifier
+  alias Explorer.Chain.Wei
+  alias Explorer.Chain.Cache.Counters.AddressesCount
+
+  defp create_token_transfer(opts \\ []) do
+    from_address = opts[:from_address] || insert(:address)
+    to_address = opts[:to_address] || insert(:address)
+
+    token = insert(:token, type: "ERC-20")
+
+    transaction =
+      :transaction
+      |> insert(from_address: from_address, to_address: token.contract_address)
+      |> with_block()
+
+    insert(:token_transfer,
+      from_address: from_address,
+      to_address: to_address,
+      token_contract_address: token.contract_address,
+      transaction: transaction,
+      block: transaction.block,
+      block_number: transaction.block_number,
+      log_index: 0,
+      token_type: "ERC-20",
+      block_consensus: true
+    )
+  end
+
+  describe "addresses event: subscriber filtering" do
+    test "broadcasts balance only to subscribed address in a batch" do
+      {:ok, balance} = Wei.cast(1)
+
+      subscribed = insert(:address, fetched_coin_balance: balance, fetched_coin_balance_block_number: 1)
+      unsubscribed = insert(:address, fetched_coin_balance: balance, fetched_coin_balance_block_number: 1)
+
+      subscribed_topic = "addresses:#{subscribed.hash}"
+      unsubscribed_topic = "addresses:#{unsubscribed.hash}"
+      @endpoint.subscribe(subscribed_topic)
+      @endpoint.subscribe(unsubscribed_topic)
+
+      start_supervised!(AddressesCount)
+      AddressesCount.consolidate()
+
+      Phoenix.PubSub.unsubscribe(BlockScoutWeb.PubSub, unsubscribed_topic)
+
+      Notifier.handle_event({:chain_event, :addresses, :realtime, [subscribed, unsubscribed]})
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^subscribed_topic, event: "balance"}, :timer.seconds(5)
+      refute_receive %Phoenix.Socket.Broadcast{topic: ^unsubscribed_topic, event: "balance"}, 100
+    end
+
+    test "handles addresses event without error when no address has subscribers" do
+      {:ok, balance} = Wei.cast(1)
+      address = insert(:address, fetched_coin_balance: balance, fetched_coin_balance_block_number: 1)
+
+      start_supervised!(AddressesCount)
+      AddressesCount.consolidate()
+
+      Notifier.handle_event({:chain_event, :addresses, :realtime, [address]})
+    end
+  end
+
+  describe "address_coin_balances event: subscriber filtering" do
+    test "handles event without error when no address has subscribers" do
+      address = insert(:address)
+      block = insert(:block)
+
+      Notifier.handle_event(
+        {:chain_event, :address_coin_balances, :realtime,
+         [%{address_hash: address.hash, block_number: block.number, value: 1}]}
+      )
+    end
+
+    test "skips unsubscribed addresses in a batch" do
+      subscribed_address = insert(:address)
+      unsubscribed_address = insert(:address)
+
+      coin_balance =
+        insert(:address_coin_balance,
+          address: subscribed_address,
+          address_hash: subscribed_address.hash,
+          delta: 500
+        )
+
+      subscribed_topic = "addresses:#{subscribed_address.hash}"
+      @endpoint.subscribe(subscribed_topic)
+
+      Notifier.handle_event(
+        {:chain_event, :address_coin_balances, :realtime,
+         [
+           %{address_hash: subscribed_address.hash, block_number: coin_balance.block_number, value: 1},
+           %{address_hash: unsubscribed_address.hash, block_number: coin_balance.block_number, value: 1}
+         ]}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{topic: ^subscribed_topic, event: "coin_balance"}, :timer.seconds(5)
+    end
+  end
+
+  describe "address_token_balances event: subscriber filtering" do
+    test "handles event without error when no address has subscribers" do
+      address = insert(:address)
+      block = insert(:block)
+
+      Notifier.handle_event(
+        {:chain_event, :address_token_balances, :realtime,
+         [%{address_hash: address.hash, block_number: block.number}]}
+      )
+    end
+  end
+
+  describe "internal_transactions event: subscriber filtering" do
+    test "handles event without error when no address has subscribers" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      internal_transaction =
+        insert(:internal_transaction,
+          transaction: transaction,
+          transaction_index: transaction.index,
+          index: 0,
+          block_number: transaction.block_number
+        )
+
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [internal_transaction]})
+    end
+
+    test "processes only internal transactions with subscribed addresses" do
+      subscribed_address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(from_address: subscribed_address)
+        |> with_block()
+
+      subscribed_it =
+        insert(:internal_transaction,
+          transaction: transaction,
+          from_address: subscribed_address,
+          transaction_index: transaction.index,
+          index: 0,
+          block_number: transaction.block_number
+        )
+
+      unsubscribed_transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      unsubscribed_it =
+        insert(:internal_transaction,
+          transaction: unsubscribed_transaction,
+          transaction_index: unsubscribed_transaction.index,
+          index: 0,
+          block_number: unsubscribed_transaction.block_number
+        )
+
+      topic = "addresses_old:#{subscribed_address.hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event(
+        {:chain_event, :internal_transactions, :realtime, [subscribed_it, unsubscribed_it]}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "internal_transaction",
+                       payload: %{internal_transaction: _}
+                     },
+                     :timer.seconds(5)
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "internal_transaction"}, 100
+    end
+  end
+
+  describe "token_transfers event: subscriber filtering" do
+    test "handles event without error when no channel has subscribers" do
+      token_transfer = create_token_transfer()
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer]})
+    end
+
+    test "processes transfers when subscribed to from_address channel" do
+      token_transfer = create_token_transfer()
+      topic = "addresses:#{token_transfer.from_address_hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "token_transfer",
+                       payload: %{token_transfers: _}
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "processes transfers when subscribed to to_address channel" do
+      token_transfer = create_token_transfer()
+      topic = "addresses:#{token_transfer.to_address_hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "token_transfer",
+                       payload: %{token_transfers: _}
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "processes transfers when subscribed to token channel" do
+      token_transfer = create_token_transfer()
+      topic = "tokens:#{token_transfer.token_contract_address_hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [token_transfer]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "token_transfer",
+                       payload: %{token_transfer: 1}
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "processes only relevant transfers in a mixed batch" do
+      subscribed_address = insert(:address)
+      subscribed_transfer = create_token_transfer(from_address: subscribed_address)
+      unsubscribed_transfer = create_token_transfer()
+
+      subscribed_topic = "addresses:#{subscribed_address.hash}"
+      @endpoint.subscribe(subscribed_topic)
+
+      Notifier.handle_event(
+        {:chain_event, :token_transfers, :realtime, [subscribed_transfer, unsubscribed_transfer]}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^subscribed_topic,
+                       event: "token_transfer",
+                       payload: %{token_transfers: _}
+                     },
+                     :timer.seconds(5)
+
+      unsubscribed_topic = "addresses:#{unsubscribed_transfer.from_address_hash}"
+      refute_receive %Phoenix.Socket.Broadcast{topic: ^unsubscribed_topic}, 100
+    end
+  end
+
+  describe "address_current_token_balances event: subscriber filtering" do
+    test "handles event without error when address has no subscribers" do
+      address = insert(:address)
+      token_balance = insert(:address_current_token_balance, address: address)
+
+      Notifier.handle_event(
+        {:chain_event, :address_current_token_balances, :realtime,
+         %{address_current_token_balances: [token_balance], address_hash: address.hash}}
+      )
+    end
+
+    test "processes balances when address has subscribers" do
+      address = insert(:address)
+
+      token_balance =
+        insert(:address_current_token_balance,
+          address: address,
+          token_type: "ERC-20",
+          value: 1_000_000_000_000_000_000
+        )
+
+      topic = "addresses:#{address.hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event(
+        {:chain_event, :address_current_token_balances, :realtime,
+         %{address_current_token_balances: [token_balance], address_hash: address.hash}}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "updated_token_balances_erc_20",
+                       payload: %{token_balances: _, overflow: _}
+                     },
+                     :timer.seconds(5)
+    end
+  end
+end

--- a/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
@@ -108,8 +108,7 @@ defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
       block = insert(:block)
 
       Notifier.handle_event(
-        {:chain_event, :address_token_balances, :realtime,
-         [%{address_hash: address.hash, block_number: block.number}]}
+        {:chain_event, :address_token_balances, :realtime, [%{address_hash: address.hash, block_number: block.number}]}
       )
     end
   end
@@ -165,9 +164,7 @@ defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
       topic = "addresses_old:#{subscribed_address.hash}"
       @endpoint.subscribe(topic)
 
-      Notifier.handle_event(
-        {:chain_event, :internal_transactions, :realtime, [subscribed_it, unsubscribed_it]}
-      )
+      Notifier.handle_event({:chain_event, :internal_transactions, :realtime, [subscribed_it, unsubscribed_it]})
 
       assert_receive %Phoenix.Socket.Broadcast{
                        topic: ^topic,
@@ -240,9 +237,7 @@ defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
       subscribed_topic = "addresses:#{subscribed_address.hash}"
       @endpoint.subscribe(subscribed_topic)
 
-      Notifier.handle_event(
-        {:chain_event, :token_transfers, :realtime, [subscribed_transfer, unsubscribed_transfer]}
-      )
+      Notifier.handle_event({:chain_event, :token_transfers, :realtime, [subscribed_transfer, unsubscribed_transfer]})
 
       assert_receive %Phoenix.Socket.Broadcast{
                        topic: ^subscribed_topic,


### PR DESCRIPTION
Closes #14327 

## Changelog
- Add check before preload
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Real-time WebSocket broadcasts now only target channels with active subscribers. Expensive preload/grouping and broadcast work are skipped when no subscribers exist, reducing bandwidth and load for address balances, token transfers, internal transactions, and transaction events.

* **Tests**
  * Added tests verifying broadcasts are emitted only to subscribed topics across all realtime event types and that no-op behavior is safe when there are no subscribers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->