### PR TITLE
fix: Fix API v2 CSV export endpoints accept "application/csv" header

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/csv_export_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/csv_export_controller.ex
@@ -132,11 +132,7 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
 
   defp items_csv(
          conn,
-         %{
-           address_hash_param: address_hash_string,
-           from_period: _from_period,
-           to_period: _to_period
-         } = params,
+         %{address_hash_param: address_hash_string} = params,
          csv_export_module
        )
        when is_binary(address_hash_string) do
@@ -213,8 +209,8 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
       base_params() ++
         [
           address_hash_param(),
-          from_period_param(),
-          to_period_param(),
+          optional_from_period_param(),
+          optional_to_period_param(),
           filter_type_param(),
           filter_value_param()
         ],
@@ -251,8 +247,8 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
       base_params() ++
         [
           address_hash_param(),
-          from_period_param(),
-          to_period_param(),
+          optional_from_period_param(),
+          optional_to_period_param(),
           filter_type_param(),
           filter_value_param()
         ],
@@ -289,8 +285,8 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
       base_params() ++
         [
           address_hash_param(),
-          from_period_param(),
-          to_period_param(),
+          optional_from_period_param(),
+          optional_to_period_param(),
           filter_type_param(),
           filter_value_param()
         ],
@@ -327,8 +323,8 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
       base_params() ++
         [
           address_hash_param(),
-          from_period_param(),
-          to_period_param(),
+          optional_from_period_param(),
+          optional_to_period_param(),
           filter_type_param(),
           filter_value_param()
         ],
@@ -366,8 +362,8 @@ defmodule BlockScoutWeb.API.V2.CsvExportController do
       base_params() ++
         [
           address_hash_param(),
-          from_period_param(),
-          to_period_param(),
+          optional_from_period_param(),
+          optional_to_period_param(),
           filter_type_param(),
           filter_value_param()
         ],

--- a/apps/block_scout_web/lib/block_scout_web/router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/router.ex
@@ -64,7 +64,7 @@ defmodule BlockScoutWeb.Router do
 
   pipeline :rate_limit do
     plug(:fetch_query_params)
-    plug(:accepts, ["json"])
+    plug(:accepts, ["json", "csv"])
     plug(BlockScoutWeb.Plug.RateLimit)
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -91,7 +91,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     )
 
     plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
-    plug(:accepts, ["csv"])
+    plug(:accepts, ["json", "csv"])
     plug(CheckApiV2)
     plug(:fetch_session)
     plug(:protect_from_forgery)

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -81,6 +81,23 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
     plug(OpenApiSpex.Plug.PutApiSpec, module: BlockScoutWeb.Specs.Public)
   end
 
+  pipeline :api_v2_csv do
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      query_string_length: @max_query_string_length,
+      pass: ["*/*"],
+      json_decoder: JSON
+    )
+
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
+    plug(:accepts, ["csv"])
+    plug(CheckApiV2)
+    plug(:fetch_session)
+    plug(:protect_from_forgery)
+    plug(OpenApiSpex.Plug.PutApiSpec, module: BlockScoutWeb.Specs.Public)
+  end
+
   pipeline :api_v2_no_session do
     plug(
       Plug.Parsers,
@@ -245,13 +262,9 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:address_hash_param/token-balances", V2.AddressController, :token_balances)
       get("/:address_hash_param/tokens", V2.AddressController, :tokens)
       get("/:address_hash_param/transactions", V2.AddressController, :transactions)
-      get("/:address_hash_param/transactions/csv", V2.CsvExportController, :transactions_csv)
       get("/:address_hash_param/token-transfers", V2.AddressController, :token_transfers)
-      get("/:address_hash_param/token-transfers/csv", V2.CsvExportController, :token_transfers_csv)
       get("/:address_hash_param/internal-transactions", V2.AddressController, :internal_transactions)
-      get("/:address_hash_param/internal-transactions/csv", V2.CsvExportController, :internal_transactions_csv)
       get("/:address_hash_param/logs", V2.AddressController, :logs)
-      get("/:address_hash_param/logs/csv", V2.CsvExportController, :logs_csv)
       get("/:address_hash_param/blocks-validated", V2.AddressController, :blocks_validated)
       get("/:address_hash_param/coin-balance-history", V2.AddressController, :coin_balance_history)
       get("/:address_hash_param/coin-balance-history-by-day", V2.AddressController, :coin_balance_history_by_day)
@@ -261,7 +274,6 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
 
       if @chain_identity == {:optimism, :celo} do
         get("/:address_hash_param/celo/election-rewards", V2.AddressController, :celo_election_rewards)
-        get("/:address_hash_param/celo/election-rewards/csv", V2.CsvExportController, :celo_election_rewards_csv)
       end
 
       if @chain_type == :ethereum do
@@ -480,9 +492,27 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
 
     scope "/advanced-filters" do
       get("/", V2.AdvancedFilterController, :list)
-      get("/csv", V2.AdvancedFilterController, :list_csv)
       get("/methods", V2.AdvancedFilterController, :list_methods)
     end
+  end
+
+  scope "/v2", as: :api_v2 do
+    pipe_through(:api_v2_csv)
+
+    get("/addresses/:address_hash_param/transactions/csv", V2.CsvExportController, :transactions_csv)
+    get("/addresses/:address_hash_param/token-transfers/csv", V2.CsvExportController, :token_transfers_csv)
+    get("/addresses/:address_hash_param/internal-transactions/csv", V2.CsvExportController, :internal_transactions_csv)
+    get("/addresses/:address_hash_param/logs/csv", V2.CsvExportController, :logs_csv)
+
+    if @chain_identity == {:optimism, :celo} do
+      get(
+        "/addresses/:address_hash_param/celo/election-rewards/csv",
+        V2.CsvExportController,
+        :celo_election_rewards_csv
+      )
+    end
+
+    get("/advanced-filters/csv", V2.AdvancedFilterController, :list_csv)
   end
 
   scope "/legacy" do

--- a/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
@@ -39,7 +39,7 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
     )
 
     plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
