### PR TITLE
doc: document reCAPTCHA as headers in refetch-metadata OpenAPI spec

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
@@ -21,6 +21,12 @@ defmodule BlockScoutWeb.CaptchaHelper do
       * `"recaptcha_v3_response"` - A reCAPTCHA v3 response token
       * `"recaptcha_response"` - A reCAPTCHA v2 response token
 
+      These keys are the internal contract of this function, not a wire format.
+      `/api/v2/key` passes request params through as-is, so there they match the
+      body params; for rate limited endpoints
+      `BlockScoutWeb.RateLimit.collect_recaptcha_headers/1` builds this map from
+      the `recaptcha-*` request headers instead.
+
     ## Returns
     - `true` if the CAPTCHA challenge is passed or if a valid bypass token is provided.
     - `false` if the CAPTCHA challenge fails, input is missing, CAPTCHA is disabled,
@@ -72,7 +78,7 @@ defmodule BlockScoutWeb.CaptchaHelper do
 
     ## Returns
     - `true` if either:
-      * A valid API key is provided for an allowed endpoint
+      * A valid scoped bypass token is provided for `scope`
       * The CAPTCHA verification succeeds
     - `false` otherwise
   """

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -728,15 +728,14 @@ defmodule BlockScoutWeb.API.V2.TokenController do
   operation :refetch_metadata,
     summary: "Trigger a refresh of metadata for a specific NFT",
     description:
-      "Triggers a refresh of metadata for a specific NFT instance. Useful when the NFT's metadata has been updated but is not yet reflected in the BlockScout database.",
+      "Triggers a refresh of metadata for a specific NFT instance. Useful when the NFT's metadata has been updated but is not yet reflected in the BlockScout database. The endpoint is rate limited per IP; once the limit is reached, a valid reCAPTCHA header is required to proceed.",
     parameters:
       base_params() ++
         [
           address_hash_param(),
           token_id_param(),
-          recaptcha_response_param(),
           scoped_recaptcha_bypass_token_param()
-        ],
+        ] ++ recaptcha_params(),
     responses: [
       ok:
         {"Metadata refresh has been successfully initiated.", "application/json",

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/general.ex
@@ -737,17 +737,46 @@ defmodule BlockScoutWeb.Schemas.API.V2.General do
   end
 
   @doc """
