### PR TITLE
chore: Improve endpoint availability fault tolerance

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_checker.ex
@@ -56,6 +56,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   alias EthereumJSONRPC.Utility.EndpointAvailabilityObserver
 
   @check_interval :timer.seconds(1)
+  @sync_interval :timer.minutes(1)
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -64,6 +65,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   def init(_) do
     if Application.get_env(:ethereum_jsonrpc, __MODULE__)[:enabled] do
       schedule_next_check()
+      schedule_sync()
 
       {:ok, %{unavailable_endpoints_arguments: []}}
     else
@@ -133,6 +135,19 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
     {:noreply, %{state | unavailable_endpoints_arguments: new_unavailable_endpoints}}
   end
 
+  def handle_info(:sync, %{unavailable_endpoints_arguments: unavailable_endpoints_arguments} = state) do
+    unavailable_endpoints_arguments
+    |> Enum.map(fn {json_rpc_named_arguments, url_type} ->
+      [url] = json_rpc_named_arguments[:transport_options][:urls]
+      {url_type, url}
+    end)
+    |> EndpointAvailabilityObserver.sync_unavailable_urls()
+
+    schedule_sync()
+
+    {:noreply, state}
+  end
+
   @doc """
   Retrieves the latest block number from an Ethereum node to check endpoint availability.
 
@@ -158,5 +173,9 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityChecker do
   @spec schedule_next_check() :: reference()
   defp schedule_next_check do
     Process.send_after(self(), :check, @check_interval)
+  end
+
+  defp schedule_sync do
+    Process.send_after(self(), :sync, @sync_interval)
   end
 end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/endpoint_availability_observer.ex
@@ -73,6 +73,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
   @max_error_count 3
   @window_duration 3
   @cleaning_interval :timer.seconds(1)
+  @empty_unavailable_endpoints %{ws: [], trace: [], http: [], eth_call: []}
 
   @type url_type :: :ws | :trace | :http | :eth_call
 
@@ -83,7 +84,7 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
   def init(_) do
     schedule_next_cleaning()
 
-    {:ok, %{error_counts: %{}, unavailable_endpoints: %{ws: [], trace: [], http: [], eth_call: []}}}
+    {:ok, %{error_counts: %{}, unavailable_endpoints: @empty_unavailable_endpoints}}
   end
 
   @doc """
@@ -132,6 +133,20 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
   @spec filter_unavailable_urls([String.t()], url_type()) :: [String.t()]
   def filter_unavailable_urls(urls, url_type) do
     GenServer.call(__MODULE__, {:filter_unavailable_urls, urls, url_type})
+  end
+
+  @doc """
+    Sets the actual unavailable endpoints to provided params.
+
+    ## Parameters
+    - `urls_with_types`: List of `{url_type, url}` tuples
+
+    ## Returns
+    - `:ok`
+  """
+  @spec sync_unavailable_urls([{url_type(), String.t()}]) :: :ok
+  def sync_unavailable_urls(urls_with_types) do
+    GenServer.cast(__MODULE__, {:sync_unavailable_urls, urls_with_types})
   end
 
   @doc """
@@ -268,6 +283,15 @@ defmodule EthereumJSONRPC.Utility.EndpointAvailabilityObserver do
 
     {:noreply,
      %{state | unavailable_endpoints: %{unavailable_endpoints | url_type => unavailable_endpoints[url_type] -- [url]}}}
+  end
+
+  def handle_cast({:sync_unavailable_urls, urls_with_types}, state) do
+    unavailable_endpoints =
+      urls_with_types
+      |> Enum.group_by(fn {url_type, _} -> url_type end, fn {_, url} -> url end)
+      |> Map.new()
+
+    {:noreply, %{state | unavailable_endpoints: Map.merge(@empty_unavailable_endpoints, unavailable_endpoints)}}
   end
 
   # For each URL and URL type combination, checks if the last error timestamp is


### PR DESCRIPTION
## Motivation

In case of unexpected crashes of `EndpointAvailabilityChecker` or `EndpointAvailabilityObserver` their states may diverge.

## Changelog

Periodically sync actual unavailable endpoints between `EndpointAvailabilityChecker` and `EndpointAvailabilityObserver`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new periodic background sync to continuously refresh endpoint availability status.
  * Introduced a bulk refresh mechanism to update unavailable endpoints using the latest discovered URL set.

* **Bug Fixes**
  * Improved consistency of how unavailable endpoints are stored, rebuilt, and kept in sync over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->