### PR TITLE
fix: distinguish eth_call reverts from RPC errors in proxy fetch

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -65,6 +65,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   @zero_address_hash_string "0x0000000000000000000000000000000000000000"
   @zero_bytes32_string "0x0000000000000000000000000000000000000000000000000000000000000000"
+  @vm_execution_error "VM execution error"
 
   @type options :: [{:api?, true | false}]
 
@@ -361,9 +362,27 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   defp handle_response({:storage, _}, %{result: result}) when is_binary(result), do: {:ok, result}
   defp handle_response({:call, _}, %{result: result}) when is_binary(result), do: {:ok, result}
-  # TODO: it'll be better to return nil only for the revert-related errors
-  defp handle_response({:call, _}, %{error: _}), do: {:ok, nil}
+  defp handle_response({:call, _}, %{error: error}) do
+    if revert_error?(error), do: {:ok, nil}, else: :error
+  end
+
   defp handle_response(_, _), do: :error
+
+  defp revert_error?(error) do
+    error
+    |> error_message()
+    |> case do
+      message when is_binary(message) ->
+        String.contains?(message, "execution reverted") or String.contains?(message, @vm_execution_error)
+
+      _ ->
+        false
+    end
+  end
+
+  defp error_message(%{message: message}), do: to_string(message)
+  defp error_message(error) when is_binary(error) or is_atom(error), do: to_string(error)
+  defp error_message(error), do: inspect(error)
 
   @doc """
   Returns combined ABI from proxy and implementation smart-contracts

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -259,8 +259,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   ## Returns
   - `{:ok, [{any(), ResolverBehaviour.fetched_values()}]}` if all of the values are fetched successfully,
-    map can contain nil values for failed/reverted eth_call requests.
-  - `:error` if the prefetching failed.
+    map can contain nil values for reverted eth_call requests.
+  - `:error` if the prefetching failed or an eth_call failed with a non-revert RPC error.
   """
   @spec prefetch_values([{any(), ResolverBehaviour.fetch_requirements()}], Hash.Address.t()) ::
           {:ok, [{any(), ResolverBehaviour.fetched_values()}]} | :error
@@ -296,8 +296,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   ## Returns
   - `{:ok, prefetched_values()}` if all of the values are fetched successfully,
-    map can contain nil values for failed/reverted eth_call requests.
-  - `:error` if the prefetching failed.
+    map can contain nil values for reverted eth_call requests.
+  - `:error` if the prefetching failed or an eth_call failed with a non-revert RPC error.
   """
   @spec fetch_values([ResolverBehaviour.fetch_requirement()], Hash.Address.t()) ::
           {:ok, %{ResolverBehaviour.fetch_requirement() => String.t() | nil}} | :error
@@ -334,15 +334,15 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Fetches value for the given eth_getStorageAt or eth_call request for a given address hash.
 
-  The eth_call request is allowed to fail/revert, nil will be returned in such case.
+  Reverted eth_call requests return nil; other RPC failures return `:error`.
 
   ## Parameters
   - `req`: The eth_getStorageAt or eth_call request to fetch the value for.
   - `address_hash`: The address hash to fetch the value for.
 
   ## Returns
-  - `{:ok, String.t() | nil}` if the value is fetched successfully.
-  - `:error` if the fetch request failed.
+  - `{:ok, String.t() | nil}` if the value is fetched successfully or the eth_call reverted.
+  - `:error` if the fetch request failed with a non-revert RPC error.
   """
   @spec fetch_value(ResolverBehaviour.fetch_requirement(), Hash.Address.t()) :: {:ok, String.t() | nil} | :error
   def fetch_value(req, address_hash) do

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -248,7 +248,7 @@ defmodule Explorer.TestHelper do
          mocks |> Keyword.get(:eip1967, @zero_address_hash) |> encode_in_batch_response(id1),
          mocks |> Keyword.get(:eip1822, @zero_address_hash) |> encode_in_batch_response(id2),
          mocks |> Keyword.get(:eip1967_beacon, @zero_address_hash) |> encode_in_batch_response(id3),
-         %{id: id4, error: "error"},
+         %{id: id4, error: %{code: 3, message: "execution reverted"}},
          mocks |> Keyword.get(:eip1967_oz, @zero_address_hash) |> encode_in_batch_response(id5)
        ] ++
          Enum.map(rest, fn

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -305,6 +305,46 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
     assert implementation_abi == @implementation_abi
   end
 
+  describe "fetch_value/2 and fetch_values/2" do
+    setup do
+      address = insert(:address)
+      %{address: address}
+    end
+
+    test "returns nil when eth_call reverts", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, "execution reverted"}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == {:ok, nil}
+    end
+
+    test "returns error when eth_call fails with a non-revert error", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, :timeout}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == :error
+    end
+
+    test "returns error when batched eth_call fails with a non-revert error", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:ok, [%{id: 0, error: "timeout"}]}
+      end)
+
+      assert Proxy.fetch_values([{:call, "0x5c60da1b"}], address.hash) == :error
+    end
+
+    test "returns nil for reverted batched eth_call", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:ok, [%{id: 0, error: %{code: 3, message: "execution reverted"}}]}
+      end)
+
+      assert Proxy.fetch_values([{:call, "0x5c60da1b"}], address.hash) ==
+               {:ok, %{{:call, "0x5c60da1b"} => nil}}
+    end
+  end
+
   test "extract_address_hash/1" do
     assert Proxy.extract_address_hash(nil) == nil
     assert Proxy.extract_address_hash("0x") == nil


### PR DESCRIPTION
## Motivation

`Proxy.fetch_value/2` and `Proxy.fetch_values/2` should return `nil` only when an `eth_call` reverts, and `:error` on real RPC/transport failures. Previously every `eth_call` error was treated as `{:ok, nil}`.

## Changelog

### Bug Fixes

- Return `{:ok, nil}` only for revert errors (`execution reverted`, `VM execution error`).
- Return `:error` for other RPC failures.
- Added regression tests.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed smart contract proxy `eth_call` handling so revert-related call failures return `nil` implementation results (`{:ok, nil}` / `{:ok, %{… => nil}}` for batches).
  * Updated behavior so non-revert failures (e.g., timeouts) no longer appear as successful “nil implementation” results.
  * Improved recognition of revert errors from structured JSON-RPC error payloads, including within batched calls.
* **Tests**
  * Added coverage for `fetch_value/2` and `fetch_values/2` across revert and non-revert `eth_call` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->