### PR TITLE
perf: Push token balance staleness filter into SQL and add supporting index

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -196,7 +196,8 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
     ] do
   config :explorer, index_operation, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -128,7 +128,8 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
     ] do
   config :explorer, migrator, enabled: false
 end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -430,6 +430,10 @@ defmodule Explorer.Application do
           Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
           :indexer
         ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
+          :indexer
+        ),
         Explorer.Migrator.RefetchContractCodes
         |> configure_mode_dependent_process(:indexer)
         |> configure_chain_type_dependent_process(:zksync),

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2445,10 +2445,11 @@ defmodule Explorer.Chain do
     Repo.exists?(query)
   end
 
-  @spec fetch_last_token_balances_include_unfetched([Hash.Address.t()], [api?]) :: []
-  def fetch_last_token_balances_include_unfetched(address_hashes, options \\ []) when is_list(address_hashes) do
+  @spec fetch_last_token_balances_include_unfetched([Hash.Address.t()], Block.block_number(), [api?]) :: []
+  def fetch_last_token_balances_include_unfetched(address_hashes, stale_balance_window, options \\ [])
+      when is_list(address_hashes) do
     address_hashes
-    |> CurrentTokenBalance.last_token_balances_include_unfetched()
+    |> CurrentTokenBalance.last_token_balances_include_unfetched(stale_balance_window)
     |> select_repo(options).all()
   end
 

--- a/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/current_token_balance.ex
@@ -178,15 +178,17 @@ defmodule Explorer.Chain.Address.CurrentTokenBalance do
   end
 
   @doc """
-  Builds an `t:Ecto.Query.t/0` to fetch the current token balances of the given addresses (include unfetched).
+  Builds an `t:Ecto.Query.t/0` to fetch the current token balances of the given addresses (include unfetched)
+  with `block_number` older than the given stale balance window.
   """
-  def last_token_balances_include_unfetched(address_hashes) when is_list(address_hashes) do
+  def last_token_balances_include_unfetched(address_hashes, stale_balance_window) when is_list(address_hashes) do
     fiat_balance = fiat_value_query()
 
     from(
       ctb in __MODULE__,
       where: ctb.address_hash in ^address_hashes,
       where: ctb.token_type != "ERC-7984",
+      where: ctb.block_number < ^stale_balance_window,
       left_join: t in assoc(ctb, :token),
       on: ctb.token_contract_address_hash == t.contract_address_hash,
       preload: [token: t],

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -70,7 +70,8 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_create_addresses_hash_contract_code_not_null_index_finished,
     key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished,
     key: :fill_internal_transactions_address_ids_finished,
-    key: :heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished
+    key: :heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished,
+    key: :heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished
 
   @dialyzer :no_match
 
@@ -87,6 +88,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
   }
 
   alias Explorer.Migrator.HeavyDbIndexOperation.{
+    CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
     CreateAddressesHashContractCodeNotNullIndex,
     CreateAddressesTransactionsCountAscCoinBalanceDescHashPartialIndex,
     CreateAddressesTransactionsCountDescPartialIndex,
@@ -293,6 +295,13 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     set_and_return_migration_status(
       CreateSmartContractsLanguageIndex,
       &set_heavy_indexes_create_smart_contracts_language_index_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished) do
+    set_and_return_migration_status(
+      CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
+      &set_heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation do
               | :arbitrum_batch_l2_blocks
               | :smart_contracts_additional_sources
               | :tokens
+              | :address_current_token_balances
   @doc """
   Specifies the type of operation to be performed on the database index.
 

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_address_current_token_balances_address_hash_block_number_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_address_current_token_balances_address_hash_block_number_index.ex
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex do
+  @moduledoc """
+  Create B-tree index `address_current_token_balances_address_hash_block_number_index` on
+  `address_current_token_balances` table for (`address_hash`, `block_number`) columns.
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  require Logger
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
+
+  @table_name :address_current_token_balances
+  @index_name "address_current_token_balances_address_hash_block_number_index"
+  @operation_type :create
+  @table_columns ["address_hash", "block_number"]
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations, do: []
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation do
+    HeavyDbIndexOperationHelper.create_db_index(@index_name, @table_name, @table_columns)
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    operation = HeavyDbIndexOperationHelper.create_index_query_string(@index_name, @table_name, @table_columns)
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation)
+  end
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation_status do
+    HeavyDbIndexOperationHelper.db_index_creation_status(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def restart_db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache do
+    BackgroundMigrations.set_heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished(
+      true
+    )
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -156,9 +156,8 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
       stale_balance_window ->
         address_hashes
         |> Enum.uniq()
-        |> Chain.fetch_last_token_balances_include_unfetched()
+        |> Chain.fetch_last_token_balances_include_unfetched(stale_balance_window)
         |> delete_invalid_balances()
-        |> Enum.filter(fn ctb -> ctb.block_number < stale_balance_window end)
         |> prepare_ctb_params_for_buffer()
     end
   end


### PR DESCRIPTION
## Motivation

`last_token_balances_include_unfetched` (used by the on-demand token balance fetcher on address page views) ranked in the top 5 queries by `total_exec_time` in `pg_stat_statements` (~9.4M ms across 29k calls, ~205M rows returned). The query fetched every current token balance row for an address, joined the wide `tokens` row to all of them, shipped everything to the app, and only then filtered by `block_number < stale_balance_window` in Elixir — discarding ~99% of rows on hot addresses and repeat page views. This moves that predicate into SQL and adds an index to support it.

## Changelog

### Enhancements

- `CurrentTokenBalance.last_token_balances_include_unfetched/2` now accepts a `stale_balance_window` and filters `block_number < stale_balance_window` in the query, so only stale rows are fetched and joined instead of an address's entire balance history. The in-Elixir `Enum.filter` on `block_number` in the on-demand fetcher is removed accordingly.
- Added background heavy DB index migration `CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex` creating `address_current_token_balances_address_hash_block_number_index` on `(address_hash, block_number)` via `CREATE INDEX CONCURRENTLY`, so non-stale rows are rejected inside the index rather than via heap fetches.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Token balance updates now identify stale balances more precisely using the configured block window.
  - Address-based token balance lookups are optimized for faster retrieval, particularly when processing balances that require fetching.
  - Background processing can track completion of the address token balance optimization without interrupting normal operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->