### PR TITLE
fix: use struct field access for token balance broadcast filter

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -128,7 +128,7 @@ defmodule BlockScoutWeb.Notifier do
   def handle_event({:chain_event, :address_token_balances, type, address_token_balances})
       when type in [:realtime, :on_demand] do
     address_token_balances
-    |> Enum.filter(fn balance -> address_has_subscribers?(balance[:address_hash]) end)
+    |> Enum.filter(fn balance -> address_has_subscribers?(balance.address_hash) end)
     |> Enum.each(&broadcast_address_token_balance/1)
   end
 


### PR DESCRIPTION
## Motivation

Production `RealtimeEventHandlers.Main` GenServer was crashing with `UndefinedFunctionError` because the `:address_token_balances` handler in `notifier.ex` filtered subscribers using `balance[:address_hash]` (the `Access` `[]` syntax, introduced in #14430). Access works for maps but not structs, and the `:on_demand` token-balance fetcher broadcasts actual `%Explorer.Chain.Address.TokenBalance{}` structs, so every such broadcast crashed the handler.

The genuine error from logs:
`{"message":"GenServer BlockScoutWeb.RealtimeEventHandlers.Main terminating\n** (UndefinedFunctionError) function Explorer.Chain.Address.TokenBalance.fetch/2 is undefined (Explorer.Chain.Address.TokenBalance does not implement the Access behaviour\n\nYou can use the \"struct.field\" syntax to access struct fields. You can also use Access.key!/1 to access struct fields dynamically inside get_in/put_in/update_in)\n    (explorer 11.2.2) Explorer.Chain.Address.TokenBalance.fetch(%Explorer.Chain.Address.TokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_token_balances\">, id: 167057203, value: Decimal.new(\"0\"), block_number: 6059771, value_fetched_at: ~U[2026-07-12 10:16:21.619794Z], token_id: nil, token_type: \"ERC-20\", refetch_after: nil, retries_count: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<110, 31, 55, 4, 69, 170, 89, 121, 42, 1, 53, 165, 45, 150, 9, 252, 122, 97, 187, 122>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<2, 11, 252, 101, 10, 54, 95, 139, 178, 104, 25, 222, 170, 191, 62, 33, 41, 16, 24, 180>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, inserted_at: ~U[2026-07-12 10:16:21.619973Z], updated_at: ~U[2026-07-12 10:16:21.619973Z]}, :address_hash)\n    (elixir 1.19.4) lib/access.ex:326: Access.get/3\n    (block_scout_web 11.2.2) lib/block_scout_web/notifier.ex:131: anonymous fn/1 in BlockScoutWeb.Notifier.handle_event/1\n    (elixir 1.19.4) lib/enum.ex:4445: Enum.filter_list/2\n    (block_scout_web 11.2.2) lib/block_scout_web/notifier.ex:131: BlockScoutWeb.Notifier.handle_event/1\n    (block_scout_web 11.2.2) lib/block_scout_web/realtime_event_handlers/main.ex:64: BlockScoutWeb.RealtimeEventHandlers.Main.handle_info/2\n    (stdlib 6.2.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3\n    (stdlib 6.2.2.2) gen_server.erl:2433: :gen_server.handle_msg/6\nLast message: {:chain_event, :address_token_balances, :on_demand, [%Explorer.Chain.Address.TokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_token_balances\">, id: 167057203, value: Decimal.new(\"0\"), block_number: 6059771, value_fetched_at: ~U[2026-07-12 10:16:21.619794Z], token_id: nil, token_type: \"ERC-20\", refetch_after: nil, retries_count: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<110, 31, 55, 4, 69, 170, 89, 121, 42, 1, 53, 165, 45, 150, 9, 252, 122, 97, 187, 122>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<2, 11, 252, 101, 10, 54, 95, 139, 178, 104, 25, 222, 170, 191, 62, 33, 41, 16, 24, 180>>}, token: #Ecto.Association.NotLoaded<association :token is not loaded>, inserted_at: ~U[2026-07-12 10:16:21.619973Z], updated_at: ~U[2026-07-12 10:16:21.619973Z]}, %Explorer.Chain.Address.TokenBalance{__meta__: #Ecto.Schema.Metadata<:loaded, \"address_token_balances\">, id: 167057204, value: Decimal.new(\"0\"), block_number: 6059771, value_fetched_at: ~U[2026-07-12 10:16:21.619785Z], token_id: nil, token_type: \"ERC-20\", refetch_after: nil, retries_count: nil, address_hash: %Explorer.Chain.Hash{byte_count: 20, bytes: <<242, 0, 237, 255, 113, 155, 5, 25, 235, 60, 237, 60, 192, 88, 2, 212, 147, 160, 76, 168>>}, address: #Ecto.Association.NotLoaded<association :address is not loaded>, token_contract_address_hash: %Explorer.Chain.Hash{byte_count: 20, ...}, ...}]}","time":"2026-07-12T10:20:47.055Z","metadata":{},"severity":"error"}`

## Changelog

### Bug Fixes

- Fix `UndefinedFunctionError` crash in `BlockScoutWeb.RealtimeEventHandlers.Main` when broadcasting on-demand token balances, by using struct field access (`balance.address_hash`) instead of the `Access` `[]` syntax in the `:address_token_balances` event handler.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of address token balance updates to ensure relevant balance changes continue to be broadcast correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->