### PR TITLE
fix: correct API v2 schemas and drop dead internal-tx limit param

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/internal_transaction_controller.ex
@@ -29,7 +29,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       "Retrieves a paginated list of internal transactions. Internal transactions are generated during contract execution and not directly recorded on the blockchain.",
     parameters:
       base_params() ++
-        [query_transaction_hash_param(), limit_param(), include_zero_value_param()] ++
+        [query_transaction_hash_param(), include_zero_value_param()] ++
         define_paging_params(["index", "block_number", "transaction_index"]),
     responses: [
       ok:
@@ -61,7 +61,6 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
       options =
         options(paging_options, %{
           transaction_hash: transaction_hash,
-          limit: params[:limit],
           include_zero_value: Map.get(params, :include_zero_value, true)
         })
 
@@ -102,7 +101,7 @@ defmodule BlockScoutWeb.API.V2.InternalTransactionController do
     paging_options
     |> Keyword.put(:transaction_hash, params.transaction_hash)
     |> Keyword.put(:exclude_origin_internal_transaction, true)
-    |> Keyword.put(:include_zero_value, Map.get(params, :include_zero_value, true))
+    |> Keyword.put(:include_zero_value, params.include_zero_value)
     |> Keyword.merge(@api_true)
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/optimism/transaction_withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/optimism/transaction_withdrawal.ex
@@ -22,8 +22,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Optimism.TransactionWithdrawal do
       l1_transaction_hash: General.FullHashNullable,
       portal_contract_address_hash: General.AddressHashNullable,
       msg_nonce_raw: General.IntegerString,
-      msg_sender_address_hash: General.FullHashNullable,
-      msg_target_address_hash: General.FullHashNullable,
+      msg_sender_address_hash: General.AddressHashNullable,
+      msg_target_address_hash: General.AddressHashNullable,
       msg_value: General.IntegerStringNullable,
       msg_gas_limit: General.IntegerStringNullable,
       msg_data: General.HexDataNullable

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/optimism/withdrawal.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/optimism/withdrawal.ex
@@ -23,8 +23,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Optimism.Withdrawal do
       msg_nonce: %Schema{type: :integer},
       msg_nonce_raw: General.IntegerString,
       msg_nonce_version: %Schema{type: :integer},
-      msg_sender_address_hash: General.FullHashNullable,
-      msg_target_address_hash: General.FullHashNullable,
+      msg_sender_address_hash: General.AddressHashNullable,
+      msg_target_address_hash: General.AddressHashNullable,
       msg_value: General.IntegerStringNullable,
       portal_contract_address_hash: General.AddressHashNullable,
       status: %Schema{

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/raw_trace.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/raw_trace.ex
@@ -13,11 +13,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.RawTrace do
     properties: %{
       callType: %Schema{type: :string, enum: ["call", "callcode", "delegatecall", "staticcall"]},
       from: General.AddressHash,
-      gas: General.HexData,
+      gas: General.HexQuantity,
       input: General.HexData,
       init: General.HexData,
       to: General.AddressHash,
-      value: General.HexData
+      value: General.HexQuantity
     },
     required: [:from, :gas, :input, :value],
     additionalProperties: false
@@ -26,7 +26,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.RawTrace do
   result_schema = %Schema{
     type: :object,
     properties: %{
-      gasUsed: General.HexData,
+      gasUsed: General.HexQuantity,
       output: General.HexData
     },
     required: [:gasUsed, :output],


### PR DESCRIPTION
## Motivation

Review of the `dev` branch surfaced several API v2 OpenAPI schema inaccuracies and a dead endpoint parameter. These changes make the generated spec match the actual response payloads and remove code that has no effect.

## Changelog

### Bug Fixes

- **Optimism withdrawal schemas**: `msg_sender_address_hash` and `msg_target_address_hash` in both `Optimism.TransactionWithdrawal` and `Optimism.Withdrawal` now use `General.AddressHashNullable` instead of `General.FullHashNullable`. These fields are produced by `truncate_address_hash/1`, which returns a 20-byte `0x`-address, not a 32-byte full hash.
- **RawTrace schema**: `gas`, `value`, and `gasUsed` now use `General.HexQuantity` instead of `General.HexData`. They are emitted via `integer_to_quantity/1` (minimal-hex JSON-RPC QUANTITY), so `HexQuantity` is the correct type; byte-payload fields (`input`, `init`, `output`) remain `General.HexData`.
- **Internal transactions endpoint**: removed the `limit` query param, which was documented and plumbed into `options/2` but never consumed anywhere in the internal-transaction query path. Also resolved `include_zero_value` only once instead of applying its default twice.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Improvements**
  * Updated internal transaction endpoints to use validated request parameters and removed the unsupported `limit` parameter.
  * Improved Optimism withdrawal schemas by accurately identifying nullable sender and target address fields.
  * Updated raw trace schemas so gas values use quantity formats and destination fields use address formats.
  * These changes improve API consistency and OpenAPI documentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->