### PR TITLE
feat: add on-demand fungible token metadata refetch

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -12,6 +12,7 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   alias Explorer.Migrator.BackfillMetadataURL
   alias Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch, as: NFTCollectionMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch, as: TokenInstanceMetadataRefetchOnDemand
+  alias Indexer.Fetcher.OnDemand.TokenMetadataRefetch, as: TokenMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.TokenTotalSupply, as: TokenTotalSupplyOnDemand
   alias Indexer.Fetcher.TokenInstance.Helper, as: TokenInstanceHelper
   alias Plug.Conn
@@ -770,6 +771,40 @@ defmodule BlockScoutWeb.API.V2.TokenController do
       conn
       |> AccessHelper.conn_to_ip_string()
       |> TokenInstanceMetadataRefetchOnDemand.trigger_refetch(token_instance_with_token)
+
+      conn
+      |> put_status(200)
+      |> json(%{message: "OK"})
+    end
+  end
+
+  operation :trigger_token_metadata_refetch,
+    summary: "Trigger metadata refetch for a fungible token",
+    description:
+      "Triggers an on-chain metadata refetch for an indexed fungible token identified by its contract address.",
+    parameters: base_params() ++ [address_hash_param(), recaptcha_response_param()],
+    responses: [
+      ok:
+        {"Token metadata refetch triggered.", "application/json",
+         %Schema{type: :object, properties: %{message: %Schema{type: :string}}}},
+      unprocessable_entity: JsonErrorResponse.response(),
+      not_found: NotFoundResponse.response()
+    ]
+
+  @doc """
+  Handles PATCH requests to `/api/v2/tokens/:address_hash_param/refetch-metadata` endpoint.
+  """
+  @spec trigger_token_metadata_refetch(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def trigger_token_metadata_refetch(conn, params) do
+    address_hash_string = params[:address_hash_param]
+    ip = AccessHelper.conn_to_ip_string(conn)
+
+    with {:format, {:ok, address_hash}} <- {:format, Chain.string_to_address_hash(address_hash_string)},
+         {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params),
+         {:not_found, {:ok, %Token{cataloged: true} = token}} <-
+           {:not_found, Chain.token_from_address_hash(address_hash, @api_true)},
+         {:not_found, true} <- {:not_found, Chain.erc_20_token?(token) or Token.zrc_2_token?(token)} do
+      TokenMetadataRefetchOnDemand.trigger_refetch(ip, token)
 
       conn
       |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/tokens_api_v2_router.ex
@@ -66,6 +66,8 @@ defmodule BlockScoutWeb.Routers.TokensApiV2Router do
   scope "/", as: :api_v2 do
     pipe_through(:api_v2_no_forgery_protect)
 
+    patch("/:address_hash_param/refetch-metadata", V2.TokenController, :trigger_token_metadata_refetch)
+
     patch("/:address_hash_param/instances/:token_id_param/refetch-metadata", V2.TokenController, :refetch_metadata)
 
     patch(

--- a/apps/block_scout_web/priv/rate_limit_config.json
+++ b/apps/block_scout_web/priv/rate_limit_config.json
@@ -40,6 +40,14 @@
     "bypass_token_scope": "token_instance_refetch_metadata",
     "isolate_rate_limit?": true
   },
+  "api/v2/tokens/:param/refetch-metadata": {
+    "recaptcha_to_bypass_429": true,
+    "ip": {
+      "period": "1h",
+      "limit": 10
+    },
+    "isolate_rate_limit?": true
+  },
   "api/v2/advanced-filters/csv": {
     "recaptcha_to_bypass_429": true,
     "ip": {

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1811,6 +1811,8 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
 
+      start_supervised!({Task.Supervisor, name: TokenMetadataRefetchOnDemand.TaskSupervisor})
+
       start_supervised!(
         {TokenMetadataRefetchOnDemand,
          [mocked_json_rpc_named_arguments, [name: TokenMetadataRefetchOnDemand]]}

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -1797,6 +1797,18 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     setup :verify_on_exit!
 
     setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      original_config = :persistent_term.get(:rate_limit_config)
+      old_recaptcha_env = Application.get_env(:block_scout_web, :recaptcha)
+      original_api_rate_limit = Application.get_env(:block_scout_web, :api_rate_limit)
+
+      v2_secret_key = "v2_secret_key"
+
+      Application.put_env(:block_scout_web, :recaptcha,
+        v2_secret_key: v2_secret_key,
+        v3_secret_key: "v3_secret_key",
+        is_disabled: false
+      )
+
       mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
 
       start_supervised!(
@@ -1804,7 +1816,29 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
          [mocked_json_rpc_named_arguments, [name: TokenMetadataRefetchOnDemand]]}
       )
 
-      :ok
+      Application.put_env(:block_scout_web, :api_rate_limit, Keyword.put(original_api_rate_limit, :disabled, false))
+
+      :persistent_term.put(:rate_limit_config, %{
+        static_match: %{},
+        wildcard_match: %{},
+        parametrized_match: %{
+          ["api", "v2", "tokens", ":param", "refetch-metadata"] => %{
+            ip: %{period: 3_600_000, limit: 10},
+            recaptcha_to_bypass_429: true,
+            bucket_key_prefix: "api/v2/tokens/:param/refetch-metadata_",
+            isolate_rate_limit?: true
+          }
+        }
+      })
+
+      on_exit(fn ->
+        :persistent_term.put(:rate_limit_config, original_config)
+        Application.put_env(:block_scout_web, :recaptcha, old_recaptcha_env)
+        Application.put_env(:block_scout_web, :api_rate_limit, original_api_rate_limit)
+        :ets.delete_all_objects(BlockScoutWeb.RateLimit.Hammer.ETS)
+      end)
+
+      {:ok, %{v2_secret_key: v2_secret_key}}
     end
 
     test "re-fetches fungible token metadata", %{conn: conn} do
@@ -1876,6 +1910,41 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       token = insert(:token, type: "ERC-721")
 
       request = patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/refetch-metadata")
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+
+    test "requires recaptcha after the isolated rate limit is exceeded", %{
+      v2_secret_key: v2_secret_key
+    } do
+      token = build(:token, type: "ERC-20")
+      endpoint = "/api/v2/tokens/#{token.contract_address.hash}/refetch-metadata"
+
+      Enum.each(9..0, fn expected_remaining ->
+        request =
+          Phoenix.ConnTest.build_conn()
+          |> put_req_header("user-agent", "test-agent")
+          |> patch(endpoint)
+
+        assert %{"message" => "Not found"} = json_response(request, 404)
+        assert get_resp_header(request, "x-ratelimit-remaining") == [to_string(expected_remaining)]
+      end)
+
+      request =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("user-agent", "test-agent")
+        |> patch(endpoint)
+
+      assert json_response(request, 429)
+
+      expected_body = "secret=#{v2_secret_key}&response=123"
+      recaptcha_success_expectation_with_req_body(expected_body)
+
+      request =
+        Phoenix.ConnTest.build_conn()
+        |> put_req_header("user-agent", "test-agent")
+        |> put_req_header("recaptcha-v2-response", "123")
+        |> patch(endpoint)
 
       assert %{"message" => "Not found"} = json_response(request, 404)
     end
@@ -1997,7 +2066,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       expected_body = "secret=#{v2_secret_key}&response=123"
 
-      token_instance_success_metadata_expectation_with_req_body(expected_body)
+      recaptcha_success_expectation_with_req_body(expected_body)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
@@ -2386,7 +2455,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       # Set up normal reCAPTCHA validation for the second request
       expected_body = "secret=#{v2_secret_key}&response=correct_recaptcha_token"
 
-      token_instance_success_metadata_expectation_with_req_body(expected_body)
+      recaptcha_success_expectation_with_req_body(expected_body)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
 
@@ -2490,7 +2559,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
       # Set up normal reCAPTCHA validation for the second request
       expected_body = "secret=#{v2_secret_key}&response=correct_recaptcha_token"
 
-      token_instance_success_metadata_expectation_with_req_body(expected_body)
+      recaptcha_success_expectation_with_req_body(expected_body)
 
       TestHelper.fetch_token_uri_mock(url, token_contract_address_hash_string)
       metadata = %{"name" => "Super Token"}
@@ -2952,7 +3021,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     )
   end
 
-  defp token_instance_success_metadata_expectation_with_req_body(expected_body) do
+  defp recaptcha_success_expectation_with_req_body(expected_body) do
     Tesla.Test.expect_tesla_call(
       times: 1,
       returns: fn %{body: ^expected_body}, _opts ->

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/token_controller_test.exs
@@ -16,6 +16,7 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
   alias Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch, as: TokenInstanceMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch, as: NFTCollectionMetadataRefetchOnDemand
+  alias Indexer.Fetcher.OnDemand.TokenMetadataRefetch, as: TokenMetadataRefetchOnDemand
 
   describe "/tokens/{address_hash}" do
     test "get 404 on non existing address", %{conn: conn} do
@@ -1790,6 +1791,96 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
     end
   end
 
+  describe "/tokens/{address_hash}/refetch-metadata" do
+    setup :set_mox_from_context
+
+    setup :verify_on_exit!
+
+    setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
+
+      start_supervised!(
+        {TokenMetadataRefetchOnDemand,
+         [mocked_json_rpc_named_arguments, [name: TokenMetadataRefetchOnDemand]]}
+      )
+
+      :ok
+    end
+
+    test "re-fetches fungible token metadata", %{conn: conn} do
+      token =
+        insert(:token,
+          name: "Old name",
+          symbol: "OLD",
+          type: "ERC-20",
+          icon_url: "https://example.com/token-icon.png"
+        )
+
+      expect_token_metadata_rpc_response("New name", "NEW")
+
+      request = patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/refetch-metadata")
+
+      assert %{"message" => "OK"} = json_response(request, 200)
+
+      Explorer.DataCase.wait_for_results(fn ->
+        updated_token =
+          Repo.one!(
+            from(t in Token,
+              where:
+                t.contract_address_hash == ^token.contract_address_hash and t.name == "New name" and
+                  t.symbol == "NEW"
+            )
+          )
+
+        assert updated_token.name == "New name"
+        assert updated_token.symbol == "NEW"
+        assert updated_token.metadata_updated_at
+        assert updated_token.icon_url == token.icon_url
+      end)
+    end
+
+    test "preserves admin-curated name and symbol", %{conn: conn} do
+      token =
+        insert(:token,
+          name: "Admin name",
+          symbol: "ADMIN",
+          type: "ERC-20",
+          icon_url: "https://example.com/admin-token-icon.png",
+          is_verified_via_admin_panel: true,
+          metadata_updated_at: nil
+        )
+
+      expect_token_metadata_rpc_response("On-chain name", "CHAIN")
+
+      request = patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/refetch-metadata")
+
+      assert %{"message" => "OK"} = json_response(request, 200)
+
+      Explorer.DataCase.wait_for_results(fn ->
+        updated_token =
+          Repo.one!(
+            from(t in Token,
+              where:
+                t.contract_address_hash == ^token.contract_address_hash and
+                  not is_nil(t.metadata_updated_at)
+            )
+          )
+
+        assert updated_token.name == "Admin name"
+        assert updated_token.symbol == "ADMIN"
+        assert updated_token.icon_url == token.icon_url
+      end)
+    end
+
+    test "doesn't re-fetch metadata for an NFT collection", %{conn: conn} do
+      token = insert(:token, type: "ERC-721")
+
+      request = patch(conn, "/api/v2/tokens/#{token.contract_address.hash}/refetch-metadata")
+
+      assert %{"message" => "Not found"} = json_response(request, 404)
+    end
+  end
+
   describe "/tokens/{address_hash}/instances/{token_id}/refetch-metadata" do
     setup :set_mox_from_context
 
@@ -2488,6 +2579,29 @@ defmodule BlockScoutWeb.API.V2.TokenControllerTest do
 
       assert %{"message" => "Wrong API key"} = json_response(request, 401)
     end
+  end
+
+  defp expect_token_metadata_rpc_response(name, symbol) do
+    string_selector = %ABI.FunctionSelector{function: nil, types: [:string]}
+    encoded_name = ABI.TypeEncoder.encode([name], string_selector) |> Base.encode16(case: :lower)
+    encoded_symbol = ABI.TypeEncoder.encode([symbol], string_selector) |> Base.encode16(case: :lower)
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn requests, _opts ->
+      {:ok,
+       Enum.map(requests, fn
+         %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: _}, "latest"]} ->
+           %{id: id, result: "0x0000000000000000000000000000000000000000000000000000000000000012"}
+
+         %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: _}, "latest"]} ->
+           %{id: id, result: "0x" <> encoded_name}
+
+         %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: _}, "latest"]} ->
+           %{id: id, result: "0x" <> encoded_symbol}
+
+         %{id: id, method: "eth_call", params: [%{data: "0x18160ddd", to: _}, "latest"]} ->
+           %{id: id, result: "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"}
+       end)}
+    end)
   end
 
   defp compare_holders_item(%CurrentTokenBalance{} = ctb, json) do

