### PR TITLE
fix: Reconcile stuck pending smart_contract_verification_statuses

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -993,7 +993,9 @@ defmodule Explorer.Chain.SmartContract do
     # Prepares the queries to update Explorer.Chain.Address to mark the contract as
     # verified, clear the primary flag for the contract address in
     # Explorer.Chain.Address.Name if any (enforce ShareLocks tables order (see
-    # docs: sharelocks.md)) and insert the contract details.
+    # docs: sharelocks.md)), insert the contract details and set the primary mark for
+    # the contract name. The primary name is set inside the transaction so it is rolled
+    # back together with the contract if any step fails.
     insert_contract_query =
       Multi.new()
       |> Multi.run(:set_address_verified, fn repo, _ -> set_address_verified(repo, address_hash) end)
@@ -1001,6 +1003,10 @@ defmodule Explorer.Chain.SmartContract do
         AddressName.clear_primary_address_names(repo, address_hash)
       end)
       |> Multi.insert(:smart_contract, smart_contract_changeset)
+      |> Multi.run(:set_primary_address_name, fn repo, %{smart_contract: %SmartContract{name: name}} ->
+        result = AddressName.create_primary_address_name(repo, name, address_hash)
+        {:ok, result}
+      end)
 
     # Updates the queries from the previous step with inserting additional sources
     # of the contract
@@ -1015,9 +1021,6 @@ defmodule Explorer.Chain.SmartContract do
     insert_result =
       insert_contract_query_with_additional_sources
       |> Repo.transaction()
-
-    # Set the primary mark for the contract name
-    AddressName.create_primary_address_name(Repo, Changeset.get_field(smart_contract_changeset, :name), address_hash)
 
     case insert_result do
       {:ok, %{smart_contract: smart_contract}} ->

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -121,7 +121,7 @@ defmodule Explorer.Chain.SmartContract do
   }
 
   alias Explorer.Chain.Address.Name, as: AddressName
-  alias Explorer.Chain.SmartContract.{Proxy, VerifiedContractAddressesQuery}
+  alias Explorer.Chain.SmartContract.{Proxy, VerificationStatus, VerifiedContractAddressesQuery}
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias Explorer.Helper, as: ExplorerHelper
   alias Explorer.SmartContract.Helper
@@ -910,26 +910,37 @@ defmodule Explorer.Chain.SmartContract do
       address_hash
       |> address_hash_to_smart_contract(api?: true)
 
-    cond do
-      is_nil(smart_contract) ->
-        create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
+    result =
+      cond do
+        is_nil(smart_contract) ->
+          create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
 
-      smart_contract.partially_verified && attrs.partially_verified &&
-          Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] ->
-        changeset =
-          invalid_contract_changeset(
-            %SmartContract{address_hash: address_hash},
-            Helper.add_contract_code_md5(attrs),
-            "Cannot update partially verified smart contract with another partially verified contract",
-            nil,
-            verification_with_files?
-          )
+        smart_contract.partially_verified && attrs.partially_verified &&
+            Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] ->
+          changeset =
+            invalid_contract_changeset(
+              %SmartContract{address_hash: address_hash},
+              Helper.add_contract_code_md5(attrs),
+              "Cannot update partially verified smart contract with another partially verified contract",
+              nil,
+              verification_with_files?
+            )
 
-        {:error, %{changeset | action: :insert}}
+          {:error, %{changeset | action: :insert}}
 
-      true ->
-        update_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
+        true ->
+          update_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
+      end
+
+    with {:ok, _} <- result do
+      # The contract is now verified through some path. Reconcile any verification-status
+      # rows for this address that were left pending (e.g. an RPC worker that raised before
+      # updating the status, or verification that completed via a path which does not write
+      # the status table). See Explorer.Chain.SmartContract.VerificationStatus.
+      VerificationStatus.set_pending_statuses_to_passed(address_hash)
     end
