### PR TITLE
fix: enqueue transactions and addresses to multichain queue on block full refetch

### DIFF
--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -224,6 +224,7 @@ defmodule Explorer.Chain.Block do
   alias EthereumJSONRPC.Utility.RangesHelper
 
   alias Explorer.Chain.{
+    Address,
     Block,
     DenormalizationHelper,
     Hash,
@@ -235,8 +236,10 @@ defmodule Explorer.Chain.Block do
   }
 
   alias Explorer.{Chain, Helper, PagingOptions, Repo}
+  alias Explorer.Chain.Address.CoinBalance
   alias Explorer.Chain.Block.{EmissionReward, Reward, SecondDegreeRelation}
   alias Explorer.Chain.InternalTransaction.DeleteQueue, as: InternalTransactionDeleteQueue
+  alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.Utility.MissingBlockRange
 
   @optional_attrs ~w(size refetch_needed total_difficulty difficulty base_fee_per_gas)a
@@ -623,14 +626,24 @@ defmodule Explorer.Chain.Block do
     |> Decimal.div_int(base_fee_max_change_denominator)
   end
 
+  # A single `full_refetch/1` call may cover millions of blocks, so the block numbers are
+  # processed in fixed-size batches. Each batch runs in its own database transaction with
+  # bounded queries, keeping transaction size, lock duration and memory usage predictable
+  # regardless of the total range size. Overridable via the `:full_refetch_batch_size`
+  # application env (e.g. in tests).
+  @default_full_refetch_batch_size 100
+
   @doc """
   Queues blocks for a full refetch and marks them as needing refetch.
 
   This function accepts either a block ranges string, a list of block numbers,
   or a single block number. When given a ranges string, it parses the string into
   individual block numbers. It then enqueues the blocks for internal transaction
-  cleanup and marks the corresponding blocks with `refetch_needed: true` inside a
-  single database transaction.
+  cleanup and marks the corresponding blocks with `refetch_needed: true`.
+
+  Because a single call may cover millions of blocks, the work is split into
+  fixed-size batches. Each batch runs in its own database transaction, so atomicity
+  is per-batch rather than across the whole range.
 
   ## Parameters
 
@@ -638,22 +651,22 @@ defmodule Explorer.Chain.Block do
 
   ## Returns
 
-    - The result of `Repo.transaction/2` for range strings and lists.
-    - The delegated result for a single block number.
+    - `:ok` if all batches were processed successfully.
+    - `{:error, reason}` if a batch's transaction failed, in which case the remaining batches are not processed.
 
   ## Examples
 
       iex> full_refetch("1..3,5..6")
-      {:ok, _}
+      :ok
 
       iex> full_refetch([10, 11, 12])
-      {:ok, _}
+      :ok
 
       iex> full_refetch(15)
-      {:ok, _}
+      :ok
 
   """
-  @spec full_refetch(binary() | [integer()] | integer()) :: {:ok, any()} | {:error, any()}
+  @spec full_refetch(binary() | [integer()] | integer()) :: :ok | {:error, any()}
   def full_refetch(block_ranges_string) when is_binary(block_ranges_string) do
     block_ranges_string
     |> RangesHelper.parse_block_ranges_to_numbers()
@@ -661,17 +674,37 @@ defmodule Explorer.Chain.Block do
   end
 
   def full_refetch(block_numbers) when is_list(block_numbers) do
