### PR TITLE
feat: add json_rpc_calls_count metric for per-method request counts

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -24,7 +24,7 @@ defmodule EthereumJSONRPC.HTTP.Helper do
   @spec decode_requests(binary()) :: [map()]
   def decode_requests(json_string) do
     case Jason.decode(json_string) do
-      {:ok, decoded} -> List.wrap(decoded)
+      {:ok, decoded} -> decoded |> List.wrap() |> Enum.filter(&is_map/1)
       _ -> []
     end
   end
@@ -95,6 +95,7 @@ defmodule EthereumJSONRPC.HTTP.Helper do
 
   defp eth_call_method_id(_request), do: nil
 
+  @spec method_id_from_data(binary() | nil) :: binary() | nil
   defp method_id_from_data("0x" <> _rest = data) when byte_size(data) >= 10,
     do: binary_part(data, 0, 10)
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/helper.ex
@@ -9,6 +9,54 @@ defmodule EthereumJSONRPC.HTTP.Helper do
   alias EthereumJSONRPC.Prometheus.Instrumenter
 
   @doc """
+  Decodes a raw JSON-RPC payload into a list of request maps.
+
+  Both single requests (a JSON object) and batch requests (a JSON array) are
+  normalized to a list, so callers can treat every payload uniformly. Returns an
+  empty list when the payload cannot be decoded.
+
+  ## Parameters
+  - `json_string`: The raw JSON string payload sent to the node
+
+  ## Returns
+  - A list of decoded request maps, or `[]` when decoding fails.
+  """
+  @spec decode_requests(binary()) :: [map()]
+  def decode_requests(json_string) do
+    case Jason.decode(json_string) do
+      {:ok, decoded} -> List.wrap(decoded)
+      _ -> []
+    end
+  end
+
+  @doc """
+  Reports the number of individual JSON-RPC calls, grouped by method, to the
+  `json_rpc_calls_count` Prometheus metric.
+
+  Unlike `json_rpc_requests_count`, which counts one increment per HTTP request
+  (labeled by the first method of a batch), this counts each request within a
+  batch, giving the exact number of requests per method. Calls to the L1 node
+  made by rollup modules (`l1?` is `true`) are reported to the separate
+  `l1_json_rpc_calls_count` metric instead.
+
+  ## Parameters
+  - `requests`: The decoded JSON-RPC requests (as returned by `decode_requests/1`)
+  - `l1?`: Whether the request targets the L1 node. Defaults to `false`.
+
+  ## Returns
+  - `:ok`
+  """
+  @spec track_json_rpc_calls([map()], boolean()) :: :ok
+  def track_json_rpc_calls(requests, l1? \\ false) do
+    requests
+    |> Enum.frequencies_by(&Map.get(&1, "method"))
+    |> Enum.each(fn
+      {nil, _count} -> :ok
+      {method, count} -> Instrumenter.json_rpc_calls(method, l1?, count)
+    end)
+  end
+
+  @doc """
   Tracks which contract methods are called via `eth_call` JSON-RPC requests.
 
   For every `eth_call` in the payload (both single requests and batches) the
@@ -18,23 +66,18 @@ defmodule EthereumJSONRPC.HTTP.Helper do
   rollup modules (`l1?` is `true`) are reported to the separate
   `l1_eth_call_requests_count` metric instead.
 
-  Only runs its work when `method` is `"eth_call"`, so the extra JSON decoding
-  cost is avoided for all other requests.
-
   ## Parameters
-  - `json_string`: The raw JSON string payload sent to the node
-  - `method`: The JSON-RPC method already extracted from the payload
+  - `requests`: The decoded JSON-RPC requests (as returned by `decode_requests/1`)
   - `l1?`: Whether the request targets the L1 node. Defaults to `false`.
 
   ## Returns
   - `:ok`
   """
