### PR TITLE
chore: Optimize logs by address queries

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -212,13 +212,24 @@ defmodule Explorer.Chain do
         from_block = from_block(options)
         to_block = to_block(options)
 
-        base =
-          Log
-          |> Log.address_match_query(address_hash)
-          |> join(:inner, [log], block in Block, on: block.number == log.block_number)
-          |> where([_l, block], block.consensus == true)
-          |> order_by([log], desc: log.block_number, desc: log.index)
-          |> limit(^paging_options.page_size)
+        query =
+          Log.address_match_union_query(
+            address_hash,
+            fn address_match_dynamic ->
+              Log
+              |> where(^address_match_dynamic)
+              |> join(:inner, [log], block in Block, on: block.number == log.block_number)
+              |> where([_l, block], block.consensus == true)
+              |> page_logs(paging_options)
+              |> filter_topic(Keyword.get(options, :topic))
+              |> BlockReaderGeneral.where_block_number_in_period(from_block, to_block)
+            end,
+            fn query ->
+              query
+              |> order_by([log], desc: log.block_number, desc: log.index)
+              |> limit(^paging_options.page_size)
+            end
+          )
 
         transaction_preloads =
           if csv_export? do
@@ -233,10 +244,7 @@ defmodule Explorer.Chain do
             )
           end
 
-        base
-        |> page_logs(paging_options)
-        |> filter_topic(Keyword.get(options, :topic))
-        |> BlockReaderGeneral.where_block_number_in_period(from_block, to_block)
+        query
         |> select_repo(options).all(ExplorerHelper.maybe_timeout(timeout))
         |> Enum.take(paging_options.page_size)
         |> Log.preload_block(select_repo(options))

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -55,7 +55,7 @@ defmodule Explorer.Chain.Address.Counters do
   @transactions_types [:transactions_from, :transactions_to, :transactions_contract]
 
   defp address_hash_to_logs_query(address_hash) do
-    Log.address_match_query(Log, address_hash)
+    Log.address_match_union_query(address_hash, fn address_match_dynamic -> where(Log, ^address_match_dynamic) end)
   end
 
   defp address_hash_to_validated_blocks_query(address_hash) do
@@ -67,7 +67,11 @@ defmodule Explorer.Chain.Address.Counters do
   end
 
   def check_if_logs_at_address(address_hash, options \\ []) do
-    select_repo(options).exists?(address_hash_to_logs_query(address_hash))
+    address_hash
+    |> Log.address_match_dynamics()
+    |> Enum.any?(fn address_match_dynamic ->
+      select_repo(options).exists?(where(Log, ^address_match_dynamic))
+    end)
   end
 
   def check_if_token_transfers_at_address(address_hash, options \\ []) do

--- a/apps/explorer/lib/explorer/chain/beacon/deposit.ex
+++ b/apps/explorer/lib/explorer/chain/beacon/deposit.ex
@@ -274,25 +274,33 @@ defmodule Explorer.Chain.Beacon.Deposit do
         ]
   def get_logs_with_deposits(deposit_contract_address_hash, log_block_number, log_index, limit) do
     query =
-      Log
-      |> Log.join_transaction_query()
-      |> Log.address_match_query(deposit_contract_address_hash)
-      |> where(as(:transaction).block_consensus == true)
-      |> Log.filter_by_topic_query(:first_topic, @deposit_event_signature)
-      |> where([log], {log.block_number, log.index} > {^log_block_number, ^log_index})
-      |> limit(^limit)
-      |> select([log], %{
-        first_topic: log.first_topic,
-        first_topic_id: log.first_topic_id,
-        data: log.data,
-        index: log.index,
-        block_number: log.block_number,
-        block_hash: as(:transaction).block_hash,
-        transaction_hash: as(:transaction).hash,
-        from_address_hash: as(:transaction).from_address_hash,
-        block_timestamp: as(:transaction).block_timestamp
-      })
-      |> order_by([log], asc: log.block_number, asc: log.index)
+      Log.address_match_union_query(
+        deposit_contract_address_hash,
+        fn address_match_dynamic ->
+          Log
+          |> Log.join_transaction_query()
+          |> where(^address_match_dynamic)
+          |> where(as(:transaction).block_consensus == true)
+          |> Log.filter_by_topic_query(:first_topic, @deposit_event_signature)
+          |> where([log], {log.block_number, log.index} > {^log_block_number, ^log_index})
+          |> select([log], %{
+            first_topic: log.first_topic,
+            first_topic_id: log.first_topic_id,
+            data: log.data,
+            index: log.index,
+            block_number: log.block_number,
+            block_hash: as(:transaction).block_hash,
+            transaction_hash: as(:transaction).hash,
+            from_address_hash: as(:transaction).from_address_hash,
+            block_timestamp: as(:transaction).block_timestamp
+          })
+        end,
+        fn query ->
+          query
+          |> order_by([log], asc: log.block_number, asc: log.index)
+          |> limit(^limit)
+        end
+      )
 
     query
     |> Repo.all()

