### PR TITLE
perf: Fetch address existence checks in a single query

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex
@@ -109,6 +109,8 @@ defmodule BlockScoutWeb.API.V2.AddressView do
     creation_transaction_hash = creator_hash && AddressView.transaction_hash(address)
     token = address.token && TokenView.render("token.json", %{token: address.token})
 
+    existence_checks = Counters.address_existence_checks(address.hash, @api_true)
+
     extended_info =
       Map.merge(base_info, %{
         "creator_address_hash" => creator_hash && Address.checksum(creator_hash),
@@ -118,12 +120,12 @@ defmodule BlockScoutWeb.API.V2.AddressView do
         "coin_balance" => balance,
         "exchange_rate" => exchange_rate,
         "block_number_balance_updated_at" => address.fetched_coin_balance_block_number,
-        "has_validated_blocks" => Counters.check_if_validated_blocks_at_address(address.hash, @api_true),
-        "has_logs" => Counters.check_if_logs_at_address(address.hash, @api_true),
-        "has_tokens" => Counters.check_if_tokens_at_address(address.hash, @api_true),
-        "has_token_transfers" => Counters.check_if_token_transfers_at_address(address.hash, @api_true),
+        "has_validated_blocks" => existence_checks.has_validated_blocks,
+        "has_logs" => existence_checks.has_logs,
+        "has_tokens" => existence_checks.has_tokens,
+        "has_token_transfers" => existence_checks.has_token_transfers,
         "watchlist_address_id" => WatchlistAddress.select_watchlist_address_id(get_watchlist_id(conn), address.hash),
-        "has_beacon_chain_withdrawals" => Counters.check_if_withdrawals_at_address(address.hash, @api_true)
+        "has_beacon_chain_withdrawals" => existence_checks.has_beacon_chain_withdrawals
       })
 
     extended_info

--- a/apps/explorer/lib/explorer/chain/address/counters.ex
+++ b/apps/explorer/lib/explorer/chain/address/counters.ex
@@ -80,8 +80,41 @@ defmodule Explorer.Chain.Address.Counters do
   @spec check_if_withdrawals_at_address(Hash.Address.t()) :: boolean()
   def check_if_withdrawals_at_address(address_hash, options \\ []) do
     address_hash
-    |> Withdrawal.address_hash_to_withdrawals_unordered_query()
+    |> Withdrawal.address_hash_to_withdrawals_existence_query()
     |> select_repo(options).exists?()
+  end
+
+  @doc """
+    Performs all existence checks needed by the address view in a single
+    database round trip: `SELECT exists(...), exists(...), ...`.
+  """
+  @spec address_existence_checks(Hash.Address.t(), Keyword.t()) :: %{
+          has_validated_blocks: boolean(),
+          has_logs: boolean(),
+          has_tokens: boolean(),
+          has_token_transfers: boolean(),
+          has_beacon_chain_withdrawals: boolean()
+        }
+  def address_existence_checks(address_hash, options \\ []) do
+    validated_blocks_query = address_hash |> address_hash_to_validated_blocks_query() |> select([_], 1)
+    logs_query = address_hash |> address_hash_to_logs_query() |> select([_], 1)
+    token_balances_query = address_hash |> address_hash_to_token_balances_query() |> select([_], 1)
+    token_transfers_from_query = from(tt in TokenTransfer, where: tt.from_address_hash == ^address_hash, select: 1)
+    token_transfers_to_query = from(tt in TokenTransfer, where: tt.to_address_hash == ^address_hash, select: 1)
+    withdrawals_query = Withdrawal.address_hash_to_withdrawals_existence_query(address_hash)
+
+    query =
+      from(f in fragment("SELECT 1"),
+        select: %{
+          has_validated_blocks: exists(validated_blocks_query),
+          has_logs: exists(logs_query),
+          has_tokens: exists(token_balances_query),
+          has_token_transfers: exists(token_transfers_from_query) or exists(token_transfers_to_query),
+          has_beacon_chain_withdrawals: exists(withdrawals_query)
+        }
+      )
+
+    select_repo(options).one(query)
   end
 
   def address_hash_to_transaction_count_query(address_hash) do

--- a/apps/explorer/lib/explorer/chain/withdrawal.ex
+++ b/apps/explorer/lib/explorer/chain/withdrawal.ex
@@ -86,6 +86,16 @@ defmodule Explorer.Chain.Withdrawal do
     )
   end
 
