### PR TITLE
fix: Fix OnDemand.TokenBalance import matching

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -253,13 +253,15 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
           acc
       end)
 
-    {:ok,
-     %{
-       address_token_balances: imported_tbs
-     }} = Chain.import(%{address_token_balances: %{params: import_params}, broadcast: :on_demand})
+    unless Enum.empty?(import_params) do
+      {:ok,
+       %{
+         address_token_balances: imported_tbs
+       }} = Chain.import(%{address_token_balances: %{params: import_params}, broadcast: :on_demand})
 
-    unless imported_tbs == [] do
-      Publisher.broadcast(%{address_token_balances: imported_tbs}, :on_demand)
+      unless imported_tbs == [] do
+        Publisher.broadcast(%{address_token_balances: imported_tbs}, :on_demand)
+      end
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historic token balance imports by skipping empty fetch results.
  * Prevented balance broadcasts when an import produces no records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->