### PR TITLE
fix: guard Integer.parse against malformed version strings in Solidit…

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -318,8 +318,10 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
           |> String.replace("v", "")
           |> String.split(".")
           |> Enum.map(fn str ->
-            {num, _} = Integer.parse(str)
-            num
+            case Integer.parse(str) do
+              {num, _} -> num
+              :error -> 0
+            end
           end)
 
         Enum.fetch!(digits, 0) > 0 || Enum.fetch!(digits, 1) >= 6


### PR DESCRIPTION
Originally created in https://github.com/blockscout/blockscout/pull/14547

## Problem

Closes #14505

`apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex:321` had an unguarded `Integer.parse/1` call:

```elixir
{num, _} = Integer.parse(str)
```

If `str` is not a valid integer (e.g. malformed version string), `Integer.parse/1` returns `:error`, causing a `FunctionClauseError` crash.

## Fix

Added a `case` to handle the `:error` return from `Integer.parse/1`, defaulting to `0` for non-numeric segments. This prevents a crash on malformed version strings while preserving existing behavior for valid versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solidity compiler version handling so version checks no longer fail when a version component isn’t a plain integer.
  * Made version comparison more tolerant, helping compiler detection continue smoothly instead of stopping on parsing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->