### PR TITLE
chore: Update swagger spec for /preview

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -1074,7 +1074,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
           }
         ],
     responses: [
-      ok: {"Lightweight transaction preview.", "application/json", %Schema{type: :object}},
+      ok: {"Lightweight transaction preview.", "application/json", Schemas.Transaction.Preview},
       not_found: NotFoundResponse.response(),
       unprocessable_entity: JsonErrorResponse.response()
     ]

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.Schemas.API.V2.Transaction.PreviewAddress do
+  @moduledoc """
+  Lightweight address representation used in the transaction preview endpoint.
+  Contains only the hash, display name, ENS domain name, and metadata tags.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.{General, Proxy}
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    description: "Lightweight address in transaction preview",
+    type: :object,
+    nullable: true,
+    properties: %{
+      hash: General.AddressHash,
+      name: %Schema{type: :string, description: "Display name of the address (contract name or address name)", nullable: true},
+      ens_domain_name: %Schema{
+        type: :string,
+        description: "ENS domain name associated with the address. Populated only when preload_ens=true is passed.",
+        nullable: true
+      },
+      metadata: %Schema{
+        allOf: [Proxy.Metadata],
+        description: "Address metadata tags from the Metadata microservice. Populated only when preload_metadata=true is passed.",
+        nullable: true
+      }
+    },
+    required: [:hash, :name, :ens_domain_name, :metadata],
+    additionalProperties: false
+  })
+end
+
+defmodule BlockScoutWeb.Schemas.API.V2.Transaction.Preview do
+  @moduledoc """
+  Schema for the lightweight transaction preview response returned by
+  `GET /api/v2/transactions/:transaction_hash/preview`.
+
+  Used for rendering OG/social-media previews with minimal data.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.General
+  alias BlockScoutWeb.Schemas.API.V2.Transaction.PreviewAddress
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    description: "Lightweight transaction preview for social media embeds",
+    type: :object,
+    properties: %{
+      status: %Schema{
+        type: :string,
+        enum: ["ok", "error"],
+        nullable: true,
+        description: "Transaction execution status"
+      },
+      timestamp: General.TimestampNullable,
+      method: General.MethodNameNullable,
+      from: %Schema{allOf: [PreviewAddress], nullable: true},
+      to: %Schema{allOf: [PreviewAddress], nullable: true}
+    },
+    required: [:status, :timestamp, :method, :from, :to],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
@@ -15,7 +15,11 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.PreviewAddress do
     nullable: true,
     properties: %{
       hash: General.AddressHash,
-      name: %Schema{type: :string, description: "Display name of the address (contract name or address name)", nullable: true},
+      name: %Schema{
+        type: :string,
+        description: "Display name of the address (contract name or address name)",
+        nullable: true
+      },
       ens_domain_name: %Schema{
         type: :string,
         description: "ENS domain name associated with the address. Populated only when preload_ens=true is passed.",
@@ -23,7 +27,8 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.PreviewAddress do
       },
       metadata: %Schema{
         allOf: [Proxy.Metadata],
-        description: "Address metadata tags from the Metadata microservice. Populated only when preload_metadata=true is passed.",
+        description:
+          "Address metadata tags from the Metadata microservice. Populated only when preload_metadata=true is passed.",
         nullable: true
       }
     },

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -3555,7 +3555,13 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       from_hash = Address.checksum(transaction.from_address_hash)
       to_hash = Address.checksum(transaction.to_address_hash)
 
-      metadata_tag = %{"name" => "Test 1", "tagType" => "name", "meta" => Jason.encode!(%{})}
+      metadata_tag = %{
+        "slug" => "test-1",
+        "name" => "Test 1",
+        "tagType" => "name",
+        "ordinal" => 0,
+        "meta" => Jason.encode!(%{})
+      }
 
       Bypass.expect_once(bypass, "GET", "/api/v1/metadata", fn conn ->
         Plug.Conn.resp(


### PR DESCRIPTION
## Motivation

## Changelog

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Improvements**
  * Enhanced transaction preview responses with a clearly defined, documented structure.
  * Added detailed sender and recipient address information, including hashes, names, ENS domains, and metadata.
  * Documented transaction status, timestamp, and method fields.
  * Responses now reject unsupported additional fields for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->