### PR TITLE
chore: Fix transform addresses tests for zksync

### DIFF
--- a/apps/indexer/lib/indexer/transform/addresses.ex
+++ b/apps/indexer/lib/indexer/transform/addresses.ex
@@ -232,6 +232,128 @@ defmodule Indexer.Transform.Addresses do
 
   defstruct pending: false
 
+  if @chain_type == :zksync do
+    @created_contract_doc """
+    A contract created in an internal transaction has its `created_contract_address_hash` extracted.
+    The `created_contract_code` is ignored as it isn't the deployed bytecode on zksync.
+
+        iex> Indexer.Transform.Addresses.extract_addresses(
+        ...>   %{
+        ...>     internal_transactions: [
+        ...>       %{
+        ...>         block_number: 3,
+        ...>         created_contract_address_hash: "0x0000000000000000000000000000000000000003",
+        ...>         created_contract_code: "0x"
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> )
+        [
+          %{
+            fetched_coin_balance_block_number: 3,
+            hash: "0x0000000000000000000000000000000000000003"
+          }
+        ]
+    """
+
+    @merged_contract_code_doc """
+    When a contract's code is fetched and the contract is used in transactions in the same fetched data, the
+    `contract_code` is merged with the greatest `block_number`
+
+        iex> Indexer.Transform.Addresses.extract_addresses(
+        ...>   %{
+        ...>     codes: [
+        ...>       %{
+        ...>         address: "0x0000000000000000000000000000000000000001",
+        ...>         code: "0x"
+        ...>       }
+        ...>     ],
+        ...>     transactions: [
+        ...>       %{
+        ...>         block_number: 2,
+        ...>         from_address_hash: "0x0000000000000000000000000000000000000001",
+        ...>         nonce: 4
+        ...>       },
+        ...>       %{
+        ...>         block_number: 3,
+        ...>         to_address_hash: "0x0000000000000000000000000000000000000001",
+        ...>         nonce: 5
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> )
+        [
+          %{
+            contract_code: "0x",
+            fetched_coin_balance_block_number: 3,
+            hash: "0x0000000000000000000000000000000000000001",
+            nonce: 4
+          }
+        ]
+    """
+  else
+    @created_contract_doc """
+    A contract created in an internal transaction has its `created_contract_address_hash` and
+    `created_contract_code` extracted.
+
+        iex> Indexer.Transform.Addresses.extract_addresses(
+        ...>   %{
+        ...>     internal_transactions: [
+        ...>       %{
+        ...>         block_number: 3,
+        ...>         created_contract_address_hash: "0x0000000000000000000000000000000000000003",
+        ...>         created_contract_code: "0x"
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> )
+        [
+          %{
+            contract_code: "0x",
+            fetched_coin_balance_block_number: 3,
+            hash: "0x0000000000000000000000000000000000000003"
+          }
+        ]
+    """
+
+    @merged_contract_code_doc """
+    When a contract is created and then used in internal transactions and transaction in the same fetched data, the
+    `created_contract_code` is merged with the greatest `block_number`
+
+        iex> Indexer.Transform.Addresses.extract_addresses(
+        ...>   %{
+        ...>     internal_transactions: [
+        ...>       %{
+        ...>         block_number: 1,
+        ...>         created_contract_code: "0x",
+        ...>         created_contract_address_hash: "0x0000000000000000000000000000000000000001"
+        ...>       }
+        ...>     ],
+        ...>     transactions: [
+        ...>       %{
+        ...>         block_number: 2,
+        ...>         from_address_hash: "0x0000000000000000000000000000000000000001",
+        ...>         nonce: 4
+        ...>       },
+        ...>       %{
+        ...>         block_number: 3,
+        ...>         to_address_hash: "0x0000000000000000000000000000000000000001",
+        ...>         nonce: 5
+        ...>       }
+        ...>     ]
+        ...>   }
+        ...> )
+        [
+          %{
+            contract_code: "0x",
+            fetched_coin_balance_block_number: 3,
+            hash: "0x0000000000000000000000000000000000000001",
+            nonce: 4
+          }
+        ]
+    """
+  end
+
   @doc """
   Extract addresses from block, internal transaction, transaction, and log parameters.
 
@@ -254,8 +376,7 @@ defmodule Indexer.Transform.Addresses do
         }
       ]
 
-  Internal transactions can have their `from_address_hash`, `to_address_hash` and/or `created_contract_address_hash`
-  extracted.
+  Internal transactions can have their `from_address_hash` and/or `to_address_hash` extracted.
 
       iex> Indexer.Transform.Addresses.extract_addresses(
       ...>   %{
@@ -267,11 +388,6 @@ defmodule Indexer.Transform.Addresses do
       ...>       %{
       ...>         block_number: 2,
       ...>         to_address_hash: "0x0000000000000000000000000000000000000002"
-      ...>       },
-      ...>       %{
-      ...>         block_number: 3,
-      ...>         created_contract_address_hash: "0x0000000000000000000000000000000000000003",
-      ...>         created_contract_code: "0x"
       ...>       }
       ...>     ]
       ...>   }
@@ -284,14 +400,10 @@ defmodule Indexer.Transform.Addresses do
         %{
           fetched_coin_balance_block_number: 2,
           hash: "0x0000000000000000000000000000000000000002"
-        },
-        %{
-          contract_code: "0x",
-          fetched_coin_balance_block_number: 3,
-          hash: "0x0000000000000000000000000000000000000003"
         }
       ]
 
+  #{@created_contract_doc}
   Transactions can have their `from_address_hash` and/or `to_address_hash` extracted.
 
       iex> Indexer.Transform.Addresses.extract_addresses(
@@ -399,41 +511,7 @@ defmodule Indexer.Transform.Addresses do
         }
       ]
 
-  When a contract is created and then used in internal transactions and transaction in the same fetched data, the
-  `created_contract_code` is merged with the greatest `block_number`
-
-      iex> Indexer.Transform.Addresses.extract_addresses(
-      ...>   %{
-      ...>     internal_transactions: [
-      ...>       %{
-      ...>         block_number: 1,
-      ...>         created_contract_code: "0x",
-      ...>         created_contract_address_hash: "0x0000000000000000000000000000000000000001"
-      ...>       }
-      ...>     ],
-      ...>     transactions: [
-      ...>       %{
-      ...>         block_number: 2,
-      ...>         from_address_hash: "0x0000000000000000000000000000000000000001",
-      ...>         nonce: 4
-      ...>       },
-      ...>       %{
-      ...>         block_number: 3,
-      ...>         to_address_hash: "0x0000000000000000000000000000000000000001",
-      ...>         nonce: 5
-      ...>       }
-      ...>     ]
-      ...>   }
-      ...> )
-      [
-        %{
-          contract_code: "0x",
-          fetched_coin_balance_block_number: 3,
-          hash: "0x0000000000000000000000000000000000000001",
-          nonce: 4
-        }
-      ]
-
+  #{@merged_contract_code_doc}
   All data must have some way of extracting the `fetched_coin_balance_block_number` or an `ArgumentError` will be raised when
   none of the supported extract formats matches the params.
 

--- a/apps/indexer/test/indexer/transform/addresses_test.exs
+++ b/apps/indexer/test/indexer/transform/addresses_test.exs
@@ -4,6 +4,10 @@ defmodule Indexer.Transform.AddressesTest do
 
   alias Indexer.Transform.Addresses
 
+  @chain_type Application.compile_env(:explorer, :chain_type)
+
+  @created_contract_code_extracted? @chain_type != :zksync
+
   doctest Addresses
 
   describe "extract_addresses/1" do
@@ -60,6 +64,22 @@ defmodule Indexer.Transform.AddressesTest do
     end
 
     test "differing contract code is ignored" do
+      expected_address =
+        if @created_contract_code_extracted? do
+          %{
+            fetched_coin_balance_block_number: 2,
+            contract_code: "0x1",
+            hash: "0x0000000000000000000000000000000000000001",
+            nonce: nil
+          }
+        else
+          %{
+            fetched_coin_balance_block_number: 2,
+            hash: "0x0000000000000000000000000000000000000001",
+            nonce: nil
+          }
+        end
+
       assert Addresses.extract_addresses(%{
                internal_transactions: [
                  %{
@@ -73,14 +93,7 @@ defmodule Indexer.Transform.AddressesTest do
                    created_contract_address_hash: "0x0000000000000000000000000000000000000001"
                  }
                ]
-             }) == [
-               %{
-                 fetched_coin_balance_block_number: 2,
-                 contract_code: "0x1",
-                 hash: "0x0000000000000000000000000000000000000001",
-                 nonce: nil
-               }
-             ]
+             }) == [expected_address]
     end
 
     test "extracts address params from code params" do
@@ -154,6 +167,16 @@ defmodule Indexer.Transform.AddressesTest do
         block_reward_contract_beneficiaries: [beneficiary]
       }
 
+      created_contract_address = %{
+        hash: internal_transaction.created_contract_address_hash,
+        fetched_coin_balance_block_number: internal_transaction.block_number
+      }
+
+      created_contract_address =
+        if @created_contract_code_extracted?,
+          do: Map.put(created_contract_address, :contract_code, internal_transaction.created_contract_code),
+          else: created_contract_address
+
       assert Addresses.extract_addresses(blockchain_data) == [
                %{hash: block.miner_hash, fetched_coin_balance_block_number: block.number},
                %{
@@ -164,11 +187,7 @@ defmodule Indexer.Transform.AddressesTest do
                  hash: internal_transaction.to_address_hash,
                  fetched_coin_balance_block_number: internal_transaction.block_number
                },
-               %{
-                 hash: internal_transaction.created_contract_address_hash,
-                 contract_code: internal_transaction.created_contract_code,
-                 fetched_coin_balance_block_number: internal_transaction.block_number
-               },
+               created_contract_address,
                %{
                  hash: transaction.from_address_hash,
                  fetched_coin_balance_block_number: transaction.block_number,
@@ -223,10 +242,14 @@ defmodule Indexer.Transform.AddressesTest do
         ]
       }
 
-      assert Addresses.extract_addresses(blockchain_data) ==
-               [
-                 %{hash: hash, fetched_coin_balance_block_number: 34, contract_code: "code", nonce: 12}
-               ]
+      expected_address =
+        if @created_contract_code_extracted? do
+          %{hash: hash, fetched_coin_balance_block_number: 34, contract_code: "code", nonce: 12}
+        else
+          %{hash: hash, fetched_coin_balance_block_number: 34, nonce: 12}
+        end
+
+      assert Addresses.extract_addresses(blockchain_data) == [expected_address]
     end
 
     test "only entities data defined in @entity_to_address_map are collected" do
@@ -273,7 +296,7 @@ defmodule Indexer.Transform.AddressesTest do
              }) == []
     end
 
-    if Application.compile_env(:explorer, :chain_type) == :eden do
+    if @chain_type == :eden do
       test "recipients of the batched calls are extracted with the coin balance block number" do
         first_call_hash = "0x11f60a633dd30a8d1a26dd6e20167a9293fb4647"
         second_call_hash = "0xcfc096e58b1f858e5a3ee88ecaeccb2b464625b5"


### PR DESCRIPTION
## Motivation

`Indexer.Transform.Addresses` tests were not adapted for `zksync` chain type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified address extraction behavior by blockchain type.
  - Documented that zkSync ignores code created during contract execution, while other supported chains continue to extract and merge it.

- **Bug Fixes**
  - Updated address extraction expectations to accurately reflect chain-specific contract code handling.
  - Improved validation for differing and duplicate contract addresses across supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->