### PR TITLE
fix: guard Integer.parse against non-numeric input in ABI array parsing

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -197,8 +197,8 @@ defmodule EthereumJSONRPC.Contract do
 
       el ->
         case Integer.parse(el) do
-          {int, _} -> int
-          :error -> {:error, :invalid_integer}
+          {int, ""} -> int
+          _ -> {:error, :invalid_integer}
         end
     end)
   end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/contract.ex
@@ -196,8 +196,10 @@ defmodule EthereumJSONRPC.Contract do
         el
 
       el ->
-        {int, _} = Integer.parse(el)
-        int
+        case Integer.parse(el) do
+          {int, _} -> int
+          :error -> {:error, :invalid_integer}
+        end
     end)
   end
 


### PR DESCRIPTION
Changes `{int, _} = Integer.parse(el)` to use a case statement that handles non-numeric input gracefully.

Closes #14497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid integer array inputs during contract argument formatting.
  * Invalid values now fail gracefully with a clear error instead of causing an unexpected crash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->