### PR TITLE
feat: Add /api/v2/transactions/{hash}/preview endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -1045,6 +1045,75 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     end
   end
 
+  @preview_necessity_by_association %{
+    :block => :optional,
+    [from_address: [:names, :smart_contract]] => :optional,
+    [to_address: [:names, :smart_contract]] => :optional
+  }
+
+  operation :preview,
+    summary: "Get lightweight transaction preview for social media embeds",
+    description: "Returns minimal transaction data (status, timestamp, method, from/to) for rendering OG previews.",
+    parameters:
+      [transaction_hash_param() | base_params()] ++
+        [
+          %OpenApiSpex.Parameter{
+            name: :preload_ens,
+            in: :query,
+            schema: %Schema{type: :boolean},
+            required: false,
+            description: "Preload ENS domain names for addresses (default: false)"
+          },
+          %OpenApiSpex.Parameter{
+            name: :preload_metadata,
+            in: :query,
+            schema: %Schema{type: :boolean},
+            required: false,
+            description: "Preload address metadata/name tags (default: false)"
+          },
+          %OpenApiSpex.Parameter{
+            name: :decode_input,
+            in: :query,
+            schema: %Schema{type: :boolean},
+            required: false,
+            description: "Decode transaction input to resolve method name (default: false)"
+          }
+        ],
+    responses: [
+      ok: {"Lightweight transaction preview.", "application/json", %Schema{type: :object}},
+      not_found: NotFoundResponse.response(),
+      unprocessable_entity: JsonErrorResponse.response()
+    ]
+
+  @doc """
+    Function to handle GET requests to `/api/v2/transactions/:transaction_hash_param/preview` endpoint.
+  """
+  @spec preview(Plug.Conn.t(), map()) :: Plug.Conn.t() | {atom(), any()}
+  def preview(conn, %{transaction_hash_param: transaction_hash_string} = params) do
+    options =
+      [necessity_by_association: @preview_necessity_by_association]
+      |> Keyword.merge(@api_true)
+
+    with {:ok, transaction, _transaction_hash} <- validate_transaction(transaction_hash_string, params, options) do
+      preloaded =
+        transaction
+        |> maybe_preload_preview_ens(params)
+        |> maybe_preload_preview_metadata(params)
+
+      conn
+      |> put_status(200)
+      |> render(:preview, %{transaction: preloaded, decode_input: params[:decode_input] == true})
+    end
+  end
+
+  defp maybe_preload_preview_ens(transaction, %{preload_ens: true}), do: maybe_preload_ens_to_transaction(transaction)
+  defp maybe_preload_preview_ens(transaction, _params), do: transaction
+
+  defp maybe_preload_preview_metadata(transaction, %{preload_metadata: true}),
+    do: maybe_preload_metadata_to_transaction(transaction)
+
+  defp maybe_preload_preview_metadata(transaction, _params), do: transaction
+
   operation :blobs,
     summary: "List blobs for a transaction",
     description: "Retrieves blobs for a specific transaction (Ethereum only).",

--- a/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/api_router.ex
@@ -190,6 +190,7 @@ defmodule BlockScoutWeb.Routers.ApiRouter do
       get("/:transaction_hash_param/raw-trace", V2.TransactionController, :raw_trace)
       get("/:transaction_hash_param/state-changes", V2.TransactionController, :state_changes)
       get("/:transaction_hash_param/summary", V2.TransactionController, :summary)
+      get("/:transaction_hash_param/preview", V2.TransactionController, :preview)
 
       chain_scope :neon do
         get("/:transaction_hash_param/external-transactions", V2.TransactionController, :external_transactions)

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -86,6 +86,22 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     |> prepare_transaction(conn, true, block_height, nil, decoded_input, nil)
   end
 
+  def render("preview.json", %{transaction: transaction, decode_input: decode_input}) do
+    decoded_input =
+      if decode_input do
+        [decoded] = Transaction.decode_transactions([transaction], true, @api_true)
+        decoded
+      end
+
+    %{
+      "status" => transaction.status,
+      "timestamp" => block_timestamp(transaction),
+      "method" => Transaction.method_name(transaction, decoded_input),
+      "from" => preview_address(transaction.from_address, transaction.from_address_hash),
+      "to" => preview_address(transaction.to_address, transaction.to_address_hash)
+    }
+  end
+
   def render("raw_trace.json", %{raw_traces: raw_traces}) do
     raw_traces
   end
@@ -899,6 +915,24 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   def block_timestamp(%Transaction{block: %Block{} = block}), do: block.timestamp
   def block_timestamp(%Block{} = block), do: block.timestamp
   def block_timestamp(_), do: nil
+
+  defp preview_address(%Address{} = address, _hash) do
+    %{
+      "hash" => Address.checksum(address),
+      "name" => Helper.address_name(address),
+      "ens_domain_name" => address.ens_domain_name
+    }
+  end
+
+  defp preview_address(_, nil), do: nil
+
+  defp preview_address(_, hash) do
+    %{
+      "hash" => Address.checksum(hash),
+      "name" => nil,
+      "ens_domain_name" => nil
+    }
+  end
 
   defp prepare_state_change(%StateChange{} = state_change) do
     coin_or_transfer =


### PR DESCRIPTION
## Motivation

## Changelog
- Add /api/v2/transactions/{hash}/preview endpoint
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a v2 API endpoint for quickly previewing transaction details by transaction hash.
  * Preview responses include status, timestamp, method, sender, and recipient information.
  * Added optional controls for input decoding, ENS names, and address metadata through query parameters.
  * When enabled, decoded transaction input can be used to determine the displayed method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->