### PR TITLE
fix: Add missed metadata field to /preview

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -920,7 +920,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     %{
       "hash" => Address.checksum(address),
       "name" => Helper.address_name(address),
-      "ens_domain_name" => address.ens_domain_name
+      "ens_domain_name" => address.ens_domain_name,
+      "metadata" => address.metadata
     }
   end
 
@@ -930,7 +931,8 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
     %{
       "hash" => Address.checksum(hash),
       "name" => nil,
-      "ens_domain_name" => nil
+      "ens_domain_name" => nil,
+      "metadata" => nil
     }
   end
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -3503,18 +3503,33 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
     setup do
       bypass = Bypass.open()
       old_bens_env = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS, [])
+      old_metadata_env = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, [])
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
 
       Application.put_env(:block_scout_web, :chain_id, 1)
 
-      Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS,
-        service_url: "http://localhost:#{bypass.port}",
-        enabled: true
+      Application.put_env(
+        :explorer,
+        Explorer.MicroserviceInterfaces.BENS,
+        Keyword.merge(old_bens_env || [],
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+      )
+
+      Application.put_env(
+        :explorer,
+        Explorer.MicroserviceInterfaces.Metadata,
+        Keyword.merge(old_metadata_env || [],
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
       )
 
       on_exit(fn ->
         Bypass.down(bypass)
         Application.put_env(:explorer, Explorer.MicroserviceInterfaces.BENS, old_bens_env)
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.Metadata, old_metadata_env)
         Application.put_env(:block_scout_web, :chain_id, old_chain_id)
       end)
 
@@ -3533,6 +3548,45 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
         get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/preview", %{"preload_ens" => "true"})
 
       assert %{"from" => %{"ens_domain_name" => "preview.eth"}} = json_response(request, 200)
+    end
+
+    test "preloads metadata when preload_metadata is requested", %{conn: conn, bypass: bypass} do
+      transaction = :transaction |> insert() |> with_block(status: :ok)
+      from_hash = Address.checksum(transaction.from_address_hash)
+      to_hash = Address.checksum(transaction.to_address_hash)
+
+      metadata_tag = %{"name" => "Test 1", "tagType" => "name", "meta" => Jason.encode!(%{})}
+
+      Bypass.expect_once(bypass, "GET", "/api/v1/metadata", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!(%{
+            "addresses" => %{
+              from_hash => %{"tags" => [metadata_tag]},
+              to_hash => %{"tags" => [metadata_tag]}
+            }
+          })
+        )
+      end)
+
+      request =
+        get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/preview", %{"preload_metadata" => "true"})
+
+      response = json_response(request, 200)
+
+      assert %{"from" => %{"metadata" => %{"tags" => [%{"name" => "Test 1"}]}}} = response
+      assert %{"to" => %{"metadata" => %{"tags" => [%{"name" => "Test 1"}]}}} = response
+    end
+
+    test "returns nil metadata when preload_metadata is not requested", %{conn: conn} do
+      transaction = :transaction |> insert() |> with_block(status: :ok)
+
+      request = get(conn, "/api/v2/transactions/#{to_string(transaction.hash)}/preview")
+
+      response = json_response(request, 200)
+      assert %{"from" => %{"metadata" => nil}} = response
+      assert %{"to" => %{"metadata" => nil}} = response
     end
 
     test "queries no microservice when neither preload is requested", %{conn: conn} do


### PR DESCRIPTION
## Motivation

Missed `metadata` field to /preview

## Changelog
- Add missed `metadata` field to /preview
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction previews now include address metadata when available.
  * Metadata is returned as `nil` when only an address hash is provided or metadata preloading is not requested.
  * Address information is now handled consistently across transaction preview responses, improving the completeness and reliability of preview details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->