### PR TITLE
fix: Fix tuple json encoding error

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/smart_contract.ex
@@ -94,7 +94,12 @@ defmodule BlockScoutWeb.Schemas.API.V2.SmartContract do
         sourcify_repo_url: %Schema{type: :string, nullable: true},
         decoded_constructor_args: %Schema{
           type: :array,
-          items: %Schema{type: :array, items: %Schema{anyOf: [%Schema{type: :object}, %Schema{type: :string}]}},
+          items: %Schema{
+            type: :array,
+            items: %Schema{
+              anyOf: [%Schema{type: :array}, %Schema{type: :object}, %Schema{type: :string}]
+            }
+          },
           nullable: true
         },
         is_verified_via_verifier_alliance: %Schema{type: :boolean, nullable: true},

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/smart_contract_controller_test.exs
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
   use BlockScoutWeb.ConnCase, async: false
   use BlockScoutWeb.ChannelCase, async: false
 
+  import ExUnit.CaptureLog
   import Mox
 
   alias BlockScoutWeb.AddressContractView
@@ -345,6 +346,46 @@ defmodule BlockScoutWeb.API.V2.SmartContractControllerTest do
       for prop <- result_props do
         assert correct_response[prop] == response[prop]
       end
+    end
+
+    test "get smart-contract with decoded tuple constructor", %{conn: conn} do
+      tuple_input = %{
+        "components" => [
+          %{"name" => "twitter", "type" => "string"},
+          %{"name" => "telegram", "type" => "string"},
+          %{"name" => "discord", "type" => "string"},
+          %{"name" => "website", "type" => "string"},
+          %{"name" => "farcaster", "type" => "string"}
+        ],
+        "name" => "socials_",
+        "type" => "tuple"
+      }
+
+      tuple_type = ABI.FunctionSelector.parse_specification_type(tuple_input)
+
+      constructor_arguments =
+        [{"", "", "", "", ""}]
+        |> ABI.TypeEncoder.encode([tuple_type])
+        |> Base.encode16(case: :lower)
+
+      target_contract =
+        insert(:smart_contract,
+          abi: [%{"inputs" => [tuple_input], "type" => "constructor"}],
+          constructor_arguments: "0x" <> constructor_arguments
+        )
+
+      EthereumJSONRPC.Mox
+      |> TestHelper.mock_generic_proxy_requests()
+
+      log =
+        capture_log(fn ->
+          request = get(conn, "/api/v2/smart-contracts/#{Address.checksum(target_contract.address_hash)}")
+          response = json_response(request, 200)
+
+          assert response["decoded_constructor_args"] == [[["", "", "", "", ""], tuple_input]]
+        end)
+
+      refute log =~ ~s(Error determining value json for "tuple")
     end
 
     test "get smart-contract data from bytecode twin without constructor args", %{conn: conn} do

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
@@ -2,9 +2,132 @@
 defmodule BlockScoutWeb.API.V2.TransactionViewTest do
   use BlockScoutWeb.ConnCase, async: true
 
+  import ExUnit.CaptureLog
+
   alias BlockScoutWeb.API.V2.TransactionView
