### PR TITLE
chore: Remove deprecated blocks join in token_transfers_query_function

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/advanced_filter_controller_test.exs
@@ -2,6 +2,7 @@
 defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
   use BlockScoutWeb.ConnCase
 
+  alias Explorer.Chain.Cache.BackgroundMigrations
   alias Explorer.Chain.SmartContract
   alias Explorer.Chain.{AdvancedFilter, Data, Hash}
   alias Explorer.{Factory, TestHelper}
@@ -665,6 +666,41 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert response = json_response(request, 200)
 
       assert Enum.count(response["items"]) == 9
+    end
+
+    test "excludes token transfers from non-consensus blocks (denormalization finished)", %{conn: conn} do
+      set_denormalization_finished(tt: true, transactions: true)
+
+      assert_only_consensus_token_transfers_returned(conn)
+    end
+
+    test "excludes token transfers from non-consensus blocks (denormalization not finished)", %{conn: conn} do
+      set_denormalization_finished(tt: false, transactions: false)
+
+      assert_only_consensus_token_transfers_returned(conn)
+    end
+
+    test "filters token transfers by age when only transactions denormalization is not finished", %{conn: conn} do
+      set_denormalization_finished(tt: true, transactions: false)
+
+      block = insert(:block, consensus: false)
+      transaction = insert(:transaction)
+
+      insert(:token_transfer,
+        transaction: transaction,
+        block: block,
+        block_number: block.number,
+        block_consensus: false
+      )
+
+      request =
+        get(conn, "/api/v2/advanced-filters", %{
+          "age_from" => DateTime.to_iso8601(block.timestamp),
+          "transaction_types" => "ERC-20"
+        })
+
+      assert response = json_response(request, 200)
+      assert response["items"] == []
     end
 
     test "filter by from address include", %{conn: conn} do
@@ -1551,6 +1587,39 @@ defmodule BlockScoutWeb.API.V2.AdvancedFilterControllerTest do
       assert response = json_response(request, 200)
       assert response == [%{"method_id" => "0x60fe47b1", "name" => ""}]
     end
+  end
+
+  defp set_denormalization_finished(tt: tt_finished?, transactions: transactions_finished?) do
+    old_tt_finished? = BackgroundMigrations.get_tt_denormalization_finished()
+    old_transactions_finished? = BackgroundMigrations.get_transactions_denormalization_finished()
+
+    BackgroundMigrations.set_tt_denormalization_finished(tt_finished?)
+    BackgroundMigrations.set_transactions_denormalization_finished(transactions_finished?)
+
+    on_exit(fn ->
+      BackgroundMigrations.set_tt_denormalization_finished(old_tt_finished?)
+      BackgroundMigrations.set_transactions_denormalization_finished(old_transactions_finished?)
+    end)
+  end
+
+  defp assert_only_consensus_token_transfers_returned(conn) do
+    consensus_transaction = :transaction |> insert() |> with_block()
+    insert(:token_transfer, transaction: consensus_transaction)
+
+    non_consensus_block = insert(:block, consensus: false)
+    non_consensus_transaction = :transaction |> insert() |> with_block()
+
+    insert(:token_transfer,
+      transaction: non_consensus_transaction,
+      block: non_consensus_block,
+      block_number: non_consensus_block.number,
+      block_consensus: false
+    )
+
+    request = get(conn, "/api/v2/advanced-filters", %{"transaction_types" => "ERC-20"})
+
+    assert response = json_response(request, 200)
+    assert Enum.map(response["items"], & &1["hash"]) == [to_string(consensus_transaction.hash)]
   end
 
   defp check_paginated_response(all_advanced_filters, first_page, second_page) do

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -524,53 +524,25 @@ defmodule Explorer.Chain.AdvancedFilter do
 
   defp token_transfers_query_function(paging_options, options) do
     token_transfer_query =
