### PR TITLE
fix: Add missing async importers for token balances and instances

### DIFF
--- a/apps/indexer/lib/indexer/block/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/fetcher.ex
@@ -273,7 +273,7 @@ defmodule Indexer.Block.Fetcher do
              state,
              merge_options(basic_import_options, additional_options)
              |> import_options(chain_type_import_options)
-             |> extend_with_asyncable_import_options(tokens, token_transfers, address_token_balances)
+             |> extend_with_asyncable_import_options(tokens, token_transfers, address_token_balances, callback_module)
            ) do
       Prometheus.Instrumenter.set_block_batch_fetch(fetch_time, callback_module)
       result = {:ok, %{inserted: inserted, errors: blocks_errors}}
@@ -460,7 +460,7 @@ defmodule Indexer.Block.Fetcher do
 
   defp merge_option_values(_value1, value2), do: value2
 
-  defp extend_with_asyncable_import_options(import_options, tokens, token_transfers, token_balances) do
+  defp extend_with_asyncable_import_options(import_options, tokens, token_transfers, token_balances, callback_module) do
     current_token_balances_params =
       token_balances
       |> MapSet.to_list()
@@ -468,7 +468,7 @@ defmodule Indexer.Block.Fetcher do
 
     if enable_partial_async_import?() do
       TokenInstanceImporter.add(tokens, token_transfers)
-      CurrentTokenBalanceImporter.add(current_token_balances_params)
+      CurrentTokenBalanceImporter.add(current_token_balances_params, callback_module == Indexer.Block.Realtime.Fetcher)
       import_options
     else
       token_instances = TokenInstances.params_set(%{token_transfers_params: token_transfers})
@@ -585,8 +585,8 @@ defmodule Indexer.Block.Fetcher do
     result
   end
 
-  def async_import_token_instances(%{token_transfers: token_transfers}) do
-    TokenInstanceRealtime.async_fetch(token_transfers)
+  def async_import_token_instances(%{token_instances: token_instances}) do
+    TokenInstanceRealtime.async_fetch(token_instances)
   end
 
   def async_import_token_instances(_), do: :ok

--- a/apps/indexer/lib/indexer/fetcher/address_importer.ex
+++ b/apps/indexer/lib/indexer/fetcher/address_importer.ex
@@ -70,6 +70,10 @@ defmodule Indexer.Fetcher.AddressImporter do
     {:noreply, state}
   end
 
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
+
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
     {:noreply, state}
   end

--- a/apps/indexer/lib/indexer/fetcher/current_token_balance_importer.ex
+++ b/apps/indexer/lib/indexer/fetcher/current_token_balance_importer.ex
@@ -9,6 +9,7 @@ defmodule Indexer.Fetcher.CurrentTokenBalanceImporter do
   require Logger
 
   alias Explorer.Chain
+  alias Indexer.Block.Fetcher
 
   @default_update_interval :timer.minutes(1)
 
@@ -33,20 +34,25 @@ defmodule Indexer.Fetcher.CurrentTokenBalanceImporter do
     {:ok, %{}}
   end
 
-  def add(ctb_params) do
-    GenServer.cast(__MODULE__, {:add, ctb_params})
+  def add(ctb_params, realtime? \\ false) do
+    GenServer.cast(__MODULE__, {:add, ctb_params, realtime?})
   end
 
-  def handle_cast({:add, ctb_params}, state) do
+  def handle_cast({:add, ctb_params, realtime?}, state) do
     result_state =
       Enum.reduce(ctb_params, state, fn params, acc ->
         key = {params.address_hash, params.token_contract_address_hash, params.token_id}
         existing_record = acc[key]
 
-        if is_nil(existing_record) or existing_record.block_number <= params.block_number do
-          Map.put(acc, key, params)
-        else
-          acc
+        cond do
+          is_nil(existing_record) ->
+            Map.put(acc, key, {params, realtime?})
+
+          elem(existing_record, 0).block_number <= params.block_number ->
+            Map.put(acc, key, {params, elem(existing_record, 1) or realtime?})
+
+          true ->
+            acc
         end
       end)
 
@@ -71,6 +77,10 @@ defmodule Indexer.Fetcher.CurrentTokenBalanceImporter do
     {:noreply, state}
   end
 
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
+
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
     {:noreply, state}
   end