+
+    result
   end
 
   @doc """
@@ -1012,11 +1023,19 @@ defmodule Explorer.Chain.SmartContract do
       {:ok, %{smart_contract: smart_contract}} ->
         {:ok, smart_contract}
 
-      {:error, :smart_contract, changeset, _} ->
-        {:error, changeset}
+      {:error, failed_operation, failed_value, _changes_so_far} ->
+        Logger.error(fn ->
+          [
+            "Failed to create smart contract for ",
+            to_string(address_hash),
+            " at step ",
+            inspect(failed_operation),
+            ": ",
+            inspect(failed_value)
+          ]
+        end)
 
-      {:error, :set_address_verified, message, _} ->
-        {:error, message}
+        {:error, failed_value}
     end
   end
 
@@ -1117,8 +1136,19 @@ defmodule Explorer.Chain.SmartContract do
       {:ok, %{smart_contract: smart_contract}} ->
         {:ok, smart_contract}
 
-      {:error, :smart_contract, changeset, _} ->
-        {:error, changeset}
+      {:error, failed_operation, failed_value, _changes_so_far} ->
+        Logger.error(fn ->
+          [
+            "Failed to update smart contract for ",
+            to_string(address_hash),
+            " at step ",
+            inspect(failed_operation),
+            ": ",
+            inspect(failed_value)
+          ]
+        end)
+
+        {:error, failed_value}
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/smart_contract/verification_status.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/verification_status.ex
@@ -87,8 +87,7 @@ defmodule Explorer.Chain.SmartContract.VerificationStatus do
   end
 
   @doc """
-  Marks every pending (`status = 0`) verification attempt for the given address as
-  passed (`status = 1`).
+  Marks every pending (`status = 0`) verification attempt for the given address as passed (`status = 1`).
 
   This reconciles status rows that were left pending because the verification worker
   never reached `update_status/2` — e.g. it raised after inserting the pending row, or
@@ -96,7 +95,12 @@ defmodule Explorer.Chain.SmartContract.VerificationStatus do
   v2, UI, Sourcify, eth_bytecode_db, Verifier Alliance). It is meant to be called
   whenever a smart contract becomes verified through any path.
 