-  alias Explorer.Repo
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
+  alias Explorer.Chain.Transaction
+  alias Explorer.Repo
+
+  @tuple_input %{
+    "components" => [
+      %{"name" => "twitter", "type" => "string"},
+      %{"name" => "telegram", "type" => "string"},
+      %{"name" => "discord", "type" => "string"},
+      %{"name" => "website", "type" => "string"},
+      %{"name" => "farcaster", "type" => "string"}
+    ],
+    "name" => "socials_",
+    "type" => "tuple"
+  }
+  @tuple_type "(string,string,string,string,string)"
+  @tuple_value {"", "", "", "", ""}
+  @tuple_json ["", "", "", "", ""]
+
+  test "decodes a tuple value from transaction input and renders it without logging a warning" do
+    function_abi = %{
+      "inputs" => [@tuple_input],
+      "name" => "launch",
+      "outputs" => [],
+      "type" => "function"
+    }
+
+    selector = ABI.FunctionSelector.parse_specification_item(function_abi)
+
+    input =
+      [@tuple_value]
+      |> ABI.TypeEncoder.encode(selector)
+      |> Base.encode16(case: :lower)
+
+    smart_contract =
+      :smart_contract
+      |> insert(abi: [function_abi])
+      |> Repo.preload(:address)
+
+    transaction =
+      :transaction
+      |> insert(to_address: smart_contract.address, input: "0x" <> input)
+      |> Repo.preload(to_address: :smart_contract)
+
+    log =
+      capture_log(fn ->
+        assert [decoded_input] = Transaction.decode_transactions([transaction], true, api?: true)
+
+        assert TransactionView.decoded_input(decoded_input) == %{
+                 "method_id" => Base.encode16(selector.method_id, case: :lower),
+                 "method_call" => "launch((string,string,string,string,string) socials_)",
+                 "parameters" => [
+                   %{"name" => "socials_", "type" => @tuple_type, "value" => @tuple_json}
+                 ]
+               }
+      end)
+
+    refute log =~ "Error determining value json"
+  end
+
+  test "decodes a tuple value from an event log and renders it without logging a warning" do
+    event_input = Map.put(@tuple_input, "indexed", false)
+    event_abi = %{"anonymous" => false, "inputs" => [event_input], "name" => "Launched", "type" => "event"}
+    selector = ABI.FunctionSelector.parse_specification_item(event_abi)
+    <<method_id::binary-size(4), _::binary>> = selector.method_id
+    method_id_string = Base.encode16(method_id, case: :lower)
+
+    data =
+      [@tuple_value]
+      |> ABI.TypeEncoder.encode(selector.types)
+      |> Base.encode16(case: :lower)
+
+    smart_contract =
+      :smart_contract
+      |> insert(abi: [event_abi])
+      |> Repo.preload(:address)
+
+    address =
+      Repo.preload(smart_contract.address, [
+        :names,
+        :smart_contract,
+        Implementation.proxy_implementations_smart_contracts_association()
+      ])
+
+    {:ok, log_data} = Explorer.Chain.Data.cast("0x" <> data)
+
+    decoded_log =
+      :log
+      |> build(
+        address: address,
+        address_hash: address.hash,
+        data: log_data,
+        first_topic: topic("0x" <> Base.encode16(selector.method_id, case: :lower)),
+        transaction_hash: build(:transaction).hash
+      )
+      |> List.wrap()
+      |> TransactionView.decode_logs(false)
+      |> List.first()
+
+    captured_log =
+      capture_log(fn ->
+        assert {:ok, decoded_method_id, method_call, mapping} = decoded_log
+
+        assert TransactionView.render("decoded_log_input.json", %{
+                 method_id: decoded_method_id,
+                 text: method_call,
+                 mapping: mapping
+               }) == %{
+                 "method_id" => method_id_string,
+                 "method_call" => "Launched((string,string,string,string,string) socials_)",
+                 "parameters" => [
+                   %{
+                     "indexed" => false,
+                     "name" => "socials_",
+                     "type" => @tuple_type,
+                     "value" => @tuple_json
+                   }
+                 ]
+               }
+      end)
+
+    refute captured_log =~ "Error determining value json"
+  end
 
   describe "decode_logs/2" do
     test "doesn't use decoding candidate event with different 2nd, 3d or 4th topic" do

--- a/apps/explorer/lib/explorer/chain/decoding_helper.ex
+++ b/apps/explorer/lib/explorer/chain/decoding_helper.ex
@@ -8,18 +8,28 @@ defmodule Explorer.Chain.DecodingHelper do
 
   require Logger
 
-  def value_json(type, value) do
-    decoded_type = FunctionSelector.decode_type(type)
+  def value_json(type_specification, value) do
+    decoded_type =
+      case type_specification do
+        %{"type" => _type} -> FunctionSelector.parse_specification_type(type_specification)
+        type -> FunctionSelector.decode_type(type)
+      end
 
     do_value_json(decoded_type, value)
   rescue
     exception ->
       Logger.warning(fn ->
-        ["Error determining value json for #{inspect(type)}: ", Exception.format(:error, exception, __STACKTRACE__)]
+        [
+          "Error determining value json for #{inspect(type_name(type_specification))}: ",
+          Exception.format(:error, exception, __STACKTRACE__)
+        ]
       end)
 
       nil
   end
+
+  defp type_name(%{"type" => type}), do: type
+  defp type_name(type), do: type
 
   defp do_value_json({:bytes, _}, value) do
     do_value_json(:bytes, value)

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -1487,8 +1487,8 @@ defmodule Explorer.Chain.SmartContract do
     constructor_arguments
     |> ExplorerHelper.decode_data(input_types)
     |> Enum.zip(constructor_abi["inputs"])
