### PR TITLE
fix: Handle incorrect number of top-level calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - Use Repo.replica as a default repo for transaction preload ([#14591](https://github.com/blockscout/blockscout/issues/14591))
 - Differentiate blocks count event by type ([#14573](https://github.com/blockscout/blockscout/issues/14573))
-- Add availability to bradcast blocks count instead of full block ([#14571](https://github.com/blockscout/blockscout/issues/14571))
+- Add availability to broadcast blocks count instead of full block ([#14571](https://github.com/blockscout/blockscout/issues/14571))
 
 ## 11.2.2
 

--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -197,9 +197,20 @@ defmodule Indexer.Fetcher.InternalTransaction do
       :block_number ->
         Logger.debug("fetching internal transactions by blocks")
 
-        block_numbers_or_transactions
-        |> check_and_filter_block_numbers()
-        |> EthereumJSONRPC.fetch_block_internal_transactions(json_rpc_named_arguments)
+        block_numbers = check_and_filter_block_numbers(block_numbers_or_transactions)
+
+        case EthereumJSONRPC.fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments) do
+          {:error, errors} = error ->
+            # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
+            if incorrect_top_level_calls_error?(errors) do
+              handle_incorrect_top_level_calls(block_numbers, json_rpc_named_arguments)
+            else
+              error
+            end
+
+          result ->
+            result
+        end
 
       :transaction_params ->
         Logger.debug("fetching internal transactions by transactions")
@@ -232,6 +243,29 @@ defmodule Indexer.Fetcher.InternalTransaction do
     else
       @default_block_traceable_variants
     end
+  end
+
+  defp handle_incorrect_top_level_calls(block_numbers, json_rpc_named_arguments) do
+    Logger.warning(
+      "failed to fetch internal transactions by blocks due to incorrect number of top-level calls, " <>
+        "retrying by transactions for blocks #{inspect(block_numbers)}"
+    )
+
+    block_numbers
+    |> Transaction.get_transactions_of_block_numbers()
+    |> Enum.reduce_while({:ok, []}, fn transaction, {:ok, acc} ->
+      case fetch_internal_transactions_by_transactions([transaction], json_rpc_named_arguments) do
+        {:ok, internal_transactions} ->
+          {:cont, {:ok, acc ++ internal_transactions}}
+
+        {:error, _reason, _stacktrace} = error ->
+          {:halt, {:error, error}}
+
+        {:error, errors} ->
+          # credo:disable-for-lines:2 Credo.Check.Refactor.Nesting
+          if incorrect_top_level_calls_error?(errors), do: {:cont, {:ok, acc}}, else: {:halt, {:error, errors}}
+      end
+    end)
   end
 
   defp drop_genesis(block_numbers, json_rpc_named_arguments) do
@@ -281,6 +315,13 @@ defmodule Indexer.Fetcher.InternalTransaction do
       end
     end)
   end
+
+  defp incorrect_top_level_calls_error?(errors) when is_list(errors) do
+    Enum.any?(errors, &incorrect_top_level_calls_error?/1)
+  end
+
+  defp incorrect_top_level_calls_error?(%{message: "incorrect number of top-level calls"}), do: true
+  defp incorrect_top_level_calls_error?(_), do: false
 
   defp fetch_internal_transactions_by_transactions(transactions, json_rpc_named_arguments) do
     transactions

--- a/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/internal_transaction_test.exs
@@ -320,6 +320,104 @@ defmodule Indexer.Fetcher.InternalTransactionTest do
       assert Repo.exists?(from(i in Chain.InternalTransaction, where: i.block_number == ^block_number))
     end
 
+    test "retries fetching by transactions when fetching by block returns incorrect number of top-level calls", %{
+      json_rpc_named_arguments: json_rpc_named_arguments
+    } do
+      block = insert(:block, number: 1)
+      transaction1 = insert(:transaction) |> with_block(block)
+      insert(:transaction) |> with_block(block)
+      block_hash = block.hash
+      block_number = block.number
+
+      insert(:pending_block_operation,
+        block_hash: block_hash,
+        block_number: block_number
+      )
+
+      json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :variant, EthereumJSONRPC.Geth)
+
+      if json_rpc_named_arguments[:transport] == EthereumJSONRPC.Mox do
+        EthereumJSONRPC.Mox
+        |> expect(:json_rpc, fn
+          [%{id: id, method: "debug_traceBlockByNumber"}], _options ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 error: %{
+                   code: -32000,
+                   message: "incorrect number of top-level calls"
+                 }
+               }
+             ]}
+        end)
+        |> expect(:json_rpc, fn
+          [%{id: id, method: "debug_traceTransaction"}], _options ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 result: %{
+                   "blockNumber" => block_number,
+                   "transactionIndex" => transaction1.index,
+                   "transactionHash" => transaction1.hash,
+                   "index" => 0,
+                   "traceAddress" => [],
+                   "type" => "call",
+                   "callType" => "call",
+                   "from" => "0xa931c862e662134b85e4dc4baf5c70cc9ba74db4",
+                   "to" => "0x1469b17ebf82fedf56f04109e5207bdc4554288c",
+                   "gas" => "0x8600",
+                   "gasUsed" => "0x7d37",
+                   "input" => "0xb118e2db0000000000000000000000000000000000000000000000000000000000000008",
+                   "output" => "0x",
+                   "value" => "0x174876e800"
+                 }
+               }
+             ]}
+        end)
+        |> expect(:json_rpc, fn
+          [%{id: id, method: "debug_traceTransaction"}], _options ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 error: %{
+                   code: -32000,
+                   message: "incorrect number of top-level calls"
+                 }
+               }
+             ]}
+        end)
+      end
+
+      config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+      Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, Keyword.put(config, :allow_empty_traces?, true))
+
+      on_exit(fn -> Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, config) end)
+
+      CoinBalanceCatchup.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      start_token_balance_fetcher(json_rpc_named_arguments)
+
+      assert %{block_hash: ^block_hash} = Repo.get(PendingBlockOperation, block_hash)
+
+      assert :ok ==
+               InternalTransaction.run(
+                 [block_number],
+                 json_rpc_named_arguments
+               )
+
+      assert nil == Repo.get(PendingBlockOperation, block_hash)
+
+      assert Repo.exists?(
+               from(
+                 internal_transaction in Chain.InternalTransaction,
+                 where: internal_transaction.block_number == ^block_number
+               )
+             )
+    end
+
     test "handles failure by retrying only unique numbers", %{
       json_rpc_named_arguments: json_rpc_named_arguments
     } do


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/11907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal transaction fetching by automatically retrying and switching to transaction-level retrieval when block-level JSON-RPC calls fail with an “incorrect number of top-level calls” error.
* **Tests**
  * Added coverage to verify the retry/fallback behavior for this specific failure scenario during internal transaction trace retrieval.
* **Documentation**
  * Updated the changelog wording and clarified the blocks-count broadcast change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->