-  Returns a parameter definition for reCAPTCHA response token.
+  Returns parameter definitions for the reCAPTCHA headers.
+
+  These headers are consumed by the rate limiter, not by the controller: they are
+  checked only once the endpoint's rate limit has been reached, and a successful
+  verification allows the request instead of returning 429. Only one of them is
+  used per request, in the order listed below.
   """
-  @spec recaptcha_response_param() :: Parameter.t()
-  def recaptcha_response_param do
-    %Parameter{
-      name: :recaptcha_response,
-      in: :query,
-      schema: %Schema{type: :string},
-      required: false,
-      description: "reCAPTCHA response token"
-    }
+  @spec recaptcha_params() :: [Parameter.t()]
+  def recaptcha_params do
+    [
+      %Parameter{
+        name: :"recaptcha-v2-response",
+        in: :header,
+        schema: %Schema{type: :string},
+        required: false,
+        description: "reCAPTCHA v2 response token"
+      },
+      %Parameter{
+        name: :"recaptcha-v3-response",
+        in: :header,
+        schema: %Schema{type: :string},
+        required: false,
+        description: "reCAPTCHA v3 response token"
+      },
+      %Parameter{
+        name: :"scoped-recaptcha-bypass-token",
+        in: :header,
+        schema: %Schema{type: :string},
+        required: false,
+        description:
+          "Bypass token issued to trusted clients for this specific endpoint. May also be passed as the `scoped_recaptcha_bypass_token` query parameter; the header takes precedence"
+      },
+      %Parameter{
+        name: :"recaptcha-bypass-token",
+        in: :header,
+        schema: %Schema{type: :string},
+        required: false,
+        description: "Bypass token issued to trusted clients for all reCAPTCHA-protected endpoints"
+      }
+    ]
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

A report against `PATCH /api/v2/tokens/{address_hash_param}/instances/{token_id_param}/refetch-metadata` claimed the endpoint had lost its CAPTCHA enforcement, citing that the operation declares `recaptcha_response_param()` while the controller body never reads it.

The enforcement is intact — the CAPTCHA is verified by the rate limiter, not the controller — but the OpenAPI declaration was genuinely wrong, and is what made it look absent. It declared:

```elixir
%Parameter{name: :recaptcha_response, in: :query, ...}
```

whereas `BlockScoutWeb.RateLimit.collect_recaptcha_headers/1` reads the CAPTCHA from **headers**: `recaptcha-v2-response`, `recaptcha-v3-response`, `scoped-recaptcha-bypass-token`, `recaptcha-bypass-token`. No code path reads a `recaptcha_response` query parameter, so the documented parameter had no effect while the four real headers went undocumented.

The one exception is `scoped_recaptcha_bypass_token`, which `collect_recaptcha_headers/1` does accept as a query parameter as a fallback behind the `scoped-recaptcha-bypass-token` header. That parameter was already documented and stays.

## Changelog

### Enhancements

- `BlockScoutWeb.Schemas.API.V2.General.recaptcha_params/0` documents all four reCAPTCHA headers consumed by the rate limiter, listed in the same precedence order as `collect_recaptcha_headers/1`, including the previously undocumented `scoped-recaptcha-bypass-token` used by trusted clients via `RE_CAPTCHA_TOKEN_INSTANCE_REFETCH_METADATA_SCOPED_BYPASS_TOKEN`.
- The description of the `scoped-recaptcha-bypass-token` header notes that the same value may be supplied as the `scoped_recaptcha_bypass_token` query parameter, and that the header takes precedence — so the two entries in the rendered spec don't read as contradictory.
- The `refetch_metadata` operation description now states that the endpoint is rate limited per IP and that a reCAPTCHA header is required only once that limit is reached, rather than on every request.
- `CaptchaHelper.recaptcha_passed?/1` docs now note that its map keys (`"recaptcha_response"`, `"recaptcha_v3_response"`, `"recaptcha_bypass_token"`) are an internal contract rather than a wire format: `/api/v2/key` passes request params through unchanged, while for rate limited endpoints the map is built from headers.

### Bug Fixes

- `refetch_metadata` no longer advertises a `recaptcha_response` query parameter that no code path reads, and now documents the headers that are actually consumed.
- Corrected the `recaptcha_passed?/2` docs, which claimed the function returns `true` when "a valid API key is provided for an allowed endpoint". There is no API key involved; the check is a scoped bypass token matched against `scope`.

### Incompatible Changes

- `BlockScoutWeb.Schemas.API.V2.General.recaptcha_response_param/0` is removed and replaced by `recaptcha_params/0`, which returns a list of `Parameter.t()` rather than a single one. It had one call site in the repository, updated here. `scoped_recaptcha_bypass_token_param/0` is unchanged.
- The published OpenAPI document for `refetch_metadata` drops the `recaptcha_response` query parameter and gains four header parameters. This corrects documentation only; the parameter was never read, so no request that worked before stops working.

## Upgrading

No database changes and no configuration changes. Generated API clients should be regenerated to pick up the corrected parameter definitions for `refetch_metadata`.

Callers that were sending `?recaptcha_response=...` in reliance on the old spec were never having it verified. To pass a CAPTCHA on this endpoint, send `recaptcha-v2-response` or `recaptcha-v3-response` as a request header instead.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it. _(N/A — spec and docs only, no new behavior. The existing 96 tests in `token_controller_test.exs` pass, including the two that exercise the `scoped_recaptcha_bypass_token` query parameter.)_
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again. _(See note below — request parameters are not asserted against the spec anywhere in this repo today.)_
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CAPTCHA authentication requirements for token metadata refetching.
  * Documented IP rate limiting, reCAPTCHA v2/v3 responses, and scoped or global bypass tokens.
  * Updated API parameter documentation to reflect supported CAPTCHA headers and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->