### PR TITLE
chore: Improve filling migration scheduling

### DIFF
--- a/apps/explorer/lib/explorer/migrator/address_current_token_balance_token_type.ex
+++ b/apps/explorer/lib/explorer/migrator/address_current_token_balance_token_type.ex
@@ -45,7 +45,9 @@ defmodule Explorer.Migrator.AddressCurrentTokenBalanceTokenType do
         update: [set: [token_type: token.type]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/address_token_balance_token_type.ex
+++ b/apps/explorer/lib/explorer/migrator/address_token_balance_token_type.ex
@@ -45,7 +45,9 @@ defmodule Explorer.Migrator.AddressTokenBalanceTokenType do
         update: [set: [token_type: token.type]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/arbitrum_da_records_normalization.ex
+++ b/apps/explorer/lib/explorer/migrator/arbitrum_da_records_normalization.ex
@@ -56,7 +56,9 @@ defmodule Explorer.Migrator.ArbitrumDaRecordsNormalization do
         }
       end)
 
-    Repo.insert_all(BatchToDaBlob, records, timeout: :infinity)
+    {count, _} = Repo.insert_all(BatchToDaBlob, records, timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
@@ -64,14 +64,13 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
       |> Enum.map(&process_result/1)
       |> Enum.map(&Map.merge(&1, %{updated_at: now, inserted_at: now}))
 
-    {_, result} =
+    {count, _} =
       Repo.insert_all(Instance, prepared_params,
         on_conflict: token_instance_on_conflict(),
-        conflict_target: [:token_id, :token_contract_address_hash],
-        returning: true
+        conflict_target: [:token_id, :token_contract_address_hash]
       )
 
-    result
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db.ex
@@ -138,8 +138,8 @@ defmodule Explorer.Migrator.BackfillMultichainSearchDB do
 
             # credo:disable-for-next-line Credo.Check.Refactor.Nesting
             case MultichainSearch.batch_import(to_import) do
-              {:ok, _} = result ->
-                result
+              {:ok, _} ->
+                Enum.count(addresses) + Enum.count(blocks) + Enum.count(transactions)
 
               {:error, _} ->
                 Logger.error(fn ->

--- a/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db_current_token_balances.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_multichain_search_db_current_token_balances.ex
@@ -81,8 +81,8 @@ defmodule Explorer.Migrator.BackfillMultichainSearchDbCurrentTokenBalances do
     }
 
     case MultichainSearch.batch_import(to_import) do
-      {:ok, _} = result ->
-        result
+      {:ok, _} ->
+        Enum.count(balances)
 
       {:error, _} ->
         Logger.error(fn ->

--- a/apps/explorer/lib/explorer/migrator/celo_accounts.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_accounts.ex
@@ -62,6 +62,8 @@ defmodule Explorer.Migrator.CeloAccounts do
         params: unique_pending_operation_params
       }
     })
+
+    Enum.count(logs)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/celo_aggregated_election_rewards.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_aggregated_election_rewards.ex
@@ -88,6 +88,8 @@ defmodule Explorer.Migrator.CeloAggregatedElectionRewards do
         params: aggregates
       }
     })
+
+    Enum.count(aggregates)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/celo_l2_epochs.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_l2_epochs.ex
@@ -96,6 +96,8 @@ defmodule Explorer.Migrator.CeloL2Epochs do
         timestamps: Import.timestamps()
       }
     )
+
+    Enum.count(changes_list)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
+++ b/apps/explorer/lib/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts.ex
@@ -64,7 +64,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
   @impl FillingMigration
   def update_batch(block_numbers) do
     if Enum.empty?(block_numbers) do
-      {:ok, []}
+      0
     else
       # Find all selfdestruct internal transactions in these blocks
       selfdestruct_query =
@@ -81,7 +81,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
       selfdestruct_transactions = Repo.all(selfdestruct_query, timeout: :infinity)
 
       if Enum.empty?(selfdestruct_transactions) do
-        {:ok, []}
+        0
       else
         # Get unique transaction block numbers and indexes to check for create/create2
         transaction_identifiers =
@@ -119,7 +119,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
           |> Enum.uniq()
 
         if Enum.empty?(addresses_to_empty) do
-          {:ok, []}
+          0
         else
           # Only update addresses that still have non-empty contract_code
           update_query =
