### PR TITLE
fix: refetch multichain queue and eden OpenAPI spec generation

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
@@ -137,7 +137,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
     properties: %{
       to: General.AddressHashNullable,
       value: General.IntegerString,
-      input: General.HexString
+      input: General.HexData
     },
     required: [:to, :value, :input],
     additionalProperties: false

--- a/apps/explorer/lib/explorer/chain/block.ex
+++ b/apps/explorer/lib/explorer/chain/block.ex
@@ -243,6 +243,7 @@ defmodule Explorer.Chain.Block do
   alias Explorer.Chain.Block.{EmissionReward, Reward, SecondDegreeRelation}
   alias Explorer.Chain.InternalTransaction.DeleteQueue, as: InternalTransactionDeleteQueue
   alias Explorer.MicroserviceInterfaces.MultichainSearch
+  alias Explorer.Utility.AddressIdToAddressHash
   alias Explorer.Utility.MissingBlockRange
 
   @optional_attrs ~w(size refetch_needed total_difficulty difficulty base_fee_per_gas)a
@@ -832,17 +833,23 @@ defmodule Explorer.Chain.Block do
       |> Repo.all()
       |> List.flatten()
 
-    internal_transaction_address_hashes =
+    # `InternalTransaction` stores participant addresses as `address_id` foreign keys into
+    # `address_ids_to_address_hashes`, and exposes the hashes only as virtual fields, so the ids
+    # are collected here and resolved to hashes in bulk.
+    internal_transaction_address_ids =
       from(internal_transaction in InternalTransaction,
         where: internal_transaction.block_number in ^block_numbers,
         select: [
-          internal_transaction.from_address_hash,
-          internal_transaction.to_address_hash,
-          internal_transaction.created_contract_address_hash
+          internal_transaction.from_address_id,
+          internal_transaction.to_address_id,
+          internal_transaction.created_contract_address_id
         ]
       )
       |> Repo.all()
       |> List.flatten()
+      |> Enum.reject(&is_nil/1)
+
+    internal_transaction_address_hashes = AddressIdToAddressHash.ids_to_hashes(internal_transaction_address_ids)
 
     transaction_address_hashes =
       Enum.flat_map(transactions, &[&1.from_address_hash, &1.to_address_hash, &1.created_contract_address_hash])


### PR DESCRIPTION
## Motivation

Two independent defects surfaced in tests:

1. `Explorer.Chain.BlockTest` failed with `Ecto.QueryError: field `from_address_hash` in `select` is a virtual field in schema `Explorer.Chain.InternalTransaction``. `InternalTransaction` now stores participant addresses as `address_id` foreign keys into `address_ids_to_address_hashes` and exposes the hashes only as virtual fields, but `Explorer.Chain.Block.touched_addresses_in_refetch/2` still selected those virtual fields directly.

2. Building the OpenAPI spec under `CHAIN_TYPE=eden` crashed with `UndefinedFunctionError: function `BlockScoutWeb.Schemas.API.V2.General.HexString.schema/0` is undefined`. The eden transaction call schema referenced a nonexistent `General.HexString` module.

## Changelog

### Bug Fixes

- Fixed `Explorer.Chain.Block.touched_addresses_in_refetch/2` to select the `from_address_id`/`to_address_id`/`created_contract_address_id` columns and resolve them to hashes via `AddressIdToAddressHash.ids_to_hashes/1`, instead of selecting the now-virtual `*_address_hash` fields of `InternalTransaction`.
- Fixed eden transaction OpenAPI schema to reference the existing `General.HexData` module instead of the nonexistent `General.HexString`, which crashed spec generation under `CHAIN_TYPE=eden`.



## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for transaction input data to accept valid hexadecimal payloads.
  * Improved internal transaction address handling for more reliable display of sender, recipient, and contract creation addresses.
  * Reduced inconsistencies when transaction address information is unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->