--- a/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/utility/rate_limit_config_helper_test.exs
@@ -68,6 +68,16 @@ defmodule BlockScoutWeb.Utility.RateLimitConfigHelperTest do
                "api/account/v2/authenticate_via_wallet_"
 
       assert config[:static_match]["api/account/v2/authenticate_via_wallet"][:isolate_rate_limit?] == true
+
+      token_metadata_refetch_config =
+        config[:parametrized_match][["api", "v2", "tokens", ":param", "refetch-metadata"]]
+
+      assert token_metadata_refetch_config[:ip] == %{period: 3_600_000, limit: 10}
+      assert token_metadata_refetch_config[:recaptcha_to_bypass_429] == true
+      assert token_metadata_refetch_config[:isolate_rate_limit?] == true
+
+      assert token_metadata_refetch_config[:bucket_key_prefix] ==
+               "api/v2/tokens/:param/refetch-metadata_"
     end
 
     test "correctly categorizes different path types when fetching config" do

--- a/apps/indexer/lib/indexer/application.ex
+++ b/apps/indexer/lib/indexer/application.ex
@@ -13,6 +13,7 @@ defmodule Indexer.Application do
   alias Indexer.Fetcher.OnDemand.NFTCollectionMetadataRefetch, as: NFTCollectionMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.TokenBalance, as: TokenBalanceOnDemand
   alias Indexer.Fetcher.OnDemand.TokenInstanceMetadataRefetch, as: TokenInstanceMetadataRefetchOnDemand
