### PR TITLE
fix: use /coins/markets endpoint to fetch circulating_supply for tokens

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -268,6 +268,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
             fragment("COALESCE(EXCLUDED.circulating_market_cap, ?)", token.circulating_market_cap),
           volume_24h: fragment("COALESCE(EXCLUDED.volume_24h, ?)", token.volume_24h),
           circulating_supply: fragment("COALESCE(EXCLUDED.circulating_supply, ?)", token.circulating_supply),
+          total_supply: fragment("COALESCE(EXCLUDED.total_supply, ?)", token.total_supply),
           icon_url: fragment("COALESCE(?, EXCLUDED.icon_url)", token.icon_url),
           decimals: fragment("COALESCE(?, EXCLUDED.decimals)", token.decimals),
           inserted_at: fragment("LEAST(?, EXCLUDED.inserted_at)", token.inserted_at),
@@ -276,7 +277,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
       ],
       where:
         fragment(
-          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.type, EXCLUDED.fiat_value, EXCLUDED.circulating_market_cap, EXCLUDED.volume_24h, EXCLUDED.circulating_supply, EXCLUDED.icon_url, EXCLUDED.decimals) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          "(EXCLUDED.name, EXCLUDED.symbol, EXCLUDED.type, EXCLUDED.fiat_value, EXCLUDED.circulating_market_cap, EXCLUDED.volume_24h, EXCLUDED.circulating_supply, EXCLUDED.total_supply, EXCLUDED.icon_url, EXCLUDED.decimals) IS DISTINCT FROM (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
           token.name,
           token.symbol,
           token.type,
@@ -284,6 +285,7 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           token.circulating_market_cap,
           token.volume_24h,
           token.circulating_supply,
+          token.total_supply,
           token.icon_url,
           token.decimals
         )
@@ -309,10 +311,11 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           | :circulating_market_cap
           | :volume_24h
           | :circulating_supply
+          | :total_supply
           | :decimals
         ]
   def market_data_fields_to_update do
-    [:name, :symbol, :type, :fiat_value, :circulating_market_cap, :volume_24h, :circulating_supply, :decimals]
+    [:name, :symbol, :type, :fiat_value, :circulating_market_cap, :volume_24h, :circulating_supply, :total_supply, :decimals]
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/tokens.ex
@@ -315,7 +315,17 @@ defmodule Explorer.Chain.Import.Runner.Tokens do
           | :decimals
         ]
   def market_data_fields_to_update do
-    [:name, :symbol, :type, :fiat_value, :circulating_market_cap, :volume_24h, :circulating_supply, :total_supply, :decimals]
+    [
+      :name,
+      :symbol,
+      :type,
+      :fiat_value,
+      :circulating_market_cap,
+      :volume_24h,
+      :circulating_supply,
+      :total_supply,
+      :decimals
+    ]
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/market/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/market/source/coin_gecko.ex
@@ -47,11 +47,11 @@ defmodule Explorer.Market.Source.CoinGecko do
 
     case Source.http_request(
            base_url()
-           |> URI.append_path("/simple/price")
-           |> URI.append_query("vs_currencies=#{config(:currency)}")
-           |> URI.append_query("include_market_cap=true")
-           |> URI.append_query("include_24hr_vol=true")
+           |> URI.append_path("/coins/markets")
+           |> URI.append_query("vs_currency=#{config(:currency)}")
            |> URI.append_query("ids=#{joined_token_ids}")
+           |> URI.append_query("per_page=#{batch_size}")
+           |> URI.append_query("page=1")
            |> URI.to_string(),
            headers()
          ) do
@@ -214,19 +214,24 @@ defmodule Explorer.Market.Source.CoinGecko do
   end
 
   defp put_market_data_to_tokens(tokens, market_data) do
