### PR TITLE
fix: Sort data before inserting to export queues

### DIFF
--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -892,7 +892,7 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
         }
       end)
 
-    main_queue = hashes_to_queue ++ addresses_to_queue
+    main_queue = Enum.sort_by(hashes_to_queue ++ addresses_to_queue, &{&1.hash, &1.hash_type})
 
     balances_queue = compose_balances_queue(address_coin_balances, address_token_balances)
 
@@ -937,7 +937,10 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
         }
       end)
 
-    coin_balances_queue ++ token_balances_queue
+    Enum.sort_by(
+      coin_balances_queue ++ token_balances_queue,
+      &{&1.address_hash, &1.token_contract_address_hash_or_native, &1[:token_id]}
+    )
   end
 
   @spec http_post_request(String.t(), map()) :: {:ok, any()} | {:error, String.t()}


### PR DESCRIPTION
## Motivation

Prevent deadlocks on export queues data insert.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in search results by applying stable sorting to queue entries and combined coin and token balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->