@@ -141,7 +141,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContracts do
             )
           end
 
-          {:ok, count}
+          count
         end
       end
     end

--- a/apps/explorer/lib/explorer/migrator/empty_internal_transactions_data.ex
+++ b/apps/explorer/lib/explorer/migrator/empty_internal_transactions_data.ex
@@ -55,85 +55,89 @@ defmodule Explorer.Migrator.EmptyInternalTransactionsData do
 
   @impl FillingMigration
   def update_batch(block_numbers) do
-    Repo.transaction(
-      fn ->
-        lock_query =
-          from(
-            it in InternalTransaction,
-            select: select_ctid(it),
-            select_merge: %{error: it.error},
-            where:
-              it.block_number in ^block_numbers and
-                (not is_nil(it.trace_address) or it.value == ^0 or
-                   (is_nil(it.call_type_enum) and not is_nil(it.call_type)) or
-                   not is_nil(it.error) or (not is_nil(it.created_contract_address_hash) and is_nil(it.to_address_hash))),
-            order_by: [asc: it.block_number, asc: it.transaction_index, asc: it.index],
-            lock: "FOR UPDATE"
-          )
+    {:ok, {count, _}} =
+      Repo.transaction(
+        fn ->
+          lock_query =
+            from(
+              it in InternalTransaction,
+              select: select_ctid(it),
+              select_merge: %{error: it.error},
+              where:
+                it.block_number in ^block_numbers and
+                  (not is_nil(it.trace_address) or it.value == ^0 or
+                     (is_nil(it.call_type_enum) and not is_nil(it.call_type)) or
+                     not is_nil(it.error) or
+                     (not is_nil(it.created_contract_address_hash) and is_nil(it.to_address_hash))),
+              order_by: [asc: it.block_number, asc: it.transaction_index, asc: it.index],
+              lock: "FOR UPDATE"
+            )
 
-        extract_error_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            where: not is_nil(it.error),
-            distinct: true,
-            select: it.error
-          )
+          extract_error_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              where: not is_nil(it.error),
+              distinct: true,
+              select: it.error
+            )
 
-        error_messages = Repo.all(extract_error_query, timeout: :infinity)
+          error_messages = Repo.all(extract_error_query, timeout: :infinity)
 
-        TransactionError.find_or_create_multiple(error_messages)
+          TransactionError.find_or_create_multiple(error_messages)
 
-        update_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            left_join: te in TransactionError,
-            on: te.message == locked_it.error,
-            update: [
-              set: [
-                error: nil,
-                error_id:
-                  fragment(
-                    "CASE WHEN ? IS NOT NULL THEN COALESCE(?, ?) ELSE ? END",
-                    it.error,
-                    te.id,
-                    it.error_id,
-                    it.error_id
-                  ),
-                call_type_enum:
-                  fragment(
-                    "CASE WHEN ? IS NULL AND ? IS NOT NULL THEN (?::internal_transactions_call_type) ELSE ? END",
-                    it.call_type_enum,
-                    it.call_type,
-                    it.call_type,
-                    it.call_type_enum
-                  ),
-                call_type:
-                  fragment(
-                    "CASE WHEN ? IS NULL AND ? IS NOT NULL THEN NULL ELSE ? END",
-                    it.call_type_enum,
-                    it.call_type,
-                    it.call_type
-                  ),
-                trace_address: nil,
-                value: fragment("CASE WHEN ? = 0 THEN NULL ELSE ? END", it.value, it.value),
-                to_address_hash:
-                  fragment(
-                    "CASE WHEN ? IS NOT NULL AND ? IS NULL THEN ? ELSE ? END",
-                    it.created_contract_address_hash,
-                    it.to_address_hash,
-                    it.created_contract_address_hash,
-                    it.to_address_hash
-                  )
+          update_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              left_join: te in TransactionError,
+              on: te.message == locked_it.error,
+              update: [
+                set: [
+                  error: nil,
+                  error_id:
+                    fragment(
+                      "CASE WHEN ? IS NOT NULL THEN COALESCE(?, ?) ELSE ? END",
+                      it.error,
+                      te.id,
+                      it.error_id,
+                      it.error_id
+                    ),
+                  call_type_enum:
+                    fragment(
+                      "CASE WHEN ? IS NULL AND ? IS NOT NULL THEN (?::internal_transactions_call_type) ELSE ? END",
+                      it.call_type_enum,
+                      it.call_type,
+                      it.call_type,
+                      it.call_type_enum
+                    ),
+                  call_type:
+                    fragment(
+                      "CASE WHEN ? IS NULL AND ? IS NOT NULL THEN NULL ELSE ? END",
+                      it.call_type_enum,
+                      it.call_type,
+                      it.call_type
+                    ),
+                  trace_address: nil,
+                  value: fragment("CASE WHEN ? = 0 THEN NULL ELSE ? END", it.value, it.value),
+                  to_address_hash:
+                    fragment(
+                      "CASE WHEN ? IS NOT NULL AND ? IS NULL THEN ? ELSE ? END",
+                      it.created_contract_address_hash,
+                      it.to_address_hash,
+                      it.created_contract_address_hash,
+                      it.to_address_hash
+                    )
+                ]
               ]
-            ]
-          )
+            )
 