-  Returns `{number_of_updated_rows, nil}`.
+  ## Parameters
+  - `address_hash`: The address of the verified contract, as an `Explorer.Chain.Hash.Address`
+    struct or a `0x`-prefixed string. `nil` or an unparsable value is treated as a no-op.
+
+  ## Returns
+  - `{number_of_updated_rows, nil}`: the number of pending rows that were marked as passed.
   """
   @spec set_pending_statuses_to_passed(Hash.Address.t() | binary() | nil) :: {non_neg_integer(), nil}
   def set_pending_statuses_to_passed(address_hash) do

--- a/apps/explorer/lib/explorer/chain/smart_contract/verification_status.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/verification_status.ex
@@ -86,6 +86,37 @@ defmodule Explorer.Chain.SmartContract.VerificationStatus do
     |> Repo.update()
   end
 
+  @doc """
+  Marks every pending (`status = 0`) verification attempt for the given address as
+  passed (`status = 1`).
+
+  This reconciles status rows that were left pending because the verification worker
+  never reached `update_status/2` — e.g. it raised after inserting the pending row, or
+  the contract was ultimately verified via a path that does not write this table (API
+  v2, UI, Sourcify, eth_bytecode_db, Verifier Alliance). It is meant to be called
+  whenever a smart contract becomes verified through any path.
+
+  Returns `{number_of_updated_rows, nil}`.
+  """
+  @spec set_pending_statuses_to_passed(Hash.Address.t() | binary() | nil) :: {non_neg_integer(), nil}
+  def set_pending_statuses_to_passed(address_hash) do
+    case normalize_address_hash(address_hash) do
+      {:ok, hash} ->
+        now = DateTime.utc_now()
+
+        __MODULE__
+        |> where([vs], vs.contract_address_hash == ^hash and vs.status == 0)
+        |> Repo.update_all(set: [status: 1, updated_at: now])
+
+      :error ->
+        {0, nil}
+    end
+  end
+
+  defp normalize_address_hash(%Hash{} = hash), do: {:ok, hash}
+  defp normalize_address_hash(address_hash) when is_binary(address_hash), do: Chain.string_to_address_hash(address_hash)
+  defp normalize_address_hash(_), do: :error
+
   def fetch_status(uid) do
     case validate_uid(uid) do
       {:ok, valid_uid} ->

--- a/apps/explorer/priv/repo/migrations/20260724144709_reconcile_pending_smart_contract_verification_statuses.exs
+++ b/apps/explorer/priv/repo/migrations/20260724144709_reconcile_pending_smart_contract_verification_statuses.exs
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Repo.Migrations.ReconcilePendingSmartContractVerificationStatuses do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE smart_contract_verification_statuses st
+    SET status = 1, updated_at = now()
+    FROM smart_contracts s
+    WHERE st.contract_address_hash = s.address_hash
+      AND st.status = 0
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract/verification_status_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/verification_status_test.exs
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.SmartContract.VerificationStatusTest do
+  use Explorer.DataCase, async: true
+
+  alias Explorer.Chain.SmartContract.VerificationStatus
+
+  describe "set_pending_statuses_to_passed/1" do
+    test "flips all pending rows for the address to passed and returns the count" do
+      address = insert(:address)
+      hash_string = to_string(address.hash)
+
+      {:ok, _} = VerificationStatus.insert_status("uid-1", :pending, hash_string)
+      {:ok, _} = VerificationStatus.insert_status("uid-2", :pending, hash_string)
+
+      assert {2, nil} = VerificationStatus.set_pending_statuses_to_passed(address.hash)
+
+      assert Repo.get_by(VerificationStatus, uid: "uid-1").status == 1
+      assert Repo.get_by(VerificationStatus, uid: "uid-2").status == 1
+    end
+
+    test "accepts a 0x-prefixed string address" do
+      address = insert(:address)
+      {:ok, _} = VerificationStatus.insert_status("uid-1", :pending, to_string(address.hash))
+
+      assert {1, nil} = VerificationStatus.set_pending_statuses_to_passed(to_string(address.hash))
+
+      assert Repo.get_by(VerificationStatus, uid: "uid-1").status == 1
+    end
+
+    test "leaves already passed/failed rows and rows of other addresses untouched" do
+      address = insert(:address)
+      other_address = insert(:address)
+      hash_string = to_string(address.hash)
+
+      {:ok, _} = VerificationStatus.insert_status("pending", :pending, hash_string)
+      {:ok, _} = VerificationStatus.insert_status("passed", :pass, hash_string)
+      {:ok, _} = VerificationStatus.insert_status("failed", :fail, hash_string)
+      {:ok, _} = VerificationStatus.insert_status("other", :pending, to_string(other_address.hash))
+
+      assert {1, nil} = VerificationStatus.set_pending_statuses_to_passed(address.hash)
+
+      assert Repo.get_by(VerificationStatus, uid: "pending").status == 1
+      assert Repo.get_by(VerificationStatus, uid: "passed").status == 1
+      assert Repo.get_by(VerificationStatus, uid: "failed").status == 2
+      assert Repo.get_by(VerificationStatus, uid: "other").status == 0
+    end
+
+    test "returns {0, nil} when there are no pending rows for the address" do
+      address = insert(:address)
+
+      assert {0, nil} = VerificationStatus.set_pending_statuses_to_passed(address.hash)
+    end
+
+    test "returns {0, nil} for a nil or invalid address" do
+      assert {0, nil} = VerificationStatus.set_pending_statuses_to_passed(nil)
+      assert {0, nil} = VerificationStatus.set_pending_statuses_to_passed("not-an-address")
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -5,6 +5,7 @@ defmodule Explorer.Chain.SmartContractTest do
   import ExUnit.CaptureLog
   import Mox
   alias Explorer.Chain.{Address, SmartContract}
+  alias Explorer.Chain.SmartContract.VerificationStatus
 
   doctest Explorer.Chain.SmartContract
 
@@ -108,6 +109,93 @@ defmodule Explorer.Chain.SmartContractTest do
       assert {:ok, %SmartContract{} = smart_contract} = SmartContract.create_smart_contract(valid_attrs)
 
       assert Repo.get_by(Address, hash: smart_contract.address_hash).verified == true
+    end
+
+    test "returns an error tuple (does not raise) when a non-primary Multi step fails", %{valid_attrs: valid_attrs} do
+      # An additional source is inserted under a string-keyed Multi step
+      # ("smart_contract_additional_source_0"), which the result `case` used to leave
+      # unmatched -> CaseClauseError. An invalid additional source must now surface as a
+      # clean error tuple instead of crashing the verification worker.
+      invalid_secondary_sources = [
+        %{
+          file_name: "storage.sol",
+          # contract_source_code intentionally omitted -> invalid changeset
+          address_hash: valid_attrs.address_hash
+        }
+      ]
+
+      log =
+        capture_log(fn ->
+          assert {:error, %Ecto.Changeset{valid?: false}} =
+                   SmartContract.create_smart_contract(valid_attrs, [], invalid_secondary_sources)
+        end)
+
+      assert log =~ "Failed to create smart contract"
+      # transaction rolled back -> no contract persisted
+      refute Repo.get_by(SmartContract, address_hash: valid_attrs.address_hash)
+    end
+  end
+
+  describe "create_or_update_smart_contract/3" do
+    setup do
+      smart_contract_bytecode =
+        "0x608060405234801561001057600080fd5b5060df8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806360fe47b114604e5780636d4ce63c146078575b600080fd5b348015605957600080fd5b5060766004803603810190808035906020019092919050505060a0565b005b348015608357600080fd5b50608a60aa565b6040518082815260200191505060405180910390f35b8060008190555050565b600080549050905600a165627a7a7230582040d82a7379b1ee1632ad4d8a239954fd940277b25628ead95259a85c5eddb2120029"
+
+      address =
+        insert(
+          :address,
+          hash: "0x0f95fa9bc0383e699325f2658d04e8d96d87b90c",
+          contract_code: smart_contract_bytecode
+        )
+
+      valid_attrs = %{
+        address_hash: "0x0f95fa9bc0383e699325f2658d04e8d96d87b90c",
+        name: "SimpleStorage",
+        compiler_version: "0.4.23",
+        optimization: false,
+        contract_source_code:
+          "pragma solidity ^0.4.23; contract SimpleStorage {uint storedData; function set(uint x) public {storedData = x; } function get() public constant returns (uint) {return storedData; } }",
+        abi: [%{"type" => "function", "name" => "get", "inputs" => [], "outputs" => []}],
+        partially_verified: false,
+        external_libraries: [],
+        secondary_sources: []
+      }
+
+      {:ok, valid_attrs: valid_attrs, address: address}
+    end
+
+    test "reconciles pending verification statuses to passed on successful verification", %{
+      valid_attrs: valid_attrs,
+      address: address
+    } do
+      {:ok, _} = VerificationStatus.insert_status("pending-uid", :pending, to_string(address.hash))
+
+      assert {:ok, %SmartContract{}} = SmartContract.create_or_update_smart_contract(address.hash, valid_attrs, false)
+
+      assert Repo.get_by(VerificationStatus, uid: "pending-uid").status == 1
+    end
+
+    test "does not reconcile pending statuses when verification does not succeed", %{address: address} do
+      initial = Application.get_env(:block_scout_web, :contract) || []
+
+      Application.put_env(
+        :block_scout_web,
+        :contract,
+        Keyword.merge(initial, partial_reverification_disabled: true)
+      )
+
+      on_exit(fn -> Application.put_env(:block_scout_web, :contract, initial) end)
+
+      # existing partially verified contract -> re-verifying with a partial one is rejected
+      insert(:smart_contract, address_hash: address.hash, partially_verified: true, contract_code_md5: "123")
+
+      {:ok, _} = VerificationStatus.insert_status("pending-uid", :pending, to_string(address.hash))
+
+      attrs = %{partially_verified: true, external_libraries: [], secondary_sources: []}
+
+      assert {:error, _} = SmartContract.create_or_update_smart_contract(address.hash, attrs, false)
+
+      assert Repo.get_by(VerificationStatus, uid: "pending-uid").status == 0
     end
   end
 

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -131,8 +131,9 @@ defmodule Explorer.Chain.SmartContractTest do
         end)
 
       assert log =~ "Failed to create smart contract"
-      # transaction rolled back -> no contract persisted
+      # transaction rolled back -> no contract and no primary name persisted
       refute Repo.get_by(SmartContract, address_hash: valid_attrs.address_hash)
+      refute Repo.get_by(Address.Name, address_hash: valid_attrs.address_hash, primary: true)
     end
   end
 


### PR DESCRIPTION
## Motivation

In production a large number of `smart_contract_verification_statuses` rows remained at `status = 0` (pending) even though the corresponding contract was already verified (714 such rows observed, all `updated_at = inserted_at`, i.e. never advanced). The status table is only ever advanced synchronously inside the RPC verification worker's `publish_and_update_status/4`, and only for the `json_api`/`flattened_api` job types. It is left pending forever whenever (1) the worker raises between `insert_status(:pending)` and `update_status` (any exception bypasses both the `:pass` and `:fail` branches — a clean `{:error}` would have written `:fail`), or (2) the contract is ultimately verified through a path that never writes this table (API v2, UI, Sourcify, eth_bytecode_db, Verifier Alliance). One concrete crash source was found: `create_smart_contract/1` and `update_smart_contract/1` matched only a subset of `Ecto.Multi` failures in their result `case`, so a failure in any other step (e.g. `:clear_primary_address_names`, or a string-keyed `smart_contract_additional_source_N` insert) raised `CaseClauseError`, crashing the worker and stranding the pending row.

## Changelog

### Enhancements

Reconcile the verification-status table on every verification path: `SmartContract.create_or_update_smart_contract/3` now, on success, calls the new `VerificationStatus.set_pending_statuses_to_passed/1`, flipping any `status = 0` rows for that address to `:pass`. This is the single choke point all EVM verification paths funnel through (Solidity/RPC, API v2, Vyper, Stylus, Geas, eth_bytecode_db, genesis), so it heals both orphan mechanisms — cross-path verification and a worker that persisted the contract but crashed before updating status. Added a foreground data migration (`ReconcilePendingSmartContractVerificationStatuses`) that back-fills the existing stuck rows by setting `status = 1` for every pending status whose contract is already present in `smart_contracts`. Added unit tests for `set_pending_statuses_to_passed/1` and integration tests asserting reconciliation happens on success and not on failure.

### Bug Fixes

Made the `Ecto.Multi` result `case` in `create_smart_contract/1` and `update_smart_contract/1` total: a catch-all `{:error, failed_operation, failed_value, _}` clause now logs the failing step and returns `{:error, failed_value}` instead of raising `CaseClauseError`, so an unexpected transaction-step failure surfaces as a clean error tuple (turned into `status = :fail` by the RPC worker) rather than crashing the worker and leaving a permanently pending row. Moved the primary-address-name creation in `create_smart_contract/1` into the `Ecto.Multi` transaction (as a `:set_primary_address_name` step, mirroring `update_smart_contract/1`), so it is rolled back together with the contract instead of being written unconditionally after a rolled-back transaction. Added regression tests that an invalid additional source returns an error tuple without raising and leaves no primary name behind.

### Incompatible Changes

None.

## Upgrading

No database reset or reindex required. The included foreground migration (`ReconcilePendingSmartContractVerificationStatuses`) runs automatically on deploy and back-fills existing already-verified-but-pending rows via `UPDATE smart_contract_verification_statuses st SET status = 1, updated_at = now() FROM smart_contracts s WHERE st.contract_address_hash = s.address_hash AND st.status = 0;`. It is a single indexed-join `UPDATE` over a small table and completes near-instantly, but it does briefly lock the affected rows during the migration step. The migration's `down/0` is a no-op, as the reconciliation is not reversible. Going forward such rows self-heal on the next verification of that address, so no manual intervention is needed.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Smart contract verification statuses now automatically move from pending to passed after successful contract creation or updates.
  * Added reconciliation for any remaining pending verification statuses via a database migration.
  * Improved transaction failure handling for smart contract create/update to return consistent errors while preserving rollback behavior.
  * Primary address name creation is now executed within the transaction to prevent partial writes.

* **New Features**
  * Added a helper to mark all pending verification statuses for a contract address as passed.

* **Tests**
  * Added tests for pending-to-passed status updates, including `0x` handling and nil/invalid inputs.
  * Added coverage to ensure invalid sources fail gracefully without persisting contract or primary address name, and that failure is logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->