### PR TITLE
fix: Fix import result merging for chunked data

### DIFF
--- a/apps/explorer/lib/explorer/chain/import.ex
+++ b/apps/explorer/lib/explorer/chain/import.ex
@@ -460,12 +460,19 @@ defmodule Explorer.Chain.Import do
   defp handle_task_results(task_results, acc_changes) do
     Enum.reduce_while(task_results, {:ok, acc_changes}, fn task_result, {:ok, acc_changes_inner} ->
       case task_result do
-        {:ok, {:ok, changes}} -> {:cont, {:ok, Map.merge(acc_changes_inner, changes)}}
+        {:ok, {:ok, changes}} -> {:cont, {:ok, merge_task_result(acc_changes_inner, changes)}}
         {:ok, {:exception, exception, stacktrace}} -> reraise exception, stacktrace
         {:ok, error} -> {:halt, error}
         {:exit, reason} -> {:halt, reason}
         nil -> {:halt, :timeout}
       end
+    end)
+  end
+
+  defp merge_task_result(changes_acc, changes) do
+    Map.merge(changes_acc, changes, fn
+      _k, v1, v2 when is_list(v1) and is_list(v2) -> v1 ++ v2
+      _k, _v1, v2 -> v2
     end)
   end
 

--- a/apps/explorer/test/explorer/chain/import_test.exs
+++ b/apps/explorer/test/explorer/chain/import_test.exs
@@ -482,7 +482,14 @@ defmodule Explorer.Chain.ImportTest do
         }
       }
 
-      Import.all(params)
+      ctb_chunk_size = Application.get_env(:explorer, :token_balances_import_chunk_size)
+      Application.put_env(:explorer, :token_balances_import_chunk_size, 1)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, :token_balances_import_chunk_size, ctb_chunk_size)
+      end)
+
+      assert {:ok, %{address_current_token_balances: [_, _]}} = Import.all(params)
 
       count =
         CurrentTokenBalance


### PR DESCRIPTION
## Motivation

If `Stage.chunk_every/4` is used for any data during `Import.all/1`, the result batch will include records only from the last batch.

## Changelog

Fixed merging import result for same keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how imported results are combined across parallel tasks, ensuring list-based values are preserved and appended correctly instead of being overwritten.
  * More reliably reports imported token balance data, with test coverage updated to verify the expected aggregated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->