### PR TITLE
chore: Optimize transactions event notifying

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -334,26 +334,10 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   def handle_event({:chain_event, :transactions, :realtime, transactions}) do
-    base_preloads = [
-      :block,
-      created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
-    ]
+    broadcast_transactions_websocket_v2(transactions)
 
-    preloads =
-      if API_V2.enabled?(),
-        do: [{:token_transfers, [token: Reputation.reputation_association()]} | base_preloads],
-        else: base_preloads
-
-    transactions
-    |> Repo.preload(preloads)
-    |> broadcast_transactions_websocket_v2()
-    |> Enum.map(fn transaction ->
-      # Disable parsing of token transfers from websocket for transaction tab because we display token transfers at a separate tab
-      Map.put(transaction, :token_transfers, [])
-    end)
-    |> Enum.each(&broadcast_transaction/1)
+    # TODO: delete duplicated event when old UI becomes deprecated
+    broadcast_transactions_websocket_v1(transactions)
   end
 
   def handle_event({:chain_event, :transaction_stats}) do
@@ -788,16 +772,10 @@ defmodule BlockScoutWeb.Notifier do
   end
 
   defp broadcast_transactions_websocket_v2(transactions) do
-    pending_transactions =
-      Enum.filter(transactions, fn
+    {pending_transactions, validated_transactions} =
+      Enum.split_with(transactions, fn
         %Transaction{block_number: nil} -> true
         _ -> false
-      end)
-
-    validated_transactions =
-      Enum.filter(transactions, fn
-        %Transaction{block_number: nil} -> false
-        _ -> true
       end)
 
     broadcast_transactions_websocket_v2_inner(
@@ -807,8 +785,6 @@ defmodule BlockScoutWeb.Notifier do
     )
 
     broadcast_transactions_websocket_v2_inner(validated_transactions, "transactions:new_transaction", "transaction")
-
-    transactions
   end
 
   defp broadcast_transactions_websocket_v2_inner(transactions, default_channel, event) do
@@ -818,17 +794,47 @@ defmodule BlockScoutWeb.Notifier do
       })
     end
 
-    relevant_transactions = Enum.filter(transactions, &transaction_has_subscribers?/1)
+    case Enum.filter(transactions, &transaction_has_subscribers?/1) do
+      [] ->
+        :ok
 
-    prepared_transactions =
-      TransactionView.render("transactions.json", %{
-        transactions: Repo.preload(relevant_transactions, @transaction_associations),
-        conn: nil
-      })
+      relevant_transactions ->
+        prepared_transactions =
+          TransactionView.render("transactions.json", %{
+            transactions: Repo.preload(relevant_transactions, transaction_broadcast_associations()),
+            conn: nil
+          })
 
-    relevant_transactions
-    |> Enum.zip(prepared_transactions)
-    |> group_by_address_hashes_and_broadcast(event, :transactions, & &1["hash"])
+        relevant_transactions
+        |> Enum.zip(prepared_transactions)
+        |> group_by_address_hashes_and_broadcast(event, :transactions, & &1["hash"])
+    end
+  end
+
+  # TODO: delete this function when old UI becomes deprecated
+  defp broadcast_transactions_websocket_v1(transactions) do
+    relevant_transactions =
+      if has_subscribers?("transactions_old:new_transaction") or
+           has_subscribers?("transactions_old:new_pending_transaction") do
+        transactions
+      else
+        Enum.filter(transactions, &transaction_has_old_subscribers?/1)
+      end
+
+    if relevant_transactions != [] do
+      relevant_transactions
+      |> Repo.preload([:block | @transaction_associations])
+      |> Enum.map(fn transaction ->
+        Map.put(transaction, :token_transfers, [])
+      end)
+      |> Enum.each(&broadcast_transaction/1)
+    end
+  end
+
+  defp transaction_broadcast_associations do
+    if API_V2.enabled?(),
+      do: [:block, {:token_transfers, [token: Reputation.reputation_association()]} | @transaction_associations],
+      else: [:block | @transaction_associations]
   end
 
   defp broadcast_transaction(%Transaction{block_number: nil} = pending) do
@@ -942,10 +948,15 @@ defmodule BlockScoutWeb.Notifier do
   defp address_has_subscribers?(nil), do: false
 
   defp address_has_subscribers?(address_hash) do
-    hash_string = to_string(address_hash)
+    has_subscribers?("addresses:" <> to_string(address_hash)) or
+      address_has_old_subscribers?(address_hash)
+  end
 
-    has_subscribers?("addresses:" <> hash_string) or
-      has_subscribers?("addresses_old:" <> hash_string)
+  # TODO: delete this function when old UI becomes deprecated
+  defp address_has_old_subscribers?(nil), do: false
+
+  defp address_has_old_subscribers?(address_hash) do
+    has_subscribers?("addresses_old:" <> to_string(address_hash))
   end
 
   defp token_transfer_has_subscribers?(tt) do
@@ -967,5 +978,12 @@ defmodule BlockScoutWeb.Notifier do
     address_has_subscribers?(transaction.from_address_hash) or
       address_has_subscribers?(transaction.to_address_hash) or
       address_has_subscribers?(transaction.created_contract_address_hash)
+  end
+
+  # TODO: delete this function when old UI becomes deprecated
+  defp transaction_has_old_subscribers?(transaction) do
+    has_subscribers?("transactions_old:" <> to_string(transaction.hash)) or
+      address_has_old_subscribers?(transaction.from_address_hash) or
+      address_has_old_subscribers?(transaction.to_address_hash)
   end
 end

--- a/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/notifier_subscriber_filter_test.exs
@@ -4,8 +4,12 @@ defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
     async: false
 
   alias BlockScoutWeb.Notifier
