### PR TITLE
fix: Rollback priority of address higher than ENS in search redirect

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/v2/search_view.ex
@@ -174,12 +174,12 @@ defmodule BlockScoutWeb.API.V2.SearchView do
     %{"type" => "address", "parameter" => Address.checksum(item.hash)}
   end
 
-  defp redirect_search_results(%{name: name, protocol: _protocol}) do
-    %{"type" => "ens_domain", "parameter" => name}
-  end
-
   defp redirect_search_results(%{address_hash: address_hash}) when not is_nil(address_hash) do
     %{"type" => "address", "parameter" => address_hash}
+  end
+
+  defp redirect_search_results(%{name: name, protocol: _protocol}) do
+    %{"type" => "ens_domain", "parameter" => name}
   end
 
   defp redirect_search_results(%Block{} = item) do

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -2014,7 +2014,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       %{"redirect" => false, "type" => nil, "parameter" => nil} = json_response(request, 200)
     end
 
-    test "finds ens domain with partial query (without dot)", %{conn: conn} do
+    test "finds resolved address of ens domain with partial query (without dot)", %{conn: conn} do
       bypass = Bypass.open()
       bens_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.BENS)
       old_chain_id = Application.get_env(:block_scout_web, :chain_id)
@@ -2037,6 +2037,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
       partial_name = "vitalik"
       full_name = "vitalik.eth"
       ens_address = insert(:address)
+      ens_address_hash_string = to_string(ens_address)
 
       ens_response = """
       {
@@ -2045,7 +2046,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
               "id": "0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
               "name": "#{full_name}",
               "resolved_address": {
-                  "hash": "#{to_string(ens_address)}"
+                  "hash": "#{ens_address_hash_string}"
               },
               "owner": {
                   "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
@@ -2076,7 +2077,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
       request = get(conn, "/api/v2/search/check-redirect?q=#{partial_name}")
 
-      assert %{"redirect" => true, "type" => "ens_domain", "parameter" => ^full_name} =
+      assert %{"redirect" => true, "type" => "address", "parameter" => ^ens_address_hash_string} =
                json_response(request, 200)
     end
   end


### PR DESCRIPTION
## Motivation

https://github.com/blockscout/blockscout/pull/14301/ brought check-redirect API endpoint unwanted behaviour. It redirects to ENS endpoint instead of address page.

### Expected behaviour

```
curl "https://optimism-sepolia.k8s-dev.blockscout.com/api/v2/search/check-redirect?q=vitalik.eth"
{"parameter":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","redirect":true,"type":"address"}
```

### Actual behaviour

```
curl "https://optimism-sepolia.k8s-dev.blockscout.com/api/v2/search/check-redirect?q=vitalik.eth"
{"parameter":"vitalik.eth","redirect":true,"type":"ens_domain"}
```

## Changelog

Rollback priorities of `redirect_search_results/1` function clauses: address clause must have higher priority than ENS clause.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result routing when an entry matches both an address and a named domain.
  * Matching address results now open the address page instead of the domain page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->