-    currency = config(:currency)
-    market_cap = currency <> "_market_cap"
-    volume_24h = currency <> "_24h_vol"
+    # /coins/markets returns an array of coin objects keyed by "id"
+    market_data_map =
+      market_data
+      |> Enum.reduce(%{}, fn coin_data, acc ->
+        Map.put(acc, coin_data["id"], coin_data)
+      end)
 
     tokens
     |> Enum.reduce([], fn token, to_import ->
-      case Map.fetch(market_data, token.id) do
-        {:ok, %{^currency => fiat_value, ^market_cap => market_cap, ^volume_24h => volume_24h}} ->
+      case Map.fetch(market_data_map, token.id) do
+        {:ok, coin_data} ->
           token_with_market_data =
             Map.merge(token, %{
-              fiat_value: Source.to_decimal(fiat_value),
-              circulating_market_cap: Source.to_decimal(market_cap),
-              volume_24h: Source.to_decimal(volume_24h)
+              fiat_value: Source.to_decimal(coin_data["current_price"]),
+              circulating_market_cap: Source.to_decimal(coin_data["market_cap"]),
+              volume_24h: Source.to_decimal(coin_data["total_volume"]),
+              circulating_supply: Source.to_decimal(coin_data["circulating_supply"]),
+              total_supply: Source.to_decimal(coin_data["total_supply"])
             })
 
           [token_with_market_data | to_import]

--- a/apps/explorer/test/explorer/market/fetcher/token_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/token_test.exs
@@ -37,11 +37,15 @@ defmodule Explorer.Market.Fetcher.TokenTest do
 
       Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
+      previous_fetcher_enabled = :persistent_term.get(:market_token_fetcher_enabled, false)
+      :persistent_term.put(:market_token_fetcher_enabled, true)
+
       on_exit(fn ->
         Application.put_env(:explorer, Explorer.Market.Source, source_configuration)
         Application.put_env(:explorer, Explorer.Market.Fetcher.Token, fetcher_configuration)
         Application.put_env(:explorer, Explorer.Market.Source.CoinGecko, coin_gecko_configuration)
         Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        :persistent_term.put(:market_token_fetcher_enabled, previous_fetcher_enabled)
       end)
 
       [_token_with_no_exchange_rate | tokens] =

--- a/apps/explorer/test/explorer/market/fetcher/token_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/token_test.exs
@@ -399,7 +399,20 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       end)
 
       Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
-        Conn.resp(conn, 200, Utils.JSON.encode!([%{"id" => "zero_token", "current_price" => 0, "market_cap" => 0, "total_volume" => 0, "circulating_supply" => 0, "total_supply" => 0}]))
+        Conn.resp(
+          conn,
+          200,
+          Utils.JSON.encode!([
+            %{
+              "id" => "zero_token",
+              "current_price" => 0,
+              "market_cap" => 0,
+              "total_volume" => 0,
+              "circulating_supply" => 0,
+              "total_supply" => 0
+            }
+          ])
+        )
       end)
 
       GenServer.start_link(TokenFetcher, [])

--- a/apps/explorer/test/explorer/market/fetcher/token_test.exs
+++ b/apps/explorer/test/explorer/market/fetcher/token_test.exs
@@ -74,10 +74,15 @@ defmodule Explorer.Market.Fetcher.TokenTest do
 
       token_exchange_rates =
         tokens