+  alias Indexer.Fetcher.OnDemand.TokenMetadataRefetch, as: TokenMetadataRefetchOnDemand
   alias Indexer.Fetcher.OnDemand.TokenTotalSupply, as: TokenTotalSupplyOnDemand
   alias Indexer.Fetcher.TokenInstance.MediaType, as: TokenInstanceMediaType
   alias Indexer.Fetcher.TokenInstance.Refetch, as: TokenInstanceRefetch
@@ -66,6 +67,7 @@ defmodule Indexer.Application do
       {ContractCreatorOnDemand.Supervisor, [json_rpc_named_arguments]},
       {NFTCollectionMetadataRefetchOnDemand.Supervisor, [json_rpc_named_arguments]},
       {TokenInstanceMetadataRefetchOnDemand.Supervisor, [json_rpc_named_arguments]},
+      {TokenMetadataRefetchOnDemand.Supervisor, [json_rpc_named_arguments]},
       {TokenInstanceMediaType.Supervisor, []},
       {TokenInstanceRefetch.Supervisor, []},
       {TokenTotalSupplyOnDemand.Supervisor, []},

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_metadata_refetch.ex
@@ -30,7 +30,9 @@ defmodule Indexer.Fetcher.OnDemand.TokenMetadataRefetch do
 
   @impl true
   def handle_cast({:refetch, token}, json_rpc_named_arguments) do
