### PR TITLE
perf: use equality and UNION ALL instead of = ANY for topic filters in Etherscan getLogs

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -6,7 +6,7 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [from: 2, where: 3, subquery: 1, order_by: 3]
+  import Ecto.Query, only: [dynamic: 2, from: 2, where: 2, where: 3, subquery: 1, order_by: 3, union_all: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{DenormalizationHelper, Log, Transaction}
@@ -76,13 +76,16 @@ defmodule Explorer.Etherscan.Logs do
     paging_options = if is_nil(paging_options), do: @default_paging_options, else: paging_options
     prepared_filter = Map.merge(@base_filter, filter)
 
+    # With `union_multiple_values: true` `where_topic_match/3` may turn the
+    # query into a UNION ALL, so it must be applied last: `where/3` on a
+    # combination query would only affect its first branch.
     logs_query =
       Log
-      |> where_topic_match(prepared_filter)
       |> where([log], log.address_hash == ^address_hash)
       |> where([log], log.block_number >= ^prepared_filter.from_block)
       |> where([log], log.block_number <= ^prepared_filter.to_block)
       |> page_logs(paging_options)
+      |> where_topic_match(prepared_filter, union_multiple_values: true)
 
     if DenormalizationHelper.transactions_denormalization_finished?() do
       all_transaction_logs_query =
@@ -236,7 +239,11 @@ defmodule Explorer.Etherscan.Logs do
     topic2_3_opr: {:third_topic, :fourth_topic}
   }
 
-  defp where_topic_match(query, filter) do
+  # Above this number of values for a single topic, fall back to
+  # `= ANY(...)` to keep query size and planning time bounded.
+  @max_topic_union_branches 16
+
+  defp where_topic_match(query, filter, opts \\ []) do
     filter = sanitize_filter_topics(filter)
 
     case Enum.filter(@topics, &filter[&1]) do
@@ -244,11 +251,45 @@ defmodule Explorer.Etherscan.Logs do
         query
 
       [topic] ->
-        where(query, [l], field(l, ^topic) in ^List.wrap(filter[topic]))
+        where_single_topic_match(query, topic, filter[topic], opts)
 
       _ ->
         where_multiple_topics_match(query, filter)
     end
+  end
+
+  # With `union_multiple_values: true`, a single topic with multiple values
+  # is combined with UNION ALL (one equality branch per value) instead of
+  # `topic = ANY(...)`: a scalar-array condition on a topic column prevents
+  # PostgreSQL from returning rows in `(block_number, index)` order from the
+  # (address_hash, first_topic, block_number, index) index, forcing it to
+  # materialize and sort every match in the block range before applying the
+  # LIMIT. With UNION ALL each branch is an ordered index scan, so the
+  # planner can merge branches and stop at the LIMIT. The resulting
+  # combination query must be wrapped in `subquery/1` by the caller before
+  # any further composition.
+  defp where_single_topic_match(query, topic, values, opts) when is_list(values) do
+    if Keyword.get(opts, :union_multiple_values, false) and length(values) <= @max_topic_union_branches do
+      values
+      |> Enum.map(fn value -> where(query, [l], field(l, ^topic) == ^value) end)
+      |> Enum.reduce(fn branch, acc -> union_all(acc, ^branch) end)
+    else
+      where(query, ^topic_condition(topic, values))
+    end
+  end
+
+  defp where_single_topic_match(query, topic, value, _opts) do
+    where(query, [l], field(l, ^topic) == ^value)
+  end
+
+  # Equality instead of `= ANY(...)` for scalar values matters for
+  # performance: see `where_single_topic_match/3`.
+  defp topic_condition(topic, values) when is_list(values) do
+    dynamic([l], field(l, ^topic) in ^values)
+  end
+
+  defp topic_condition(topic, value) do
+    dynamic([l], field(l, ^topic) == ^value)
   end
 
   defp sanitize_filter_topics(filter) do
@@ -299,12 +340,20 @@ defmodule Explorer.Etherscan.Logs do
 
   defp where_multiple_topics_match(query, filter, topic_operation, "and") do
     {topic_a, topic_b} = @topic_operations[topic_operation]
-    where(query, [l], field(l, ^topic_a) == ^filter[topic_a] and field(l, ^topic_b) in ^List.wrap(filter[topic_b]))
+
+    where(
+      query,
+      ^dynamic([l], ^topic_condition(topic_a, filter[topic_a]) and ^topic_condition(topic_b, filter[topic_b]))
+    )
   end
 
   defp where_multiple_topics_match(query, filter, topic_operation, "or") do
     {topic_a, topic_b} = @topic_operations[topic_operation]