-    plug(:accepts, ["csv"])
+    plug(:accepts, ["json", "csv"])
     plug(CheckApiV2)
     plug(:fetch_session)
     plug(:protect_from_forgery)

--- a/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
@@ -29,6 +29,23 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
     plug(OpenApiSpex.Plug.PutApiSpec, module: BlockScoutWeb.Specs.Public)
   end
 
+  pipeline :api_v2_csv do
+    plug(
+      Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      query_string_length: @max_query_string_length,
+      pass: ["*/*"],
+      json_decoder: JSON
+    )
+
+    plug(BlockScoutWeb.Plug.Logger, application: :api_v2)
+    plug(:accepts, ["csv"])
+    plug(CheckApiV2)
+    plug(:fetch_session)
+    plug(:protect_from_forgery)
+    plug(OpenApiSpex.Plug.PutApiSpec, module: BlockScoutWeb.Specs.Public)
+  end
+
   pipeline :api_v2_no_forgery_protect do
     plug(
       Plug.Parsers,
@@ -70,8 +87,6 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
     get("/:address_hash_param/counters", V2.TokenController, :counters)
     get("/:address_hash_param/transfers", V2.TokenController, :transfers)
     get("/:address_hash_param/holders", V2.TokenController, :holders)
-    get("/:address_hash_param/holders/csv", V2.CsvExportController, :export_token_holders)
-    get("/:address_hash_param/transfers/csv", V2.CsvExportController, :export_token_transfers)
     get("/:address_hash_param/instances", V2.TokenController, :instances)
     get("/:address_hash_param/instances/:token_id_param", V2.TokenController, :instance)
     get("/:address_hash_param/instances/:token_id_param/media-type", V2.TokenController, :media_type)
@@ -83,5 +98,12 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
       V2.TokenController,
       :transfers_count_by_instance
     )
+  end
+
+  scope "/", as: :api_v2 do
+    pipe_through(:api_v2_csv)
+
+    get("/:address_hash_param/holders/csv", V2.CsvExportController, :export_token_holders)
+    get("/:address_hash_param/transfers/csv", V2.CsvExportController, :export_token_transfers)
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
@@ -53,6 +53,25 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
       assert conn.status == 429
     end
 