-      if DenormalizationHelper.transactions_denormalization_finished?() do
-        from(token_transfer in TokenTransfer,
-          as: :token_transfer,
-          join: transaction in assoc(token_transfer, :transaction),
-          as: :transaction,
-          join: token in assoc(token_transfer, :token),
-          as: :token,
-          select: %TokenTransfer{
-            token_transfer
-            | token_id: fragment("UNNEST(?)", token_transfer.token_ids),
-              amount:
-                fragment("UNNEST(COALESCE(?, ARRAY[COALESCE(?, 1)]))", token_transfer.amounts, token_transfer.amount),
-              reverse_index_in_batch:
-                fragment("GENERATE_SERIES(COALESCE(ARRAY_LENGTH(?, 1), 1), 1, -1)", token_transfer.amounts),
-              token_decimals: token.decimals
-          },
-          where: transaction.block_consensus == true,
-          order_by: [
-            desc: token_transfer.block_number,
-            desc: token_transfer.log_index
-          ]
-        )
-      else
-        from(token_transfer in TokenTransfer,
-          as: :token_transfer,
-          join: transaction in assoc(token_transfer, :transaction),
-          as: :transaction,
-          join: token in assoc(token_transfer, :token),
-          as: :token,
-          join: block in assoc(token_transfer, :block),
-          as: :block,
-          select: %TokenTransfer{
-            token_transfer
-            | token_id: fragment("UNNEST(?)", token_transfer.token_ids),
-              amount:
-                fragment("UNNEST(COALESCE(?, ARRAY[COALESCE(?, 1)]))", token_transfer.amounts, token_transfer.amount),
-              reverse_index_in_batch:
-                fragment("GENERATE_SERIES(COALESCE(ARRAY_LENGTH(?, 1), 1), 1, -1)", token_transfer.amounts),
-              token_decimals: token.decimals
-          },
-          where: block.consensus == true,
-          order_by: [
-            desc: token_transfer.block_number,
-            desc: token_transfer.log_index
-          ]
-        )
-      end
+      TokenTransfer.only_consensus_transfers_query()
+      |> from(as: :token_transfer)
+      |> join(:inner, [token_transfer: token_transfer], transaction in assoc(token_transfer, :transaction),
+        as: :transaction
+      )
+      |> join(:inner, [token_transfer: token_transfer], token in assoc(token_transfer, :token), as: :token)
+      |> maybe_join_token_transfer_block()
+      |> select([token_transfer: token_transfer, token: token], %TokenTransfer{
+        token_transfer
+        | token_id: fragment("UNNEST(?)", token_transfer.token_ids),
+          amount: fragment("UNNEST(COALESCE(?, ARRAY[COALESCE(?, 1)]))", token_transfer.amounts, token_transfer.amount),
+          reverse_index_in_batch:
+            fragment("GENERATE_SERIES(COALESCE(ARRAY_LENGTH(?, 1), 1), 1, -1)", token_transfer.amounts),
+          token_decimals: token.decimals
+      })
+      |> order_by([token_transfer: token_transfer],
+        desc: token_transfer.block_number,
+        desc: token_transfer.log_index
+      )
 
     query_function =
       (&make_token_transfer_query_unnested/2)
@@ -592,6 +564,16 @@ defmodule Explorer.Chain.AdvancedFilter do
       filtered_and_paginated_query
       |> repo.all(repo_options)
       |> repo.preload([:transaction, [token: Reputation.reputation_association()]])
+    end
+  end
+
+  defp maybe_join_token_transfer_block(query) do
+    if DenormalizationHelper.transactions_denormalization_finished?() do
+      query
+    else
+      with_named_binding(query, :block, fn query, binding ->
+        join(query, :inner, [token_transfer: token_transfer], block in assoc(token_transfer, :block), as: ^binding)
+      end)
     end
   end
 


### PR DESCRIPTION
Resolved https://github.com/blockscout/blockscout/issues/13325

Other places of blocks joining in token transfers queries are removed already by using `TokenTransfer.only_consensus_transfers_query()` or are still needed there even if the migration is already finished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added legacy Ethereum JSON-RPC endpoints with documented validation and error responses.
  * Added token batch lookup, NFT media-type detection, and token-address CSV exports.
  * Added Shibarium deposit and withdrawal API support.
  * Added Stability validator, ZkSync batch, search-result, and expanded OpenAPI schemas.
  * Added pending-status information for internal-transaction responses.

* **Improvements**
  * Modernized cursor pagination across API endpoints and removed unnecessary pagination parameters.
  * Added `/api/v1/search` compatibility routing and improved ENS search results.

* **Breaking Changes**
  * Removed MUD API endpoints and legacy logs functionality.
  * Updated API and Docker release version to 12.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->