### PR TITLE
fix: return {:error, ...} from verifier try/rescue instead of silent :ok

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -45,6 +45,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
             Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
+        {:error, Exception.message(exception)}
     end
   end
 


### PR DESCRIPTION
The rescue blocks in solidity/verifier.ex and vyper/verifier.ex return `:ok` from Logger.error instead of `{:error, reason}`. This causes CaseClauseError in callers.

Closes #14499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart contract verification error handling so unexpected failures now return a clear error message instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->