### PR TITLE
fix: Let INDEXER_OPTIMISM_L1_BATCH_INBOX/SUBMITTER override SystemConfig

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
@@ -1565,6 +1565,11 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
   # If SystemConfig has obsolete implementation, the values are fallen back from the corresponding
   # env variables (INDEXER_OPTIMISM_L1_START_BLOCK, INDEXER_OPTIMISM_L1_BATCH_INBOX, INDEXER_OPTIMISM_L1_BATCH_SUBMITTER).
   #
+  # Moreover, if INDEXER_OPTIMISM_L1_BATCH_INBOX and/or INDEXER_OPTIMISM_L1_BATCH_SUBMITTER are explicitly set,
+  # they take precedence over the corresponding values read from the SystemConfig contract. This is needed when
+  # the on-chain SystemConfig `batchInbox` (or `batcherHash`) diverges from the address the batcher actually uses,
+  # e.g. during an inbox migration where the SystemConfig value is updated ahead of the batcher.
+  #
   # ## Parameters
   # - `contract_address`: An address of SystemConfig contract.
   # - `json_rpc_named_arguments`: Configuration parameters for the JSON RPC connection.
@@ -1628,6 +1633,12 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
         _ ->
           {fallback_start_block, env[:inbox], env[:submitter]}
       end
+
+    # An explicitly configured inbox/submitter overrides the value read from the SystemConfig contract.
+    # Only kicks in when the corresponding env variable holds a correct address, so the on-chain value
+    # is still used by default.
+    batch_inbox = if Helper.address_correct?(env[:inbox]), do: env[:inbox], else: batch_inbox
+    batch_submitter = if Helper.address_correct?(env[:submitter]), do: env[:submitter], else: batch_submitter
 
     if !is_nil(start_block) and Helper.address_correct?(batch_inbox) and Helper.address_correct?(batch_submitter) do
       {start_block, String.downcase(batch_inbox), String.downcase(batch_submitter)}

--- a/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
@@ -1579,6 +1579,7 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
   # - `nil` in case of error.
   @spec read_system_config(String.t(), EthereumJSONRPC.json_rpc_named_arguments()) ::
           {non_neg_integer(), String.t(), String.t()} | nil
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp read_system_config(contract_address, json_rpc_named_arguments) do
     requests = [
       # startBlock() public getter


### PR DESCRIPTION
## Motivation

On OP Mainnet the transaction batches indexer stopped detecting new batches (last detected batch `467750`) and did not recover on its own.

Debugging showed that the batcher is healthy and still posting to inbox `0xff00000000000000000000000000000000000010`, but the SystemConfig contract's `batchInbox()` getter now returns `0x00c65a7bb8d6351c1cf70c95a316cc6a92839c98` — an address that is not a contract and has never received a transaction. `Indexer.Fetcher.Optimism.TransactionBatch` reads the inbox from SystemConfig on init and keeps only L1 transactions where `from == batcherHash` and `to == batchInbox`, so with a diverged inbox every batch transaction is dropped by `transactions_filter`. The result is "Found 0 batch(es)" with no error in the logs, and resetting the `optimism_batches_fetcher_last_l1_block_hash` counter does not help because the filter target itself is wrong.

`read_system_config` only fell back to `INDEXER_OPTIMISM_L1_BATCH_INBOX` / `INDEXER_OPTIMISM_L1_BATCH_SUBMITTER` when the SystemConfig call returned `nil`, so there was no way to override a non-nil but incorrect on-chain value. This PR lets an explicitly set env var take precedence over the SystemConfig value, so operators can keep indexing batches through such a divergence.

## Changelog

### Enhancements

- `INDEXER_OPTIMISM_L1_BATCH_INBOX` and `INDEXER_OPTIMISM_L1_BATCH_SUBMITTER`, when set to a correct address, now take precedence over the `batchInbox` / `batcherHash` values read from the SystemConfig contract in `Indexer.Fetcher.Optimism.TransactionBatch`. The override is guarded by `Helper.address_correct?/1`, so when the env vars are unset the on-chain values are used exactly as before.

### Bug Fixes

- Fixes OP batches indexing silently stalling (0 batches detected, no error) when the SystemConfig `batchInbox` diverges from the address the batcher actually posts to. Operators can now set `INDEXER_OPTIMISM_L1_BATCH_INBOX` to the real inbox to recover.

For an OP chain affected by an inbox/submitter divergence:

1. Set `INDEXER_OPTIMISM_L1_BATCH_INBOX` (and/or `INDEXER_OPTIMISM_L1_BATCH_SUBMITTER`) to the address the batcher actually uses.
2. Stop the batches fetcher, run `UPDATE last_fetched_counters SET value = 0 WHERE counter_type = 'optimism_batches_fetcher_last_l1_block_hash';`, then start it so it rewinds to the last indexed batch's L1 block and backfills the gap with the correct filter.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding SystemConfig batch inbox and batcher values through environment configuration.
  * Valid configured addresses now take precedence over on-chain values, while invalid or unset values safely retain the on-chain configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->