+    block_numbers
+    |> Enum.chunk_every(full_refetch_batch_size())
+    |> Enum.reduce_while(:ok, fn batch, _acc ->
+      case full_refetch_batch(batch) do
+        {:ok, _result} -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  def full_refetch(block_number), do: full_refetch([block_number])
+
+  defp full_refetch_batch_size do
+    Application.get_env(:explorer, :full_refetch_batch_size, @default_full_refetch_batch_size)
+  end
+
+  # Processes a single batch of block numbers in one database transaction: enqueues them for
+  # internal transaction cleanup, marks them as needing refetch, and enqueues the blocks,
+  # their transactions and touched addresses for export to the Multichain Service.
+  @spec full_refetch_batch([integer()]) :: {:ok, any()} | {:error, any()}
+  defp full_refetch_batch(block_numbers) do
     Repo.transaction(
       fn ->
         # TODO: delete other crucial entities as well
         InternalTransactionDeleteQueue.batch_insert(block_numbers)
         set_refetch_needed(block_numbers)
+        send_refetched_data_to_multichain_queue(block_numbers)
       end,
       timeout: :infinity
     )
   end
-
-  def full_refetch(block_number), do: full_refetch([block_number])
 
   @spec set_refetch_needed(integer | [integer]) :: :ok
   def set_refetch_needed(block_numbers) when is_list(block_numbers) do
@@ -695,6 +728,62 @@ defmodule Explorer.Chain.Block do
   end
 
   def set_refetch_needed(block_number), do: set_refetch_needed([block_number])
+
+  # Re-enqueues the blocks, their transactions, and the addresses they touched for export to
+  # the Multichain Service database.
+  #
+  # On re-import, a block is re-queued for export because `full_refetch/1` flips its
+  # `refetch_needed` flag, so the imported block row differs from the stored one and is
+  # returned by the import runner (which is what feeds the export queue). Transactions and
+  # addresses, however, are re-imported with identical data, so the corresponding runners'
+  # `... IS DISTINCT FROM ...` on-conflict guards skip them: they are neither updated nor
+  # returned, and thus never reach the export queue. To keep the Multichain Service in sync
+  # we collect them here and hand them to `MultichainSearch.send_data_to_queue/1`, reusing
+  # the same formatting and queueing logic as the import pipeline.
+  #
+  # Balances are intentionally excluded: `address_coin_balances` is passed as an empty list
+  # so that `send_data_to_queue/1` does not derive coin balances from the addresses, and no
+  # token balances are passed either. Only the main export queue is populated.
+  #
+  # This operates on a single `full_refetch/1` batch, so its queries are already bounded by
+  # the batch size.
+  @spec send_refetched_data_to_multichain_queue([integer()]) :: :ignore | :ok
+  defp send_refetched_data_to_multichain_queue(block_numbers) do
+    if MultichainSearch.enabled?() do
+      transactions = from(transaction in Transaction, where: transaction.block_number in ^block_numbers) |> Repo.all()
+
+      MultichainSearch.send_data_to_queue(%{
+        addresses: touched_addresses_in_refetch(block_numbers, transactions),
+        blocks: from(block in Block, where: block.number in ^block_numbers) |> Repo.all(),
+        transactions: transactions,
+        address_coin_balances: [],
+        address_current_token_balances: []
+      })
+    else
+      :ignore
+    end
+  end
+
+  # Collects the addresses touched by the given blocks: those with a coin balance recorded at
+  # those blocks, plus the from/to/created-contract addresses of the blocks' transactions.
+  @spec touched_addresses_in_refetch([integer()], [Transaction.t()]) :: [Address.t()]
+  defp touched_addresses_in_refetch(block_numbers, transactions) do
+    coin_balance_address_hashes =
+      from(coin_balance in CoinBalance,
+        where: coin_balance.block_number in ^block_numbers,
+        select: coin_balance.address_hash
+      )
+      |> Repo.all()
+
+    transaction_address_hashes =
+      transactions
+      |> Enum.flat_map(&[&1.from_address_hash, &1.to_address_hash, &1.created_contract_address_hash])
+      |> Enum.reject(&is_nil/1)
+
+    address_hashes = Enum.uniq(coin_balance_address_hashes ++ transaction_address_hashes)
+
+    from(address in Address, where: address.hash in ^address_hashes) |> Repo.all()
+  end
 
   @doc """
   Generates a query to fetch blocks by their hashes.

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -228,9 +228,11 @@ defmodule Explorer.Chain.Block do
     Block,
     DenormalizationHelper,
     Hash,
+    InternalTransaction,
     PendingBlockOperation,
     PendingOperationsHelper,
     PendingTransactionOperation,
+    TokenTransfer,
     Transaction,
     Wei
   }
@@ -633,6 +635,10 @@ defmodule Explorer.Chain.Block do
   # application env (e.g. in tests).
   @default_full_refetch_batch_size 100
 
+  # Max number of hashes per `IN (...)` query when resolving touched addresses, kept well
+  # under the Postgres bind-parameter limit (65535).
+  @address_query_chunk_size 10_000
+
   @doc """
   Queues blocks for a full refetch and marks them as needing refetch.
 
@@ -764,8 +770,14 @@ defmodule Explorer.Chain.Block do
     end
   end
 
-  # Collects the addresses touched by the given blocks: those with a coin balance recorded at
-  # those blocks, plus the from/to/created-contract addresses of the blocks' transactions.
+  # Collects the addresses touched by the given blocks, matching the set the import pipeline
+  # exports: block miners, coin-balance owners recorded at those blocks, and the participant
+  # addresses of the blocks' transactions, token transfers and internal transactions
+  # (from/to/created-contract/token-contract). `nil` hashes are dropped and the result is
+  # deduplicated.
+  #
+  # The `Address` lookup is chunked because the collected hash set can exceed the Postgres
+  # bind-parameter limit (65535) for a single `IN (...)` query on a large refetch batch.
   @spec touched_addresses_in_refetch([integer()], [Transaction.t()]) :: [Address.t()]
   defp touched_addresses_in_refetch(block_numbers, transactions) do
     coin_balance_address_hashes =
@@ -775,14 +787,51 @@ defmodule Explorer.Chain.Block do
       )
       |> Repo.all()
 
