### PR TITLE
chore: Trim leading zeroes in log topics

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -145,7 +145,7 @@ for migrator <- [
       Explorer.Migrator.FillInternalTransactionsAddressIds,
       Explorer.Migrator.TransactionHasTokenTransfers,
       Explorer.Migrator.DeleteNonConsensusLogs,
-      Explorer.Migrator.FillLogsTransactionIndexAddressId
+      Explorer.Migrator.FillLogsOptimizedFields
     ] do
   config :explorer, migrator, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -82,7 +82,7 @@ for migrator <- [
       Explorer.Migrator.FillInternalTransactionsAddressIds,
       Explorer.Migrator.TransactionHasTokenTransfers,
       Explorer.Migrator.DeleteNonConsensusLogs,
-      Explorer.Migrator.FillLogsTransactionIndexAddressId,
+      Explorer.Migrator.FillLogsOptimizedFields,
 
       # Heavy DB index operations
       Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex,

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -229,7 +229,6 @@ defmodule Explorer.Application do
         configure_mode_dependent_process(Explorer.Migrator.EmptyInternalTransactionsData, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.FillInternalTransactionsAddressIds, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.DeleteNonConsensusLogs, :indexer),
-        configure_mode_dependent_process(Explorer.Migrator.FillLogsOptimizedFields, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesVerifiedIndex,
           :indexer
@@ -449,13 +448,10 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransactionIndexNotNull,
-          :indexer
-        ),
-        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.UpdateLogsPrimaryKey,
           :indexer
         ),
+        configure_mode_dependent_process(Explorer.Migrator.FillLogsOptimizedFields, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumberDescIndexDescIndex,
           :indexer
@@ -478,6 +474,10 @@ defmodule Explorer.Application do
         ),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.DropLogsDepositsWithdrawalsIndex,
+          :indexer
+        ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransactionIndexNotNull,
           :indexer
         ),
         Explorer.Migrator.RefetchContractCodes

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -229,7 +229,7 @@ defmodule Explorer.Application do
         configure_mode_dependent_process(Explorer.Migrator.EmptyInternalTransactionsData, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.FillInternalTransactionsAddressIds, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.DeleteNonConsensusLogs, :indexer),
-        configure_mode_dependent_process(Explorer.Migrator.FillLogsTransactionIndexAddressId, :indexer),
+        configure_mode_dependent_process(Explorer.Migrator.FillLogsOptimizedFields, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesVerifiedIndex,
           :indexer

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -248,11 +248,14 @@ defmodule Explorer.Chain do
   defp filter_topic(base_query, null) when null in [nil, "", "null"], do: base_query
 
   defp filter_topic(base_query, topic) do
-    from(log in base_query,
-      where:
-        log.first_topic == ^topic or log.second_topic == ^topic or log.third_topic == ^topic or
-          log.fourth_topic == ^topic
-    )
+    dynamic =
+      dynamic(
+        [log],
+        log.first_topic == ^topic or
+          ^Log.filter_by_topic_dynamic([:second_topic, :third_topic, :fourth_topic], [[topic], [topic], [topic]])
+      )
+
+    from(log in base_query, where: ^dynamic)
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -55,9 +55,7 @@ defmodule Explorer.Chain.Address.Counters do
   @transactions_types [:transactions_from, :transactions_to, :transactions_contract]
 
   defp address_hash_to_logs_query(address_hash) do
-    Log
-    |> Log.join_address_mapping_query()
-    |> where(as(:address_mapping).address_hash == ^address_hash)
+    Log.address_match_query(Log, address_hash)
   end
 
   defp address_hash_to_validated_blocks_query(address_hash) do

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Chain.Address.Counters do
   use Utils.RuntimeEnvHelper,
     chain_identity: [:explorer, :chain_identity]
 
-  import Ecto.Query, only: [from: 2, limit: 2, select: 3, union_all: 2, where: 3]
+  import Ecto.Query
 
   import Explorer.Chain,
     only: [select_repo: 1, wrapped_union_subquery: 1]
@@ -55,7 +55,9 @@ defmodule Explorer.Chain.Address.Counters do
   @transactions_types [:transactions_from, :transactions_to, :transactions_contract]
 
   defp address_hash_to_logs_query(address_hash) do
-    from(l in Log, where: l.address_hash == ^address_hash)
+    Log
+    |> Log.join_address_mapping_query()
+    |> where(as(:address_mapping).address_hash == ^address_hash)
   end
 
   defp address_hash_to_validated_blocks_query(address_hash) do

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -347,10 +347,18 @@ defmodule Explorer.Chain.Block do
     )
   end
 
+  @doc """
+  Adds a filter by block numbers to the given query.
+  """
+  @spec by_numbers_query(Ecto.Queryable.t(), [block_number()]) :: Ecto.Query.t()
   def by_numbers_query(query \\ __MODULE__, block_numbers) do
     where(query, [b], b.number in ^block_numbers)
   end
 
