### PR TITLE
fix: Prevent stuck pending_block_operations from zero-value internal transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -209,9 +209,14 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
 
   @impl Runner
   def prepare_data(changes_list) do
-    changes_list
-    |> maybe_reject_zero_value()
-    |> adjust_insert_params()
+    # Note: zero-value internal transactions are NOT rejected here. `prepare_data/1`
+    # is applied to the params before the block-completeness validation
+    # (`invalid_block_numbers/2`) runs. Dropping the only internal transaction of a
+    # transaction at this point would make that transaction look permanently
+    # un-traced, marking the whole block invalid and leaving it stuck in
+    # `pending_block_operations` forever. The zero-value rejection is instead applied
+    # right before insert (see `insert/3`), so it never affects validation.
+    adjust_insert_params(changes_list)
   end
 
   def run_insert_only(changes_list, %{timestamps: timestamps} = options) when is_map(options) do
@@ -255,6 +260,9 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
 
     ordered_changes_list =
       valid_internal_transactions
+      # Reject zero-value internal transactions only here, right before the DB write,
+      # so it never affects block-completeness validation (see `prepare_data/1`).
+      |> maybe_reject_zero_value()
       |> Enum.map(fn internal_transaction ->
         Map.put(internal_transaction, :trace_address, nil)
       end)

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -632,7 +632,7 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
     end
   end
 
-  describe "prepare_data/1 zero value filtering" do
+  describe "zero value internal transactions filtering" do
     setup do
       original_config = Application.get_env(:explorer, DeleteZeroValueInternalTransactions)
 
@@ -643,112 +643,111 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       :ok
     end
 
-    test "removes zero-value call internal transactions before border block" do
+    test "prepare_data/1 does not drop zero-value calls (filtering happens at insert/3, after validation)" do
       Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
       block = insert(:block)
 
       params = [
-        %{
-          type: :call,
-          block_number: block.number - 1,
-          value: Wei.from(Decimal.new(0), :wei)
-        },
-        %{
-          type: :call,
-          block_number: block.number - 1,
-          value: Wei.from(Decimal.new(1), :wei)
-        },
-        %{
-          type: "call",
-          block_number: block.number - 1,
-          value: 0
-        }
+        %{type: :call, block_number: block.number - 1, value: Wei.from(Decimal.new(0), :wei)},
+        %{type: :call, block_number: block.number - 1, value: Wei.from(Decimal.new(1), :wei)},
+        %{type: "call", block_number: block.number - 1, value: 0},
+        %{type: :call, block_number: block.number - 1, value: nil}
       ]
 
-      result = InternalTransactions.prepare_data(params)
-
-      assert length(result) == 1
-      assert hd(result).value.value == Decimal.new(1)
+      # Dropping zero-value calls here would make their parent transactions look
+      # un-traced during block validation, so prepare_data/1 must keep them all.
+      assert length(InternalTransactions.prepare_data(params)) == 4
     end
 
-    test "does not remove zero-value calls after border block" do
+    test "run/3 excludes zero-value calls from persistence while still validating the block and clearing its pending operation" do
       Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
-      block = insert(:block)
 
-      params = [
-        %{
-          type: :call,
-          block_number: block.number + 1,
-          value: Wei.from(Decimal.new(0), :wei)
-        },
-        %{
-          type: "call",
-          block_number: block.number + 1,
-          value: 0
-        }
-      ]
+      full_block = insert(:block)
+      transaction_a = insert(:transaction) |> with_block(full_block)
+      transaction_b = insert(:transaction) |> with_block(full_block)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
-      assert [_, _] = InternalTransactions.prepare_data(params)
+      # transaction_a keeps a normal, non-zero-value internal transaction
+      transaction_a_changes = make_internal_transaction_changes(transaction_a, 0, nil)
+
+      # transaction_b's only internal transaction is a zero-value call subject to deletion
+      transaction_b_changes =
+        transaction_b
+        |> make_internal_transaction_changes(0, nil)
+        |> Map.put(:value, Wei.from(Decimal.new(0), :wei))
+
+      assert {:ok, _} = run_internal_transactions([transaction_a_changes, transaction_b_changes])
+
+      # The block is validated: consensus kept, refetch not requested, pending op cleared
+      assert %{consensus: true, refetch_needed: refetch_needed} = Repo.get(Block, full_block.hash)
+      refute refetch_needed
+      assert PendingBlockOperation |> Repo.get(full_block.hash) |> is_nil()
+
+      # transaction_a's internal transaction is persisted
+      refute from(i in InternalTransaction,
+               where: i.block_number == ^transaction_a.block_number and i.transaction_index == ^transaction_a.index
+             )
+             |> Repo.one()
+             |> is_nil()
+
+      # transaction_b's zero-value internal transaction is excluded from persistence
+      assert from(i in InternalTransaction,
+               where: i.block_number == ^transaction_b.block_number and i.transaction_index == ^transaction_b.index
+             )
+             |> Repo.one()
+             |> is_nil()
     end
 