-        Repo.update_all(update_query, [], timeout: :infinity)
-      end,
-      timeout: :infinity
-    )
+          Repo.update_all(update_query, [], timeout: :infinity)
+        end,
+        timeout: :infinity
+      )
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/filecoin_pending_address_operations.ex
+++ b/apps/explorer/lib/explorer/migrator/filecoin_pending_address_operations.ex
@@ -65,6 +65,8 @@ defmodule Explorer.Migrator.FilecoinPendingAddressOperations do
       timeout: :infinity,
       timestamps: Import.timestamps()
     )
+
+    Enum.count(ordered_address_hashes)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/fill_internal_transactions_address_ids.ex
+++ b/apps/explorer/lib/explorer/migrator/fill_internal_transactions_address_ids.ex
@@ -57,85 +57,88 @@ defmodule Explorer.Migrator.FillInternalTransactionsAddressIds do
 
   @impl FillingMigration
   def update_batch(block_numbers) do
-    Repo.transaction(
-      fn ->
-        lock_query =
-          from(
-            it in InternalTransaction,
-            select: select_ctid(it),
-            select_merge: %{
-              from_address_hash: it.from_address_hash,
-              to_address_hash: it.to_address_hash,
-              created_contract_address_hash: it.created_contract_address_hash
-            },
-            where:
-              it.block_number in ^block_numbers and
-                (not is_nil(it.from_address_hash) or not is_nil(it.to_address_hash) or
-                   not is_nil(it.created_contract_address_hash)),
-            order_by: [asc: it.block_number, asc: it.transaction_index, asc: it.index],
-            lock: "FOR UPDATE"
-          )
+    {:ok, {count, _}} =
+      Repo.transaction(
+        fn ->
+          lock_query =
+            from(
+              it in InternalTransaction,
+              select: select_ctid(it),
+              select_merge: %{
+                from_address_hash: it.from_address_hash,
+                to_address_hash: it.to_address_hash,
+                created_contract_address_hash: it.created_contract_address_hash
+              },
+              where:
+                it.block_number in ^block_numbers and
+                  (not is_nil(it.from_address_hash) or not is_nil(it.to_address_hash) or
+                     not is_nil(it.created_contract_address_hash)),
+              order_by: [asc: it.block_number, asc: it.transaction_index, asc: it.index],
+              lock: "FOR UPDATE"
+            )
 
-        from_address_hashes_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            where: not is_nil(it.from_address_hash),
-            distinct: true,
-            select: it.from_address_hash
-          )
+          from_address_hashes_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              where: not is_nil(it.from_address_hash),
+              distinct: true,
+              select: it.from_address_hash
+            )
 
-        to_address_hashes_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            where: not is_nil(it.to_address_hash),
-            distinct: true,
-            select: it.to_address_hash
-          )
+          to_address_hashes_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              where: not is_nil(it.to_address_hash),
+              distinct: true,
+              select: it.to_address_hash
+            )
 
-        created_contract_address_hashes_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            where: not is_nil(it.created_contract_address_hash),
-            distinct: true,
-            select: it.created_contract_address_hash
-          )
+          created_contract_address_hashes_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              where: not is_nil(it.created_contract_address_hash),
+              distinct: true,
+              select: it.created_contract_address_hash
+            )
 