--- a/apps/explorer/lib/explorer/chain/log.ex
+++ b/apps/explorer/lib/explorer/chain/log.ex
@@ -956,7 +956,8 @@ defmodule Explorer.Chain.Log do
   After the optimized fields migration has finished, address hashes are converted
   to address ids and matched through `address_id`. While the migration is in
   progress, the condition matches both `address_id` and the legacy
-  `address_hash` field.
+  `address_hash` field with `OR`. Queries that fetch a page of logs of a single
+  address should use `address_match_union_query/3` instead.
   """
   @spec address_match_query(Ecto.Queryable.t(), Hash.Address.t() | [Hash.Address.t()] | binary() | [binary()]) ::
           Ecto.Query.t()
@@ -976,27 +977,106 @@ defmodule Explorer.Chain.Log do
   end
 
   def address_match_query(query, address_hash) do
+    where(query, ^address_match_dynamic(address_hash))
+  end
+
+  @doc """
+  Returns the list of independent conditions matching logs of the given address.
+
+  While the optimized fields migration is in progress, logs of the same address
+  are stored either with the new `address_id` or with the legacy `address_hash`,
+  so two conditions are returned. In all other cases the list holds a single
+  condition.
+
+  The conditions are meant to be combined with `UNION ALL`, one query branch per
+  condition (see `address_match_union_query/3`), rather than with `OR`: a single
+  `OR` condition doesn't let
+  PostgreSQL use the `address_id` and `address_hash` indexes to return already
+  ordered rows, forcing it to collect and sort every log of the address before
+  applying the `LIMIT`. With `UNION ALL` each branch is an ordered index scan,
+  so the planner can merge the branches and stop at the `LIMIT`.
+
+  The conditions never match the same log twice, so that `UNION ALL` doesn't
+  produce duplicates: the legacy condition is limited to the logs which have no
+  `address_id` yet. Both fields can be filled at once, since a log re-imported
+  before it is migrated keeps its `address_hash` while the upsert fills
+  `address_id`.
+  """
+  @spec address_match_dynamics(Hash.Address.t() | binary()) :: [Ecto.Query.dynamic_expr()]
+  def address_match_dynamics(address_hash) do
     cond do
       LogHelper.fill_optimized_fields_migration_finished?() ->
         address_id = AddressIdToAddressHash.hash_to_id(address_hash)
-        where(query, [l], ^address_id_match_dynamic(address_id))
+
+        [address_id_match_dynamic(address_id)]
 
       LogHelper.fill_optimized_fields_migration_started?() ->
         address_id = AddressIdToAddressHash.hash_to_id(address_hash)
-        where(query, [l], ^address_id_or_hash_match_dynamic(address_id, address_hash))
+
+        if address_id do
+          [
+            dynamic([l], l.address_id == ^address_id),
+            dynamic([l], is_nil(l.address_id) and l.address_hash == ^address_hash)
+          ]
+        else
+          [dynamic([l], l.address_hash == ^address_hash)]
+        end
 
       true ->
-        where(query, [l], l.address_hash == ^address_hash)
+        [dynamic([l], l.address_hash == ^address_hash)]
+    end
+  end
+
+  defp address_match_dynamic(address_hash) do
+    address_hash
+    |> address_match_dynamics()
+    |> Enum.reduce(fn match_dynamic, acc -> dynamic([l], ^acc or ^match_dynamic) end)
+  end
+
+  @doc """
+  Builds a logs query for the given address hash, combining one query branch per
+  `address_match_dynamics/1` condition with `UNION ALL`.
+
+  `branch_fun` receives an address match condition and must return the complete
+  branch: every filter, join and select has to be applied inside it, since
+  `where/3`, `join/5` and `select/3` applied to a combination query would only
+  affect its first branch.
+
+  `paging_fun` applies the ordering and the limit. It is applied to every branch
+  and then to the whole combination, so that each branch stays an ordered index
+  scan bounded by the limit instead of being fully materialized and sorted.
+  Queries without ordering can omit it: an outer `LIMIT` alone already stops
+  `UNION ALL` branches early.
+
+  A single condition, which is the case for every address once the optimized
+  fields migration has finished, produces no combination at all.
+  """
+  @spec address_match_union_query(
+          Hash.Address.t() | binary(),
+          (Ecto.Query.dynamic_expr() -> Ecto.Queryable.t()),
+          (Ecto.Queryable.t() -> Ecto.Queryable.t())
+        ) :: Ecto.Query.t()
+  def address_match_union_query(address_hash, branch_fun, paging_fun \\ fn query -> query end) do
+    branches =
+      address_hash
+      |> address_match_dynamics()
+      |> Enum.map(fn address_match_dynamic -> address_match_dynamic |> branch_fun.() |> paging_fun.() end)
+
+    case branches do
+      [branch] ->
+        branch
+
+      branches ->
+        branches
+        |> Enum.map(&Chain.wrapped_union_subquery/1)
+        |> Enum.reduce(fn branch, acc -> union_all(acc, ^branch) end)
+        |> Chain.wrapped_union_subquery()
+        |> paging_fun.()
     end
   end
 
   defp address_id_match_dynamic(nil), do: dynamic(false)
   defp address_id_match_dynamic(address_id), do: dynamic([l], l.address_id == ^address_id)
-
-  defp address_id_or_hash_match_dynamic(nil, address_hash), do: dynamic([l], l.address_hash == ^address_hash)
-
-  defp address_id_or_hash_match_dynamic(address_id, address_hash),
-    do: dynamic([l], l.address_id == ^address_id or l.address_hash == ^address_hash)
 
   @doc """
   Joins the log first topic lookup table to the given logs query.

