### PR TITLE
perf: skip expensive cleanup queries in lose_consensus when no blocks…

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/blocks.ex
@@ -606,78 +606,86 @@ defmodule Explorer.Chain.Import.Runner.Blocks do
       GenServer.cast(Indexer.Fetcher.Beacon.Deposit, {:lost_consensus, minimum_recent_block_number})
     end
 
-    repo.update_all(
-      from(
-        transaction in Transaction,
-        join: s in subquery(acquire_query),
-        on: transaction.block_hash == s.hash,
-        # we don't want to remove consensus from blocks that will be upserted
-        where: transaction.block_hash not in ^consensus_hashes
-      ),
-      [set: [block_consensus: false, updated_at: updated_at]],
-      timeout: timeout
-    )
+    if Enum.empty?(removed_consensus_blocks) do
+      removed_consensus_block_numbers
+      |> Enum.reject(&Enum.member?(consensus_block_numbers, &1))
+      |> MissingBlockRange.add_ranges_by_block_numbers()
 
-    repo.update_all(
-      from(
-        token_transfer in TokenTransfer,
-        join: s in subquery(acquire_query),
-        on: token_transfer.block_number == s.number and token_transfer.block_hash == s.hash,
-        # we don't want to remove consensus from blocks that will be upserted
-        where: token_transfer.block_hash not in ^consensus_hashes
-      ),
-      [set: [block_consensus: false, updated_at: updated_at]],
-      timeout: timeout
-    )
-
-    # Query to find addresses created in lost consensus blocks
-    created_contract_addresses_query =
-      from(
-        t in Transaction,
-        join: s in subquery(acquire_query),
-        on: t.block_hash == s.hash,
-        # we don't want to remove contract code from blocks that will be upserted
-        where: t.block_hash not in ^consensus_hashes,
-        where: not is_nil(t.created_contract_address_hash),
-        select: t.created_contract_address_hash
+      {:ok, removed_consensus_blocks}
+    else
+      repo.update_all(
+        from(
+          transaction in Transaction,
+          join: s in subquery(acquire_query),
+          on: transaction.block_hash == s.hash,
+          # we don't want to remove consensus from blocks that will be upserted
+          where: transaction.block_hash not in ^consensus_hashes
+        ),
+        [set: [block_consensus: false, updated_at: updated_at]],
+        timeout: timeout
       )
 
-    # Delete smart contracts for addresses created in lost consensus blocks
-    repo.delete_all(
-      from(
-        sc in SmartContract,
-        where: sc.address_hash in subquery(created_contract_addresses_query)
-      ),
-      timeout: timeout
-    )
+      repo.update_all(
+        from(
+          token_transfer in TokenTransfer,
+          join: s in subquery(acquire_query),
+          on: token_transfer.block_number == s.number and token_transfer.block_hash == s.hash,
+          # we don't want to remove consensus from blocks that will be upserted
+          where: token_transfer.block_hash not in ^consensus_hashes
+        ),
+        [set: [block_consensus: false, updated_at: updated_at]],
+        timeout: timeout
+      )
 
-    # Clear contract code from addresses created in lost consensus blocks
-    repo.update_all(
-      from(
-        address in Address,
-        where: address.hash in subquery(created_contract_addresses_query)
-      ),
-      [set: [contract_code: nil, updated_at: updated_at]],
-      timeout: timeout
-    )
+      # Query to find addresses created in lost consensus blocks
+      created_contract_addresses_query =
+        from(
+          t in Transaction,
+          join: s in subquery(acquire_query),
+          on: t.block_hash == s.hash,
+          # we don't want to remove contract code from blocks that will be upserted
+          where: t.block_hash not in ^consensus_hashes,
+          where: not is_nil(t.created_contract_address_hash),
+          select: t.created_contract_address_hash
+        )
 
-    if Application.get_env(:explorer, :chain_type) == :zilliqa do
+      # Delete smart contracts for addresses created in lost consensus blocks
       repo.delete_all(
         from(
-          zrc2_token_transfer in Zrc2TokenTransfer,
-          join: s in subquery(acquire_query),
-          on: zrc2_token_transfer.block_number == s.number and zrc2_token_transfer.block_hash == s.hash,
-          where: zrc2_token_transfer.block_hash not in ^consensus_hashes
+          sc in SmartContract,
+          where: sc.address_hash in subquery(created_contract_addresses_query)
         ),
         timeout: timeout
       )
+
+      # Clear contract code from addresses created in lost consensus blocks
+      repo.update_all(
+        from(
+          address in Address,
+          where: address.hash in subquery(created_contract_addresses_query)
+        ),
+        [set: [contract_code: nil, updated_at: updated_at]],
+        timeout: timeout
+      )
+
+      if Application.get_env(:explorer, :chain_type) == :zilliqa do
+        repo.delete_all(
+          from(
+            zrc2_token_transfer in Zrc2TokenTransfer,
+            join: s in subquery(acquire_query),
+            on: zrc2_token_transfer.block_number == s.number and zrc2_token_transfer.block_hash == s.hash,
+            where: zrc2_token_transfer.block_hash not in ^consensus_hashes
+          ),
+          timeout: timeout
+        )
+      end
+
+      removed_consensus_block_numbers
+      |> Enum.reject(&Enum.member?(consensus_block_numbers, &1))
+      |> MissingBlockRange.add_ranges_by_block_numbers()
+
+      {:ok, removed_consensus_blocks}
     end
-
-    removed_consensus_block_numbers
-    |> Enum.reject(&Enum.member?(consensus_block_numbers, &1))
-    |> MissingBlockRange.add_ranges_by_block_numbers()
-
-    {:ok, removed_consensus_blocks}
   rescue
     postgrex_error in Postgrex.Error ->
       {:error, %{exception: postgrex_error}}

--- a/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/blocks_test.exs
@@ -899,6 +899,26 @@ defmodule Explorer.Chain.Import.Runner.BlocksTest do
       refute_received {:"$gen_cast", {:lost_consensus, _}}
     end
 
+    test "returns empty list and skips cleanup when no blocks lose consensus" do
+      existing_block = insert(:block, consensus: true, number: 5)
+
+      new_block =
+        params_for(:block,
+          miner_hash: insert(:address).hash,
+          parent_hash: existing_block.hash,
+          number: 6
+        )
+
+      %Ecto.Changeset{valid?: true, changes: new_block_changes} = Block.changeset(%Block{}, new_block)
+
+      opts = %{
+        timeout: 60_000,
+        timestamps: %{updated_at: DateTime.utc_now()}
+      }
+
+      assert {:ok, []} = Blocks.process_blocks_consensus([new_block_changes], Repo, opts)
+    end
+
     test "triggers beacon deposit reorg handling on fresh blocks" do
       Application.put_env(:explorer, Explorer.Chain.Cache.BlockNumber, enabled: true)
 


### PR DESCRIPTION
## Motivation

`lose_consensus/3` in `Explorer.Chain.Import.Runner.Blocks` runs five sequential SQL operations inside a single DB transaction on every block import. Four of those operations join the `transactions` table:

1. `UPDATE blocks SET consensus=false` — fast, touches blocks table only
2. `UPDATE transactions SET block_consensus=false` ← joins transactions
3. `UPDATE token_transfers SET block_consensus=false` ← joins transactions
4. `DELETE FROM smart_contracts` ← joins transactions twice (via subquery)
5. `UPDATE addresses SET contract_code=nil` ← joins transactions

In steady state (no chain reorg), operations 2–5 always produce **0 rows**. The lock subquery (`acquire_query`) matches only the blocks being imported right now, and those are then excluded by `WHERE block_hash NOT IN consensus_hashes`. PostgreSQL still executes the full join to discover there is nothing to do.

On chains with large transaction tables this may causes connection pool exhaustion: every concurrent block import holds an open DB connection for the full duration of all five operations while performing an expensive scan of the transactions table. Step 1 already tells us whether any blocks actually lost consensus via its return value (`removed_consensus_blocks`). When that list is empty there is no cleanup work to do and the subsequent queries can be skipped entirely.

Observed in production on a high-TPS EVM network: with a transactions table holding more than 10 billion rows, this pattern caused 194 of 200 pool connections to be consumed simultaneously by this query — all in `active` state with `wait_event = LWLock / BufferMapping` — with individual executions running for up to 3 minutes. The fix reduced active connections to ~40 in steady state and eliminated the query from `pg_stat_activity` entirely.

## Changelog

### Enhancements

- `lose_consensus/3` now returns early after step 1 (`UPDATE blocks`) when `removed_consensus_blocks` is empty. The `FOR NO KEY UPDATE` lock is still acquired in step 1, preserving the sharelock ordering invariant documented in `sharelocks.md`. When a chain reorg is detected (`removed_consensus_blocks` non-empty), the full cleanup sequence runs unchanged.
- Added a test covering the no-reorg early-exit path in `Explorer.Chain.Import.Runner.BlocksTest`.

### Bug Fixes

_None._

### Incompatible Changes

_None._

## Upgrading

No action required. No database migrations, API changes, or configuration changes.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] I added a test covering the new early-exit path (`blocks_test.exs`).
- [x] No regression test needed — this is a performance optimisation with no behavioural change in the reorg path.
- [x] Documentation updated if needed. N/A — no new env vars, no API changes.
- [x] API endpoints modified. N/A
- [x] New DB indices added. N/A
- [x] Chain type added/removed. N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block consensus loss handling with conditional cleanup logic to prevent unnecessary database operations when no consensus changes occur.

* **Tests**
  * Added test coverage for block consensus verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->