-    TokenUpdater.run([token], json_rpc_named_arguments)
+    Task.Supervisor.start_child(__MODULE__.TaskSupervisor, fn ->
+      TokenUpdater.run([token], json_rpc_named_arguments)
+    end)
 
     {:noreply, json_rpc_named_arguments}
   end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_metadata_refetch.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_metadata_refetch.ex
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Indexer.Fetcher.OnDemand.TokenMetadataRefetch do
+  @moduledoc """
+  Re-fetches fungible token metadata.
+  """
+
+  use GenServer
+  use Indexer.Fetcher, restart: :permanent
+
+  alias Explorer.Chain.Token
+  alias Explorer.Utility.RateLimiter
+  alias Indexer.Fetcher.TokenUpdater
+
+  @spec trigger_refetch(String.t() | nil, Token.t()) :: :ok
+  def trigger_refetch(caller \\ nil, token) do
+    case RateLimiter.check_rate(caller, :on_demand) do
+      :allow -> GenServer.cast(__MODULE__, {:refetch, token})
+      :deny -> :ok
+    end
+  end
+
+  def start_link([init_opts, server_opts]) do
+    GenServer.start_link(__MODULE__, init_opts, server_opts)
+  end
+
+  @impl true
+  def init(json_rpc_named_arguments) do
+    {:ok, json_rpc_named_arguments}
+  end
+
+  @impl true
+  def handle_cast({:refetch, token}, json_rpc_named_arguments) do
+    TokenUpdater.run([token], json_rpc_named_arguments)
+
+    {:noreply, json_rpc_named_arguments}
+  end
+end


