### PR TITLE
chore: Hibernate BufferedTask on empty queue

### DIFF
--- a/apps/indexer/lib/indexer/buffered_task.ex
+++ b/apps/indexer/lib/indexer/buffered_task.ex
@@ -698,7 +698,9 @@ defmodule Indexer.BufferedTask do
   # This message is scheduled by the flush_interval to ensure regular processing of
   # accumulated data, pushing it to the queue and triggering batch processing.
   def handle_info(:flush, state) do
-    {:noreply, flush(state)}
+    state
+    |> flush()
+    |> noreply_maybe_hibernate()
   end
 
   # Handles graceful shutdown. A fetcher implementing BufferedTask behaviour
@@ -1428,6 +1430,15 @@ defmodule Indexer.BufferedTask do
     |> push_back(back_entries)
     |> push_front(front_entries)
     |> flush()
+  end
+
+  defp noreply_maybe_hibernate(%__MODULE__{bound_queue: %BoundQueue{size: 0}, task_ref_to_batch: tasks} = state)
+       when tasks == %{} do
+    {:noreply, state, :hibernate}
+  end
+
+  defp noreply_maybe_hibernate(%__MODULE__{} = state) do
+    {:noreply, state}
   end
 
   defp increased_delay, do: Application.get_env(:indexer, :fetcher_init_delay)

--- a/apps/indexer/test/indexer/buffered_task_test.exs
+++ b/apps/indexer/test/indexer/buffered_task_test.exs
@@ -237,14 +237,14 @@ defmodule Indexer.BufferedTaskTest do
       refute flush_timer == nil
     end
 
-    test "with 0 size without maximum size schedules next flush" do
+    test "with 0 size without maximum size schedules next flush and hibernates" do
       bound_queue = %BoundQueue{}
 
       refute BoundQueue.shrunk?(bound_queue)
 
       start_supervised!({Task.Supervisor, name: BufferedTaskSup})
 
-      assert {:noreply, %BufferedTask{flush_timer: flush_timer}} =
+      assert {:noreply, %BufferedTask{flush_timer: flush_timer}, :hibernate} =
                BufferedTask.handle_info(:flush, %BufferedTask{
                  callback_module: ShrinkableTask,
                  callback_module_state: nil,
@@ -260,7 +260,7 @@ defmodule Indexer.BufferedTaskTest do
       refute flush_timer == nil
     end
 
-    test "with 0 size with maximum size calls init/2 to get work that was shed before scheduling next flush" do
+    test "with 0 size with maximum size calls init/2 to get work that was shed before scheduling next flush and hibernates" do
       {:ok, bound_queue} = BoundQueue.push_back(%BoundQueue{}, 1)
       {:ok, bound_queue} = BoundQueue.push_back(bound_queue, 2)
       {:ok, bound_queue} = BoundQueue.shrink(bound_queue)
@@ -271,7 +271,7 @@ defmodule Indexer.BufferedTaskTest do
 
       start_supervised!({Task.Supervisor, name: BufferedTaskSup})
 
-      assert {:noreply, %BufferedTask{flush_timer: flush_timer}} =
+      assert {:noreply, %BufferedTask{flush_timer: flush_timer}, :hibernate} =
                BufferedTask.handle_info(:flush, %BufferedTask{
                  callback_module: ShrinkableTask,
                  callback_module_state: nil,


### PR DESCRIPTION
## Motivation

In order to prevent memory leaks in old heap it's useful to execute garbage collect when fetcher is not busy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved background processing efficiency by allowing idle task handling to enter a low-resource sleep state when no work is queued or in progress.
* **Bug Fixes**
  * Preserved normal processing behavior when queued or in-flight tasks remain.
  * Updated flush handling to correctly transition between active and idle states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->