### PR TITLE
perf: reduce query count and payload in transaction API endpoint

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -58,7 +58,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   alias Explorer.Chain.Beacon.Deposit, as: BeaconDeposit
   alias Explorer.Chain.Beacon.Reader, as: BeaconReader
   alias Explorer.Chain.Cache.Counters.{NewPendingTransactionsCount, Transactions24hCount}
-  alias Explorer.Chain.{FheOperation, Hash, Transaction}
+  alias Explorer.Chain.{FheOperation, Hash, SmartContract, Transaction}
   alias Explorer.Chain.Optimism.TransactionBatch, as: OptimismTransactionBatch
   alias Explorer.Chain.Scroll.Reader, as: ScrollReader
   alias Explorer.Chain.Token.Instance
@@ -88,6 +88,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   end
 
   # TODO might be redundant to preload blob fields in some of the endpoints
+  # `to_address` keeps the full `:smart_contract` preload (with `abi`) since it
+  # feeds transaction input decoding; the other addresses only need address info.
   @transaction_necessity_by_association %{
                                           :block => :optional,
                                           [
@@ -95,7 +97,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                               :scam_badge,
                                               :names,
                                               :token,
-                                              :smart_contract,
+                                              SmartContract.association_without_abi(),
                                               proxy_implementations_association()
                                             ]
                                           ] => :optional,
@@ -103,7 +105,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                             from_address: [
                                               :scam_badge,
                                               :names,
-                                              :smart_contract,
+                                              SmartContract.association_without_abi(),
                                               proxy_implementations_association()
                                             ]
                                           ] => :optional,
