### PR TITLE
fix: Fix state changes for sponsored transactions

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     Module to interact with Transaction Interpretation Service
   """
 
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+
   import BlockScoutWeb.Chain, only: [transaction_to_internal_transactions: 2]
 
   alias BlockScoutWeb.API.V2.{Helper, InternalTransactionView, TokenTransferView, TokenView, TransactionView}
@@ -142,12 +144,15 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
 
   defp prepare_request_body(transaction) do
     transaction =
-      Chain.select_repo(@api_true).preload(transaction, [
-        :block,
-        to_address: [:scam_badge, :names, :smart_contract],
-        from_address: [:scam_badge, :names, :smart_contract],
-        created_contract_address: [:scam_badge, :names, :token, :smart_contract]
-      ])
+      Chain.select_repo(@api_true).preload(
+        transaction,
+        [
+          :block,
+          to_address: [:scam_badge, :names, :smart_contract],
+          from_address: [:scam_badge, :names, :smart_contract],
+          created_contract_address: [:scam_badge, :names, :token, :smart_contract]
+        ] ++ chain_type_address_preloads()
+      )
 
     token_transfers = transaction |> fetch_token_transfers() |> Enum.reverse()
     internal_transactions = transaction |> fetch_internal_transactions() |> Enum.reverse()
@@ -181,30 +186,49 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     decoded_input_data = decoded_input |> Transaction.format_decoded_input() |> TransactionView.decoded_input()
 
     %{
-      data: %{
-        to:
-          Helper.address_with_info(nil, transaction_with_meta.to_address, transaction_with_meta.to_address_hash, true),
-        from:
-          Helper.address_with_info(
-            nil,
-            transaction_with_meta.from_address,
-            transaction_with_meta.from_address_hash,
-            true
-          ),
-        hash: transaction_with_meta.hash,
-        type: transaction_with_meta.type,
-        value: transaction_with_meta.value,
-        method: Transaction.method_name(transaction_with_meta, Transaction.format_decoded_input(decoded_input)),
-        status: transaction_with_meta.status,
-        transaction_types: TransactionView.transaction_types(transaction_with_meta),
-        raw_input: transaction_with_meta.input,
-        decoded_input: decoded_input_data,
-        token_transfers: prepare_token_transfers(token_transfers_with_meta, decoded_input),
-        internal_transactions: prepare_internal_transactions(internal_transactions_with_meta, transaction_with_meta)
-      },
+      data:
+        %{
+          to:
+            Helper.address_with_info(nil, transaction_with_meta.to_address, transaction_with_meta.to_address_hash, true),
+          from:
+            Helper.address_with_info(
+              nil,
+              transaction_with_meta.from_address,
+              transaction_with_meta.from_address_hash,
+              true
+            ),
+          hash: transaction_with_meta.hash,
+          type: transaction_with_meta.type,
+          value: transaction_with_meta.value,
+          method: Transaction.method_name(transaction_with_meta, Transaction.format_decoded_input(decoded_input)),
+          status: transaction_with_meta.status,
+          transaction_types: TransactionView.transaction_types(transaction_with_meta),
+          raw_input: transaction_with_meta.input,
+          decoded_input: decoded_input_data,
+          token_transfers: prepare_token_transfers(token_transfers_with_meta, decoded_input),
+          internal_transactions: prepare_internal_transactions(internal_transactions_with_meta, transaction_with_meta)
+        }
+        |> extend_data_with_chain_type_fields(transaction_with_meta),
       logs_data: %{items: prepare_logs(logs_with_meta, transaction_with_meta)},
       chain_id: :block_scout_web |> Application.get_env(:chain_id) |> ExplorerHelper.parse_integer()
     }
+  end
+
+  @spec extend_data_with_chain_type_fields(map(), Transaction.t()) :: map()
+  case @chain_type do
+    :eden ->
+      defp chain_type_address_preloads,
+        do: [fee_payer_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]]
+
+      defp extend_data_with_chain_type_fields(data, transaction) do
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+        BlockScoutWeb.API.V2.EdenView.extend_transaction_interpretation_request(data, transaction)
+      end
+
+    _ ->
+      defp chain_type_address_preloads, do: []
+
+      defp extend_data_with_chain_type_fields(data, _transaction), do: data
   end
 
   defp fetch_token_transfers(transaction) do

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -4,6 +4,8 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
     Transaction state changes related functions
   """
 
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+
   import Explorer.Chain.Address.Reputation, only: [reputation_association: 0]
   import Explorer.PagingOptions, only: [default_paging_options: 0]
   import Explorer.Chain.SmartContract, only: [burn_address_hash_string: 0]
