### PR TITLE
fix: add required max_body_size option to Tesla.Middleware.Compression

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -71,6 +71,13 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
     )
   end
 
-  defp compression_middleware(true), do: [{Tesla.Middleware.Compression, format: "gzip", max_body_size: :infinity}]
+  defp compression_middleware(true) do
+    max_body_size =
+      Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.HTTP, [])
+      |> Keyword.get(:response_decompression_max_body_size, 100 * 1024 * 1024)
+
+    [{Tesla.Middleware.Compression, format: "gzip", max_body_size: max_body_size}]
+  end
+
   defp compression_middleware(false), do: []
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -71,6 +71,6 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
     )
   end
 
-  defp compression_middleware(true), do: [{Tesla.Middleware.Compression, format: "gzip"}]
+  defp compression_middleware(true), do: [{Tesla.Middleware.Compression, format: "gzip", max_body_size: :infinity}]
   defp compression_middleware(false), do: []
 end


### PR DESCRIPTION
## Motivation

After merging `master` into `dev`, two tests in `EthereumJSONRPC.HTTP.TeslaTest` started failing because a newer version of the `tesla` dependency made `:max_body_size` a required option on `Tesla.Middleware.Compression`. The middleware now raises `ArgumentError` at runtime if the option is omitted, as a deliberate guardrail against zip-bomb attacks.

## Changelog

### Bug Fixes

- Fixed `ArgumentError` raised by `Tesla.Middleware.Compression` due to missing required `:max_body_size` option. Set to `:infinity` to preserve pre-existing behavior (no decompression cap enforced).

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP compression handling by adding configurable maximum decompressed body size when compression is enabled. The limit is now read from the HTTP settings (`:response_decompression_max_body_size`), defaulting to **100 MB**, and applied alongside gzip compression to better support larger payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->