### PR TITLE
fix(HeavyDbIndexOperation): prevent deadlocks on fresh DB by serializing same-table index operations in init()

### DIFF
--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
@@ -157,6 +157,9 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
              {:migration_finished?, false} <- {:migration_finished?, migration_finished?()},
              {:dependent_from_migrations_completed?, true} <-
                {:dependent_from_migrations_completed?, dependent_from_migrations_completed?()},
+             {:no_other_heavy_migration_on_same_table?, true} <-
+               {:no_other_heavy_migration_on_same_table?,
+                not running_other_heavy_migration_exists?(migration_name())},
              {:db_index_operation, :ok} <- {:db_index_operation, db_index_operation()} do
           MigrationStatus.set_status(migration_name(), "completed")
           update_cache()

--- a/apps/explorer/test/explorer/migrator/heavy_db_index_operation/green_install_no_deadlock_test.exs
+++ b/apps/explorer/test/explorer/migrator/heavy_db_index_operation/green_install_no_deadlock_test.exs
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Migrator.HeavyDbIndexOperation.GreenInstallNoDeadlockTest do
+  use Explorer.DataCase, async: false
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockHashIndex
+  alias Explorer.Migrator.HeavyDbIndexOperation.DropLogsBlockNumberAscIndexAscIndex
+
+  describe "Green install: same-table migrations run sequentially without deadlocks" do
+    setup do
+      configuration = Application.get_env(:explorer, HeavyDbIndexOperation)
+      Application.put_env(:explorer, HeavyDbIndexOperation, check_interval: 200)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, HeavyDbIndexOperation, configuration)
+      end)
+
+      :ok
+    end
+
+    test "two migrations on the same table do not run db_index_operation concurrently in init()" do
+      # Both migrations operate on the :logs table
+      create_migration_name = "heavy_indexes_create_logs_block_hash_index"
+      drop_migration_name = "heavy_indexes_drop_logs_block_number_asc__index_asc_index"
+
+      # Ensure clean state: no blocks exist (green install), no migration statuses
+      assert MigrationStatus.get_status(create_migration_name) == nil
+      assert MigrationStatus.get_status(drop_migration_name) == nil
+
+      # Start both migrations simultaneously (simulating application boot)
+      CreateLogsBlockHashIndex.start_link([])
+      DropLogsBlockNumberAscIndexAscIndex.start_link([])
+
+      # Wait for the async polling cycle to process
+      Process.sleep(500)
+
+      # Both should eventually complete without deadlock errors
+      # The key assertion: neither migration crashed, both reached a valid state
+      create_status = MigrationStatus.get_status(create_migration_name)
+      drop_status = MigrationStatus.get_status(drop_migration_name)
+
+      # At least one should be completed (the one that ran first in init())
+      # The other may be "started" or "completed" depending on timing
+      completed_count =
+        Enum.count([create_status, drop_status], fn status -> status == "completed" end)
+
+      started_count =
+        Enum.count([create_status, drop_status], fn status -> status == "started" end)
+
+      # Both migrations should be in a valid non-error state
+      assert completed_count + started_count == 2
+
+      # Verify the create index exists and is valid
+      create_index_name = "logs_block_hash_index"
+      assert Helper.db_index_exists_and_valid?(create_index_name) == %{exists?: true, valid?: true}
+
+      # Verify the drop index no longer exists
+      drop_index_name = "logs_block_number_ASC_index_ASC_index"
+      drop_index_status = Helper.db_index_exists_and_valid?(drop_index_name)
+      assert drop_index_status == %{exists?: false, valid?: nil}
+    end
+
+    test "migration with unmet dependencies defers to async path on green install" do
+      migration_name = "heavy_indexes_create_logs_address_hash_block_number_desc_index_desc_index"
+      index_name = "logs_address_hash_block_number_DESC_index_DESC_index"
+
+      assert MigrationStatus.get_status(migration_name) == nil
+
+      # Start migration without its dependencies being completed
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashBlockNumberDescIndexDescIndex.start_link([])
+      Process.sleep(100)
+
+      # On green install with unmet deps, it should NOT run db_index_operation in init()
+      # Status should remain nil (not "completed" and not "started" yet)
+      assert MigrationStatus.get_status(migration_name) == nil
+
+      # Now mark dependencies as completed
+      insert(:db_migration_status,
+        migration_name: "heavy_indexes_drop_logs_block_number_asc__index_asc_index",
+        status: "completed"
+      )
+
+      insert(:db_migration_status, migration_name: "heavy_indexes_create_logs_block_hash_index", status: "completed")
+
+      # Wait for polling cycle to pick up the completed deps
+      Process.sleep(500)
+
+      assert MigrationStatus.get_status(migration_name) == "completed"
+      assert Helper.db_index_exists_and_valid?(index_name) == %{exists?: true, valid?: true}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

On green install (fresh database), all ~50+ `HeavyDbIndexOperation` GenServers start simultaneously and run `db_index_operation()` synchronously during `init()`. This causes PostgreSQL deadlocks (`40P01`) when multiple `CREATE/DROP INDEX CONCURRENTLY` operations compete for `ShareUpdateExclusiveLock` on the same table.

---

## Changes

- Added `running_other_heavy_migration_exists?()` guard to the green install path in `init()`, so migrations on the same table serialize through the async polling mechanism instead of running DDL concurrently.
- Added test `green_install_no_deadlock_test.exs` with two scenarios:
  1. Two same-table migrations started simultaneously complete without deadlock.
  2. Migration with unmet dependencies defers to async path on green install.

---

## How to Test

```bash
mix test test/explorer/migrator/heavy_db_index_operation/green_install_no_deadlock_test.exs
```

Deploy on a fresh database and verify no deadlock errors in logs.

---

## Checklist

- [x] Tests added — 2 scenarios in `green_install_no_deadlock_test.exs`
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** Adds a guard to an existing code path. Completed migrations still short-circuit via `:ignore`. Only affects the green install scenario — existing installs with already-completed migrations are unaffected.

**Type:** 🐛 Bug fix
**Closes:** #12795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of database index migrations during installs, reducing the risk of deadlocks when multiple migrations run at once.
  * Ensured migrations with unmet dependencies wait appropriately before running, helping installs complete more consistently.
* **Tests**
  * Added coverage for simultaneous heavy index migrations and dependency-driven install flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->