### PR TITLE
refactor: simplify smart-contract reader helpers and decoded_input_data clauses

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -859,97 +859,37 @@ defmodule Explorer.Chain.Transaction do
     )
   end
 
-  # if to_address's smart_contract is nil reduce to the case when to_address is not loaded
+  # if to_address's smart_contract is nil, decode without contract ABI
   def decoded_input_data(
-        %__MODULE__{
-          to_address: %{smart_contract: nil},
-          input: input,
-          hash: hash
-        },
-        skip_sig_provider?,
-        options,
-        methods_map,
-        smart_contract_full_abi_map
-      ) do
-    decoded_input_data(
-      %__MODULE__{
-        to_address: %NotLoaded{},
-        input: input,
-        hash: hash
-      },
-      skip_sig_provider?,
-      options,
-      methods_map,
-      smart_contract_full_abi_map
-    )
-  end
-
-  # if to_address's smart_contract is not loaded reduce to the case when to_address is not loaded
-  def decoded_input_data(
-        %__MODULE__{
-          to_address: %{smart_contract: %NotLoaded{}},
-          input: input,
-          hash: hash
-        },
-        skip_sig_provider?,
-        options,
-        methods_map,
-        smart_contract_full_abi_map
-      ) do
-    decoded_input_data(
-      %__MODULE__{
-        to_address: %NotLoaded{},
-        input: input,
-        hash: hash
-      },
-      skip_sig_provider?,
-      options,
-      methods_map,
-      smart_contract_full_abi_map
-    )
-  end
-
-  # if to_address is not loaded try decoding by method candidates in the DB
-  def decoded_input_data(
-        %__MODULE__{
-          to_address: %NotLoaded{},
-          input: %{bytes: <<method_id::binary-size(4), _::binary>> = data} = input,
-          hash: hash
-        },
+        %__MODULE__{to_address: %{smart_contract: nil}, input: input, hash: hash},
         skip_sig_provider?,
         options,
         methods_map,
         _smart_contract_full_abi_map
       ) do
-    {:ok, method_id} = MethodIdentifier.cast(method_id)
-    methods = check_methods_cache(method_id, methods_map, options)
-
-    candidates =
-      methods
-      |> Enum.flat_map(fn candidate ->
-        case do_decoded_input_data(
-               data,
-               [candidate.abi],
-               hash
-             ) do
-          {:ok, _, _, _} = decoded -> [decoded]
-          _ -> []
-        end
-      end)
-
-    {:error, :contract_not_verified,
-     if(candidates == [], do: decode_function_call_via_sig_provider(input, hash, skip_sig_provider?), else: candidates)}
+    decode_without_contract_abi(input, hash, skip_sig_provider?, options, methods_map)
   end
 
-  # if to_address is not loaded and input is not a method call return error
+  # if to_address's smart_contract is not loaded, decode without contract ABI
   def decoded_input_data(
-        %__MODULE__{to_address: %NotLoaded{}},
-        _,
-        _,
-        _,
-        _
+        %__MODULE__{to_address: %{smart_contract: %NotLoaded{}}, input: input, hash: hash},
+        skip_sig_provider?,
+        options,
+        methods_map,
+        _smart_contract_full_abi_map
       ) do
-    {:error, :contract_not_verified, []}
+    decode_without_contract_abi(input, hash, skip_sig_provider?, options, methods_map)
+  end
+
+  # if to_address is not loaded, decode without contract ABI
+  def decoded_input_data(
+        %__MODULE__{to_address: %NotLoaded{}, input: input, hash: hash},
+        skip_sig_provider?,
+        options,
+        methods_map,
+        _smart_contract_full_abi_map
+      ) do
+    decode_without_contract_abi(input, hash, skip_sig_provider?, options, methods_map)
   end
 
   def decoded_input_data(
@@ -1034,6 +974,30 @@ defmodule Explorer.Chain.Transaction do
         {:error, :contract_verified, result}
     end
   end
+
+  defp decode_without_contract_abi(
+         %{bytes: <<method_id::binary-size(4), _::binary>> = data} = input,
+         hash,
+         skip_sig_provider?,
+         options,
+         methods_map
+       ) do
+    {:ok, method_id} = MethodIdentifier.cast(method_id)
+    methods = check_methods_cache(method_id, methods_map, options)
+
+    candidates =
+      Enum.flat_map(methods, fn candidate ->
+        case do_decoded_input_data(data, [candidate.abi], hash) do
+          {:ok, _, _, _} = decoded -> [decoded]
+          _ -> []
+        end
+      end)
+
+    {:error, :contract_not_verified,
+     if(candidates == [], do: decode_function_call_via_sig_provider(input, hash, skip_sig_provider?), else: candidates)}
+  end
+
+  defp decode_without_contract_abi(_, _, _, _, _), do: {:error, :contract_not_verified, []}
 
   defp do_decoded_input_data(data, full_abi, hash) do
     with {:ok, {selector, values}} <- find_and_decode(full_abi, data, hash),

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -461,7 +461,7 @@ defmodule Explorer.SmartContract.Reader do
         options
       ) do
     abi = get_abi(contract_address_hash, :proxy, options)
