### PR TITLE
fix: Fix 422 in /api/v2/blocks/:block_number/countdown

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -13,7 +13,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
       next_page_params: 3,
       next_page_params: 5,
       paging_options: 1,
-      param_to_block_number: 1,
+      param_to_block_number: 2,
       put_key_value_to_paging_options: 3,
       split_list_by_page: 1,
       parse_block_hash_or_number_param: 1,
@@ -582,7 +582,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
           | {:average_block_time, {:error, :disabled}}
           | {:remaining_blocks, 0}
   def block_countdown(conn, %{block_number_param: block_number}) do
-    with {:format, {:ok, target_block_number}} <- {:format, param_to_block_number(block_number)},
+    with {:format, {:ok, target_block_number}} <- {:format, param_to_block_number(block_number, false)},
          {:max_block, current_block_number} when not is_nil(current_block_number) <-
            {:max_block, BlockNumber.get_max()},
          {:average_block_time, average_block_time} when is_struct(average_block_time) <-

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block/countdown.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block/countdown.ex
@@ -11,44 +11,43 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Countdown do
     title: "BlockCountdown",
     description: "Block countdown information showing estimated time until a target block is reached",
     type: :object,
+    additionalProperties: false,
     properties: %{
-      current_block: %Schema{
+      current_block_number: %Schema{
         type: :integer,
         description: "The current highest block number in the blockchain",
         minimum: 0,
         example: 22_566_361
       },
-      countdown_block: %Schema{
+      countdown_block_number: %Schema{
         type: :integer,
         description: "The target block number for the countdown",
         minimum: 0,
         example: 22_600_000
       },
-      remaining_blocks: %Schema{
+      remaining_blocks_count: %Schema{
         type: :integer,
         description: "Number of blocks remaining until the target block is reached",
         minimum: 0,
         example: 33_639
       },
-      estimated_time_in_sec: %Schema{
-        type: :number,
-        format: :float,
+      estimated_time_in_seconds: %Schema{
+        type: :string,
         description: "Estimated time in seconds until the target block is reached",
-        minimum: 0,
-        example: 404_868.0
+        example: "404868.0"
       }
     },
     required: [
-      :current_block,
-      :countdown_block,
-      :remaining_blocks,
-      :estimated_time_in_sec
+      :current_block_number,
+      :countdown_block_number,
+      :remaining_blocks_count,
+      :estimated_time_in_seconds
     ],
     example: %{
-      current_block: 22_566_361,
-      countdown_block: 22_600_000,
-      remaining_blocks: 33_639,
-      estimated_time_in_sec: 404_868.0
+      current_block_number: 22_566_361,
+      countdown_block_number: 22_600_000,
+      remaining_blocks_count: 33_639,
+      estimated_time_in_seconds: "404868.0"
     }
   })
 end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
   alias Explorer.Chain.{Address, Block, InternalTransaction, Transaction, Withdrawal}
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
+  alias Explorer.Chain.Cache.{BlockNumber, Counters.AverageBlockTime}
 
   setup do
     Supervisor.terminate_child(Explorer.Supervisor, Explorer.Chain.Cache.Blocks.child_id())
@@ -222,6 +223,46 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
                  | _
                ]
              } = json_response(request, 422)
+    end
+  end
+
+  describe "/blocks/{block_number}/countdown" do
+    setup do
+      start_supervised!(AverageBlockTime)
+      Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
+
+      Supervisor.terminate_child(Explorer.Supervisor, BlockNumber.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, BlockNumber.child_id())
+
+      on_exit(fn ->
+        Application.put_env(:explorer, AverageBlockTime, enabled: false, cache_period: 1_800_000)
+      end)
+    end
+
+    test "returns countdown information for a future block", %{conn: conn} do
+      current_block_number = 110
+      target_block_number = 120
+      average_block_time = 15
+      first_timestamp = Timex.now()
+
+      for number <- 1..current_block_number do
+        insert(:block,
+          number: number,
+          timestamp: Timex.shift(first_timestamp, seconds: number * average_block_time),
+          consensus: true
+        )
+      end
+
+      AverageBlockTime.refresh()
+
+      request = get(conn, "/api/v2/blocks/#{target_block_number}/countdown")
+
+      assert %{
+               "current_block_number" => ^current_block_number,
+               "countdown_block_number" => ^target_block_number,
+               "remaining_blocks_count" => 10,
+               "estimated_time_in_seconds" => "150.0"
+             } = json_response(request, 200)
     end
   end
 


### PR DESCRIPTION
## Motivation

422 on /api/v2/blocks/:block_number/countdown
## Changelog
- Remove block height validation in countdown

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added and validated the block countdown API for future block targets.
  * Countdown responses now provide current and target block numbers, remaining blocks, and estimated time in seconds.

* **Bug Fixes**
  * Improved block target parsing and validation for countdown requests.

* **API Updates**
  * Updated response field names and formats for consistency, including `estimated_time_in_seconds`.
  * Responses now reject unspecified additional properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->