@@ -81,14 +83,16 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
       block_transactions
       |> Enum.find(&(&1.hash == transaction.hash))
       |> Repo.preload(
-        token_transfers: [
-          token: reputation_association(),
+        [
+          token_transfers: [
+            token: reputation_association(),
+            from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
+            to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
+          ],
+          block: [miner: [:names, :smart_contract, proxy_implementations_association()]],
           from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
           to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
-        ],
-        block: [miner: [:names, :smart_contract, proxy_implementations_association()]],
-        from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-        to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]
+        ] ++ chain_type_address_preloads()
       )
       |> Transaction.preload_internal_transactions(
         from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
@@ -115,8 +119,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
   end
 
   defp transaction_to_coin_balances(transaction, previous_block_number, options) do
-    Enum.reduce(
-      transaction.internal_transactions,
+    initial_coin_balances =
       %{
         transaction.from_address_hash =>
           {transaction.from_address, coin_balance(transaction.from_address_hash, previous_block_number, options)},
@@ -124,9 +127,37 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
           {transaction.to_address, coin_balance(transaction.to_address_hash, previous_block_number, options)},
         transaction.block.miner_hash =>
           {transaction.block.miner, coin_balance(transaction.block.miner_hash, previous_block_number, options)}
-      },
+      }
+      |> put_fee_payer_coin_balance(transaction, previous_block_number, options)
+
+    Enum.reduce(
+      transaction.internal_transactions,
+      initial_coin_balances,
       &internal_transaction_to_coin_balances(&1, previous_block_number, options, &2)
     )
+  end
+
+  if @chain_type == :eden do
+    defp put_fee_payer_coin_balance(
+           coin_balances,
+           %Transaction{fee_payer_address_hash: fee_payer_address_hash} = transaction,
+           previous_block_number,
+           options
+         )
+         when not is_nil(fee_payer_address_hash) do
+      Map.put_new_lazy(coin_balances, fee_payer_address_hash, fn ->
+        {transaction.fee_payer_address, coin_balance(fee_payer_address_hash, previous_block_number, options)}
+      end)
+    end
+  end
+
+  defp put_fee_payer_coin_balance(coin_balances, _transaction, _previous_block_number, _options), do: coin_balances
+
+  if @chain_type == :eden do
+    defp chain_type_address_preloads,
+      do: [fee_payer_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]]
+  else
+    defp chain_type_address_preloads, do: []
   end
 
   defp internal_transaction_to_coin_balances(

--- a/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/transaction_state_helper.ex
@@ -129,6 +129,7 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
           {transaction.block.miner, coin_balance(transaction.block.miner_hash, previous_block_number, options)}
       }
       |> put_fee_payer_coin_balance(transaction, previous_block_number, options)