-    outputs = query_function_with_custom_abi(contract_address_hash, params, from, leave_error_as_map, abi)
+    outputs = query_function_with_custom_abi(contract_address_hash, params, from, leave_error_as_map, abi, options)
     names = parse_names_from_abi(abi, method_id)
     %{output: outputs, names: names}
   end

--- a/apps/explorer/lib/explorer/smart_contract/reader.ex
+++ b/apps/explorer/lib/explorer/smart_contract/reader.ex
@@ -73,30 +73,17 @@ defmodule Explorer.SmartContract.Reader do
         ) ::
           functions_results()
   def query_verified_contract(address_hash, functions, from, leave_error_as_map, mabi, options \\ []) do
-    query_verified_contract_inner(address_hash, functions, mabi, from, leave_error_as_map, options)
+    contract_address = Hash.to_string(address_hash)
+    abi = prepare_abi(mabi, address_hash)
+    query_contract(contract_address, from, abi, functions, leave_error_as_map, options)
   end
 
   @spec query_verified_contract(Hash.Address.t(), functions(), true | false, SmartContract.abi() | nil) ::
           functions_results()
   def query_verified_contract(address_hash, functions, leave_error_as_map, mabi \\ nil) do
-    query_verified_contract_inner(address_hash, functions, mabi, nil, leave_error_as_map)
-  end
-
-  @spec query_verified_contract_inner(
-          Hash.Address.t(),
-          functions(),
-          SmartContract.abi() | nil,
-          String.t() | nil,
-          true | false,
-          Keyword.t()
-        ) ::
-          functions_results()
-  defp query_verified_contract_inner(address_hash, functions, mabi, from, leave_error_as_map, options \\ []) do
     contract_address = Hash.to_string(address_hash)
-
     abi = prepare_abi(mabi, address_hash)
-
-    query_contract(contract_address, from, abi, functions, leave_error_as_map, options)
+    query_contract(contract_address, nil, abi, functions, leave_error_as_map)
   end
 
   defp prepare_abi(nil, address_hash) do
@@ -130,7 +117,16 @@ defmodule Explorer.SmartContract.Reader do
           Keyword.t()
         ) :: functions_results()
   def query_contract(contract_address, from \\ nil, abi, functions, leave_error_as_map, options \\ []) do
-    query_contract_inner(contract_address, abi, functions, nil, from, leave_error_as_map, options)
+    requests =
+      Enum.map(functions, fn {method_id, args} ->
+        req = %{contract_address: contract_address, method_id: method_id, args: args, block_number: nil}
+        if from && from != "", do: Map.put(req, :from, from), else: req
+      end)
+
+    requests
+    |> query_contracts(abi, [], leave_error_as_map, options)
+    |> Enum.zip(requests)
+    |> Enum.into(%{}, fn {response, request} -> {request.method_id, response} end)
   end
 
   @spec query_contract_by_block_number(
@@ -140,28 +136,15 @@ defmodule Explorer.SmartContract.Reader do
           non_neg_integer()
         ) :: functions_results()
   def query_contract_by_block_number(contract_address, abi, functions, block_number, leave_error_as_map \\ false) do
-    query_contract_inner(contract_address, abi, functions, block_number, nil, leave_error_as_map)
-  end
-
-  defp query_contract_inner(contract_address, abi, functions, block_number, from, leave_error_as_map, options \\ []) do
     requests =
