### PR TITLE
chore: Add api-v2-temp-token-ttl

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/api_key_controller.ex
@@ -45,8 +45,8 @@ defmodule BlockScoutWeb.API.V2.APIKeyController do
       params["in_header"]
       |> case do
         "true" ->
-          put_resp_header(
-            conn,
+          conn
+          |> put_resp_header(
             @api_v2_temp_token_header_key,
             Crypto.sign(
               conn.secret_key_base,
@@ -55,6 +55,10 @@ defmodule BlockScoutWeb.API.V2.APIKeyController do
               keys: Plug.Keys,
               max_age: ttl
             )
+          )
+          |> put_resp_header(
+            @api_v2_temp_token_header_key <> "-ttl",
+            ttl |> Integer.to_string()
           )
 
         _ ->

--- a/apps/block_scout_web/test/block_scout_web/rate_limit_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/rate_limit_test.exs
@@ -385,6 +385,9 @@ defmodule BlockScoutWeb.RateLimitTest do
       [token] = Plug.Conn.get_resp_header(conn, "api-v2-temp-token")
       assert conn.resp_cookies["api_v2_temp_token"] == nil
 
+      ttl = div(Application.get_env(:block_scout_web, :api_rate_limit)[:api_v2_token_ttl], 1000)
+      assert Plug.Conn.get_resp_header(conn, "api-v2-temp-token-ttl") == [Integer.to_string(ttl)]
+
       # Now make request with the token
       conn =
         conn


### PR DESCRIPTION
## Motivation

## Changelog
- Add `api-v2-temp-token-ttl` (value in seconds) in `api/v2/key`
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temporary API v2 tokens issued in response headers now include a header indicating the token’s remaining lifetime.

* **Bug Fixes**
  * Improved visibility into temporary token expiration by returning the configured TTL in seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->