### PR TITLE
fix: support bytes32 ERC-20 name and symbol decoding

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/erc20.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/erc20.ex
@@ -8,6 +8,10 @@ defmodule EthereumJSONRPC.ERC20 do
     Currently supports fetching token properties like name, symbol and decimals
     through direct contract calls.
 
+    Some older tokens (for example Maker/MKR) return `bytes32` for `name()` /
+    `symbol()` instead of `string`. The ABI below includes both return types so
+    decoding can fall back to `bytes32` when the dynamic-string decode fails.
+
     ## Examples
 
         iex> EthereumJSONRPC.ERC20.fetch_token_properties(
@@ -32,6 +36,8 @@ defmodule EthereumJSONRPC.ERC20 do
   @selector_name "06fdde03"
   # symbol()
   @selector_symbol "95d89b41"
+  # `string` variants must come before `bytes32` so `Encoder.decode_result/3`
+  # prefers the standard ERC-20 return type when both decode successfully.
   @erc20_contract_abi [
     %{
       "inputs" => [],
@@ -61,14 +67,38 @@ defmodule EthereumJSONRPC.ERC20 do
     },
     %{
       "inputs" => [],
+      "name" => "name",
+      "outputs" => [
+        %{
+          "internalType" => "bytes32",
+          "name" => "",
+          "type" => "bytes32"
+        }
+      ],
+      "stateMutability" => "view",
+      "type" => "function"
+    },
+    %{
+      "inputs" => [],
       "name" => "symbol",
       "outputs" => [
         %{
           "internalType" => "string",
           "name" => "",
-          # TODO: Research the compatibility of this ABI
-          # with tokens that return bytes32 for the symbol method
           "type" => "string"
+        }
+      ],
+      "stateMutability" => "view",
+      "type" => "function"
+    },
+    %{
+      "inputs" => [],
+      "name" => "symbol",
+      "outputs" => [
+        %{
+          "internalType" => "bytes32",
+          "name" => "",
+          "type" => "bytes32"
         }
       ],
       "stateMutability" => "view",
@@ -119,7 +149,8 @@ defmodule EthereumJSONRPC.ERC20 do
     |> Enum.zip(method_ids)
     |> Enum.reduce(%{}, fn
       {{:ok, [response]}, method_id}, retval ->
-        Map.put(retval, atomized_erc20_selector(method_id), response)
+        property = atomized_erc20_selector(method_id)
+        Map.put(retval, property, normalize_property(property, response))
 
       {{:error, reason}, method_id}, retval ->
         Logger.error("[EthereumJSONRPC.ERC20] Failed to fetch token property! \
@@ -146,4 +177,17 @@ defmodule EthereumJSONRPC.ERC20 do
   defp atomized_erc20_selector(@selector_decimals), do: :decimals
   defp atomized_erc20_selector(@selector_name), do: :name
   defp atomized_erc20_selector(@selector_symbol), do: :symbol
+
+  # `bytes32` name/symbol values are null-padded; strip padding to a display string.
+  defp normalize_property(property, value) when property in [:name, :symbol] and is_binary(value) do
+    cleaned = String.replace(value, <<0>>, "")
+
+    if cleaned != "" and String.valid?(cleaned) do
+      cleaned
+    else
+      nil
+    end
+  end
+
+  defp normalize_property(_property, value), do: value
 end

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/erc20_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/erc20_test.exs
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule EthereumJSONRPC.ERC20Test do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias EthereumJSONRPC.ERC20
+
+  setup :verify_on_exit!
+
+  setup do
+    %{
+      json_rpc_named_arguments: [
+        transport: EthereumJSONRPC.Mox,
+        transport_options: []
+      ]
+    }
+  end
+
+  describe "fetch_token_properties/3" do
+    test "decodes standard string name and symbol", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      token_address = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn requests, _opts ->
+        {:ok,
+         Enum.map(requests, fn
+           %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: ^token_address}, "latest"]} ->
+             %{id: id, result: "0x0000000000000000000000000000000000000000000000000000000000000006"}
+
+           %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: ^token_address}, "latest"]} ->
+             %{id: id, result: abi_encoded_string("Tether USD")}
+
+           %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: ^token_address}, "latest"]} ->
+             %{id: id, result: abi_encoded_string("USDT")}
+         end)}
+      end)
+
+      assert ERC20.fetch_token_properties(
+               token_address,
+               [:decimals, :name, :symbol],
+               json_rpc_named_arguments
+             ) == %{
+               decimals: 6,
+               name: "Tether USD",
+               symbol: "USDT"
+             }
+    end
+
+    test "falls back to bytes32 name and symbol", %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      token_address = "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn requests, _opts ->
+        {:ok,
+         Enum.map(requests, fn
+           %{id: id, method: "eth_call", params: [%{data: "0x313ce567", to: ^token_address}, "latest"]} ->
+             %{id: id, result: "0x0000000000000000000000000000000000000000000000000000000000000012"}
+
+           %{id: id, method: "eth_call", params: [%{data: "0x06fdde03", to: ^token_address}, "latest"]} ->
+             %{
+               id: id,
+               result: "0x4d616b6572000000000000000000000000000000000000000000000000000000"
+             }
+
+           %{id: id, method: "eth_call", params: [%{data: "0x95d89b41", to: ^token_address}, "latest"]} ->
+             %{
+               id: id,
+               result: "0x4d4b520000000000000000000000000000000000000000000000000000000000"
+             }
+         end)}
+      end)
+
+      assert ERC20.fetch_token_properties(
+               token_address,
+               [:decimals, :name, :symbol],
+               json_rpc_named_arguments
+             ) == %{
+               decimals: 18,
+               name: "Maker",
+               symbol: "MKR"
+             }
+    end
+  end
+
+  defp abi_encoded_string(str) do
+    encoded =
+      ABI.TypeEncoder.encode([str], %ABI.FunctionSelector{
+        function: nil,
+        types: [:string]
+      })
+
+    "0x" <> Base.encode16(encoded, case: :lower)
+  end
+end


### PR DESCRIPTION
## Summary
- Decode ERC-20 `name()` / `symbol()` when contracts return `bytes32` (e.g. Maker/MKR), matching `Explorer.Token.MetadataRetriever`.
- Prefer `string` ABI first, then fall back to `bytes32`; strip null padding for display.
- Add regression tests for both string and bytes32 return types in `EthereumJSONRPC.ERC20`.

## Motivation
`EthereumJSONRPC.ERC20.fetch_token_properties/3` (used in Arbitrum L1 token metadata for withdrawals) only declared `string` outputs. Tokens that return `bytes32` failed to decode and surfaced as `nil`, while indexing already handled this via `MetadataRetriever`.

## Changelog
**Bug Fixes**
- Fixed ERC-20 `name`/`symbol` decoding for `bytes32`-returning contracts in `EthereumJSONRPC.ERC20`.

**Enhancements:** None.

**Incompatible Changes:** None.

## Test plan
- [x] `cd apps/ethereum_jsonrpc && MIX_ENV=test mix test test/ethereum_jsonrpc/erc20_test.exs` (2 tests, 0 failures)

## Upgrading
No database reset or re-index required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ERC-20 tokens whose name and symbol values use `bytes32` encoding.
  * Token names and symbols are now cleaned of padding and treated as unavailable when invalid or empty.

* **Tests**
  * Added coverage for both standard string and `bytes32` token metadata responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->