### PR TITLE
fix: Disable ETH bytecode DB sources fetching for minimal proxies

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -146,7 +146,7 @@ defmodule BlockScoutWeb.API.V2.Helper do
 
   # We treat contracts with minimal proxy or similar standards as verified if all their implementations are verified
   defp verified_as_proxy?(%{proxy_type: proxy_type, names: names})
-       when proxy_type in [:eip1167, :eip7702, :clone_with_immutable_arguments, :erc7760] do
+       when proxy_type in [:eip1167, :eip7702, :clone_with_immutable_arguments, :erc7760, :minimal_proxy] do
     !Enum.empty?(names) && Enum.all?(names)
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/address_controller_test.exs
@@ -328,6 +328,32 @@ defmodule BlockScoutWeb.API.V2.AddressControllerTest do
              } = json_response
     end
 
+    test "get minimal_proxy contract shows is_verified true", %{conn: conn} do
+      implementation_contract = insert(:smart_contract, contract_code_md5: "abc")
+
+      proxy_address = insert(:contract_address)
+
+      insert(:transaction,
+        created_contract_address_hash: proxy_address.hash,
+        input: "0x00"
+      )
+      |> with_block(status: :ok)
+
+      insert(:proxy_implementation,
+        proxy_address_hash: proxy_address.hash,
+        proxy_type: "minimal_proxy",
+        address_hashes: [implementation_contract.address_hash],
+        names: [implementation_contract.name]
+      )
+
+      request = get(conn, "/api/v2/addresses/#{Address.checksum(proxy_address.hash)}")
+
+      json_response = json_response(request, 200)
+
+      assert json_response["is_verified"] == true
+      assert json_response["proxy_type"] == "minimal_proxy"
+    end
+
     test "get EIP-1967 proxy contract info", %{conn: conn} do
       smart_contract = insert(:smart_contract)
 

--- a/apps/explorer/lib/explorer/chain/fetcher/look_up_smart_contract_sources_on_demand.ex
+++ b/apps/explorer/lib/explorer/chain/fetcher/look_up_smart_contract_sources_on_demand.ex
@@ -26,6 +26,7 @@ defmodule Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand do
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Data, SmartContract}
   alias Explorer.Chain.Events.Publisher
+  alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
   alias Explorer.SmartContract.EthBytecodeDBInterface
   alias Explorer.SmartContract.Geas.Publisher, as: GeasPublisher
   alias Explorer.SmartContract.Solidity.Publisher, as: SolidityPublisher
@@ -37,6 +38,8 @@ defmodule Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand do
   @cache_name :smart_contracts_sources_fetching
 
   @cooldown_timeout 500
