### PR TITLE
fix: Add missing action_fallback to SolidityScanController

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/solidity_scan_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/proxy/solidity_scan_controller.ex
@@ -2,6 +2,8 @@
 defmodule BlockScoutWeb.API.V2.Proxy.SolidityScanController do
   use BlockScoutWeb, :controller
 
+  action_fallback(BlockScoutWeb.API.V2.FallbackController)
+
   alias BlockScoutWeb.AccessHelper
   alias Explorer.Chain
   alias Explorer.Chain.{Address, SmartContract}


### PR DESCRIPTION
## Motivation

The `GET /api/v2/proxy/3rdparty/solidityscan/smart-contracts/:address_hash/report` endpoint crashed with a `RuntimeError` whenever it was called for an unverified address (or a non-smart-contract, or a Vyper contract).

Genuine error from the logs:
`
{"message":"#PID<0.1638574.1> running BlockScoutWeb.Endpoint (connection #PID<0.1602981.1>, stream id 178) terminated\nServer: explorer.optimism.io:80 (http)\nRequest: GET /api/v2/proxy/3rdparty/solidityscan/smart-contracts/0xFa2a8681b1D5A5d9e2668BbC3A45dbe3df0c3A6F/report\n** (exit) an exception was raised:\n    ** (RuntimeError) expected action/2 to return a Plug.Conn, all plugs must receive a connection (conn) and return a connection, got: {:is_verified_smart_contract, false}\n        (block_scout_web 11.2.3) lib/block_scout_web/controllers/api/v2/proxy/solidity_scan_controller.ex:2: BlockScoutWeb.API.V2.Proxy.SolidityScanController.phoenix_controller_pipeline/2\n        (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2\n        (phoenix 1.6.16) lib/phoenix/router/route.ex:41: Phoenix.Router.Route.call/2\n        (phoenix 1.6.16) lib/phoenix/router.ex:354: Phoenix.Router.__call__/2\n        (block_scout_web 11.2.3) lib/block_scout_web/endpoint.ex:2: BlockScoutWeb.Endpoint.plug_builder_call/2\n        (block_scout_web 11.2.3) lib/block_scout_web/endpoint.ex:2: BlockScoutWeb.Endpoint.\"call (overridable 3)\"/2\n        (block_scout_web 11.2.3) /app/deps/spandex_phoenix/lib/spandex_phoenix.ex:151: BlockScoutWeb.Endpoint.call/2\n        (phoenix 1.6.16) lib/phoenix/endpoint/cowboy2_handler.ex:54...
`

The `solidityscan_report/2` action uses a `with` chain with no `else` branch, so on a failed match it returns a raw tuple such as `{:is_verified_smart_contract, false}` instead of a `Plug.Conn`. Because the controller did not declare `action_fallback`, Phoenix raised instead of routing the tuple to the fallback handler. This fired on any unverified-contract report request (observed being triggered by Googlebot crawling the endpoint).

## Changelog

### Bug Fixes

Added `action_fallback(BlockScoutWeb.API.V2.FallbackController)` to `BlockScoutWeb.API.V2.Proxy.SolidityScanController`. The `FallbackController` already handles every failure tuple this action returns (`:is_verified_smart_contract`, `:is_smart_contract`, `:language`, `:is_empty_response`, `:address`, `:restricted_access`, `:format_address`), so unverified contracts now correctly return `404 "Smart-contract is unverified"` instead of crashing.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Solidity Scan API requests.
  * API errors and unsuccessful responses now receive more consistent fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->