### PR TITLE
fix: Eliminate n+1 on historic exchange rate fetching

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -46,17 +46,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         conn: conn,
         watchlist_names: watchlist_names
       }) do
-    block_height = Chain.block_height(@api_true)
-    decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
-
     %{
-      "items" =>
-        transactions
-        |> with_chain_type_transformations()
-        |> Enum.zip(decoded_transactions)
-        |> Enum.map(fn {transaction, decoded_input} ->
-          prepare_transaction(transaction, conn, false, block_height, watchlist_names, decoded_input)
-        end),
+      "items" => prepare_transactions(transactions, conn, watchlist_names),
       "next_page_params" => next_page_params
     }
   end
@@ -66,29 +57,12 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
         conn: conn,
         watchlist_names: watchlist_names
       }) do
-    block_height = Chain.block_height(@api_true)
-    decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
-
-    transactions
-    |> with_chain_type_transformations()
-    |> Enum.zip(decoded_transactions)
-    |> Enum.map(fn {transaction, decoded_input} ->
-      prepare_transaction(transaction, conn, false, block_height, watchlist_names, decoded_input)
-    end)
+    prepare_transactions(transactions, conn, watchlist_names)
   end
 
   def render("transactions.json", %{transactions: transactions, next_page_params: next_page_params, conn: conn}) do
-    block_height = Chain.block_height(@api_true)
-    decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
-
     %{
-      "items" =>
-        transactions
-        |> with_chain_type_transformations()
-        |> Enum.zip(decoded_transactions)
-        |> Enum.map(fn {transaction, decoded_input} ->
-          prepare_transaction(transaction, conn, false, block_height, nil, decoded_input)
-        end),
+      "items" => prepare_transactions(transactions, conn, nil),
       "next_page_params" => next_page_params
     }
   end
@@ -100,15 +74,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   def render("transactions.json", %{transactions: transactions, conn: conn}) do
-    block_height = Chain.block_height(@api_true)
-    decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
-
-    transactions
-    |> with_chain_type_transformations()
-    |> Enum.zip(decoded_transactions)
-    |> Enum.map(fn {transaction, decoded_input} ->
-      prepare_transaction(transaction, conn, false, block_height, nil, decoded_input)
-    end)
+    prepare_transactions(transactions, conn, nil)
   end
 
   def render("transaction.json", %{transaction: transaction, conn: conn}) do
@@ -117,7 +83,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
     transaction
     |> with_chain_type_transformations()
-    |> prepare_transaction(conn, true, block_height, nil, decoded_input)
+    |> prepare_transaction(conn, true, block_height, nil, decoded_input, nil)
   end
 
   def render("raw_trace.json", %{raw_traces: raw_traces}) do
@@ -442,13 +408,35 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     end
   end
 
+  defp prepare_transactions(transactions, conn, watchlist_names) do
+    block_height = Chain.block_height(@api_true)
+    decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
+    historic_exchange_rates = historic_exchange_rates(transactions)
+
+    transactions
+    |> with_chain_type_transformations()
+    |> Enum.zip(decoded_transactions)
+    |> Enum.map(fn {transaction, decoded_input} ->
+      prepare_transaction(
+        transaction,
+        conn,
+        false,
+        block_height,
+        watchlist_names,
+        decoded_input,
+        historic_exchange_rates
+      )
+    end)
+  end
+
   defp prepare_transaction(
          transaction,
          conn,
          single_transaction?,
          block_height,
          watchlist_names,
-         decoded_input
+         decoded_input,
+         historic_exchange_rates
        )
 
   defp prepare_transaction(
@@ -457,7 +445,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
          single_transaction?,
          _block_height,
          _watchlist_names,
-         _decoded_input
+         _decoded_input,
+         _historic_exchange_rates
        ) do
     %{
       "emission_reward" => emission_reward.reward,
@@ -486,7 +475,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
          single_transaction?,
          block_height,
          watchlist_names,
-         decoded_input
+         decoded_input,
+         historic_exchange_rates
        ) do
     base_fee_per_gas = base_fee_per_gas(transaction)
     max_priority_fee_per_gas = transaction.max_priority_fee_per_gas
@@ -553,7 +543,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       "token_transfers" => token_transfers(transaction.token_transfers, conn, single_transaction?),
       "token_transfers_overflow" => token_transfers_overflow(transaction.token_transfers, single_transaction?),
       "exchange_rate" => Market.get_coin_exchange_rate().fiat_value,
