### PR TITLE
fix(api-types): regenerate types-package lockfile so npm ci works on dev

### DIFF
--- a/types-package/package-lock.json
+++ b/types-package/package-lock.json
@@ -86,10 +86,20 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Motivation

No `@blockscout/api-types` version can be published from `dev` right now — the publish workflow dies in its `Install npm dependencies` step:

```
npm error Invalid: lock file's js-yaml@4.1.1 does not satisfy js-yaml@4.2.0
```

`@redocly/openapi-core@1.34.16` (on `dev`) declares `js-yaml: "4.2.0"`, but the nested `js-yaml` entry in `types-package/package-lock.json` still resolved `4.1.1`, so `npm ci` refuses to install. Dependabot's [#14623](https://github.com/blockscout/blockscout/pull/14623) fixed the same class of drift on `master`, where `@redocly/openapi-core` is still `1.34.15` and consistent; merging `master` into `dev` did not resolve it because the inconsistent pair is dev-only.

Evidence: [run 30566146869](https://github.com/blockscout/blockscout/actions/runs/30566146869).

## Changelog

### Bug Fixes

- Regenerated `types-package/package-lock.json` (`npm install`) so `npm ci` — and therefore `publish-api-types-npm-dev.yml` — works again. One entry changed: the nested `@redocly/openapi-core/node_modules/js-yaml` moves `4.1.1` → `4.2.0`.

### Incompatible Changes

None.

## Verification

`rm -rf node_modules && npm ci` in `types-package/` fails on `dev` and succeeds with this change.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again. — n/a: the publish workflow's own `npm ci` step is the check.