-    where(query, [l], field(l, ^topic_a) == ^filter[topic_a] or field(l, ^topic_b) in ^List.wrap(filter[topic_b]))
+
+    where(
+      query,
+      ^dynamic([l], ^topic_condition(topic_a, filter[topic_a]) or ^topic_condition(topic_b, filter[topic_b]))
+    )
   end
 
   defp where_multiple_topics_match(query, _, _, _), do: query

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -450,6 +450,56 @@ defmodule Explorer.Etherscan.LogsTest do
       assert found_log.first_topic == log2.first_topic
     end
 
+    test "with address and multiple values for a topic{x}" do
+      contract_address = insert(:contract_address)
+
+      transaction =
+        %Transaction{block: block} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      log1_details = [
+        address: contract_address,
+        transaction: transaction,
+        block: block,
+        first_topic: topic(@first_topic_hex_string_1),
+        block_number: block.number
+      ]
+
+      log2_details = [
+        address: contract_address,
+        transaction: transaction,
+        block: block,
+        first_topic: topic(@first_topic_hex_string_2),
+        block_number: block.number
+      ]
+
+      log3_details = [
+        address: contract_address,
+        transaction: transaction,
+        block: block,
+        first_topic: topic(@first_topic_hex_string_3),
+        block_number: block.number
+      ]
+
+      log1 = insert(:log, log1_details)
+      log2 = insert(:log, log2_details)
+      _log3 = insert(:log, log3_details)
+
+      filter = %{
+        from_block: block.number,
+        to_block: block.number,
+        address_hash: contract_address.hash,
+        first_topic: [log1.first_topic, log2.first_topic]
+      }
+
+      found_logs = Logs.list_logs(filter)
+
+      assert Enum.map(found_logs, & &1.index) == [log1.index, log2.index]
+      assert Enum.map(found_logs, & &1.first_topic) == [log1.first_topic, log2.first_topic]
+    end
+
     test "with address and two topic{x}s" do
       contract_address = insert(:contract_address)
 


### PR DESCRIPTION
## Motivation

The query produced by `Explorer.Etherscan.Logs.list_logs/2` (backing `eth_getLogs` and the API v1 `?module=logs&action=getLogs` endpoint) is at the top of `pg_stat_statements` by `total_exec_time`. The root cause is that topic filters were always rendered as `topic = ANY($1)` (Ecto compiles `field in ^list` to a scalar-array condition even for a single value). A scalar-array condition on a topic column prevents PostgreSQL from returning rows in `(block_number, index)` order from the `(address_hash, first_topic, block_number, index)` index, so instead of an ordered index scan with a nested-loop join that stops at `LIMIT 1000`, the planner must materialize every matching log in the requested block range, join all of them to `transactions`, and top-N sort — cost proportional to the total number of matches rather than to the page size.

With this change, a scalar topic value is rendered as a plain equality (`topic = $1`), restoring the ordered-index-scan plan for the dominant "one address + one event signature" call shape. A list of up to 16 values for a single topic is rendered as a UNION ALL of equality branches, letting the planner merge-append ordered per-value index scans and terminate at the LIMIT; longer lists fall back to `= ANY(...)` to keep query size and planning time bounded. The result-set semantics of the endpoints are unchanged.

## Changelog

### Enhancements

- `Explorer.Etherscan.Logs.where_topic_match/2`: a single topic value now renders as `topic = $1` instead of `topic = ANY($1)`, allowing PostgreSQL to use an ordered scan of the `(address_hash, first_topic, block_number, index)` index and stop at the LIMIT.
- Multiple values for a single topic (up to 16) are combined via UNION ALL of equality branches instead of `= ANY(...)`, enabling merge-append of ordered index scans; larger lists keep the previous `= ANY(...)` form.
- `where_multiple_topics_match/4` (topic-pair `and`/`or` operators) now uses equality for scalar values and `IN` only for genuine lists; this also fixes the previously broken case where the first topic of a pair was a list of values (it was compared with `==` against the whole list).
- `where_topic_match/2` is now applied as the last step of building `logs_query`, and the topic-less clause wraps `logs_query` in a subquery, since the query may now be a combination (UNION ALL) query.

### Bug Fixes

### Incompatible Changes

## Upgrading

No upgrade steps required: no schema, index, or ENV changes; API responses are unchanged.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log filtering to ensure topic, address, and block-range filters are applied in the correct order for more reliable results.
  * Enhanced topic matching behavior when a topic filter includes multiple values.

* **Performance**
  * Optimized multi-value topic matching, reducing query complexity for common cases while safely handling larger lists.

* **Tests**
  * Added coverage to verify filtering by `first_topic` correctly returns only logs matching any provided topic values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->