### PR TITLE
chore: Return proper status codes and string-typed block numbers in b…

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/block_controller.ex
@@ -42,6 +42,7 @@ defmodule BlockScoutWeb.API.V2.BlockController do
   }
 
   alias BlockScoutWeb.Schemas.API.V2.ErrorResponses.NotFoundResponse
+  alias BlockScoutWeb.Schemas.API.V2.ErrorResponses.NotImplementedResponse
   alias Explorer.Chain
   alias Explorer.Chain.Arbitrum.Reader.API.Settlement, as: ArbitrumSettlementReader
   alias Explorer.Chain.Beacon.Deposit
@@ -559,7 +560,8 @@ defmodule BlockScoutWeb.API.V2.BlockController do
     responses: [
       ok: {"Block countdown information.", "application/json", Schemas.Block.Countdown},
       unprocessable_entity: JsonErrorResponse.response(),
-      not_found: NotFoundResponse.response()
+      not_found: NotFoundResponse.response(),
+      not_implemented: NotImplementedResponse.response()
     ]
 
   @doc """

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -323,21 +323,21 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     conn
     |> put_status(501)
     |> put_view(ApiView)
-    |> render(:message, %{message: "Average block time calculating is disabled, so getblockcountdown is not available"})
+    |> render(:message, %{message: "Average block time calculation is disabled, so block countdown is not available"})
   end
 
   def call(conn, {stage, _}) when stage in ~w(max_block average_block_time)a do
     conn
-    |> put_status(200)
+    |> put_status(:unprocessable_entity)
     |> put_view(ApiView)
     |> render(:message, %{message: "Chain is indexing now, try again later"})
   end
 
   def call(conn, {:remaining_blocks, _}) do
     conn
-    |> put_status(200)
+    |> put_status(:not_found)
     |> put_view(ApiView)
-    |> render(:message, %{message: "Error! Block number already pass"})
+    |> render(:message, %{message: "Block number already mined"})
   end
 
   def call(conn, {code, response}) when is_integer(code) do

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block/countdown.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/block/countdown.ex
@@ -14,22 +14,19 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Countdown do
     additionalProperties: false,
     properties: %{
       current_block_number: %Schema{
-        type: :integer,
+        type: :string,
         description: "The current highest block number in the blockchain",
-        minimum: 0,
-        example: 22_566_361
+        example: "22566361"
       },
       countdown_block_number: %Schema{
-        type: :integer,
+        type: :string,
         description: "The target block number for the countdown",
-        minimum: 0,
-        example: 22_600_000
+        example: "22600000"
       },
       remaining_blocks_count: %Schema{
-        type: :integer,
+        type: :string,
         description: "Number of blocks remaining until the target block is reached",
-        minimum: 0,
-        example: 33_639
+        example: "33639"
       },
       estimated_time_in_seconds: %Schema{
         type: :string,
@@ -44,9 +41,9 @@ defmodule BlockScoutWeb.Schemas.API.V2.Block.Countdown do
       :estimated_time_in_seconds
     ],
     example: %{
-      current_block_number: 22_566_361,
-      countdown_block_number: 22_600_000,
-      remaining_blocks_count: 33_639,
+      current_block_number: "22566361",
+      countdown_block_number: "22600000",
+      remaining_blocks_count: "33639",
       estimated_time_in_seconds: "404868.0"
     }
   })

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/block_view.ex
@@ -38,9 +38,9 @@ defmodule BlockScoutWeb.API.V2.BlockView do
         estimated_time_in_sec: estimated_time_in_sec
       }) do
     %{
-      current_block_number: current_block,
-      countdown_block_number: countdown_block,
-      remaining_blocks_count: remaining_blocks,
+      current_block_number: to_string(current_block),
+      countdown_block_number: to_string(countdown_block),
+      remaining_blocks_count: to_string(remaining_blocks),
       estimated_time_in_seconds: to_string(estimated_time_in_sec)
     }
   end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/block_controller_test.exs
@@ -260,9 +260,9 @@ defmodule BlockScoutWeb.API.V2.BlockControllerTest do
       request = get(conn, "/api/v2/blocks/#{target_block_number}/countdown")
 
       assert %{
-               "current_block_number" => current_block_number,
-               "countdown_block_number" => target_block_number,
-               "remaining_blocks_count" => 10,
+               "current_block_number" => to_string(current_block_number),
+               "countdown_block_number" => to_string(target_block_number),
+               "remaining_blocks_count" => "10",
                "estimated_time_in_seconds" => "150.0"
              } == json_response(request, 200)
     end

--- a/apps/block_scout_web/test/block_scout_web/views/api/v2/block_view_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/api/v2/block_view_test.exs
@@ -33,9 +33,9 @@ defmodule BlockScoutWeb.API.V2.BlockViewTest do
           estimated_time_in_sec: 1200
         })
 
-      assert result.current_block_number == 100
-      assert result.countdown_block_number == 200
-      assert result.remaining_blocks_count == 100
+      assert result.current_block_number == "100"
+      assert result.countdown_block_number == "200"
+      assert result.remaining_blocks_count == "100"
       assert result.estimated_time_in_seconds == "1200"
     end
   end


### PR DESCRIPTION
…lock countdown endpoint

Closes #14644 

## Changelog
- Block countdown endpoint (/api/v2/blocks/{block_number}/countdown): return 404 for already-mined blocks, 422 when chain is indexing, declare 501 in OpenAPI spec, and serialize block number fields as strings to prevent JavaScript precision loss.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **API Changes**
  - Block countdown values are now returned as strings for consistent response formatting.
  - Updated countdown API documentation to reflect unsupported scenarios.
- **Bug Fixes**
  - Improved error responses for disabled average block time and indexing states.
  - Requests involving blocks that have already been mined now return clearer not-found responses.
- **Tests**
  - Updated API and rendering checks to validate revised response formats, documentation, and status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->