### PR TITLE
fix: Adapt OnDemant IT fetcher test for rsk and filecoin

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2529,7 +2529,7 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
           "input" => "",
           "isError" => "0",
           "timeStamp" => "#{DateTime.to_unix(transaction.block.timestamp)}",
-          "to" => "",
+          "to" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
           "transactionHash" => "#{transaction.hash}",
           "type" => "create",
           "value" => "0"
@@ -5110,6 +5110,12 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
                  }
                }
              ]}
+        end)
+
+        original_config = Application.get_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth)
+
+        on_exit(fn ->
+          Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, original_config)
         end)
 
         Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, tracer: "call_tracer", debug_trace_timeout: "5s")

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/address_controller_test.exs
@@ -2500,82 +2500,58 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
       assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
     end
 
-    if Application.compile_env(:explorer, :chain_type) not in [:rsk, :filecoin] do
-      test "via on-demand fetcher", %{conn: conn} do
-        original_config = Application.get_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions)
+    test "via on-demand fetcher", %{conn: conn} do
+      original_config = Application.get_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions)
 
-        Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions,
-          enabled: true,
-          storage_period: 0
-        )
+      Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions,
+        enabled: true,
+        storage_period: 0
+      )
 
-        on_exit(fn ->
-          Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions, original_config)
-        end)
+      on_exit(fn ->
+        Application.put_env(:explorer, Explorer.Migrator.DeleteZeroValueInternalTransactions, original_config)
+      end)
 
-        transaction = :transaction |> insert() |> with_block()
+      transaction = :transaction |> insert() |> with_block()
 
-        expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
-          [%{id: id, params: _}], _ ->
-            {:ok,
-             [
-               %{
-                 id: id,
-                 result: %{
-                   "type" => "create",
-                   "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
-                   "to" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
-                   "value" => "0x0",
-                   "gas" => "0x106f5",
-                   "gasUsed" => "0x106f5",
-                   "input" =>
-                     "0x608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033",
-                   "output" =>
-                     "0x608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033"
-                 }
-               }
-             ]}
-        end)
+      mock_contract_creation_trace_fetching(transaction)
 
