### PR TITLE
chore: remove redundant token object from NFT instances list

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -250,7 +250,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       ok:
         {"NFT instances for the specified token contract, with pagination.", "application/json",
          paginated_response(
-           items: Schemas.TokenInstance,
+           items: Schemas.TokenInstanceInTokenInstancesList,
            next_page_params_example: %{
              "unique_token" => 782_098
            }

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_token_instances_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_token_instances_list.ex
@@ -7,12 +7,20 @@ defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInTokenInstancesList do
   """
   require OpenApiSpex
 
-  alias BlockScoutWeb.Schemas.API.V2.TokenInstanceInList
+  alias BlockScoutWeb.Schemas.API.V2.{General, Token.Type, TokenInstance}
   alias BlockScoutWeb.Schemas.Helper
 
   OpenApiSpex.schema(
-    TokenInstanceInList.schema()
-    |> Helper.extend_schema(title: "TokenInstanceInTokenInstancesList")
+    TokenInstance.schema()
+    |> Helper.extend_schema(
+      title: "TokenInstanceInTokenInstancesList",
+      # token_type and value are present on the holder-filtered path but absent on
+      # the unfiltered path, so they are allowed but not required.
+      properties: %{
+        token_type: Type,
+        value: General.IntegerStringNullable
+      }
+    )
     |> Map.update!(:properties, &Map.delete(&1, :token))
     |> Map.update!(:required, &List.delete(&1, :token))
   )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_token_instances_list.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/token_instance_in_token_instances_list.ex
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.Schemas.API.V2.TokenInstanceInTokenInstancesList do
+  @moduledoc """
+  This module defines the schema for a token instance item returned by the
+  `GET /api/v2/tokens/:address_hash/instances` endpoint. Unlike TokenInstanceInList,
+  the `token` field is omitted because all items belong to the same token contract.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.TokenInstanceInList
+  alias BlockScoutWeb.Schemas.Helper
+
+  OpenApiSpex.schema(
+    TokenInstanceInList.schema()
+    |> Helper.extend_schema(title: "TokenInstanceInTokenInstancesList")
+    |> Map.update!(:properties, &Map.delete(&1, :token))
+    |> Map.update!(:required, &List.delete(&1, :token))
+  )
+end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -62,7 +62,15 @@ defmodule BlockScoutWeb.API.V2.AddressView do
   end
 
   def render("nft_list.json", %{token_instances: token_instances, token: token, next_page_params: next_page_params}) do
-    %{"items" => Enum.map(token_instances, &prepare_nft(&1, token)), "next_page_params" => next_page_params}
+    %{
+      "items" =>
+        Enum.map(token_instances, fn nft ->
+          nft
+          |> prepare_nft(token)
+          |> Map.delete("token")
+        end),
+      "next_page_params" => next_page_params
+    }
   end
 
   def render("nft_list.json", %{token_instances: token_instances, next_page_params: next_page_params}) do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -76,7 +76,12 @@ defmodule BlockScoutWeb.API.V2.TokenView do
         token: token
       }) do
     %{
-      "items" => Enum.map(token_instances, &render("token_instance.json", %{token_instance: &1, token: token})),
+      "items" =>
+        Enum.map(token_instances, fn instance ->
+          instance
+          |> prepare_token_instance(token)
+          |> Map.delete("token")
+        end),
       "next_page_params" => next_page_params
     }
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1183,6 +1183,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       assert data = json_response(request, 200)
       assert compare_item(instance, data)
       assert Address.checksum(instance.owner_address_hash) == data["owner"]["hash"]
+      assert data["token"]["address_hash"] == Address.checksum(token.contract_address_hash)
+      assert data["token"]["type"] == token.type
     end
 
     test "get 404 on token instance which is not presented in DB", %{conn: conn} do
@@ -2529,23 +2531,21 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
   end
 
   def compare_item(%Instance{token: %Token{} = token} = instance, json) do
-    token_type = token.type
     value = to_string(value(token.type, instance))
     id = to_string(instance.token_id)
     metadata = instance.metadata
-    token_address_hash = Address.checksum(token.contract_address_hash)
     app_url = instance.metadata["external_url"]
     animation_url = instance.metadata["animation_url"]
     image_url = instance.metadata["image_url"]
-    token_name = token.name
     owner_address_hash = Address.checksum(instance.owner.hash)
     is_contract = !is_nil(instance.owner.contract_code)
     is_unique = value == "1"
 
+    refute Map.has_key?(json, "token")
+
     assert %{
              "id" => ^id,
              "metadata" => ^metadata,
-             "token" => %{"address_hash" => ^token_address_hash, "name" => ^token_name, "type" => ^token_type},
              "external_app_url" => ^app_url,
              "animation_url" => ^animation_url,
              "image_url" => ^image_url,
@@ -2564,7 +2564,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     assert to_string(instance.token_id) == json["id"]
     assert Utils.JSON.decode!(Utils.JSON.encode!(instance.metadata)) == json["metadata"]
     assert json["is_unique"]
-    compare_item(Repo.preload(instance, [{:token, :contract_address}]).token, json["token"])
   end
 
   defp value("ERC-721", _), do: 1

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2541,8 +2541,6 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     is_contract = !is_nil(instance.owner.contract_code)
     is_unique = value == "1"
 
-    refute Map.has_key?(json, "token")
-
     assert %{
              "id" => ^id,
              "metadata" => ^metadata,


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/8805

## Motivation

`GET api/v2/tokens/:address_hash/instances` is scoped to a single token contract, so embedding the full `token` object on every item in the paginated list is redundant. Consumers can fetch token details once from `GET api/v2/tokens/:address_hash`. Removing the field reduces response payload size.

## Changelog

### Enhancements

- Removed `token` field from each item in the response of `GET api/v2/tokens/:address_hash/instances` (both the unfiltered path and the `?holder_address_hash=` filtered path).
- `GET api/v2/tokens/:address_hash/instances/:token_id` (single-instance endpoint) is **not affected** — it continues to return the `token` object.
- `GET api/v2/addresses/:address_hash/nft` is **not affected** — it continues to return `token` per item because instances may belong to different token contracts.
- Updated `TokenInstanceInList` OpenAPI schema to reflect the removed field; `TokenInstance` schema (used by the single-instance endpoint) is unchanged.
- Updated `TokenController` OpenAPI operation for `instances` to reference `TokenInstanceInList` instead of `TokenInstance`.
- Adjusted token controller tests: removed `token` assertions from list-endpoint helpers, added `refute Map.has_key?(json, "token")` for list items, and added explicit `token` field assertions to the single-instance test.


### Incompatible Changes

- The `token` key is no longer present in items returned by `GET api/v2/tokens/:address_hash/instances`. Frontend consumers (e.g. [blockscout/frontend#1346](https://github.com/blockscout/frontend/issues/1346)) must fetch token details separately.

## Upgrading

No database changes. No reindex required.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the token instances API response: instance items no longer include a nested token object; token type and value remain on the instance.
* **Tests**
  * Adjusted tests to reflect the new instance JSON shape and to verify token address and type appear where expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->