### PR TITLE
fix: log error instead of silent empty map on CBOR decode failure

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -491,7 +491,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
       decoded_meta
     else
       _ ->
-        Logger.warning("Failed to decode CBOR metadata from bytecode")
+        Logger.warning("Failed to decode CBOR metadata from bytecode, falling back to empty metadata")
         %{}
     end
   end

--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -491,6 +491,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
       decoded_meta
     else
       _ ->
+        Logger.warning("Failed to decode CBOR metadata from bytecode")
         %{}
     end
   end


### PR DESCRIPTION
`apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex:488-496`

When CBOR metadata in bytecode is corrupt, logs the error instead of silently returning `%{}`.

Closes #14502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning log when contract metadata decoding fails, making issues easier to identify and troubleshoot.
  * Decoding failures still fall back safely to avoid disrupting the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->