### PR TITLE
fix: handle not-loaded gas_token associations in Celo transaction view

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/celo_view.ex
@@ -10,6 +10,7 @@ defmodule BlockScoutWeb.API.V2.CeloView do
   import Explorer.Chain.SmartContract, only: [dead_address_hash_string: 0]
 
   alias BlockScoutWeb.API.V2.{Helper, TokenTransferView, TokenView, TransactionView}
+  alias Ecto.Association.NotLoaded
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Address.Reputation, Block, Token, TokenTransfer, Transaction, Wei}
   alias Explorer.Chain.Cache.{CeloCoreContracts, CeloEpochs}
@@ -290,8 +291,11 @@ defmodule BlockScoutWeb.API.V2.CeloView do
         Map.get(transaction, :gas_token_contract_address),
         Map.get(transaction, :gas_token)
       } do
-        # {_, %NotLoaded{}} ->
-        #   nil
+        {%NotLoaded{}, _} ->
+          nil
+
+        {_, %NotLoaded{}} ->
+          nil
 
         {nil, _} ->
           nil


### PR DESCRIPTION
## Motivation

On the `:celo` chain type, `TransactionView.render("transactions.json", ...)` routes each transaction through `CeloView.extend_transaction_json_response/2`, which inspects the `gas_token_contract_address` (`belongs_to`) and `gas_token` (`has_one :through`) associations. When a transaction is rendered without these associations preloaded, both are `#Ecto.Association.NotLoaded`. The `case` only guarded against `{nil, _}`, so a not-loaded (≠ `nil`) `gas_token_contract_address` fell through to the final branch and called `TokenView.render("token.json", %{token: <NotLoaded>})`, which tried to read `token.contract_address_hash` and raised `KeyError`. The code already anticipated this via a commented-out `{_, %NotLoaded{}} -> nil` clause, but it was disabled.

## Changelog

### Bug Fixes

Enabled explicit `NotLoaded` handling in `CeloView.extend_transaction_json_response/2`: added the `Ecto.Association.NotLoaded` alias and `{%NotLoaded{}, _} -> nil` / `{_, %NotLoaded{}} -> nil` clauses so rendering a transaction without preloaded `gas_token_contract_address` or `gas_token` returns `nil` instead of raising `KeyError`. Production behavior is unchanged because these associations are preloaded there.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to docs repository.
  - [ ] ENV vars: updated env vars list and set version parameter to `master`.
  - [ ] Deprecated vars: added to deprecated env vars list.
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction data handling for Celo gas tokens.
  * Prevented unavailable gas token details from appearing incorrectly in transaction responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->