### PR TITLE
chore: Optimize deriving current token balances

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -184,6 +184,28 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :delete_address_token_balances
       )
     end)
+    |> Multi.run(:select_address_current_token_balances_for_delete, fn repo, %{lose_consensus: non_consensus_blocks} ->
+      Instrumenter.block_import_stage_runner(
+        fn -> select_address_current_token_balances_for_delete(repo, non_consensus_blocks, insert_options) end,
+        :address_referencing,
+        :blocks,
+        :select_address_current_token_balances_for_delete
+      )
+    end)
+    |> Multi.run(:derive_address_current_token_balances, fn repo,
+                                                            %{
+                                                              select_address_current_token_balances_for_delete:
+                                                                address_current_token_balances_for_delete
+                                                            } ->
+      Instrumenter.block_import_stage_runner(
+        fn ->
+          derive_address_current_token_balances(repo, address_current_token_balances_for_delete, insert_options)
+        end,
+        :address_referencing,
+        :blocks,
+        :derive_address_current_token_balances
+      )
+    end)
     |> Multi.run(:delete_address_current_token_balances, fn repo, %{lose_consensus: non_consensus_blocks} ->
       Instrumenter.block_import_stage_runner(
         fn -> delete_address_current_token_balances(repo, non_consensus_blocks, insert_options) end,
@@ -192,16 +214,18 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         :delete_address_current_token_balances
       )
     end)
-    |> Multi.run(:derive_address_current_token_balances, fn repo,
-                                                            %{
-                                                              delete_address_current_token_balances:
-                                                                deleted_address_current_token_balances
-                                                            } ->
+    |> Multi.run(:insert_derived_address_current_token_balances, fn repo,
+                                                                    %{
+                                                                      derive_address_current_token_balances:
+                                                                        derived_address_current_token_balances
+                                                                    } ->
       Instrumenter.block_import_stage_runner(
-        fn -> derive_address_current_token_balances(repo, deleted_address_current_token_balances, insert_options) end,
+        fn ->
+          insert_derived_address_current_token_balances(repo, derived_address_current_token_balances, insert_options)
+        end,
         :address_referencing,
         :blocks,
-        :derive_address_current_token_balances
+        :insert_derived_address_current_token_balances
       )
     end)
     |> Multi.run(:save_internal_transactions_for_delete, fn repo, %{lose_consensus: non_consensus_blocks} ->
@@ -223,7 +247,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     |> Multi.run(:blocks_update_token_holder_counts, fn repo,
                                                         %{
                                                           delete_address_current_token_balances: deleted,
-                                                          derive_address_current_token_balances: inserted
+                                                          insert_derived_address_current_token_balances: inserted
                                                         } ->
       Instrumenter.block_import_stage_runner(
         fn ->
@@ -793,6 +817,26 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
     end
   end
 
+  defp select_address_current_token_balances_for_delete(_, [], _), do: {:ok, []}
+
+  defp select_address_current_token_balances_for_delete(repo, non_consensus_blocks, %{timeout: timeout}) do
+    non_consensus_block_numbers = Enum.map(non_consensus_blocks, fn {number, _hash} -> number end)
+
+    query =
+      from(ctb in Address.CurrentTokenBalance,
+        select:
+          map(ctb, [
+            :address_hash,
+            :token_contract_address_hash,
+            :token_id,
+            :value
+          ]),
+        where: ctb.block_number in ^non_consensus_block_numbers
+      )
+
+    {:ok, repo.all(query, timeout: timeout)}
+  end
+
   defp delete_address_current_token_balances(_, [], _), do: {:ok, []}
 
   defp delete_address_current_token_balances(repo, non_consensus_blocks, %{timeout: timeout}) do
@@ -842,7 +886,7 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
   defp derive_address_current_token_balances(
          repo,
          deleted_address_current_token_balances,
-         %{timeout: timeout} = options
+         %{timeout: timeout}
        )
        when is_list(deleted_address_current_token_balances) do
     base_query =
@@ -867,10 +911,12 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
         deleted_address_current_token_balances
       )
 
-    current_token_balances =
-      query
-      |> repo.all()
+    {:ok, repo.all(query, timeout: timeout)}
+  end
 
+  defp insert_derived_address_current_token_balances(_, [], _), do: {:ok, []}
+
+  defp insert_derived_address_current_token_balances(repo, current_token_balances, %{timeout: timeout} = options) do
     timestamps = Import.timestamps()
 
     result =


### PR DESCRIPTION
## Motivation

Deriving new current token balances may be a long operation. It's better to not hold lock on `address_current_token_balances` during this time. In order to do this we should execute delete from current token balances only after the new balances are derived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the block import pipeline to optimize token balance data processing and improve data flow efficiency during consensus loss events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->