### PR TITLE
fix: Adapt uncataloged_token_transfer_block_numbers for arc

### DIFF
--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -138,7 +138,12 @@ defmodule Explorer.Chain.TokenTransfer do
   use Explorer.Schema
 
   use Utils.CompileTimeEnvHelper, chain_identity: [:explorer, :chain_identity]
-  use Utils.RuntimeEnvHelper, chain_identity: [:explorer, :chain_identity]
+
+  use Utils.RuntimeEnvHelper,
+    chain_identity: [:explorer, :chain_identity],
+    chain_type: [:explorer, :chain_type],
+    arc_native_token_address: [:indexer, [:arc, :arc_native_token_address]],
+    arc_native_token_system_address: [:indexer, [:arc, :arc_native_token_system_address]]
 
   require Explorer.Chain.TokenTransfer.Schema
 
@@ -691,16 +696,40 @@ defmodule Explorer.Chain.TokenTransfer do
     query =
       from(l in Log,
         as: :log,
-        where:
-          l.first_topic == ^@constant or
-            l.first_topic == ^@erc1155_single_transfer_signature or
-            l.first_topic == ^@erc1155_batch_transfer_signature,
+        where: ^token_transfer_log_filter_dynamic(),
         where: not exists(token_transfer_exists_query()),
         select: l.block_number,
         distinct: l.block_number
       )
 
     Repo.stream_reduce(query, [], &[&1 | &2])
+  end
+
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defp token_transfer_log_filter_dynamic do
+    base_filter =
+      dynamic(
+        [log: l],
+        l.first_topic == ^@constant or
+          l.first_topic == ^@erc1155_single_transfer_signature or
+          l.first_topic == ^@erc1155_batch_transfer_signature
+      )
+
+    case chain_type() do
+      :arc ->
+        dynamic(
+          [log: l],
+          (^base_filter and
+             not (l.first_topic == ^@constant and l.address_hash == ^arc_native_token_address())) or
+            ((l.first_topic == ^@arc_native_coin_transferred_event or
+                l.first_topic == ^@arc_native_coin_minted_event or
+                l.first_topic == ^@arc_native_coin_burned_event) and
+               l.address_hash == ^arc_native_token_system_address())
+        )
+
+      _ ->
+        base_filter
+    end
   end
 
   # Builds a query to check if a token transfer exists for a given log. Handles


### PR DESCRIPTION
## Motivation

`TokenTransfer.uncataloged_token_transfer_block_numbers/0` function is inconsistent with token transfers parsing rules for `arc` chain type in `Indexer.Transform.TokenTransfers`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token transfer detection for ARC networks, so transfer history and uncataloged-token handling are more accurate.
  * Added support for ARC native coin events, helping ensure native token transfers, mints, and burns are recognized correctly.
  * Continued support for standard token transfer and ERC-1155 activity across other chain types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->