+  @doc """
+  Adds a consensus filter to the given block query.
+  """
+  @spec consensus_query(Ecto.Queryable.t(), boolean()) :: Ecto.Query.t()
   def consensus_query(query \\ __MODULE__, consensus) do
     where(query, [b], b.consensus == ^consensus)
   end

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -364,22 +364,6 @@ defmodule Explorer.Chain.Block do
   end
 
   @doc """
-  Adds a filter by block numbers to the given query.
-  """
-  @spec by_numbers_query(Ecto.Queryable.t(), [block_number()]) :: Ecto.Query.t()
-  def by_numbers_query(query \\ __MODULE__, block_numbers) do
-    where(query, [b], b.number in ^block_numbers)
-  end
-
-  @doc """
-  Adds a consensus filter to the given block query.
-  """
-  @spec consensus_query(Ecto.Queryable.t(), boolean()) :: Ecto.Query.t()
-  def consensus_query(query \\ __MODULE__, consensus) do
-    where(query, [b], b.consensus == ^consensus)
-  end
-
-  @doc """
     Returns a query that filters blocks where consensus is true.
 
     ## Returns

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -347,6 +347,14 @@ defmodule Explorer.Chain.Block do
     )
   end
 
+  def by_numbers_query(query \\ __MODULE__, block_numbers) do
+    where(query, [b], b.number in ^block_numbers)
+  end
+
+  def consensus_query(query \\ __MODULE__, consensus) do
+    where(query, [b], b.consensus == ^consensus)
+  end
+
   @doc """
   Adds a filter by block numbers to the given query.
   """

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -79,7 +79,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :fill_internal_transactions_address_ids_finished,
     key: :heavy_indexes_create_transactions_token_transfer_method_id_ordered_index_finished,
     key: :create_logs_block_number_transaction_index_index_unique_index_finished,
-    key: :fill_logs_transaction_index_address_id_finished
+    key: :fill_logs_optimized_fields_finished
 
   @dialyzer :no_match
 
@@ -91,7 +91,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     BackfillMultichainSearchDbCurrentTokenBalances,
     EmptyInternalTransactionsData,
     FillInternalTransactionsAddressIds,
-    FillLogsTransactionIndexAddressId,
+    FillLogsOptimizedFields,
     SanitizeDuplicatedLogIndexLogs,
     TokenTransferTokenType,
     TransactionHasTokenTransfers,
@@ -491,10 +491,10 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     )
   end
 
-  defp handle_fallback(:fill_logs_transaction_index_address_id_finished) do
+  defp handle_fallback(:fill_logs_optimized_fields_finished) do
     set_and_return_migration_status(
-      FillLogsTransactionIndexAddressId,
-      &set_fill_logs_transaction_index_address_id_finished/1
+      FillLogsOptimizedFields,
+      &set_fill_logs_optimized_fields_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/chain/hash/trimmed.ex
+++ b/apps/explorer/lib/explorer/chain/hash/trimmed.ex
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Hash.Trimmed do
+  @moduledoc """
+  A 32-byte hash that is stored in the database without leading zero bytes.
+
+  This type keeps the public representation compatible with `Explorer.Chain.Hash.Full`: values are cast and loaded
+  as 32-byte hashes, but dumped to the database in a compact `bytea` format with leading zero bytes removed.
+  """
+
+  alias Explorer.Chain.Hash
+  alias Explorer.Chain.Hash.Full
+
+  use Ecto.Type
+
+  @byte_count 32
+  @hexadecimal_digit_count Hash.hexadecimal_digits_per_byte() * @byte_count
+
+  @typedoc """
+  A #{@byte_count}-byte hash stored in the database without leading zero bytes.
+  """
+  @type t :: %Hash{byte_count: unquote(@byte_count), bytes: <<_::unquote(@byte_count * Hash.bits_per_byte())>>}
+
+  @doc """
+  Casts `term` to `t:t/0` using `Explorer.Chain.Hash.Full.cast/1`.
+
+  If the `term` is already in `t:t/0`, then it is returned.
+
+      iex> Explorer.Chain.Hash.Trimmed.cast(
+      ...>   %Explorer.Chain.Hash{
+      ...>     byte_count: 32,
+      ...>     bytes: <<0x00000000000000000000000000000000000000000000000000000000000000ff ::
+      ...>              big-integer-size(32)-unit(8)>>
+      ...>   }
+      ...> )
+      {
+        :ok,
+        %Explorer.Chain.Hash{
+          byte_count: 32,
+          bytes: <<0x00000000000000000000000000000000000000000000000000000000000000ff :: big-integer-size(32)-unit(8)>>
+        }
+      }
+
+  If the `term` is a `String.t` that starts with `0x`, then it is converted to `t:t/0`.
+
+      iex> Explorer.Chain.Hash.Trimmed.cast("0x00000000000000000000000000000000000000000000000000000000000000ff")
+      {
+        :ok,
+        %Explorer.Chain.Hash{
+          byte_count: 32,
+          bytes: <<0x00000000000000000000000000000000000000000000000000000000000000ff :: big-integer-size(32)-unit(8)>>
+        }
+      }
+
+  `String.t` format must always have #{@hexadecimal_digit_count} hexadecimal digits after the `0x` base prefix.
+
+      iex> Explorer.Chain.Hash.Trimmed.cast("0xff")
+      :error
+
+  """
+  @impl Ecto.Type
+  @spec cast(term()) :: {:ok, t()} | :error
+  def cast(term), do: Full.cast(term)
+
+  @doc """
+  Dumps the hash to compact `:binary` (`bytea`) format used in database.
+
+  Leading zero bytes are removed before storing the value.
+
+      iex> Explorer.Chain.Hash.Trimmed.dump(
+      ...>   %Explorer.Chain.Hash{
+      ...>     byte_count: 32,
+      ...>     bytes: <<0x00000000000000000000000000000000000000000000000000000000000000ff ::
+      ...>              big-integer-size(32)-unit(8)>>
+      ...>   }
+      ...> )
+      {:ok, <<0xff>>}
+
+  A zero hash is stored as an empty binary.
+
+      iex> Explorer.Chain.Hash.Trimmed.dump(
+      ...>   %Explorer.Chain.Hash{
+      ...>     byte_count: 32,
+      ...>     bytes: <<0::256>>
+      ...>   }
+      ...> )
+      {:ok, <<>>}
+
+  If the field from the struct is an incorrect format such as `t:Explorer.Chain.Hash.Address.t/0`, `:error` is returned.
+
+      iex> Explorer.Chain.Hash.Trimmed.dump(
+      ...>   %Explorer.Chain.Hash{
+      ...>     byte_count: 20,
+      ...>     bytes: <<0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed :: big-integer-size(20)-unit(8)>>
+      ...>   }
+      ...> )
+      :error
+
+  """
+  @impl Ecto.Type
+  @spec dump(term()) :: {:ok, binary()} | :error
+  def dump(%Hash{byte_count: @byte_count, bytes: bytes}) do
+    {:ok, trim_leading_zeroes(bytes)}
+  end
+
+  def dump(term), do: Full.dump(term)
+
+  @doc """
+  Loads the compact binary hash from the database.
+
+  The binary is left-padded with zero bytes up to #{@byte_count} bytes and loaded as `Explorer.Chain.Hash.Full`.
+
+      iex> Explorer.Chain.Hash.Trimmed.load(<<0xff>>)
+      {
+        :ok,
+        %Explorer.Chain.Hash{
+          byte_count: 32,
+          bytes: <<0x00000000000000000000000000000000000000000000000000000000000000ff :: big-integer-size(32)-unit(8)>>
+        }
+      }
+
+  An empty binary is loaded as a zero hash.
+
+      iex> Explorer.Chain.Hash.Trimmed.load(<<>>)
+      {
+        :ok,
+        %Explorer.Chain.Hash{
+          byte_count: 32,
+          bytes: <<0::256>>
+        }
+      }
+
+  If the binary hash is longer than #{@byte_count} bytes, `:error` is returned.
+
+      iex> Explorer.Chain.Hash.Trimmed.load(<<0::264>>)
+      :error
+
+  """
+  @impl Ecto.Type
+  @spec load(term()) :: {:ok, t()} | :error
+  def load(bytes) when is_binary(bytes) and byte_size(bytes) <= @byte_count do
+    padding_size = @byte_count - byte_size(bytes)
+    padded = <<0::size(padding_size)-unit(8), bytes::binary>>
+
+    Full.load(padded)
+  end
+
+  def load(_), do: :error
+
+  @doc """
+  The underlying database type: `binary`. `binary` is used because stored values have variable byte length.
+  """
+  @impl Ecto.Type
+  @spec type() :: :binary
+  def type, do: :binary
+
+  defp trim_leading_zeroes(<<0, rest::binary>>), do: trim_leading_zeroes(rest)
+
+  defp trim_leading_zeroes(bytes), do: bytes
+end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -686,6 +686,16 @@ defmodule Explorer.Chain.Log do
     )
   end
 
+  @doc """
+  Filters logs by one or multiple topic fields.
+
+  When `topic_name` is an atom, filters the query by the given topic field and
+  values. `topic_values` can be a single value or a list of values.
+
+  When `topic_names` and `topic_values_list` are lists, builds an `OR` condition
+  where each topic field is matched against the corresponding list of values.
+  """
+  @spec filter_by_topic_query(Ecto.Queryable.t(), atom() | [atom()], any() | [[any()]]) :: Ecto.Query.t()
   def filter_by_topic_query(query, topic_name, topic_values) when is_atom(topic_name) do
     where(query, [l], ^topic_filter_dynamic(topic_name, List.wrap(topic_values)))
   end

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -48,9 +48,9 @@ defmodule Explorer.Chain.Log.Schema do
       typed_schema "logs" do
         field(:data, Data, null: false)
         field(:first_topic, Hash.Full)
-        field(:second_topic, Hash.Full)
-        field(:third_topic, Hash.Full)
-        field(:fourth_topic, Hash.Full)
+        field(:second_topic, Hash.Trimmed)
+        field(:third_topic, Hash.Trimmed)
+        field(:fourth_topic, Hash.Trimmed)
         field(:index, :integer, primary_key: true, null: false)
         field(:block_number, :integer, primary_key: true)
 
@@ -539,10 +539,10 @@ defmodule Explorer.Chain.Log do
         [%Transaction{hash: transaction_hash, block_number: block_number, index: transaction_index}] ->
           # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           cond do
-            LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+            LogHelper.fill_optimized_fields_migration_finished?() ->
               where(query, [log], log.block_number == ^block_number and log.transaction_index == ^transaction_index)
 
-            LogHelper.fill_transaction_index_address_id_migration_started?() ->
+            LogHelper.fill_optimized_fields_migration_started?() ->
               where(
                 query,
                 [log],
@@ -626,10 +626,26 @@ defmodule Explorer.Chain.Log do
   """
   @spec first_topic_is_not_deposit_or_withdrawal_signature() :: Ecto.Query.dynamic_expr()
   def first_topic_is_not_deposit_or_withdrawal_signature do
