### PR TITLE
chore: Add refetch_needed_blocks_count indexer metric

### DIFF
--- a/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
+++ b/apps/explorer/lib/explorer/chain/metrics/queries/indexer_metrics.ex
@@ -84,6 +84,62 @@ defmodule Explorer.Chain.Metrics.Queries.IndexerMetrics do
   defp normalize_missing_blocks_count(value), do: value
 
   @doc """
+  Query to get the number of consensus blocks that require refetch
+  """
+  # sobelow_skip ["SQL"]
+  @spec refetch_needed_blocks_count() :: integer()
+  def refetch_needed_blocks_count do
+    block_ranges = RangesHelper.get_block_ranges()
+
+    if block_ranges == [] do
+      0
+    else
+      {range_conditions, params} =
+        Enum.reduce(block_ranges, {[], []}, fn
+          first..last//_, {conditions, acc_params} ->
+            from = min(first, last)
+            to = max(first, last)
+            param_index_from = length(acc_params) + 1
+            param_index_to = length(acc_params) + 2
+
+            condition = "(b.number >= $#{param_index_from}::bigint AND b.number <= $#{param_index_to}::bigint)"
+
+            {[condition | conditions], [to, from | acc_params]}
+
+          start_from, {conditions, acc_params} ->
+            param_index = length(acc_params) + 1
+            condition = "b.number >= $#{param_index}::bigint"
+            {[condition | conditions], [start_from | acc_params]}
+        end)
+
+      range_filter =
+        range_conditions
+        |> Enum.reverse()
+        |> Enum.join(" OR ")
+
+      sql_string = """
+      SELECT COUNT(1) AS refetch_needed_blocks_count
+      FROM blocks b
+      WHERE b.consensus AND b.refetch_needed
+      AND (#{range_filter});
+      """
+
+      case SQL.query(Repo, sql_string, Enum.reverse(params), timeout: :infinity) do
+        {:ok,
+         %Postgrex.Result{
+           command: :select,
+           columns: ["refetch_needed_blocks_count"],
+           rows: [[refetch_needed_blocks_count]]
+         }} ->
+          refetch_needed_blocks_count
+
+        _ ->
+          0
+      end
+    end
+  end
+
+  @doc """
   Query to get the number of missing internal transactions in the DB
   """
   @spec missing_internal_transactions_count() :: integer()

--- a/apps/explorer/test/explorer/chain/metrics/indexer_metrics_test.exs
+++ b/apps/explorer/test/explorer/chain/metrics/indexer_metrics_test.exs
@@ -34,6 +34,41 @@ defmodule Explorer.Chain.Metrics.Queries.IndexerMetricsTest do
     end
   end
 
+  describe "refetch_needed_blocks_count/0" do
+    test "counts only consensus blocks marked for refetch within configured ranges and latest tail" do
+      previous_block_ranges = Application.get_env(:indexer, :block_ranges)
+      on_exit(fn -> Application.put_env(:indexer, :block_ranges, previous_block_ranges) end)
+
+      Application.put_env(:indexer, :block_ranges, "1..3,5..latest")
+
+      # within ranges, consensus and refetch_needed -> counted
+      insert(:block, number: 1, consensus: true, refetch_needed: true)
+      insert(:block, number: 7, consensus: true, refetch_needed: true)
+      # within ranges but not marked -> not counted
+      insert(:block, number: 2, consensus: true, refetch_needed: false)
+      # marked but not consensus -> not counted
+      insert(:block, number: 3, consensus: false, refetch_needed: true)
+      # marked and consensus but outside the ranges -> not counted
+      insert(:block, number: 4, consensus: true, refetch_needed: true)
+
+      assert IndexerMetrics.refetch_needed_blocks_count() == 2
+    end
+
+    test "counts only within finite ranges" do
+      previous_block_ranges = Application.get_env(:indexer, :block_ranges)
+      on_exit(fn -> Application.put_env(:indexer, :block_ranges, previous_block_ranges) end)
+
+      Application.put_env(:indexer, :block_ranges, "10..12,20..22")
+
+      insert(:block, number: 11, consensus: true, refetch_needed: true)
+      insert(:block, number: 21, consensus: true, refetch_needed: true)
+      # outside the finite ranges -> not counted
+      insert(:block, number: 30, consensus: true, refetch_needed: true)
+
+      assert IndexerMetrics.refetch_needed_blocks_count() == 2
+    end
+  end
+
   describe "missing_internal_transactions_count/0" do
     test "counts pending block operations when pending_operations_type is blocks" do
       previous_explorer_config = Application.get_env(:explorer, :json_rpc_named_arguments)