-      "historic_exchange_rate" => historic_exchange_rate(block_timestamp),
+      "historic_exchange_rate" => historic_exchange_rate(block_timestamp, historic_exchange_rates),
       "method" => Transaction.method_name(transaction, decoded_input),
       "transaction_types" => transaction_types(transaction),
       "transaction_tag" =>
@@ -945,6 +935,41 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
       end
 
     Map.merge(map, %{"change" => change})
+  end
+
+  defp historic_exchange_rates(transactions) do
+    cutoff = DateTime.shift(DateTime.utc_now(), day: -1)
+
+    dates =
+      transactions
+      |> Enum.flat_map(&historic_exchange_rate_dates(&1, cutoff))
+      |> Enum.uniq()
+
+    Market.get_coin_exchange_rates_at_dates(dates, @api_true)
+  end
+
+  defp historic_exchange_rate_dates(%Transaction{} = transaction, cutoff) do
+    transaction
+    |> block_timestamp()
+    |> historic_exchange_rate_dates(cutoff)
+  end
+
+  defp historic_exchange_rate_dates(%DateTime{} = timestamp, cutoff) do
+    if DateTime.before?(timestamp, cutoff), do: [DateTime.to_date(timestamp)], else: []
+  end
+
+  defp historic_exchange_rate_dates(_, _cutoff), do: []
+
+  defp historic_exchange_rate(block_timestamp, nil), do: historic_exchange_rate(block_timestamp)
+  defp historic_exchange_rate(nil, _historic_exchange_rates), do: nil
+
+  defp historic_exchange_rate(block_timestamp, historic_exchange_rates) do
+    historic_exchange_rates
+    |> Map.get(DateTime.to_date(block_timestamp))
+    |> case do
+      %{fiat_value: fiat_value} -> fiat_value
+      nil -> nil
+    end
   end
 
   defp historic_exchange_rate(nil), do: nil

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -228,6 +228,8 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
 
   describe "/blocks/{block_number}/countdown" do
     setup do
+      average_block_time_config = Application.get_env(:explorer, AverageBlockTime)
+
       start_supervised!(AverageBlockTime)
       Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
 
@@ -235,7 +237,7 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       Supervisor.restart_child(Explorer.Supervisor, BlockNumber.child_id())
 
       on_exit(fn ->
-        Application.put_env(:explorer, AverageBlockTime, enabled: false, cache_period: 1_800_000)
+        Application.put_env(:explorer, AverageBlockTime, average_block_time_config)
       end)
     end
 
