### PR TITLE
feat: add ENS and metadata preloads to advanced-filters to/from fields

### DIFF
--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -154,9 +154,9 @@ defmodule Explorer.Chain.AdvancedFilter do
     |> Enum.sort(&sort_function/2)
     |> take_page_size(paging_options)
     |> Chain.select_repo(options).preload(
-      from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      created_contract_address: [:names, :smart_contract, proxy_implementations_association()]
+      from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association(), :metadata],
+      to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association(), :metadata],
+      created_contract_address: [:names, :smart_contract, proxy_implementations_association(), :metadata]
     )
     |> sanitize_fee()
     |> assign_type()


### PR DESCRIPTION
Closes #14443

## Changes
- Enriched `from_address` and `to_address` with ENS names and metadata preloads in `AdvancedFilter.list/1`
- Matches the style used in other API v2 endpoints

## Motivation
As requested by @vbaranov in #14443 for better consistency across the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Advanced filters now display more complete contract and address metadata, providing enhanced information visibility when filtering transactions and addresses in the Explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->