### PR TITLE
perf: optimize topic-only getLogs ordering and add supporting logs index

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -195,7 +195,8 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockNumberCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex
+      Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
     ] do
   config :explorer, index_operation, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -127,7 +127,8 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsBlockNumberCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex
+      Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
     ] do
   config :explorer, migrator, enabled: false
 end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -426,6 +426,10 @@ defmodule Explorer.Application do
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesHashContractCodeNotNullIndex,
           :indexer
         ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+          :indexer
+        ),
         Explorer.Migrator.RefetchContractCodes
         |> configure_mode_dependent_process(:indexer)
         |> configure_chain_type_dependent_process(:zksync),

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -69,7 +69,8 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_drop_transactions_created_contract_address_hash_with_pending_index_a_finished,
     key: :heavy_indexes_create_addresses_hash_contract_code_not_null_index_finished,
     key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished,
-    key: :fill_internal_transactions_address_ids_finished
+    key: :fill_internal_transactions_address_ids_finished,
+    key: :heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished
 
   @dialyzer :no_match
 
@@ -97,6 +98,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     CreateInternalTransactionsBlockNumberDescTransactionIndexDescIndexDescIndex,
     CreateLogsAddressHashBlockNumberDescIndexDescIndex,
     CreateLogsAddressHashFirstTopicBlockNumberIndexIndex,
+    CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
     CreateLogsBlockHashIndex,
     CreateLogsDepositsWithdrawalsIndex,
     CreateSmartContractsLanguageIndex,
@@ -412,6 +414,13 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     set_and_return_migration_status(
       FillInternalTransactionsAddressIds,
       &set_fill_internal_transactions_address_ids_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished) do
+    set_and_return_migration_status(
+      CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+      &set_heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished/1
     )
   end
 

--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -143,7 +143,12 @@ defmodule Explorer.Etherscan.Logs do
   def list_logs(filter, paging_options) do
     paging_options = if is_nil(paging_options), do: @default_paging_options, else: paging_options
     prepared_filter = Map.merge(@base_filter, filter)
-    logs_query = where_topic_match(Log, prepared_filter)
+
+    logs_query =
+      Log
+      |> where_topic_match(prepared_filter)
+      |> where([log], log.block_number >= ^prepared_filter.from_block)
+      |> where([log], log.block_number <= ^prepared_filter.to_block)
 
     if DenormalizationHelper.transactions_denormalization_finished?() do
       block_transaction_query =
@@ -169,7 +174,7 @@ defmodule Explorer.Etherscan.Logs do
           on:
             block_transaction_data.transaction_hash == log.transaction_hash and
               block_transaction_data.block_hash == log.block_hash,
-          order_by: block_transaction_data.block_number,
+          order_by: log.block_number,
           limit: 1000,
           select: block_transaction_data,
           select_merge: map(log, ^@log_fields)