@@ -258,11 +260,11 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       request = get(conn, "/api/v2/blocks/#{target_block_number}/countdown")
 
       assert %{
-               "current_block_number" => ^current_block_number,
-               "countdown_block_number" => ^target_block_number,
+               "current_block_number" => current_block_number,
+               "countdown_block_number" => target_block_number,
                "remaining_blocks_count" => 10,
                "estimated_time_in_seconds" => "150.0"
-             } = json_response(request, 200)
+             } == json_response(request, 200)
     end
   end
 

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/transaction_view_test.exs
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.API.V2.TransactionViewTest do
-  use BlockScoutWeb.ConnCase, async: true
+  use BlockScoutWeb.ConnCase, async: false
 
   import ExUnit.CaptureLog
 
   alias BlockScoutWeb.API.V2.TransactionView
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias Explorer.Chain.Transaction
+  alias Explorer.Market.MarketHistory
   alias Explorer.Repo
 
   @tuple_input %{
@@ -23,6 +24,51 @@ defmodule BlockScoutWeb.API.V2.TransactionViewTest do
   @tuple_type "(string,string,string,string,string)"
   @tuple_value {"", "", "", "", ""}
   @tuple_json ["", "", "", "", ""]
+
+  test "loads historic exchange rates once for a transaction list", %{conn: conn} do
+    first_date = ~D[2026-07-20]
+    second_date = ~D[2026-07-21]
+
+    first_rate = insert(:market_history, date: first_date, closing_price: Decimal.new("1.25"))
+    second_rate = insert(:market_history, date: second_date, closing_price: Decimal.new("2.50"))
+
+    transactions =
+      [
+        insert(:transaction, block_timestamp: DateTime.new!(first_date, ~T[12:00:00])),
+        insert(:transaction, block_timestamp: DateTime.new!(first_date, ~T[13:00:00])),
+        insert(:transaction, block_timestamp: DateTime.new!(second_date, ~T[12:00:00]))
+      ]
+      |> Enum.map(&Map.put(&1, :block, nil))
+
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:explorer, :repo, :query],
+        &__MODULE__.handle_market_history_query/4,
+        self()
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    items = TransactionView.render("transactions.json", %{transactions: transactions, conn: conn})
+
+    assert Enum.map(items, & &1["historic_exchange_rate"]) == [
+             first_rate.closing_price,
+             first_rate.closing_price,
+             second_rate.closing_price
+           ]
+
+    assert_receive :market_history_query
+    refute_receive :market_history_query
+  end
+
+  def handle_market_history_query(_event, _measurements, metadata, test_pid) do
+    if metadata.source == MarketHistory.__schema__(:source) do
+      send(test_pid, :market_history_query)
+    end
+  end
 
   test "decodes a tuple value from transaction input and renders it without logging a warning" do
     function_abi = %{

--- a/apps/explorer/lib/explorer/market/market.ex
+++ b/apps/explorer/lib/explorer/market/market.ex
@@ -124,6 +124,21 @@ defmodule Explorer.Market do
   end
 
   @doc """
+  Retrieves native coin exchange rates for the specified dates.
+
+  The returned map is keyed by date and does not contain entries for dates
+  without market history.
+  """
+  @spec get_coin_exchange_rates_at_dates([Date.t()], Keyword.t()) :: %{Date.t() => Token.t()}
+  def get_coin_exchange_rates_at_dates(dates, options) do
+    dates
+    |> MarketHistory.prices_at_dates(false, options)
+    |> Map.new(fn market_history ->
+      {market_history.date, MarketHistory.to_token(market_history)}
+    end)
+  end
+
+  @doc """
   Checks if the market token fetcher is enabled in the application.
 
   This function retrieves the enablement status from persistent term storage

--- a/apps/explorer/lib/explorer/market/market_history.ex
+++ b/apps/explorer/lib/explorer/market/market_history.ex
@@ -41,6 +41,23 @@ defmodule Explorer.Market.MarketHistory do
     Chain.select_repo(options).one(query)
   end
 
+  @doc """
+  Returns the market history (for the secondary coin if specified) for the given dates.
+  """
+  @spec prices_at_dates([Date.t()], boolean(), [Chain.api?()]) :: [t()]
+  def prices_at_dates(dates, secondary_coin? \\ false, options \\ [])
+  def prices_at_dates([], _secondary_coin?, _options), do: []
+
+  def prices_at_dates(dates, secondary_coin?, options) do
+    query =
+      from(
+        mh in __MODULE__,
+        where: mh.date in ^dates and mh.secondary_coin == ^secondary_coin?
+      )
+
+    Chain.select_repo(options).all(query)
+  end
+
   @doc false
   @spec bulk_insert([map()]) :: {:ok, {non_neg_integer(), nil | [term()]}} | {:error, term()}
   def bulk_insert(records) do

--- a/apps/explorer/test/explorer/market/market_history_test.exs
+++ b/apps/explorer/test/explorer/market/market_history_test.exs
@@ -2,8 +2,23 @@
 defmodule Explorer.Market.MarketHistoryTest do
   use Explorer.DataCase
 
-  alias Explorer.Repo
   alias Explorer.Market.MarketHistory
+  alias Explorer.Repo
+
+  describe "prices_at_dates/3" do
+    test "returns primary coin history for the requested dates" do
+      first = insert(:market_history, date: ~D[2026-07-20], secondary_coin: false)
+      second = insert(:market_history, date: ~D[2026-07-21], secondary_coin: false)
+      insert(:market_history, date: ~D[2026-07-20], secondary_coin: true)
+
+      assert MarketHistory.prices_at_dates([first.date, second.date, ~D[2026-07-22]])
+             |> MapSet.new() == MapSet.new([first, second])
+    end
+
+    test "returns no records for an empty date list" do
+      assert MarketHistory.prices_at_dates([]) == []
+    end
+  end
 
   describe "bulk_insert/1" do
     test "replaces existing records" do


### PR DESCRIPTION
## Motivation

## Changelog
-  Eliminate n+1 on historic exchange rate fetching
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved transaction-list loading by reducing repeated historical exchange-rate lookups.
  * Historical exchange rates are now retrieved efficiently across all transactions in a list.

* **Reliability**
  * Transaction responses continue to provide accurate historical exchange-rate values for each transaction date.
  * Improved handling of block countdown test configuration helps preserve existing application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->