### PR TITLE
feat: add ETH Swarm (bzz://) support for token metadata

### DIFF
--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -661,7 +661,11 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   @type nft_url_class ::
-          {:ipfs, binary() | nil} | {:arweave, binary()} | {:regular, binary()} | {:bare_path, binary() | nil}
+          {:ipfs, binary() | nil}
+          | {:arweave, binary()}
+          | {:swarm, binary() | nil}
+          | {:regular, binary()}
+          | {:bare_path, binary() | nil}
 
   @doc """
   Classifies an NFT URL into one of: `{:ipfs, resource_id}`, `{:arweave, resource_id}`, `{:regular, url}`, or `{:bare_path, path}`.
@@ -677,11 +681,24 @@ defmodule Explorer.Token.MetadataRetriever do
         resource_id = if is_binary(path) and path != "", do: host <> path, else: host
         {:arweave, resource_id}
 
+      %URI{scheme: "bzz", host: host, path: path} ->
+        uid =
+          cond do
+            is_binary(host) and is_binary(path) -> host <> path
+            is_binary(host) -> host
+            true -> nil
+          end
+
+        {:swarm, uid}
+
       %URI{scheme: _, path: "/ipfs/" <> resource_id} ->
         {:ipfs, resource_id}
 
       %URI{scheme: _, path: "ipfs/" <> resource_id} ->
         {:ipfs, resource_id}
+
+      %URI{scheme: _, path: "/bzz/" <> resource_id} ->
+        {:swarm, resource_id}
 
       %URI{scheme: scheme} when not is_nil(scheme) ->
         {:regular, url}
@@ -706,6 +723,13 @@ defmodule Explorer.Token.MetadataRetriever do
 
       {:arweave, resource_id} ->
         {arweave_link(resource_id), ar_headers()}
+
+      {:swarm, resource_id} ->
+        if is_binary(resource_id) do
+          {swarm_link(resource_id), []}
+        else
+          {url, []}
+        end
 
       {:regular, url} ->
         {url, []}
@@ -861,19 +885,7 @@ defmodule Explorer.Token.MetadataRetriever do
       {:arweave, resource_id} ->
         fetch_from_arweave(resource_id, hex_token_id)
 
-      %URI{scheme: "bzz", host: host, path: path} ->
-        # bzz://<hash>[/optional/path] — normalise to bare hash
-        uid =
-          cond do
-            is_binary(host) and is_binary(path) -> host <> path
-            is_binary(host) -> host
-            true -> nil
-          end
-
-        fetch_from_swarm_if_valid_hash(uid, hex_token_id)
-
-      %URI{scheme: _, path: "/bzz/" <> resource_id} ->
-        # https://gateway.ethswarm.org/bzz/<hash>[/path] — preserve deep path
+      {:swarm, resource_id} ->
         fetch_from_swarm_if_valid_hash(resource_id, hex_token_id)
 
       {:regular, url} ->

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -712,6 +712,7 @@ defmodule Explorer.Token.MetadataRetriever do
   Resolves an NFT media URL to a fetchable gateway URL with appropriate headers (e.g. IPFS gateway, Arweave gateway).
   """
   @spec resolve_nft_media_url(binary()) :: {binary(), list()}
+  # credo:disable-for-next-line /Complexity/
   def resolve_nft_media_url(url) do
     case classify_nft_url(url) do
       {:ipfs, resource_id} ->
@@ -726,7 +727,7 @@ defmodule Explorer.Token.MetadataRetriever do
 
       {:swarm, resource_id} ->
         if is_binary(resource_id) do
-          {swarm_link(resource_id), []}
+          {swarm_link(resource_id), swarm_headers()}
         else
           {url, []}
         end

--- a/apps/explorer/lib/explorer/token/metadata_retriever.ex
+++ b/apps/explorer/lib/explorer/token/metadata_retriever.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Token.MetadataRetriever do
   @vm_execution_error "VM execution error"
   @invalid_base64_data "invalid data:application/json;base64"
   @invalid_ipfs_path "invalid ipfs path"
+  @invalid_swarm_path "invalid swarm path"
   @default_headers [{"User-Agent", "blockscout-11.2.0"}]
 
   # https://eips.ethereum.org/EIPS/eip-1155#metadata
@@ -554,6 +555,42 @@ defmodule Explorer.Token.MetadataRetriever do
     "https://arweave.net/#{uid}"
   end
 
+  @doc """
+  Generates an ETH Swarm gateway link for the given hash.
+
+  The hash can be a 64-character hex Swarm hash (keccak-256 based) or any
+  Swarm-compatible identifier (e.g. from SOC or feeds). The configured
+  gateway URL defaults to `https://gateway.ethswarm.org`.
+
+  ## Parameters
+  - uid: The Swarm hash or resource identifier.
+
+  ## Returns
+  - A string representing the full URL to the resource on the Swarm gateway.
+
+  ## Examples
+
+      iex> swarm_link("1234abcd" <> String.duplicate("0", 56))
+      "https://gateway.ethswarm.org/bzz/1234abcd" <> String.duplicate("0", 56) <> "/"
+
+  """
+  @spec swarm_link(uid :: any()) :: String.t()
+  def swarm_link(uid) do
+    uid = to_string(uid)
+
+    base_url =
+      :indexer
+      |> Application.get_env(:swarm, [])
+      |> Keyword.get(:gateway_url, "https://gateway.ethswarm.org")
+      |> String.trim_trailing("/")
+
+    if String.contains?(uid, "/") do
+      "#{base_url}/bzz/#{uid}"
+    else
+      "#{base_url}/bzz/#{uid}/"
+    end
+  end
+
   defp maybe_add_ipfs_gateway_params_to_url?(url, true), do: url
 
   defp maybe_add_ipfs_gateway_params_to_url?(url, _) do
@@ -696,6 +733,31 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   @doc """
+  Returns the headers for making requests to the ETH Swarm gateway.
+
+  If `INDEXER_SWARM_GATEWAY_BEARER_TOKEN` is configured the token is sent as
+  an `Authorization: Bearer <token>` header, which is the mechanism used by
+  private / gateway-as-a-service Swarm nodes.
+
+  ## Examples
+
+      iex> Explorer.Token.MetadataRetriever.swarm_headers()
+      [{"User-Agent", "blockscout-11.0.1"}]
+
+  """
+  @spec swarm_headers() :: [{binary(), binary()}]
+  def swarm_headers do
+    swarm_params = Application.get_env(:indexer, :swarm, [])
+    bearer_token = Keyword.get(swarm_params, :bearer_token)
+
+    if is_binary(bearer_token) and String.trim(bearer_token) != "" do
+      [{"Authorization", "Bearer #{bearer_token}"} | @default_headers]
+    else
+      @default_headers
+    end
+  end
+
+  @doc """
     Fetch/parse metadata using smart-contract's response
   """
   @spec(
@@ -799,6 +861,21 @@ defmodule Explorer.Token.MetadataRetriever do
       {:arweave, resource_id} ->
         fetch_from_arweave(resource_id, hex_token_id)
 
+      %URI{scheme: "bzz", host: host, path: path} ->
+        # bzz://<hash>[/optional/path] — normalise to bare hash
+        uid =
+          cond do
+            is_binary(host) and is_binary(path) -> host <> path
+            is_binary(host) -> host
+            true -> nil
+          end
+
+        fetch_from_swarm_if_valid_hash(uid, hex_token_id)
+
+      %URI{scheme: _, path: "/bzz/" <> resource_id} ->
+        # https://gateway.ethswarm.org/bzz/<hash>[/path] — preserve deep path
+        fetch_from_swarm_if_valid_hash(resource_id, hex_token_id)
+
       {:regular, url} ->
         fetch_metadata_inner(url, ipfs_params, token_id, hex_token_id, from_base_uri?)
 
@@ -850,6 +927,19 @@ defmodule Explorer.Token.MetadataRetriever do
     fetch_metadata_inner(arweave_url, ipfs_params, nil, hex_token_id)
   end
 
+  defp fetch_from_swarm(uid, hex_token_id) do
+    url = swarm_link(uid)
+    fetch_metadata_inner(url, [ipfs?: false, swarm?: true], nil, hex_token_id)
+  end
+
+  defp fetch_from_swarm_if_valid_hash(uid, hex_token_id) do
+    if is_binary(uid) and valid_swarm_hash?(uid) do
+      fetch_from_swarm(uid, hex_token_id)
+    else
+      {:error, @invalid_swarm_path}
+    end
+  end
+
   defp fetch_metadata_inner(uri, ipfs_params, token_id, hex_token_id, from_base_uri? \\ false)
 
   defp fetch_metadata_inner(uri, ipfs_params, token_id, hex_token_id, from_base_uri?) do
@@ -891,7 +981,8 @@ defmodule Explorer.Token.MetadataRetriever do
   @spec fetch_metadata_from_uri(String.t(), keyword(), String.t() | nil) :: {:ok, %{metadata: any}} | {:error, binary()}
   def fetch_metadata_from_uri(uri, ipfs_params, hex_token_id \\ nil) do
     case Application.get_env(:indexer, Indexer.Fetcher.TokenInstance.Helper)[:host_filtering_enabled?] &&
-           !ipfs?(ipfs_params) && !arweave?(ipfs_params) && MetadataURIValidator.validate_uri(uri) do
+           !ipfs?(ipfs_params) && !arweave?(ipfs_params) && !swarm?(ipfs_params) &&
+           MetadataURIValidator.validate_uri(uri) do
       {:error, reason} ->
         if reason == :blacklist do
           Logger.warning(
@@ -912,7 +1003,12 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   defp fetch_metadata_from_uri_request(uri, hex_token_id, ipfs_params) do
-    headers = if ipfs?(ipfs_params), do: ipfs_headers(), else: @default_headers
+    headers =
+      cond do
+        ipfs?(ipfs_params) -> ipfs_headers()
+        swarm?(ipfs_params) -> swarm_headers()
+        true -> @default_headers
+      end
 
     case HttpClient.get(uri, headers,
            recv_timeout: 30_000,
@@ -957,7 +1053,7 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   defp process_result(metadata, uri, ipfs_params) do
-    if arweave?(ipfs_params) || ipfs?(ipfs_params) do
+    if arweave?(ipfs_params) || ipfs?(ipfs_params) || swarm?(ipfs_params) do
       {:ok, metadata}
     else
       {:ok_store_uri, metadata, uri}
@@ -970,6 +1066,10 @@ defmodule Explorer.Token.MetadataRetriever do
 
   defp arweave?(ipfs_params) do
     Keyword.get(ipfs_params, :arweave?)
+  end
+
+  defp swarm?(ipfs_params) do
+    Keyword.get(ipfs_params, :swarm?)
   end
 
   defp check_content_type(content_type, uri, hex_token_id, body, ipfs_params) do
@@ -1058,6 +1158,22 @@ defmodule Explorer.Token.MetadataRetriever do
   end
 
   def valid_ipfs_path?(_), do: false
+
+  @doc """
+  Returns `true` when `hash` is a valid ETH Swarm keccak-256 content address.
+
+  Swarm hashes (both legacy and new-style) are 64 lower-case hex characters.
+  The function also accepts hashes embedded in a path (e.g.
+  `"<hash>/path/to/file"`) by checking only the first path segment, so that
+  deep-linked Swarm URLs work correctly.
+  """
+  @spec valid_swarm_hash?(binary()) :: boolean()
+  def valid_swarm_hash?(hash) when is_binary(hash) do
+    bare = hash |> String.split("/") |> List.first()
+    String.match?(bare, ~r/^[0-9a-f]{64}$/)
+  end
+
+  def valid_swarm_hash?(_), do: false
 
   defp fetch_from_ipfs_if_valid_path(resource_id, hex_token_id) do
     if is_binary(resource_id) and valid_ipfs_path?(public_ipfs_link(resource_id)) do

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -1276,4 +1276,193 @@ defmodule Explorer.Token.MetadataRetrieverTest do
       assert MetadataRetriever.fetch_json({:ok, [invalid_path]}) == {:error, "invalid ipfs path"}
     end
   end
+
+  describe "swarm_link/1" do
+    @swarm_hash String.duplicate("a", 64)
+
+    test "returns default gateway URL when no config override is set" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, [])
+
+      expected = "https://gateway.ethswarm.org/bzz/#{@swarm_hash}/"
+      assert MetadataRetriever.swarm_link(@swarm_hash) == expected
+    end
+
+    test "uses configured gateway_url" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://my-swarm-node.example.com")
+
+      expected = "https://my-swarm-node.example.com/bzz/#{@swarm_hash}/"
+      assert MetadataRetriever.swarm_link(@swarm_hash) == expected
+    end
+
+    test "strips trailing slash from configured gateway_url" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://my-swarm-node.example.com/")
+
+      expected = "https://my-swarm-node.example.com/bzz/#{@swarm_hash}/"
+      assert MetadataRetriever.swarm_link(@swarm_hash) == expected
+    end
+
+    test "preserves deep path without forcing trailing slash" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://my-swarm-node.example.com/")
+
+      uid = "#{@swarm_hash}/metadata.json"
+      expected = "https://my-swarm-node.example.com/bzz/#{uid}"
+
+      assert MetadataRetriever.swarm_link(uid) == expected
+    end
+  end
+
+  describe "swarm_headers/0" do
+    test "returns only default headers when no bearer token is configured" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, [])
+
+      assert MetadataRetriever.swarm_headers() == MetadataRetriever.ar_headers()
+    end
+
+    test "prepends Authorization header when bearer_token is configured" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, bearer_token: "secret-token")
+
+      headers = MetadataRetriever.swarm_headers()
+      assert {"Authorization", "Bearer secret-token"} in headers
+      assert headers == [{"Authorization", "Bearer secret-token"} | MetadataRetriever.ar_headers()]
+    end
+
+    test "does not prepend Authorization header when bearer_token is empty" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, bearer_token: "")
+
+      assert MetadataRetriever.swarm_headers() == MetadataRetriever.ar_headers()
+    end
+
+    test "does not prepend Authorization header when bearer_token is whitespace" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, bearer_token: "   ")
+
+      assert MetadataRetriever.swarm_headers() == MetadataRetriever.ar_headers()
+    end
+  end
+
+  describe "valid_swarm_hash?/1" do
+    @valid_hash String.duplicate("a1", 32)
+
+    test "returns true for a 64-character lowercase hex hash" do
+      assert MetadataRetriever.valid_swarm_hash?(@valid_hash)
+    end
+
+    test "returns true for a hash embedded in a path" do
+      assert MetadataRetriever.valid_swarm_hash?("#{@valid_hash}/path/to/resource")
+    end
+
+    test "returns false for uppercase hex" do
+      refute MetadataRetriever.valid_swarm_hash?(String.upcase(@valid_hash))
+    end
+
+    test "returns false for a hash that is too short" do
+      refute MetadataRetriever.valid_swarm_hash?(String.duplicate("a", 63))
+    end
+
+    test "returns false for a hash that is too long" do
+      refute MetadataRetriever.valid_swarm_hash?(String.duplicate("a", 65))
+    end
+
+    test "returns false for an empty string" do
+      refute MetadataRetriever.valid_swarm_hash?("")
+    end
+
+    test "returns false for non-binary" do
+      refute MetadataRetriever.valid_swarm_hash?(nil)
+    end
+  end
+
+  describe "ETH Swarm URI routing" do
+    @valid_hash String.duplicate("b2", 32)
+    @swarm_metadata %{"name" => "Swarm NFT", "description" => "stored on Swarm"}
+
+    test "fetch_json resolves bzz:// URI scheme via Swarm gateway" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://gateway.ethswarm.org")
+
+      expected_url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/"
+
+      Explorer.HttpClient.Mox
+      |> expect(:get, fn ^expected_url, _headers, _opts ->
+        {:ok,
+         %{
+           status_code: 200,
+           body: Jason.encode!(@swarm_metadata),
+           headers: [{"content-type", "application/json"}]
+         }}
+      end)
+
+      assert {:ok, %{metadata: metadata}} =
+               MetadataRetriever.fetch_json({:ok, ["bzz://#{@valid_hash}"]})
+
+      assert metadata["name"] == "Swarm NFT"
+    end
+
+    test "fetch_json resolves https://gateway.ethswarm.org/bzz/<hash>/ URL" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://gateway.ethswarm.org")
+
+      url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/"
+
+      Explorer.HttpClient.Mox
+      |> expect(:get, fn ^url, _headers, _opts ->
+        {:ok,
+         %{
+           status_code: 200,
+           body: Jason.encode!(@swarm_metadata),
+           headers: [{"content-type", "application/json"}]
+         }}
+      end)
+
+      assert {:ok, %{metadata: metadata}} =
+               MetadataRetriever.fetch_json({:ok, [url]})
+
+      assert metadata["description"] == "stored on Swarm"
+    end
+
+    test "fetch_json preserves deep path for https swarm URLs" do
+      original = Application.get_env(:indexer, :swarm, [])
+      on_exit(fn -> Application.put_env(:indexer, :swarm, original) end)
+      Application.put_env(:indexer, :swarm, gateway_url: "https://gateway.ethswarm.org")
+
+      url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/meta/1.json"
+
+      Explorer.HttpClient.Mox
+      |> expect(:get, fn ^url, _headers, _opts ->
+        {:ok,
+         %{
+           status_code: 200,
+           body: Jason.encode!(@swarm_metadata),
+           headers: [{"content-type", "application/json"}]
+         }}
+      end)
+
+      assert {:ok, %{metadata: metadata}} =
+               MetadataRetriever.fetch_json({:ok, [url]})
+
+      assert metadata["name"] == "Swarm NFT"
+    end
+
+    test "fetch_json returns error for invalid Swarm hash in bzz:// URI" do
+      assert MetadataRetriever.fetch_json({:ok, ["bzz://not-a-valid-hash"]}) ==
+               {:error, "invalid swarm path"}
+    end
+  end
 end

