### PR TITLE
fix: Handle Solidity function type in decoded ABI values

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/smart_contract_view.ex
@@ -385,6 +385,12 @@ defmodule BlockScoutWeb.API.V2.SmartContractView do
     SmartContractView.cast_address(value)
   end
 
+  # A Solidity `function` type is a 24-byte value (address + selector). Since
+  # ex_abi 0.8.4 it is decoded into a raw binary, so render it as hex.
+  def render_json(value, type) when type in [:function, "function"] and is_binary(value) do
+    "0x" <> Base.encode16(value, case: :lower)
+  end
+
   def render_json(value, type) when type in [:string, "string"] do
     to_string(value)
   end

--- a/apps/explorer/lib/explorer/chain/decoding_helper.ex
+++ b/apps/explorer/lib/explorer/chain/decoding_helper.ex
@@ -79,5 +79,23 @@ defmodule Explorer.Chain.DecodingHelper do
     "0x" <> Base.encode16(value, case: :lower)
   end
 
+  # A Solidity `function` type is a 24-byte value (20-byte address + 4-byte
+  # selector). Since ex_abi 0.8.4 it is decoded into a raw binary, so encode it
+  # as hex like `bytes`, rather than trying to render it as a string.
+  defp base_value_json(:function, value) do
+    "0x" <> Base.encode16(value, case: :lower)
+  end
+
+  defp base_value_json(_, value) when is_binary(value) do
+    # A `string` parameter may contain bytes that are not valid UTF-8 (e.g. a
+    # contract emitted arbitrary data under a `string` type). Such a binary
+    # cannot be JSON-encoded as a string, so fall back to a hex representation.
+    if String.valid?(value) do
+      value
+    else
+      "0x" <> Base.encode16(value, case: :lower)
+    end
+  end
+
   defp base_value_json(_, value), do: to_string(value)
 end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14671

## Motivation

After bumping `ex_abi` `0.8.3` -> `0.8.4`, the `GET /api/v2/transactions/{hash}/logs` endpoint started returning `500` errors:
```
** (Jason.EncodeError) invalid byte 0x8E in <<41, 8, 142, 235, ...>>
```

The bump pulled in [poanetwork/ex_abi#184](https://github.com/poanetwork/ex_abi/pull/184), which added support for the Solidity `function` type, decoding it as a raw 24-byte binary (20-byte address + 4-byte selector, i.e. `bytes24`).

Blockscout's decoded-value renderers had no clause for the `:function` type, so the raw binary fell through to a `to_string/1` fallback and was passed to Jason as if it were a UTF-8 string. When the bytes are not valid UTF-8, `Jason.encode!/1` raises and the whole request fails with `500`.

The same latent crash exists on a second path: a contract read method returning a `function` type, rendered via `SmartContractView.render_json/2`.

## Changelog

### Bug Fixes

- Render the Solidity `function` type as hex in `DecodingHelper.value_json/2`, matching `ex_abi`'s `bytes24` treatment. This fixes `500` (`Jason.EncodeError`) responses on decoded event/call parameters, including the transaction logs endpoint.
- Render the `function` type as hex in `SmartContractView.render_json/2`, fixing the same crash for contract read-method output.
- Guard the generic `value_json/2` fallback so a non-UTF-8 `string` parameter degrades to a hex representation instead of crashing the JSON encoder.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API responses for Solidity `function` values by encoding them as lowercase hexadecimal with a `0x` prefix.
  * Added consistent handling for binary values: readable text remains unchanged, while non-text data is returned as hexadecimal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->