-        from_address_hashes_query
-        |> union_all(^to_address_hashes_query)
-        |> union_all(^created_contract_address_hashes_query)
-        |> Repo.all()
-        |> Enum.uniq()
-        |> AddressIdToAddressHash.find_or_create_multiple()
+          from_address_hashes_query
+          |> union_all(^to_address_hashes_query)
+          |> union_all(^created_contract_address_hashes_query)
+          |> Repo.all()
+          |> Enum.uniq()
+          |> AddressIdToAddressHash.find_or_create_multiple()
 
-        update_query =
-          from(it in InternalTransaction,
-            inner_join: locked_it in subquery(lock_query),
-            on: join_on_ctid(it, locked_it),
-            left_join: from_map in AddressIdToAddressHash,
-            on: from_map.address_hash == locked_it.from_address_hash,
-            left_join: to_map in AddressIdToAddressHash,
-            on: to_map.address_hash == locked_it.to_address_hash,
-            left_join: created_map in AddressIdToAddressHash,
-            on: created_map.address_hash == locked_it.created_contract_address_hash,
-            update: [
-              set: [
-                from_address_id: from_map.address_id,
-                to_address_id: coalesce(to_map.address_id, created_map.address_id),
-                created_contract_address_id: created_map.address_id,
-                from_address_hash: nil,
-                to_address_hash: nil,
-                created_contract_address_hash: nil
+          update_query =
+            from(it in InternalTransaction,
+              inner_join: locked_it in subquery(lock_query),
+              on: join_on_ctid(it, locked_it),
+              left_join: from_map in AddressIdToAddressHash,
+              on: from_map.address_hash == locked_it.from_address_hash,
+              left_join: to_map in AddressIdToAddressHash,
+              on: to_map.address_hash == locked_it.to_address_hash,
+              left_join: created_map in AddressIdToAddressHash,
+              on: created_map.address_hash == locked_it.created_contract_address_hash,
+              update: [
+                set: [
+                  from_address_id: from_map.address_id,
+                  to_address_id: coalesce(to_map.address_id, created_map.address_id),
+                  created_contract_address_id: created_map.address_id,
+                  from_address_hash: nil,
+                  to_address_hash: nil,
+                  created_contract_address_hash: nil
+                ]
               ]
-            ]
-          )
+            )
 
-        Repo.update_all(update_query, [], timeout: :infinity)
-      end,
-      timeout: :infinity
-    )
+          Repo.update_all(update_query, [], timeout: :infinity)
+        end,
+        timeout: :infinity
+      )
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/filling_migration.ex
+++ b/apps/explorer/lib/explorer/migrator/filling_migration.ex
@@ -109,9 +109,9 @@ defmodule Explorer.Migrator.FillingMigration do
       usage during migration.
 
     ## Returns
-    N/A
+    Number of processed elements.
   """
-  @callback update_batch([any()]) :: any()
+  @callback update_batch([any()]) :: non_neg_integer()
 
   @doc """
     This callback updates the migration completion status in the cache.
@@ -279,10 +279,12 @@ defmodule Explorer.Migrator.FillingMigration do
             {:stop, :normal, new_state}
 
           {identifiers, new_state} ->
-            identifiers
-            |> Enum.chunk_every(batch_size())
-            |> Enum.map(&run_task/1)
-            |> Task.await_many(:infinity)
+            migrated_count =
+              identifiers
+              |> Enum.chunk_every(batch_size())
+              |> Enum.map(&run_task/1)
+              |> Task.await_many(:infinity)
+              |> Enum.sum()
 
             unquote do
               if !opts[:skip_meta_update?] do
@@ -292,7 +294,10 @@ defmodule Explorer.Migrator.FillingMigration do
               end
             end
 
-            schedule_batch_migration()
+            case migrated_count do
+              0 -> schedule_batch_migration(0)
+              _ -> schedule_batch_migration()
+            end
 
             {:noreply, new_state}
         end

--- a/apps/explorer/lib/explorer/migrator/merge_adjacent_missing_block_ranges.ex
+++ b/apps/explorer/lib/explorer/migrator/merge_adjacent_missing_block_ranges.ex
@@ -65,6 +65,8 @@ defmodule Explorer.Migrator.MergeAdjacentMissingBlockRanges do
       |> RangesHelper.sanitize_ranges()
       |> MissingBlockRange.save_batch(nil)
     end)
