### PR TITLE
feat: track eth_call requests by method id in L1/L2 metrics

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -4,6 +4,86 @@ defmodule EthereumJSONRPC.HTTP.Helper do
   Helper functions for `EthereumJSONRPC.HTTP` implementations.
   """
 
+  require Logger
+
+  alias EthereumJSONRPC.Prometheus.Instrumenter
+
+  @doc """
+  Tracks which contract methods are called via `eth_call` JSON-RPC requests.
+
+  For every `eth_call` in the payload (both single requests and batches) the
+  method id (first 4 bytes of the `data` field, e.g. `"0x70a08231"`) is
+  extracted, logged at the `debug` level and reported to the
+  `eth_call_requests_count` Prometheus metric. Requests to the L1 node made by
+  rollup modules (`l1?` is `true`) are reported to the separate
+  `l1_eth_call_requests_count` metric instead.
+
+  Only runs its work when `method` is `"eth_call"`, so the extra JSON decoding
+  cost is avoided for all other requests.
+
+  ## Parameters
+  - `json_string`: The raw JSON string payload sent to the node
+  - `method`: The JSON-RPC method already extracted from the payload
+  - `l1?`: Whether the request targets the L1 node. Defaults to `false`.
+
+  ## Returns
+  - `:ok`
+  """
+  @spec track_eth_call_methods(binary(), binary() | {:error, Jason.DecodeError.t()} | nil, boolean()) :: :ok
+  def track_eth_call_methods(json_string, method, l1? \\ false)
+
+  def track_eth_call_methods(json_string, "eth_call", l1?) do
+    json_string
+    |> get_eth_call_method_ids_from_json_string()
+    |> Enum.frequencies()
+    |> Enum.each(fn {method_id, count} ->
+      Logger.debug(fn ->
+        "eth_call request to method id #{method_id} on #{if l1?, do: "L1", else: "L2"} (count: #{count})"
+      end)
+
+      Instrumenter.eth_call_requests(method_id, l1?, count)
+    end)
+  end
+
+  def track_eth_call_methods(_json_string, _method, _l1?), do: :ok
+
+  @doc """
+  Extracts the method ids (first 4 bytes of the `data` field) of all `eth_call`
+  requests contained in a JSON string payload.
+
+  Supports both single objects and batch requests (arrays). Non-`eth_call`
+  requests and requests without a decodable `data` field are ignored.
+
+  ## Parameters
+  - `json_string`: The JSON string to parse
+
+  ## Returns
+  - A list of method id binaries (hex strings with `0x` prefix). Empty when the
+    payload contains no `eth_call` request or cannot be decoded.
+  """
+  @spec get_eth_call_method_ids_from_json_string(binary()) :: [binary()]
+  def get_eth_call_method_ids_from_json_string(json_string) do
+    case Jason.decode(json_string) do
+      {:ok, decoded_json} ->
+        decoded_json
+        |> List.wrap()
+        |> Enum.map(&eth_call_method_id/1)
+        |> Enum.reject(&is_nil/1)
+
+      _ ->
+        []
+    end
+  end
+
+  defp eth_call_method_id(%{"method" => "eth_call", "params" => [%{} = call_params | _]}) do
+    (call_params["data"] || call_params["input"]) |> method_id_from_data()
+  end
+
+  defp eth_call_method_id(_request), do: nil
+
+  defp method_id_from_data("0x" <> _rest = data) when byte_size(data) >= 10, do: binary_part(data, 0, 10)
+  defp method_id_from_data(_data), do: nil
+
   @doc """
   Extracts the JSON-RPC method from a JSON string payload.
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -38,6 +38,7 @@ defmodule EthereumJSONRPC.HTTP.Helper do
     |> Enum.frequencies()
     |> Enum.each(fn {method_id, count} ->
       Logger.debug(fn ->
+        # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         "eth_call request to method id #{method_id} on #{if l1?, do: "L1", else: "L2"} (count: #{count})"
       end)
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -17,6 +17,7 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
     l1? = Keyword.get(options, :layer) == :l1
 
     Instrumenter.json_rpc_requests(method, l1?)
+    Helper.track_eth_call_methods(json, method, l1?)
 
     case HTTPoison.post(url, json, headers, HTTPoisonHelper.request_opts(options)) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -19,6 +19,7 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
     l1? = Keyword.get(options, :layer) == :l1
 
     Instrumenter.json_rpc_requests(method, l1?)
+    Helper.track_eth_call_methods(json, method, l1?)
 
     case do_post(url, json, headers, options) do
       {:ok, %Tesla.Env{body: body, status: status_code, headers: headers}} ->

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
@@ -20,6 +20,18 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
     help: "Number of JSON RPC requests errors to the L1 node made by rollup modules"
   ]
 