--- a/apps/explorer/test/explorer/chain/address/counters_test.exs
+++ b/apps/explorer/test/explorer/chain/address/counters_test.exs
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Address.CountersTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Address.Counters
+
+  describe "check_if_logs_at_address/2" do
+    test "detects logs stored with `address_id` and with the legacy `address_hash` while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      address_with_migrated_log = insert(:address)
+      address_with_legacy_log = insert(:address)
+      address_without_logs = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      log_params = [block: transaction.block, block_number: transaction.block_number, transaction: transaction]
+
+      # already migrated log, matched by `address_id`
+      insert(:log, log_params ++ [index: 1, address: address_with_migrated_log, address_hash: nil])
+      # not yet migrated log, matched by the legacy `address_hash`
+      insert(:log, log_params ++ [index: 2, address: address_with_legacy_log, address_mapping: nil])
+
+      assert Counters.check_if_logs_at_address(address_with_migrated_log.hash)
+      assert Counters.check_if_logs_at_address(address_with_legacy_log.hash)
+      refute Counters.check_if_logs_at_address(address_without_logs.hash)
+    end
+  end
+
+  describe "address_limited_counters/2" do
+    test "counts logs matched by `address_id` and by the legacy `address_hash` while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(to_address: address)
+        |> with_block()
+
+      log_params = [
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        address: address
+      ]
+
+      # already migrated logs, matched by `address_id`
+      insert(:log, log_params ++ [index: 1, address_hash: nil])
+      insert(:log, log_params ++ [index: 2, address_hash: nil])
+      # not yet migrated log, matched by the legacy `address_hash`
+      insert(:log, log_params ++ [index: 3, address_mapping: nil])
+      # re-imported log with both fields filled, counted once
+      insert(:log, log_params ++ [index: 4])
+      # log of another address
+      insert(:log, log_params ++ [index: 5, address: insert(:address), address_mapping: nil])
+
+      assert %{logs: 4} = Counters.address_limited_counters(address.hash, [])
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain/beacon/deposit_test.exs
+++ b/apps/explorer/test/explorer/chain/beacon/deposit_test.exs
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Beacon.DepositTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Beacon.Deposit
+  alias Explorer.Chain.Hash
+
+  @deposit_event_signature "0x649BBC62D0E31342AFEA4E5CD82D4049E7E1EE912FC0889AA790803BE39038C5"
+
+  describe "get_logs_with_deposits/4" do
+    test "fetches logs matched by `address_id` and by the legacy `address_hash` while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      deposit_contract_address = insert(:address)
+      {:ok, first_topic} = Hash.Full.cast(@deposit_event_signature)
+
+      transaction =
+        :transaction
+        |> insert(to_address: deposit_contract_address)
+        |> with_block()
+
+      log_params = [
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        address: deposit_contract_address,
+        first_topic: first_topic
+      ]
+
+      # already migrated log, matched by `address_id`
+      insert(:log, log_params ++ [index: 1, address_hash: nil])
+      # not yet migrated log, matched by the legacy `address_hash`
+      insert(:log, log_params ++ [index: 2, address_mapping: nil])
+      # re-imported log with both fields filled, returned once
+      insert(:log, log_params ++ [index: 3])
+      # log of another address
+      insert(:log, log_params ++ [index: 4, address: insert(:address), address_mapping: nil])
+      # log with another first topic
+      insert(:log, log_params ++ [index: 5, first_topic: nil, address_hash: nil])
+
+      logs = Deposit.get_logs_with_deposits(deposit_contract_address.hash, transaction.block_number - 1, 0, 10)
+
+      assert [1, 2, 3] == Enum.map(logs, & &1.index)
+
+      assert Enum.all?(logs, fn log ->
+               log.block_number == transaction.block_number and log.transaction_hash == transaction.hash and
+                 log.from_address_hash == transaction.from_address_hash and log.first_topic == first_topic
+             end)
+    end
+
+    test "respects the limit and the paging key while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      deposit_contract_address = insert(:address)
+      {:ok, first_topic} = Hash.Full.cast(@deposit_event_signature)
+
+      transaction =
+        :transaction
+        |> insert(to_address: deposit_contract_address)
+        |> with_block()
+
+      log_params = [
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        address: deposit_contract_address,
+        first_topic: first_topic
+      ]
+
+      insert(:log, log_params ++ [index: 1, address_hash: nil])
+      insert(:log, log_params ++ [index: 2, address_mapping: nil])
+      insert(:log, log_params ++ [index: 3, address_hash: nil])
+
+      assert [1] ==
+               deposit_contract_address.hash
+               |> Deposit.get_logs_with_deposits(transaction.block_number - 1, 0, 1)
+               |> Enum.map(& &1.index)
+
+      assert [2, 3] ==
+               deposit_contract_address.hash
+               |> Deposit.get_logs_with_deposits(transaction.block_number, 1, 10)
+               |> Enum.map(& &1.index)
+    end
+  end
+end

