### PR TITLE
feat: enrich from/to addresses in advanced filters with ENS and metadata

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/advanced_filter_controller.ex
@@ -5,6 +5,8 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   import BlockScoutWeb.Chain, only: [paginate_list: 4, fetch_scam_token_toggle: 2, maybe_override_page_size: 2]
+  import Explorer.MicroserviceInterfaces.BENS, only: [maybe_preload_ens: 1]
+  import Explorer.MicroserviceInterfaces.Metadata, only: [maybe_preload_metadata: 1]
   import Explorer.PagingOptions, only: [default_paging_options: 0]
 
   alias BlockScoutWeb.AccessHelper
@@ -288,6 +290,11 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterController do
 
     {advanced_filters, next_page_params} =
       paginate_list(advanced_filters_plus_one, %{}, full_options[:paging_options], paging_function: &paging_params/1)
+
+    advanced_filters =
+      advanced_filters
+      |> maybe_preload_ens()
+      |> maybe_preload_metadata()
 
     decoded_transactions =
       advanced_filters

--- a/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
+++ b/apps/explorer/lib/explorer/chain/address/metadata_preloader.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
   alias Explorer.Chain.{
     Address,
     Address.CurrentTokenBalance,
+    AdvancedFilter,
     Beacon.Deposit,
     Block,
     InternalTransaction,
@@ -23,6 +24,7 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
 
   @type supported_types ::
           Address.t()
+          | AdvancedFilter.t()
           | Block.t()
           | CurrentTokenBalance.t()
           | InternalTransaction.t()
@@ -205,6 +207,16 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
     [to_string(to_address_hash), to_string(from_address_hash)]
   end
 
+  defp item_to_address_hash_strings(%AdvancedFilter{
+         from_address_hash: from_address_hash,
+         to_address_hash: to_address_hash,
+         created_contract_address_hash: created_contract_address_hash
+       }) do
+    [from_address_hash, to_address_hash, created_contract_address_hash]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&to_string/1)
+  end
+
   defp item_to_address_hash_strings(%Log{address_hash: address_hash}) do
     [to_string(address_hash)]
   end
@@ -310,6 +322,29 @@ defmodule Explorer.Chain.Address.MetadataPreloader do
         created_contract_address:
           alter_address(transaction.created_contract_address, created_contract_address_hash, names, field_to_put_info),
         from_address: alter_address(transaction.from_address, from_address_hash, names, field_to_put_info)
+    }
+  end
+
+  defp put_meta_to_item(
+         %AdvancedFilter{
+           from_address_hash: from_address_hash,
+           to_address_hash: to_address_hash,
+           created_contract_address_hash: created_contract_address_hash
+         } = advanced_filter,
+         names,
+         field_to_put_info
+       ) do
+    %AdvancedFilter{
+      advanced_filter
+      | from_address: alter_address(advanced_filter.from_address, from_address_hash, names, field_to_put_info),
+        to_address: alter_address(advanced_filter.to_address, to_address_hash, names, field_to_put_info),
+        created_contract_address:
+          alter_address(
+            advanced_filter.created_contract_address,
+            created_contract_address_hash,
+            names,
+            field_to_put_info
+          )
     }
   end
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14443

## Motivation

For consistency with other API v2 endpoints (transactions, internal transactions, token transfers), the `/api/v2/advanced-filters` response should enrich `from`, `to`, and `created_contract` address objects with ENS domain names and metadata tags from the BENS and Metadata microservices.

## Changelog

### Enhancements

- Add `AdvancedFilter` as a supported type in `Explorer.Chain.Address.MetadataPreloader` — adds `item_to_address_hash_strings/1` and `put_meta_to_item/3` clauses to extract and enrich `from_address`, `to_address`, and `created_contract_address`.
- Call `maybe_preload_ens/1` and `maybe_preload_metadata/1` in `AdvancedFilterController.list/2` after pagination, so `ens_domain_name` and `metadata` fields are populated on address objects in the response.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Advanced filter search results now consistently display ENS names and address metadata information, providing complete context for transaction queries and address details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->