### PR TITLE
chore: Optimize fetch_coin_balance query

### DIFF
--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -386,15 +386,20 @@ defmodule Explorer.Chain.Address.CoinBalance do
   end
 
   defp fetch_coin_balance(address_hash, block_number) do
-    coin_balance_subquery =
+    latest_balances_query =
       from(
         cb in CoinBalance,
         where: cb.address_hash == ^address_hash,
         where: cb.block_number <= ^block_number,
+        order_by: [desc: :block_number],
+        limit: ^2
+      )
+
+    coin_balance_subquery =
+      from(
+        cb in subquery(latest_balances_query),
         inner_join: b in Block,
         on: cb.block_number == b.number,
-        limit: ^2,
-        order_by: [desc: :block_number],
         select_merge: %{block_timestamp: b.timestamp}
       )
 


### PR DESCRIPTION
## Motivation

Postgres might use the wrong index because of block join happens in the same subquery as the balance filtering.

## Changelog

Separate balance filtering from blocks joining in `fetch_coin_balance` subqueries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coin balance retrieval to consistently use the two most recent qualifying balance records.
  * Ensured balance results are matched with the correct block timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->