-    test "does not remove non-call internal transactions" do
+    test "run_insert_only/2 excludes zero-value calls from persistence" do
       Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
-      block = insert(:block)
 
-      params = [
-        %{
-          type: :create,
-          block_number: block.number - 1,
-          value: Wei.from(Decimal.new(0), :wei)
-        },
-        %{
-          type: "create",
-          block_number: block.number - 1,
-          value: 0
-        }
-      ]
+      full_block = insert(:block)
+      transaction = insert(:transaction) |> with_block(full_block)
 
-      assert [_, _] = InternalTransactions.prepare_data(params)
+      zero_value_changes =
+        transaction
+        |> make_internal_transaction_changes(0, nil)
+        |> Map.put(:value, Wei.from(Decimal.new(0), :wei))
+
+      non_zero_value_changes = make_internal_transaction_changes(transaction, 1, nil)
+
+      InternalTransactions.run_insert_only([zero_value_changes, non_zero_value_changes], %{
+        timeout: :infinity,
+        timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+      })
+
+      persisted_indexes =
+        from(i in InternalTransaction,
+          where: i.block_number == ^transaction.block_number and i.transaction_index == ^transaction.index,
+          select: i.index,
+          order_by: i.index
+        )
+        |> Repo.all()
+
+      assert persisted_indexes == [1]
     end
 
-    test "treats nil value as zero" do
-      Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: true, storage_period: 0)
-      block = insert(:block)
-
-      params = [
-        %{
-          type: :call,
-          block_number: block.number - 1,
-          value: nil
-        },
-        %{
-          type: "call",
-          block_number: block.number - 1,
-          value: nil
-        }
-      ]
-
-      assert [] == InternalTransactions.prepare_data(params)
-    end
-
-    test "does not filter anything when feature is disabled" do
+    test "run/3 keeps zero-value calls when the feature is disabled" do
       Application.put_env(:explorer, DeleteZeroValueInternalTransactions, enabled: false, storage_period: 0)
-      block = insert(:block)
 
-      params = [
-        %{
-          type: :call,
-          block_number: block.number - 1,
-          value: Wei.from(Decimal.new(0), :wei)
-        },
-        %{
-          type: "call",
-          block_number: block.number - 1,
-          value: 0
-        }
-      ]
+      full_block = insert(:block)
+      transaction = insert(:transaction) |> with_block(full_block)
+      insert(:pending_block_operation, block_hash: full_block.hash, block_number: full_block.number)
 
-      assert [_, _] = InternalTransactions.prepare_data(params)
+      zero_value_changes =
+        transaction
+        |> make_internal_transaction_changes(0, nil)
+        |> Map.put(:value, Wei.from(Decimal.new(0), :wei))
+
+      assert {:ok, _} = run_internal_transactions([zero_value_changes])
+
+      refute from(i in InternalTransaction,
+               where: i.block_number == ^transaction.block_number and i.transaction_index == ^transaction.index
+             )
+             |> Repo.one()
+             |> is_nil()
+
+      assert PendingBlockOperation |> Repo.get(full_block.hash) |> is_nil()
     end
   end
 


### PR DESCRIPTION
## Motivation

Blocks were never disappearing from the `pending_block_operations` table on chains with `DeleteZeroValueInternalTransactions` enabled below the migration's border. A block whose transaction has a single zero-value `call` internal transaction (e.g. system/precompile calls, value-less calls) got permanently stuck: the operation was re-queued, re-fetched, and re-failed on every cycle.

Root cause: `Explorer.Chain.Import.Runner.InternalTransactions.prepare_data/1` is applied by `Chain.import` to the params before the block-completeness validation (`invalid_block_numbers/2`) runs. It called `maybe_reject_zero_value/1`, dropping the zero-value internal transaction ahead of validation. With that transaction's only trace removed, the validation saw a transaction with no matching internal transaction, marked the block invalid, and never cleared its pending operation.

## Changelog

### Bug Fixes

Moved the zero-value internal transactions rejection out of `prepare_data/1` and into `insert/3`, so it runs right before the DB write and after block-completeness validation. Blocks whose transactions are only traced by zero-value calls now validate correctly, their `pending_block_operations` rows are removed, and `update_transactions` correctly populates those transactions' first-trace fields (status, gas_used, created contract). Zero-value internal transaction rows are still kept out of the database, preserving the intent of `DeleteZeroValueInternalTransactions`. Both the main import path (`run/3`) and the on-demand path (`run_insert_only/2`) pass through `insert/3`, so both are covered.


## Upgrading

_No upgrade steps required. Blocks previously stuck in `pending_block_operations` will be cleared on their next fetch cycle once this change is deployed._

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the handling of zero-value internal transactions during chain import so they no longer interfere with block-completeness validation.
  * Updated the import flow to reject and exclude zero-value internal transactions at the correct stage, ensuring they don’t get persisted improperly.

* **Tests**
  * Revised and extended coverage to reflect the updated lifecycle: zero-value transactions are preserved during preparation but excluded during insertion/run, including feature-disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->