### PR TITLE
fix: log warning when bytecode metadata hex parsing fails

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -481,6 +481,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
       {meta, last_2_bytes}
     else
       _ ->
+        Logger.warning("Could not extract CBOR metadata from deployed bytecode")
         {"", ""}
     end
   end


### PR DESCRIPTION
`apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex:479`

Adds logging when the last 2 bytes of bytecode fail to parse as hex, instead of silently falling through.

Closes #14503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contract bytecode metadata extraction by logging a warning when metadata can’t be read, making failures easier to spot during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->