@@ -83,10 +93,22 @@ defmodule Indexer.Fetcher.CurrentTokenBalanceImporter do
   defp do_update(ctb_map) when ctb_map == %{}, do: ctb_map
 
   defp do_update(ctb_map) do
-    ctb_params = Map.values(ctb_map)
+    ctb_params =
+      ctb_map
+      |> Map.values()
+      |> Enum.map(&elem(&1, 0))
 
     case Chain.import(%{address_current_token_balances: %{params: ctb_params}, timeout: :infinity}) do
-      {:ok, _imported} ->
+      {:ok, %{address_current_token_balances: imported}} ->
+        {realtime_imported, catchup_imported} =
+          Enum.split_with(
+            imported,
+            &elem(ctb_map[{&1.address_hash, &1.token_contract_address_hash, &1.token_id}] || {nil, false}, 1)
+          )
+
+        Fetcher.async_import_current_token_balances(%{address_current_token_balances: realtime_imported}, true)
+        Fetcher.async_import_current_token_balances(%{address_current_token_balances: catchup_imported}, false)
+
         Logger.info("[CurrentTokenBalanceImporter] imported #{Enum.count(ctb_params)} balances")
 
         %{}

--- a/apps/indexer/lib/indexer/fetcher/token_instance/realtime.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance/realtime.ex
@@ -59,19 +59,15 @@ defmodule Indexer.Fetcher.TokenInstance.Realtime do
 
   def async_fetch(_data, true), do: :ok
 
-  def async_fetch(token_transfers, _disabled?) when is_list(token_transfers) do
+  def async_fetch(token_instances, _disabled?) when is_list(token_instances) do
     data =
-      token_transfers
-      |> Enum.reject(fn token_transfer -> is_nil(token_transfer.token_ids) end)
-      |> Enum.map(fn token_transfer ->
-        Enum.map(token_transfer.token_ids, fn token_id ->
-          %{
-            contract_address_hash: token_transfer.token_contract_address_hash,
-            token_id: token_id
-          }
-        end)
+      token_instances
+      |> Enum.map(fn token_instance ->
+        %{
+          contract_address_hash: token_instance.token_contract_address_hash,
+          token_id: token_instance.token_id
+        }
       end)
-      |> List.flatten()
       |> Enum.uniq()
 
     BufferedTask.buffer(__MODULE__, data, true)

--- a/apps/indexer/lib/indexer/fetcher/token_instance_importer.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_instance_importer.ex
@@ -9,6 +9,7 @@ defmodule Indexer.Fetcher.TokenInstanceImporter do
   require Logger
 
   alias Explorer.Chain
+  alias Indexer.Block.Fetcher
   alias Indexer.Transform.TokenInstances
 
   @default_update_interval :timer.minutes(1)
@@ -73,6 +74,10 @@ defmodule Indexer.Fetcher.TokenInstanceImporter do
     {:noreply, state}
   end
 
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    {:noreply, state}
+  end
+
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
     {:noreply, state}
   end
@@ -93,7 +98,9 @@ defmodule Indexer.Fetcher.TokenInstanceImporter do
            token_instances: %{params: token_instances_params},
            timeout: :infinity
          }) do
-      {:ok, _imported} ->
+      {:ok, imported} ->
+        Fetcher.async_import_token_instances(imported)
+
         Logger.info(
           "TokenInstanceImporter imported #{Enum.count(tokens_params)} tokens and #{Enum.count(token_instances_params)} token instances"
         )

--- a/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_instance/realtime_test.exs
@@ -112,7 +112,7 @@ defmodule Indexer.Fetcher.TokenInstance.RealtimeTest do
         )
 
       TokenInstanceRealtime.async_fetch([
-        %{token_contract_address_hash: token.contract_address_hash, token_ids: [Decimal.new(777)]}
+        %{token_contract_address_hash: token.contract_address_hash, token_id: Decimal.new(777)}
       ])
 
       instance =


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14277

## Changelog

- Handle `:normal` task exit in async importers
- Added async import token instances and balances after successful import of placeholders in `TokenInstanceImporter` and `CurrentTokenBalanceImporter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token instance syncing to pull from the correct dataset and build requests with a single token ID per instance.
  * Improved token balance updates to better distinguish realtime versus catchup processing after successful imports.
  * Reduced background noise by gracefully ignoring normal process-exit signals during address and token instance imports.
* **Tests**
  * Updated token instance realtime fetch expectations to match the revised request payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->