### PR TITLE
fix: guard Integer.parse against non-numeric query parameter in AddressController

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -68,11 +68,10 @@ defmodule BlockScoutWeb.AddressController do
 
     items_count =
       if items_count_str do
-        items_count = case Integer.parse(items_count_str) do
+        case Integer.parse(items_count_str) do
           {int, ""} -> int
           _ -> 0
         end
-        items_count
       else
         0
       end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -68,7 +68,10 @@ defmodule BlockScoutWeb.AddressController do
 
     items_count =
       if items_count_str do
-        {items_count, _} = Integer.parse(items_count_str)
+        items_count = case Integer.parse(items_count_str) do
+          {int, _} -> int
+          :error -> 0
+        end
         items_count
       else
         0

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -69,8 +69,8 @@ defmodule BlockScoutWeb.AddressController do
     items_count =
       if items_count_str do
         items_count = case Integer.parse(items_count_str) do
-          {int, _} -> int
-          :error -> 0
+          {int, ""} -> int
+          _ -> 0
         end
         items_count
       else


### PR DESCRIPTION
`apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex:71`

Changes `{items_count, _} = Integer.parse(items_count_str)` to handle non-numeric input gracefully.

Closes #14500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid item count values in the address JSON response, preventing errors when the value is missing or not a valid number.
  * Requests with malformed count input now safely fall back to `0` instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->