+    miner_hashes =
+      from(block in Block, where: block.number in ^block_numbers, select: block.miner_hash) |> Repo.all()
+
+    token_transfer_address_hashes =
+      from(token_transfer in TokenTransfer,
+        where: token_transfer.block_number in ^block_numbers,
+        select: [
+          token_transfer.from_address_hash,
+          token_transfer.to_address_hash,
+          token_transfer.token_contract_address_hash
+        ]
+      )
+      |> Repo.all()
+      |> List.flatten()
+
+    internal_transaction_address_hashes =
+      from(internal_transaction in InternalTransaction,
+        where: internal_transaction.block_number in ^block_numbers,
+        select: [
+          internal_transaction.from_address_hash,
+          internal_transaction.to_address_hash,
+          internal_transaction.created_contract_address_hash
+        ]
+      )
+      |> Repo.all()
+      |> List.flatten()
+
     transaction_address_hashes =
-      transactions
-      |> Enum.flat_map(&[&1.from_address_hash, &1.to_address_hash, &1.created_contract_address_hash])
+      Enum.flat_map(transactions, &[&1.from_address_hash, &1.to_address_hash, &1.created_contract_address_hash])
+
+    address_hashes =
+      [
+        coin_balance_address_hashes,
+        miner_hashes,
+        token_transfer_address_hashes,
+        internal_transaction_address_hashes,
+        transaction_address_hashes
+      ]
+      |> Enum.concat()
       |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
 
-    address_hashes = Enum.uniq(coin_balance_address_hashes ++ transaction_address_hashes)
-
-    from(address in Address, where: address.hash in ^address_hashes) |> Repo.all()
+    address_hashes
+    |> Enum.chunk_every(@address_query_chunk_size)
+    |> Enum.flat_map(&Repo.all(from(address in Address, where: address.hash in ^&1)))
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -25,6 +25,12 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
   @max_concurrency 5
   @post_timeout :timer.minutes(5)
 
