### PR TITLE
fix: guard Integer.parse in pagination key parsing against non-numeric input

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/chain.ex
+++ b/apps/block_scout_web/lib/block_scout_web/chain.ex
@@ -191,7 +191,10 @@ defmodule BlockScoutWeb.Chain do
     current_items_count =
       cond do
         is_binary(current_items_count_object) ->
-          {current_items_count, _} = Integer.parse(current_items_count_object)
+          current_items_count = case Integer.parse(current_items_count_object) do
+      {int, _} -> int
+      :error -> 0
+    end
           current_items_count
 
         is_integer(current_items_count_object) ->


### PR DESCRIPTION
`apps/block_scout_web/lib/block_scout_web/chain.ex:194`

Changes `{current_items_count, _} = Integer.parse(...)` to handle non-numeric pagination keys gracefully.

Closes #14501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of item counts when incoming values are invalid or missing, preventing unexpected crashes.
  * The app now safely falls back to zero in these cases and continues calculating totals as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->