-    dynamic(
-      [log: log],
-      log.first_topic not in [^TokenTransfer.weth_deposit_signature(), ^TokenTransfer.weth_withdrawal_signature()]
-    )
+    topic_values = [TokenTransfer.weth_deposit_signature(), TokenTransfer.weth_withdrawal_signature()]
+
+    if LogHelper.fill_optimized_fields_migration_finished?() do
+      dynamic([log: log], log.first_topic not in ^topic_values)
+    else
+      trimmed_values =
+        topic_values
+        |> Enum.flat_map(fn topic ->
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          case Hash.Trimmed.dump(topic) do
+            {:ok, trimmed} -> [trimmed]
+            :error -> []
+          end
+        end)
+
+      dynamic(
+        [log: log],
+        log.first_topic not in ^topic_values and log.first_topic not in type(^trimmed_values, {:array, :binary})
+      )
+    end
   end
 
   @doc """
@@ -670,12 +686,55 @@ defmodule Explorer.Chain.Log do
     )
   end
 
+  def filter_by_topic_query(query, topic_name, topic_values) when is_atom(topic_name) do
+    where(query, [l], ^topic_filter_dynamic(topic_name, List.wrap(topic_values)))
+  end
+
+  def filter_by_topic_query(query, topic_names, topic_values_list)
+      when is_list(topic_names) and is_list(topic_values_list) do
+    where(query, [l], ^filter_by_topic_dynamic(topic_names, topic_values_list))
+  end
+
+  def filter_by_topic_dynamic(topic_names, topic_values_list) do
+    topic_names
+    |> Enum.zip(topic_values_list)
+    |> Enum.reduce(dynamic(false), fn {topic_name, topic_values}, dynamic ->
+      dynamic(
+        [l],
+        ^dynamic or ^topic_filter_dynamic(topic_name, topic_values)
+      )
+    end)
+  end
+
+  def topic_filter_dynamic(:first_topic, topic_values), do: dynamic([l], l.first_topic in ^topic_values)
+
+  def topic_filter_dynamic(topic_name, topic_values) do
+    if LogHelper.fill_optimized_fields_migration_finished?() do
+      dynamic([l], field(l, ^topic_name) in ^topic_values)
+    else
+      extended_values =
+        topic_values
+        |> Enum.flat_map(fn topic ->
+          # credo:disable-for-next-line Credo.Check.Refactor.Nesting
+          case Hash.Full.dump(topic) do
+            {:ok, extended} -> [extended]
+            :error -> []
+          end
+        end)
+
+      dynamic(
+        [l],
+        field(l, ^topic_name) in ^topic_values or field(l, ^topic_name) in type(^extended_values, {:array, :binary})
+      )
+    end
+  end
+
   defp by_transaction_query(query, transaction_hash, block_number, transaction_index) do
     cond do
-      LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+      LogHelper.fill_optimized_fields_migration_finished?() ->
         where(query, [l], l.block_number == ^block_number and l.transaction_index == ^transaction_index)
 
-      LogHelper.fill_transaction_index_address_id_migration_started?() ->
+      LogHelper.fill_optimized_fields_migration_started?() ->
         where(
           query,
           [l],
@@ -694,13 +753,13 @@ defmodule Explorer.Chain.Log do
   @spec join_transaction_query(Ecto.Queryable.t()) :: Ecto.Query.t()
   def join_transaction_query(query \\ __MODULE__) do
     cond do
-      LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+      LogHelper.fill_optimized_fields_migration_finished?() ->
         join(query, :inner, [l], t in Transaction,
           on: l.block_number == t.block_number and l.transaction_index == t.index,
           as: :transaction
         )
 
-      LogHelper.fill_transaction_index_address_id_migration_started?() ->
+      LogHelper.fill_optimized_fields_migration_started?() ->
         join(query, :inner, [l], t in Transaction,
           on: l.transaction_hash == t.hash or (l.block_number == t.block_number and l.transaction_index == t.index),
           as: :transaction
@@ -718,7 +777,7 @@ defmodule Explorer.Chain.Log do
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def join_to_token_transfer_query(query) do
     cond do
-      LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+      LogHelper.fill_optimized_fields_migration_finished?() ->
         query
         |> join(:left, [tt], t in assoc(tt, :transaction))
         |> join(:left, [tt, t], l in __MODULE__,
@@ -726,7 +785,7 @@ defmodule Explorer.Chain.Log do
           as: :log
         )
 
-      LogHelper.fill_transaction_index_address_id_migration_started?() ->
+      LogHelper.fill_optimized_fields_migration_started?() ->
         query
         |> join(:left, [tt], t in assoc(tt, :transaction))
         |> join(:left, [tt, t], l in __MODULE__,
@@ -764,11 +823,11 @@ defmodule Explorer.Chain.Log do
 
   def address_match_query(query, address_hashes) when is_list(address_hashes) do
     cond do
-      LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+      LogHelper.fill_optimized_fields_migration_finished?() ->
         address_ids = AddressIdToAddressHash.hashes_to_ids(address_hashes)
         where(query, [l], l.address_id in ^address_ids)
 
-      LogHelper.fill_transaction_index_address_id_migration_started?() ->
+      LogHelper.fill_optimized_fields_migration_started?() ->
         address_ids = AddressIdToAddressHash.hashes_to_ids(address_hashes)
         where(query, [l], l.address_id in ^address_ids or l.address_hash in ^address_hashes)
 
@@ -779,11 +838,11 @@ defmodule Explorer.Chain.Log do
 
   def address_match_query(query, address_hash) do
     cond do
-      LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+      LogHelper.fill_optimized_fields_migration_finished?() ->
         address_id = AddressIdToAddressHash.hash_to_id(address_hash)
         where(query, [l], ^address_id_match_dynamic(address_id))
 
-      LogHelper.fill_transaction_index_address_id_migration_started?() ->
+      LogHelper.fill_optimized_fields_migration_started?() ->
         address_id = AddressIdToAddressHash.hash_to_id(address_hash)
         where(query, [l], ^address_id_or_hash_match_dynamic(address_id, address_hash))
 

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -202,7 +202,8 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
           )
 
         LogHelper.fill_optimized_fields_migration_started?() ->
-          {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+          {:ok, cast_first_topic} = Hash.Full.cast(@message_passed_event)
+          {:ok, extended_first_topic} = Hash.Full.dump(cast_first_topic)
 
           join(query, :left, [w, l2_transaction], log in Log,
             on:
@@ -214,7 +215,8 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
           )
 
         true ->
-          {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+          {:ok, cast_first_topic} = Hash.Full.cast(@message_passed_event)
+          {:ok, extended_first_topic} = Hash.Full.dump(cast_first_topic)
 
           join(query, :left, [w, l2_transaction], log in Log,
             on:

--- a/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/optimism/withdrawal.ex
@@ -81,27 +81,34 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
         |> then(fn query ->
           # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           cond do
-            LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+            LogHelper.fill_optimized_fields_migration_finished?() ->
               join(query, :left, [w, l2_transaction], log in Log,
                 on:
                   log.block_number == w.l2_block_number and log.transaction_index == l2_transaction.index and
                     log.first_topic == ^@message_passed_event and
-                    log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
+                    log.second_topic == fragment("bytea_ltrim_zeroes(numeric_to_bytea32(msg_nonce))")
               )
 
-            LogHelper.fill_transaction_index_address_id_migration_started?() ->
+            LogHelper.fill_optimized_fields_migration_started?() ->
+              {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+
               join(query, :left, [w, l2_transaction], log in Log,
                 on:
                   (log.transaction_hash == w.l2_transaction_hash or
                      (log.block_number == w.l2_block_number and log.transaction_index == l2_transaction.index)) and
-                    log.first_topic == ^@message_passed_event and
-                    log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
+                    (log.first_topic == ^@message_passed_event or
+                       log.first_topic == type(^extended_first_topic, :binary)) and
+                    (log.second_topic == fragment("numeric_to_bytea32(msg_nonce)") or
+                       log.second_topic == fragment("bytea_ltrim_zeroes(numeric_to_bytea32(msg_nonce))"))
               )
 
             true ->
+              {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+
               join(query, :left, [w, l2_transaction], log in Log,
                 on:
-                  log.transaction_hash == w.l2_transaction_hash and log.first_topic == ^@message_passed_event and
+                  log.transaction_hash == w.l2_transaction_hash and
+                    log.first_topic == type(^extended_first_topic, :binary) and
                     log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
               )
           end
@@ -186,27 +193,32 @@ defmodule Explorer.Chain.Optimism.Withdrawal do
     )
     |> then(fn query ->
       cond do
-        LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+        LogHelper.fill_optimized_fields_migration_finished?() ->
           join(query, :left, [w, l2_transaction], log in Log,
             on:
               log.block_number == w.l2_block_number and log.transaction_index == l2_transaction.index and
                 log.first_topic == ^@message_passed_event and
-                log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
+                log.second_topic == fragment("bytea_ltrim_zeroes(numeric_to_bytea32(msg_nonce))")
           )
 
-        LogHelper.fill_transaction_index_address_id_migration_started?() ->
+        LogHelper.fill_optimized_fields_migration_started?() ->
+          {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+
           join(query, :left, [w, l2_transaction], log in Log,
             on:
               (log.transaction_hash == w.l2_transaction_hash or
                  (log.block_number == w.l2_block_number and log.transaction_index == l2_transaction.index)) and
-                log.first_topic == ^@message_passed_event and
-                log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
+                (log.first_topic == ^@message_passed_event or log.first_topic == type(^extended_first_topic, :binary)) and
+                (log.second_topic == fragment("numeric_to_bytea32(msg_nonce)") or
+                   log.second_topic == fragment("bytea_ltrim_zeroes(numeric_to_bytea32(msg_nonce))"))
           )
 
         true ->
+          {:ok, extended_first_topic} = Hash.Full.dump(@message_passed_event)
+
           join(query, :left, [w, l2_transaction], log in Log,
             on:
-              log.transaction_hash == w.l2_transaction_hash and log.first_topic == ^@message_passed_event and
+              log.transaction_hash == w.l2_transaction_hash and log.first_topic == type(^extended_first_topic, :binary) and
                 log.second_topic == fragment("numeric_to_bytea32(msg_nonce)")
           )
       end

--- a/apps/explorer/lib/explorer/chain/zilliqa/zrc2/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/zilliqa/zrc2/token_transfer.ex
@@ -118,9 +118,10 @@ defmodule Explorer.Chain.Zilliqa.Zrc2.TokenTransfer do
     Log
     |> join(:inner, [l], b in Block, on: b.number == l.block_number and b.consensus == true)
     |> Log.join_transaction_query()
-    |> join(:left, [l], a in TokenAdapter, on: a.zrc2_address_hash == l.address_hash)
+    |> Log.join_address_mapping_query()
+    |> join(:left, [l], a in TokenAdapter, on: a.zrc2_address_hash == as(:address_mapping).address_hash)
     |> where([l], l.block_number == ^block_number and l.first_topic in ^transfer_events)
-    |> select([l, b, t, a], %{
+    |> select([l, b, t, _am, a], %{
       first_topic: l.first_topic,
       data: l.data,
       address_hash: l.address_hash,

--- a/apps/explorer/lib/explorer/chain/zilliqa/zrc2/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/zilliqa/zrc2/token_transfer.ex
@@ -119,12 +119,14 @@ defmodule Explorer.Chain.Zilliqa.Zrc2.TokenTransfer do
     |> join(:inner, [l], b in Block, on: b.number == l.block_number and b.consensus == true)
     |> Log.join_transaction_query()
     |> Log.join_address_mapping_query()
-    |> join(:left, [l], a in TokenAdapter, on: a.zrc2_address_hash == as(:address_mapping).address_hash)
+    |> join(:left, [l], a in TokenAdapter,
+      on: a.zrc2_address_hash == coalesce(l.address_hash, as(:address_mapping).address_hash)
+    )
     |> where([l], l.block_number == ^block_number and l.first_topic in ^transfer_events)
     |> select([l, b, t, _am, a], %{
       first_topic: l.first_topic,
       data: l.data,
-      address_hash: l.address_hash,
+      address_hash: coalesce(l.address_hash, as(:address_mapping).address_hash),
       transaction_hash: t.hash,
       index: l.index,
       block_number: l.block_number,

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -174,14 +174,14 @@ defmodule Explorer.Etherscan.Logs do
         |> then(fn query ->
           # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           cond do
-            LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+            LogHelper.fill_optimized_fields_migration_finished?() ->
               join(query, :inner, [log], block_transaction_data in subquery(block_transaction_query),
                 on:
                   block_transaction_data.transaction_index == log.transaction_index and
                     block_transaction_data.block_number == log.block_number
               )
 
-            LogHelper.fill_transaction_index_address_id_migration_started?() ->
+            LogHelper.fill_optimized_fields_migration_started?() ->
               join(query, :inner, [log], block_transaction_data in subquery(block_transaction_query),
                 on:
                   (block_transaction_data.transaction_hash == log.transaction_hash and
@@ -233,14 +233,14 @@ defmodule Explorer.Etherscan.Logs do
         |> then(fn query ->
           # credo:disable-for-next-line Credo.Check.Refactor.Nesting
           cond do
-            LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+            LogHelper.fill_optimized_fields_migration_finished?() ->
               join(query, :inner, [log], block_transaction_data in subquery(block_transaction_query),
                 on:
                   block_transaction_data.transaction_index == log.transaction_index and
                     block_transaction_data.block_number == log.block_number
               )
 
-            LogHelper.fill_transaction_index_address_id_migration_started?() ->
+            LogHelper.fill_optimized_fields_migration_started?() ->
               join(query, :inner, [log], block_transaction_data in subquery(block_transaction_query),
                 on:
                   (block_transaction_data.transaction_hash == log.transaction_hash and
@@ -295,7 +295,7 @@ defmodule Explorer.Etherscan.Logs do
         query
 
       [topic] ->
-        where(query, [l], field(l, ^topic) in ^List.wrap(filter[topic]))
+        Log.filter_by_topic_query(query, topic, filter[topic])
 
       _ ->
         where_multiple_topics_match(query, filter)
@@ -350,12 +350,20 @@ defmodule Explorer.Etherscan.Logs do
 
   defp where_multiple_topics_match(query, filter, topic_operation, "and") do
     {topic_a, topic_b} = @topic_operations[topic_operation]
-    where(query, [l], field(l, ^topic_a) == ^filter[topic_a] and field(l, ^topic_b) in ^List.wrap(filter[topic_b]))
+
+    dynamic =
+      dynamic(
+        [l],
+        ^Log.topic_filter_dynamic(topic_a, [filter[topic_a]]) and
+          ^Log.topic_filter_dynamic(topic_b, List.wrap(filter[topic_b]))
+      )
+
+    where(query, [l], ^dynamic)
   end
 
   defp where_multiple_topics_match(query, filter, topic_operation, "or") do
     {topic_a, topic_b} = @topic_operations[topic_operation]
-    where(query, [l], field(l, ^topic_a) == ^filter[topic_a] or field(l, ^topic_b) in ^List.wrap(filter[topic_b]))
+    where(query, [l], ^Log.filter_by_topic_dynamic([topic_a, topic_b], [[filter[topic_a]], List.wrap(filter[topic_b])]))
   end
 
   defp where_multiple_topics_match(query, _, _, _), do: query

--- a/apps/explorer/lib/explorer/migrator/celo_accounts.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_accounts.ex
@@ -36,15 +36,17 @@ defmodule Explorer.Migrator.CeloAccounts do
 
   @impl FillingMigration
   def unprocessed_data_query do
-    pending_op_hashes_query = from(op in PendingAccountOperation, select: op.address_hash)
-    existing_account_hashes_query = from(a in Account, select: a.address_hash)
+    pending_op_hashes_query =
+      from(op in PendingAccountOperation, select: fragment("bytea_ltrim_zeroes(?)", op.address_hash))
+
+    existing_account_hashes_query = from(a in Account, select: fragment("bytea_ltrim_zeroes(?)", a.address_hash))
     excluded_hashes_query = pending_op_hashes_query |> union(^existing_account_hashes_query)
 
     from(
       log in Log,
       where:
         log.first_topic in ^Events.account_events() and
-          fragment("substring(? FROM octet_length(?) - 20 + 1 FOR 20)", log.second_topic, log.second_topic) not in subquery(
+          fragment("substring(? FROM greatest(octet_length(?) - 20 + 1, 1) FOR 20)", log.second_topic, log.second_topic) not in subquery(
             excluded_hashes_query
           ),
       order_by: [asc: log.block_number, asc: log.index]

--- a/apps/explorer/lib/explorer/migrator/celo_accounts.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_accounts.ex
@@ -44,7 +44,7 @@ defmodule Explorer.Migrator.CeloAccounts do
       log in Log,
       where:
         log.first_topic in ^Events.account_events() and
-          fragment("SUBSTRING(? from 13)", log.second_topic) not in subquery(excluded_hashes_query),
+          fragment("right(?, 20)", log.second_topic) not in subquery(excluded_hashes_query),
       order_by: [asc: log.block_number, asc: log.index]
     )
   end

--- a/apps/explorer/lib/explorer/migrator/celo_accounts.ex
+++ b/apps/explorer/lib/explorer/migrator/celo_accounts.ex
@@ -44,7 +44,9 @@ defmodule Explorer.Migrator.CeloAccounts do
       log in Log,
       where:
         log.first_topic in ^Events.account_events() and
-          fragment("right(?, 20)", log.second_topic) not in subquery(excluded_hashes_query),
+          fragment("substring(? FROM octet_length(?) - 20 + 1 FOR 20)", log.second_topic, log.second_topic) not in subquery(
+            excluded_hashes_query
+          ),
       order_by: [asc: log.block_number, asc: log.index]
     )
   end

--- a/apps/explorer/lib/explorer/migrator/delete_non_consensus_logs.ex
+++ b/apps/explorer/lib/explorer/migrator/delete_non_consensus_logs.ex
@@ -36,11 +36,14 @@ defmodule Explorer.Migrator.DeleteNonConsensusLogs do
 
   @impl FillingMigration
   def update_batch(block_numbers) do
-    Log
-    |> join(:inner, [l], b in Block, on: l.block_hash == b.hash)
-    |> where([l], l.block_number in ^block_numbers)
-    |> where([l, b], b.consensus == false)
-    |> Repo.delete_all(timeout: :infinity)
+    {count, _} =
+      Log
+      |> join(:inner, [l], b in Block, on: l.block_hash == b.hash)
+      |> where([l], l.block_number in ^block_numbers)
+      |> where([l, b], b.consensus == false)
+      |> Repo.delete_all(timeout: :infinity)
+
+    count
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
+++ b/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
-defmodule Explorer.Migrator.FillLogsTransactionIndexAddressId do
+defmodule Explorer.Migrator.FillLogsOptimizedFields do
   @moduledoc """
   Fills `transaction_index`, `address_id` fields in `logs` table.
   """
@@ -82,7 +82,10 @@ defmodule Explorer.Migrator.FillLogsTransactionIndexAddressId do
                 set: [
                   address_id: it_to_hash_map.address_id,
                   address_hash: nil,
-                  transaction_index: t.index
+                  transaction_index: t.index,
+                  second_topic: fragment("bytea_ltrim_zeroes(?)", l.second_topic),
+                  third_topic: fragment("bytea_ltrim_zeroes(?)", l.third_topic),
+                  fourth_topic: fragment("bytea_ltrim_zeroes(?)", l.fourth_topic)
                 ]
               ]
             )
@@ -97,6 +100,6 @@ defmodule Explorer.Migrator.FillLogsTransactionIndexAddressId do
 
   @impl FillingMigration
   def update_cache do
-    BackgroundMigrations.set_fill_logs_transaction_index_address_id_finished(true)
+    BackgroundMigrations.set_fill_logs_optimized_fields_finished(true)
   end
 end

--- a/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
+++ b/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
@@ -16,7 +16,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFields do
   alias Explorer.Repo
   alias Explorer.Utility.AddressIdToAddressHash
 
-  @migration_name "fill_logs_transaction_index_address_id"
+  @migration_name "fill_logs_optimized_fields"
 
   @impl FillingMigration
   def migration_name, do: @migration_name

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_id_block_number_desc_index_desc_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_id_block_number_desc_index_desc_index.ex
@@ -9,7 +9,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumber
   require Logger
 
   alias Explorer.Chain.Cache.BackgroundMigrations
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
 
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
@@ -28,7 +28,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumber
   def index_name, do: @index_name
 
   @impl HeavyDbIndexOperation
-  def dependent_from_migrations, do: [FillLogsTransactionIndexAddressId.migration_name()]
+  def dependent_from_migrations, do: [FillLogsOptimizedFields.migration_name()]
 
   @impl HeavyDbIndexOperation
   def db_index_operation do

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_address_hash_block_number_desc_index_desc_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_address_hash_block_number_desc_index_desc_index.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashBlockNumber
 
   use Explorer.Migrator.HeavyDbIndexOperation
 
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
   @table_name :logs
@@ -23,7 +23,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashBlockNumber
   def index_name, do: @index_name
 
   @impl HeavyDbIndexOperation
-  def dependent_from_migrations, do: [FillLogsTransactionIndexAddressId.migration_name()]
+  def dependent_from_migrations, do: [FillLogsOptimizedFields.migration_name()]
 
   @impl HeavyDbIndexOperation
   def db_index_operation do

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_address_hash_first_topic_block_number_index_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_address_hash_first_topic_block_number_index_index.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashFirstTopicB
 
   use Explorer.Migrator.HeavyDbIndexOperation
 
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
   alias Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashBlockNumberDescIndexDescIndex
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
@@ -26,7 +26,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashFirstTopicB
   @impl HeavyDbIndexOperation
   def dependent_from_migrations,
     do: [
-      FillLogsTransactionIndexAddressId.migration_name(),
+      FillLogsOptimizedFields.migration_name(),
       DropLogsAddressHashBlockNumberDescIndexDescIndex.migration_name()
     ]
 

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_deposits_withdrawals_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/drop_logs_deposits_withdrawals_index.ex
@@ -8,7 +8,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsDepositsWithdrawalsInd
 
   use Explorer.Migrator.HeavyDbIndexOperation
 
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
 
   alias Explorer.Migrator.HeavyDbIndexOperation.{
     DropLogsAddressHashBlockNumberDescIndexDescIndex,
@@ -33,7 +33,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.DropLogsDepositsWithdrawalsInd
   @impl HeavyDbIndexOperation
   def dependent_from_migrations,
     do: [
-      FillLogsTransactionIndexAddressId.migration_name(),
+      FillLogsOptimizedFields.migration_name(),
       DropLogsAddressHashBlockNumberDescIndexDescIndex.migration_name(),
       DropLogsAddressHashFirstTopicBlockNumberIndexIndex.migration_name()
     ]

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/validate_logs_block_number_transaction_index_not_null.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/validate_logs_block_number_transaction_index_not_null.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransac
 
   use Explorer.Migrator.HeavyDbIndexOperation
 
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
 
   @table_name :logs
   @index_name "logs_not_null_constraints"
@@ -25,7 +25,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransac
   @impl HeavyDbIndexOperation
   def dependent_from_migrations,
     do: [
-      FillLogsTransactionIndexAddressId.migration_name()
+      FillLogsOptimizedFields.migration_name()
     ]
 
   @impl HeavyDbIndexOperation

--- a/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
+++ b/apps/explorer/lib/explorer/migrator/sanitize_duplicated_log_index_logs.ex
@@ -77,7 +77,9 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogs do
 
         {[id | ids],
          [
-           %Log{log | index: new_index} |> Map.from_struct() |> Map.drop([:block, :address, :transaction, :__meta__])
+           %Log{log | index: new_index}
+           |> Map.from_struct()
+           |> Map.drop([:block, :address, :transaction, :__meta__, :address_by_hash, :address_mapping])
            | logs
          ], Map.put(ids_to_new_index, id, new_index)}
       end)

--- a/apps/explorer/lib/explorer/utility/log_helper.ex
+++ b/apps/explorer/lib/explorer/utility/log_helper.ex
@@ -11,13 +11,13 @@ defmodule Explorer.Utility.LogHelper do
     BackgroundMigrations.get_heavy_indexes_update_logs_primary_key_finished()
   end
 
-  @spec fill_transaction_index_address_id_migration_finished? :: boolean()
-  def fill_transaction_index_address_id_migration_finished? do
-    BackgroundMigrations.get_fill_logs_transaction_index_address_id_finished()
+  @spec fill_optimized_fields_migration_finished? :: boolean()
+  def fill_optimized_fields_migration_finished? do
+    BackgroundMigrations.get_fill_logs_optimized_fields_finished()
   end
 
-  @spec fill_transaction_index_address_id_migration_started? :: boolean()
-  def fill_transaction_index_address_id_migration_started? do
+  @spec fill_optimized_fields_migration_started? :: boolean()
+  def fill_optimized_fields_migration_started? do
     BackgroundMigrations.get_create_logs_block_number_transaction_index_index_unique_index_finished()
   end
 end

--- a/apps/explorer/priv/repo/migrations/20260619133008_create_bytea_ltrim_zeroes_function.exs
+++ b/apps/explorer/priv/repo/migrations/20260619133008_create_bytea_ltrim_zeroes_function.exs
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Repo.Migrations.CreateByteaLtrimZeroesFunction do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE OR REPLACE FUNCTION bytea_ltrim_zeroes(b BYTEA)
+    RETURNS BYTEA AS $$
+    DECLARE
+        i INT := 0;
+    BEGIN
+        WHILE i < octet_length(b) AND get_byte(b, i) = 0 LOOP
+            i := i + 1;
+        END LOOP;
+        RETURN substr(b, i + 1);
+    END;
+    $$ LANGUAGE plpgsql IMMUTABLE STRICT;
+    """)
+  end
+
+  def down do
+    execute("DROP FUNCTION IF EXISTS bytea_ltrim_zeroes(b BYTEA);")
+  end
+end

