### PR TITLE
fix: use named volume for backend dets to fix permission errors

### DIFF
--- a/docker-compose/anvil.yml
+++ b/docker-compose/anvil.yml
@@ -92,3 +92,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -105,3 +105,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/erigon.yml
+++ b/docker-compose/erigon.yml
@@ -85,3 +85,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/external-db.yml
+++ b/docker-compose/external-db.yml
@@ -68,3 +68,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/external-frontend.yml
+++ b/docker-compose/external-frontend.yml
@@ -81,3 +81,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/geth-clique-consensus.yml
+++ b/docker-compose/geth-clique-consensus.yml
@@ -86,3 +86,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/geth.yml
+++ b/docker-compose/geth.yml
@@ -85,3 +85,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/hardhat-network.yml
+++ b/docker-compose/hardhat-network.yml
@@ -92,3 +92,6 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+
+volumes:
+  backend-dets:

--- a/docker-compose/no-services.yml
+++ b/docker-compose/no-services.yml
@@ -61,3 +61,6 @@ services:
       service: proxy
     volumes:
       - "./proxy/explorer.conf.template:/etc/nginx/templates/default.conf.template"
+
+volumes:
+  backend-dets:

--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -14,4 +14,7 @@ services:
       -  ../envs/common-blockscout.env
     volumes:
       - ./logs/:/app/logs/
-      - ./dets/:/app/dets/
+      - backend-dets:/app/dets/
+
+volumes:
+  backend-dets:

--- a/docker-compose/services/backend.yml
+++ b/docker-compose/services/backend.yml
@@ -15,6 +15,3 @@ services:
     volumes:
       - ./logs/:/app/logs/
       - backend-dets:/app/dets/
-
-volumes:
-  backend-dets:


### PR DESCRIPTION
Fixes #13583

## Motivation

When `./dets/` is bind-mounted from a host directory owned by `root:root`, the container's non-root user (`blockscout`, UID 10001) cannot write to it, causing an `eacces` error on DETS `queue_storage` open and crashing the indexer.

This PR replaces the bind-mount with a Docker named volume (`backend-dets`) so Docker manages ownership automatically and the app user always has write access. The `logs` directory keeps its bind-mount, since users need direct host access to log files.

Because Docker Compose's `extends:` merges only the referenced **service** definition and ignores top-level keys such as `volumes:`, the named volume must be declared in each entry-point compose file — otherwise `docker compose up` fails with:

```
service "backend" refers to undefined volume backend-dets: invalid compose project
```

## Changelog

### Bug Fixes

- Replaced the `./dets/:/app/dets/` bind-mount with a `backend-dets` Docker named volume on the backend service (`docker-compose/services/backend.yml`).
- Declared the top-level `volumes: backend-dets:` in all 9 entry-point compose files that extend the backend service: `docker-compose.yml`, `anvil.yml`, `erigon.yml`, `geth.yml`, `external-frontend.yml`, `external-db.yml`, `geth-clique-consensus.yml`, `hardhat-network.yml`, `no-services.yml`.

Validated with `docker compose config` for the default and each `-f <file>` entry point — the volume resolves with no "undefined volume" error.

## Upgrading

No action required for a fresh setup. Users who previously ran with the `./dets/` host bind-mount have their dets data on the host directory; it will not migrate into the new named volume automatically (dets is a rebuildable queue/cache, so this is safe).

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared Docker volume for backend data across multiple compose setups.
  * Updated backend storage to use a named volume for more reliable persistence.

* **Bug Fixes**
  * Corrected a compose service reference in one configuration so service wiring is properly aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->