### PR TITLE
fix: support v27+ proveBatchesSharedBridge calldata for zkSync

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/zksync/constants/contracts.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/zksync/constants/contracts.ex
@@ -57,6 +57,7 @@ defmodule EthereumJSONRPC.ZkSync.Constants.Contracts do
   @selector_prove_batches "7f61885c"
   @selector_prove_batches_shared_bridge_c37533bb "c37533bb"
   @selector_prove_batches_shared_bridge_e12a6137 "e12a6137"
+  @selector_prove_batches_shared_bridge_9271e450 "9271e450"
 
   @doc """
     Returns selector of the `proveBatches` function
@@ -72,6 +73,11 @@ defmodule EthereumJSONRPC.ZkSync.Constants.Contracts do
     Returns selector of the `proveBatchesSharedBridge` function with selector e12a6137
   """
   def prove_batches_shared_bridge_e12a6137_selector, do: @selector_prove_batches_shared_bridge_e12a6137
+
+  @doc """
+    Returns selector of the `proveBatchesSharedBridge` function with selector 9271e450
+  """
+  def prove_batches_shared_bridge_9271e450_selector, do: @selector_prove_batches_shared_bridge_9271e450
 
   @doc """
     Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
@@ -129,6 +135,31 @@ defmodule EthereumJSONRPC.ZkSync.Constants.Contracts do
       types: [
         # _chainId
         {:uint, 256},
+        # _processBatchFrom
+        {:uint, 256},
+        # _processBatchTo
+        {:uint, 256},
+        # _proofData
+        :bytes
+      ]
+    }
+
+  @doc """
+    Returns selector with ABI (object of `ABI.FunctionSelector`) of the function:
+
+      proveBatchesSharedBridge(
+        address _chainAddress,
+        uint256 _processBatchFrom,
+        uint256 _processBatchTo,
+        bytes calldata _proofData
+      )
+  """
+  def prove_batches_shared_bridge_9271e450_selector_with_abi,
+    do: %ABI.FunctionSelector{
+      function: "proveBatchesSharedBridge",
+      types: [
+        # _chainAddress
+        :address,
         # _processBatchFrom
         {:uint, 256},
         # _processBatchTo

--- a/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
+++ b/apps/indexer/lib/indexer/fetcher/zksync/utils/rpc.ex
@@ -415,6 +415,13 @@ defmodule Indexer.Fetcher.ZkSync.Utils.Rpc do
 
           Enum.to_list(process_from..process_to)
 
+        # v27+ proveBatchesSharedBridge (uint256 _chainId replaced by address _chainAddress)
+        "0x9271e450" <> encoded_params ->
+          [_chain_address, process_from, process_to, _proof_data] =
+            decode_params(encoded_params, ZkSyncContracts.prove_batches_shared_bridge_9271e450_selector_with_abi())
+
+          Enum.to_list(process_from..process_to)
+
         _ ->
           log_error("Unknown calldata format: #{calldata}")
 

--- a/apps/indexer/test/indexer/fetcher/zksync/utils/rpc_test.exs
+++ b/apps/indexer/test/indexer/fetcher/zksync/utils/rpc_test.exs
@@ -73,4 +73,23 @@ defmodule Indexer.Fetcher.ZkSync.Utils.RpcTest do
                ZksyncRpc.fetch_transaction_receipt_by_hash(raw_transaction_hash, json_rpc_named_arguments)
     end
   end
+
+  describe "get_proven_batches_from_calldata/1" do
+    test "returns proven batch numbers from v27+ proveBatchesSharedBridge calldata" do
+      calldata =
+        "0x9271e450" <>
+          # _chainAddress
+          "0000000000000000000000001111111111111111111111111111111111111111" <>
+          # _processBatchFrom
+          "000000000000000000000000000000000000000000000000000000000000000c" <>
+          # _processBatchTo
+          "000000000000000000000000000000000000000000000000000000000000000e" <>
+          # offset to _proofData
+          "0000000000000000000000000000000000000000000000000000000000000080" <>
+          # empty _proofData
+          "0000000000000000000000000000000000000000000000000000000000000000"
+
+      assert ZksyncRpc.get_proven_batches_from_calldata(calldata) == [12, 13, 14]
+    end
+  end
 end


### PR DESCRIPTION
No associated issue.

## Motivation

zkSync v27+ ValidatorTimelock can call `proveBatchesSharedBridge(address,uint256,uint256,bytes)`, which uses selector `0x9271e450`.

Blockscout currently handles the existing `proveBatchesSharedBridge` calldata formats, but not this newer address-based format. As a result, proven batches submitted through this selector are not detected and the zkSync batch status tracker logs `Unknown calldata format` during polling.

## Changelog

### Enhancements

None.

### Bug Fixes

Added support for decoding zkSync v27+ `proveBatchesSharedBridge` calldata with selector `0x9271e450`.

The new ABI variant uses `address _chainAddress` instead of `uint256 _chainId`, then decodes `_processBatchFrom` and `_processBatchTo` to mark the proven batch range.

### Incompatible Changes

None.

## Upgrading

No upgrade steps are required.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it. Not applicable; this is a bug fix.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again. 
- [x] I updated documentation if needed. No documentation changes are needed because this only adds support for an additional existing zkSync calldata format.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description. Not applicable; no API endpoint changes.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools. Not applicable; no DB index changes.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly. Not applicable; no chain type changes.