### PR TITLE
fix: Prevent decoded_input_data crash on partial to_address map

### DIFF
--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -998,8 +998,13 @@ defmodule Explorer.Chain.Transaction do
     )
   end
 
+  # Fallback for a to_address that is neither a loaded `Address`, `nil`, nor
+  # `NotLoaded`. This happens when ENS/metadata preloading replaces an unloaded
+  # to_address with a bare map (e.g. `%{ens_domain_name: ...}` or
+  # `%{metadata: ...}`, see `Explorer.Chain.Address.MetadataPreloader.alter_address/4`).
+  # Such a map carries no contract data, so there is nothing to decode.
   def decoded_input_data(
-        %__MODULE__{to_address: %{metadata: _, ens_domain_name: _}},
+        %__MODULE__{},
         _,
         _,
         _,


### PR DESCRIPTION
## Motivation

`GET /api/v2/blocks/{hash}/transactions` (and other tx endpoints) crashes with `FunctionClauseError` in `Explorer.Chain.Transaction.decoded_input_data/5` when a transaction's `to_address` arrives as a bare single-key map such as `%{ens_domain_name: nil}` (or `%{metadata: nil}`).

Root cause: since #14165, `to_address` is preloaded as an optional association without `:smart_contract`. When the `to_address_hash` has no `Address` row in the DB (e.g. Arbitrum system/precompile targets), the preload leaves `to_address` as `nil`. The endpoint then runs `maybe_preload_ens_for_transactions()` and `maybe_preload_metadata()`; for an unloaded address `Explorer.Chain.Address.MetadataPreloader.alter_address/4` returns a bare map containing only the field being preloaded. When exactly one of the ENS/Metadata microservices is enabled, that map ends up with a single key. The former final `decoded_input_data/5` clause required both `metadata` and `ens_domain_name` keys, so it matched nothing, and neither did any earlier clause (not an `%Address{}`, no `smart_contract`/`contract_code` key) — raising `FunctionClauseError`.

## Changelog

### Bug Fixes

Broadened the final fallback clause of `Explorer.Chain.Transaction.decoded_input_data/5` from `%__MODULE__{to_address: %{metadata: _, ens_domain_name: _}}` to a true catch-all `%__MODULE__{}` returning `{:error, :no_to_address}`. All decodable cases (loaded `Address`, `NotLoaded`, `nil`, empty input) are handled by earlier clauses, so only genuinely non-decodable partial-map `to_address` values reach this fallback — regardless of which or how many of the ENS/Metadata preloaders ran.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction input decoding when the destination address has incomplete or unexpected data.
  - Transactions in this scenario now return a consistent “no destination address” error instead of failing to match expected address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->