--- a/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
+++ b/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
@@ -1,10 +1,10 @@
-defmodule Explorer.Migrator.FillLogsTransactionIndexAddressIdTest do
+defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
   use Explorer.DataCase, async: false
 
   import Ecto.Query
 
   alias Explorer.Chain.Log
-  alias Explorer.Migrator.{FillLogsTransactionIndexAddressId, MigrationStatus}
+  alias Explorer.Migrator.{FillLogsOptimizedFields, MigrationStatus}
   alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockNumberTransactionIndexIndexUniqueIndex
   alias Explorer.Repo
   alias Explorer.Utility.AddressIdToAddressHash
@@ -20,9 +20,9 @@ defmodule Explorer.Migrator.FillLogsTransactionIndexAddressIdTest do
 
     assert MigrationStatus.get_status("fill_logs_transaction_index_address_id") == nil
 
-    Application.put_env(:explorer, FillLogsTransactionIndexAddressId, batch_size: 100, timeout: 0)
+    Application.put_env(:explorer, FillLogsOptimizedFields, batch_size: 100, timeout: 0)
 
-    FillLogsTransactionIndexAddressId.start_link([])
+    FillLogsOptimizedFields.start_link([])
 
     wait_for_results(fn ->
       Repo.one!(

--- a/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
+++ b/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
@@ -18,7 +18,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
       "completed"
     )
 
-    assert MigrationStatus.get_status("fill_logs_transaction_index_address_id") == nil
+    assert MigrationStatus.get_status("fill_logs_optimized_fields") == nil
 
     Application.put_env(:explorer, FillLogsOptimizedFields, batch_size: 100, timeout: 0)
 
@@ -27,7 +27,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
     wait_for_results(fn ->
       Repo.one!(
         from(ms in MigrationStatus,
-          where: ms.migration_name == ^"fill_logs_transaction_index_address_id" and ms.status == "completed"
+          where: ms.migration_name == ^"fill_logs_optimized_fields" and ms.status == "completed"
         )
       )
     end)

--- a/apps/explorer/test/explorer/migrator/sanitize_duplicated_log_index_logs_test.exs
+++ b/apps/explorer/test/explorer/migrator/sanitize_duplicated_log_index_logs_test.exs
@@ -58,11 +58,12 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogsTest do
                  updated_logs
                )
 
