### PR TITLE
feat: add method inputs in ABI - like format in the logs endpoints

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -735,6 +735,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
             |> Keyword.merge(
               necessity_by_association: %{
                 [address: [:names, :smart_contract, proxy_implementations_smart_contracts_association()]] => :optional,
+                [transaction: [to_address: [:smart_contract, proxy_implementations_smart_contracts_association()]]] =>
+                  :optional,
                 :block => :optional
               }
             )

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -784,11 +784,13 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   """
   @spec logs(Plug.Conn.t(), map()) :: Plug.Conn.t() | {atom(), any()}
   def logs(conn, %{transaction_hash_param: transaction_hash_string} = params) do
-    with {:ok, _transaction, transaction_hash} <- validate_transaction(transaction_hash_string, params) do
+    with {:ok, transaction, transaction_hash} <- validate_transaction(transaction_hash_string, params) do
       full_options =
         [
           necessity_by_association: %{
             [address: [:names, :smart_contract, proxy_implementations_smart_contracts_association()]] => :optional,
+            [transaction: [to_address: [:smart_contract, proxy_implementations_smart_contracts_association()]]] =>
+              :optional,
             :block => :optional
           }
         ]
@@ -802,6 +804,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       conn
       |> put_status(200)
       |> render(:logs, %{
+        transaction: transaction,
         transaction_hash: transaction_hash,
         logs: logs |> maybe_preload_ens() |> maybe_preload_metadata(),
         next_page_params: next_page_params

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/decoded_log_input.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general/decoded_log_input.ex
@@ -9,6 +9,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.General.DecodedLogInput do
     properties: %{
       method_id: %Schema{type: :string, nullable: true},
       method_call: %Schema{type: :string, nullable: true},
+      abi: %Schema{type: :object, nullable: true},
       parameters: %Schema{
         type: :array,
         items: %Schema{

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -7,6 +7,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     chain_identity: [:explorer, :chain_identity],
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
+  alias ABI.FunctionSelector
+
   alias BlockScoutWeb.API.V2.{
     ApiView,
     Helper,
@@ -199,14 +201,22 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     |> put_pending_status(Map.get(assigns, :pending_status?, false))
   end
 
-  def render("logs.json", %{logs: logs, next_page_params: next_page_params, transaction_hash: transaction_hash}) do
+  def render(
+        "logs.json",
+        %{logs: logs, next_page_params: next_page_params, transaction_hash: transaction_hash} = assigns
+      ) do
     decoded_logs = decode_logs(logs, false)
+
+    transaction = Map.get(assigns, :transaction)
+    transaction_or_hash = transaction || transaction_hash
 
     %{
       "items" =>
         logs
         |> Enum.zip(decoded_logs)
-        |> Enum.map(fn {log, decoded_log} -> prepare_log(log, transaction_hash, decoded_log) end),
+        |> Enum.map(fn {log, decoded_log} ->
+          prepare_log(log, transaction_or_hash, decoded_log)
+        end),
       "next_page_params" => next_page_params
     }
   end
@@ -218,7 +228,9 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "items" =>
         logs
         |> Enum.zip(decoded_logs)
-        |> Enum.map(fn {log, decoded_log} -> prepare_log(log, log.transaction, decoded_log) end),
+        |> Enum.map(fn {log, decoded_log} ->
+          prepare_log(log, log.transaction, decoded_log)
+        end),
       "next_page_params" => next_page_params
     }
   end
@@ -399,7 +411,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   def prepare_log(log, transaction_or_hash, decoded_log, tags_for_address_needed? \\ false) do
-    decoded = process_decoded_log(decoded_log)
+    decoded = process_decoded_log(decoded_log) |> enrich_decoded_with_event_abi(log)
 
     %{
       "transaction_hash" => get_transaction_hash(transaction_or_hash),
@@ -463,6 +475,32 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       _ ->
         nil
     end
+  end
+
+  defp enrich_decoded_with_event_abi(nil, _log), do: nil
+
+  defp enrich_decoded_with_event_abi(decoded, log) do
+    proxy_implementations =
+      case log.address do
+        %{proxy_implementations: %NotLoaded{}} -> nil
+        %{proxy_implementations: implementations} -> implementations
+        _ -> nil
+      end
+
+    smart_contract =
+      case log.address do
+        %{smart_contract: %NotLoaded{}} -> nil
+        %{smart_contract: sc} -> sc
+        _ -> nil
+      end
+
+    full_abi =
+      (extract_implementations_abi(proxy_implementations) ++
+         try_to_get_abi(smart_contract))
+      |> Enum.uniq()
+
+    event_abi = extract_event_abi(full_abi, log.first_topic && log.first_topic.bytes)
+    Map.put(decoded, "abi", event_abi)
   end
 
   defp prepare_transaction(
@@ -721,6 +759,30 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       %{"name" => name, "type" => type, "indexed" => indexed?, "value" => DecodingHelper.value_json(type, value)}
     end)
   end
+
+  defp extract_event_abi(full_abi, first_topic_bytes) when is_list(full_abi) and is_binary(first_topic_bytes) do
+    Enum.find(full_abi, fn abi_item ->
+      abi_item["type"] in ["event", "function"] and abi_selector_matches_topic?(abi_item, first_topic_bytes)
+    end)
+  end
+
+  defp extract_event_abi(_full_abi, _first_topic), do: nil
+
+  defp abi_selector_matches_topic?(abi_item, first_topic_bytes) when byte_size(first_topic_bytes) >= 4 do
+    include_events = abi_item["type"] == "event"
+
+    case ABI.parse_specification([abi_item], include_events?: include_events) do
+      [%FunctionSelector{method_id: method_id}] when is_binary(method_id) ->
+        binary_part(first_topic_bytes, 0, byte_size(method_id)) == method_id
+
+      _ ->
+        false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp abi_selector_matches_topic?(_abi_item, _first_topic_bytes), do: false
 
   @spec format_status(
           :pending

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -3196,7 +3196,7 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       compare_item(log, log_from_api)
       assert not is_nil(log_from_api["decoded"])
 
-      assert log_from_api["decoded"] == %{
+      assert Map.drop(log_from_api["decoded"], ["abi"]) == %{
                "method_call" =>
                  "OptionSettled(uint256 indexed accountId, address option, uint256 subId, int256 amount, int256 value)",
                "method_id" => "d20a68b2",
@@ -3233,6 +3233,9 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
                  }
                ]
              }
+
+      assert log_from_api["decoded"]["abi"]["name"] == "OptionSettled"
+      assert log_from_api["decoded"]["abi"]["type"] == "event"
     end
 
     test "test corner case, when preload functions face absent smart contract", %{conn: conn} do
@@ -3337,6 +3340,48 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
       assert Enum.count(response["items"]) == 2
 
       Bypass.down(bypass)
+    end
+
+    test "includes called method ABI and arguments", %{conn: conn} do
+      event_abi = %{
+        "name" => "Set",
+        "type" => "event",
+        "inputs" => [%{"name" => "x", "type" => "uint256", "indexed" => false, "internalType" => "uint256"}],
+        "anonymous" => false
+      }
+
+      contract_address = insert(:contract_address)
+      insert(:smart_contract, address_hash: contract_address.hash, abi: [event_abi])
+
+      topic1_bytes = ExKeccak.hash_256("Set(uint256)")
+      topic1 = "0x" <> Base.encode16(topic1_bytes, case: :lower)
+
+      log_data = "0x0000000000000000000000000000000000000000000000000000000000000032"
+
+      transaction = :transaction |> insert() |> with_block()
+
+      insert(:log,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        address: contract_address,
+        first_topic: TestHelper.topic(topic1),
+        data: log_data
+      )
+
+      request = get(conn, "/api/v2/addresses/#{contract_address.hash}/logs")
+
+      assert response = json_response(request, 200)
+      assert [log_from_api] = response["items"]
+
+      assert log_from_api["decoded"]["abi"]["name"] == "Set"
+      assert log_from_api["decoded"]["abi"]["type"] == "event"
+
+      assert log_from_api["decoded"]["abi"]["inputs"] == [
+               %{"indexed" => false, "internalType" => "uint256", "name" => "x", "type" => "uint256"}
+             ]
+
+      refute Map.has_key?(log_from_api, "called_method")
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -951,7 +951,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                %{"indexed" => false, "internalType" => "uint256", "name" => "x", "type" => "uint256"}
              ]
 
-      refute Map.has_key?(log_from_api, "called_method")
+      refute Map.has_key?(log_from_api["decoded"], "called_method")
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -911,6 +911,48 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
       check_paginated_response(response, response_2nd_page, logs)
     end
+
+    test "includes called method ABI and arguments", %{conn: conn} do
+      event_abi = %{
+        "name" => "Set",
+        "type" => "event",
+        "inputs" => [%{"name" => "x", "type" => "uint256", "indexed" => false, "internalType" => "uint256"}],
+        "anonymous" => false
+      }
+
+      contract_address = insert(:contract_address)
+      insert(:smart_contract, address_hash: contract_address.hash, abi: [event_abi])
+
+      topic1_bytes = ExKeccak.hash_256("Set(uint256)")
+      topic1 = "0x" <> Base.encode16(topic1_bytes, case: :lower)
+
+      log_data = "0x0000000000000000000000000000000000000000000000000000000000000032"
+
+      transaction = :transaction |> insert() |> with_block()
+
+      insert(:log,
+        transaction: transaction,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        address: contract_address,
+        first_topic: TestHelper.topic(topic1),
+        data: log_data
+      )
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/logs")
+
+      assert response = json_response(request, 200)
+      assert [log_from_api] = response["items"]
+
+      assert log_from_api["decoded"]["abi"]["name"] == "Set"
+      assert log_from_api["decoded"]["abi"]["type"] == "event"
+
+      assert log_from_api["decoded"]["abi"]["inputs"] == [
+               %{"indexed" => false, "internalType" => "uint256", "name" => "x", "type" => "uint256"}
+             ]
+
+      refute Map.has_key?(log_from_api, "called_method")
+    end
   end
 
   describe "/transactions/{transaction_hash}/token-transfers" do
@@ -3121,7 +3163,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       log_from_api = Enum.at(response["logs_data"]["items"], 0)
       assert not is_nil(log_from_api["decoded"])
 
-      assert log_from_api["decoded"] == %{
+      assert Map.drop(log_from_api["decoded"], ["abi"]) == %{
                "method_call" =>
                  "OptionSettled(uint256 indexed accountId, address option, uint256 subId, int256 amount, int256 value)",
                "method_id" => "d20a68b2",
@@ -3158,6 +3200,9 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
                  }
                ]
              }
+
+      assert log_from_api["decoded"]["abi"]["name"] == "OptionSettled"
+      assert log_from_api["decoded"]["abi"]["type"] == "event"
     end
 
     test "test corner case, when preload functions face absent smart contract", %{conn: conn} do


### PR DESCRIPTION
Closes #13783

## Motivation

The frontend needs ABI-like decoded log data to render transaction and address logs the same way as other explorers. Issue #13783 asks for the called method/event ABI (in smart-contract ABI format) alongside decoded argument values on:

- `/api/v2/transactions/{hash}/logs`
- `/api/v2/addresses/{hash}/logs`

This PR adds an `abi` field to each log's existing `decoded` payload, populated from the verified contract ABI when the log topic matches an event selector.

## Changelog

### Enhancements

- Add `abi` to `decoded` in v2 log responses, containing the matched event ABI entry (name, type, inputs, etc.) in the same shape as `/api/v2/smart-contracts/{hash}`.
- Enrich decoded logs via `enrich_decoded_with_event_abi/2` in `TransactionView`, resolving ABI from the log address smart contract and proxy implementations.
- Preload transaction `to_address` smart contract associations for transaction logs so `smart_contract` metadata stays available.
- Update OpenAPI `DecodedLogInput` schema to document the new `abi` field.
- Add regression tests for transaction and address log endpoints; update existing decoded-log assertions to allow the new field.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.