+  @spec address_hash_to_withdrawals_existence_query(Hash.Address.t()) :: Ecto.Query.t()
+  def address_hash_to_withdrawals_existence_query(address_hash) do
+    from(withdrawal in __MODULE__,
+      left_join: block in assoc(withdrawal, :block),
+      where: withdrawal.address_hash == ^address_hash,
+      where: block.consensus == true,
+      select: 1
+    )
+  end
+
   @spec blocks_without_withdrawals_query(non_neg_integer()) :: Ecto.Query.t()
   def blocks_without_withdrawals_query(from_block) do
     from(withdrawal in __MODULE__,


### PR DESCRIPTION
## Motivation

Profiling of `GET /api/v2/addresses/{hash}` showed that the counters portion of the render took **~994ms avg / 1394ms max** out of a ~2s total response time.

The cause: five uncached existence checks executed sequentially inside `prepare_address/2` in `apps/block_scout_web/lib/block_scout_web/views/api/v2/address_view.ex`, each a separate round trip to `Explorer.Repo.Replica1`:

| Check | Avg |
|---|---|
| `check_if_validated_blocks_at_address/2` | ~167ms |
| `check_if_logs_at_address/2` | ~182ms |
| `check_if_tokens_at_address/2` | ~178ms |
| `check_if_token_transfers_at_address/2` (2 queries, `\|\|`-short-circuited) | ~282ms |
| `check_if_withdrawals_at_address/2` | ~183ms |

Each individual `EXISTS` probe is a cheap index lookup — the cost was dominated by per-query overhead (pool checkout, round trip, planning) repeated up to six times per request.

## Changelog

### Enhancements

- Added `Explorer.Chain.Address.Counters.address_existence_checks/2`, which resolves all five existence probes in **one** database round trip via a single `SELECT exists(...), exists(...), ... FROM (SELECT 1)` statement, reusing the existing private query builders (`address_hash_to_validated_blocks_query/1`, `address_hash_to_logs_query/1`, `address_hash_to_token_balances_query/1`).
- `prepare_address/2` in `AddressView` now makes a single `address_existence_checks/2` call and reads the `has_validated_blocks`, `has_logs`, `has_tokens`, `has_token_transfers` and `has_beacon_chain_withdrawals` booleans from the returned map.
- Added `Explorer.Chain.Withdrawal.address_hash_to_withdrawals_existence_query/1` — a lean variant of `address_hash_to_withdrawals_unordered_query/1` that drops the `select: withdrawal` and `preload: [block: block]` clauses, which are useless under `exists?` and disallowed inside a subquery. The `consensus == true` block join is preserved, so results are identical. `check_if_withdrawals_at_address/2` now uses this cheaper query as well.

Net effect: 1 replica connection and 1 round trip per address request instead of up to 6 sequential ones. Error semantics are unchanged — a DB error still raises and fails the request, exactly as before.

The `watchlist_address_id` lookup is intentionally left out of the combined query: it targets a different repo (`Explorer.Repo.Account`) and short-circuits to `nil` with zero queries for anonymous requests.

Generated SQL:

```sql
SELECT exists((SELECT 1 FROM "blocks" AS sb0 WHERE (sb0."miner_hash" = $1))),
       exists((SELECT 1 FROM "logs" AS sl0 WHERE (sl0."address_hash" = $2))),
       exists((SELECT 1 FROM "address_current_token_balances" AS sa0 WHERE (sa0."address_hash" = $3) AND ((sa0."value" > 0) OR (sa0."token_type" = 'ERC-7984')))),
       exists((SELECT 1 FROM "token_transfers" AS st0 WHERE (st0."from_address_hash" = $4))) OR exists((SELECT 1 FROM "token_transfers" AS st0 WHERE (st0."to_address_hash" = $5))),
       exists((SELECT 1 FROM "withdrawals" AS sw0 LEFT OUTER JOIN "blocks" AS sb1 ON sb1."hash" = sw0."block_hash" WHERE (sw0."address_hash" = $6) AND (sb1."consensus" = TRUE)))
FROM (SELECT 1) AS f0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address information responses by consolidating checks for transactions, logs, token activity, balances, and withdrawals.
  * Corrected withdrawal detection for addresses associated with consensus blocks.
  * Reduced unnecessary processing when determining available address activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->