### PR TITLE
feat: track L1 JSON RPC requests from rollups in separate metrics

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/arbitrum_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/arbitrum_controller_test.exs
@@ -911,7 +911,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumControllerTest do
       end
     end
 
-    # Sets up `:meck` to make `Indexer.Helper.json_rpc_named_arguments/1` return
+    # Sets up `:meck` to make `Indexer.Helper.l1_json_rpc_named_arguments/1` return
     # the Mox transport (via `EthereumJSONRPC.Mox`) regardless of the configured URL,
     # and seeds the Arbitrum fetcher config so `get_json_rpc(:l1)` and
     # `get_l1_rollup_address/0` return usable values. Also installs `Mox.set_mox_global`
@@ -936,7 +936,7 @@ defmodule BlockScoutWeb.API.V2.ArbitrumControllerTest do
 
       :meck.new(Indexer.Helper, [:passthrough])
 
-      :meck.expect(Indexer.Helper, :json_rpc_named_arguments, fn _rpc_url ->
+      :meck.expect(Indexer.Helper, :l1_json_rpc_named_arguments, fn _rpc_url ->
         [
           transport: EthereumJSONRPC.Mox,
           transport_options: [],

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -14,20 +14,21 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
   @impl HTTP
   def json_rpc(url, json, headers, options) when is_binary(url) and is_list(options) do
     method = Helper.get_method_from_json_string(json)
+    l1? = Keyword.get(options, :layer) == :l1
 
-    Instrumenter.json_rpc_requests(method)
+    Instrumenter.json_rpc_requests(method, l1?)
 
     case HTTPoison.post(url, json, headers, HTTPoisonHelper.request_opts(options)) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->
         with {:ok, decoded_body} <- Jason.decode(body),
              true <- Helper.response_body_has_error?(decoded_body) do
-          Instrumenter.json_rpc_errors(method)
+          Instrumenter.json_rpc_errors(method, l1?)
         end
 
         {:ok, %{body: Helper.try_unzip(body, headers), status_code: status_code}}
 
       {:error, %HTTPoison.Error{reason: reason}} ->
-        Instrumenter.json_rpc_errors(method)
+        Instrumenter.json_rpc_errors(method, l1?)
 
         {:error, reason}
     end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -16,20 +16,21 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
   @impl HTTP
   def json_rpc(url, json, headers, options) when is_binary(url) and is_list(options) do
     method = Helper.get_method_from_json_string(json)
+    l1? = Keyword.get(options, :layer) == :l1
 
-    Instrumenter.json_rpc_requests(method)
+    Instrumenter.json_rpc_requests(method, l1?)
 
     case do_post(url, json, headers, options) do
       {:ok, %Tesla.Env{body: body, status: status_code, headers: headers}} ->
         with {:ok, decoded_body} <- Jason.decode(body),
              true <- Helper.response_body_has_error?(decoded_body) do
-          Instrumenter.json_rpc_errors(method)
+          Instrumenter.json_rpc_errors(method, l1?)
         end
 
         {:ok, %{body: Helper.try_unzip(body, headers), status_code: status_code}}
 
       {:error, error} ->
-        Instrumenter.json_rpc_errors(method)
+        Instrumenter.json_rpc_errors(method, l1?)
 
         {:error, error}
     end

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
@@ -9,29 +9,50 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
   @counter [name: :json_rpc_requests_count, labels: [:method], help: "Number of JSON RPC requests"]
   @counter [name: :json_rpc_requests_errors_count, labels: [:method], help: "Number of JSON RPC requests errors"]
 
+  @counter [
+    name: :l1_json_rpc_requests_count,
+    labels: [:method],
+    help: "Number of JSON RPC requests to the L1 node made by rollup modules"
+  ]
+  @counter [
+    name: :l1_json_rpc_requests_errors_count,
+    labels: [:method],
+    help: "Number of JSON RPC requests errors to the L1 node made by rollup modules"
+  ]
+
   @doc """
   Increments the JSON-RPC requests counter for a given method.
+
+  Requests to the L1 node made by rollup modules are counted separately via the
+  `l1_json_rpc_requests_count` metric when `l1?` is `true`.
 
   ## Parameters
 
     - `method` (String): The name of the JSON-RPC method.
+    - `l1?` (boolean, optional): Whether the request targets the L1 node. Defaults to `false`.
     - `req_count` (integer, optional): The number of requests to increment by. Defaults to 1.
   """
-  @spec json_rpc_requests(String.t(), non_neg_integer()) :: :ok
-  def json_rpc_requests(method, req_count \\ 1) do
-    Counter.inc([name: :json_rpc_requests_count, labels: [method]], req_count)
+  @spec json_rpc_requests(String.t(), boolean(), non_neg_integer()) :: :ok
+  def json_rpc_requests(method, l1? \\ false, req_count \\ 1) do
+    counter_name = if l1?, do: :l1_json_rpc_requests_count, else: :json_rpc_requests_count
+    Counter.inc([name: counter_name, labels: [method]], req_count)
   end
 
   @doc """
   Increments the counter for JSON-RPC errors for a given method.
 
+  Errors of requests to the L1 node made by rollup modules are counted separately
+  via the `l1_json_rpc_requests_errors_count` metric when `l1?` is `true`.
+
   ## Parameters
 
     - `method` (string): The name of the JSON-RPC method that encountered an error.
+    - `l1?` (boolean, optional): Whether the request targets the L1 node. Defaults to `false`.
     - `error_count` (integer, optional): The number of errors to increment the counter by. Defaults to 1.
   """
-  @spec json_rpc_errors(String.t(), non_neg_integer()) :: :ok
-  def json_rpc_errors(method, error_count \\ 1) do
-    Counter.inc([name: :json_rpc_requests_errors_count, labels: [method]], error_count)
+  @spec json_rpc_errors(String.t(), boolean(), non_neg_integer()) :: :ok
+  def json_rpc_errors(method, l1? \\ false, error_count \\ 1) do
+    counter_name = if l1?, do: :l1_json_rpc_requests_errors_count, else: :json_rpc_requests_errors_count
+    Counter.inc([name: counter_name, labels: [method]], error_count)
   end
 end

--- a/apps/explorer/lib/explorer/arbitrum/claim_rollup_message.ex
+++ b/apps/explorer/lib/explorer/arbitrum/claim_rollup_message.ex
@@ -719,7 +719,7 @@ defmodule Explorer.Arbitrum.ClaimRollupMessage do
   @spec get_json_rpc(:l1 | :l2) :: EthereumJSONRPC.json_rpc_named_arguments()
   defp get_json_rpc(:l1) do
     config_common = Application.get_all_env(:indexer)[Indexer.Fetcher.Arbitrum]
-    IndexerHelper.json_rpc_named_arguments(config_common[:l1_rpc])
+    IndexerHelper.l1_json_rpc_named_arguments(config_common[:l1_rpc])
   end
 
   defp get_json_rpc(:l2) do

--- a/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
+++ b/apps/explorer/lib/explorer/chain/cache/optimism_finalization_period.ex
@@ -23,7 +23,7 @@ defmodule Explorer.Chain.Cache.OptimismFinalizationPeriod do
     # call FINALIZATION_PERIOD_SECONDS() public getter of L2OutputOracle contract on L1
     request = Contract.eth_call_request("0xf4daa291", output_oracle, 0, nil, nil)
 
-    case json_rpc(request, Indexer.Helper.json_rpc_named_arguments(optimism_l1_rpc)) do
+    case json_rpc(request, Indexer.Helper.l1_json_rpc_named_arguments(optimism_l1_rpc)) do
       {:ok, value} ->
         {:update, quantity_to_integer(value)}
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/tracking_batches_statuses.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/tracking_batches_statuses.ex
@@ -189,7 +189,7 @@ defmodule Indexer.Fetcher.Arbitrum.TrackingBatchesStatuses do
     # Set up initial configuration structure
     initial_config = %{
       l1_rpc: %{
-        json_rpc_named_arguments: IndexerHelper.json_rpc_named_arguments(l1_rpc),
+        json_rpc_named_arguments: IndexerHelper.l1_json_rpc_named_arguments(l1_rpc),
         logs_block_range: l1_rpc_block_range,
         chunk_size: l1_rpc_chunk_size,
         track_finalization: track_l1_transaction_finalization,

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/tracking_messages_on_l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/tracking_messages_on_l1.ex
@@ -126,7 +126,7 @@ defmodule Indexer.Fetcher.Arbitrum.TrackingMessagesOnL1 do
 
     # Set up initial configuration structure
     initial_config = %{
-      json_l1_rpc_named_arguments: IndexerHelper.json_rpc_named_arguments(l1_rpc),
+      json_l1_rpc_named_arguments: IndexerHelper.l1_json_rpc_named_arguments(l1_rpc),
       json_l2_rpc_named_arguments: json_rpc_named_arguments,
       l1_rpc_block_range: l1_rpc_block_range,
       l1_rpc_chunk_size: l1_rpc_chunk_size,

--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -116,7 +116,7 @@ defmodule Indexer.Fetcher.Optimism do
     with {:system_config_valid, true} <- {:system_config_valid, Helper.address_correct?(system_config)},
          _ <- RollupL1ReorgMonitor.wait_for_start(caller),
          {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(optimism_l1_rpc)},
-         json_rpc_named_arguments = Helper.json_rpc_named_arguments(optimism_l1_rpc),
+         json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(optimism_l1_rpc),
          {optimism_portal, start_block_l1} <- read_system_config(system_config, json_rpc_named_arguments),
          {:contract_is_valid, true} <-
            {:contract_is_valid, caller != Indexer.Fetcher.Optimism.OutputRoot or Helper.address_correct?(output_oracle)},

--- a/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/dispute_game.ex
@@ -64,7 +64,7 @@ defmodule Indexer.Fetcher.Optimism.DisputeGame do
 
     with {:system_config_valid, true} <- {:system_config_valid, IndexerHelper.address_correct?(system_config)},
          {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(rpc)},
-         json_rpc_named_arguments = IndexerHelper.json_rpc_named_arguments(rpc),
+         json_rpc_named_arguments = IndexerHelper.l1_json_rpc_named_arguments(rpc),
          {optimism_portal, _} <- Optimism.read_system_config(system_config, json_rpc_named_arguments),
          dispute_game_factory = get_dispute_game_factory_address(optimism_portal, json_rpc_named_arguments),
          {:dispute_game_factory_available, true} <- {:dispute_game_factory_available, !is_nil(dispute_game_factory)},

--- a/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism/transaction_batch.ex
@@ -94,7 +94,7 @@ defmodule Indexer.Fetcher.Optimism.TransactionBatch do
            {:genesis_block_l2_invalid, is_nil(env[:genesis_block_l2]) or env[:genesis_block_l2] < 0},
          _ <- RollupL1ReorgMonitor.wait_for_start(__MODULE__),
          {:rpc_l1_undefined, false} <- {:rpc_l1_undefined, is_nil(optimism_l1_rpc)},
-         json_rpc_named_arguments = Helper.json_rpc_named_arguments(optimism_l1_rpc),
+         json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(optimism_l1_rpc),
          {:system_config_read, {start_block_l1, batch_inbox, batch_submitter}} <-
            {:system_config_read, read_system_config(system_config, json_rpc_named_arguments)},
          {:batch_inbox_valid, true} <- {:batch_inbox_valid, Helper.address_correct?(batch_inbox)},

--- a/apps/indexer/lib/indexer/fetcher/rollup_l1_reorg_monitor.ex
+++ b/apps/indexer/lib/indexer/fetcher/rollup_l1_reorg_monitor.ex
@@ -109,7 +109,7 @@ defmodule Indexer.Fetcher.RollupL1ReorgMonitor do
     else
       l1_rpc = Enum.at(modules_using_reorg_monitor, 0).l1_rpc_url()
 
-      json_rpc_named_arguments = Helper.json_rpc_named_arguments(l1_rpc)
+      json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(l1_rpc)
 
       {:ok, block_check_interval, _} = Helper.get_block_check_interval(json_rpc_named_arguments)
 

--- a/apps/indexer/lib/indexer/fetcher/scroll/batch.ex
+++ b/apps/indexer/lib/indexer/fetcher/scroll/batch.ex
@@ -91,7 +91,7 @@ defmodule Indexer.Fetcher.Scroll.Batch do
          start_block = env[:start_block],
          true <- start_block > 0,
          {last_l1_block_number, last_l1_transaction_hash} = Reader.last_l1_batch_item(),
-         json_rpc_named_arguments = Helper.json_rpc_named_arguments(rpc),
+         json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(rpc),
          {:ok, block_check_interval, safe_block} <- Helper.get_block_check_interval(json_rpc_named_arguments),
          {:start_block_valid, true, _, _} <-
            {:start_block_valid,

--- a/apps/indexer/lib/indexer/fetcher/scroll/bridge_l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/scroll/bridge_l1.ex
@@ -78,7 +78,7 @@ defmodule Indexer.Fetcher.Scroll.BridgeL1 do
          start_block = env[:start_block],
          true <- start_block > 0,
          {last_l1_block_number, last_l1_transaction_hash} = Reader.last_l1_bridge_item(),
-         json_rpc_named_arguments = Helper.json_rpc_named_arguments(rpc),
+         json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(rpc),
          {:ok, block_check_interval, safe_block} <- Helper.get_block_check_interval(json_rpc_named_arguments),
          {:start_block_valid, true, _, _} <-
            {:start_block_valid,

--- a/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
+++ b/apps/indexer/lib/indexer/fetcher/shibarium/l1.ex
@@ -136,7 +136,7 @@ defmodule Indexer.Fetcher.Shibarium.L1 do
          {last_l1_block_number, last_l1_transaction_hash} <- get_last_l1_item(),
          {:start_block_valid, true} <-
            {:start_block_valid, start_block <= last_l1_block_number || last_l1_block_number == 0},
-         json_rpc_named_arguments = Helper.json_rpc_named_arguments(rpc),
+         json_rpc_named_arguments = Helper.l1_json_rpc_named_arguments(rpc),
          {:ok, last_l1_transaction} <-
            Helper.get_transaction_by_hash(last_l1_transaction_hash, json_rpc_named_arguments),
          {:l1_transaction_not_found, false} <-

--- a/apps/indexer/lib/indexer/helper.ex
+++ b/apps/indexer/lib/indexer/helper.ex
@@ -224,10 +224,15 @@ defmodule Indexer.Helper do
   end
 
   @doc """
-  Forms JSON RPC named arguments for the given RPC URL.
+  Forms JSON RPC named arguments for the given L1 (parent chain) RPC URL.
+
+  Rollup modules use this helper to build named arguments for their L1 node, so
+  the resulting `http_options` are tagged with `layer: :l1` so that requests to
+  the L1 node are tracked by the dedicated
+  `l1_json_rpc_requests_count`/`l1_json_rpc_requests_errors_count` metrics.
   """
-  @spec json_rpc_named_arguments(binary()) :: list()
-  def json_rpc_named_arguments(rpc_url) when is_binary(rpc_url) do
+  @spec l1_json_rpc_named_arguments(binary()) :: list()
+  def l1_json_rpc_named_arguments(rpc_url) when is_binary(rpc_url) do
     normalized_rpc_url =
       rpc_url
       |> trim_url()
@@ -241,13 +246,14 @@ defmodule Indexer.Helper do
         http_options: [
           recv_timeout: :timer.minutes(10),
           timeout: :timer.minutes(10),
-          pool: :ethereum_jsonrpc
+          pool: :ethereum_jsonrpc,
+          layer: :l1
         ]
       ]
     ]
   end
 
-  def json_rpc_named_arguments(_rpc_url), do: raise(ArgumentError, "RPC URL must be a non-empty string")
+  def l1_json_rpc_named_arguments(_rpc_url), do: raise(ArgumentError, "RPC URL must be a non-empty string")
 
   defp validate_rpc_url!(""), do: raise(ArgumentError, "RPC URL must be a non-empty string")
   defp validate_rpc_url!(rpc_url), do: rpc_url

--- a/apps/indexer/test/indexer/helper_test.exs
+++ b/apps/indexer/test/indexer/helper_test.exs
@@ -4,12 +4,12 @@ defmodule Indexer.HelperTest do
 
   alias Indexer.Helper
 
-  describe "json_rpc_named_arguments/1" do
+  describe "l1_json_rpc_named_arguments/1" do
     test "builds expected JSON-RPC named arguments from RPC URL" do
       rpc_url = "https://rpc.example"
       timeout = :timer.minutes(10)
 
-      assert Helper.json_rpc_named_arguments(rpc_url) ==
+      assert Helper.l1_json_rpc_named_arguments(rpc_url) ==
                [
                  transport: EthereumJSONRPC.HTTP,
                  transport_options: [
@@ -18,7 +18,8 @@ defmodule Indexer.HelperTest do
                    http_options: [
                      recv_timeout: timeout,
                      timeout: timeout,
-                     pool: :ethereum_jsonrpc
+                     pool: :ethereum_jsonrpc,
+                     layer: :l1
                    ]
                  ]
                ]
@@ -26,20 +27,20 @@ defmodule Indexer.HelperTest do
 
     test "handles nil RPC URL" do
       assert_raise ArgumentError, "RPC URL must be a non-empty string", fn ->
-        Helper.json_rpc_named_arguments(nil)
+        Helper.l1_json_rpc_named_arguments(nil)
       end
     end
 
     test "handles empty string RPC URL" do
       assert_raise ArgumentError, "RPC URL must be a non-empty string", fn ->
-        Helper.json_rpc_named_arguments("")
+        Helper.l1_json_rpc_named_arguments("")
       end
     end
 
     test "normalizes trailing slash in RPC URL" do
       timeout = :timer.minutes(10)
 
-      assert Helper.json_rpc_named_arguments("https://rpc.example/") ==
+      assert Helper.l1_json_rpc_named_arguments("https://rpc.example/") ==
                [
                  transport: EthereumJSONRPC.HTTP,
                  transport_options: [
@@ -48,7 +49,8 @@ defmodule Indexer.HelperTest do
                    http_options: [
                      recv_timeout: timeout,
                      timeout: timeout,
-                     pool: :ethereum_jsonrpc
+                     pool: :ethereum_jsonrpc,
+                     layer: :l1
                    ]
                  ]
                ]


### PR DESCRIPTION
## Motivation

The `json_rpc_requests_count` / `json_rpc_requests_errors_count` metrics (introduced in the `EthereumJSONRPC.HTTP.HTTPoison`/`EthereumJSONRPC.HTTP.Tesla` modules) counted **all** JSON RPC requests together, mixing calls to the L2 / main indexed chain node with calls made by rollup modules to the L1 (parent chain) node. There was no way to distinguish how many requests were made to L1 versus L2.

This PR adds dedicated metrics for L1 requests so the two can be told apart.

## Changelog

### Enhancements

- Added two new Prometheus counters in `EthereumJSONRPC.Prometheus.Instrumenter`:
  - `l1_json_rpc_requests_count` — number of JSON RPC requests to the L1 node made by rollup modules.
  - `l1_json_rpc_requests_errors_count` — number of errored JSON RPC requests to the L1 node made by rollup modules.
- L1 requests from rollups (Optimism, Arbitrum, Scroll, Shibarium, etc.) are now counted separately from regular L2 / main-chain requests, which keep using `json_rpc_requests_count` / `json_rpc_requests_errors_count`.
- Implementation: `Indexer.Helper.l1_json_rpc_named_arguments/1` (the single chokepoint that builds every rollup's L1 connection) tags its `http_options` with `layer: :l1`; the `EthereumJSONRPC.HTTP.HTTPoison` and `EthereumJSONRPC.HTTP.Tesla` transports read `layer` and route the request/error counters accordingly.

### Incompatible Changes

- Renamed `Indexer.Helper.json_rpc_named_arguments/1` → `Indexer.Helper.l1_json_rpc_named_arguments/1` to reflect that it is used exclusively for L1 node connections and to remove ambiguity. All call sites and tests were updated.

## Upgrading

No database reset or re-index required. The rename is internal (module function); external consumers of the Prometheus metrics gain the new `l1_json_rpc_requests_count` / `l1_json_rpc_requests_errors_count` series, while the existing `json_rpc_requests_count` / `json_rpc_requests_errors_count` series now exclude L1 rollup requests.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved monitoring for Layer 1 blockchain requests by reporting request and error metrics separately.
  - Improved reliability of rollup indexing and related cross-chain data processing by using dedicated Layer 1 connection settings.
  - Updated supported rollup workflows, including Arbitrum, Optimism, Scroll, and Shibarium, to better track Layer 1 activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->