--- a/apps/indexer/lib/indexer/prometheus/instrumenter.ex
+++ b/apps/indexer/lib/indexer/prometheus/instrumenter.ex
@@ -53,6 +53,7 @@ defmodule Indexer.Prometheus.Instrumenter do
 
   # metrics of indexing monitor
   @gauge [name: :missing_blocks_count, help: "Number of blocks missing in the chain"]
+  @gauge [name: :refetch_needed_blocks_count, help: "Number of consensus blocks that require refetch"]
   @gauge [
     name: :missing_internal_transactions_count,
     help: "Number of blocks with not yet fetched internal transactions"
@@ -223,6 +224,12 @@ defmodule Indexer.Prometheus.Instrumenter do
   """
   @spec missing_blocks_count(integer()) :: :ok
   def missing_blocks_count(value), do: Gauge.set([name: :missing_blocks_count], value)
+
+  @doc """
+  Defines the metric for the number of consensus blocks that require refetch.
+  """
+  @spec refetch_needed_blocks_count(integer()) :: :ok
+  def refetch_needed_blocks_count(value), do: Gauge.set([name: :refetch_needed_blocks_count], value)
 
   @doc """
   Defines the metric for the number of blocks with not yet fetched internal transactions.

--- a/apps/indexer/lib/indexer/prometheus/metrics.ex
+++ b/apps/indexer/lib/indexer/prometheus/metrics.ex
@@ -12,6 +12,7 @@ defmodule Indexer.Prometheus.Metrics do
   @interval :timer.hours(1)
   @default_metrics_list [
     :missing_blocks_count,
+    :refetch_needed_blocks_count,
     :missing_internal_transactions_count,
     :multichain_search_db_main_export_queue_count,
     :multichain_search_db_export_balances_queue_count,


### PR DESCRIPTION
## Motivation

Analogically to the `missing_blocks_count/0` metric, we need visibility into how many consensus blocks are marked for refetch (`consensus AND refetch_needed`). Exposing this as a Prometheus gauge lets operators monitor the backlog of blocks awaiting refetch. The base query is `SELECT count(*) FROM blocks WHERE consensus AND refetch_needed;`, constrained by the configured `block_ranges` just like `missing_blocks_count/0`.

## Changelog

### Enhancements

- Added `Explorer.Chain.Metrics.Queries.IndexerMetrics.refetch_needed_blocks_count/0`, which counts consensus blocks with `refetch_needed = true`, filtered by the configured `block_ranges` (returns `0` when no ranges are set), following the same range-handling approach as `missing_current_token_balances_count/0`.
- Added the `refetch_needed_blocks_count` Prometheus gauge and its setter in `Indexer.Prometheus.Instrumenter`.
- Registered `:refetch_needed_blocks_count` in `Indexer.Prometheus.Metrics` default metrics list so it is collected on the hourly cycle.
- Added tests covering the `..latest` tail, finite ranges, and the consensus / refetch_needed / out-of-range exclusions.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for consensus blocks that require refetching.
  - Added a Prometheus gauge reporting the number of blocks needing refetch.
  - Included the metric in the periodic metrics update cycle.
  - Counts are limited to configured block ranges and return safely when no matching data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->