-  @spec track_eth_call_methods(binary(), binary() | {:error, Jason.DecodeError.t()} | nil, boolean()) :: :ok
-  def track_eth_call_methods(json_string, method, l1? \\ false)
-
-  def track_eth_call_methods(json_string, "eth_call", l1?) do
-    json_string
-    |> get_eth_call_method_ids_from_json_string()
+  @spec track_eth_call_methods([map()], boolean()) :: :ok
+  def track_eth_call_methods(requests, l1? \\ false) do
+    requests
+    |> Enum.map(&eth_call_method_id/1)
+    |> Enum.reject(&is_nil/1)
     |> Enum.frequencies()
     |> Enum.each(fn {method_id, count} ->
       Logger.debug(fn ->
@@ -46,66 +89,16 @@ defmodule EthereumJSONRPC.HTTP.Helper do
     end)
   end
 
-  def track_eth_call_methods(_json_string, _method, _l1?), do: :ok
-
-  @doc """
-  Extracts the method ids (first 4 bytes of the `data` field) of all `eth_call`
-  requests contained in a JSON string payload.
-
-  Supports both single objects and batch requests (arrays). Non-`eth_call`
-  requests and requests without a decodable `data` field are ignored.
-
-  ## Parameters
-  - `json_string`: The JSON string to parse
-
-  ## Returns
-  - A list of method id binaries (hex strings with `0x` prefix). Empty when the
-    payload contains no `eth_call` request or cannot be decoded.
-  """
-  @spec get_eth_call_method_ids_from_json_string(binary()) :: [binary()]
-  def get_eth_call_method_ids_from_json_string(json_string) do
-    case Jason.decode(json_string) do
-      {:ok, decoded_json} ->
-        decoded_json
-        |> List.wrap()
-        |> Enum.map(&eth_call_method_id/1)
-        |> Enum.reject(&is_nil/1)
-
-      _ ->
-        []
-    end
-  end
-
   defp eth_call_method_id(%{"method" => "eth_call", "params" => [%{} = call_params | _]}) do
     (call_params["data"] || call_params["input"]) |> method_id_from_data()
   end
 
   defp eth_call_method_id(_request), do: nil
 
-  defp method_id_from_data("0x" <> _rest = data) when byte_size(data) >= 10, do: binary_part(data, 0, 10)
+  defp method_id_from_data("0x" <> _rest = data) when byte_size(data) >= 10,
+    do: binary_part(data, 0, 10)
+
   defp method_id_from_data(_data), do: nil
-
-  @doc """
-  Extracts the JSON-RPC method from a JSON string payload.
-
-  Supports both single objects and batch requests (arrays).
-
-  ## Parameters
-  - `json_string`: The JSON string to parse
-
-  ## Returns
-  - The method name as a binary, or `{:error, Jason.DecodeError.t()}` if extraction fails
-  """
-  @spec get_method_from_json_string(binary()) :: binary() | {:error, Jason.DecodeError.t()}
-  def get_method_from_json_string(json_string) do
-    with {:ok, decoded_json} <- Jason.decode(json_string) do
-      if is_map(decoded_json) do
-        Map.get(decoded_json, "method")
-      else
-        decoded_json |> Enum.at(0) |> Map.get("method")
-      end
-    end
-  end
 
   @spec response_body_has_error?(map() | [map()]) :: boolean()
   def response_body_has_error?(decoded_body) when is_map(decoded_body) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/httpoison.ex
@@ -13,11 +13,13 @@ defmodule EthereumJSONRPC.HTTP.HTTPoison do
 
   @impl HTTP
   def json_rpc(url, json, headers, options) when is_binary(url) and is_list(options) do
-    method = Helper.get_method_from_json_string(json)
+    requests = Helper.decode_requests(json)
+    method = requests |> List.first(%{}) |> Map.get("method")
     l1? = Keyword.get(options, :layer) == :l1
 
     Instrumenter.json_rpc_requests(method, l1?)
-    Helper.track_eth_call_methods(json, method, l1?)
+    Helper.track_json_rpc_calls(requests, l1?)
+    Helper.track_eth_call_methods(requests, l1?)
 
     case HTTPoison.post(url, json, headers, HTTPoisonHelper.request_opts(options)) do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code, headers: headers}} ->

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http/tesla.ex
@@ -15,11 +15,13 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
 
   @impl HTTP
   def json_rpc(url, json, headers, options) when is_binary(url) and is_list(options) do
