### PR TITLE
feat: apply scam token filter to GraphQL token transfer queries

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/graphql/resolvers/token_transfer.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/resolvers/token_transfer.ex
@@ -10,25 +10,30 @@ defmodule BlockScoutWeb.GraphQL.Resolvers.TokenTransfer do
     GraphQL.get_token_transfer(args)
   end
 
-  def get_by(_, %{token_contract_address_hash: token_contract_address_hash} = args, _) do
+  def get_by(_, %{token_contract_address_hash: token_contract_address_hash} = args, resolution) do
     connection_args = Map.take(args, [:after, :before, :first, :last])
 
     replica = Repo.replica()
+    scam_opts = scam_token_opts(resolution)
 
     token_contract_address_hash
-    |> GraphQL.list_token_transfers_query()
+    |> GraphQL.list_token_transfers_query(scam_opts)
     |> Connection.from_query(&replica.all/1, connection_args, options(args))
   end
 
-  def get_by(%Address{hash: address_hash}, args, _) do
+  def get_by(%Address{hash: address_hash}, args, resolution) do
     connection_args = Map.take(args, [:after, :before, :first, :last])
 
     replica = Repo.replica()
+    scam_opts = scam_token_opts(resolution)
 
     address_hash
-    |> TokenTransfer.token_transfers_by_address_hash(nil, nil, [], nil, [])
+    |> TokenTransfer.token_transfers_by_address_hash(nil, nil, [], nil, scam_opts)
     |> Connection.from_query(&replica.all/1, connection_args, options(args))
   end
+
+  defp scam_token_opts(%{context: context}),
+    do: [show_scam_tokens?: Map.get(context, :show_scam_tokens?, false)]
 
   defp options(%{before: _}), do: []
 

--- a/apps/block_scout_web/lib/block_scout_web/graphql/schema.ex
+++ b/apps/block_scout_web/lib/block_scout_web/graphql/schema.ex
@@ -9,6 +9,7 @@ defmodule BlockScoutWeb.GraphQL.Schema do
   alias Absinthe.Middleware.Dataloader, as: AbsintheDataloaderMiddleware
   alias Absinthe.Plugin, as: AbsinthePlugin
 
+  alias BlockScoutWeb.Chain, as: BlockScoutWebChain
   alias BlockScoutWeb.GraphQL.Middleware.ApiEnabled, as: ApiEnabledMiddleware
 
   alias BlockScoutWeb.GraphQL.Resolvers.{
@@ -131,9 +132,21 @@ defmodule BlockScoutWeb.GraphQL.Schema do
     if Application.get_env(:block_scout_web, Api.GraphQL)[:enabled] do
       loader = Dataloader.add_source(Dataloader.new(), :db, Chain.data())
 
+      show_scam_tokens? =
+        case Map.fetch(context, :conn) do
+          {:ok, conn} ->
+            []
+            |> BlockScoutWebChain.fetch_scam_token_toggle(conn)
+            |> Keyword.get(:show_scam_tokens?, false)
+
+          :error ->
+            false
+        end
+
       context
       |> Map.put(:loader, loader)
       |> Map.put(:api_enabled, true)
+      |> Map.put(:show_scam_tokens?, show_scam_tokens?)
     else
       context
       |> Map.put(:api_enabled, false)

--- a/apps/explorer/lib/explorer/graphql.ex
+++ b/apps/explorer/lib/explorer/graphql.ex
@@ -12,7 +12,7 @@ defmodule Explorer.GraphQL do
       where: 3
     ]
 
