### PR TITLE
feat: Add logs address_hash/first_topic/second_topic index

### DIFF
--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -196,7 +196,8 @@ for index_operation <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
     ] do
   config :explorer, index_operation, enabled: true
 end

--- a/apps/explorer/config/runtime/test.exs
+++ b/apps/explorer/config/runtime/test.exs
@@ -128,7 +128,8 @@ for migrator <- [
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsCreatedContractAddressHashIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsFromAddressHashPartialIndex,
       Explorer.Migrator.HeavyDbIndexOperation.DropInternalTransactionsToAddressHashPartialIndex,
-      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex
+      Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
+      Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex
     ] do
   config :explorer, migrator, enabled: false
 end

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -430,6 +430,10 @@ defmodule Explorer.Application do
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
           :indexer
         ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+          :indexer
+        ),
         Explorer.Migrator.RefetchContractCodes
         |> configure_mode_dependent_process(:indexer)
         |> configure_chain_type_dependent_process(:zksync),

--- a/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
+++ b/apps/explorer/lib/explorer/chain/cache/background_migrations.ex
@@ -70,7 +70,8 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     key: :heavy_indexes_create_addresses_hash_contract_code_not_null_index_finished,
     key: :heavy_indexes_create_address_ids_internal_transactions_indexes_finished,
     key: :fill_internal_transactions_address_ids_finished,
-    key: :heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished
+    key: :heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished,
+    key: :heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished
 
   @dialyzer :no_match
 
@@ -99,6 +100,7 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     CreateInternalTransactionsBlockNumberDescTransactionIndexDescIndexDescIndex,
     CreateLogsAddressHashBlockNumberDescIndexDescIndex,
     CreateLogsAddressHashFirstTopicBlockNumberIndexIndex,
+    CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
     CreateLogsBlockHashIndex,
     CreateLogsDepositsWithdrawalsIndex,
     CreateSmartContractsLanguageIndex,
@@ -300,6 +302,13 @@ defmodule Explorer.Chain.Cache.BackgroundMigrations do
     set_and_return_migration_status(
       CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex,
       &set_heavy_indexes_create_address_current_token_balances_address_hash_block_number_index_finished/1
+    )
+  end
+
+  defp handle_fallback(:heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished) do
+    set_and_return_migration_status(
+      CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex,
+      &set_heavy_indexes_create_logs_address_hash_first_topic_second_topic_block_number_index_finished/1
     )
   end
 


### PR DESCRIPTION
## Motivation

The `?module=logs&action=getLogs` RPC endpoint (`Explorer.Etherscan.Logs.list_logs/2`) filters logs by `address_hash`, `first_topic`, `second_topic = ANY(...)`, and a `block_number` range. The best existing index, `logs_address_hash_first_topic_block_number_index_index`, covers only `(address_hash, first_topic, block_number, index)`, so the `second_topic` predicate is evaluated as a heap filter: every candidate row matching the address+topic0 prefix is fetched from the heap just to check `second_topic`, and the planner may instead pick a costly `BitmapAnd` of the single-column `logs_second_topic_index` with the address index. For a hot address with a common `first_topic` and a selective `second_topic`, this burns DB CPU on wasted heap fetches or large bitmap operations. Adding a composite index on `(address_hash, first_topic, second_topic, block_number, index)` turns the `second_topic` filter into an index condition and, combined with the ordering by `block_number, index`, lets the `LIMIT` short-circuit the scan. The index is created online via the existing background heavy-DB-index-operation machinery so it does not lock the table.

## Changelog

### Enhancements

Added a new background heavy-DB-index-operation migration `Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressHashFirstTopicSecondTopicBlockNumberIndex` that creates the B-tree index `logs_address_hash_first_topic_second_topic_block_number_index` on `logs (address_hash, first_topic, second_topic, block_number, index)` using `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. The migration declares a dependency on `CreateAddressCurrentTokenBalancesAddressHashBlockNumberIndex` (from #14592) via `dependent_from_migrations`, so it only starts after that index finishes, avoiding concurrent heavy index builds. The migration is registered in `config.exs`, disabled in `runtime/test.exs`, supervised as a mode-dependent process in `application.ex`, and integrated into the `BackgroundMigrations` cache (key, alias, and fallback handler), mirroring the pattern established in #14592.


## Upgrading

_No manual steps required. The index is built online in the background on the indexer node after deploy; no database reset or reindex is needed. On very large `logs` tables the concurrent build may take significant time and disk, but it does not block reads or writes._

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.