@@ -202,7 +207,7 @@ defmodule Explorer.Etherscan.Logs do
         from(log in logs_query,
           join: block_transaction_data in subquery(block_transaction_query),
           on: block_transaction_data.transaction_hash == log.transaction_hash,
-          order_by: block_transaction_data.block_number,
+          order_by: log.block_number,
           limit: 1000,
           select: block_transaction_data,
           select_merge: map(log, ^@log_fields)

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_hash_first_topic_second_topic_block_number_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_hash_first_topic_second_topic_block_number_index.ex
@@ -11,8 +11,6 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopi
 
   alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
-
-  alias Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
   @table_name :logs
@@ -30,10 +28,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopi
   def index_name, do: @index_name
 
   @impl HeavyDbIndexOperation
-  def dependent_from_migrations,
-    do: [
-      CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex.migration_name()
-    ]
+  def dependent_from_migrations, do: []
 
   @impl HeavyDbIndexOperation
   def db_index_operation do

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_hash_first_topic_second_topic_block_number_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_hash_first_topic_second_topic_block_number_index.ex
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex do
+  @moduledoc """
+  Create B-tree index `logs_address_hash_first_topic_second_topic_block_number_index` on
+  `logs` table for (`address_hash`, `first_topic`, `second_topic`, `block_number`, `index`) columns.
+  """
+
+  use Explorer.Migrator.HeavyDbIndexOperation
+
+  require Logger
+
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
+  alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
+
+  @table_name :logs
+  @index_name "logs_address_hash_first_topic_second_topic_block_number_index"
+  @operation_type :create
+  @table_columns ["address_hash", "first_topic", "second_topic", "block_number", "index"]
+
+  @impl HeavyDbIndexOperation
+  def table_name, do: @table_name
+
+  @impl HeavyDbIndexOperation
+  def operation_type, do: @operation_type
+
+  @impl HeavyDbIndexOperation
+  def index_name, do: @index_name
+
+  @impl HeavyDbIndexOperation
+  def dependent_from_migrations,
+    do: [
+      CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex.migration_name()
+    ]
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation do
+    HeavyDbIndexOperationHelper.create_db_index(@index_name, @table_name, @table_columns)
+  end
+
+  @impl HeavyDbIndexOperation
+  def check_db_index_operation_progress do
+    operation = HeavyDbIndexOperationHelper.create_index_query_string(@index_name, @table_name, @table_columns)
+    HeavyDbIndexOperationHelper.check_db_index_operation_progress(@index_name, operation)
+  end
+
+  @impl HeavyDbIndexOperation
+  def db_index_operation_status do
+    HeavyDbIndexOperationHelper.db_index_creation_status(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def restart_db_index_operation do
+    HeavyDbIndexOperationHelper.safely_drop_db_index(@index_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def running_other_heavy_migration_exists?(migration_name) do
+    MigrationStatus.running_other_heavy_migration_for_table_exists?(@table_name, migration_name)
+  end
+
+  @impl HeavyDbIndexOperation
+  def update_cache do
+    BackgroundMigrations.set_heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished(
+      true
+    )
+  end
+end

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -1,8 +1,8 @@
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
-#export CHROMEDRIVER_VERSION=148.0.7778.179
+#export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
+export CHROMEDRIVER_VERSION=150.0.7871.125
 curl -L -O "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip"
 unzip -j chromedriver-linux64.zip
 sudo chmod +x chromedriver


### PR DESCRIPTION
## Motivation

The topic-only branch of `Explorer.Etherscan.Logs.list_logs/2` (used by `eth_getLogs` when a topic filter is supplied without an `address_hash`) sorted the joined result by the transactions subquery's `block_number` (`ORDER BY s1.block_number, l0.index`). Because the sort key came from the joined table and the block-range predicate lived only on the transactions subquery, PostgreSQL had to compute the full join and sort the entire result set before applying `LIMIT 1000`. This mirrors the situation fixed for the `address_hash` branch in #14588, but that fix did not apply here since this branch never carried the range predicate on `logs`. Separately, the `address_hash` + `first_topic` + `second_topic` filter shape of `eth_getLogs` had no covering index, forcing `second_topic` to be evaluated as a heap filter (or a costly `BitmapAnd` of single-column topic indexes); this PR also adds the composite index that turns that predicate into an index condition.

## Changelog

### Enhancements

Optimized the topic-only `eth_getLogs` query so it can terminate early at `LIMIT 1000` instead of sorting the whole join. Two coordinated changes: (1) pushed the block-number range predicate onto the `logs` table (`log.block_number >= from_block AND <= to_block`), which is equivalent because the join is on `block_hash` and `block_hash` functionally determines `block_number`, so no correctly-joined row is dropped; (2) changed the ordering from the transactions subquery's `block_number` to `log.block_number` in both the denormalized and non-denormalized sub-branches. Together this lets the planner seek into the existing `logs (block_number ASC, index ASC)` index, scan in order, filter by topic, nested-loop into the transactions subquery, and stop at 1000 rows.

Added a new B-tree index `logs_address_hash_first_topic_second_topic_block_number_index` on `logs (address_hash, first_topic, second_topic, block_number, index)`, created online via the background heavy-DB-index-operation machinery (`Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex`, using `CREATE INDEX CONCURRENTLY IF NOT EXISTS`). This supports the `address_hash` + `first_topic` + `second_topic` + block-range `eth_getLogs` filter shape, letting the `second_topic` predicate be satisfied as an index condition rather than a heap filter and avoiding `BitmapAnd` plans over the single-column topic indexes. The migration is registered in `config.exs`, disabled in `runtime/test.exs`, supervised as a mode-dependent indexer process in `application.ex`, and integrated into the `BackgroundMigrations` cache (key, alias, and fallback handler).

## Upgrading

No manual steps required. The new index is built online in the background on the indexer node after deploy; no database reset or reindex is needed. On very large `logs` tables the concurrent build may take significant time and disk, but it does not block reads or writes.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log filtering so block-number lower/upper bounds are applied consistently.
  * Corrected log ordering to reliably sort by block number, then log index.

* **Performance**
  * Added a new database index to speed up common log lookup patterns.

* **Chores**
  * Pinned the headless browser driver to a fixed version to improve installation reliability in automated environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->