### PR TITLE
fix: Add missing preload_contract_creation_internal_transaction condition

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_controller.ex
@@ -126,7 +126,7 @@ defmodule BlockScoutWeb.AddressController do
       render(
         conn,
         "_show_address_transactions.html",
-        address: address,
+        address: fully_preloaded_address,
         coin_balance_status: CoinBalanceOnDemand.trigger_fetch(ip, address),
         exchange_rate: Market.get_coin_exchange_rate(),
         filter: params["filter"],

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -880,7 +880,13 @@ defmodule Explorer.Chain do
     query
     |> join_associations(necessity_by_association)
     |> select_repo(options).one()
-    |> Address.maybe_preload_contract_creation_internal_transaction(select_repo(options))
+    |> then(fn address ->
+      if Keyword.get(options, :preload_contract_creation_internal_transaction, false) do
+        Address.maybe_preload_contract_creation_internal_transaction(address, select_repo(options))
+      else
+        address
+      end
+    end)
     |> SmartContract.compose_address_for_unverified_smart_contract(hash, options)
     |> case do
       nil -> {:error, :not_found}


### PR DESCRIPTION
## Motivation

`Chain.hash_to_address/2` should also use the `:preload_contract_creation_internal_transaction` option to decide preload necessity like it's done in `Address.find_contract_address/2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address lookup behavior by only loading contract-creation internal transaction details when explicitly requested, reducing unnecessary data loading for standard queries.
  * Fixed the JSON address view to use the fully preloaded address data, ensuring address transaction templates receive the expected smart-contract associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->