### PR TITLE
fix: Reorganize logs indexes creation order

### DIFF
--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -229,7 +229,6 @@ defmodule Explorer.Application do
         configure_mode_dependent_process(Explorer.Migrator.EmptyInternalTransactionsData, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.FillInternalTransactionsAddressIds, :indexer),
         configure_mode_dependent_process(Explorer.Migrator.DeleteNonConsensusLogs, :indexer),
-        configure_mode_dependent_process(Explorer.Migrator.FillLogsCompressedData, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateAddressesVerifiedIndex,
           :indexer
@@ -453,11 +452,6 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.UpdateLogsPrimaryKey,
-          :indexer
-        ),
-        configure_mode_dependent_process(Explorer.Migrator.FillLogsOptimizedFields, :indexer),
-        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumberDescIndexDescIndex,
           :indexer
         ),
@@ -466,9 +460,19 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsDepositsWithdrawalsIndexWithUpdatedPk,
+          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdFirstTopicIdSecondTopicBlockNumberIndex,
           :indexer
         ),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex,
+          :indexer
+        ),
+        configure_mode_dependent_process(Explorer.Migrator.FillLogsOptimizedFields, :indexer),
+        configure_mode_dependent_process(
+          Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransactionIndexNotNull,
+          :indexer
+        ),
+        configure_mode_dependent_process(Explorer.Migrator.FillLogsCompressedData, :indexer),
         configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.DropLogsAddressHashBlockNumberDescIndexDescIndex,
           :indexer
@@ -482,19 +486,15 @@ defmodule Explorer.Application do
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsBlockNumberTransactionIndexNotNull,
-          :indexer
-        ),
-        configure_mode_dependent_process(
           Explorer.Migrator.HeavyDbIndexOperation.ValidateLogsFirstTopicIdFkey,
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex,
+          Explorer.Migrator.HeavyDbIndexOperation.UpdateLogsPrimaryKey,
           :indexer
         ),
         configure_mode_dependent_process(
-          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdFirstTopicIdSecondTopicBlockNumberIndex,
+          Explorer.Migrator.HeavyDbIndexOperation.CreateLogsDepositsWithdrawalsIndexWithUpdatedPk,
           :indexer
         ),
         Explorer.Migrator.RefetchContractCodes

--- a/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
+++ b/apps/explorer/lib/explorer/migrator/fill_logs_optimized_fields.ex
@@ -12,7 +12,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFields do
   alias Explorer.Chain.Cache.{BackgroundMigrations, BlockNumber}
   alias Explorer.Chain.{Log, Transaction}
   alias Explorer.Migrator.FillingMigration
-  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockNumberTransactionIndexIndexUniqueIndex
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex
   alias Explorer.Repo
   alias Explorer.Utility.{AddressIdToAddressHash, LogFirstTopic}
 
@@ -23,7 +23,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFields do
 
   @impl FillingMigration
   def dependent_from_migrations,
-    do: [CreateLogsBlockNumberTransactionIndexIndexUniqueIndex.migration_name()]
+    do: [CreateLogsFirstTopicIdIndex.migration_name()]
 
   @impl FillingMigration
   def last_unprocessed_identifiers(%{"max_block_number" => -1} = state), do: {[], state}

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_id_block_number_desc_index_desc_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_address_id_block_number_desc_index_desc_index.ex
@@ -9,8 +9,9 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumber
   require Logger
 
   alias Explorer.Chain.Cache.BackgroundMigrations
-  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
 
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockNumberTransactionIndexIndexUniqueIndex
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
   @table_name :logs
@@ -28,7 +29,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdBlockNumber
   def index_name, do: @index_name
 
   @impl HeavyDbIndexOperation
-  def dependent_from_migrations, do: [FillLogsOptimizedFields.migration_name()]
+  def dependent_from_migrations, do: [CreateLogsBlockNumberTransactionIndexIndexUniqueIndex.migration_name()]
 
   @impl HeavyDbIndexOperation
   def db_index_operation do

--- a/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_first_topic_id_index.ex
+++ b/apps/explorer/lib/explorer/migrator/heavy_db_index_operation/create_logs_first_topic_id_index.ex
@@ -8,7 +8,8 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex do
 
   require Logger
 
-  alias Explorer.Migrator.{FillLogsOptimizedFields, HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.{HeavyDbIndexOperation, MigrationStatus}
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsAddressIdFirstTopicIdSecondTopicBlockNumberIndex
   alias Explorer.Migrator.HeavyDbIndexOperation.Helper, as: HeavyDbIndexOperationHelper
 
   @table_name :logs
@@ -28,7 +29,7 @@ defmodule Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex do
   @impl HeavyDbIndexOperation
   def dependent_from_migrations,
     do: [
-      FillLogsOptimizedFields.migration_name()
+      CreateLogsAddressIdFirstTopicIdSecondTopicBlockNumberIndex.migration_name()
     ]
 
   @impl HeavyDbIndexOperation

--- a/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
+++ b/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
@@ -5,7 +5,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
 
   alias Explorer.Chain.{Log, TokenTransfer}
   alias Explorer.Migrator.{FillLogsOptimizedFields, MigrationStatus}
-  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsBlockNumberTransactionIndexIndexUniqueIndex
+  alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex
   alias Explorer.{Repo, TestHelper}
   alias Explorer.Utility.{AddressIdToAddressHash, LogFirstTopic}
 
@@ -24,7 +24,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
     )
 
     MigrationStatus.set_status(
-      CreateLogsBlockNumberTransactionIndexIndexUniqueIndex.migration_name(),
+      CreateLogsFirstTopicIdIndex.migration_name(),
       "completed"
     )
 
@@ -78,7 +78,7 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
     log = insert(:log, transaction: nil, transaction_index: 5)
 
     MigrationStatus.set_status(
-      CreateLogsBlockNumberTransactionIndexIndexUniqueIndex.migration_name(),
+      CreateLogsFirstTopicIdIndex.migration_name(),
       "completed"
     )
 


### PR DESCRIPTION
## Motivation

`logs` address id and topic ids indexes should be created before the `fill_logs_optimized_fields` starts, otherwise, queries based on `fill_optimized_fields_migration_finished/started?` conditions won't have necessary indexes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log database migration ordering so indexes and optimized log data are prepared in the correct sequence.
  * Added an index to improve access to logs by their first topic.
  * Updated log indexing and primary-key migration sequencing for more reliable database upgrades.
  * Improved migration validation to support smoother upgrades and reduce the risk of incomplete log data preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->