### PR TITLE
fix: Don't start health monitor in tests

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -215,6 +215,8 @@ config :explorer, Explorer.Utility.RateLimiter, enabled: true
 config :explorer, Explorer.Utility.Hammer.Redis, enabled: true
 config :explorer, Explorer.Utility.Hammer.ETS, enabled: true
 
+config :explorer, Explorer.Chain.Health.Monitor, enabled: true
+
 config :explorer, Explorer.Repo,
   migration_timestamps: [type: :utc_datetime_usec],
   disconnect_on_error_codes: [:query_canceled]

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -48,6 +48,8 @@ config :explorer, Explorer.Utility.RateLimiter, enabled: false
 config :explorer, Explorer.Utility.Hammer.Redis, enabled: false
 config :explorer, Explorer.Utility.Hammer.ETS, enabled: true
 
+config :explorer, Explorer.Chain.Health.Monitor, enabled: false
+
 for migrator <- [
       # Background migrations
       Explorer.Migrator.TransactionsDenormalization,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -76,7 +76,6 @@ defmodule Explorer.Application do
         id: LookUpSmartContractSourcesTaskSupervisor
       ),
       Supervisor.child_spec({Task.Supervisor, name: Explorer.WETHMigratorSupervisor}, id: WETHMigratorSupervisor),
-      Explorer.Chain.Health.Monitor,
       {Registry, keys: :duplicate, name: Registry.ChainEvents, id: Registry.ChainEvents},
       Accounts,
       AddressesCoinBalanceSum,
@@ -125,6 +124,7 @@ defmodule Explorer.Application do
   defp configurable_children do
     configurable_children_set =
       [
+        configure(Explorer.Chain.Health.Monitor),
         only_in_mode(Explorer.SmartContract.SolcDownloader, :api),
         only_in_mode(Explorer.SmartContract.VyperDownloader, :api),
         only_in_mode({Admin.Recovery, [[], [name: Admin.Recovery]]}, :api),


### PR DESCRIPTION
## Motivation

Unnecessary start of `Explorer.Chain.Health.Monitor` may lead to mock errors and process terminations which may cause an application crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made Health.Monitor startup configurable, allowing it to be enabled or disabled based on application settings rather than always being active.
  * Explicitly disabled Health.Monitor in test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->