+      |> put_calls_recipients_coin_balances(transaction, previous_block_number, options)
 
     Enum.reduce(
       transaction.internal_transactions,
@@ -152,6 +153,48 @@ defmodule BlockScoutWeb.Models.TransactionStateHelper do
   end
 
   defp put_fee_payer_coin_balance(coin_balances, _transaction, _previous_block_number, _options), do: coin_balances
+
+  if @chain_type == :eden do
+    alias Explorer.Chain.Address
+
+    defp put_calls_recipients_coin_balances(coin_balances, transaction, previous_block_number, options) do
+      transaction
+      |> Transaction.calls_value_by_recipient()
+      |> Map.keys()
+      |> Enum.reject(&Map.has_key?(coin_balances, &1))
+      |> case do
+        [] ->
+          coin_balances
+
+        address_hashes ->
+          addresses = hashes_to_addresses(address_hashes, options)
+
+          Enum.reduce(address_hashes, coin_balances, fn address_hash, acc ->
+            Map.put(
+              acc,
+              address_hash,
+              {addresses[address_hash] || %Address{hash: address_hash},
+               coin_balance(address_hash, previous_block_number, options)}
+            )
+          end)
+      end
+    end
+
+    defp hashes_to_addresses(address_hashes, options) do
+      address_hashes
+      |> Chain.hashes_to_addresses(options)
+      |> Chain.select_repo(options).preload([
+        :scam_badge,
+        :names,
+        :smart_contract,
+        proxy_implementations_association()
+      ])
+      |> Map.new(&{&1.hash, &1})
+    end
+  else
+    defp put_calls_recipients_coin_balances(coin_balances, _transaction, _previous_block_number, _options),
+      do: coin_balances
+  end
 
   if @chain_type == :eden do
     defp chain_type_address_preloads,

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/eden/call.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/eden/call.ex
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.Schemas.API.V2.Eden.Call do
+  @moduledoc false
+  require OpenApiSpex
+  alias BlockScoutWeb.Schemas.API.V2.General
+
+  OpenApiSpex.schema(%{
+    type: :object,
+    nullable: false,
+    properties: %{
+      to: General.AddressHashNullable,
+      value: General.IntegerString,
+      input: General.HexString
+    },
+    required: [:to, :value, :input],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction.ex
@@ -3,6 +3,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
   @moduledoc false
   alias BlockScoutWeb.API.V2.ZkSyncView
   alias BlockScoutWeb.Schemas.API.V2.{Address, General, Token}
+  alias BlockScoutWeb.Schemas.API.V2.Eden.Call, as: EdenCall
   alias BlockScoutWeb.Schemas.API.V2.Transaction.Fee
   alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
@@ -142,18 +143,6 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
     additionalProperties: false
   }
 
-  @eden_call_schema %Schema{
-    type: :object,
-    nullable: false,
-    properties: %{
-      to: General.AddressHashNullable,
-      value: General.IntegerString,
-      input: General.HexString
-    },
-    required: [:to, :value, :input],
-    additionalProperties: false
-  }
-
   @doc """
    Applies chain-specific field customizations to the given schema based on the configured chain type.
 
@@ -216,7 +205,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.ChainTypeCustomizations do
         |> Helper.extend_schema(
           properties: %{
             fee_payer: %Schema{allOf: [Address], nullable: true},
-            calls: %Schema{type: :array, items: @eden_call_schema, nullable: true}
+            calls: %Schema{type: :array, items: EdenCall, nullable: true}
           },
           required: [:fee_payer, :calls]
         )

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/summary_just_request_body.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/summary_just_request_body.ex
@@ -5,7 +5,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.SummaryJustRequestBody do
   """
   require OpenApiSpex
 
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+
   alias BlockScoutWeb.Schemas.API.V2.{Address, InternalTransaction, Log, TokenTransfer}
+  alias BlockScoutWeb.Schemas.API.V2.Eden.Call, as: EdenCall
+  alias BlockScoutWeb.Schemas.Helper
   alias OpenApiSpex.Schema
 
   logs_data_schema = %Schema{
@@ -49,6 +53,20 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.SummaryJustRequestBody do
     },
     additionalProperties: false
   }
+
+  data_schema =
+    case @chain_type do
+      :eden ->
+        Helper.extend_schema(data_schema,
+          properties: %{
+            fee_payer: %Schema{allOf: [Address], nullable: true},
+            calls: %Schema{type: :array, items: EdenCall, nullable: true}
+          }
+        )
+
+      _ ->
+        data_schema
+    end
 
   OpenApiSpex.schema(%{
     type: :object,

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/eden_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/eden_view.ex
@@ -49,11 +49,39 @@ defmodule BlockScoutWeb.API.V2.EdenView do
       |> Map.put("calls", prepare_calls(transaction.calls, single_transaction?))
     end
 
+    @doc """
+    Extends the body of the transaction interpretation request with the Eden-specific fields.
+
+    Without the calls the service has no way to tell that the transaction is a batch: its `to` and
+    `value` are the compatibility fields derived from the first call and from the sum of all the
+    calls, and the batched calls produce no internal transactions.
+
+    ## Parameters
+    - `data`: A map defining the `data` part of the request body which will be extended.
+    - `transaction`: The transaction structure.
+
+    ## Returns
+    - A map extended with the data related to Eden.
+    """
+    @spec extend_transaction_interpretation_request(map(), Transaction.t()) :: map()
+    def extend_transaction_interpretation_request(data, %Transaction{} = transaction) do
+      data
+      |> Map.put(
+        :fee_payer,
+        APIHelper.address_with_info(nil, transaction.fee_payer_address, transaction.fee_payer_address_hash, false)
+      )
+      |> Map.put(:calls, prepare_calls(transaction.calls))
+    end
+
     @spec prepare_calls(term(), boolean()) :: [map()] | nil
-    defp prepare_calls(calls, true = _single_transaction?) when is_list(calls),
-      do: Enum.map(calls, &prepare_call/1)
+    defp prepare_calls(calls, true = _single_transaction?), do: prepare_calls(calls)
 
     defp prepare_calls(_calls, _single_transaction?), do: nil
+
+    @spec prepare_calls(term()) :: [map()] | nil
+    defp prepare_calls(calls) when is_list(calls), do: Enum.map(calls, &prepare_call/1)
+
+    defp prepare_calls(_calls), do: nil
 
     # A call is stored as it comes from the JSON RPC response: `to` is a plain address string which
     # is `nil` for a contract creation call, `value` is an integer and `input` is a hex string.
@@ -74,5 +102,8 @@ defmodule BlockScoutWeb.API.V2.EdenView do
   else
     def extend_transaction_json_response(out_json, _, _, _, _),
       do: out_json
+
+    def extend_transaction_interpretation_request(data, _),
+      do: data
   end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/transaction_state_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/transaction_state_view.ex
@@ -5,7 +5,7 @@ defmodule BlockScoutWeb.TransactionStateView do
   alias Explorer.Chain
   alias Explorer.Chain.{Address, Wei}
 
-  import Explorer.Chain.Transaction.StateChange, only: [from_loss: 1, has_diff?: 1, to_profit: 1]
+  import Explorer.Chain.Transaction.StateChange, only: [fee_payer_loss: 1, from_loss: 1, has_diff?: 1, to_profit: 1]
 
   def not_negative?(%Wei{value: val}) do
     not Decimal.negative?(val)
@@ -24,7 +24,7 @@ defmodule BlockScoutWeb.TransactionStateView do
   end
 
   def has_state_changes?(transaction) do
-    has_diff?(from_loss(transaction)) or has_diff?(to_profit(transaction))
+    has_diff?(from_loss(transaction)) or has_diff?(to_profit(transaction)) or has_diff?(fee_payer_loss(transaction))
   end
 
   def display_value(balance, :coin, _token_id) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -3451,19 +3451,21 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       test "attributes the fee state change to the fee payer instead of the sender", %{conn: conn} do
         block_before = insert(:block)
         fee_payer = insert(:address)
+        recipient = insert(:address)
 
         transaction =
           :transaction
           |> insert(
             type: 118,
             fee_payer_address_hash: fee_payer.hash,
-            calls: @eden_calls,
+            calls: [%{"to" => to_string(recipient.hash), "value" => 0, "input" => "0xdeadbeef"}],
+            to_address: recipient,
             gas_price: 1_000,
             value: 0
           )
           |> with_block(status: :ok, gas_used: 147)
 
-        insert_coin_balances_before(transaction, fee_payer, block_before)
+        insert_coin_balances_before(transaction, [fee_payer, recipient], block_before)
 
         request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
 
@@ -3479,22 +3481,28 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         assert changes[Address.checksum(transaction.block.miner_hash)] == "147000"
       end
 
-      test "charges the sender for the value and the fee payer for the fee", %{conn: conn} do
+      test "credits every recipient of the batched calls with its own value", %{conn: conn} do
         block_before = insert(:block)
         fee_payer = insert(:address)
+        recipient_a = insert(:address)
+        recipient_b = insert(:address)
 
         transaction =
           :transaction
           |> insert(
             type: 118,
             fee_payer_address_hash: fee_payer.hash,
-            calls: @eden_calls,
-            gas_price: 1_000,
-            value: 3
+            calls: [
+              %{"to" => to_string(recipient_a.hash), "value" => 1, "input" => "0x"},
+              %{"to" => to_string(recipient_b.hash), "value" => 2, "input" => "0x"}
+            ],
+            to_address: recipient_a,
+            value: 3,
+            gas_price: 1_000
           )
           |> with_block(status: :ok, gas_used: 147)
 
-        insert_coin_balances_before(transaction, fee_payer, block_before)
+        insert_coin_balances_before(transaction, [fee_payer, recipient_a, recipient_b], block_before)
 
         request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
 
@@ -3505,7 +3513,69 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
 
         assert changes[Address.checksum(fee_payer.hash)] == "-147000"
         assert changes[Address.checksum(transaction.from_address_hash)] == "-3"
-        assert changes[Address.checksum(transaction.to_address_hash)] == "3"
+        assert changes[Address.checksum(recipient_a.hash)] == "1"
+        assert changes[Address.checksum(recipient_b.hash)] == "2"
+      end
+
+      test "sums up the batched calls sharing the same recipient", %{conn: conn} do
+        block_before = insert(:block)
+        fee_payer = insert(:address)
+        recipient = insert(:address)
+
+        transaction =
+          :transaction
+          |> insert(
+            type: 118,
+            fee_payer_address_hash: fee_payer.hash,
+            calls: [
+              %{"to" => to_string(recipient.hash), "value" => 1, "input" => "0x"},
+              %{"to" => to_string(recipient.hash), "value" => 2, "input" => "0x"}
+            ],
+            to_address: recipient,
+            value: 3,
+            gas_price: 1_000
+          )
+          |> with_block(status: :ok, gas_used: 147)
+
+        insert_coin_balances_before(transaction, [fee_payer, recipient], block_before)
+
+        request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
+
+        assert response = json_response(request, 200)
+
+        changes =
+          Map.new(response["items"], fn item -> {item["address"]["hash"], item["change"]} end)
+
+        assert changes[Address.checksum(transaction.from_address_hash)] == "-3"
+        assert changes[Address.checksum(recipient.hash)] == "3"
+      end
+
+      test "credits the recipients of the calls which have no address indexed yet", %{conn: conn} do
+        block_before = insert(:block)
+        fee_payer = insert(:address)
+        recipient_hash = "0x11f60a633dd30a8d1a26dd6e20167a9293fb4647"
+
+        transaction =
+          :transaction
+          |> insert(
+            type: 118,
+            fee_payer_address_hash: fee_payer.hash,
+            calls: [%{"to" => recipient_hash, "value" => 3, "input" => "0x"}],
+            value: 3,
+            gas_price: 1_000
+          )
+          |> with_block(status: :ok, gas_used: 147)
+
+        insert_coin_balances_before(transaction, [fee_payer], block_before)
+
+        request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
+
+        assert response = json_response(request, 200)
+
+        changes =
+          Map.new(response["items"], fn item -> {item["address"]["hash"], item["change"]} end)
+
+        assert changes[Address.checksum(recipient_hash)] == "3"
       end
 
       test "charges the sender for both the value and the fee for regular transactions", %{conn: conn} do
@@ -3516,7 +3586,7 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
           |> insert(type: 2, gas_price: 1_000, value: 3)
           |> with_block(status: :ok, gas_used: 147)
 
-        insert_coin_balances_before(transaction, nil, block_before)
+        insert_coin_balances_before(transaction, [], block_before)
 
         request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
 
@@ -3530,13 +3600,14 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       end
     end
 
-    defp insert_coin_balances_before(transaction, fee_payer, block_before) do
+    defp insert_coin_balances_before(transaction, extra_addresses, block_before) do
       [
         {transaction.from_address, transaction.from_address_hash},
         {transaction.to_address, transaction.to_address_hash},
         {transaction.block.miner, transaction.block.miner_hash}
       ]
-      |> Enum.concat(if fee_payer, do: [{fee_payer, fee_payer.hash}], else: [])
+      |> Enum.concat(Enum.map(extra_addresses, &{&1, &1.hash}))
+      |> Enum.uniq_by(fn {_address, address_hash} -> address_hash end)
       |> Enum.each(fn {address, address_hash} ->
         insert(:address_coin_balance,
           address: address,

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -3447,6 +3447,103 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         assert item["calls"] == nil
         assert "sponsored_transaction" in item["transaction_types"]
       end
+
+      test "attributes the fee state change to the fee payer instead of the sender", %{conn: conn} do
+        block_before = insert(:block)
+        fee_payer = insert(:address)
+
+        transaction =
+          :transaction
+          |> insert(
+            type: 118,
+            fee_payer_address_hash: fee_payer.hash,
+            calls: @eden_calls,
+            gas_price: 1_000,
+            value: 0
+          )
+          |> with_block(status: :ok, gas_used: 147)
+
+        insert_coin_balances_before(transaction, fee_payer, block_before)
+
+        request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
+
+        assert response = json_response(request, 200)
+
+        changes =
+          Map.new(response["items"], fn item -> {item["address"]["hash"], item["change"]} end)
+
+        assert changes[Address.checksum(fee_payer.hash)] == "-147000"
+
+        refute Map.has_key?(changes, Address.checksum(transaction.from_address_hash))
+
+        assert changes[Address.checksum(transaction.block.miner_hash)] == "147000"
+      end
+
+      test "charges the sender for the value and the fee payer for the fee", %{conn: conn} do
+        block_before = insert(:block)
+        fee_payer = insert(:address)
+
+        transaction =
+          :transaction
+          |> insert(
+            type: 118,
+            fee_payer_address_hash: fee_payer.hash,
+            calls: @eden_calls,
+            gas_price: 1_000,
+            value: 3
+          )
+          |> with_block(status: :ok, gas_used: 147)
+
+        insert_coin_balances_before(transaction, fee_payer, block_before)
+
+        request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
+
+        assert response = json_response(request, 200)
+
+        changes =
+          Map.new(response["items"], fn item -> {item["address"]["hash"], item["change"]} end)
+
+        assert changes[Address.checksum(fee_payer.hash)] == "-147000"
+        assert changes[Address.checksum(transaction.from_address_hash)] == "-3"
+        assert changes[Address.checksum(transaction.to_address_hash)] == "3"
+      end
+
+      test "charges the sender for both the value and the fee for regular transactions", %{conn: conn} do
+        block_before = insert(:block)
+
+        transaction =
+          :transaction
+          |> insert(type: 2, gas_price: 1_000, value: 3)
+          |> with_block(status: :ok, gas_used: 147)
+
+        insert_coin_balances_before(transaction, nil, block_before)
+
+        request = get(conn, "/api/v2/transactions/#{transaction.hash}/state-changes")
+
+        assert response = json_response(request, 200)
+
+        changes =
+          Map.new(response["items"], fn item -> {item["address"]["hash"], item["change"]} end)
+
+        assert changes[Address.checksum(transaction.from_address_hash)] == "-147003"
+        assert changes[Address.checksum(transaction.to_address_hash)] == "3"
+      end
+    end
+
+    defp insert_coin_balances_before(transaction, fee_payer, block_before) do
+      [
+        {transaction.from_address, transaction.from_address_hash},
+        {transaction.to_address, transaction.to_address_hash},
+        {transaction.block.miner, transaction.block.miner_hash}
+      ]
+      |> Enum.concat(if fee_payer, do: [{fee_payer, fee_payer.hash}], else: [])
+      |> Enum.each(fn {address, address_hash} ->
+        insert(:address_coin_balance,
+          address: address,
+          address_hash: address_hash,
+          block_number: block_before.number
+        )
+      end)
     end
   end
 

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -2248,6 +2248,40 @@ defmodule Explorer.Chain.Transaction do
   end
 
   @doc """
+    Aggregates the values of the calls batched in an Eden sponsored transaction by their recipients.
+
+    The `to_address_hash` and the `value` of such a transaction are the compatibility fields derived
+    from the first call and from the sum of all the calls respectively, so the calls are the only
+    source of the actual recipients and of the amounts they receive.
+
+    The calls without a recipient (the contract creations) and the malformed ones are skipped.
+
+    ## Parameters
+    - `transaction`: The transaction entity.
+
+    ## Returns
+    - A map of the recipient address hashes to the total value each of them receives within the
+      transaction. Empty for the transactions which are not the sponsored ones.
+  """
+  @spec calls_value_by_recipient(__MODULE__.t()) :: %{Hash.Address.t() => Wei.t()}
+  if @chain_type == :eden do
+    def calls_value_by_recipient(%__MODULE__{calls: calls}) when is_list(calls) do
+      Enum.reduce(calls, %{}, fn call, acc ->
+        with {:ok, address_hash} <- call |> Map.get("to") |> Hash.Address.cast(),
+             {:ok, value} <- call |> Map.get("value") |> Wei.cast() do
+          Map.update(acc, address_hash, value, &Wei.sum(&1, value))
+        else
+          _ -> acc
+        end
+      end)
+    end
+
+    def calls_value_by_recipient(%__MODULE__{}), do: %{}
+  else
+    def calls_value_by_recipient(%__MODULE__{}), do: %{}
+  end
+
+  @doc """
   Calculates burnt fees for a transaction as `base_fee_per_gas * gas_used`.
 
   ## Parameters

--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -4,6 +4,8 @@ defmodule Explorer.Chain.Transaction.StateChange do
     Helper functions and struct for storing state changes
   """
 
+  use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
+
   use Utils.RuntimeEnvHelper,
     miner_gets_burnt_fees?: [:explorer, [Explorer.Chain.Transaction, :block_miner_gets_burnt_fees?]]
 
@@ -59,6 +61,7 @@ defmodule Explorer.Chain.Transaction.StateChange do
     coin_balances =
       coin_balances
       |> update_balance(transaction.from_address_hash, &Wei.sub(&1, from_loss(transaction)))
+      |> update_balance(fee_payer_address_hash(transaction), &Wei.sub(&1, fee_payer_loss(transaction)))
       |> update_balance(transaction.to_address_hash, &Wei.sum(&1, to_profit(transaction)))
       |> update_balance(block.miner_hash, &Wei.sum(&1, miner_profit(transaction, block)))
 
@@ -199,17 +202,53 @@ defmodule Explorer.Chain.Transaction.StateChange do
   """
   @spec from_loss(Transaction.t() | InternalTransaction.t()) :: Wei.t()
   def from_loss(%Transaction{} = transaction) do
-    {_, fee} = Transaction.fee(transaction, :wei)
+    fee = sender_fee(transaction)
 
     if error?(transaction) do
-      %Wei{value: fee}
+      fee
     else
-      Wei.sum(transaction.value, %Wei{value: fee})
+      Wei.sum(transaction.value, fee)
     end
   end
 
   def from_loss(%InternalTransaction{} = transaction) do
     transaction.value || Wei.zero()
+  end
+
+  @doc """
+  Returns the balance change of the fee payer (sponsor) of a transaction.
+
+  Equals to the transaction fee for the transactions which fee is paid by an address other than
+  the transaction sender (the Eden sponsored transactions), zero otherwise.
+  """
+  @spec fee_payer_loss(Transaction.t()) :: Wei.t()
+  if @chain_type == :eden do
+    def fee_payer_loss(%Transaction{fee_payer_address_hash: nil}), do: Wei.zero()
+
+    def fee_payer_loss(%Transaction{} = transaction), do: transaction_fee(transaction)
+  else
+    def fee_payer_loss(%Transaction{}), do: Wei.zero()
+  end
+
+  if @chain_type == :eden do
+    defp sender_fee(%Transaction{fee_payer_address_hash: nil} = transaction), do: transaction_fee(transaction)
+
+    defp sender_fee(%Transaction{}), do: Wei.zero()
+  else
+    defp sender_fee(%Transaction{} = transaction), do: transaction_fee(transaction)
+  end
+
+  if @chain_type == :eden do
+    defp fee_payer_address_hash(%Transaction{fee_payer_address_hash: fee_payer_address_hash}),
+      do: fee_payer_address_hash
+  else
+    defp fee_payer_address_hash(%Transaction{}), do: nil
+  end
+
+  defp transaction_fee(transaction) do
+    {_, fee} = Transaction.fee(transaction, :wei)
+
+    %Wei{value: fee}
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/transaction/state_change.ex
+++ b/apps/explorer/lib/explorer/chain/transaction/state_change.ex
@@ -62,7 +62,7 @@ defmodule Explorer.Chain.Transaction.StateChange do
       coin_balances
       |> update_balance(transaction.from_address_hash, &Wei.sub(&1, from_loss(transaction)))
       |> update_balance(fee_payer_address_hash(transaction), &Wei.sub(&1, fee_payer_loss(transaction)))
-      |> update_balance(transaction.to_address_hash, &Wei.sum(&1, to_profit(transaction)))
+      |> credit_recipients(transaction)
       |> update_balance(block.miner_hash, &Wei.sum(&1, miner_profit(transaction, block)))
 
     if error?(transaction) do
@@ -71,6 +71,30 @@ defmodule Explorer.Chain.Transaction.StateChange do
       transaction.internal_transactions
       |> Enum.reduce(coin_balances, &update_coin_balances_from_internal_transaction(&1, &2))
     end
+  end
+
+  # Credits the addresses which receive the value of the transaction.
+  #
+  # An Eden sponsored transaction carries an ordered list of the batched calls, each one with its
+  # own recipient and value, so every one of them is credited separately. The `to_address_hash` and
+  # the `value` of such a transaction are just the compatibility fields derived from the first call
+  # and from the sum of all the calls, hence they are not used here.
+  if @chain_type == :eden do
+    defp credit_recipients(coin_balances, %Transaction{calls: [_ | _]} = transaction) do
+      if error?(transaction) do
+        coin_balances
+      else
+        transaction
+        |> Transaction.calls_value_by_recipient()
+        |> Enum.reduce(coin_balances, fn {address_hash, value}, acc ->
+          update_balance(acc, address_hash, &Wei.sum(&1, value))
+        end)
+      end
+    end
+  end
+
+  defp credit_recipients(coin_balances, transaction) do
+    update_balance(coin_balances, transaction.to_address_hash, &Wei.sum(&1, to_profit(transaction)))
   end
 
   defp update_coin_balances_from_internal_transaction(

--- a/apps/explorer/test/explorer/chain/transaction_test.exs
+++ b/apps/explorer/test/explorer/chain/transaction_test.exs
@@ -923,6 +923,38 @@ defmodule Explorer.Chain.TransactionTest do
     end
   end
 
+  if Application.compile_env(:explorer, :chain_type) == :eden do
+    describe "calls_value_by_recipient/1" do
+      test "sums up the values of the batched calls per recipient" do
+        first_recipient = "0x11f60a633dd30a8d1a26dd6e20167a9293fb4647"
+        second_recipient = "0xcfc096e58b1f858e5a3ee88ecaeccb2b464625b5"
+
+        transaction = %Transaction{
+          calls: [
+            %{"to" => first_recipient, "value" => 1, "input" => "0x"},
+            %{"to" => second_recipient, "value" => 2, "input" => "0x"},
+            %{"to" => first_recipient, "value" => 3, "input" => "0x"}
+          ]
+        }
+
+        assert %{} = values = Transaction.calls_value_by_recipient(transaction)
+
+        assert Map.new(values, fn {address_hash, value} -> {to_string(address_hash), to_string(value.value)} end) ==
+                 %{first_recipient => "4", second_recipient => "2"}
+      end
+
+      test "skips the calls without a recipient" do
+        transaction = %Transaction{calls: [%{"to" => nil, "value" => 1, "input" => "0x"}]}
+
+        assert Transaction.calls_value_by_recipient(transaction) == %{}
+      end
+
+      test "returns an empty map for the transactions which are not sponsored ones" do
+        assert Transaction.calls_value_by_recipient(%Transaction{calls: nil}) == %{}
+      end
+    end
+  end
+
   describe "get_method_name/1" do
     test "returns method name for transaction with input data starting with 0x" do
       transaction =

--- a/apps/indexer/lib/indexer/transform/address_coin_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances.ex
@@ -4,7 +4,9 @@ defmodule Indexer.Transform.AddressCoinBalances do
   Extracts `Explorer.Chain.Address.CoinBalance` params from other schema's params.
   """
 
-  use Utils.CompileTimeEnvHelper, chain_identity: [:explorer, :chain_identity]
+  use Utils.CompileTimeEnvHelper,
+    chain_identity: [:explorer, :chain_identity],
+    chain_type: [:explorer, :chain_type]
 
   use Utils.RuntimeEnvHelper,
     chain_type: [:explorer, :chain_type],
@@ -238,6 +240,16 @@ defmodule Indexer.Transform.AddressCoinBalances do
                 is_binary(recipient_address_hash) and
                 recipient_address_hash != @burn_address_hash_string do
       MapSet.put(initial, %{address_hash: recipient_address_hash, block_number: block_number})
+    end
+  end
+
+  if @chain_type == :eden do
+    defp transactions_params_chain_type_fields_reducer(
+           %{block_number: block_number, fee_payer_address_hash: fee_payer_address_hash},
+           initial
+         )
+         when is_integer(block_number) and is_binary(fee_payer_address_hash) do
+      MapSet.put(initial, %{address_hash: fee_payer_address_hash, block_number: block_number})
     end
   end
 

--- a/apps/indexer/lib/indexer/transform/address_coin_balances.ex
+++ b/apps/indexer/lib/indexer/transform/address_coin_balances.ex
@@ -245,13 +245,39 @@ defmodule Indexer.Transform.AddressCoinBalances do
 
   if @chain_type == :eden do
     defp transactions_params_chain_type_fields_reducer(
-           %{block_number: block_number, fee_payer_address_hash: fee_payer_address_hash},
+           %{block_number: block_number} = transaction_params,
            initial
          )
-         when is_integer(block_number) and is_binary(fee_payer_address_hash) do
-      MapSet.put(initial, %{address_hash: fee_payer_address_hash, block_number: block_number})
+         when is_integer(block_number) do
+      initial
+      |> put_fee_payer(transaction_params, block_number)
+      |> put_calls_recipients(transaction_params, block_number)
     end
   end
 
   defp transactions_params_chain_type_fields_reducer(_, acc), do: acc
+
+  if @chain_type == :eden do
+    alias Explorer.Chain
+
+    defp put_fee_payer(acc, %{fee_payer_address_hash: fee_payer_address_hash}, block_number)
+         when is_binary(fee_payer_address_hash) do
+      MapSet.put(acc, %{address_hash: fee_payer_address_hash, block_number: block_number})
+    end
+
+    defp put_fee_payer(acc, _transaction_params, _block_number), do: acc
+
+    defp put_calls_recipients(acc, %{calls: calls}, block_number) when is_list(calls) do
+      Enum.reduce(calls, acc, fn call, inner_acc ->
+        address_hash = Map.get(call, "to")
+
+        case Chain.string_to_address_hash(address_hash) do
+          {:ok, _} -> MapSet.put(inner_acc, %{address_hash: address_hash, block_number: block_number})
+          :error -> inner_acc
+        end
+      end)
+    end
+
+    defp put_calls_recipients(acc, _transaction_params, _block_number), do: acc
+  end
 end

--- a/apps/indexer/lib/indexer/transform/addresses.ex
+++ b/apps/indexer/lib/indexer/transform/addresses.ex
@@ -569,6 +569,7 @@ defmodule Indexer.Transform.Addresses do
 
     addresses
     |> List.flatten()
+    |> Enum.concat(chain_type_addresses(fetched_data, state))
     |> merge_addresses()
   end
 
@@ -576,6 +577,46 @@ defmodule Indexer.Transform.Addresses do
     do: Enum.flat_map(items, &extract_addresses_from_item(&1, fields, state))
 
   def extract_addresses_from_item(item, fields, state), do: Enum.flat_map(fields, &extract_fields(&1, item, state))
+
+  if @chain_type == :eden do
+    alias Explorer.Chain
+
+    @eden_call_fields [
+      [
+        %{from: :block_number, to: :fetched_coin_balance_block_number},
+        %{from: :to_address_hash, to: :hash}
+      ]
+    ]
+
+    # The recipients of the calls batched in an Eden sponsored transaction are stored in the `calls`
+    # JSON field, so they can't be declared in `@entity_to_address_map`, which supports the plain
+    # fields only. The calls are flattened into the items of the shape the declarations expect
+    # instead, so that the pending transactions keep being handled the same way.
+    defp chain_type_addresses(fetched_data, state) do
+      fetched_data
+      |> Map.get(:transactions)
+      |> Kernel.||([])
+      |> Enum.flat_map(&transaction_to_call_items/1)
+      |> extract_addresses_from_collection(@eden_call_fields, state)
+    end
+
+    defp transaction_to_call_items(%{calls: calls} = transaction) when is_list(calls) do
+      block_number = Map.take(transaction, [:block_number])
+
+      Enum.flat_map(calls, fn call ->
+        to_address_hash = Map.get(call, "to")
+
+        case Chain.string_to_address_hash(to_address_hash) do
+          {:ok, _} -> [Map.put(block_number, :to_address_hash, to_address_hash)]
+          :error -> []
+        end
+      end)
+    end
+
+    defp transaction_to_call_items(_transaction), do: []
+  else
+    defp chain_type_addresses(_fetched_data, _state), do: []
+  end
 
   def merge_addresses(addresses) when is_list(addresses) do
     addresses

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -247,6 +247,48 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
     end
   end
 
+  if Application.compile_env(:explorer, :chain_type) == :eden do
+    describe "params_set/1 transactions_params on Eden chain" do
+      test "with sponsored transaction extracts fee_payer_address_hash" do
+        block_number = 1
+
+        from_address_hash = to_string(Factory.address_hash())
+        fee_payer_address_hash = to_string(Factory.address_hash())
+
+        transaction_params =
+          :transaction
+          |> Factory.params_for()
+          |> Map.put(:block_number, block_number)
+          |> Map.put(:from_address_hash, from_address_hash)
+          |> Map.put(:fee_payer_address_hash, fee_payer_address_hash)
+
+        params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
+
+        assert MapSet.size(params_set) == 2
+        assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+        assert MapSet.member?(params_set, %{address_hash: fee_payer_address_hash, block_number: block_number})
+      end
+
+      test "with regular transaction extracts nothing extra" do
+        block_number = 1
+
+        from_address_hash = to_string(Factory.address_hash())
+
+        transaction_params =
+          :transaction
+          |> Factory.params_for()
+          |> Map.put(:block_number, block_number)
+          |> Map.put(:from_address_hash, from_address_hash)
+          |> Map.put(:fee_payer_address_hash, nil)
+
+        params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
+
+        assert MapSet.size(params_set) == 1
+        assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+      end
+    end
+  end
+
   if Application.compile_env(:explorer, :chain_type) == :arc do
     describe "params_set/1 logs_params on Arc chain" do
       test "with EIP-7708 Transfer queues non-burn from_address and to_address for coin balances" do

--- a/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
+++ b/apps/indexer/test/indexer/transform/address_coin_balances_test.exs
@@ -269,6 +269,37 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
         assert MapSet.member?(params_set, %{address_hash: fee_payer_address_hash, block_number: block_number})
       end
 
+      test "with sponsored transaction extracts the recipients of the batched calls" do
+        block_number = 1
+
+        from_address_hash = to_string(Factory.address_hash())
+        fee_payer_address_hash = to_string(Factory.address_hash())
+        first_call_address_hash = to_string(Factory.address_hash())
+        second_call_address_hash = to_string(Factory.address_hash())
+
+        transaction_params =
+          :transaction
+          |> Factory.params_for()
+          |> Map.put(:block_number, block_number)
+          |> Map.put(:from_address_hash, from_address_hash)
+          |> Map.put(:fee_payer_address_hash, fee_payer_address_hash)
+          |> Map.put(:calls, [
+            %{"to" => first_call_address_hash, "value" => 1, "input" => "0x"},
+            %{"to" => second_call_address_hash, "value" => 2, "input" => "0x"},
+            %{"to" => nil, "value" => 3, "input" => "0xc0ffee"},
+            %{"to" => "0xdeadbeef", "value" => 4, "input" => "0x"},
+            %{"to" => 12_345, "value" => 5, "input" => "0x"}
+          ])
+
+        params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
+
+        assert MapSet.size(params_set) == 4
+        assert MapSet.member?(params_set, %{address_hash: from_address_hash, block_number: block_number})
+        assert MapSet.member?(params_set, %{address_hash: fee_payer_address_hash, block_number: block_number})
+        assert MapSet.member?(params_set, %{address_hash: first_call_address_hash, block_number: block_number})
+        assert MapSet.member?(params_set, %{address_hash: second_call_address_hash, block_number: block_number})
+      end
+
       test "with regular transaction extracts nothing extra" do
         block_number = 1
 
@@ -280,6 +311,7 @@ defmodule Indexer.Transform.AddressCoinBalancesTest do
           |> Map.put(:block_number, block_number)
           |> Map.put(:from_address_hash, from_address_hash)
           |> Map.put(:fee_payer_address_hash, nil)
+          |> Map.put(:calls, nil)
 
         params_set = AddressCoinBalances.params_set(%{transactions_params: [transaction_params]})
 

--- a/apps/indexer/test/indexer/transform/addresses_test.exs
+++ b/apps/indexer/test/indexer/transform/addresses_test.exs
@@ -272,6 +272,59 @@ defmodule Indexer.Transform.AddressesTest do
                ]
              }) == []
     end
+
+    if Application.compile_env(:explorer, :chain_type) == :eden do
+      test "recipients of the batched calls are extracted with the coin balance block number" do
+        first_call_hash = "0x11f60a633dd30a8d1a26dd6e20167a9293fb4647"
+        second_call_hash = "0xcfc096e58b1f858e5a3ee88ecaeccb2b464625b5"
+
+        addresses =
+          Addresses.extract_addresses(%{
+            transactions: [
+              %{
+                block_number: 34,
+                from_address_hash: "0x0000000000000000000000000000000000000001",
+                nonce: 12,
+                calls: [
+                  %{"to" => first_call_hash, "value" => 1, "input" => "0x"},
+                  %{"to" => second_call_hash, "value" => 2, "input" => "0x"},
+                  %{"to" => nil, "value" => 3, "input" => "0xc0ffee"}
+                ]
+              }
+            ]
+          })
+
+        assert Enum.find(addresses, &(&1.hash == first_call_hash)) ==
+                 %{hash: first_call_hash, fetched_coin_balance_block_number: 34}
+
+        assert Enum.find(addresses, &(&1.hash == second_call_hash)) ==
+                 %{hash: second_call_hash, fetched_coin_balance_block_number: 34}
+
+        refute Enum.any?(addresses, &is_nil(&1.hash))
+      end
+
+      test "recipients of the batched calls without a `block_number` aren't extracted" do
+        assert Addresses.extract_addresses(%{
+                 transactions: [
+                   %{calls: [%{"to" => "0x11f60a633dd30a8d1a26dd6e20167a9293fb4647", "value" => 1, "input" => "0x"}]}
+                 ]
+               }) == []
+      end
+
+      test "recipients of the batched calls which aren't valid address hashes aren't extracted" do
+        assert Addresses.extract_addresses(%{
+                 transactions: [
+                   %{
+                     block_number: 34,
+                     calls: [
+                       %{"to" => "0xdeadbeef", "value" => 1, "input" => "0x"},
+                       %{"to" => 12_345, "value" => 2, "input" => "0x"}
+                     ]
+                   }
+                 ]
+               }) == []
+      end
+    end
   end
 
   describe "extract_addresses_from_collection/2" do


### PR DESCRIPTION
Resolves https://github.com/blockscout/frontend/issues/3633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eden transaction support for fee-payer metadata and batched calls.
  * Transaction details now show individual call recipients and aggregated transferred values.
  * Added Eden API fields for `fee_payer` and `calls`, including call recipient, value, and input data.
  * Address and balance tracking now includes valid batched-call recipients.
* **Bug Fixes**
  * Corrected state-change reporting to include fee-payer balance deductions and combined sender value-and-fee changes.
  * Invalid or incomplete call destinations are safely excluded from transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->