### PR TITLE
chore: Propagate cache between api pods as well

### DIFF
--- a/apps/explorer/lib/explorer/chain/map_cache.ex
+++ b/apps/explorer/lib/explorer/chain/map_cache.ex
@@ -180,26 +180,19 @@ defmodule Explorer.Chain.MapCache do
       end
 
       @doc """
-      Applies a ConCache write locally, then propagates it from indexer nodes.
+      Applies a ConCache write locally, then propagates it to other nodes.
 
       With the default `propagate: true`, the given zero-arity function runs on this node first.
-      When `Explorer.mode/0` is `:indexer`, the same function is multicast to `Node.list/0` with
-      `propagate: false` so API nodes apply the write without re-propagating.
+      Then, the same function is multicast to `Node.list/0` with
+      `propagate: false` so other nodes apply the write without re-propagating.
       """
       def do_raw(function, propagate \\ true) do
         function.()
 
-        case Explorer.mode() do
-          :indexer ->
-            if propagate do
-              Node.list() |> :erpc.multicast(__MODULE__, :do_raw, [function, false])
-            else
-              Logger.error("[#{__MODULE__}] Indexer got unexpected propagation call to do_raw/2")
-              :ok
-            end
-
-          _ ->
-            :ok
+        if propagate do
+          Node.list() |> :erpc.multicast(__MODULE__, :do_raw, [function, false])
+        else
+          :ok
         end
       end
 

--- a/apps/explorer/lib/explorer/chain/map_cache.ex
+++ b/apps/explorer/lib/explorer/chain/map_cache.ex
@@ -120,7 +120,6 @@ defmodule Explorer.Chain.MapCache do
 
     # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
     quote do
-      require Logger
       alias Explorer.Chain.MapCache
 
       @behaviour MapCache

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -160,6 +160,7 @@ defmodule Explorer.Chain.OrderedCache do
     quote do
       require Logger
       alias Explorer.Chain.OrderedCache
+      alias Explorer.Helper
 
       @behaviour OrderedCache
 
@@ -297,11 +298,10 @@ defmodule Explorer.Chain.OrderedCache do
       def update(element), do: update([element])
 
       @doc """
-      Merges prepared elements into the local ordered cache, then propagates from indexer nodes.
+      Merges prepared elements into the local ordered cache, then propagates to other nodes.
 
-      Always updates the local ids list and element entries first. When `Explorer.mode/0` is
-      `:indexer` and `propagate` is `true`, multicasts the same prepared elements to `Node.list/0`
-      with `propagate: false` so API nodes apply the write without re-propagating.
+      Always updates the local ids list and element entries first. Then multicasts the same prepared elements to `Node.list/0`
+      with `propagate: false` so other nodes apply the write without re-propagating.
       """
       def do_raw_update(prepared_elements, propagate) do
         ConCache.update(cache_name(), ids_list_key(), fn ids ->
@@ -313,17 +313,10 @@ defmodule Explorer.Chain.OrderedCache do
           {:ok, %ConCache.Item{value: updated_list, ttl: :infinity}}
         end)
 
-        case Explorer.mode() do
-          :indexer ->
-            if propagate do
-              Node.list() |> :erpc.multicast(__MODULE__, :do_raw_update, [prepared_elements, false])
-            else
-              Logger.error("Indexer got unexpected propagation call to do_raw_update/2")
-              :ok
-            end
-
-          _ ->
-            :ok
+        if propagate do
+          Node.list() |> :erpc.multicast(__MODULE__, :do_raw_update, [prepared_elements, false])
+        else
+          :ok
         end
       end
 

--- a/apps/explorer/lib/explorer/chain/ordered_cache.ex
+++ b/apps/explorer/lib/explorer/chain/ordered_cache.ex
@@ -160,7 +160,6 @@ defmodule Explorer.Chain.OrderedCache do
     quote do
       require Logger
       alias Explorer.Chain.OrderedCache
-      alias Explorer.Helper
 
       @behaviour OrderedCache
 


### PR DESCRIPTION
## Motivation

Scaling API pods increases DB load from non-indexer cache updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when updating cached chain data across application nodes.
  * Cache updates now reliably propagate to all nodes when synchronization is enabled, regardless of application operating mode.
  * Local updates are applied before remote synchronization, helping ensure every node reflects the latest data.
  * Prevented unnecessary propagation when synchronization is disabled, reducing redundant cache activity and improving update reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->