### PR TITLE
fix: return error tuple from Solidity verifier on unexpected exception

### DIFF
--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -45,6 +45,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
             Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
+        {:error, Exception.message(exception)}
     end
   end
 

--- a/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
+++ b/apps/explorer/lib/explorer/smart_contract/solidity/verifier.ex
@@ -45,6 +45,7 @@ defmodule Explorer.SmartContract.Solidity.Verifier do
             Exception.format(:error, exception, __STACKTRACE__)
           ]
         end)
+
         {:error, Exception.message(exception)}
     end
   end

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -400,6 +400,25 @@ defmodule Explorer.SmartContract.Solidity.VerifierTest do
         assert {:error, :compilation, "Function, variable, struct or modifier declaration expected."} =
                  Verifier.evaluate_authenticity(contract_address.hash, params)
       end
+
+      test "returns {:error, message} instead of :ok when verification raises an exception", %{
+        contract_code_info: contract_code_info
+      } do
+        contract_address = insert(:contract_address, contract_code: contract_code_info.bytecode)
+
+        # Omitting "contract_source_code" makes the internal `Map.fetch!/2` raise a
+        # KeyError, which is caught by the try/rescue in evaluate_authenticity/2.
+        # Before the fix the rescue silently returned :ok (the result of Logger.error/1);
+        # now it must return an {:error, message} tuple.
+        params = %{
+          "compiler_version" => contract_code_info.version,
+          "name" => contract_code_info.name,
+          "optimization" => contract_code_info.optimized
+        }
+
+        assert {:error, message} = Verifier.evaluate_authenticity(contract_address.hash, params)
+        assert is_binary(message)
+      end
     end
 
     describe "extract_bytecode_and_metadata_hash/1" do

--- a/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
+++ b/apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs
@@ -417,7 +417,7 @@ defmodule Explorer.SmartContract.Solidity.VerifierTest do
         }
 
         assert {:error, message} = Verifier.evaluate_authenticity(contract_address.hash, params)
-        assert is_binary(message)
+        assert message =~ "contract_source_code"
       end
     end
 


### PR DESCRIPTION
Closes https://github.com/blockscout/blockscout/issues/14499

## Motivation

`Explorer.SmartContract.Solidity.Verifier.evaluate_authenticity/2` wraps its work in a `try/rescue`. When an exception was raised, the last expression in the `rescue` block was `Logger.error/1`, which returns `:ok`. The function therefore returned a bare `:ok` on failure — indistinguishable from a successful verification, even though nothing was verified. This silently masked verification errors from callers.

## Changelog

### Enhancements

- Added a regression test in `apps/explorer/test/explorer/smart_contract/solidity/verifier_test.exs` that triggers the rescue path (by omitting `contract_source_code` so an internal `Map.fetch!/2` raises `KeyError`) and asserts an `{:error, message}` tuple is returned. Verified the test fails against the pre-fix code (returns `:ok`) and passes with the fix.

### Bug Fixes

- `evaluate_authenticity/2` now returns `{:error, Exception.message(exception)}` when its inner logic raises, instead of implicitly returning `:ok`. This makes the exception path consistent with the function's other failure returns (`{:error, :name}`, `{:error, :generated_bytecode}`, etc.) and surfaces failures to callers.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart contract verification error handling: failed evaluations now return an explicit `{:error, message}` result instead of an ambiguous success outcome.
  * Verification now correctly reports missing required contract information with a clear message (including the `"contract_source_code"` field).
* **Tests**
  * Added a test to confirm the new error-return behavior when required input is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->