### PR TITLE
feat: mark instance unhealthy when cache block lags DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preload only listened entities before broadcast ([#14430](https://github.com/blockscout/blockscout/issues/14430))
 - Add hot smart contracts caching ([#14320](https://github.com/blockscout/blockscout/issues/14320))
 - Add MinimalProxy detection for mid-bytecode EIP-1167-like pattern ([#14426](https://github.com/blockscout/blockscout/issues/14426))
+- Mark instance unhealthy when cache block lags DB ([#14449](https://github.com/blockscout/blockscout/pull/14449))
 
 ### 🐛 Bug Fixes
 

--- a/apps/explorer/lib/explorer/chain/health/helper.ex
+++ b/apps/explorer/lib/explorer/chain/health/helper.ex
@@ -193,6 +193,8 @@ defmodule Explorer.Chain.Health.Helper do
         with true <- last_block_db_delay > blocks_indexing_delay_threshold,
              {:empty_health_latest_block_number_from_node, false} <-
                {:empty_health_latest_block_number_from_node, is_nil(health_status.health_latest_block_number_from_node)},
+             {:empty_health_latest_block_number_from_db, false} <-
+               {:empty_health_latest_block_number_from_db, is_nil(health_status.health_latest_block_number_from_db)},
              true <-
                Decimal.compare(
                  Decimal.sub(
@@ -204,6 +206,7 @@ defmodule Explorer.Chain.Health.Helper do
           no_new_block_status(last_block_db_delay)
         else
           {:empty_health_latest_block_number_from_node, true} -> no_new_block_status(last_block_db_delay)
+          {:empty_health_latest_block_number_from_db, true} -> true
           _ -> true
         end
 

--- a/apps/explorer/lib/explorer/chain/health/helper.ex
+++ b/apps/explorer/lib/explorer/chain/health/helper.ex
@@ -189,24 +189,50 @@ defmodule Explorer.Chain.Health.Helper do
       blocks_indexing_delay_threshold =
         Application.get_env(:explorer, Explorer.Chain.Health.Monitor)[:healthy_blocks_period]
 
-      with true <- last_block_db_delay > blocks_indexing_delay_threshold,
-           {:empty_health_latest_block_number_from_node, false} <-
-             {:empty_health_latest_block_number_from_node, is_nil(health_status.health_latest_block_number_from_node)},
-           true <-
-             Decimal.compare(
-               Decimal.sub(
-                 health_status.health_latest_block_number_from_node,
-                 health_status.health_latest_block_number_from_db
-               ),
-               Decimal.new(@max_blocks_gap_between_node_and_db)
-             ) == :gt do
-        no_new_block_status(last_block_db_delay)
-      else
-        {:empty_health_latest_block_number_from_node, true} -> no_new_block_status(last_block_db_delay)
-        _ -> true
+      db_freshness_result =
+        with true <- last_block_db_delay > blocks_indexing_delay_threshold,
+             {:empty_health_latest_block_number_from_node, false} <-
+               {:empty_health_latest_block_number_from_node, is_nil(health_status.health_latest_block_number_from_node)},
+             true <-
+               Decimal.compare(
+                 Decimal.sub(
+                   health_status.health_latest_block_number_from_node,
+                   health_status.health_latest_block_number_from_db
+                 ),
+                 Decimal.new(@max_blocks_gap_between_node_and_db)
+               ) == :gt do
+          no_new_block_status(last_block_db_delay)
+        else
+          {:empty_health_latest_block_number_from_node, true} -> no_new_block_status(last_block_db_delay)
+          _ -> true
+        end
+
+      case db_freshness_result do
+        true -> check_cache_lag(health_status, blocks_indexing_delay_threshold)
+        error -> error
       end
     else
       {false, @no_items_error_code, "There are no blocks in the DB."}
+    end
+  end
+
+  defp check_cache_lag(health_status, threshold) do
+    cache_ts_raw = health_status[:health_latest_block_timestamp_from_cache]
+    db_ts_raw = health_status[:health_latest_block_timestamp_from_db]
+
+    if is_nil(cache_ts_raw) or is_nil(db_ts_raw) do
+      true
+    else
+      {:ok, cache_ts} = DateTime.from_unix(Decimal.to_integer(cache_ts_raw))
+      {:ok, db_ts} = DateTime.from_unix(Decimal.to_integer(db_ts_raw))
+      cache_lag_ms = DateTime.diff(db_ts, cache_ts, :millisecond)
+
+      if cache_lag_ms > threshold do
+        {false, @no_new_items_error_code,
+         "Cache block is lagging behind DB block by #{round(cache_lag_ms / 1_000 / 60)} mins. Check the cache update mechanism."}
+      else
+        true
+      end
     end
   end
 

--- a/apps/explorer/test/explorer/chain/health/helper_test.exs
+++ b/apps/explorer/test/explorer/chain/health/helper_test.exs
@@ -25,6 +25,78 @@ defmodule Explorer.Chain.Health.HelperTest do
     end
   end
 
+  describe "blocks_indexing_healthy?/1" do
+    setup do
+      Application.put_env(:explorer, Explorer.Chain.Health.Monitor, healthy_blocks_period: 300_000)
+      :ok
+    end
+
+    defp unix_now, do: DateTime.to_unix(DateTime.utc_now())
+
+    defp base_status(overrides \\ %{}) do
+      now = unix_now()
+
+      Map.merge(
+        %{
+          health_latest_block_timestamp_from_db: Decimal.new(now),
+          health_latest_block_number_from_db: Decimal.new(100),
+          health_latest_block_timestamp_from_cache: Decimal.new(now),
+          health_latest_block_number_from_cache: Decimal.new(100),
+          health_latest_block_number_from_node: Decimal.new(100),
+          health_latest_batch_timestamp_from_db: nil,
+          health_latest_batch_number_from_db: nil,
+          health_latest_batch_average_time_from_db: nil
+        },
+        overrides
+      )
+    end
+
+    test "returns true when nil" do
+      assert true == HealthHelper.blocks_indexing_healthy?(nil)
+    end
+
+    test "returns error when db has no blocks" do
+      status = base_status(%{health_latest_block_timestamp_from_db: nil})
+      assert {false, _, _} = HealthHelper.blocks_indexing_healthy?(status)
+    end
+
+    test "returns true when db and cache are both current" do
+      assert true == HealthHelper.blocks_indexing_healthy?(base_status())
+    end
+
+    test "returns true when cache timestamps are absent" do
+      status = base_status(%{health_latest_block_timestamp_from_cache: nil})
+      assert true == HealthHelper.blocks_indexing_healthy?(status)
+    end
+
+    test "returns error when cache lags behind db beyond threshold" do
+      now = unix_now()
+      stale = now - 600
+
+      status =
+        base_status(%{
+          health_latest_block_timestamp_from_db: Decimal.new(now),
+          health_latest_block_timestamp_from_cache: Decimal.new(stale)
+        })
+
+      assert {false, 5001, message} = HealthHelper.blocks_indexing_healthy?(status)
+      assert message =~ "Cache block is lagging"
+    end
+
+    test "returns true when cache lag is within threshold" do
+      now = unix_now()
+      recent = now - 60
+
+      status =
+        base_status(%{
+          health_latest_block_timestamp_from_db: Decimal.new(now),
+          health_latest_block_timestamp_from_cache: Decimal.new(recent)
+        })
+
+      assert true == HealthHelper.blocks_indexing_healthy?(status)
+    end
+  end
+
   describe "last_db_block_status/0" do
     test "return no_blocks errors if db is empty" do
       assert {:error, :no_blocks} = HealthHelper.last_db_block_status()


### PR DESCRIPTION
## Motivation

The `/api/health` endpoint reported `healthy: true` even when the in-memory block cache was thousands of blocks behind the database. This masked a real operational problem — stale data being served from cache — with no observable signal in health checks.

## Changelog

### Enhancements

- Added a cache-vs-DB lag check in `Explorer.Chain.Health.Helper.blocks_indexing_healthy?/1`. If the cache block's timestamp is more than `HEALTH_MONITOR_BLOCKS_PERIOD` behind the DB block's timestamp, the instance is now marked unhealthy with error code `5001` and a human-readable message indicating the lag in minutes.
- Added tests for `blocks_indexing_healthy?/1` covering: healthy state, missing cache data (graceful skip), lag within threshold, and lag exceeding threshold.

### Bug Fixes

### Incompatible Changes

## Upgrading

No database changes. No new ENV vars — the check reuses the existing `HEALTH_MONITOR_BLOCKS_PERIOD` (default `5m`). Instances where the block cache consistently lags more than this threshold will now return HTTP 500 from `/api/health`.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now include cache freshness: instances are marked unhealthy when cached block data lags the database beyond configured thresholds, improving status accuracy.

* **Tests**
  * Added tests for cache lag scenarios, threshold boundaries, and missing timestamps to validate health-check behavior.

* **Documentation**
  * Changelog entry added noting the cache-lag health check update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->