-        |> Enum.reduce(%{}, fn %{contract_address_hash: contract_address_hash}, acc ->
-          Map.put(acc, "#{contract_address_hash}_id", %{
-            "usd" => 1..100 |> Enum.random() |> Decimal.new() |> Decimal.mult(Decimal.from_float(0.7))
-          })
+        |> Enum.map(fn %{contract_address_hash: contract_address_hash} ->
+          %{
+            "id" => "#{contract_address_hash}_id",
+            "current_price" => 1..100 |> Enum.random() |> Decimal.new() |> Decimal.mult(Decimal.from_float(0.7)),
+            "market_cap" => 1..100 |> Enum.random() |> Decimal.new() |> Decimal.mult(Decimal.from_float(0.7)),
+            "total_volume" => 1..100 |> Enum.random() |> Decimal.new() |> Decimal.mult(Decimal.from_float(0.7)),
+            "circulating_supply" => 1_000_000,
+            "total_supply" => 2_000_000
+          }
         end)
 
       joined_ids =
@@ -88,10 +93,10 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       Bypass.expect_once(
         bypass,
         "GET",
-        "/simple/price",
+        "/coins/markets",
         fn conn ->
           assert conn.query_string ==
-                   "vs_currencies=usd&include_market_cap=true&include_24hr_vol=true&ids=#{joined_ids}"
+                   "vs_currency=usd&ids=#{joined_ids}&per_page=10&page=1"
 
           Conn.resp(conn, 200, Utils.JSON.encode!(token_exchange_rates))
         end
@@ -103,7 +108,8 @@ defmodule Explorer.Market.Fetcher.TokenTest do
 
       Repo.all(Token)
       |> Enum.each(fn %{contract_address_hash: contract_address_hash, fiat_value: fiat_value} ->
-        assert token_exchange_rates[contract_address_hash]["usd"] == fiat_value
+        matching = Enum.find(token_exchange_rates, &(&1["id"] == "#{contract_address_hash}_id"))
+        assert matching["current_price"] == fiat_value
       end)
     end
 
@@ -149,12 +155,12 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       Bypass.expect_once(
         bypass,
         "GET",
-        "/simple/price",
+        "/coins/markets",
         fn conn ->
           assert conn.query_string ==
-                   "vs_currencies=usd&include_market_cap=true&include_24hr_vol=true&ids=#{joined_ids}"
+                   "vs_currency=usd&ids=#{joined_ids}&per_page=10&page=1"
 
-          Conn.resp(conn, 200, "{}")
+          Conn.resp(conn, 200, "[]")
         end
       )
 
@@ -208,10 +214,10 @@ defmodule Explorer.Market.Fetcher.TokenTest do
       Bypass.expect(
         bypass,
         "GET",
-        "/simple/price",
+        "/coins/markets",
         fn conn ->
           assert conn.query_string ==
-                   "vs_currencies=usd&include_market_cap=true&include_24hr_vol=true&ids=#{joined_ids}"
+                   "vs_currency=usd&ids=#{joined_ids}&per_page=10&page=1"
 
           Conn.resp(conn, 429, "Too many requests")
         end
@@ -320,15 +326,18 @@ defmodule Explorer.Market.Fetcher.TokenTest do
         Conn.resp(conn, 200, Utils.JSON.encode!(coins_list))
       end)
 
-      token_exchange_rates = %{
-        "returned_token" => %{
-          "usd" => 5.0,
-          "usd_market_cap" => 1000.0,
-          "usd_24h_vol" => 500.0
+      token_exchange_rates = [
+        %{
+          "id" => "returned_token",
+          "current_price" => 5.0,
+          "market_cap" => 1000.0,
+          "total_volume" => 500.0,
+          "circulating_supply" => 1_000_000,
+          "total_supply" => 2_000_000
         }
-      }
+      ]
 
-      Bypass.expect_once(bypass, "GET", "/simple/price", fn conn ->
+      Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
         Conn.resp(conn, 200, Utils.JSON.encode!(token_exchange_rates))
       end)
 
@@ -389,12 +398,8 @@ defmodule Explorer.Market.Fetcher.TokenTest do
         Conn.resp(conn, 200, Utils.JSON.encode!(coins_list))
       end)
 
-      Bypass.expect_once(bypass, "GET", "/simple/price", fn conn ->
-        Conn.resp(
-          conn,
-          200,
-          Utils.JSON.encode!(%{"zero_token" => %{"usd" => 0, "usd_market_cap" => 0, "usd_24h_vol" => 0}})
-        )
+      Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
+        Conn.resp(conn, 200, Utils.JSON.encode!([%{"id" => "zero_token", "current_price" => 0, "market_cap" => 0, "total_volume" => 0, "circulating_supply" => 0, "total_supply" => 0}]))
       end)
 
       GenServer.start_link(TokenFetcher, [])
@@ -439,20 +444,26 @@ defmodule Explorer.Market.Fetcher.TokenTest do
         Conn.resp(conn, 200, Utils.JSON.encode!(coins_list))
       end)
 
-      token_exchange_rates = %{
-        "zero_price_token" => %{
-          "usd" => 0,
-          "usd_market_cap" => 0,
-          "usd_24h_vol" => 0
+      token_exchange_rates = [
+        %{
+          "id" => "zero_price_token",
+          "current_price" => 0,
+          "market_cap" => 0,
+          "total_volume" => 0,
+          "circulating_supply" => 0,
+          "total_supply" => 0
         },
-        "real_price_token" => %{
-          "usd" => 10.0,
-          "usd_market_cap" => 5000.0,
-          "usd_24h_vol" => 100.0
+        %{
+          "id" => "real_price_token",
+          "current_price" => 10.0,
+          "market_cap" => 5000.0,
+          "total_volume" => 100.0,
+          "circulating_supply" => 1_000_000,
+          "total_supply" => 2_000_000
         }
-      }
+      ]
 
-      Bypass.expect_once(bypass, "GET", "/simple/price", fn conn ->
+      Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
         Conn.resp(conn, 200, Utils.JSON.encode!(token_exchange_rates))
       end)
 

--- a/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
+++ b/apps/explorer/test/explorer/market/source/coin_gecko_test.exs
@@ -147,9 +147,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
         Conn.resp(conn, 200, json_coins_list())
       end)
 
-      Bypass.expect_once(bypass, "GET", "/simple/price", fn conn ->
-        assert conn.query_string == "vs_currencies=aed&include_market_cap=true&include_24hr_vol=true&ids=4,3,1"
-        Conn.resp(conn, 200, json_simple_price())
+      Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
+        assert conn.query_string == "vs_currency=aed&ids=4,3,1&per_page=5&page=1"
+        Conn.resp(conn, 200, json_coins_markets())
       end)
 
       assert {:ok, [], true,
@@ -165,7 +165,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
                   },
                   circulating_market_cap: Decimal.new("100"),
                   fiat_value: Decimal.new("1"),
-                  volume_24h: Decimal.new("10")
+                  volume_24h: Decimal.new("10"),
+                  circulating_supply: Decimal.new("1000000"),
+                  total_supply: Decimal.new("2000000")
                 },
                 %{
                   id: "3",
@@ -178,7 +180,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
                   },
                   circulating_market_cap: Decimal.new("300.03"),
                   fiat_value: Decimal.new("3.3"),
-                  volume_24h: Decimal.new("33.333")
+                  volume_24h: Decimal.new("33.333"),
+                  circulating_supply: Decimal.new("3000000"),
+                  total_supply: Decimal.new("6000000")
                 },
                 %{
                   id: "4",
@@ -191,7 +195,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
                   },
                   circulating_market_cap: Decimal.new("4"),
                   fiat_value: Decimal.new("4"),
