### PR TITLE
fix: Fix traceable_blocks_dynamic_query

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -1019,8 +1019,13 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
       block_ranges = RangesHelper.get_trace_block_ranges()
 
       Enum.reduce(block_ranges, dynamic([_], false), fn
-        _from.._to//_ = range, acc -> dynamic([block], ^acc or block.number in ^range)
-        num_to_latest, acc -> dynamic([block], ^acc or block.number >= ^num_to_latest)
+        _from.._to//_ = range, acc ->
+          lower = min(range.first, range.last)
+          upper = max(range.first, range.last)
+          dynamic([block], ^acc or (block.number >= ^lower and block.number <= ^upper))
+
+        num_to_latest, acc ->
+          dynamic([block], ^acc or block.number >= ^num_to_latest)
       end)
     else
       dynamic([_], true)

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -293,6 +293,42 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
 
         on_exit(fn -> Application.put_env(:indexer, :trace_block_ranges, original_config) end)
       end
+
+      test "does not set refetch_needed=true for non-traceable blocks and multiple ranges" do
+        original_config = Application.get_env(:indexer, :trace_block_ranges)
+
+        full_block = insert(:block)
+        transaction_a = insert(:transaction) |> with_block(full_block)
+        transaction_b = insert(:transaction) |> with_block(full_block)
+
+        Application.put_env(
+          :indexer,
+          :trace_block_ranges,
+          "#{full_block.number - 2}..#{full_block.number - 1},#{full_block.number + 1}..latest"
+        )
+
+        insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
+
+        transaction_a_changes = make_internal_transaction_changes(transaction_a, 0, nil)
+
+        assert {:ok, _} = run_internal_transactions([transaction_a_changes])
+
+        assert from(i in InternalTransaction,
+                 where: i.block_number == ^transaction_a.block_number and i.transaction_index == ^transaction_a.index
+               )
+               |> Repo.one()
+               |> is_nil()
+
+        assert from(i in InternalTransaction,
+                 where: i.block_number == ^transaction_b.block_number and i.transaction_index == ^transaction_b.index
+               )
+               |> Repo.one()
+               |> is_nil()
+
+        assert %{consensus: true, refetch_needed: false} = Repo.get(Block, full_block.hash)
+
+        on_exit(fn -> Application.put_env(:indexer, :trace_block_ranges, original_config) end)
+      end
     end
 
     if Application.compile_env(:explorer, :chain_type) == :zetachain do


### PR DESCRIPTION
## Motivation

Ecto doesn't support `in ^range` condition in query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved block-range filtering during transaction imports: range checks now use explicit lower/upper boundary comparisons for trace ranges, yielding more consistent and predictable handling of trace-block filters without altering other import behavior.

* **Tests**
  * Added a test ensuring no unnecessary refetch is triggered for non-traceable blocks when multiple trace ranges are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->