-        Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, tracer: "call_tracer", debug_trace_timeout: "5s")
-
-        expected_result = [
-          %{
-            "blockNumber" => "#{transaction.block_number}",
-            "callType" => "",
-            "contractAddress" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
-            "errCode" => "",
-            "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
-            "gas" => "67317",
-            "gasUsed" => "67317",
-            "index" => "0",
-            "input" => "",
-            "isError" => "0",
-            "timeStamp" => "#{DateTime.to_unix(transaction.block.timestamp)}",
-            "to" => "",
-            "transactionHash" => "#{transaction.hash}",
-            "type" => "create",
-            "value" => "0"
-          }
-        ]
-
-        params = %{
-          "module" => "account",
-          "action" => "txlistinternal",
-          "txhash" => "#{transaction.hash}",
-          "include_zero_value" => "true"
+      expected_result = [
+        %{
+          "blockNumber" => "#{transaction.block_number}",
+          "callType" => "",
+          "contractAddress" => "0x205a6b72ce16736c9d87172568a9c0cb9304de0d",
+          "errCode" => "",
+          "from" => "0x117b358218da5a4f647072ddb50ded038ed63d17",
+          "gas" => "67317",
+          "gasUsed" => "67317",
+          "index" => "0",
+          "input" => "",
+          "isError" => "0",
+          "timeStamp" => "#{DateTime.to_unix(transaction.block.timestamp)}",
+          "to" => "",
+          "transactionHash" => "#{transaction.hash}",
+          "type" => "create",
+          "value" => "0"
         }
+      ]
 
-        assert response =
-                 conn
-                 |> get("/api/v1", params)
-                 |> json_response(200)
+      params = %{
+        "module" => "account",
+        "action" => "txlistinternal",
+        "txhash" => "#{transaction.hash}",
+        "include_zero_value" => "true"
+      }
 
-        assert response["result"] == expected_result
-        assert response["status"] == "1"
-        assert response["message"] == "OK"
-        assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
-      end
+      assert response =
+               conn
+               |> get("/api/v1", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert :ok = ExJsonSchema.Validator.validate(txlistinternal_schema(), response)
     end
   end
 
@@ -5064,6 +5040,80 @@ defmodule BlockScoutWeb.API.RPC.AddressControllerTest do
 
       assert result == {:required_params, {:ok, params}}
     end
+  end
+
+  @contract_creation_from "0x117b358218da5a4f647072ddb50ded038ed63d17"
+  @contract_creation_address "0x205a6b72ce16736c9d87172568a9c0cb9304de0d"
+  @contract_creation_gas "0x106f5"
+  @contract_creation_init "0x608060405234801561001057600080fd5b50610150806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033"
+  @contract_creation_code "0x608060405234801561001057600080fd5b50600436106100365760003560e01c80632e64cec11461003b5780636057361d14610059575b600080fd5b610043610075565b60405161005091906100d9565b60405180910390f35b610073600480360381019061006e919061009d565b61007e565b005b60008054905090565b8060008190555050565b60008135905061009781610103565b92915050565b6000602082840312156100b3576100b26100fe565b5b60006100c184828501610088565b91505092915050565b6100d3816100f4565b82525050565b60006020820190506100ee60008301846100ca565b92915050565b6000819050919050565b600080fd5b61010c816100f4565b811461011757600080fd5b5056fea26469706673582212209a159a4f3847890f10bfb87871a61eba91c5dbf5ee3cf6398207e292eee22a1664736f6c63430008070033"
+
+  case Application.compile_env(:explorer, :chain_type) do
+    chain_type when chain_type in [:rsk, :filecoin] ->
+      # `EthereumJSONRPC.RSK` and `EthereumJSONRPC.Filecoin` variants don't support tracing of a
+      # single transaction, so the on-demand fetcher falls back to `trace_block` for them
+      defp mock_contract_creation_trace_fetching(transaction) do
+        block_number = transaction.block_number
+        block_quantity = EthereumJSONRPC.integer_to_quantity(block_number)
+        transaction_hash = to_string(transaction.hash)
+        transaction_index = transaction.index
+
+        expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
+          [%{id: id, method: "trace_block", params: [^block_quantity]}], _ ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 result: [
+                   %{
+                     "type" => "create",
+                     "subtraces" => 0,
+                     "traceAddress" => [],
+                     "action" => %{
+                       "from" => @contract_creation_from,
+                       "gas" => @contract_creation_gas,
+                       "value" => "0x0",
+                       "init" => @contract_creation_init
+                     },
+                     "result" => %{
+                       "address" => @contract_creation_address,
+                       "gasUsed" => @contract_creation_gas,
+                       "code" => @contract_creation_code
+                     },
+                     "blockNumber" => block_number,
+                     "transactionHash" => transaction_hash,
+                     "transactionPosition" => transaction_index
+                   }
+                 ]
+               }
+             ]}
+        end)
+      end
+
+    _ ->
+      defp mock_contract_creation_trace_fetching(_transaction) do
+        expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn
+          [%{id: id, params: _}], _ ->
+            {:ok,
+             [
+               %{
+                 id: id,
+                 result: %{
+                   "type" => "create",
+                   "from" => @contract_creation_from,
+                   "to" => @contract_creation_address,
+                   "value" => "0x0",
+                   "gas" => @contract_creation_gas,
+                   "gasUsed" => @contract_creation_gas,
+                   "input" => @contract_creation_init,
+                   "output" => @contract_creation_code
+                 }
+               }
+             ]}
+        end)
+
+        Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth, tracer: "call_tracer", debug_trace_timeout: "5s")
+      end
   end
 
   defp listaccounts_schema do

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -545,8 +545,12 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   defp filter_by_address(internal_transactions, address_hash, direction) do
     Enum.filter(internal_transactions, fn internal_transaction ->
       case direction do
-        d when d in [:to, :to_address_hash] ->
+        :to ->
           internal_transaction.to_address_hash == address_hash
+
+        :to_address_hash ->
+          internal_transaction.to_address_hash == address_hash and
+            is_nil(internal_transaction.created_contract_address_hash)
 
         d when d in [:from, :from_address_hash] ->
           internal_transaction.from_address_hash == address_hash
@@ -755,16 +759,16 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   end
 
   defp serialize(internal_transaction_params) do
+    to_address_hash = convert_to_address_hash(internal_transaction_params[:to_address_hash])
+    created_contract_address_hash = convert_to_address_hash(internal_transaction_params[:created_contract_address_hash])
+
     %InternalTransaction{}
     |> InternalTransaction.changeset(internal_transaction_params)
     |> Ecto.Changeset.apply_changes()
     |> Map.put(:transaction_hash, internal_transaction_params[:transaction_hash])
     |> Map.put(:from_address_hash, convert_to_address_hash(internal_transaction_params[:from_address_hash]))
-    |> Map.put(:to_address_hash, convert_to_address_hash(internal_transaction_params[:to_address_hash]))
-    |> Map.put(
-      :created_contract_address_hash,
-      convert_to_address_hash(internal_transaction_params[:created_contract_address_hash])
-    )
+    |> Map.put(:to_address_hash, to_address_hash || created_contract_address_hash)
+    |> Map.put(:created_contract_address_hash, created_contract_address_hash)
   end
 
   defp convert_to_address_hash(nil), do: nil

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -400,6 +400,59 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
     assert result |> Enum.filter(&(&1.block_number == 2)) |> Enum.count() == 1
   end
 
+  test "fetch_by_address/2 (contract creation)" do
+    address = insert(:address)
+    address_hash_str = to_string(address.hash)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    insert(:deleted_internal_transactions_address_placeholder,
+      address_id: id_to_hash.address_id,
+      block_number: 1,
+      count_tos: 1,
+      count_froms: 0
+    )
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, 2, fn [%{id: id, params: ["0x1", _]}], _ ->
+      {:ok,
+       [
+         %{
+           id: id,
+           result: [
+             %{
+               "result" => %{
+                 "from" => "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                 "gas" => "0x106f5",
+                 "gasUsed" => "0x106f5",
+                 "input" => "0x6080",
+                 "output" => "0x6080",
+                 "to" => address_hash_str,
+                 "type" => "CREATE",
+                 "value" => "0x0"
+               },
+               "txHash" => "0x32b17f27ddb546eab3c4c33f31eb22c1cb992d4ccc50dae26922805b717efe5c"
+             }
+           ]
+         }
+       ]}
+    end)
+
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth,
+      tracer: "call_tracer",
+      debug_trace_timeout: "5s",
+      block_traceable?: true
+    )
+
+    opts = [paging_options: %PagingOptions{page_size: 1}]
+
+    assert [%InternalTransaction{type: :create, to_address_hash: to_address_hash}] =
+             InternalTransactionOnDemand.fetch_by_address(address.hash, Keyword.put(opts, :direction, :to))
+
+    assert to_address_hash == address.hash
+
+    assert [] =
+             InternalTransactionOnDemand.fetch_by_address(address.hash, Keyword.put(opts, :direction, :to_address_hash))
+  end
+
   test "fetch_by_address/2 (no suitable placeholders)" do
     address = insert(:address)
     address_hash_str = to_string(address.hash)
@@ -473,7 +526,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
              %{
                created_contract_address_hash: created_contract_address_hash,
                from_address_hash: from_address_hash,
-               to_address_hash: nil,
+               to_address_hash: to_address_hash,
                block_timestamp: ^block_timestamp,
                transaction_hash: ^transaction_hash,
                error: nil
@@ -481,6 +534,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
            ] = InternalTransactionOnDemand.etherscan_fetch_by_transaction(transaction, %{})
 
     assert to_string(created_contract_address_hash) == "0x205a6b72ce16736c9d87172568a9c0cb9304de0d"
+    assert to_string(to_address_hash) == "0x205a6b72ce16736c9d87172568a9c0cb9304de0d"
     assert to_string(from_address_hash) == "0x117b358218da5a4f647072ddb50ded038ed63d17"
   end
 end


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14315

Also fixed the difference between on-demand and from-db filtering by `to_address_hash` behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved internal transaction address filtering for regular transactions and contract-creation transactions.
  - Contract-creation results now consistently include the created contract address.
  - Updated transaction serialization and address-based lookups for more accurate results.

- **Tests**
  - Expanded coverage across all supported chain types.
  - Added validation for transaction traces, contract creation, and address filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->