### PR TITLE
fix: prevent Memory.Monitor crash on restarting OnDemand fetchers

### DIFF
--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -270,14 +270,19 @@ defmodule Indexer.Memory.Monitor do
       |> Supervisor.which_children()
       |> Enum.filter(fn {name, _, _, _} -> is_atom(name) and String.contains?(to_string(name), "OnDemand") end)
       |> Enum.flat_map(fn
-        {_, pid, :supervisor, _} ->
+        {_, pid, :supervisor, _} when is_pid(pid) ->
           pid
           |> Supervisor.which_children()
           |> Enum.filter(&(elem(&1, 2) == :worker))
           |> Enum.map(&elem(&1, 1))
+          |> Enum.filter(&is_pid/1)
 
-        {_, pid, _, _} ->
+        {_, pid, _, _} when is_pid(pid) ->
           [pid]
+
+        # child is :undefined or :restarting (not currently running)
+        _ ->
+          []
       end)
     end)
   end

--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -267,12 +267,12 @@ defmodule Indexer.Memory.Monitor do
     |> Enum.reject(&is_nil(Process.whereis(&1)))
     |> Enum.flat_map(fn supervisor ->
       supervisor
-      |> Supervisor.which_children()
+      |> safe_which_children()
       |> Enum.filter(fn {name, _, _, _} -> is_atom(name) and String.contains?(to_string(name), "OnDemand") end)
       |> Enum.flat_map(fn
         {_, pid, :supervisor, _} when is_pid(pid) ->
           pid
-          |> Supervisor.which_children()
+          |> safe_which_children()
           |> Enum.filter(&(elem(&1, 2) == :worker))
           |> Enum.map(&elem(&1, 1))
           |> Enum.filter(&is_pid/1)
@@ -285,6 +285,15 @@ defmodule Indexer.Memory.Monitor do
           []
       end)
     end)
+  end
+
+  # `Supervisor.which_children/1` performs a `GenServer.call`, which exits with
+  # `:noproc` if the supervisor terminates between the pid check and the call.
+  # Treat that expected race as an empty child list instead of crashing.
+  defp safe_which_children(supervisor) do
+    Supervisor.which_children(supervisor)
+  catch
+    :exit, _ -> []
   end
 
   defp name(pid) do


### PR DESCRIPTION
## Motivation

`Indexer.Memory.Monitor` crashed in production during its periodic `:check`:
```
** (stop) exited in: GenServer.call(:undefined, :which_children, :infinity)
** (EXIT) no process: the process is not alive or there's no process
```
(indexer 11.2.4) lib/indexer/memory/monitor.ex:275: Indexer.Memory.Monitor.on_demand_fetchers/0


`Supervisor.which_children/1` returns tuples `{name, child, type, modules}` where `child` is a pid, `:undefined`, or `:restarting`. It is `:undefined`/`:restarting` when a child is momentarily not running (being restarted or down). `on_demand_fetchers/0` matched `{_, pid, :supervisor, _}` unconditionally and then called `Supervisor.which_children(pid)`. When `pid` was `:undefined`, this became `GenServer.call(:undefined, :which_children, :infinity)` and crashed, taking down the `Indexer.Memory.Monitor` GenServer. The same non-pid value could also flow into the returned fetcher list and later break `memory/1`'s `is_pid` guard.

This is a transient-state race that occurs when an `OnDemand` fetcher happens to be mid-restart while the monitor collects memory metrics.

## Changelog

### Bug Fixes

- Guard `on_demand_fetchers/0` in `Indexer.Memory.Monitor` against non-pid supervisor children (`:undefined`/`:restarting`), skipping them instead of calling `Supervisor.which_children/1` on them. Inner worker children are also filtered to real pids.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process monitoring reliability by excluding undefined, stopped, or restarting workers from on-demand fetch results.
  * Only active worker processes are now returned for further processing.
  * Prevented monitoring failures when supervised processes terminate during discovery; these situations are now handled safely without interrupting monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->