-                  volume_24h: Decimal.new("4")
+                  volume_24h: Decimal.new("4"),
+                  circulating_supply: Decimal.new("4000000"),
+                  total_supply: Decimal.new("8000000")
                 }
               ]} == CoinGecko.fetch_tokens(nil, 5)
     end
@@ -202,9 +208,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
         Conn.resp(conn, 200, json_coins_list())
       end)
 
-      Bypass.expect_once(bypass, "GET", "/simple/price", fn conn ->
-        assert conn.query_string == "vs_currencies=aed&include_market_cap=true&include_24hr_vol=true&ids=4,3"
-        Conn.resp(conn, 200, json_simple_price())
+      Bypass.expect_once(bypass, "GET", "/coins/markets", fn conn ->
+        assert conn.query_string == "vs_currency=aed&ids=4,3&per_page=2&page=1"
+        Conn.resp(conn, 200, json_coins_markets())
       end)
 
       assert {:ok,
@@ -232,7 +238,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
                   },
                   circulating_market_cap: Decimal.new("300.03"),
                   fiat_value: Decimal.new("3.3"),
-                  volume_24h: Decimal.new("33.333")
+                  volume_24h: Decimal.new("33.333"),
+                  circulating_supply: Decimal.new("3000000"),
+                  total_supply: Decimal.new("6000000")
                 },
                 %{
                   id: "4",
@@ -245,7 +253,9 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
                   },
                   circulating_market_cap: Decimal.new("4"),
                   fiat_value: Decimal.new("4"),
-                  volume_24h: Decimal.new("4")
+                  volume_24h: Decimal.new("4"),
+                  circulating_supply: Decimal.new("4000000"),
+                  total_supply: Decimal.new("8000000")
                 }
               ]} == CoinGecko.fetch_tokens(nil, 2)
     end
@@ -704,25 +714,34 @@ defmodule Explorer.Market.Source.CoinGeckoTest do
     """
   end
 
-  defp json_simple_price do
+  defp json_coins_markets do
     """
-    {
-      "1": {
-        "aed": 1,
-        "aed_market_cap": 100,
-        "aed_24h_vol": 10
+    [
+      {
+        "id": "1",
+        "current_price": 1,
+        "market_cap": 100,
+        "total_volume": 10,
+        "circulating_supply": 1000000,
+        "total_supply": 2000000
       },
-      "3": {
-        "aed": 3.3,
-        "aed_market_cap": 300.03,
-        "aed_24h_vol": 33.333
+      {
+        "id": "3",
+        "current_price": 3.3,
+        "market_cap": 300.03,
+        "total_volume": 33.333,
+        "circulating_supply": 3000000,
+        "total_supply": 6000000
       },
-      "4": {
-        "aed": 4,
-        "aed_market_cap": 4,
-        "aed_24h_vol": 4
+      {
+        "id": "4",
+        "current_price": 4,
+        "market_cap": 4,
+        "total_volume": 4,
+        "circulating_supply": 4000000,
+        "total_supply": 8000000
       }
-    }
+    ]
     """
   end
 


### PR DESCRIPTION
Closes #14532

Finalization of https://github.com/blockscout/blockscout/pull/14546

CoinGecko's /simple/price endpoint does not return circulating_supply, causing token.circulating_supply to always be nil in the database. Switch to /coins/markets which returns circulating_supply and total_supply in addition to price, market_cap, and volume.


## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token market data now includes **circulating supply** and **total supply**.
  * Coin market imports now use CoinGecko’s richer **coins/markets** endpoint for improved pricing and volume coverage.

* **Bug Fixes**
  * Token market records now update correctly when **total supply** changes.
  * Market data is matched to tokens more reliably using **coin IDs**.

* **Tests**
  * Updated CoinGecko and token market fetch tests to use the new endpoint, request format, and **array-based** response payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->