--- a/apps/explorer/test/explorer/token/metadata_retriever_test.exs
+++ b/apps/explorer/test/explorer/token/metadata_retriever_test.exs
@@ -1398,15 +1398,12 @@ defmodule Explorer.Token.MetadataRetrieverTest do
 
       expected_url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/"
 
-      Explorer.HttpClient.Mox
-      |> expect(:get, fn ^expected_url, _headers, _opts ->
-        {:ok,
-         %{
-           status_code: 200,
-           body: Jason.encode!(@swarm_metadata),
-           headers: [{"content-type", "application/json"}]
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^expected_url}, _opts ->
+          {:ok, %Tesla.Env{status: 200, body: Jason.encode!(@swarm_metadata)}}
+        end
+      )
 
       assert {:ok, %{metadata: metadata}} =
                MetadataRetriever.fetch_json({:ok, ["bzz://#{@valid_hash}"]})
@@ -1421,15 +1418,12 @@ defmodule Explorer.Token.MetadataRetrieverTest do
 
       url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/"
 
-      Explorer.HttpClient.Mox
-      |> expect(:get, fn ^url, _headers, _opts ->
-        {:ok,
-         %{
-           status_code: 200,
-           body: Jason.encode!(@swarm_metadata),
-           headers: [{"content-type", "application/json"}]
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok, %Tesla.Env{status: 200, body: Jason.encode!(@swarm_metadata)}}
+        end
+      )
 
       assert {:ok, %{metadata: metadata}} =
                MetadataRetriever.fetch_json({:ok, [url]})
@@ -1444,15 +1438,12 @@ defmodule Explorer.Token.MetadataRetrieverTest do
 
       url = "https://gateway.ethswarm.org/bzz/#{@valid_hash}/meta/1.json"
 
-      Explorer.HttpClient.Mox
-      |> expect(:get, fn ^url, _headers, _opts ->
-        {:ok,
-         %{
-           status_code: 200,
-           body: Jason.encode!(@swarm_metadata),
-           headers: [{"content-type", "application/json"}]
-         }}
-      end)
+      Tesla.Test.expect_tesla_call(
+        times: 1,
+        returns: fn %{url: ^url}, _opts ->
+          {:ok, %Tesla.Env{status: 200, body: Jason.encode!(@swarm_metadata)}}
+        end
+      )
 
       assert {:ok, %{metadata: metadata}} =
                MetadataRetriever.fetch_json({:ok, [url]})


### PR DESCRIPTION
Finalization of https://github.com/blockscout/blockscout/pull/14290

## Summary

Adds first-class support for **ETH Swarm** hashes in the token metadata pipeline, mirroring the existing Arweave integration.

The implementation works with **any content stored on Swarm**, not just `/bzz` uploads — because the entry point is the 64-character keccak-256 *hash* (content address), which is shared by:
- `/bzz/<hash>` — regular chunk uploads
- SOC (Single Owner Chunks) references
- Feed manifests (which resolve to a content-address under the hood)

A 200 response from the Swarm gateway is therefore sufficient proof that the content exists, regardless of how it was originally uploaded.

---

## Changes

### `apps/explorer/lib/explorer/token/metadata_retriever.ex`

| Addition | Purpose |
|---|---|
| `@invalid_swarm_path` | Error constant (mirrors `@invalid_ipfs_path`) |
| `swarm_link/1` | Builds `<gateway>/bzz/<hash>/`; defaults to `https://gateway.ethswarm.org`; overridable via `config :indexer, :swarm, gateway_url:` |
| `swarm_headers/0` | Returns `Authorization: Bearer <token>` when `config :indexer, :swarm, bearer_token:` is set — supports private / paid gateway nodes |
| `valid_swarm_hash?/1` | Validates 64-char lowercase hex Swarm hash |
| `bzz://` clause in `fetch_from_ipfs_or_ar?/5` | Routes `bzz://<hash>[/path]` URIs |
| `/bzz/<hash>` clause in `fetch_from_ipfs_or_ar?/5` | Routes plain HTTPS Swarm gateway URLs |
| `fetch_from_swarm/2` + `fetch_from_swarm_if_valid_hash/2` | Fetcher (mirrors `fetch_from_arweave/2`) |
| `swarm?/1` predicate | Threaded through host-filtering bypass, header selection, and `process_result/3` |

### `apps/explorer/test/explorer/token/metadata_retriever_test.exs`

New describe blocks:
- `swarm_link/1` — default gateway, custom gateway, trailing-slash stripping
- `swarm_headers/0` — no token, bearer token configured
- `valid_swarm_hash?/1` — valid, embedded path, uppercase, too short/long, empty, non-binary
- ETH Swarm URI routing — `bzz://` scheme, plain HTTPS `/bzz/`, invalid hash error

---

## Configuration (optional)

```elixir
# config/runtime.exs  (or config.exs)
config :indexer, :swarm,
  gateway_url: System.get_env("INDEXER_SWARM_GATEWAY_URL", "https://gateway.ethswarm.org"),
  bearer_token: System.get_env("INDEXER_SWARM_GATEWAY_BEARER_TOKEN")
```

Both keys are optional — the module works with zero configuration using the public Swarm gateway.

---

## Related

Closes #<issue> (if any)

Follows the same pattern as the Arweave integration introduced in [this commit](https://github.com/blockscout/blockscout/blob/5b62fd2e34e8f9cbad6bdcaa8c41f28e187516b9/apps/explorer/lib/explorer/token/metadata_retriever.ex#L794).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token metadata retrieval now supports Ethereum Swarm (bzz:// and gateway URLs) alongside IPFS and Arweave.
  * Swarm URIs are auto-recognized and resolved via a configurable gateway; requests can include an optional bearer token.
  * Swarm sources are treated like IPFS/Arweave for metadata vs. URI storage decisions and invalid Swarm paths return a clear error.

* **Tests**
  * Added tests for Swarm gateway routing, header handling (including bearer token behavior), and hash/URI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->