-        assert %Log{log4 | address: nil, block: nil, transaction: nil} == %Log{
+        assert %Log{log4 | address: nil, block: nil, transaction: nil, address_mapping: nil} == %Log{
                  Repo.one(Log |> where([log], log.block_number != ^block.number))
                  | address: nil,
                    block: nil,
-                   transaction: nil
+                   transaction: nil,
+                   address_mapping: nil
                }
       end
 
@@ -145,11 +146,12 @@ defmodule Explorer.Migrator.SanitizeDuplicatedLogIndexLogsTest do
         assert [%{log_index: 1, block_number: ^block_number}] =
                  Repo.all(TokenTransfer |> where([tt], tt.token_type == "ERC-721"))
 
-        assert %Log{log4 | address: nil, block: nil, transaction: nil} == %Log{
+        assert %Log{log4 | address: nil, block: nil, transaction: nil, address_mapping: nil} == %Log{
                  Repo.one(Log |> where([log], log.block_number != ^block.number))
                  | address: nil,
                    block: nil,
-                   transaction: nil
+                   transaction: nil,
+                   address_mapping: nil
                }
       end
 

--- a/apps/indexer/lib/indexer/fetcher/celo/epoch_block_operations/validator_and_group_payments_prior_l2_migration.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/epoch_block_operations/validator_and_group_payments_prior_l2_migration.ex
@@ -23,10 +23,10 @@ defmodule Indexer.Fetcher.Celo.EpochBlockOperations.ValidatorAndGroupPaymentsPri
       |> where([log], log.first_topic == ^epoch_payment_distributions_signature)
       |> then(fn query ->
         cond do
-          LogHelper.fill_transaction_index_address_id_migration_finished?() ->
+          LogHelper.fill_optimized_fields_migration_finished?() ->
             where(query, [log], is_nil(log.transaction_index))
 
-          LogHelper.fill_transaction_index_address_id_migration_started?() ->
+          LogHelper.fill_optimized_fields_migration_started?() ->
             where(query, [log], is_nil(log.transaction_hash) and is_nil(log.transaction_index))
 
           true ->

--- a/apps/indexer/lib/indexer/fetcher/celo/epoch_block_operations/voter_payments.ex
+++ b/apps/indexer/lib/indexer/fetcher/celo/epoch_block_operations/voter_payments.ex
@@ -3,7 +3,7 @@ defmodule Indexer.Fetcher.Celo.EpochBlockOperations.VoterPayments do
   @moduledoc """
   Fetches voter payments for the epoch block.
   """
-  import Ecto.Query, only: [from: 2, select: 3]
+  import Ecto.Query
 
   import Explorer.Helper,
     only: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -960,10 +960,10 @@ config :explorer, Explorer.Migrator.TransactionHasTokenTransfers,
   batch_size: ConfigHelper.parse_integer_env_var("MIGRATION_TRANSACTION_HAS_TOKEN_TRANSFERS_BATCH_SIZE", 100),
   concurrency: ConfigHelper.parse_integer_env_var("MIGRATION_TRANSACTION_HAS_TOKEN_TRANSFERS_CONCURRENCY", 10)
 
-config :explorer, Explorer.Migrator.FillLogsTransactionIndexAddressId,
-  batch_size: ConfigHelper.parse_integer_env_var("MIGRATION_FILL_LOGS_TRANSACTION_INDEX_ADDRESS_ID_BATCH_SIZE", 30),
-  concurrency: ConfigHelper.parse_integer_env_var("MIGRATION_FILL_LOGS_TRANSACTION_INDEX_ADDRESS_ID_CONCURRENCY", 10),
-  timeout: ConfigHelper.parse_time_env_var("MIGRATION_FILL_LOGS_TRANSACTION_INDEX_ADDRESS_ID_TIMEOUT", "5s")
+config :explorer, Explorer.Migrator.FillLogsOptimizedFields,
+  batch_size: ConfigHelper.parse_integer_env_var("MIGRATION_FILL_LOGS_OPTIMIZED_FIELDS_BATCH_SIZE", 30),
+  concurrency: ConfigHelper.parse_integer_env_var("MIGRATION_FILL_LOGS_OPTIMIZED_FIELDS_CONCURRENCY", 10),
+  timeout: ConfigHelper.parse_time_env_var("MIGRATION_FILL_LOGS_OPTIMIZED_FIELDS_TIMEOUT", "5s")
 
 config :explorer, Explorer.Chain.BridgedToken,
   eth_omni_bridge_mediator: System.get_env("BRIDGED_TOKENS_ETH_OMNI_BRIDGE_MEDIATOR"),

--- a/cspell.json
+++ b/cspell.json
@@ -405,6 +405,8 @@
         "lockedgold",
         "loggable",
         "LPAD",
+        "ltrim",
+        "Ltrim",
         "LUKSO",
         "luxon",
         "mabi",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved log handling and filtering for optimized log fields, including migration-aware topic matching and more reliable topic/value combinations.
  * Added support for compact “trimmed” hash storage and normalized byte trimming to improve consistency across log queries.

* **Bug Fixes**
  * Fixed and aligned address/log matching across background migrations and multiple chain/indexer fetch flows (including optimized join keys and topic handling).
  * Updated migration tracking and indexing prerequisites to use the latest log-fill workflow.

* **Chores / Tests**
  * Renamed and updated tests; added cspell entries for new terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->