@@ -119,14 +121,18 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)
 
   @token_transfers_necessity_by_association %{
-    [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-    [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
+    [from_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
+      :optional,
+    [to_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
+      :optional,
     [token: reputation_association()] => :optional
   }
 
   @token_transfers_in_transaction_necessity_by_association %{
-    [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-    [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
+    [from_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
+      :optional,
+    [to_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
+      :optional,
     [token: reputation_association()] => :optional
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -88,37 +88,21 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   end
 
   # TODO might be redundant to preload blob fields in some of the endpoints
-  # `to_address` keeps the full `:smart_contract` preload (with `abi`) since it
-  # feeds transaction input decoding; the other addresses only need address info.
-  @transaction_necessity_by_association %{
-                                          :block => :optional,
-                                          [
-                                            created_contract_address: [
-                                              :scam_badge,
-                                              :names,
-                                              :token,
-                                              SmartContract.association_without_abi(),
-                                              proxy_implementations_association()
-                                            ]
-                                          ] => :optional,
-                                          [
-                                            from_address: [
-                                              :scam_badge,
-                                              :names,
-                                              SmartContract.association_without_abi(),
-                                              proxy_implementations_association()
-                                            ]
-                                          ] => :optional,
-                                          [
-                                            to_address: [
-                                              :scam_badge,
-                                              :names,
-                                              :smart_contract,
-                                              proxy_implementations_association()
-                                            ]
-                                          ] => :optional
-                                        }
+  # Address-info preloads for the transaction participants (from/to/created and
+  # token transfer addresses) are intentionally absent here: the `transaction`
+  # action loads them all in a single deduplicated pass via
+  # `Chain.preload_transaction_participants/3` using
+  # `@transaction_participants_necessity_by_association`.
+  @transaction_necessity_by_association %{:block => :optional}
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)
+
+  @transaction_participants_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :token => :optional,
+    SmartContract.association_without_abi() => :optional,
+    proxy_implementations_association() => :optional
+  }
 
   @token_transfers_necessity_by_association %{
     [from_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
@@ -128,11 +112,10 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     [token: reputation_association()] => :optional
   }
 
+  # Transfer from/to address preloads are handled by
+  # `Chain.preload_transaction_participants/3`, see
+  # `@transaction_necessity_by_association`.
   @token_transfers_in_transaction_necessity_by_association %{
-    [from_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
-      :optional,
-    [to_address: [:scam_badge, :names, SmartContract.association_without_abi(), proxy_implementations_association()]] =>
-      :optional,
     [token: reputation_association()] => :optional
   }
 
@@ -216,6 +199,12 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
              transaction,
              @token_transfers_in_transaction_necessity_by_association,
              @api_true |> fetch_scam_token_toggle(conn)
+           ),
+         preloaded <-
+           Chain.preload_transaction_participants(
+             preloaded,
+             @transaction_participants_necessity_by_association,
+             @api_true
            ) do
       conn
       |> put_status(200)

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -114,7 +114,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
   # Transfer from/to address preloads are handled by
   # `Chain.preload_transaction_participants/3`, see
-  # `@transaction_necessity_by_association`.
+  # `@transaction_participants_necessity_by_association`.
   @token_transfers_in_transaction_necessity_by_association %{
     [token: reputation_association()] => :optional
   }

--- a/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
+++ b/apps/block_scout_web/lib/block_scout_web/models/get_address_tags.ex
@@ -4,7 +4,7 @@ defmodule BlockScoutWeb.Models.GetAddressTags do
   Get various types of tags associated with the address
   """
 
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query, only: [from: 2, select_merge: 3, where: 3]
 
   import Explorer.Chain, only: [select_repo: 1]
 
@@ -27,6 +27,37 @@ defmodule BlockScoutWeb.Models.GetAddressTags do
 
   def get_address_tags(_, _, _), do: %{common_tags: [], personal_tags: [], watchlist_names: []}
 
+  @doc """
+  Same as `get_address_tags/3` for multiple addresses at once, using a single
+  query per tag type instead of a query per address per tag type.
+
+  Returns a map keyed by address hash with values of the same shape as
+  `get_address_tags/3` returns.
+  """
+  def get_address_tags_batch(address_hashes, current_user, opts \\ [])
+
+  def get_address_tags_batch([], _, _), do: %{}
+
+  def get_address_tags_batch(address_hashes, current_user, opts) do
+    common_tags = address_hashes |> get_tags_on_addresses(opts) |> Enum.group_by(& &1.address_hash)
+
+    personal_tags = address_hashes |> get_personal_tags_on_addresses(current_user) |> Enum.group_by(& &1.address_hash)
+
+    watchlist_names =
+      address_hashes
+      |> get_watchlist_names_on_addresses(current_user)
+      |> Enum.group_by(& &1.address_hash, &Map.delete(&1, :address_hash))
+
+    Map.new(address_hashes, fn address_hash ->
+      {address_hash,
+       %{
+         common_tags: Map.get(common_tags, address_hash, []),
+         personal_tags: Map.get(personal_tags, address_hash, []),
+         watchlist_names: Map.get(watchlist_names, address_hash, [])
+       }}
+    end)
+  end
+
   def get_public_tags(address_hash, opts \\ []) when not is_nil(address_hash) do
     %{
       common_tags: get_tags_on_address(address_hash, opts)
@@ -36,46 +67,82 @@ defmodule BlockScoutWeb.Models.GetAddressTags do
   def get_tags_on_address(address_hash, opts \\ [])
 
   def get_tags_on_address(address_hash, opts) when not is_nil(address_hash) do
-    query =
-      from(
-        tt in AddressTag,
-        left_join: att in AddressToTag,
-        on: tt.id == att.tag_id,
-        where: att.address_hash == ^address_hash,
-        where: tt.label != ^"validator",
-        select: %{label: tt.label, display_name: tt.display_name, address_hash: att.address_hash}
-      )
-
-    select_repo(opts).all(query)
+    common_tags_base_query()
+    |> where([tt, att], att.address_hash == ^address_hash)
+    |> select_repo(opts).all()
   end
 
   def get_tags_on_address(_, _), do: []
 
-  def get_personal_tags(address_hash, %{id: id}) when not is_nil(address_hash) do
-    query =
-      from(
-        ta in TagAddress,
-        where: ta.address_hash_hash == ^address_hash,
-        where: ta.identity_id == ^id,
-        select: %{label: ta.name, display_name: ta.name, address_hash: ta.address_hash}
-      )
+  defp get_tags_on_addresses(address_hashes, opts) do
+    common_tags_base_query()
+    |> where([tt, att], att.address_hash in ^address_hashes)
+    |> select_repo(opts).all()
+  end
 
-    Repo.account_repo().all(query)
+  defp common_tags_base_query do
+    from(
+      tt in AddressTag,
+      left_join: att in AddressToTag,
+      on: tt.id == att.tag_id,
+      where: tt.label != ^"validator",
+      select: %{label: tt.label, display_name: tt.display_name, address_hash: att.address_hash}
+    )
+  end
+
+  def get_personal_tags(address_hash, %{id: id}) when not is_nil(address_hash) do
+    id
+    |> personal_tags_base_query()
+    |> where([ta], ta.address_hash_hash == ^address_hash)
+    |> Repo.account_repo().all()
   end
 
   def get_personal_tags(_, _), do: []
 
-  def get_watchlist_names_on_address(address_hash, %{watchlist_id: watchlist_id}) when not is_nil(address_hash) do
-    query =
-      from(
-        wa in WatchlistAddress,
-        where: wa.address_hash_hash == ^address_hash,
-        where: wa.watchlist_id == ^watchlist_id,
-        select: %{label: wa.name, display_name: wa.name}
-      )
+  defp get_personal_tags_on_addresses(address_hashes, %{id: id}) do
+    id
+    |> personal_tags_base_query()
+    |> where([ta], ta.address_hash_hash in ^address_hashes)
+    |> Repo.account_repo().all()
+  end
 
-    Repo.account_repo().all(query)
+  defp get_personal_tags_on_addresses(_, _), do: []
+
+  defp personal_tags_base_query(identity_id) do
+    from(
+      ta in TagAddress,
+      where: ta.identity_id == ^identity_id,
+      select: %{label: ta.name, display_name: ta.name, address_hash: ta.address_hash}
+    )
+  end
+
+  def get_watchlist_names_on_address(address_hash, %{watchlist_id: watchlist_id}) when not is_nil(address_hash) do
+    watchlist_id
+    |> watchlist_names_base_query()
+    |> where([wa], wa.address_hash_hash == ^address_hash)
+    |> Repo.account_repo().all()
   end
 
   def get_watchlist_names_on_address(_, _), do: []
+
+  defp get_watchlist_names_on_addresses(address_hashes, %{watchlist_id: watchlist_id}) do
+    watchlist_id
+    |> watchlist_names_base_query()
+    |> where([wa], wa.address_hash_hash in ^address_hashes)
+    |> select_merge([wa], %{address_hash: wa.address_hash})
+    |> Repo.account_repo().all()
+  end
+
+  defp get_watchlist_names_on_addresses(_, _), do: []
+
+  # `address_hash` is not selected here on purpose: the per-address variant
+  # returns these maps directly in the API response, so the batch variant
+  # `select_merge`s it in only for grouping.
+  defp watchlist_names_base_query(watchlist_id) do
+    from(
+      wa in WatchlistAddress,
+      where: wa.watchlist_id == ^watchlist_id,
+      select: %{label: wa.name, display_name: wa.name}
+    )
+  end
 end

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/helper.ex
@@ -33,6 +33,20 @@ defmodule BlockScoutWeb.API.V2.Helper do
     })
   end
 
+  def address_with_info(_conn, address, address_hash, true, {:address_tags, address_tags}) do
+    %{
+      common_tags: public_tags,
+      personal_tags: private_tags,
+      watchlist_names: watchlist_names
+    } = Map.get(address_tags, address_hash, %{common_tags: [], personal_tags: [], watchlist_names: []})
+
+    Map.merge(address_with_info(address, address_hash), %{
+      "private_tags" => private_tags,
+      "watchlist_names" => watchlist_names,
+      "public_tags" => public_tags
+    })
+  end
+
   def address_with_info(_conn, address, address_hash, false, nil) do
     Map.merge(address_with_info(address, address_hash), %{
       "private_tags" => [],

--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/transaction_view.ex
@@ -9,7 +9,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   alias BlockScoutWeb.API.V2.{ApiView, Helper, InternalTransactionView, TokenTransferView, TokenView}
 
-  alias BlockScoutWeb.Models.GetTransactionTags
+  alias BlockScoutWeb.Models.{GetAddressTags, GetTransactionTags}
   alias BlockScoutWeb.{TransactionStateView, TransactionView}
   alias Ecto.Association.NotLoaded
   alias Explorer.{Chain, Market}
@@ -27,6 +27,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   }
 
   alias Explorer.Chain.Block.Reward
+  alias Explorer.Chain.Cache.BlockNumber
   alias Explorer.Chain.Cache.Counters.AverageBlockTime
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation, as: ProxyImplementation
   alias Explorer.Chain.Transaction.StateChange
@@ -78,7 +79,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   def render("transaction.json", %{transaction: transaction, conn: conn}) do
-    block_height = Chain.block_height(@api_true)
+    block_height = BlockNumber.get_max()
     [decoded_input] = Transaction.decode_transactions([transaction], false, @api_true)
 
     transaction
@@ -425,7 +426,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
   end
 
   defp prepare_transactions(transactions, conn, watchlist_names) do
-    block_height = Chain.block_height(@api_true)
+    block_height = BlockNumber.get_max()
     decoded_transactions = Transaction.decode_transactions(transactions, true, @api_true)
     historic_exchange_rates = historic_exchange_rates(transactions)
 
@@ -508,6 +509,13 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
     block_timestamp = block_timestamp(transaction)
 
+    tags_data =
+      if single_transaction? do
+        batched_address_tags(transaction, conn)
+      else
+        watchlist_names
+      end
+
     result = %{
       "hash" => transaction.hash,
       "result" => status,
@@ -520,7 +528,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
           transaction.from_address,
           transaction.from_address_hash,
           single_transaction?,
-          watchlist_names
+          tags_data
         ),
       "to" =>
         Helper.address_with_info(
@@ -528,7 +536,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
           transaction.to_address,
           transaction.to_address_hash,
           single_transaction?,
-          watchlist_names
+          tags_data
         ),
       "created_contract" =>
         Helper.address_with_info(
@@ -536,7 +544,7 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
           transaction.created_contract_address,
           transaction.created_contract_address_hash,
           single_transaction?,
-          watchlist_names
+          tags_data
         ),
       "confirmations" => transaction.block |> Chain.confirmations(block_height: block_height) |> format_confirmations(),
       "confirmation_duration" => processing_time_duration(transaction),
@@ -576,6 +584,17 @@ defmodule BlockScoutWeb.API.V2.TransactionView do
 
   defp base_fee_per_gas(transaction) do
     transaction.block && transaction.block.base_fee_per_gas
+  end
+
+  # Fetches tags for from/to/created addresses with one query per tag type
+  # instead of up to three queries per address.
+  defp batched_address_tags(transaction, conn) do
+    address_hashes =
+      [transaction.from_address_hash, transaction.to_address_hash, transaction.created_contract_address_hash]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    {:address_tags, GetAddressTags.get_address_tags_batch(address_hashes, current_user(conn), @api_true)}
   end
 
   defp gas_price_for_display(transaction) do

--- a/apps/explorer/config/config.exs
+++ b/apps/explorer/config/config.exs
@@ -23,6 +23,8 @@ config :explorer, Explorer.ChainSpec.GenesisData, enabled: true
 
 config :explorer, Explorer.Chain.Cache.BlockNumber, enabled: true
 
+config :explorer, Explorer.Chain.Cache.ContractMethods, enabled: true
+
 config :explorer, Explorer.Chain.Cache.Counters.AddressesCoinBalanceSum,
   enabled: true,
   ttl_check_interval: :timer.seconds(1)

--- a/apps/explorer/config/test.exs
+++ b/apps/explorer/config/test.exs
@@ -103,6 +103,7 @@ end
 
 config :logger, :explorer, path: Path.absname("logs/test/explorer.log")
 
+config :explorer, Explorer.Chain.Cache.ContractMethods, enabled: false
 config :explorer, Explorer.Chain.Fetcher.CheckBytecodeMatchingOnDemand, enabled: false
 config :explorer, Explorer.Chain.Fetcher.FetchValidatorInfoOnDemand, enabled: false
 config :explorer, Explorer.Tags.AddressTag.Cataloger, enabled: false

--- a/apps/explorer/lib/explorer/application.ex
+++ b/apps/explorer/lib/explorer/application.ex
@@ -32,6 +32,7 @@ defmodule Explorer.Application do
     TransactionsCount
   }
 
+  alias Explorer.Chain.Cache.ContractMethods, as: ContractMethodsCache
   alias Explorer.Chain.Optimism.InteropMessage, as: OptimismInteropMessage
   alias Explorer.Chain.Supply.RSK
 
@@ -105,6 +106,10 @@ defmodule Explorer.Application do
           global_ttl: :infinity
         ),
         con_cache_child_spec(RSK.cache_name(), ttl_check_interval: :timer.minutes(1), global_ttl: :timer.minutes(30)),
+        con_cache_child_spec(ContractMethodsCache.cache_name(),
+          ttl_check_interval: :timer.minutes(1),
+          global_ttl: :infinity
+        ),
         {Redix, redix_opts()},
         {Explorer.Utility.ReplicaAccessibilityManager, []},
         :hackney_pool.child_spec(:default,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1148,6 +1148,68 @@ defmodule Explorer.Chain do
   def get_token_transfers_per_transaction_preview_count, do: @token_transfers_per_transaction_preview
 
   @doc """
+  Loads address-info associations for every address participating in the
+  transaction — `from`/`to`/`created_contract` plus each preloaded token
+  transfer's `from`/`to` — in a single query pass, deduplicating addresses
+  shared between the transaction and its token transfers.
+
+  All participants share `address_necessity_by_association` (typically with the
+  ABI-less smart-contract preload, see
+  `Explorer.Chain.SmartContract.association_without_abi/0`). The `to_address`
+  additionally gets the full `:smart_contract` association when it is a
+  contract, since transaction input and revert-reason decoding need its `abi`.
+  """
+  @spec preload_transaction_participants(Transaction.t(), %{any() => :optional | :required}, [api?]) ::
+          Transaction.t()
+  def preload_transaction_participants(%Transaction{} = transaction, address_necessity_by_association, options) do
+    token_transfers = if is_list(transaction.token_transfers), do: transaction.token_transfers, else: []
+
+    participant_hashes =
+      [
+        transaction.from_address_hash,
+        transaction.to_address_hash,
+        transaction.created_contract_address_hash
+        | Enum.flat_map(token_transfers, &[&1.from_address_hash, &1.to_address_hash])
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    addresses =
+      Address
+      |> where([address], address.hash in ^participant_hashes)
+      |> join_associations(address_necessity_by_association)
+      |> select_repo(options).all()
+      |> Map.new(&{&1.hash, &1})
+
+    to_address =
+      addresses
+      |> Map.get(transaction.to_address_hash)
+      |> preload_full_smart_contract(options)
+
+    %Transaction{
+      transaction
+      | from_address: Map.get(addresses, transaction.from_address_hash),
+        to_address: to_address,
+        created_contract_address: Map.get(addresses, transaction.created_contract_address_hash),
+        token_transfers:
+          Enum.map(token_transfers, fn %TokenTransfer{} = token_transfer ->
+            %TokenTransfer{
+              token_transfer
+              | from_address: Map.get(addresses, token_transfer.from_address_hash),
+                to_address: Map.get(addresses, token_transfer.to_address_hash)
+            }
+          end)
+    }
+  end
+
+  defp preload_full_smart_contract(%Address{contract_code: contract_code} = address, options)
+       when not is_nil(contract_code) do
+    select_repo(options).preload(address, :smart_contract, force: true)
+  end
+
+  defp preload_full_smart_contract(address, _options), do: address
+
+  @doc """
   Converts list of `t:Explorer.Chain.Transaction.t/0` `hashes` to the list of `t:Explorer.Chain.Transaction.t/0`s for
   those `hashes`.
 

--- a/apps/explorer/lib/explorer/chain/cache/contract_methods.ex
+++ b/apps/explorer/lib/explorer/chain/cache/contract_methods.ex
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Cache.ContractMethods do
+  @moduledoc """
+  Cache for `Explorer.Chain.ContractMethod` lookups by method id and for ABI
+  candidates returned by the sig-provider microservice.
+
+  Candidates for a 4-byte selector change only when new methods are inserted on
+  contract verification, so found entries are cached with a long TTL and empty
+  results with a short one, keeping transaction input decoding off the DB and
+  HTTP paths for hot method ids.
+  """
+
+  alias Explorer.Chain.ContractMethod
+
+  @cache_name :contract_methods
+  @found_ttl :timer.hours(1)
+  @not_found_ttl :timer.minutes(5)
+
+  @spec cache_name() :: atom()
+  def cache_name, do: @cache_name
+
+  @doc """
+  Same as `Explorer.Chain.ContractMethod.find_contract_methods/2`, but serves
+  repeated lookups from cache. Ids missing from the cache are fetched from the
+  DB in a single query and cached, including ids with no known methods.
+  """
+  @spec find_contract_methods([Explorer.Chain.MethodIdentifier.t()], keyword()) :: [ContractMethod.t()]
+  def find_contract_methods(method_ids, options) do
+    if enabled?() do
+      find_contract_methods_with_cache(method_ids, options)
+    else
+      ContractMethod.find_contract_methods(method_ids, options)
+    end
+  end
+
+  @doc """
+  Fetches the sig-provider ABI candidates for a method id, calling `fallback_fn`
+  and caching its result (including an empty one) on a cache miss.
+  """
+  @spec fetch_sig_provider_abi(binary(), (-> [map()])) :: [map()]
+  def fetch_sig_provider_abi(method_id, fallback_fn) when is_function(fallback_fn, 0) do
+    if enabled?() do
+      {:ok, abi} =
+        ConCache.fetch_or_store(@cache_name, {:sig_provider_abi, method_id}, fn ->
+          {:ok, item(fallback_fn.())}
+        end)
+
+      abi
+    else
+      fallback_fn.()
+    end
+  end
+
+  defp find_contract_methods_with_cache(method_ids, options) do
+    {cached_methods, missing_ids} =
+      Enum.reduce(method_ids, {[], []}, fn method_id, {cached, missing} ->
+        case ConCache.get(@cache_name, {:contract_method, method_id}) do
+          nil -> {cached, [method_id | missing]}
+          methods -> {methods ++ cached, missing}
+        end
+      end)
+
+    fetched_methods = ContractMethod.find_contract_methods(missing_ids, options)
+    fetched_by_id = Enum.group_by(fetched_methods, & &1.identifier)
+
+    Enum.each(missing_ids, fn method_id ->
+      methods = Map.get(fetched_by_id, method_id, [])
+      ConCache.put(@cache_name, {:contract_method, method_id}, item(methods))
+    end)
+
+    cached_methods ++ fetched_methods
+  end
+
+  defp enabled? do
+    Application.get_env(:explorer, __MODULE__)[:enabled]
+  end
+
+  defp item(value) do
+    %ConCache.Item{value: value, ttl: if(value == [], do: @not_found_ttl, else: @found_ttl)}
+  end
+end

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -260,6 +260,21 @@ defmodule Explorer.Chain.SmartContract do
     @dead_address_hash_string
   end
 
+  @doc """
+  Returns a preload spec for the `:smart_contract` association that selects all
+  fields except `abi`.
+
+  ABIs of popular contracts reach hundreds of kilobytes, so preloads that only
+  need address info (name, verification flags) should use this spec. Note that
+  `abi` is `nil` (not `%NotLoaded{}`) on structs loaded this way, so it must not
+  be used on preload paths feeding transaction input decoding.
+  """
+  @spec association_without_abi() :: {:smart_contract, Ecto.Query.t()}
+  def association_without_abi do
+    {:smart_contract,
+     from(smart_contract in __MODULE__, select: struct(smart_contract, ^(__schema__(:fields) -- [:abi])))}
+  end
+
   @typedoc """
   The name of a parameter to a function or event.
   """

--- a/apps/explorer/lib/explorer/chain/transaction.ex
+++ b/apps/explorer/lib/explorer/chain/transaction.ex
@@ -345,6 +345,7 @@ defmodule Explorer.Chain.Transaction do
 
   alias Explorer.Chain.Block.Reader.General, as: BlockReaderGeneral
 
+  alias Explorer.Chain.Cache.ContractMethods, as: ContractMethodsCache
   alias Explorer.Chain.Cache.Transactions
 
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
@@ -1092,18 +1093,33 @@ defmodule Explorer.Chain.Transaction do
     end
   end
 
-  defp decode_function_call_via_sig_provider(%{bytes: data} = input, hash, skip_sig_provider?) do
+  defp decode_function_call_via_sig_provider(
+         %{bytes: <<method_id::binary-size(4), _::binary>> = data} = input,
+         hash,
+         skip_sig_provider?
+       ) do
     with true <- SigProviderInterface.enabled?(),
          false <- skip_sig_provider?,
-         {:ok, result} <- SigProviderInterface.decode_function_call(input),
-         true <- is_list(result),
-         false <- Enum.empty?(result),
-         abi <- [result |> List.first() |> Map.put("outputs", []) |> Map.put("type", "function")],
+         [_ | _] = abi <-
+           ContractMethodsCache.fetch_sig_provider_abi(method_id, fn -> request_abi_from_sig_provider(input) end),
          {:ok, _, _, _} = candidate <- do_decoded_input_data(data, abi, hash) do
       [candidate]
     else
       _ ->
         []
+    end
+  end
+
+  # inputs shorter than a 4-byte method id cannot be a function call
+  defp decode_function_call_via_sig_provider(_input, _hash, _skip_sig_provider?), do: []
+
+  defp request_abi_from_sig_provider(input) do
+    with {:ok, result} <- SigProviderInterface.decode_function_call(input),
+         true <- is_list(result),
+         false <- Enum.empty?(result) do
+      [result |> List.first() |> Map.put("outputs", []) |> Map.put("type", "function")]
+    else
+      _ -> []
     end
   end
 
@@ -2387,7 +2403,7 @@ defmodule Explorer.Chain.Transaction do
         _ -> []
       end)
       |> Enum.uniq()
-      |> ContractMethod.find_contract_methods(opts)
+      |> ContractMethodsCache.find_contract_methods(opts)
       |> Enum.into(empty_methods_map, &{&1.identifier, [&1]})
 
     # decode remaining transaction using methods map


### PR DESCRIPTION
## Motivation

Profiling of `/api/v2/transactions/:hash` (50 transactions, avg 3.1s / max 6.3s) showed most of the time spent in redundant DB round trips and oversized preload payloads:

| Stage | avg / max, ms |
|---|---|
| `hash_to_transaction` | 1123 / 2188 |
| `preload_token_transfers` | 746 / 3013 |
| render: `block_height` | 260 / 392 |
| render: from/to `address_info` | 254 + 255 |
| render: `decode_input` | 161 / 478 |

Follow-up profiling on a live instance (Robinhood chain) after the first round of fixes showed the remaining time concentrated in `hash_to_transaction` and `preload_token_transfers`, dominated by the *number of sequential preload round trips* — each participant address (tx from/to/created plus every token transfer's from/to) was loaded with its own association tree, repeating identical queries for addresses shared between the transaction and its transfers. This PR removes the avoidable work from these hot paths.

## Changelog

### Enhancements

- **Unified participant-address preloading.** New `Chain.preload_transaction_participants/3` loads address info for *all* transaction participants — `from`/`to`/`created_contract` plus each embedded token transfer's `from`/`to` — in a single deduplicated `WHERE hash IN (...)` query with one shared wave of nested preloads (`scam_badge`, `names`, `token`, ABI-less `smart_contract`, `proxy_implementations`). The single-transaction action's necessity maps drop their per-address trees accordingly (`@transaction_necessity_by_association` is now just `:block` + chain-type extras). `to_address` additionally gets the full `:smart_contract` (with `abi`) when it is a contract, since input and revert-reason decoding read the preloaded ABI. For a transfer-heavy transaction this cuts ~32 queries in ~6–7 dependent waves down to ~12 queries in ~5 waves. List endpoints are unchanged.
- **Block height from cache.** `transaction.json` and `transactions.json` renders now use `Cache.BlockNumber.get_max()` (kept fresh by the indexer, DB fallback on miss) instead of running a `max(number)` aggregate query on every request.
- **Batched address tag queries.** New `GetAddressTags.get_address_tags_batch/3` fetches tags for `from`/`to`/`created_contract` addresses with one `WHERE address_hash IN (...)` query per tag type instead of up to 3 queries per address (9 → 3 queries for authenticated users, 2–3 → 1 for anonymous). Shared query bodies are extracted into base-query functions with dynamic address filters. Response shape is unchanged.
- **Slim `smart_contract` preloads.** New `SmartContract.association_without_abi/0` preloads the association without the `abi` column (ABIs of popular contracts reach hundreds of KB); used by the unified participant preload above.
- **Method id / sig-provider caching.** New `Explorer.Chain.Cache.ContractMethods` (ConCache, 1h TTL for found entries, 5m for misses, negative results included) backs `ContractMethod` lookups by method id in `decode_transactions/3` and caches ABI candidates returned by the sig-provider microservice, removing a synchronous HTTP call from the decode path for recently seen selectors. Controlled by `config :explorer, Explorer.Chain.Cache.ContractMethods, enabled:` and disabled in the test env to keep DB sandbox isolation.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction details now display public, private, and watchlist address tags more consistently.
  * Contract method and signature decoding benefits from improved caching for faster repeated lookups.
  * Transaction participants and token-transfer addresses are loaded more efficiently.
* **Performance**
  * Reduced unnecessary smart-contract data loading to improve transaction response times and resource usage.
  * Batch processing improves performance when displaying tags and participant information across transactions.
* **Bug Fixes**
  * Improved handling of incomplete method selectors during transaction decoding.
  * Ensured contract and address details remain available across transaction and transfer views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->