### PR TITLE
chore: Name the transaction preview schemas TransactionPreview

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/transaction/preview.ex
@@ -10,6 +10,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.PreviewAddress do
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
+    title: "TransactionPreviewAddress",
     description: "Lightweight address in transaction preview",
     type: :object,
     nullable: true,
@@ -51,6 +52,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Transaction.Preview do
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
+    title: "TransactionPreview",
     description: "Lightweight transaction preview for social media embeds",
     type: :object,
     properties: %{


### PR DESCRIPTION
## Motivation

The endpoint added in #14638 defines its response as `Preview` with a nested `PreviewAddress`. Inside Elixir
those are unambiguous — the modules are `BlockScoutWeb.Schemas.API.V2.Transaction.Preview` / `.PreviewAddress`.
But component names in the generated OpenAPI spec are **global**, so they arrive at consumers stripped of that
namespace: `schemas['Preview']` sitting next to every other entity's schema, saying nothing about what it is a
preview *of*. The generated TypeScript reads:

```ts
Preview: { status, timestamp, method, from: PreviewAddress | null, to: PreviewAddress | null }
```

This renames just the generated titles, following the `title:` convention already used by ~84 schemas here
(`AddressNullable`, `TokenInstanceInList`, `SmartContractListItem`, …):

- `Preview` → `TransactionPreview`
- `PreviewAddress` → `TransactionPreviewAddress`

The Elixir module names are left alone — they are already clear, and renaming them would only add stutter
(`Transaction.TransactionPreview`).

Worth doing now rather than later: the endpoint's only consumer today is the frontend's transaction
social-preview feature (blockscout/frontend#3593), which is still on a branch, so nothing published depends
on the current names yet.

## Changelog

### Enhancements

- Explicit, self-describing OpenAPI titles for the transaction preview response and its address.

### Incompatible Changes

- Two schema names change in the generated spec and in `@blockscout/api-types`. Both were introduced in
  #14638 and have not shipped in a stable types release, so the only consumer is the frontend branch above,
  which will re-pin a beta after this merges.

## Upgrading

Nothing to do for instance operators — the response body is byte-identical, only its name in the spec changes.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed.
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer OpenAPI schema titles for transaction preview addresses and transaction previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->