### PR TITLE
fix: Don't call InternalTransaction.async_fetch from ContractCreator

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -635,7 +635,7 @@ defmodule Indexer.Block.Fetcher do
   def async_import_internal_transactions(%{blocks: blocks} = imported, realtime?) do
     blocks
     |> Enum.map(fn %Block{number: block_number} -> block_number end)
-    |> InternalTransaction.async_fetch(Map.get(imported, :transactions, []), realtime?, false, 10_000)
+    |> InternalTransaction.async_fetch(Map.get(imported, :transactions, []), realtime?, 10_000)
   end
 
   def async_import_internal_transactions(_, _), do: :ok

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -50,10 +50,10 @@ defmodule Indexer.Fetcher.InternalTransaction do
   *Note*: The internal transactions for individual transactions cannot be paginated,
   so the total number of internal transactions that could be produced is unknown.
   """
-  @spec async_fetch([Block.block_number()], [Transaction.t()], boolean(), boolean(), integer()) :: :ok
-  def async_fetch(block_numbers, transactions, realtime?, for_contract_creator? \\ false, timeout \\ 5000)
+  @spec async_fetch([Block.block_number()], [Transaction.t()], boolean(), integer()) :: :ok
+  def async_fetch(block_numbers, transactions, realtime?, timeout \\ 5000)
       when is_list(block_numbers) do
-    if disabled?() && !for_contract_creator? do
+    if disabled?() do
       :ok
     else
       data =

--- a/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/contract_creator.ex
@@ -211,10 +211,7 @@ defmodule Indexer.Fetcher.OnDemand.ContractCreator do
       if Block.indexed?(contract_creation_block_number) do
         # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
         if RangesHelper.traceable_block_number?(contract_creation_block_number) do
-          {block_numbers, transactions} =
-            PendingOperationsHelper.insert_pending_operations([contract_creation_block_number], priority)
-
-          InternalTransaction.async_fetch(block_numbers, transactions, false, true, 10_000)
+          PendingOperationsHelper.insert_pending_operations([contract_creation_block_number], priority)
         end
       else
         MissingBlockRange.add_ranges_by_block_numbers([contract_creation_block_number], priority)

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -116,7 +116,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
       updated_tokens =
         Map.put_new(
           acc[:tokens],
-          ctb.token.contract_address_hash.bytes,
+          ctb.token_contract_address_hash.bytes,
           ctb.token
         )
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14324

## Motivation

Internal transaction fetcher is not started when indexer is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token contract address association in balance indexing operations

* **Refactor**
  * Simplified internal transaction fetching function parameters and logic
  * Optimized pending operation handling for contract detection workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->