-  alias Explorer.Chain.Wei
+  alias Explorer.Chain.{Transaction, Wei}
+  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.Cache.Counters.AddressesCount
+  alias Explorer.Repo
+
+  defp without_loaded_associations(%Transaction{hash: hash}), do: Repo.get!(Transaction, hash)
 
   defp create_token_transfer(opts \\ []) do
     from_address = opts[:from_address] || insert(:address)
@@ -248,6 +252,177 @@ defmodule BlockScoutWeb.NotifierSubscriberFilterTest do
 
       unsubscribed_topic = "addresses:#{unsubscribed_transfer.from_address_hash}"
       refute_receive %Phoenix.Socket.Broadcast{topic: ^unsubscribed_topic}, 100
+    end
+  end
+
+  describe "transactions event: subscriber filtering" do
+    test "handles event without error when no channel has subscribers" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+        |> without_loaded_associations()
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
+    end
+
+    test "broadcasts the count of the batch to the default channel" do
+      transactions =
+        for _ <- 1..2 do
+          :transaction
+          |> insert()
+          |> with_block()
+          |> without_loaded_associations()
+        end
+
+      @endpoint.subscribe("transactions:new_transaction")
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, transactions})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "transactions:new_transaction",
+                       event: "transaction",
+                       payload: %{transaction: 2}
+                     },
+                     :timer.seconds(5)
+    end
+
+    test "renders the block data of a transaction when the denormalization is finished" do
+      old_denormalization_finished = BackgroundMigrations.get_transactions_denormalization_finished()
+      BackgroundMigrations.set_transactions_denormalization_finished(true)
+
+      on_exit(fn ->
+        BackgroundMigrations.set_transactions_denormalization_finished(old_denormalization_finished)
+      end)
+
+      subscribed_address = insert(:address)
+      block = insert(:block, base_fee_per_gas: 1_000_000_000)
+
+      transaction =
+        :transaction
+        |> insert(from_address: subscribed_address)
+        |> with_block(block)
+        |> without_loaded_associations()
+
+      topic = "addresses:#{subscribed_address.hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "transaction",
+                       payload: %{transactions: [%{"base_fee_per_gas" => base_fee_per_gas}]}
+                     },
+                     :timer.seconds(5)
+
+      assert Decimal.equal?(Wei.to(base_fee_per_gas, :wei), 1_000_000_000)
+    end
+
+    test "processes only transactions of subscribed addresses in a mixed batch" do
+      subscribed_address = insert(:address)
+
+      subscribed_transaction =
+        :transaction
+        |> insert(from_address: subscribed_address)
+        |> with_block()
+        |> without_loaded_associations()
+
+      unsubscribed_transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+        |> without_loaded_associations()
+
+      subscribed_topic = "addresses:#{subscribed_address.hash}"
+      @endpoint.subscribe(subscribed_topic)
+
+      Notifier.handle_event(
+        {:chain_event, :transactions, :realtime, [subscribed_transaction, unsubscribed_transaction]}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^subscribed_topic,
+                       event: "transaction",
+                       payload: %{transactions: [%{"hash" => hash}]}
+                     },
+                     :timer.seconds(5)
+
+      assert hash == subscribed_transaction.hash
+    end
+
+    test "processes pending transactions of subscribed addresses" do
+      subscribed_address = insert(:address)
+
+      pending_transaction =
+        :transaction
+        |> insert(from_address: subscribed_address)
+        |> without_loaded_associations()
+
+      topic = "addresses:#{subscribed_address.hash}"
+      @endpoint.subscribe(topic)
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [pending_transaction]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^topic,
+                       event: "pending_transaction",
+                       payload: %{transactions: _}
+                     },
+                     :timer.seconds(5)
+    end
+
+    # TODO: delete this test when old UI becomes deprecated
+    test "processes transactions of addresses subscribed to the old UI channel" do
+      subscribed_address = insert(:address)
+
+      subscribed_transaction =
+        :transaction
+        |> insert(from_address: subscribed_address)
+        |> with_block()
+        |> without_loaded_associations()
+
+      unsubscribed_transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+        |> without_loaded_associations()
+
+      subscribed_topic = "addresses_old:#{subscribed_address.hash}"
+      @endpoint.subscribe(subscribed_topic)
+
+      Notifier.handle_event(
+        {:chain_event, :transactions, :realtime, [subscribed_transaction, unsubscribed_transaction]}
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^subscribed_topic,
+                       event: "transaction",
+                       payload: %{transaction: %{hash: hash}}
+                     },
+                     :timer.seconds(5)
+
+      assert hash == subscribed_transaction.hash
+    end
+
+    # TODO: delete this test when old UI becomes deprecated
+    test "processes the whole batch when subscribed to the old UI default channel" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+        |> without_loaded_associations()
+
+      @endpoint.subscribe("transactions_old:new_transaction")
+
+      Notifier.handle_event({:chain_event, :transactions, :realtime, [transaction]})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "transactions_old:new_transaction",
+                       event: "transaction",
+                       payload: %{transaction: _}
+                     },
+                     :timer.seconds(5)
     end
   end
 


### PR DESCRIPTION
## Motivation

Transaction associations preloads are executed for all of the transactions coming to `BlockScoutWeb.Notifier` even though there may be no suscribers for particular transactions or no subscribers from old UI at all.

## Changelog

Do transaction preload only for transactions with subscribers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved realtime transaction updates by separately handling pending and confirmed transactions.
  * Added more targeted updates for subscribed addresses, reducing unrelated transaction notifications.
  * Enhanced transaction details with additional block information when available.

* **Bug Fixes**
  * Improved compatibility with older transaction and address notification channels.
  * Corrected notification behavior when no relevant subscribers are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->