+
+    Enum.count(ranges_batch)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/refetch_contract_codes.ex
+++ b/apps/explorer/lib/explorer/migrator/refetch_contract_codes.ex
@@ -59,10 +59,14 @@ defmodule Explorer.Migrator.RefetchContractCodes do
           timestamps: Import.timestamps()
         })
 
+        Enum.count(addresses_params)
+
       {:error, reason} ->
         Logger.error(fn -> ["failed to fetch contract codes: ", inspect(reason)] end,
           error_count: Enum.count(address_hashes)
         )
+
+        0
     end
   end
 

--- a/apps/explorer/lib/explorer/migrator/reindex_blocks_with_missing_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_blocks_with_missing_transactions.ex
@@ -42,13 +42,17 @@ defmodule Explorer.Migrator.ReindexBlocksWithMissingTransactions do
 
   @impl FillingMigration
   def update_batch(block_numbers) do
-    Block
-    |> where([b], b.number in ^block_numbers)
-    |> where([b], b.consensus == true)
-    |> where([b], b.refetch_needed == false)
-    |> select([b], b.number)
-    |> Repo.all()
-    |> do_update()
+    blocks =
+      Block
+      |> where([b], b.number in ^block_numbers)
+      |> where([b], b.consensus == true)
+      |> where([b], b.refetch_needed == false)
+      |> select([b], b.number)
+      |> Repo.all()
+
+    do_update(blocks)
+
+    Enum.count(blocks)
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
+++ b/apps/explorer/lib/explorer/migrator/reindex_internal_transactions_with_incompatible_status.ex
@@ -87,7 +87,7 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
 
     pending_operations_type = PendingOperationsHelper.pending_operations_type()
 
-    {_total, inserted} =
+    {count, inserted} =
       case pending_operations_type do
         "blocks" ->
           params =
@@ -127,6 +127,8 @@ defmodule Explorer.Migrator.ReindexInternalTransactionsWithIncompatibleStatus do
 
       InternalTransactionFetcher.async_fetch(block_numbers, transactions, false)
     end
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_duplicate_smart_contract_additional_sources.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_duplicate_smart_contract_additional_sources.ex
@@ -51,9 +51,12 @@ defmodule Explorer.Migrator.SanitizeDuplicateSmartContractAdditionalSources do
 
   @impl FillingMigration
   def update_batch(ids) do