+  # Max rows per `insert_all` into the export queues. A single chunk from
+  # `extract_batch_import_params_into_chunks/1` places all block and transaction hashes in
+  # its main data, which for a large refetch batch can exceed the Postgres bind-parameter
+  # limit (65535) in one statement, so the inserts are split into sub-batches.
+  @export_queue_insert_chunk_size 5_000
+
   @doc """
   Processes a batch import of data by splitting the input parameters into chunks and sending each chunk as an HTTP POST request to a configured microservice endpoint.
 
@@ -574,13 +580,21 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       |> Enum.each(fn data_chunk ->
         {prepared_main_data, prepared_balances_data} = prepare_export_data_for_queue(data_chunk)
 
-        Repo.insert_all(MainExportQueue, Helper.add_timestamps(prepared_main_data), on_conflict: :nothing)
+        prepared_main_data
+        |> Helper.add_timestamps()
+        |> Enum.chunk_every(@export_queue_insert_chunk_size)
+        |> Enum.each(&Repo.insert_all(MainExportQueue, &1, on_conflict: :nothing))
 
-        Repo.insert_all(BalancesExportQueue, Helper.add_timestamps(prepared_balances_data),
-          on_conflict: {:replace, [:value, :updated_at]},
-          conflict_target:
-            {:unsafe_fragment,
-             ~s<(address_hash, token_contract_address_hash_or_native, COALESCE(token_id, -1::integer::numeric))>}
+        prepared_balances_data
+        |> Helper.add_timestamps()
+        |> Enum.chunk_every(@export_queue_insert_chunk_size)
+        |> Enum.each(
+          &Repo.insert_all(BalancesExportQueue, &1,
+            on_conflict: {:replace, [:value, :updated_at]},
+            conflict_target:
+              {:unsafe_fragment,
+               ~s<(address_hash, token_contract_address_hash_or_native, COALESCE(token_id, -1::integer::numeric))>}
+          )
         )
       end)
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/multichain_search.ex
@@ -349,14 +349,14 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
 
     {prepared_main_data, prepared_balances_data} = prepare_export_data_for_queue(data_to_retry)
 
-    Repo.insert_all(
+    insert_all_in_chunks(
       MainExportQueue,
       Helper.add_timestamps(prepared_main_data),
       on_conflict: MainExportQueue.default_on_conflict(),
       conflict_target: [:hash, :hash_type]
     )
 
-    Repo.insert_all(
+    insert_all_in_chunks(
       BalancesExportQueue,
       Helper.add_timestamps(prepared_balances_data),
       on_conflict: BalancesExportQueue.default_on_conflict(),
@@ -580,21 +580,13 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
       |> Enum.each(fn data_chunk ->
         {prepared_main_data, prepared_balances_data} = prepare_export_data_for_queue(data_chunk)
 
-        prepared_main_data
-        |> Helper.add_timestamps()
-        |> Enum.chunk_every(@export_queue_insert_chunk_size)
-        |> Enum.each(&Repo.insert_all(MainExportQueue, &1, on_conflict: :nothing))
+        insert_all_in_chunks(MainExportQueue, Helper.add_timestamps(prepared_main_data), on_conflict: :nothing)
 
-        prepared_balances_data
-        |> Helper.add_timestamps()
-        |> Enum.chunk_every(@export_queue_insert_chunk_size)
-        |> Enum.each(
-          &Repo.insert_all(BalancesExportQueue, &1,
-            on_conflict: {:replace, [:value, :updated_at]},
-            conflict_target:
-              {:unsafe_fragment,
-               ~s<(address_hash, token_contract_address_hash_or_native, COALESCE(token_id, -1::integer::numeric))>}
-          )
+        insert_all_in_chunks(BalancesExportQueue, Helper.add_timestamps(prepared_balances_data),
+          on_conflict: {:replace, [:value, :updated_at]},
+          conflict_target:
+            {:unsafe_fragment,
+             ~s<(address_hash, token_contract_address_hash_or_native, COALESCE(token_id, -1::integer::numeric))>}
         )
       end)
 
@@ -602,6 +594,17 @@ defmodule Explorer.MicroserviceInterfaces.MultichainSearch do
     else
       :ignore
     end
+  end
+
+  # Inserts already-timestamped export-queue rows in sub-batches bounded by
+  # `@export_queue_insert_chunk_size`, so a large list never exceeds the Postgres
+  # bind-parameter limit in a single `insert_all`. `opts` (e.g. `:on_conflict`,
+  # `:conflict_target`) are passed through unchanged to each `Repo.insert_all/3` call.
+  @spec insert_all_in_chunks(module(), [map()], keyword()) :: :ok
+  defp insert_all_in_chunks(queue_schema, entries, opts) do
+    entries
+    |> Enum.chunk_every(@export_queue_insert_chunk_size)
+    |> Enum.each(&Repo.insert_all(queue_schema, &1, opts))
   end
 
   @doc """