-    method = Helper.get_method_from_json_string(json)
+    requests = Helper.decode_requests(json)
+    method = requests |> List.first(%{}) |> Map.get("method")
     l1? = Keyword.get(options, :layer) == :l1
 
     Instrumenter.json_rpc_requests(method, l1?)
-    Helper.track_eth_call_methods(json, method, l1?)
+    Helper.track_json_rpc_calls(requests, l1?)
+    Helper.track_eth_call_methods(requests, l1?)
 
     case do_post(url, json, headers, options) do
       {:ok, %Tesla.Env{body: body, status: status_code, headers: headers}} ->
@@ -40,7 +42,10 @@ defmodule EthereumJSONRPC.HTTP.Tesla do
   def json_rpc(url, _json, _headers, _options) when is_nil(url), do: {:error, "URL is nil"}
 
   defp do_post(url, json, headers, options) do
-    Tesla.post(TeslaHelper.client(options), url, json, headers: headers, opts: TeslaHelper.request_opts(options))
+    Tesla.post(TeslaHelper.client(options), url, json,
+      headers: headers,
+      opts: TeslaHelper.request_opts(options)
+    )
   rescue
     error ->
       if timeout_middleware_exception?(__STACKTRACE__) do

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
@@ -43,8 +43,7 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
   @counter [
     name: :eth_call_requests_count,
     labels: [:method_id],
-    help:
-      "Number of `eth_call` JSON RPC requests grouped by the called method id (first 4 bytes of the `data`)"
+    help: "Number of `eth_call` JSON RPC requests grouped by the called method id (first 4 bytes of the `data`)"
   ]
   @counter [
     name: :l1_eth_call_requests_count,

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/prometheus/instrumenter.ex
@@ -6,8 +6,16 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
 
   use Prometheus.Metric
 
-  @counter [name: :json_rpc_requests_count, labels: [:method], help: "Number of JSON RPC requests"]
-  @counter [name: :json_rpc_requests_errors_count, labels: [:method], help: "Number of JSON RPC requests errors"]
+  @counter [
+    name: :json_rpc_requests_count,
+    labels: [:method],
+    help: "Number of JSON RPC requests"
+  ]
+  @counter [
+    name: :json_rpc_requests_errors_count,
+    labels: [:method],
+    help: "Number of JSON RPC requests errors"
+  ]
 
   @counter [
     name: :l1_json_rpc_requests_count,
@@ -21,9 +29,22 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
   ]
 
   @counter [
+    name: :json_rpc_calls_count,
+    labels: [:method],
+    help: "Number of JSON RPC calls (each request within a batch is counted separately)"
+  ]
+  @counter [
+    name: :l1_json_rpc_calls_count,
+    labels: [:method],
+    help:
+      "Number of JSON RPC calls to the L1 node made by rollup modules (each request within a batch is counted separately)"
+  ]
+
+  @counter [
     name: :eth_call_requests_count,
     labels: [:method_id],
-    help: "Number of `eth_call` JSON RPC requests grouped by the called method id (first 4 bytes of the `data`)"
+    help:
+      "Number of `eth_call` JSON RPC requests grouped by the called method id (first 4 bytes of the `data`)"
   ]
   @counter [
     name: :l1_eth_call_requests_count,
@@ -64,8 +85,33 @@ defmodule EthereumJSONRPC.Prometheus.Instrumenter do
   """
   @spec json_rpc_errors(String.t(), boolean(), non_neg_integer()) :: :ok
   def json_rpc_errors(method, l1? \\ false, error_count \\ 1) do
-    counter_name = if l1?, do: :l1_json_rpc_requests_errors_count, else: :json_rpc_requests_errors_count
+    counter_name =
+      if l1?, do: :l1_json_rpc_requests_errors_count, else: :json_rpc_requests_errors_count
+
     Counter.inc([name: counter_name, labels: [method]], error_count)
+  end
+
+  @doc """
+  Increments the JSON-RPC calls counter for a given method by `call_count`.
+
+  Unlike `json_rpc_requests/3`, which counts one increment per HTTP request
+  (labeled by the first method of a batch), this counts each individual request
+  within a batch, grouped by its method. This gives the exact number of requests
+  per method.
+
+  Calls to the L1 node made by rollup modules are counted separately via the
+  `l1_json_rpc_calls_count` metric when `l1?` is `true`.
+
+  ## Parameters
+
+    - `method` (String): The name of the JSON-RPC method.
+    - `l1?` (boolean, optional): Whether the request targets the L1 node. Defaults to `false`.
+    - `call_count` (integer, optional): The number of calls to increment by. Defaults to 1.
+  """
+  @spec json_rpc_calls(String.t(), boolean(), non_neg_integer()) :: :ok
+  def json_rpc_calls(method, l1? \\ false, call_count \\ 1) do
+    counter_name = if l1?, do: :l1_json_rpc_calls_count, else: :json_rpc_calls_count
+    Counter.inc([name: counter_name, labels: [method]], call_count)
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

The `json_rpc_requests_count` metric increments once per HTTP POST and labels the counter with only the **first** method of a batch (via `Enum.at(0)`). Since Blockscout batches many requests into a single JSON-RPC POST, this undercounts real per-method load: e.g. `json_rpc_requests_count{method="eth_call"}` showed ~165k/hour while `eth_call_requests_count{method_id="0x70a08231"}` showed ~4.8M/hour for the same window — a ~29x gap that is exactly the average `eth_call` batch size (mostly `balanceOf` calls from the token balance fetchers).

This PR adds a sibling metric that reports the **exact number of requests per method**, without changing the existing metric.

## Changelog

### Enhancements

- Add `json_rpc_calls_count` metric (and the L1 variant `l1_json_rpc_calls_count`), labeled by `method`, that counts each request within a batch — giving exact per-method request counts. Example query: `sum by (method) (increase(json_rpc_calls_count[1h]))`.
- Decode the JSON-RPC payload **once** per request in the `Tesla`/`HTTPoison` transports and reuse it for all three metrics (`json_rpc_requests_count`, `json_rpc_calls_count`, `eth_call_requests_count`), instead of decoding the payload up to 3 times.

### Bug Fixes

- `track_eth_call_methods` no longer requires the batch's **first** element to be `eth_call`. Previously, a mixed batch whose first entry was not `eth_call` had its `eth_call` entries dropped from `eth_call_requests_count`; they are now counted.

### Incompatible Changes

- Removed the now-unused public helpers `EthereumJSONRPC.HTTP.Helper.get_method_from_json_string/1` and `EthereumJSONRPC.HTTP.Helper.get_eth_call_method_ids_from_json_string/1`. `track_eth_call_methods/3` was changed to `track_eth_call_methods/2` and now takes decoded requests instead of a raw JSON string. These are internal helpers with no external consumers.
- `json_rpc_requests_count` is intentionally **unchanged** (still one increment per HTTP request, labeled by the batch's first method), so existing dashboards and alerts keep working.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for tracking individual JSON-RPC methods.
  * Added separate metrics for Layer 1 JSON-RPC calls.
  * Added support for counting requests in both single-request and batch JSON-RPC payloads.

* **Bug Fixes**
  * Improved request decoding and method detection for JSON-RPC traffic.
  * Invalid payloads are handled safely without disrupting request tracking.
  * Improved tracking of Ethereum call method identifiers across supported request formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->