### PR TITLE
feat: add average_block_time Prometheus metric

### DIFF
--- a/apps/explorer/lib/explorer/chain/cache/counters/average_block_time.ex
+++ b/apps/explorer/lib/explorer/chain/cache/counters/average_block_time.ex
@@ -9,6 +9,7 @@ defmodule Explorer.Chain.Cache.Counters.AverageBlockTime do
 
   alias EthereumJSONRPC.Utility.RangesHelper
   alias Explorer.Chain.Block
+  alias Explorer.Prometheus.Instrumenter
   alias Explorer.Repo
   alias Timex.Duration
 
@@ -111,7 +112,11 @@ defmodule Explorer.Chain.Cache.Counters.AverageBlockTime do
         {number, DateTime.to_unix(timestamp, :millisecond)}
       end)
 
-    %{timestamps: timestamps, average: average_distance(timestamps)}
+    average = average_distance(timestamps)
+
+    Instrumenter.average_block_time(Duration.to_milliseconds(average))
+
+    %{timestamps: timestamps, average: average}
   end
 
   defp average_distance([]), do: Duration.from_milliseconds(0)

--- a/apps/explorer/lib/explorer/prometheus/instrumenter.ex
+++ b/apps/explorer/lib/explorer/prometheus/instrumenter.ex
@@ -88,6 +88,8 @@ defmodule Explorer.Prometheus.Instrumenter do
     registry: :public
   ]
 
+  @gauge [name: :average_block_time, help: "Average block time in milliseconds"]
+
   @gauge [name: :batch_average_time, help: "L2 average batch time"]
 
   @gauge [name: :latest_deposit_l1_number, help: "L2 latest deposit L1 block number"]
@@ -216,6 +218,14 @@ defmodule Explorer.Prometheus.Instrumenter do
   @spec increment_failed_uploading_media_number() :: :ok
   def increment_failed_uploading_media_number do
     Counter.inc(name: :failed_uploading_media_number, registry: :public)
+  end
+
+  @doc """
+  Defines the metric for the average block time in milliseconds.
+  """
+  @spec average_block_time(number()) :: :ok
+  def average_block_time(milliseconds) do
+    Gauge.set([name: :average_block_time], milliseconds)
   end
 
   @spec batch_average_time(integer()) :: :ok


### PR DESCRIPTION
## Motivation

The average block time is cached by `Explorer.Chain.Cache.Counters.AverageBlockTime.average_block_time/0` and already exposed via the API, but there was no Prometheus metric for it. This adds a gauge so the value can be scraped and monitored.

## Changelog

### Enhancements

- Added an `average_block_time` Prometheus gauge (in milliseconds) on the default registry, exposed at the standard `/metrics` endpoint alongside other core `Explorer` metrics.
- The gauge is set from `AverageBlockTime.refresh_timestamps/0`, so it updates on every periodic cache refresh with the same value `average_block_time/0` returns. It is fed from the locally computed average (converted via `Duration.to_milliseconds/1`) rather than by calling `average_block_time/0`, which would deadlock since that function does a `GenServer.call` to the same process.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added average block time monitoring in milliseconds.
  * Exposed average block time as a Prometheus gauge metric for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->