### PR TITLE
fix: replace dets bind-mount with named volume to prevent permission errors on container startup

### DIFF
--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -14,4 +14,7 @@ services:
       -  ../envs/common-blockscout.env
     volumes:
       - ./logs/:/app/logs/
-      - ./dets/:/app/dets/
+      - backend-dets:/app/dets/
+
+volumes:
+  backend-dets:


### PR DESCRIPTION
## Summary

Closes #13583

When using `backend.yml` with a bind-mounted `./dets/` directory owned by `root:root` on the host, the container's non-root user (`blockscout`, UID 10001) cannot write to it. This causes an `eacces` error when the indexer tries to open `./dets/queue_storage`, crashing the BEAM VM before Phoenix ever starts — resulting in `502 Bad Gateway` on all API endpoints.

---

## Changelog

**Bug Fixes**
- Replaced the `./dets/:/app/dets/` bind-mount in `docker-compose/services/backend.yml` with a Docker named volume (`backend-dets`). Docker manages the named volume's ownership automatically, so the non-root container user always has write access regardless of host directory ownership.
- `./logs/` keeps its bind-mount since users need direct host access to log files.

**Enhancements:** None.

**Incompatible Changes**
- Users who previously relied on `./dets/` as a bind-mount for persistence will need to migrate their existing DETS data into the new named volume, or accept that the volume starts fresh. DETS data is a local queue cache and is safe to lose — the indexer will rebuild it on next startup.

---

## Upgrading

If you have existing data in `./dets/` that you want to preserve:

```bash
# Copy existing dets data into the new named volume
docker run --rm \
  -v ./dets:/source \
  -v blockscout_backend-dets:/app/dets \
  alpine sh -c "cp -r /source/. /app/dets/"
```

Otherwise, simply run `docker compose up` — the named volume will be created automatically with correct ownership.

---

## Checklist

- [x] Does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] Bug fixed — bind-mount replaced with named volume; no regression test applicable (infrastructure-only change).
- [x] Documentation updated if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [x] API endpoints not modified — Swagger/OpenAPI schemas unaffected.
- [x] No new DB indices added.
- [ ] Chain type not added/removed — GitHub CI matrix unchanged.

---

## Risk & Impact

**Low.** Single-file change in `docker-compose/services/backend.yml`. The named volume is created automatically by Docker Compose on first run with correct ownership — no manual intervention required for fresh installs. Existing installs with DETS data can migrate via the one-liner above; DETS data is a rebuildable queue cache, so loss is safe.

**Type:** 🐛 Bug fix
**Closes:** #13583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend data storage to use a Docker-managed volume for improved persistence and portability.
  * Added the necessary volume configuration to support the new storage setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->