--- a/apps/explorer/test/explorer/chain_test.exs
+++ b/apps/explorer/test/explorer/chain_test.exs
@@ -106,6 +106,104 @@ defmodule Explorer.ChainTest do
       assert Enum.count(Chain.address_to_logs(address_hash, false)) == 2
     end
 
+    test "fetches logs matched by `address_id` and by the legacy `address_hash` while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      %Address{hash: address_hash} = address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(to_address: address)
+        |> with_block()
+
+      # already migrated log, matched by `address_id`
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 1,
+        address: address,
+        address_hash: nil
+      )
+
+      # not yet migrated log, matched by the legacy `address_hash`
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 2,
+        address: address,
+        address_mapping: nil
+      )
+
+      # log re-imported before it is migrated: the upsert fills `address_id` while
+      # `address_hash` is kept, so both fields match the address and the log has to
+      # be returned once
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 3,
+        address: address
+      )
+
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 4,
+        address: insert(:address),
+        address_mapping: nil
+      )
+
+      assert [3, 2, 1] == address_hash |> Chain.address_to_logs(false) |> Enum.map(& &1.index)
+
+      paging_options = %PagingOptions{page_size: 1}
+
+      assert [3] == address_hash |> Chain.address_to_logs(false, paging_options: paging_options) |> Enum.map(& &1.index)
+
+      paging_options = %PagingOptions{page_size: 50, key: {transaction.block_number, 2}}
+
+      assert [1] == address_hash |> Chain.address_to_logs(false, paging_options: paging_options) |> Enum.map(& &1.index)
+    end
+
+    test "filters logs by topic while the optimized fields migration is in progress" do
+      set_fill_logs_optimized_fields_migration_started()
+
+      %Address{hash: address_hash} = address = insert(:address)
+
+      transaction =
+        :transaction
+        |> insert(to_address: address)
+        |> with_block()
+
+      {:ok, first_topic} = Hash.Full.cast(@first_topic_hex_string)
+
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 1,
+        address: address,
+        address_hash: nil
+      )
+
+      insert(:log,
+        block: transaction.block,
+        block_number: transaction.block_number,
+        transaction: transaction,
+        index: 2,
+        address: address,
+        address_mapping: nil,
+        first_topic: first_topic
+      )
+
+      assert [2] ==
+               address_hash
+               |> Chain.address_to_logs(false, topic: @first_topic_hex_string)
+               |> Enum.map(& &1.index)
+    end
+
     test "paginates logs" do
       %Address{hash: address_hash} = address = insert(:address)
 