+    test "accepts application/csv on token-transfers CSV endpoint", %{conn: conn} do
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(from_address: address)
+        |> with_block()
+
+      insert(:token_transfer, transaction: transaction, from_address: address, block_number: transaction.block_number)
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/csv")
+        |> get("/api/v2/addresses/#{Address.checksum(address.hash)}/token-transfers/csv", %{})
+
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-type") =~ "application/csv"
+    end
+
     test "do not export token transfers to csv after rate limit is reached without recaptcha passed", %{
       conn: conn,
       v2_secret_key: recaptcha_secret_key

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/csv_export_controller_test.exs
@@ -69,7 +69,10 @@ defmodule BlockScoutWeb.Api.V2.CsvExportControllerTest do
         |> get("/api/v2/addresses/#{Address.checksum(address.hash)}/token-transfers/csv", %{})
 
       assert conn.status == 200
-      assert get_resp_header(conn, "content-type") =~ "application/csv"
+
+      assert Enum.any?(get_resp_header(conn, "content-type"), fn type ->
+               String.contains?(type, "application/csv")
+             end)
     end
 
     test "do not export token transfers to csv after rate limit is reached without recaptcha passed", %{

--- a/apps/explorer/lib/explorer/chain/csv_export/helper.ex
+++ b/apps/explorer/lib/explorer/chain/csv_export/helper.ex
@@ -54,7 +54,7 @@ defmodule Explorer.Chain.CsvExport.Helper do
     {1000, 2000}
 
   """
-  @spec block_from_period(String.t(), String.t()) :: {Block.block_number(), Block.block_number()}
+  @spec block_from_period(String.t() | nil, String.t() | nil) :: {Block.block_number(), Block.block_number()}
   def block_from_period(from_period, to_period) do
     from_block = convert_date_string_to_block(from_period, :after, :from)
     to_block = convert_date_string_to_block(to_period, :before, :to)
@@ -62,7 +62,10 @@ defmodule Explorer.Chain.CsvExport.Helper do
     {from_block, to_block}
   end
 
-  @spec convert_date_string_to_block(String.t(), :before | :after, :from | :to) :: integer()
+  @spec convert_date_string_to_block(String.t() | nil, :before | :after, :from | :to) :: integer()
+  defp convert_date_string_to_block(nil, _direction, _range_type), do: 0
+  defp convert_date_string_to_block("", _direction, _range_type), do: 0
+
   defp convert_date_string_to_block(date_string, direction, range_type) do
     with {:ok, timestamp, _utc_offset} <- date_string_to_timestamp(date_string, range_type),
          {:ok, block} <- BlockGeneralReader.timestamp_to_block_number(timestamp, direction, true) do
@@ -72,8 +75,10 @@ defmodule Explorer.Chain.CsvExport.Helper do
     end
   end
 
-  @spec date_string_to_timestamp(String.t(), :from | :to) ::
+  @spec date_string_to_timestamp(String.t() | nil, :from | :to) ::
           {:ok, DateTime.t(), Calendar.utc_offset()} | {:error, atom()}
+  defp date_string_to_timestamp(nil, _range_type), do: {:error, :invalid_date}
+
   defp date_string_to_timestamp(date_string, range_type) do
     date_string
     |> Date.from_iso8601()

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,6 +24,15 @@ for config <- "../apps/*/config/config.exs" |> Path.expand(__DIR__) |> Path.wild
   import_config config
 end
 
+config :mime, :types, %{
+  "application/csv" => ["csv"],
+  "text/csv" => ["csv"]
+}
+
+config :mime, :extensions, %{
+  "csv" => "application/csv"
+}
+
 config :phoenix, :json_library, Utils.JSON
 config :postgrex, :json_library, Utils.JSON
 


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14416

## Motivation

Resolve `Phoenix.NotAcceptableError` for `/api/v2/advanced-filters/csv` and address CSV export routes when `Accept: application/csv` is sent. The fix restores CSV support by registering CSV MIME mappings and allowing CSV in the root API rate-limit pipeline while keeping CSV exports isolated behind a dedicated `:api_v2_csv` pipeline.

## Changelog

### Bug Fixes

- Added MIME registration for `application/csv` and `text/csv`
- Added `mime` extension preference mapping for `.csv`
- Updated top-level `/api` rate limit pipeline to accept `["json", "csv"]`
- Added dedicated `:api_v2_csv` pipeline for CSV export routes
- Moved CSV export routes into the CSV-only V2 scope

## Upgrading

After merge, ensure the MIME dependency is recompiled so the new CSV MIME config is loaded:
- `mix deps.clean mime --build`

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV export now supports optional date range filtering for address-based exports (transactions, token transfers, internal transactions, logs).
  * Added CSV export endpoints for token holder and transfer data.
  * Added CSV export endpoint for advanced filters.
  * Improved API content-type negotiation to properly handle CSV requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->