### PR TITLE
fix: replace String.replace bytecode matching with prefix-based extraction

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -381,7 +381,10 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
     } = extract_bytecode_and_metadata_hash(bc_creation_transaction_input, bc_deployed_bytecode)
 
     bc_replaced_local =
-      String.replace(bc_creation_transaction_input_without_meta, local_bytecode_without_meta, "", global: false)
+      case bc_creation_transaction_input_without_meta do
+        <<^local_bytecode_without_meta::binary, rest::binary>> -> rest
+        _ -> nil
+      end
 
     has_constructor_with_params? = has_constructor_with_params?(abi)
 


### PR DESCRIPTION
Closes #14477

## Bug: String-Based Bytecode Matching Enables False Positive Verification

**Location:** `apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex`, lines 390-391

`String.replace(bc_creation_transaction_input_without_meta, local_bytecode_without_meta, "", global: false)` operates on raw hex strings, not bytecode boundaries. If ABI-encoded constructor arguments contain a hex substring matching the locally-compiled bytecode, `String.replace` removes from the wrong location, potentially producing a false positive verification.

**Fix:** Replaced `String.replace` with Elixir binary prefix matching using `<<^local_bytecode_without_meta::binary, rest::binary>>` to ensure the bytecode is only removed from its correct position as a prefix of the creation transaction input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart contract bytecode verification logic to more accurately determine verification success using enhanced pattern matching for bytecode comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->