### PR TITLE
fix: Filter non chain type related migrations in VersionUpgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Restore per-instance results for on-demand NFT metadata refetch ([#14530](https://github.com/blockscout/blockscout/pull/14530))
 - Fix Solidity verifier false positives caused by substring collisions in constructor argument matching ([#14477](https://github.com/blockscout/blockscout/issues/14477))
 - Fix Solidity verifier version-check bypass and malformed version parsing ([#14475](https://github.com/blockscout/blockscout/issues/14475))
-- Fix ungarded Integer.parse issues in Solidity version parsing ([#14505](https://github.com/blockscout/blockscout/issues/14505))
+- Fix unguarded Integer.parse issues in Solidity version parsing ([#14505](https://github.com/blockscout/blockscout/issues/14505))
 - Fix silent fallback and empty-map masking in bytecode metadata extraction and CBOR decoding ([#14504](https://github.com/blockscout/blockscout/issues/14504), [#14503](https://github.com/blockscout/blockscout/issues/14503), [#14502](https://github.com/blockscout/blockscout/issues/14502), [#14499](https://github.com/blockscout/blockscout/issues/14499), [#14497](https://github.com/blockscout/blockscout/issues/14497))
 - Fix an OpenAPI issue where CSV-returning endpoints could return 406 errors ([#14416](https://github.com/blockscout/blockscout/issues/14416))
 - Fix OpenAPI coverage for Stability validators and Shibarium endpoints ([#14323](https://github.com/blockscout/blockscout/issues/14323), [#14322](https://github.com/blockscout/blockscout/issues/14322))

--- a/apps/explorer/lib/explorer/utility/version_upgrade.ex
+++ b/apps/explorer/lib/explorer/utility/version_upgrade.ex
@@ -18,6 +18,15 @@ defmodule Explorer.Utility.VersionUpgrade do
     * `:required_completed_migrations` — a list of migration names that must
       have status `"completed"` before the upgrade is allowed
 
+  Each entry of `:required_completed_migrations` is either:
+
+    * a migration name — the migration is required on every chain type, or
+    * a `{migration_name, chain_types}` tuple — the migration is required only
+      when the current chain type is one of `chain_types`. This is meant for
+      migrations that are started only on some chain types (see
+      `Explorer.Application`), since on the other chain types they never reach
+      the `"completed"` status.
+
   Rules are evaluated based on the target version. If multiple rules match,
   the most specific one (with the highest `:since` version) is applied.
 
@@ -25,6 +34,8 @@ defmodule Explorer.Utility.VersionUpgrade do
   """
 
   use GenServer
+
+  use Utils.RuntimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Explorer.Application.Constants
   alias Explorer.Chain.Block
@@ -49,7 +60,7 @@ defmodule Explorer.Utility.VersionUpgrade do
       min_from: "11.0.2",
       required_completed_migrations: [
         FillInternalTransactionsAddressIds.migration_name(),
-        SanitizeDuplicatedLogIndexLogs.migration_name()
+        {SanitizeDuplicatedLogIndexLogs.migration_name(), [:rsk, :filecoin]}
       ]
     }
   ]
@@ -116,7 +127,10 @@ defmodule Explorer.Utility.VersionUpgrade do
 
   defp validate_required_migrations!(to_version, %{required_completed_migrations: migration_names}) do
     not_completed =
-      Enum.flat_map(migration_names, fn migration_name ->
+      migration_names
+      |> Enum.filter(&required_on_current_chain_type?/1)
+      |> Enum.map(&migration_name/1)
+      |> Enum.flat_map(fn migration_name ->
         status = MigrationStatus.get_status(migration_name)
 
         if status == "completed" do
@@ -134,6 +148,12 @@ defmodule Explorer.Utility.VersionUpgrade do
   end
 
   defp validate_required_migrations!(_to_version, _rule), do: :ok
+
+  defp required_on_current_chain_type?({_migration_name, chain_types}), do: chain_type() in chain_types
+  defp required_on_current_chain_type?(_migration_name), do: true
+
+  defp migration_name({migration_name, _chain_types}), do: migration_name
+  defp migration_name(migration_name), do: migration_name
 
   defp raise_wrong_version(from_version, to_version, min_from) do
     raise "Upgrade to #{to_version} is allowed only from version #{min_from} and higher. Current previous version: #{from_version || "(empty)"}"


### PR DESCRIPTION
## Motivation

Some background migrations run only for specific chain types.

## Changelog

Update `Explorer.Utility.VersionUpgrade` so it checks if migration is required on the current chain type before checking its completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chain-specific migration handling so only requirements relevant to the active chain are evaluated.
  * Improved support for migration definitions with associated chain-type information.
* **Bug Fixes**
  * Corrected Filecoin log-index migration checks to apply only to RSK and Filecoin environments.
  * Improved validation of required migration completion statuses.
  * Corrected a typo in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->