### PR TITLE
chore: Enhance missing current token balances metric

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
@@ -148,6 +148,8 @@ defmodule Explorer.Chain.Metrics.Queries.IndexerMetrics do
       FROM address_current_token_balances ctb
       WHERE (ctb.value_fetched_at is NULL OR ctb.value is NULL)
       AND ctb.token_type != 'ERC-7984'
+      AND (ctb.refetch_after IS NULL OR ctb.refetch_after < NOW())
+      AND NOT EXISTS (SELECT 1 FROM missing_balance_of_tokens bmt WHERE bmt.token_contract_address_hash = ctb.token_contract_address_hash)
       AND (#{range_filter});
       """
 


### PR DESCRIPTION
## Motivation

Enhance `missing_current_token_balances_count` indexer metric
- by excluding tokens not supporting balance method
- by checking refetch_after column value


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token balance data processing to correctly identify and exclude already-processed balance entries, ensuring more accurate tracking of missing balance data that requires updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->