--- a/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
+++ b/apps/explorer/test/explorer/migrator/fill_logs_optimized_fields_test.exs
@@ -3,11 +3,18 @@ defmodule Explorer.Migrator.FillLogsOptimizedFieldsTest do
 
   import Ecto.Query
 
+  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.{Log, TokenTransfer}
   alias Explorer.Migrator.{FillLogsOptimizedFields, MigrationStatus}
   alias Explorer.Migrator.HeavyDbIndexOperation.CreateLogsFirstTopicIdIndex
   alias Explorer.{Repo, TestHelper}
   alias Explorer.Utility.{AddressIdToAddressHash, LogFirstTopic}
+
+  setup do
+    initial_status = BackgroundMigrations.get_fill_logs_optimized_fields_finished()
+
+    on_exit(fn -> BackgroundMigrations.set_fill_logs_optimized_fields_finished(initial_status) end)
+  end
 
   test "fills relates fields" do
     transaction = :transaction |> insert() |> with_block()

--- a/apps/explorer/test/support/data_case.ex
+++ b/apps/explorer/test/support/data_case.ex
@@ -16,6 +16,7 @@ defmodule Explorer.DataCase do
   use ExUnit.CaseTemplate
 
   alias Ecto.Changeset
+  alias Explorer.Chain.Cache.BackgroundMigrations
 
   using do
     quote do
@@ -71,6 +72,29 @@ defmodule Explorer.DataCase do
     _error in [DBConnection.ConnectionError, Ecto.NoResultsError] ->
       Process.sleep(300)
       wait_for_results(producer, retries - 1)
+  end
+
+  @doc """
+  Emulates the state when the `fill_logs_optimized_fields` migration is started
+  but not finished yet, so logs are stored either with the new `address_id` or
+  with the legacy `address_hash`.
+
+  Both cached statuses are set explicitly and restored afterwards:
+  `Explorer.Chain.Cache.BackgroundMigrations` is a process-wide cache which is
+  not rolled back by the sandbox, so another test completing the migration
+  leaks a finished status into the whole test run.
+  """
+  def set_fill_logs_optimized_fields_migration_started do
+    initial_started? = BackgroundMigrations.get_create_logs_block_number_transaction_index_index_unique_index_finished()
+    initial_finished? = BackgroundMigrations.get_fill_logs_optimized_fields_finished()
+
+    BackgroundMigrations.set_create_logs_block_number_transaction_index_index_unique_index_finished(true)
+    BackgroundMigrations.set_fill_logs_optimized_fields_finished(false)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      BackgroundMigrations.set_create_logs_block_number_transaction_index_index_unique_index_finished(initial_started?)
+      BackgroundMigrations.set_fill_logs_optimized_fields_finished(initial_finished?)
+    end)
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

In case when `fill_logs_optimized_fields` migration hasn't finished yet, logs by address query builds with `OR` condition by `address_hash` and `address_id`. It's more efficient to use `UNION ALL` instead of `OR` especially because Postgre not always use `Bitmap OR` even if there are two indexed columns in query.

## Changelog

Use `UNION ALL` instead of `OR` condition in logs by address queries when it brings value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address-based log searches across current and legacy records.
  * Preserved topic and block-range filtering, pagination, ordering, and result limits.
  * Improved log existence checks and deposit-log retrieval for more reliable results.

* **Tests**
  * Added coverage for address matching, deposit logs, pagination, filtering, result limits, and log metadata across supported record formats.
  * Added test coverage for searches while background data updates are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->