+  @counter [
+    name: :eth_call_requests_count,
+    labels: [:method_id],
+    help: "Number of `eth_call` JSON RPC requests grouped by the called method id (first 4 bytes of the `data`)"
+  ]
+  @counter [
+    name: :l1_eth_call_requests_count,
+    labels: [:method_id],
+    help:
+      "Number of `eth_call` JSON RPC requests to the L1 node made by rollup modules, grouped by the called method id (first 4 bytes of the `data`)"
+  ]
+
   @doc """
   Increments the JSON-RPC requests counter for a given method.
 
@@ -54,5 +66,27 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
   def json_rpc_errors(method, l1? \\ false, error_count \\ 1) do
     counter_name = if l1?, do: :l1_json_rpc_requests_errors_count, else: :json_rpc_requests_errors_count
     Counter.inc([name: counter_name, labels: [method]], error_count)
+  end
+
+  @doc """
+  Increments the `eth_call` requests counter for a given method id.
+
+  The method id is the first 4 bytes of the `data` field of an `eth_call`
+  request (e.g. `"0x70a08231"` for `balanceOf(address)`). This allows tracking
+  how many `eth_call` requests are made for each specific contract method.
+
+  Requests to the L1 node made by rollup modules are counted separately via the
+  `l1_eth_call_requests_count` metric when `l1?` is `true`.
+
+  ## Parameters
+
+    - `method_id` (String): The 4-byte method id (hex string with `0x` prefix).
+    - `l1?` (boolean, optional): Whether the request targets the L1 node. Defaults to `false`.
+    - `req_count` (integer, optional): The number of requests to increment by. Defaults to 1.
+  """
+  @spec eth_call_requests(String.t(), boolean(), non_neg_integer()) :: :ok
+  def eth_call_requests(method_id, l1? \\ false, req_count \\ 1) do
+    counter_name = if l1?, do: :l1_eth_call_requests_count, else: :eth_call_requests_count
+    Counter.inc([name: counter_name, labels: [method_id]], req_count)
   end
 end


### PR DESCRIPTION
## Motivation

We want visibility into which contract methods are being called through `eth_call` JSON-RPC requests, and how often. This helps identify hot selectors and heavy on-demand read patterns. L1 `eth_call`s made by rollup modules are tracked separately from regular (L2) ones, mirroring the existing split between `json_rpc_requests_count` and `l1_json_rpc_requests_count`.

## Changelog

### Enhancements

- Add `eth_call_requests_count` Prometheus counter, labeled by `method_id` (the first 4 bytes of the `eth_call` `data` field, e.g. `0x70a08231`).
- Add `l1_eth_call_requests_count` Prometheus counter for `eth_call` requests made to the L1 node by rollup modules, tracked separately from L2.
- Add `debug`-level logging of the `eth_call` `method_id` and whether the request targets `L1` or `L2`.
- Method ids are extracted from both single and batch payloads, with a fallback from `data` to `input`. Extraction runs only when the method is `eth_call`, avoiding extra JSON decoding on all other requests.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring for Ethereum `eth_call` requests, including method identification and occurrence counts.
  - Added separate metrics for Layer 1 and Layer 2 `eth_call` traffic.
  - Supports both individual and batched requests, including common request data formats.
  - Metrics are labeled by the identified `eth_call` method for more detailed analysis.

- **Bug Fixes**
  - Invalid, unsupported, or undecodable requests are safely ignored during tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->