### PR TITLE
fix: Fix revert reason for nethermind

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/trace_replay_block_transactions.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/trace_replay_block_transactions.ex
@@ -218,7 +218,7 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
     end
   end
 
-  defp trace_replay_transaction_response_to_first_trace(%{id: id, result: %{"trace" => traces}}, id_to_params)
+  defp trace_replay_transaction_response_to_first_trace(%{id: id, result: %{"trace" => traces} = result}, id_to_params)
        when is_list(traces) and is_map(id_to_params) do
     %{
       block_hash: block_hash,
@@ -229,21 +229,21 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
 
     first_trace =
       traces
-      |> Stream.with_index()
-      |> Enum.map(fn {trace, index} ->
-        Map.merge(trace, %{
-          "blockHash" => block_hash,
-          "blockNumber" => block_number,
-          "index" => index,
-          "transactionIndex" => transaction_index,
-          "transactionHash" => transaction_hash
-        })
-      end)
-      |> Enum.filter(fn trace ->
-        Map.get(trace, "index") == 0
-      end)
+      |> List.first()
+      |> Map.merge(%{
+        "blockHash" => block_hash,
+        "blockNumber" => block_number,
+        "index" => 0,
+        "transactionIndex" => transaction_index,
+        "transactionHash" => transaction_hash
+      })
 
-    {:ok, first_trace}
+    {:ok,
+     if Map.has_key?(result, "output") do
+       Map.put(first_trace, "result", %{"output" => result["output"]})
+     else
+       first_trace
+     end}
   end
 
   defp trace_replay_transaction_response_to_first_trace(%{id: id, error: error}, id_to_params)

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/trace_replay_block_transactions.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/trace_replay_block_transactions.ex
@@ -193,6 +193,9 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
         {:ok, traces}, {:ok, acc_traces_list} ->
           {:ok, [traces | acc_traces_list]}
 
+        :ignore, acc ->
+          acc
+
         {:ok, _}, {:error, _} = acc_error ->
           acc_error
 
@@ -218,8 +221,11 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
     end
   end
 
-  defp trace_replay_transaction_response_to_first_trace(%{id: id, result: %{"trace" => traces} = result}, id_to_params)
-       when is_list(traces) and is_map(id_to_params) do
+  defp trace_replay_transaction_response_to_first_trace(
+         %{id: id, result: %{"trace" => [raw_first_trace | _]} = result},
+         id_to_params
+       )
+       when is_map(id_to_params) do
     %{
       block_hash: block_hash,
       block_number: block_number,
@@ -228,9 +234,7 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
     } = Map.fetch!(id_to_params, id)
 
     first_trace =
-      traces
-      |> List.first()
-      |> Map.merge(%{
+      Map.merge(raw_first_trace, %{
         "blockHash" => block_hash,
         "blockNumber" => block_number,
         "index" => 0,
@@ -238,12 +242,20 @@ defmodule EthereumJSONRPC.TraceReplayBlockTransactions do
         "transactionHash" => transaction_hash
       })
 
-    {:ok,
-     if Map.has_key?(result, "output") do
-       Map.put(first_trace, "result", %{"output" => result["output"]})
-     else
-       first_trace
-     end}
+    first_trace =
+      if Map.has_key?(result, "output") do
+        Map.update(first_trace, "result", %{"output" => result["output"]}, fn existing ->
+          Map.put_new(existing, "output", result["output"])
+        end)
+      else
+        first_trace
+      end
+
+    {:ok, first_trace}
+  end
+
+  defp trace_replay_transaction_response_to_first_trace(%{id: _id, result: %{"trace" => []}}, _id_to_params) do
+    :ignore
   end
 
   defp trace_replay_transaction_response_to_first_trace(%{id: id, error: error}, id_to_params)


### PR DESCRIPTION
## Motivation

Empty revert reason

## Changelog
- Explicitly forward revert reason from `trace_replayTransaction`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable selection and metadata assignment for transaction traces during replay.
  * Correctly includes output data from transaction responses and skips empty trace results to avoid processing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->