### PR TITLE
fix: Fix token import on Celo

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -448,9 +448,10 @@ defmodule Indexer.Block.Fetcher do
     Map.merge(left, right, fn _key, value1, value2 -> merge_option_values(value1, value2) end)
   end
 
-  defp merge_option_values(%{params: params1} = map1, %{params: params2}) do
+  defp merge_option_values(%{params: params1} = map1, %{params: params2} = map2) do
+    merged_map = Map.merge(map1, map2)
     merged_params = Enum.uniq(List.wrap(params1) ++ List.wrap(params2))
-    Map.put(map1, :params, merged_params)
+    Map.put(merged_map, :params, merged_params)
   end
 
   defp merge_option_values(list1, list2) when is_list(list1) and is_list(list2) do

--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -271,8 +271,7 @@ defmodule Indexer.Block.Fetcher do
          {:ok, inserted} <-
            __MODULE__.import(
              state,
-             basic_import_options
-             |> Map.merge(additional_options)
+             merge_options(basic_import_options, additional_options)
              |> import_options(chain_type_import_options)
              |> extend_with_asyncable_import_options(tokens, token_transfers, address_token_balances)
            ) do
@@ -445,6 +444,21 @@ defmodule Indexer.Block.Fetcher do
     })
   end
 
+  defp merge_options(left, right) when is_map(left) and is_map(right) do
+    Map.merge(left, right, fn _key, value1, value2 -> merge_option_values(value1, value2) end)
+  end
+
+  defp merge_option_values(%{params: params1} = map1, %{params: params2}) do
+    merged_params = Enum.uniq(List.wrap(params1) ++ List.wrap(params2))
+    Map.put(map1, :params, merged_params)
+  end
+
+  defp merge_option_values(list1, list2) when is_list(list1) and is_list(list2) do
+    Enum.uniq(list1 ++ list2)
+  end
+
+  defp merge_option_values(_value1, value2), do: value2
+
   defp extend_with_asyncable_import_options(import_options, tokens, token_transfers, token_balances) do
     current_token_balances_params =
       token_balances
@@ -459,10 +473,10 @@ defmodule Indexer.Block.Fetcher do
       token_instances = TokenInstances.params_set(%{token_transfers_params: token_transfers})
       addresses_without_nonce = process_addresses_nonce(import_options[:addresses][:params])
 
