### PR TITLE
perf: Optimize transaction to internal transaction preload

### DIFF
--- a/apps/explorer/lib/explorer/chain/internal_transaction.ex
+++ b/apps/explorer/lib/explorer/chain/internal_transaction.ex
@@ -1517,10 +1517,27 @@ defmodule Explorer.Chain.InternalTransaction do
     transactions =
       case existing_transactions do
         nil ->
-          internal_transactions
-          |> Enum.map(&{&1.block_number, &1.transaction_index})
-          |> Enum.uniq()
-          |> Transaction.by_block_number_index_query()
+          {block_numbers, transaction_indexes} =
+            internal_transactions
+            |> Enum.map(&{&1.block_number, &1.transaction_index})
+            |> Enum.uniq()
+            |> Enum.unzip()
+
+          from(
+            pair in fragment(
+              """
+              SELECT *
+              FROM unnest(?::integer[], ?::integer[]) AS pair(block_number, transaction_index)
+              """,
+              type(^block_numbers, {:array, :integer}),
+              type(^transaction_indexes, {:array, :integer})
+            ),
+            join: transaction in Transaction,
+            on:
+              transaction.block_number == pair.block_number and
+                transaction.index == pair.transaction_index,
+            select: transaction
+          )
           |> repo.all()
 
         transactions ->


### PR DESCRIPTION
## Motivation

It's more efficient to do a single index scan instead of multiple bitmap OR conditions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of parent transactions for internal transactions.
  * Ensured matching transactions are retrieved accurately using block numbers and transaction indexes.
  * Preserved transaction hash fallback behavior when parent transaction data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->