### PR TITLE
chore: Demote some logs to debug

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -37,7 +37,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   @not_a_smart_contract "Address is not a smart-contract"
 
   def call(conn, {:format, _params}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@invalid_parameters}"]
     end)
 
@@ -48,7 +48,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:format_address, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@invalid_address_hash}"]
     end)
 
@@ -59,7 +59,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:format_url, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@invalid_url}"]
     end)
 
@@ -70,7 +70,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:not_found, _, :empty_items_with_next_page_params}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       [":empty_items_with_next_page_params"]
     end)
 
@@ -79,7 +79,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:not_found, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@not_found}"]
     end)
 
@@ -90,7 +90,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:contract_interaction_disabled, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@contract_interaction_disabled}"]
     end)
 
@@ -109,7 +109,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
         :celo_election_reward_type -> @invalid_celo_election_reward_type
       end
 
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{message}"]
     end)
 
@@ -120,7 +120,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:error, :not_found}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       [":not_found"]
     end)
 
@@ -143,7 +143,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:restricted_access, true}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@restricted_access}"]
     end)
 
@@ -154,7 +154,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:already_verified, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@already_verified}"]
     end)
 
@@ -164,7 +164,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:no_json_file, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@json_not_found}"]
     end)
 
@@ -174,7 +174,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:file_error, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@error_while_reading_json}"]
     end)
 
@@ -184,7 +184,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:libs_format, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@error_in_libraries}"]
     end)
 
@@ -194,7 +194,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:lost_consensus, {:ok, block}}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@block_lost_consensus}"]
     end)
 
@@ -204,7 +204,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:lost_consensus, {:error, :not_found}}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@block_lost_consensus}"]
     end)
 
@@ -213,7 +213,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:recaptcha, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@invalid_captcha_resp}"]
     end)
 
@@ -224,7 +224,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:auth, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@unauthorized}"]
     end)
 
@@ -235,7 +235,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:sensitive_endpoints_api_key, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@not_configured_api_key}"]
     end)
 
@@ -246,7 +246,7 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
   end
 
   def call(conn, {:api_key, _}) do
-    Logger.error(fn ->
+    Logger.debug(fn ->
       ["#{@wrong_api_key}"]
     end)
 

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -340,7 +340,7 @@ defmodule Explorer.Chain.Address.Counters do
         stop = System.monotonic_time()
         diff = System.convert_time_unit(stop - start, :native, :millisecond)
 
-        Logger.info("Time consumed for transactions_from_count_task for #{address_hash} is #{diff}ms")
+        Logger.debug("Time consumed for transactions_from_count_task for #{address_hash} is #{diff}ms")
 
         AddressTabsElementsCount.save_transactions_counter_progress(address_hash, %{
           transactions_types: [:transactions_from],
@@ -365,7 +365,7 @@ defmodule Explorer.Chain.Address.Counters do
         stop = System.monotonic_time()
         diff = System.convert_time_unit(stop - start, :native, :millisecond)
 
-        Logger.info("Time consumed for transactions_to_count_task for #{address_hash} is #{diff}ms")
+        Logger.debug("Time consumed for transactions_to_count_task for #{address_hash} is #{diff}ms")
 
         AddressTabsElementsCount.save_transactions_counter_progress(address_hash, %{
           transactions_types: [:transactions_to],
@@ -390,7 +390,7 @@ defmodule Explorer.Chain.Address.Counters do
         stop = System.monotonic_time()
         diff = System.convert_time_unit(stop - start, :native, :millisecond)
 
-        Logger.info("Time consumed for transactions_created_contract_count_task for #{address_hash} is #{diff}ms")
+        Logger.debug("Time consumed for transactions_created_contract_count_task for #{address_hash} is #{diff}ms")
 
         AddressTabsElementsCount.save_transactions_counter_progress(address_hash, %{
           transactions_types: [:transactions_contract],
@@ -548,7 +548,7 @@ defmodule Explorer.Chain.Address.Counters do
       stop = System.monotonic_time()
       diff = System.convert_time_unit(stop - start, :native, :millisecond)
 
-      Logger.info("Time consumed for #{counter_type} counter task for #{address_hash} is #{diff}ms")
+      Logger.debug("Time consumed for #{counter_type} counter task for #{address_hash} is #{diff}ms")
 
       AddressTabsElementsCount.set_counter(counter_type, address_hash, result)
       AddressTabsElementsCount.drop_task(counter_type, address_hash)


### PR DESCRIPTION
## Motivation

## Changelog
- Demote some logs to debug
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the visibility of internal API fallback and address counter timing logs.
  * API responses, error handling, and counter calculations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->