### PR DESCRIPTION
Closes #14574

Companion rate limit configuration: blockscout/backend-configs#54

## Motivation

Blockscout periodically refreshes metadata for cataloged fungible tokens. When a
contract changes its on-chain name or symbol, the API and explorer can continue
showing stale values until the next scheduled refresh.

The existing admin token-info deletion endpoint is not appropriate for this use case:
it is operator-only and clears imported token information before re-fetching. This PR
adds a non-destructive, rate-limited counterpart for a single fungible token.

## Changelog

### Enhancements

- Add PATCH /api/v2/tokens/:address_hash/refetch-metadata for cataloged ERC-20 and ZRC-2 tokens.
- Queue the work asynchronously through an on-demand worker that reuses the existing TokenUpdater.
- Preserve token icons and Blockscout protection for admin-curated name and symbol values.
- Add an isolated limit of 10 requests per IP per hour, with reCAPTCHA available after the limit.
- Add OpenAPI documentation and controller integration coverage for successful fungible-token refreshes, admin-curated metadata protection, NFT rejection, rate limiting, and reCAPTCHA bypass.
- Add fallback configuration coverage that asserts the isolated 10-request limit and bucket prefix.

The response confirms that the refresh was queued. Clients can poll the existing token
endpoint to observe the updated metadata.

As with scheduled TokenUpdater runs, this endpoint does not replace name or symbol when
is_verified_via_admin_panel is true. This PR intentionally leaves that precedence
unchanged. A separate opt-in design may be appropriate for tokens that need fixed visual
metadata while keeping these contract fields mutable.

### Bug Fixes

None.

### Incompatible Changes

None.

## Upgrading

No migration or re-index is required. Deployments configured with
API_RATE_LIMIT_CONFIG_URL must add the matching endpoint entry to their remote rate limit
configuration. blockscout/backend-configs#54 adds it to the official configuration.
Until that configuration is deployed, the endpoint falls through to the broader API v2
rate limit.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not remove or change an existing public API, contract, or interface.
- [x] I added tests covering the new functionality and abuse protection.
- [x] Regression test: not applicable; this is an additive enhancement.
- [x] Documentation: the endpoint is included in OpenAPI operation metadata and no new environment variable is introduced.
- [x] The API endpoint includes OpenAPI metadata and is exercised by controller integration tests.
- [x] DB indices: not applicable; no database changes are included.
- [x] Chain-type CI matrix: not applicable; the endpoint is chain-agnostic.

Maintainer guidance is especially welcome on the endpoint shape, abuse protection, and a
future opt-in model for fixed visual metadata with mutable on-chain name and symbol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PATCH API endpoint to manually trigger on-demand metadata refetch for cataloged fungible tokens.
  * Token refetch now updates name, symbol, and decimals while preserving admin-verified values.
  * Added rate limiting and reCAPTCHA protection for these on-demand refetch requests.
* **Bug Fixes**
  * Metadata refetch is blocked for unsupported token types (such as NFT/ERC-721), returning a 404.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->