-    SmartContractAdditionalSource
-    |> where([sc], sc.id in ^ids)
-    |> Repo.delete_all(timeout: :infinity)
+    {count, _} =
+      SmartContractAdditionalSource
+      |> where([sc], sc.id in ^ids)
+      |> Repo.delete_all(timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
@@ -54,7 +54,7 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
 
   ## Returns
 
-    :ok
+    Number of updated logs
   """
   def update_batch(block_numbers) do
     logs_by_block =
@@ -170,7 +170,7 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
           )).()
     end)
 
-    :ok
+    Enum.count(logs_to_update)
   end
 
   defp process_block({block_hash, logs}) do

--- a/apps/explorer/lib/explorer/migrator/sanitize_empty_contract_code_addresses.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_empty_contract_code_addresses.ex
@@ -53,7 +53,9 @@ defmodule Explorer.Migrator.SanitizeEmptyContractCodeAddresses do
         update: [set: [contract_code: ^@empty_contract_code]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_erc_1155_token_balances_without_token_ids.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_erc_1155_token_balances_without_token_ids.ex
@@ -43,7 +43,9 @@ defmodule Explorer.Migrator.SanitizeErc1155TokenBalancesWithoutTokenIds do
   def update_batch(token_balance_ids) do
     query = from(tb in TokenBalance, where: tb.id in ^token_balance_ids)
 
-    Repo.delete_all(query, timeout: :infinity)
+    {count, _} = Repo.delete_all(query, timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_missing_token_balances.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_missing_token_balances.ex
@@ -54,19 +54,22 @@ defmodule Explorer.Migrator.SanitizeMissingTokenBalances do
         {[ctb_id | ctb_acc], [tb_id | tb_acc]}
       end)
 
-    Repo.transaction(fn ->
-      ctb_query = from(ctb in CurrentTokenBalance, where: ctb.id in ^ctb_ids)
+    {:ok, {count, _}} =
+      Repo.transaction(fn ->
+        ctb_query = from(ctb in CurrentTokenBalance, where: ctb.id in ^ctb_ids)
 
-      Repo.delete_all(ctb_query, timeout: :infinity)
+        Repo.delete_all(ctb_query, timeout: :infinity)
 
-      tb_query =
-        from(tb in TokenBalance,
-          where: tb.id in ^tb_ids,
-          update: [set: [value: nil, value_fetched_at: nil]]
-        )
+        tb_query =
+          from(tb in TokenBalance,
+            where: tb.id in ^tb_ids,
+            update: [set: [value: nil, value_fetched_at: nil]]
+          )
 
-      Repo.update_all(tb_query, [], timeout: :infinity)
-    end)
+        Repo.update_all(tb_query, [], timeout: :infinity)
+      end)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_replaced_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_replaced_transactions.ex
@@ -39,7 +39,9 @@ defmodule Explorer.Migrator.SanitizeReplacedTransactions do
   def update_batch(transaction_hashes) do
     query = from(t in Transaction, where: t.hash in ^transaction_hashes)
 
-    Repo.delete_all(query, timeout: :infinity)
+    {count, _} = Repo.delete_all(query, timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/sanitize_verified_addresses.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_verified_addresses.ex
@@ -40,7 +40,9 @@ defmodule Explorer.Migrator.SanitizeVerifiedAddresses do
         update: [set: [verified: true]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   def start_link(_) do

--- a/apps/explorer/lib/explorer/migrator/shrink_internal_transactions.ex
+++ b/apps/explorer/lib/explorer/migrator/shrink_internal_transactions.ex
@@ -54,7 +54,9 @@ defmodule Explorer.Migrator.ShrinkInternalTransactions do
         update: [set: [input: fragment("substring(? FOR 4)", it.input), output: nil]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/token_transfer_block_consensus.ex
+++ b/apps/explorer/lib/explorer/migrator/token_transfer_block_consensus.ex
@@ -47,7 +47,9 @@ defmodule Explorer.Migrator.TokenTransferBlockConsensus do
       |> join(:inner, [tt], b in assoc(tt, :block))
       |> update([tt, b], set: [block_consensus: b.consensus])
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/token_transfer_token_type.ex
+++ b/apps/explorer/lib/explorer/migrator/token_transfer_token_type.ex
@@ -61,7 +61,9 @@ defmodule Explorer.Migrator.TokenTransferTokenType do
         ]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/transaction_block_consensus.ex
+++ b/apps/explorer/lib/explorer/migrator/transaction_block_consensus.ex
@@ -48,7 +48,9 @@ defmodule Explorer.Migrator.TransactionBlockConsensus do
         update: [set: [block_consensus: block.consensus]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/transaction_has_token_transfers.ex
+++ b/apps/explorer/lib/explorer/migrator/transaction_has_token_transfers.ex
@@ -35,18 +35,21 @@ defmodule Explorer.Migrator.TransactionHasTokenTransfers do
 
   @impl FillingMigration
   def update_batch(transaction_hashes) do
-    Transaction
-    |> where([transaction], transaction.hash in ^transaction_hashes)
-    |> update([transaction],
-      set: [
-        has_token_transfers:
-          fragment(
-            "EXISTS (SELECT 1 FROM token_transfers WHERE transaction_hash = ? LIMIT 1)",
-            transaction.hash
-          )
-      ]
-    )
-    |> Repo.update_all([], timeout: :infinity)
+    {count, _} =
+      Transaction
+      |> where([transaction], transaction.hash in ^transaction_hashes)
+      |> update([transaction],
+        set: [
+          has_token_transfers:
+            fragment(
+              "EXISTS (SELECT 1 FROM token_transfers WHERE transaction_hash = ? LIMIT 1)",
+              transaction.hash
+            )
+        ]
+      )
+      |> Repo.update_all([], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/transactions_denormalization.ex
+++ b/apps/explorer/lib/explorer/migrator/transactions_denormalization.ex
@@ -47,7 +47,9 @@ defmodule Explorer.Migrator.TransactionsDenormalization do
         update: [set: [block_consensus: block.consensus, block_timestamp: block.timestamp]]
       )
 
-    Repo.update_all(query, [], timeout: :infinity)
+    {count, _} = Repo.update_all(query, [], timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/unescape_ampersands_in_tokens.ex
+++ b/apps/explorer/lib/explorer/migrator/unescape_ampersands_in_tokens.ex
@@ -52,7 +52,10 @@ defmodule Explorer.Migrator.UnescapeAmpersandsInTokens do
         }
       end)
 
-    Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+    {count, _} =
+      Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/unescape_quotes_in_tokens.ex
+++ b/apps/explorer/lib/explorer/migrator/unescape_quotes_in_tokens.ex
@@ -52,7 +52,10 @@ defmodule Explorer.Migrator.UnescapeQuotesInTokens do
         }
       end)
 
-    Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+    {count, _} =
+      Repo.insert_all(Token, params, on_conflict: {:replace, [:name, :symbol]}, conflict_target: :contract_address_hash)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/test/explorer/migrator/backfill_multichain_search_db_current_token_balances_test.exs
+++ b/apps/explorer/test/explorer/migrator/backfill_multichain_search_db_current_token_balances_test.exs
@@ -115,7 +115,7 @@ defmodule Explorer.Migrator.BackfillMultichainSearchDbCurrentTokenBalancesTest d
       end
     )
 
-    assert {:ok, {:chunks_processed, _}} =
+    assert 2 =
              BackfillMultichainSearchDbCurrentTokenBalances.update_batch([balance_1.id, balance_2.id])
   end
 

--- a/apps/explorer/test/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts_test.exs
+++ b/apps/explorer/test/explorer/migrator/empty_bytecode_for_selfdestructed_smart_contracts_test.exs
@@ -15,7 +15,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
 
   describe "update_batch/1" do
     test "returns {:ok, []} when block_numbers is empty" do
-      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([])
     end
 
     test "returns {:ok, []} when no selfdestruct transactions exist in blocks" do
@@ -30,7 +30,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         type: :call
       )
 
-      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
     end
 
     test "empties contract_code for address with selfdestruct transaction" do
@@ -55,7 +55,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 1 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code is now empty
       updated_address = Repo.get(Address, contract_address.hash)
@@ -93,7 +93,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code is still present
       updated_address = Repo.get(Address, contract_address.hash)
@@ -132,7 +132,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, []} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code is still present
       updated_address = Repo.get(Address, contract_address.hash)
@@ -176,7 +176,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 2} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 2 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify both contracts have empty contract_code
       updated_address_1 = Repo.get(Address, contract_address_1.hash)
@@ -207,7 +207,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 0} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code remains empty (no update occurred)
       updated_address = Repo.get(Address, contract_address.hash)
@@ -235,7 +235,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 0} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 0 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code remains nil
       updated_address = Repo.get(Address, address.hash)
@@ -282,7 +282,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 2} =
+      assert 2 =
                EmptyBytecodeForSelfdestructedSmartContracts.update_batch([
                  block_1.number,
                  block_2.number
@@ -343,7 +343,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
         gas: nil
       )
 
-      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 1 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify first contract is empty, second is not
       updated_address_1 = Repo.get(Address, contract_address_1.hash)
@@ -387,7 +387,7 @@ defmodule Explorer.Migrator.EmptyBytecodeForSelfdestructedSmartContractsTest do
       )
 
       # Should still only update once since it's the same address
-      assert {:ok, 1} = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
+      assert 1 = EmptyBytecodeForSelfdestructedSmartContracts.update_batch([block.number])
 
       # Verify contract_code is empty
       updated_address = Repo.get(Address, contract_address.hash)


### PR DESCRIPTION
## Motivation

Timeout between `FillingMigration` batches was added to reduce the load on the DB. But if migration reaches the area where no updates happens then there is no any load on the DB and it means that the next batch may be processed immediately.

## Changelog

Updated `FillingMigration.update_batch/1` callback to return the number of processed elements. If `0` elements were processed, run the next batch immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the migration framework and individual migrations to consistently return a numeric “rows processed/updated” count from batch operations and database actions, instead of returning raw internal result shapes.
  * Improved migration batch scheduling to use the processed count for subsequent batch timing decisions.
* **Tests**
  * Adjusted migrator tests to assert the new numeric return values for batch outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->