### PR TITLE
fix: Add required fields to SmartContract schema

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex
@@ -102,7 +102,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractController do
       ok:
         {"List of verified smart contracts matching the filter criteria, with pagination.", "application/json",
          paginated_response(
-           items: Schemas.SmartContract,
+           items: Schemas.SmartContract.ListItem,
            next_page_params_example: %{
              "smart_contract_id" => 1_947_801,
              "items_count" => 50

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
@@ -152,3 +152,50 @@ defmodule BlockScoutWeb.Schemas.API.V2.SmartContract do
     |> ChainTypeCustomizations.chain_type_fields()
   )
 end
+
+defmodule BlockScoutWeb.Schemas.API.V2.SmartContract.ListItem do
+  @moduledoc """
+  OpenAPI schema for a smart contract list item.
+
+  Matches the response shape of individual items returned by the
+  `SmartContractController.smart_contracts_list/2` action.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.SmartContract.ChainTypeCustomizations
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(
+    %{
+      description: "Smart contract list item",
+      type: :object,
+      properties: %{
+        address: BlockScoutWeb.Schemas.API.V2.Address,
+        compiler_version: %Schema{type: :string, nullable: true},
+        optimization_enabled: %Schema{type: :boolean, nullable: true},
+        transactions_count: %Schema{type: :integer, nullable: true},
+        language: %Schema{type: :string, nullable: true},
+        verified_at: %Schema{type: :string, format: :"date-time", nullable: true},
+        market_cap: %Schema{type: :string, nullable: true},
+        has_constructor_args: %Schema{type: :boolean, nullable: true},
+        coin_balance: %Schema{type: :string, nullable: true},
+        license_type: %Schema{type: :string, nullable: true},
+        certified: %Schema{type: :boolean},
+        reputation: %Schema{type: :string, nullable: true}
+      },
+      required: [
+        :address,
+        :compiler_version,
+        :optimization_enabled,
+        :language,
+        :verified_at,
+        :has_constructor_args,
+        :license_type,
+        :certified,
+        :reputation
+      ],
+      additionalProperties: false
+    }
+    |> ChainTypeCustomizations.chain_type_fields()
+  )
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
@@ -139,7 +139,14 @@ defmodule BlockScoutWeb.Schemas.API.V2.SmartContract do
         is_partially_verified: %Schema{type: :boolean, nullable: true},
         constructor_args: %Schema{type: :string, nullable: true}
       },
-      required: [],
+      required: [
+        :proxy_type,
+        :implementations,
+        :conflicting_implementations,
+        :deployed_bytecode,
+        :creation_bytecode,
+        :creation_status
+      ],
       additionalProperties: false
     }
     |> ChainTypeCustomizations.chain_type_fields()


### PR DESCRIPTION
## Motivation

The `SmartContract` OpenAPI schema had `required: []`, meaning no field was declared as required. This is incorrect — several fields are always present in every response regardless of whether the contract is verified.

## Changelog

### Enhancements

- Populated `required` list in `BlockScoutWeb.Schemas.API.V2.SmartContract` with the six fields that are guaranteed to be present in all `GET /api/v2/smart-contracts/:address` responses: `proxy_type`, `implementations`, `conflicting_implementations`, `deployed_bytecode`, `creation_bytecode`, `creation_status`.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  - Smart contract API responses now include additional required top-level fields for more consistent and complete data (improves response clarity and validation).
  - Smart contract list endpoint now returns a compact/summary item schema for each entry, reducing payload size and making list responses clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->