-    |> Enum.map(fn {value, %{"type" => type} = input_arg} ->
-      [DecodingHelper.value_json(type, value), input_arg]
+    |> Enum.map(fn {value, input_arg} ->
+      [DecodingHelper.value_json(input_arg, value), input_arg]
     end)
   rescue
     exception ->

--- a/apps/explorer/test/explorer/chain/decoding_helper_test.exs
+++ b/apps/explorer/test/explorer/chain/decoding_helper_test.exs
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.DecodingHelperTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Explorer.Chain.DecodingHelper
+
+  test "value_json/2 decodes tuple components without logging a warning" do
+    tuple_input = %{
+      "components" => [
+        %{"name" => "twitter", "type" => "string"},
+        %{"name" => "telegram", "type" => "string"},
+        %{"name" => "discord", "type" => "string"},
+        %{"name" => "website", "type" => "string"},
+        %{"name" => "farcaster", "type" => "string"}
+      ],
+      "name" => "socials_",
+      "type" => "tuple"
+    }
+
+    log =
+      capture_log(fn ->
+        assert DecodingHelper.value_json(tuple_input, {"", "", "", "", ""}) == ["", "", "", "", ""]
+      end)
+
+    refute log =~ ~s(Error determining value json for "tuple")
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -2,6 +2,7 @@
 defmodule Explorer.Chain.SmartContractTest do
   use Explorer.DataCase, async: false
 
+  import ExUnit.CaptureLog
   import Mox
   alias Explorer.Chain.{Address, SmartContract}
 
@@ -427,5 +428,36 @@ defmodule Explorer.Chain.SmartContractTest do
     implementation_abi = SmartContract.get_abi("0x" <> implementation_contract_address_hash_string)
 
     assert implementation_abi == @abi
+  end
+
+  test "format_constructor_arguments/2 decodes tuple components without logging a warning" do
+    tuple_input = %{
+      "components" => [
+        %{"name" => "twitter", "type" => "string"},
+        %{"name" => "telegram", "type" => "string"},
+        %{"name" => "discord", "type" => "string"},
+        %{"name" => "website", "type" => "string"},
+        %{"name" => "farcaster", "type" => "string"}
+      ],
+      "name" => "socials_",
+      "type" => "tuple"
+    }
+
+    tuple_type = ABI.FunctionSelector.parse_specification_type(tuple_input)
+
+    constructor_arguments =
+      [{"", "", "", "", ""}]
+      |> ABI.TypeEncoder.encode([tuple_type])
+      |> Base.encode16(case: :lower)
+
+    log =
+      capture_log(fn ->
+        assert SmartContract.format_constructor_arguments(
+                 [%{"inputs" => [tuple_input], "type" => "constructor"}],
+                 constructor_arguments
+               ) == [[["", "", "", "", ""], tuple_input]]
+      end)
+
+    refute log =~ ~s(Error determining value json for "tuple")
   end
 end

--- a/cspell.json
+++ b/cspell.json
@@ -278,6 +278,7 @@
         "ezstd",
         "Faileddi",
         "falala",
+        "farcaster",
         "feelin",
         "FEVM",
         "fhevm",


### PR DESCRIPTION
## Motivation

```
2026-07-21T14:33:56.541 application=explorer request_id=GMRK1imb5_PcsaoAAGgC [warning] Error determining value json for "tuple": ** (Protocol.UndefinedError) protocol String.Chars not implemented for Tuple

Got value:

    {"", "", "", "", ""}

    (elixir 1.19.4) lib/string/chars.ex:7: String.Chars.impl_for!/1
    (elixir 1.19.4) lib/string/chars.ex:26: String.Chars.to_string/1
    (explorer 11.2.3) lib/explorer/chain/decoding_helper.ex:16: Explorer.Chain.DecodingHelper.value_json/2
    (explorer 11.2.3) lib/explorer/chain/smart_contract.ex:1492: anonymous fn/1 in Explorer.Chain.SmartContract.format_constructor_arguments/2
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.19.4) lib/enum.ex:1688: Enum."-map/2-lists^map/1-1-"/2
    (explorer 11.2.3) lib/explorer/chain/smart_contract.ex:1490: Explorer.Chain.SmartContract.format_constructor_arguments/2
    (block_scout_web 11.2.3) lib/block_scout_web/views/api/v2/smart_contract_view.ex:217: BlockScoutWeb.API.V2.SmartContractView.prepare_smart_contract/2
    (phoenix_view 2.0.4) lib/phoenix_view.ex:577: Phoenix.View.render_to_iodata/3
    (phoenix 1.6.16) lib/phoenix/controller.ex:772: Phoenix.Controller.render_and_send/4
    (block_scout_web 11.2.3) lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex:2: BlockScoutWeb.API.V2.SmartContractController.action/2
    (block_scout_web 11.2.3) lib/block_scout_web/controllers/api/v2/smart_contract_controller.ex:2: BlockScoutWeb.API.V2.SmartContractController.phoenix_controller_pipeline/2
    (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
    (phoenix 1.6.16) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
    (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
    (phoenix 1.6.16) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2
    (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2
    (block_scout_web 11.2.3) lib/block_scout_web/endpoint.ex:2: BlockScoutWeb.Endpoint.plug_builder_call/2
    (block_scout_web 11.2.3) /Users/nikitosing/work/blockscout/blockscout/deps/plug/lib/plug/debugger.ex:155: BlockScoutWeb.Endpoint."call (overridable 3)"/2
    (block_scout_web 11.2.3) lib/block_scout_web/endpoint.ex:2: BlockScoutWeb.Endpoint."call (overridable 4)"/2
```
## Changelog
- Forward full ABI struct while decoding constructor args

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding and display of smart-contract constructor arguments with tuple values.
  * Improved decoding for tuple-typed transaction inputs and event logs, ensuring correct decoded output.
  * Prevented misleading “tuple” decoding errors from appearing in logs.
  * Updated API responses to allow nested array shapes for decoded constructor arguments.
* **Tests**
  * Added regression coverage for tuple decoding across API, views, and decoding helpers.
* **Chores**
  * Updated spellcheck allowlist to include “farcaster”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->