-      Map.merge(import_options, %{
+      merge_options(import_options, %{
         addresses: %{params: addresses_without_nonce},
         address_current_token_balances: %{params: current_token_balances_params},
-        tokens: Map.get(import_options, :tokens) || %{params: tokens},
+        tokens: %{params: tokens},
         token_instances: %{params: token_instances}
       })
     end

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -83,22 +83,24 @@ defmodule Indexer.Transform.TokenTransfers do
         erc1155_token_transfers.tokens ++
         erc20_and_erc721_token_transfers.tokens ++ weth_transfers.tokens
 
+    rough_tokens_uniq =
+      rough_tokens
+      |> Enum.uniq()
+
     rough_token_transfers =
       erc7984_token_transfers.token_transfers ++
         erc404_token_transfers.token_transfers ++
         erc1155_token_transfers.token_transfers ++
         erc20_and_erc721_token_transfers.token_transfers ++ weth_transfers.token_transfers
 
-    tokens = sanitize_token_types(rough_tokens, rough_token_transfers)
-    token_transfers = sanitize_weth_transfers(tokens, rough_token_transfers, weth_transfers.token_transfers)
+    tokens_uniq = sanitize_token_types(rough_tokens_uniq, rough_token_transfers)
+    token_transfers = sanitize_weth_transfers(tokens_uniq, rough_token_transfers, weth_transfers.token_transfers)
 
     if !skip_additional_fetchers? do
       token_transfers
       |> filter_tokens_for_supply_update()
       |> TokenTotalSupplyUpdater.add_tokens()
     end
-
-    tokens_uniq = tokens |> Enum.uniq()
 
     token_transfers_from_logs_uniq = %{
       tokens: tokens_uniq,

--- a/apps/indexer/lib/indexer/transform/token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/token_transfers.ex
@@ -85,7 +85,15 @@ defmodule Indexer.Transform.TokenTransfers do
 
     rough_tokens_uniq =
       rough_tokens
-      |> Enum.uniq()
+      |> Enum.reduce({%{}, []}, fn %{contract_address_hash: addr} = token, {seen, acc} ->
+        if Map.has_key?(seen, addr) do
+          {seen, acc}
+        else
+          {Map.put(seen, addr, true), [token | acc]}
+        end
+      end)
+      |> elem(1)
+      |> Enum.reverse()
 
     rough_token_transfers =
       erc7984_token_transfers.token_transfers ++

--- a/apps/indexer/test/indexer/transform/token_transfers_test.exs
+++ b/apps/indexer/test/indexer/transform/token_transfers_test.exs
@@ -154,6 +154,52 @@ defmodule Indexer.Transform.TokenTransfersTest do
       Application.put_env(:explorer, Explorer.Chain.TokenTransfer, env)
     end
 
+    test "deduplicates duplicate contract tokens by contract_address_hash for Celo" do
+      original_chain_type = Application.get_env(:explorer, :chain_type)
+      Application.put_env(:explorer, :chain_type, :celo)
+
+      on_exit(fn -> Application.put_env(:explorer, :chain_type, original_chain_type) end)
+
+      contract_address_hash = "0x1234567890abcdef1234567890abcdef12345678"
+
+      logs = [
+        %{
+          address_hash: contract_address_hash,
+          block_number: 1_000_001,
+          block_hash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+          data: "0x000000000000000000000000000000000000000000000000000000000000000a",
+          first_topic: "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          fourth_topic: nil,
+          index: 0,
+          second_topic: "0x000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          third_topic: "0x000000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          transaction_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        %{
+          address_hash: contract_address_hash,
+          block_number: 1_000_002,
+          block_hash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+          data:
+            "0x0000000000000000000000000000000000000000000000000000000000000001" <>
+              "000000000000000000000000000000000000000000000000000000000000000a",
+          first_topic: "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62",
+          second_topic: "0x000000000000000000000000cccccccccccccccccccccccccccccccccccccccc",
+          third_topic: "0x000000000000000000000000dddddddddddddddddddddddddddddddddddddddd",
+          fourth_topic: "0x000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          index: 1,
+          transaction_hash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ]
+
+      assert %{
+               tokens: [%{contract_address_hash: ^contract_address_hash, type: "ERC-1155"}],
+               token_transfers: [
+                 %{token_contract_address_hash: ^contract_address_hash, token_type: "ERC-1155"},
+                 %{token_contract_address_hash: ^contract_address_hash, token_type: "ERC-20"}
+               ]
+             } = TokenTransfers.parse(logs)
+    end
+
     test "parses ERC-721 transfer with addresses in data field" do
       log = %{
         address_hash: "0x58Ab73CB79c8275628E0213742a85B163fE0A9Fb",


### PR DESCRIPTION
## Motivation

The block fetcher previously merged option maps with plain `Map.merge`, which could preserve duplicate nested `:params` entries and lose uniqueness when combining import options. This PR updates `Indexer.Block.Fetcher` so merged import option maps keep only unique values.

## Changelog

### Enhancements
- Add unique-aware `merge_options/2` helper for import option map merging in fetcher.ex.

### Bug Fixes
- Fix deduplication when merging additional import options and async import option values in `Indexer.Block.Fetcher`.


Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved option merging to deep-merge nested parameters and deduplicate list values, producing more consistent import behavior (addresses, tokens and related options now combined more predictably).
  * Moved token deduplication earlier in processing to eliminate redundant work and make token-type determination more efficient and reliable; all token transfer sources are now considered when aggregating results.
* **Tests**
  * Added a test ensuring duplicate token entries sharing the same contract identifier are deduplicated while preserving all transfer records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->