### PR TITLE
fix: restore per-instance results for on-demand NFT metadata refetch

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -826,7 +826,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   defp maybe_run_fill_metadata_url_task(token_instance, token) do
     if not is_nil(token_instance.metadata) && is_nil(token_instance.skip_metadata_url) do
       Task.async(fn ->
-        BackfillMetadataURL.update_batch([
+        BackfillMetadataURL.update_batch_with_results([
           {token_instance.token_contract_address_hash, token_instance.token_id, token.type}
         ])
       end)

--- a/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
@@ -60,10 +60,11 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
     |> length()
   end
 
-  @doc """
-    Same as `update_batch/1`, but returns the upserted `Explorer.Chain.Token.Instance` records
-    instead of their count. Used by callers that need to inspect the per-instance result (e.g.
-    to detect a `blacklist` error for a single, on-demand refreshed instance).
+  `@doc` """
+    Same as `update_batch/1`, but returns the upserted `Explorer.Chain.Token.Instance` records instead of their count.
+
+    Used by callers that need to inspect the per-instance result (e.g. to detect
+    a `blacklist` error for a single, on-demand refreshed instance).
   """
   @spec update_batch_with_results([any()]) :: [map()]
   def update_batch_with_results(token_instances) do

--- a/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
@@ -55,6 +55,18 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
 
   @impl FillingMigration
   def update_batch(token_instances) do
+    token_instances
+    |> update_batch_with_results()
+    |> length()
+  end
+
+  @doc """
+    Same as `update_batch/1`, but returns the upserted `Explorer.Chain.Token.Instance` records
+    instead of their count. Used by callers that need to inspect the per-instance result (e.g.
+    to detect a `blacklist` error for a single, on-demand refreshed instance).
+  """
+  @spec update_batch_with_results([any()]) :: [map()]
+  def update_batch_with_results(token_instances) do
     now = DateTime.utc_now()
 
     prepared_params =
@@ -64,13 +76,14 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
       |> Enum.map(&process_result/1)
       |> Enum.map(&Map.merge(&1, %{updated_at: now, inserted_at: now}))
 
-    {count, _} =
+    {_, result} =
       Repo.insert_all(Instance, prepared_params,
         on_conflict: token_instance_on_conflict(),
-        conflict_target: [:token_id, :token_contract_address_hash]
+        conflict_target: [:token_id, :token_contract_address_hash],
+        returning: true
       )
 
-    count
+    result
   end
 
   @impl FillingMigration

--- a/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
+++ b/apps/explorer/lib/explorer/migrator/backfill_metadata_url.ex
@@ -60,7 +60,7 @@ defmodule Explorer.Migrator.BackfillMetadataURL do
     |> length()
   end
 
-  `@doc` """
+  @doc """
     Same as `update_batch/1`, but returns the upserted `Explorer.Chain.Token.Instance` records instead of their count.
 
     Used by callers that need to inspect the per-instance result (e.g. to detect


### PR DESCRIPTION
## Motivation

`Explorer.Migrator.BackfillMetadataURL.update_batch/1` was changed in #14493 to return an upsert count (`non_neg_integer()`) instead of the upserted records, to support the `FillingMigration` scheduling behaviour. However, `BlockScoutWeb.Api.V2.TokenController.instance/2` also calls this function directly for on-demand metadata refetch, and relies on getting back `[%{error: error}]` to detect a blacklisted/invalid `tokenURI` and drop stale metadata from the API response. Since the change, that pattern match never succeeds, so the API kept returning stale metadata even when the URI was blacklisted (e.g. pointing at a reserved/private IP for SSRF protection).

## Changelog

### Bug Fixes

- Added `Explorer.Migrator.BackfillMetadataURL.update_batch_with_results/1`, which performs the same upsert as `update_batch/1` but returns the list of upserted `Explorer.Chain.Token.Instance` records (via `returning: true`) instead of a count. `update_batch/1` now delegates to it and returns the record count, preserving the `FillingMigration` callback contract used for scheduling.
- Updated `BlockScoutWeb.Api.V2.TokenController` to call `update_batch_with_results/1` for the on-demand single-instance refetch, so a blacklisted `tokenURI` correctly nils out `metadata` in the `GET /api/v2/tokens/:address_hash/instances/:token_id` response, matching the existing regression test `"metadata dropped on token uri on demand filler"`.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again. _(existing test at `apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs:1257` now passes and covers this)_
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the background process that backfills missing metadata URL fields for token instances, making updates more consistent.
  * Enhanced batch backfilling behavior so results from each upsert are properly captured, and the batch completion count remains accurate.
  * Preserved existing behavior for tokens that don’t meet the metadata URL update conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->