### PR TITLE
fix: Improve BlockNumber cache

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/block_number.ex
+++ b/apps/explorer/lib/explorer/chain/cache/block_number.ex
@@ -14,7 +14,8 @@ defmodule Explorer.Chain.Cache.BlockNumber do
 
   alias Explorer.Chain.Block
 
-  def handle_update(_key, nil, value), do: {:ok, value}
+  def handle_update(:min, nil, value), do: {:ok, min(fetch_from_db(:min), value)}
+  def handle_update(:max, nil, value), do: {:ok, max(fetch_from_db(:max), value)}
 
   def handle_update(:min, old_value, new_value), do: {:ok, min(new_value, old_value)}
 


### PR DESCRIPTION
## Motivation

`BlockNumber` cache may store inaccurate `min` value. `min` value is updated only after block import or in `handle_fallback` which means that if block import happens before the first fallback, the min value in cache will be set to last imported block number even if it's not the real `min`.


## Changelog

Fetch the real min/max value on cache update from empty value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block number cache initialization to correctly handle minimum and maximum values from the database, ensuring more accurate cache state when starting up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->