### PR TITLE
chore: Make async logger call on API response

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
@@ -28,17 +28,22 @@ defmodule BlockScoutWeb.Plug.Logger do
       stop = System.monotonic_time()
       diff = System.convert_time_unit(stop - start, :native, :microsecond)
       status = Integer.to_string(conn.status)
+      method = conn.method
+      endpoint = endpoint(conn)
+      conn_type = connection_type(conn)
 
-      Logger.log(
-        level,
-        fn ->
-          [connection_type(conn), ?\s, status, " in ", formatted_diff(diff), " on ", conn.method, ?\s, endpoint(conn)]
-        end,
-        Keyword.merge(
-          [duration: diff, status: status, unit: "microsecond", endpoint: endpoint(conn), method: conn.method],
-          opts
+      Task.start(fn ->
+        Logger.log(
+          level,
+          fn ->
+            [conn_type, ?\s, status, " in ", formatted_diff(diff), " on ", method, ?\s, endpoint]
+          end,
+          Keyword.merge(
+            [duration: diff, status: status, unit: "microsecond", endpoint: endpoint, method: method],
+            opts
+          )
         )
-      )
+      end)
 
       conn
     end)

--- a/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
+++ b/apps/block_scout_web/lib/block_scout_web/plug/logger.ex
@@ -31,8 +31,11 @@ defmodule BlockScoutWeb.Plug.Logger do
       method = conn.method
       endpoint = endpoint(conn)
       conn_type = connection_type(conn)
+      metadata = Logger.metadata()
 
       Task.start(fn ->
+        Logger.metadata(metadata)
+
         Logger.log(
           level,
           fn ->

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -311,7 +311,7 @@ defmodule Explorer.Chain.Log do
     end
   rescue
     e ->
-      Logger.warning(fn ->
+      Logger.debug(fn ->
         [
           "Could not decode input data for log from transaction hash: ",
           Hash.to_iodata(transaction_hash),


### PR DESCRIPTION
## Motivation

## Changelog
- Plug.Logger: move Logger.log out of before_send into Task.start to prevent sync-mode logger from blocking API response
- Demote event log decode errors to debug level
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request logging performance by handling log writes asynchronously while preserving the same structured log details.
  * Reduced the severity of expected log decoding failures from warnings to debug messages, minimizing unnecessary alerts while keeping the same error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->