-  alias Explorer.{Chain, Repo}
+  alias Explorer.{Chain, Helper, Repo}
 
   alias Explorer.Chain.{
     Hash,
@@ -118,13 +118,17 @@ defmodule Explorer.GraphQL do
 
   Orders token transfers by descending block number.
   """
-  @spec list_token_transfers_query(Hash.t()) :: Ecto.Query.t()
-  def list_token_transfers_query(%Hash{byte_count: unquote(Hash.Address.byte_count())} = token_contract_address_hash) do
+  @spec list_token_transfers_query(Hash.t(), Keyword.t()) :: Ecto.Query.t()
+  def list_token_transfers_query(
+        %Hash{byte_count: unquote(Hash.Address.byte_count())} = token_contract_address_hash,
+        options \\ []
+      ) do
     from(
       tt in TokenTransfer,
       inner_join: t in assoc(tt, :transaction),
       where: tt.token_contract_address_hash == ^token_contract_address_hash,
       order_by: [desc: tt.block_number, desc: tt.log_index]
     )
+    |> Helper.maybe_hide_scam_addresses_for_token_transfers(options)
   end
 end

--- a/apps/explorer/test/explorer/graphql_test.exs
+++ b/apps/explorer/test/explorer/graphql_test.exs
@@ -255,7 +255,7 @@ defmodule Explorer.GraphQLTest do
     end
   end
 
-  describe "list_token_transfers_query/1" do
+  describe "list_token_transfers_query/1,2" do
     test "with token contract address hash with zero token transfers" do
       result =
         :address
@@ -345,6 +345,65 @@ defmodule Explorer.GraphQLTest do
       block_number_order = Enum.map(found_token_transfers, & &1.block_number)
 
       assert block_number_order == Enum.sort(block_number_order, &(&1 >= &2))
+    end
+
+    test "hides scam token transfers when hide_scam_addresses is enabled and show_scam_tokens? is false" do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      token_address = insert(:contract_address)
+      insert(:token, contract_address: token_address)
+      insert(:scam_badge_to_address, address_hash: token_address.hash)
+      transaction = insert(:transaction)
+      insert(:token_transfer, transaction: transaction, token_contract_address: token_address)
+
+      result =
+        token_address.hash
+        |> GraphQL.list_token_transfers_query(show_scam_tokens?: false)
+        |> Repo.replica().all()
+
+      assert result == []
+    end
+
+    test "shows scam token transfers when show_scam_tokens? is true" do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, true)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      token_address = insert(:contract_address)
+      insert(:token, contract_address: token_address)
+      insert(:scam_badge_to_address, address_hash: token_address.hash)
+      transaction = insert(:transaction)
+      token_transfer = insert(:token_transfer, transaction: transaction, token_contract_address: token_address)
+
+      [found_token_transfer] =
+        token_address.hash
+        |> GraphQL.list_token_transfers_query(show_scam_tokens?: true)
+        |> Repo.replica().all()
+
+      assert found_token_transfer.transaction_hash == token_transfer.transaction_hash
+      assert found_token_transfer.log_index == token_transfer.log_index
+    end
+
+    test "shows scam token transfers when hide_scam_addresses is disabled regardless of show_scam_tokens?" do
+      init_value = Application.get_env(:block_scout_web, :hide_scam_addresses)
+      Application.put_env(:block_scout_web, :hide_scam_addresses, false)
+      on_exit(fn -> Application.put_env(:block_scout_web, :hide_scam_addresses, init_value) end)
+
+      token_address = insert(:contract_address)
+      insert(:token, contract_address: token_address)
+      insert(:scam_badge_to_address, address_hash: token_address.hash)
+      transaction = insert(:transaction)
+      token_transfer = insert(:token_transfer, transaction: transaction, token_contract_address: token_address)
+
+      [found_token_transfer] =
+        token_address.hash
+        |> GraphQL.list_token_transfers_query(show_scam_tokens?: false)
+        |> Repo.replica().all()
+
+      assert found_token_transfer.transaction_hash == token_transfer.transaction_hash
+      assert found_token_transfer.log_index == token_transfer.log_index
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/12140

## Motivation

The scam token filter (`show-scam-tokens` header / `show_scam_tokens` cookie) was
already supported across REST API v2 endpoints but was not wired into the GraphQL
API. GraphQL queries for token transfers could return transfers from scam tokens
even when `hide_scam_addresses` was enabled.

## Changelog

### Enhancements

- Extended `Explorer.GraphQL.list_token_transfers_query/1` to accept an optional
  `options` keyword list (now `list_token_transfers_query/2`) and pipes the result
  through `Explorer.Helper.maybe_hide_scam_addresses_for_token_transfers/2`, so
  token-contract-scoped transfer queries respect the scam filter.
- `BlockScoutWeb.GraphQL.Schema.context/1` now reads the `show-scam-tokens` request
  header (or `show_scam_tokens` cookie) from the Plug conn that Absinthe.Plug places
  in the context, and stores the resolved boolean as `show_scam_tokens?` for use by
  resolvers.
- `BlockScoutWeb.GraphQL.Resolvers.TokenTransfer` threads `show_scam_tokens?` from
  the Absinthe resolution context into both `GraphQL.list_token_transfers_query/2`
  (token contract address transfers) and
  `TokenTransfer.token_transfers_by_address_hash/6` (address transfers), matching
  the filter behaviour of the REST API.
- Added three tests to `Explorer.GraphQLTest` covering: hiding scam transfers when
  `hide_scam_addresses` is enabled, showing them when `show_scam_tokens?: true`, and
  bypassing the filter when `hide_scam_addresses` is disabled.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scam token filtering to token transfer GraphQL queries. Users can now control visibility of token transfers involving scam addresses through a configurable toggle.

* **Tests**
  * Added comprehensive test coverage for scam token filtering behavior in token transfer queries under various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->