--- a/apps/explorer/test/explorer/chain/block_test.exs
+++ b/apps/explorer/test/explorer/chain/block_test.exs
@@ -2,10 +2,16 @@
 defmodule Explorer.Chain.BlockTest do
   use Explorer.DataCase
 
+  import Mox
+
   alias Ecto.Changeset
   alias Explorer.Chain.{Address, Block, PendingBlockOperation, Wei}
+  alias Explorer.Chain.Cache.ChainId
   alias Explorer.Chain.InternalTransaction.DeleteQueue, as: InternalTransactionDeleteQueue
+  alias Explorer.Chain.MultichainSearchDb.{BalancesExportQueue, MainExportQueue}
+  alias Explorer.MicroserviceInterfaces.MultichainSearch
   alias Explorer.PagingOptions
+  alias Explorer.TestHelper
 
   describe "changeset/2" do
     test "with valid attributes" do
@@ -403,6 +409,9 @@ defmodule Explorer.Chain.BlockTest do
   end
 
   describe "full_refetch/1" do
+    setup :set_mox_global
+    setup :verify_on_exit!
+
     test "with block numbers" do
       Enum.each(1..5, fn _i ->
         insert(:block)
@@ -459,6 +468,71 @@ defmodule Explorer.Chain.BlockTest do
       assert Repo.one(Block).refetch_needed == true
 
       assert [%{block_number: ^block_number}] = Repo.all(InternalTransactionDeleteQueue)
+    end
+
+    test "processes multiple batches and populates the multichain main export queue (blocks, transactions, addresses), leaving the balances queue empty" do
+      Supervisor.terminate_child(Explorer.Supervisor, ChainId.child_id())
+      Supervisor.restart_child(Explorer.Supervisor, ChainId.child_id())
+
+      multichain_configuration = Application.get_env(:explorer, MultichainSearch)
+      full_refetch_batch_size_config = Application.get_env(:explorer, :full_refetch_batch_size)
+
+      on_exit(fn ->
+        Application.put_env(:explorer, MultichainSearch, multichain_configuration)
+
+        if full_refetch_batch_size_config do
+          Application.put_env(:explorer, :full_refetch_batch_size, full_refetch_batch_size_config)
+        else
+          Application.delete_env(:explorer, :full_refetch_batch_size)
+        end
+      end)
+
+      bypass = Bypass.open()
+
+      Application.put_env(
+        :explorer,
+        MultichainSearch,
+        Keyword.merge(multichain_configuration || [],
+          service_url: "http://localhost:#{bypass.port}",
+          addresses_chunk_size: 7_000
+        )
+      )
+
+      # Batch size smaller than the number of blocks forces more than one batch.
+      Application.put_env(:explorer, :full_refetch_batch_size, 2)
+
+      blocks = for number <- 1..3, do: insert(:block, number: number)
+      transactions = for block <- blocks, do: :transaction |> insert() |> with_block(block)
+
+      TestHelper.get_chain_id_mock()
+
+      assert :ok = Block.full_refetch(Enum.map(blocks, & &1.number))
+
+      # All batches were processed.
+      assert Enum.all?(Repo.all(Block), &(&1.refetch_needed == true))
+      assert Repo.aggregate(InternalTransactionDeleteQueue, :count, :block_number) == 3
+
+      main_queue = Repo.all(MainExportQueue)
+
+      queued_hashes = fn hash_type ->
+        main_queue |> Enum.filter(&(&1.hash_type == hash_type)) |> Enum.map(& &1.hash) |> MapSet.new()
+      end
+
+      queued_block_hashes = queued_hashes.(:block)
+      queued_transaction_hashes = queued_hashes.(:transaction)
+      queued_address_hashes = queued_hashes.(:address)
+
+      for block <- blocks do
+        assert MapSet.member?(queued_block_hashes, block.hash.bytes)
+      end
+
+      for transaction <- transactions do
+        assert MapSet.member?(queued_transaction_hashes, transaction.hash.bytes)
+        assert MapSet.member?(queued_address_hashes, transaction.from_address_hash.bytes)
+      end
+
+      # Balances are intentionally excluded from `full_refetch/1`.
+      assert Repo.aggregate(BalancesExportQueue, :count, :id) == 0
     end
   end
 end


### PR DESCRIPTION
## Motivation

When a block is manually queued for a full re-fetch via `Explorer.Chain.Block.full_refetch/1`, only the block hash ends up in the `multichain_search_db_main_export_queue` table on re-import — its transaction hashes and touched addresses are missing, so the Multichain Service falls out of sync for those blocks.

The export queue is populated from the rows the import runners return, and those runners use an `ON CONFLICT DO UPDATE ... WHERE (...) IS DISTINCT FROM (...)` guard that skips rows whose data did not change. On a re-import the block row differs (because `full_refetch/1` flips `refetch_needed`) and is returned, but the re-imported transactions and addresses are byte-identical, so they are neither updated nor returned — and never reach the queue.

## Changelog

### Enhancements

- `full_refetch/1` now re-enqueues the affected blocks, their transactions, and the addresses they touched to `multichain_search_db_main_export_queue`, reusing `Explorer.MicroserviceInterfaces.MultichainSearch.send_data_to_queue/1` (the same formatting/queueing as the import pipeline). Touched addresses are collected from the transactions' `from`/`to`/`created_contract` addresses plus addresses with a coin balance recorded at those blocks. Balances are intentionally excluded, so `multichain_search_db_export_balances_queue` is left untouched.
- The whole `full_refetch/1` operation is processed in fixed-size batches (default `100`, overridable via the `:full_refetch_batch_size` application env), each running in its own database transaction. This keeps memory usage, lock duration, and transaction size bounded even when re-fetching millions of blocks.
- Added a regression test covering the multi-batch path: it asserts blocks, transactions, and addresses are enqueued across more than one batch and that the balances queue stays empty.

### Bug Fixes

- Transactions and touched addresses of re-fetched blocks are no longer omitted from the Multichain main export queue.

### Incompatible Changes

- `full_refetch/1` return contract changed from `{:ok, any()} | {:error, any()}` to `:ok | {:error, reason}`. Because the operation is now batched, atomicity is per-batch rather than across the whole range, and execution halts on the first failing batch (earlier batches remain committed).


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Block data refreshes now process in configurable batches, improving reliability for large operations.
  - Refreshes stop promptly when an error occurs and clearly report success or failure.
  - Related blocks, transactions, and addresses are automatically queued for Multichain export when enabled.
  - Improved coordination across address, balance, token-transfer, and Multichain Search workflows.
  - Large export operations are split into smaller batches to improve processing reliability.
  - Enhanced support for address, coin-balance, and token-transfer data exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->