### PR TITLE
fix: disallow extra properties in Optimism Alt-DA block schema

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block.ex
@@ -124,7 +124,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.ChainTypeCustomizations do
       l1_transaction_hash: General.FullHashNullable,
       l1_timestamp: General.TimestampNullable
     },
-    required: [:commitment, :l1_transaction_hash, :l1_timestamp]
+    required: [:commitment, :l1_transaction_hash, :l1_timestamp],
+    additionalProperties: false
   }
 
   @doc """


### PR DESCRIPTION
## Motivation

The Optimism block schema models blob payload variants with strict object schemas. `blob4844` and `celestia` already set `additionalProperties: false`, but the Alt-DA variant allowed undocumented fields.

This aligns the Alt-DA schema with the surrounding OpenAPI schema convention and keeps response validation strict.

## Changelog

### Bug Fixes

- Added `additionalProperties: false` to the Optimism Alt-DA blob schema.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API schema validation to enforce stricter property requirements, ensuring improved consistency and compliance with defined specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->