### PR TITLE
fix: prevent nil == nil false positive in constructor argument validation

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -450,7 +450,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
     |> String.reverse()
   end
 
-  defp replace_last_occurrence(_, _), do: nil
+  defp replace_last_occurrence(where, _), do: where
 
   defp parse_constructor_and_return_check_function(abi) do
     constructor_abi = Enum.find(abi, fn el -> el["type"] == "constructor" && el["inputs"] != [] end)


### PR DESCRIPTION
`apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex:441-453`

When `replace_last_occurrence` returns `nil` for both bytecodes (metadata not found), `nil == nil` is `true`, making two different bytecodes appear to match on constructor arguments. Changed to return the original bytecode unchanged when the splitter is not found.

Closes #14504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart contract verification handling so location/context information is preserved when input doesn’t match the expected format.
  * This prevents the app from dropping the original reference in edge cases, making validation behavior more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->