-      functions
-      |> Enum.map(fn {method_id, args} ->
-        %{
-          contract_address: contract_address,
-          method_id: method_id,
-          args: args,
-          block_number: block_number
-        }
-        |> (&if(!is_nil(from) && from != "", do: Map.put(&1, :from, from), else: &1)).()
+      Enum.map(functions, fn {method_id, args} ->
+        %{contract_address: contract_address, method_id: method_id, args: args, block_number: block_number}
       end)
 
     requests
-    |> query_contracts(abi, [], leave_error_as_map, options)
+    |> query_contracts(abi, [], leave_error_as_map)
     |> Enum.zip(requests)
-    |> Enum.into(%{}, fn {response, request} ->
-      {request.method_id, response}
-    end)
+    |> Enum.into(%{}, fn {response, request} -> {request.method_id, response} end)
   end
 
   @doc """
@@ -456,31 +439,21 @@ defmodule Explorer.SmartContract.Reader do
 
   def query_function_with_names(
         contract_address_hash,
-        %{method_id: method_id, args: args},
+        %{method_id: method_id} = params,
         :regular,
         from,
         abi,
         leave_error_as_map,
         options
       ) do
-    outputs =
-      query_function_with_custom_abi_inner(
-        contract_address_hash,
-        method_id,
-        args || [],
-        from,
-        leave_error_as_map,
-        abi,
-        options
-      )
-
+    outputs = query_function_with_custom_abi(contract_address_hash, params, from, leave_error_as_map, abi, options)
     names = parse_names_from_abi(abi, method_id)
     %{output: outputs, names: names}
   end
 
   def query_function_with_names(
         contract_address_hash,
-        %{method_id: method_id, args: args},
+        %{method_id: method_id} = params,
         :proxy,
         from,
         _abi,
@@ -488,17 +461,7 @@ defmodule Explorer.SmartContract.Reader do
         options
       ) do
     abi = get_abi(contract_address_hash, :proxy, options)
-
-    outputs =
-      query_function_with_custom_abi_inner(
-        contract_address_hash,
-        method_id,
-        args || [],
-        from,
-        leave_error_as_map,
-        abi
-      )
-
+    outputs = query_function_with_custom_abi(contract_address_hash, params, from, leave_error_as_map, abi)
     names = parse_names_from_abi(abi, method_id)
     %{output: outputs, names: names}
   end
@@ -559,20 +522,19 @@ defmodule Explorer.SmartContract.Reader do
         leave_error_as_map,
         options \\ []
       ) do
-    query_function_inner(contract_address_hash, method_id, args || [], type, from, leave_error_as_map, options)
-  end
-
-  @spec query_function_inner(Hash.t(), String.t(), [term()], atom(), String.t() | nil, true | false, [api?]) :: [%{}]
-  defp query_function_inner(contract_address_hash, method_id, args, type, from, leave_error_as_map, options) do
     abi = get_abi(contract_address_hash, type, options)
 
-    parsed_final_abi =
-      abi
-      |> ABI.parse_specification()
-
-    case process_abi(parsed_final_abi, method_id) do
+    case process_abi(ABI.parse_specification(abi), method_id) do
       %{outputs: outputs, method_id: method_id} ->
-        query_contract_and_link_outputs(contract_address_hash, args, from, abi, outputs, method_id, leave_error_as_map)
+        query_contract_and_link_outputs(
+          contract_address_hash,
+          args || [],
+          from,
+          abi,
+          outputs,
+          method_id,
+          leave_error_as_map
+        )
 
       {:error, message} ->
         {:error, message}
@@ -597,46 +559,11 @@ defmodule Explorer.SmartContract.Reader do
         custom_abi,
         options \\ []
       ) do
-    query_function_with_custom_abi_inner(
-      contract_address_hash,
-      method_id,
-      args || [],
-      from,
-      leave_error_as_map,
-      custom_abi,
-      options
-    )
-  end
-
-  @spec query_function_with_custom_abi_inner(
-          Hash.t(),
-          String.t(),
-          [term()],
-          String.t() | nil,
-          true | false,
-          [%{}],
-          Keyword.t()
-        ) :: [
-          %{}
-        ]
-  defp query_function_with_custom_abi_inner(
-         contract_address_hash,
-         method_id,
-         args,
-         from,
-         leave_error_as_map,
-         custom_abi,
-         options \\ []
-       ) do
-    parsed_abi =
-      custom_abi
-      |> ABI.parse_specification()
-
-    case process_abi(parsed_abi, method_id) do
+    case process_abi(ABI.parse_specification(custom_abi), method_id) do
       %{outputs: outputs, method_id: method_id} ->
         query_contract_and_link_outputs(
           contract_address_hash,
-          args,
+          args || [],
           from,
           custom_abi,
           outputs,


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/7744

## Motivation

`Explorer.SmartContract.Reader` had several private `_inner` helper functions that were single-caller wrappers adding nothing beyond argument reordering, making the call flow hard to follow. `Transaction.decoded_input_data/5` had two clauses that reconstructed a fake `%Transaction{to_address: %NotLoaded{}}` struct just to trigger a third clause via recursive re-dispatch, which was confusing to read.

## Changelog

### Enhancements

- **`Explorer.SmartContract.Reader`**: removed four private `_inner` wrapper functions by inlining their bodies into callers:
  - `query_verified_contract_inner/6` → inlined into both `query_verified_contract` heads
  - `query_contract_inner/7` → inlined into `query_contract` and `query_contract_by_block_number`
  - `query_function_inner/7` → inlined into `query_function`
  - `query_function_with_custom_abi_inner/7` → inlined into `query_function_with_custom_abi`; updated both `query_function_with_names` clauses to call the public `query_function_with_custom_abi` directly

- **`Transaction.decoded_input_data/5`**: extracted private `decode_without_contract_abi/5` to consolidate the "no loaded contract ABI" path. The two clauses that previously reconstructed a `%Transaction{to_address: %NotLoaded{}}` struct to trigger recursive re-dispatch now call the helper directly, alongside the original `%NotLoaded{}` clause.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable transaction decoding when contract data is missing or not preloaded, with a centralized fallback that tries method candidates and signature-based decoding.

* **Refactor**
  * Consolidated and simplified smart contract read/query flows to inline previous indirections, centralize request construction, and normalize ABI handling for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->