+
+  @bytecode_proxy_types [:eip1167, :eip7702, :minimal_proxy, :clone_with_immutable_arguments, :erc7760]
 
   @doc """
     Triggers the fetch of smart contract sources.
@@ -266,6 +269,7 @@ defmodule Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand do
     with true <- fetch_cooldown_elapsed?(address_or_address_hash_string),
          {:ok, address} <- maybe_fetch_address(address_or_address_hash_string),
          true <- Address.smart_contract_with_nonempty_code?(address),
+         false <- bytecode_proxy?(address),
          partially_verified? = address.smart_contract && address.smart_contract.partially_verified,
          true <- is_nil(partially_verified?) or partially_verified? do
       GenServer.cast(
@@ -281,6 +285,13 @@ defmodule Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand do
       {:noreply, state}
     else
       _ -> {:noreply, state}
+    end
+  end
+
+  defp bytecode_proxy?(%Address{hash: hash}) do
+    case Implementation.get_proxy_implementations(hash) do
+      %Implementation{proxy_type: proxy_type} when proxy_type in @bytecode_proxy_types -> true
+      _ -> false
     end
   end
 end

--- a/apps/explorer/test/explorer/chain/fetcher/look_up_smart_contract_sources_on_demand_test.exs
+++ b/apps/explorer/test/explorer/chain/fetcher/look_up_smart_contract_sources_on_demand_test.exs
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemandTest do
+  use Explorer.DataCase, async: false
+
+  import Mox
+
+  alias Explorer.Chain.Fetcher.LookUpSmartContractSourcesOnDemand
+
+  @ets_table :smart_contracts_sources_fetching
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    initial_config =
+      Application.get_env(:explorer, LookUpSmartContractSourcesOnDemand) || []
+
+    Application.put_env(
+      :explorer,
+      LookUpSmartContractSourcesOnDemand,
+      Keyword.merge(initial_config, fetch_interval: 0)
+    )
+
+    on_exit(fn ->
+      Application.put_env(:explorer, LookUpSmartContractSourcesOnDemand, initial_config)
+    end)
+
+    start_supervised!(LookUpSmartContractSourcesOnDemand)
+
+    :ok
+  end
+
+  describe "bytecode proxy exclusion" do
+    @bytecode_proxy_types [:eip1167, :eip7702, :minimal_proxy, :clone_with_immutable_arguments, :erc7760]
+
+    for proxy_type <- @bytecode_proxy_types do
+      test "skips verification for #{proxy_type} proxy" do
+        address = insert(:contract_address)
+        implementation_address = insert(:contract_address)
+        implementation_sc = insert(:smart_contract, address_hash: implementation_address.hash, contract_code_md5: "abc")
+
+        insert(:proxy_implementation,
+          proxy_address_hash: address.hash,
+          proxy_type: unquote(to_string(proxy_type)),
+          address_hashes: [implementation_address.hash],
+          names: [implementation_sc.name]
+        )
+
+        address_hash_string = to_string(address.hash)
+        GenServer.cast(LookUpSmartContractSourcesOnDemand, {:check_eligibility, address_hash_string})
+
+        :timer.sleep(50)
+
+        assert :ets.lookup(@ets_table, String.downcase(address_hash_string)) == []
+      end
+    end
+
+    test "does not skip verification for non-bytecode proxy types" do
+      Explorer.Mock.TeslaAdapter
+      |> stub(:call, fn env, _opts ->
+        {:ok, %Tesla.Env{env | status: 200, body: Jason.encode!(%{"sources" => []})}}
+      end)
+
+      address = insert(:contract_address)
+      implementation_address = insert(:contract_address)
+      implementation_sc = insert(:smart_contract, address_hash: implementation_address.hash, contract_code_md5: "abc")
+
+      insert(:proxy_implementation,
+        proxy_address_hash: address.hash,
+        proxy_type: "eip1967",
+        address_hashes: [implementation_address.hash],
+        names: [implementation_sc.name]
+      )
+
+      address_hash_string = to_string(address.hash)
+      GenServer.cast(LookUpSmartContractSourcesOnDemand, {:check_eligibility, address_hash_string})
+
+      :timer.sleep(100)
+
+      assert :ets.lookup(@ets_table, String.downcase(address_hash_string)) != []
+    end
+
+    test "does not skip verification for address without proxy implementation" do
+      Explorer.Mock.TeslaAdapter
+      |> stub(:call, fn env, _opts ->
+        {:ok, %Tesla.Env{env | status: 200, body: Jason.encode!(%{"sources" => []})}}
+      end)
+
+      address = insert(:contract_address)
+
+      address_hash_string = to_string(address.hash)
+      GenServer.cast(LookUpSmartContractSourcesOnDemand, {:check_eligibility, address_hash_string})
+
+      :timer.sleep(100)
+
+      assert :ets.lookup(@ets_table, String.downcase(address_hash_string)) != []
+    end
+  end
+end


### PR DESCRIPTION
Closes #13610 

## Changelog
- Disable ETH bytecode DB sources fetching for minimal proxies

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minimal proxy contracts are now correctly recognized as verified in API address responses.
  * Improved handling of proxy contracts during contract source verification and lookup.
  * Prevented unnecessary source lookups for supported bytecode-based proxy contracts.
* **Tests**
  * Added coverage for minimal proxy verification and source lookup behavior across supported proxy types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->