### PR TITLE
perf: order getLogs by log.block_number to enable early LIMIT

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -100,7 +100,7 @@ defmodule Explorer.Etherscan.Logs do
             block_timestamp: transaction.block_timestamp,
             block_consensus: transaction.block_consensus
           },
-          order_by: [asc: transaction.block_number, asc: log.index],
+          order_by: [asc: log.block_number, asc: log.index],
           limit: 1000
         )
 
@@ -125,7 +125,7 @@ defmodule Explorer.Etherscan.Logs do
             block_timestamp: block.timestamp,
             block_consensus: block.consensus
           },
-          order_by: [asc: block.number, asc: log.index],
+          order_by: [asc: log.block_number, asc: log.index],
           limit: 1000
         )
 


### PR DESCRIPTION
## Motivation

The `?module=logs&action=getLogs` RPC endpoint (`Explorer.Etherscan.Logs.list_logs/2`, `address_hash` branch) was flagged for high DB CPU consumption. The inner query ordered by `transaction.block_number` (a column from the joined `transactions` table), so Postgres could not use the `logs (address_hash, first_topic, block_number, index)` index order to stream rows and stop early at the `LIMIT 1000`. Instead it fetched every matching log, nested-loop-joined each to `transactions`, sorted the entire set, and discarded everything past row 1000. For a hot address with a common `first_topic` over a wide block range this materializes and sorts hundreds of thousands to millions of rows per call, pegging a core. Because the join condition includes `log.block_hash == transaction.block_hash`, `transaction.block_number` always equals `log.block_number` for every joined row, so ordering by the log's own column produces identical output while letting the planner do an ordered index scan, filter, nested-loop join, and stop at 1000 rows.

## Changelog

### Enhancements

Changed the `order_by` in both branches (denormalized and non-denormalized) of the `address_hash` clause of `Explorer.Etherscan.Logs.list_logs/2` to sort by `log.block_number` instead of `transaction.block_number`/`block.number`. This lets the `logs_address_hash_first_topic_block_number_index_index` index satisfy the ordering, so the `LIMIT 1000` short-circuits the scan instead of forcing a full materialize-and-sort. Output is unchanged because the block_hash join equality guarantees the two block_number values are equal for every joined row.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log ordering and pagination consistency when retrieving filtered blockchain logs.
  * Logs are now sorted using their block and transaction index values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->