### PR TITLE
chore: Use Repo.replica as a default repo for transaction preload

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -1507,13 +1507,15 @@ defmodule Explorer.Chain.InternalTransaction do
   - A list of internal transactions with the `:transaction` field populated
   - A single internal transaction with the `:transaction` field populated
   """
-  @spec preload_transaction(__MODULE__.t() | [__MODULE__.t()] | nil, module(), [Transaction.t()] | nil) ::
+  @spec preload_transaction(__MODULE__.t() | [__MODULE__.t()] | nil, module() | nil, [Transaction.t()] | nil) ::
           __MODULE__.t() | [__MODULE__.t()] | nil
-  def preload_transaction(internal_transactions, repo \\ Repo, transactions \\ nil)
+  def preload_transaction(internal_transactions, repo \\ nil, transactions \\ nil)
 
   def preload_transaction(nil, _repo, _transactions), do: nil
 
   def preload_transaction(internal_transactions, repo, existing_transactions) when is_list(internal_transactions) do
+    repo = repo || Repo.replica()
+
     transactions =
       case existing_transactions do
         nil ->

--- a/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
+++ b/apps/indexer/lib/indexer/transform/celo/transaction_token_transfers.ex
@@ -22,6 +22,7 @@ defmodule Indexer.Transform.Celo.TransactionTokenTransfers do
 
   alias Explorer.Chain.Cache.CeloCoreContracts
   alias Explorer.Chain.{Hash, InternalTransaction}
+  alias Explorer.Repo
   alias Indexer.Fetcher.TokenTotalSupplyUpdater
   @token_type "ERC-20"
   @transaction_buffer_size 20_000
@@ -98,7 +99,7 @@ defmodule Indexer.Transform.Celo.TransactionTokenTransfers do
           not Map.has_key?(internal_transaction, :error) &&
           (not Map.has_key?(internal_transaction, :call_type) || internal_transaction.call_type != "delegatecall")
       end)
-      |> InternalTransaction.preload_transaction()
+      |> InternalTransaction.preload_transaction(Repo)
       |> Enum.map(fn internal_transaction ->
         to_address_hash =
           Map.get(internal_transaction, :to_address_hash) ||


### PR DESCRIPTION
## Motivation

There is no need to use master repo for `InternalTransaction.preload_transaction/3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal transaction data loading to correctly use a read-only replica when no repository is specified.
  * Preserved behavior for nil and explicitly provided repository inputs, including existing handling for single vs. list internal transactions.
  * Updated token transfer indexing to preload internal transaction data using the appropriate repository context before transforming results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->