### PR TITLE
fix: Ignore traces of duplicated transactions

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/internal_transactions.ex
@@ -453,8 +453,11 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactions do
     else
       blocks_map = Map.new(transactions, &{&1.block_number, &1.block_hash})
 
+      existing_transactions_indexes = MapSet.new(transactions, &{&1.block_number, &1.index})
+
       valid_internal_transactions =
         internal_transactions_params
+        |> Enum.filter(&MapSet.member?(existing_transactions_indexes, {&1.block_number, &1.transaction_index}))
         |> Enum.group_by(& &1.block_number)
         |> Map.drop(invalid_block_numbers)
         |> Enum.flat_map(fn item ->

--- a/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/transactions.ex
@@ -118,8 +118,8 @@ defmodule Explorer.Chain.Import.Runner.Transactions do
     # Enforce Transaction ShareLocks order (see docs: sharelocks.md)
     ordered_changes_list =
       changes_list
+      |> Enum.sort_by(&{&1.hash, Map.get(&1, :index)})
       |> Enum.uniq_by(& &1.hash)
-      |> Enum.sort_by(& &1.hash)
 
     Import.insert_changes_list(
       repo,

--- a/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/internal_transactions_test.exs
@@ -191,6 +191,34 @@ defmodule Explorer.Chain.Import.Runner.InternalTransactionsTest do
       assert is_nil(Repo.get(Transaction, pending.hash).block_hash)
     end
 
+    test "internal transactions of a transaction index that has no transaction are ignored" do
+      transaction = insert(:transaction) |> with_block(status: :ok)
+      insert(:pending_block_operation, block_hash: transaction.block_hash, block_number: transaction.block_number)
+
+      duplicated_transaction_index = transaction.index + 1
+
+      changes = Enum.map([0, 1], &make_internal_transaction_changes(transaction, &1, nil))
+      duplicated_changes = Enum.map(changes, &%{&1 | transaction_index: duplicated_transaction_index})
+
+      assert {:ok, _} = run_internal_transactions(changes ++ duplicated_changes)
+
+      assert PendingBlockOperation |> Repo.get(transaction.block_hash) |> is_nil()
+
+      assert Repo.exists?(
+               from(it in InternalTransaction,
+                 where: it.block_number == ^transaction.block_number and it.transaction_index == ^transaction.index
+               )
+             )
+
+      refute Repo.exists?(
+               from(it in InternalTransaction,
+                 where:
+                   it.block_number == ^transaction.block_number and
+                     it.transaction_index == ^duplicated_transaction_index
+               )
+             )
+    end
+
     test "removes consensus to blocks where transactions are missing" do
       empty_block = insert(:block)
       pending = insert(:transaction)


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14329

## Motivation

We should ignore traces of duplicated transactions as well, otherwise, the internal transactions import will fails on related transactions update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction import accuracy by ignoring internal transaction data that does not correspond to an existing transaction.
  - Preserved valid internal transactions and correctly cleared pending block operations after processing.
  - Improved transaction ordering and duplicate handling during imports for more consistent results.

- **Tests**
  - Added regression coverage to verify that invalid transaction indexes are ignored while valid transactions are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->