### PR TITLE
feat: Add api/v2/tokens/batch

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -813,6 +813,57 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     end
   end
 
+  @max_batch_size 50
+
+  operation :tokens_batch,
+    summary: "Get token info for a batch of token addresses",
+    description: "Retrieves token information for a list of token contract addresses.",
+    parameters: base_params(),
+    request_body:
+      {"List of token contract address hashes", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{
+           address_hashes: %Schema{
+             type: :array,
+             items: Schemas.General.AddressHash,
+             maxItems: @max_batch_size
+           }
+         },
+         required: [:address_hashes]
+       }},
+    responses: [
+      ok:
+        {"List of tokens for given addresses.", "application/json",
+         %Schema{type: :array, items: Schemas.Token.Response}},
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
+
+  @doc """
+  Handles POST requests to `/api/v2/tokens/batch` endpoint.
+  """
+  @spec tokens_batch(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def tokens_batch(%Conn{body_params: %{address_hashes: address_hashes}} = conn, _params)
+      when is_list(address_hashes) do
+    valid_hashes =
+      address_hashes
+      |> Enum.flat_map(fn hash_string ->
+        case Chain.string_to_address_hash(hash_string) do
+          {:ok, hash} -> [hash]
+          _ -> []
+        end
+      end)
+      |> Enum.uniq()
+
+    tokens = Token.get_by_contract_address_hashes(valid_hashes, @token_options)
+
+    conn
+    |> put_status(200)
+    |> render(:tokens_batch, %{tokens: tokens})
+  end
+
+  def tokens_batch(_conn, _params), do: {:format, nil}
+
   defp get_api_key(conn) do
     case Conn.get_req_header(conn, "x-api-key") do
       [api_key] ->

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -842,14 +842,25 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   @doc """
   Handles POST requests to `/api/v2/tokens/batch` endpoint.
   """
-  @spec tokens_batch(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def tokens_batch(%Conn{body_params: %{address_hashes: address_hashes}} = conn, _params)
-      when is_list(address_hashes) do
+  @spec tokens_batch(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:format, nil}
+  def tokens_batch(conn, params) do
+    case conn.body_params do
+      %{address_hashes: address_hashes} when is_list(address_hashes) ->
+        do_tokens_batch(conn, params, address_hashes)
+
+      _ ->
+        {:format, nil}
+    end
+  end
+
+  defp do_tokens_batch(conn, params, address_hashes) do
     valid_hashes =
       address_hashes
       |> Enum.flat_map(fn hash_string ->
-        case Chain.string_to_address_hash(hash_string) do
-          {:ok, hash} -> [hash]
+        with {:ok, hash} <- Chain.string_to_address_hash(hash_string),
+             {:ok, false} <- AccessHelper.restricted_access?(hash_string, params) do
+          [hash]
+        else
           _ -> []
         end
       end)
@@ -861,8 +872,6 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     |> put_status(200)
     |> render(:tokens_batch, %{tokens: tokens})
   end
-
-  def tokens_batch(_conn, _params), do: {:format, nil}
 
   defp get_api_key(conn) do
     case Conn.get_req_header(conn, "x-api-key") do

--- a/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
@@ -73,6 +73,8 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
       V2.TokenController,
       :trigger_nft_collection_metadata_refetch
     )
+
+    post("/batch", V2.TokenController, :tokens_batch)
   end
 
   scope "/", as: :api_v2 do

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/token_view.ex
@@ -70,6 +70,10 @@ defmodule BlockScoutWeb.API.V2.TokenView do
     %{"items" => Enum.map(tokens, &render("token.json", %{token: &1})), "next_page_params" => next_page_params}
   end
 
+  def render("tokens_batch.json", %{tokens: tokens}) do
+    Enum.map(tokens, &render("token.json", %{token: &1}))
+  end
+
   def render("token_instances.json", %{
         token_instances: token_instances,
         next_page_params: next_page_params,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -2855,6 +2855,107 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     )
   end
 
+  describe "POST /tokens/batch" do
+    test "get token info for a batch of addresses", %{conn: conn} do
+      token1 = insert(:token)
+      token2 = insert(:token)
+
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{
+          "address_hashes" => [
+            to_string(token1.contract_address.hash),
+            to_string(token2.contract_address.hash)
+          ]
+        })
+
+      assert response = json_response(request, 200)
+      assert is_list(response)
+      assert length(response) == 2
+
+      hashes = Enum.map(response, & &1["address_hash"])
+      assert Address.checksum(token1.contract_address.hash) in hashes
+      assert Address.checksum(token2.contract_address.hash) in hashes
+
+      Enum.each(response, fn item ->
+        token =
+          if item["address_hash"] == Address.checksum(token1.contract_address.hash),
+            do: token1,
+            else: token2
+
+        compare_item(token, item)
+      end)
+    end
+
+    test "returns empty list for non-existing tokens", %{conn: conn} do
+      address = build(:address)
+
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{
+          "address_hashes" => [to_string(address.hash)]
+        })
+
+      assert json_response(request, 200) == []
+    end
+
+    test "rejects invalid address hashes", %{conn: conn} do
+      token = insert(:token)
+
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{
+          "address_hashes" => [
+            to_string(token.contract_address.hash),
+            "0xinvalid",
+            "not_a_hash"
+          ]
+        })
+
+      assert %{"errors" => [_ | _]} = Phoenix.ConnTest.json_response(request, 422)
+    end
+
+    test "returns empty list for empty input", %{conn: conn} do
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{"address_hashes" => []})
+
+      assert json_response(request, 200) == []
+    end
+
+    test "deduplicates address hashes", %{conn: conn} do
+      token = insert(:token)
+      hash = to_string(token.contract_address.hash)
+
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{
+          "address_hashes" => [hash, hash, hash]
+        })
+
+      assert response = json_response(request, 200)
+      assert length(response) == 1
+      compare_item(token, List.first(response))
+    end
+
+    test "rejects batch exceeding max size", %{conn: conn} do
+      hashes = for i <- 1..51, do: "0x" <> String.pad_leading(Integer.to_string(i), 40, "0")
+
+      request =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v2/tokens/batch", %{"address_hashes" => hashes})
+
+      assert %{"errors" => [%{"detail" => detail}]} = Phoenix.ConnTest.json_response(request, 422)
+      assert detail =~ "maxItems"
+    end
+  end
+
   describe "/tokens/{address_hash}/instances/{token_id}/media-type" do
     test "get 404 on non existing address", %{conn: conn} do
       token = build(:token)


### PR DESCRIPTION
## Motivation

## Changelog
- Add `api/v2/tokens/batch`
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API v2 endpoint to perform batch token lookups for multiple address hashes in a single request.
  * Introduced a dedicated response format that returns matched tokens as a list.

* **Bug Fixes**
  * Improved input handling by rejecting invalid address hashes with a clear validation error.
  * Requests with empty inputs return an empty result.
  * Duplicate address hashes are deduplicated to avoid repeated results.
  * Requests exceeding the maximum batch size return a 422 validation error mentioning the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->