### PR TITLE
fix: Fix current token balances fetcher result

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/token_balance/current.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance/current.ex
@@ -97,7 +97,14 @@ defmodule Indexer.Fetcher.TokenBalance.Current do
         :ok
 
       {:error, reason} ->
-        Logger.debug(fn -> ["failed to import current token balances: ", inspect(reason)] end,
+        Logger.error(fn -> ["failed to import current token balances: ", inspect(reason)] end,
+          error_count: Enum.count(ctb_params)
+        )
+
+        :error
+
+      error ->
+        Logger.error(fn -> ["failed to import current token balances: ", inspect(error)] end,
           error_count: Enum.count(ctb_params)
         )
 

--- a/apps/indexer/lib/indexer/fetcher/token_balance/current.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance/current.ex
@@ -91,6 +91,7 @@ defmodule Indexer.Fetcher.TokenBalance.Current do
     case Chain.import(import_params) do
       {:ok, %{address_current_token_balances: imported_ctbs}} when imported_ctbs != [] ->
         Publisher.broadcast(%{address_current_token_balances: imported_ctbs}, :realtime)
+        :ok
 
       {:ok, _} ->
         :ok

--- a/apps/indexer/lib/indexer/fetcher/token_balance/historical.ex
+++ b/apps/indexer/lib/indexer/fetcher/token_balance/historical.ex
@@ -99,7 +99,14 @@ defmodule Indexer.Fetcher.TokenBalance.Historical do
         :ok
 
       {:error, reason} ->
-        Logger.debug(fn -> ["failed to import token balances: ", inspect(reason)] end,
+        Logger.error(fn -> ["failed to import token balances: ", inspect(reason)] end,
+          error_count: Enum.count(token_balances_params)
+        )
+
+        :error
+
+      error ->
+        Logger.error(fn -> ["failed to import token balances: ", inspect(error)] end,
           error_count: Enum.count(token_balances_params)
         )
 

--- a/apps/indexer/test/indexer/fetcher/token_balance/current_test.exs
+++ b/apps/indexer/test/indexer/fetcher/token_balance/current_test.exs
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Indexer.Fetcher.TokenBalance.CurrentTest do
+  use EthereumJSONRPC.Case
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Repo
+  alias Indexer.Fetcher.TokenBalance.Current, as: TokenBalanceCurrent
+
+  @moduletag :capture_log
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  describe "run/2" do
+    setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      TokenBalanceCurrent.Supervisor.Case.start_supervised!(json_rpc_named_arguments: json_rpc_named_arguments)
+
+      :ok
+    end
+
+    test "returns :ok for a batch that was imported and broadcasted, so it is not retried" do
+      Subscriber.to(:address_current_token_balances, :realtime)
+
+      address = insert(:address)
+      %{contract_address_hash: token_contract_address_hash} = insert(:token)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: id, method: "eth_call", params: [%{data: _, to: _}, _]}],
+                                                _options ->
+        {:ok, [%{id: id, jsonrpc: "2.0", result: "0x00000000000000000000000000000000000000000000d3c21bcecceda1000000"}]}
+      end)
+
+      assert TokenBalanceCurrent.run(
+               [{address.hash.bytes, token_contract_address_hash.bytes, 1, "ERC-20", nil, 0}],
+               nil
+             ) == :ok
+
+      assert_receive {:chain_event, :address_current_token_balances, :realtime, [%CurrentTokenBalance{}]}
+
+      assert %CurrentTokenBalance{value: value, value_fetched_at: value_fetched_at} = Repo.one(CurrentTokenBalance)
+      assert value == Decimal.new(1_000_000_000_000_000_000_000_000)
+      refute is_nil(value_fetched_at)
+    end
+  end
+
+  describe "import_token_balances/1" do
+    test "returns :ok when the current token balances were imported and broadcasted" do
+      Subscriber.to(:address_current_token_balances, :realtime)
+
+      address = insert(:address)
+      %{contract_address_hash: token_contract_address_hash} = insert(:token)
+
+      params = [
+        %{
+          address_hash: to_string(address.hash),
+          token_contract_address_hash: to_string(token_contract_address_hash),
+          block_number: 1,
+          token_type: "ERC-20",
+          token_id: nil,
+          value: Decimal.new(100),
+          value_fetched_at: DateTime.utc_now()
+        }
+      ]
+
+      assert TokenBalanceCurrent.import_token_balances(params) == :ok
+
+      assert_receive {:chain_event, :address_current_token_balances, :realtime, [%CurrentTokenBalance{}]}
+    end
+
+    test "returns :ok when there is nothing to import" do
+      assert TokenBalanceCurrent.import_token_balances([]) == :ok
+    end
+
+    test "returns :error when the current token balances have invalid data" do
+      %{contract_address_hash: token_contract_address_hash} = insert(:token)
+
+      params = [
+        %{
+          address_hash: nil,
+          token_contract_address_hash: to_string(token_contract_address_hash),
+          block_number: nil,
+          token_type: nil,
+          token_id: nil,
+          value: nil,
+          value_fetched_at: nil
+        }
+      ]
+
+      assert TokenBalanceCurrent.import_token_balances(params) == :error
+    end
+  end
+end


### PR DESCRIPTION
Related to https://github.com/blockscout/blockscout/pull/14625

## Motivation

https://github.com/blockscout/blockscout/pull/14625 introduced  **infinite retry loop in `Indexer.Fetcher.TokenBalance.Current`** (commit `820fef652d`, 2026-07-29, shipped in v11.2.4/v11.2.5).

The `BufferedTask` callback decides success by exact match on `:ok`:

```elixir
entries
|> Helper.fetch_token_balances()
|> import_token_balances()
|> case do
  :ok -> :ok
  _ -> {:retry, entries}
end
```

Before #14625, the success branch ended in `Enum.each(...)` → `:ok`. The refactor replaced it with a bare `Publisher.broadcast/2` call as the last expression — and `apps/explorer/lib/explorer/chain/events/publisher.ex:31` is a `for` comprehension, so it returns a **list** (`[:ok]`), never the atom `:ok`.

So the flow was:

1. Batch fetched via `balanceOf` → import succeeds → `imported_ctbs != []` → broadcast → returns `[:ok]`
2. `run/2` falls into `_` → `{:retry, entries}`
3. `drop_task_and_retry` pushes the same entries back to the **front** buffer and immediately respawns apps/indexer/lib/indexer/buffered_task.ex:928 — no retry counter, no backoff
4. Same `balanceOf` calls re-issued. The re-import still "succeeds with rows": `should_update?` and the `on_conflict` `WHERE` both pass because `value_fetched_at` is bumped to `now()` on every pass `apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex:296`, `apps/explorer/lib/explorer/chain/import/runner/address/current_token_balances.ex:329` → non-empty `imported_ctbs` → broadcast → retry → forever

Side effect worth noting: the loop also spams `address_current_token_balances` realtime events and churns `value_fetched_at`/`updated_at` writes on those rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token balance import failures are now logged at an error level, making issues easier to identify while preserving existing error handling and successful imports.
* **Tests**
  * Added coverage for balance retrieval, database persistence, timestamps, realtime broadcasts, bulk imports, empty imports, and invalid data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->