### PR TITLE
fix: Handle node JSONRPC errors in batched eth-rpc proxy requests

### DIFF
--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -912,8 +912,9 @@ defmodule Explorer.EthRPC do
         {:proxy, %{error: %{code: _code, message: _message} = error}} ->
           format_error(error, Map.get(request, "id"))
 
-        {:proxy, {:error, {:bad_response = error, _}}} ->
-          format_error(error, @internal_error_code, Map.get(request, "id"))
+        # the request URL is intentionally dropped from the reason to avoid exposing it
+        {:proxy, {:error, {:bad_response = error, _request_url}}} ->
+          format_error(inspect(error), @internal_error_code, Map.get(request, "id"))
 
         {:proxy, {:error, %Mint.TransportError{reason: reason}}} ->
           format_error(inspect(reason), @internal_error_code, Map.get(request, "id"))

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -907,10 +907,18 @@ defmodule Explorer.EthRPC do
         {:proxy, %{result: result}} ->
           format_success(result, Map.get(request, "id"))
 
+        # a batched request succeeded on the transport level, but the node returned
+        # a JSONRPC error object for this particular request
+        {:proxy, %{error: %{code: _code, message: _message} = error}} ->
+          format_error(error, Map.get(request, "id"))
+
         {:proxy, {:error, {:bad_response = error, _}}} ->
           format_error(error, @internal_error_code, Map.get(request, "id"))
 
         {:proxy, {:error, %Mint.TransportError{reason: reason}}} ->
+          format_error(inspect(reason), @internal_error_code, Map.get(request, "id"))
+
+        {:proxy, {:error, reason}} ->
           format_error(inspect(reason), @internal_error_code, Map.get(request, "id"))
       end
     end)
@@ -1543,6 +1551,11 @@ defmodule Explorer.EthRPC do
 
   defp format_error(message, code, id) do
     %{error: %{code: code, message: message}, id: id}
+  end
+
+  # passes an already built JSONRPC error object through, keeping the optional `data` field
+  defp format_error(%{code: _code, message: _message} = error, id) do
+    %{error: error, id: id}
   end
 
   defp do_eth_request(%{"jsonrpc" => rpc_version}) when rpc_version != "2.0" do

--- a/apps/explorer/test/explorer/eth_rpc_test.exs
+++ b/apps/explorer/test/explorer/eth_rpc_test.exs
@@ -108,6 +108,19 @@ defmodule Explorer.EthRPCTest do
     assert response == %{error: %{code: -32_603, message: ":timeout"}, id: 1}
   end
 
+  test "undecodable node response for a proxied request is returned as an internal error without the node URL" do
+    set_extended_proxy_methods_enabled(true)
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: 1, jsonrpc: "2.0", method: "net_version", params: []}], _options ->
+      {:error, {:bad_response, "http://node.example.com:8545"}}
+    end)
+
+    request = %{"id" => 1, "jsonrpc" => "2.0", "method" => "net_version", "params" => []}
+
+    assert [response] = EthRPC.responses([request])
+    assert response == %{error: %{code: -32_603, message: ":bad_response"}, id: 1}
+  end
+
   test "default proxy methods remain available when feature flag is disabled" do
     set_extended_proxy_methods_enabled(false)
 

--- a/apps/explorer/test/explorer/eth_rpc_test.exs
+++ b/apps/explorer/test/explorer/eth_rpc_test.exs
@@ -66,6 +66,48 @@ defmodule Explorer.EthRPCTest do
     assert response == %{error: %{code: -32_602, message: "Invalid address"}, id: 1}
   end
 
+  test "JSONRPC error returned by the node for a proxied request is passed through" do
+    set_extended_proxy_methods_enabled(true)
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: 3, jsonrpc: "2.0", method: "eth_getProof", params: _}], _options ->
+      {:ok,
+       [
+         %{
+           id: 3,
+           jsonrpc: "2.0",
+           error: %{code: -32_602, message: "distance to target block exceeds maximum proof window"}
+         }
+       ]}
+    end)
+
+    request = %{
+      "id" => 3,
+      "jsonrpc" => "2.0",
+      "method" => "eth_getProof",
+      "params" => ["0x96f56752bde1b9f6f86393658a79dec9f7095de3", [], "0x2d69fc1"]
+    }
+
+    assert [response] = EthRPC.responses([request])
+
+    assert response == %{
+             error: %{code: -32_602, message: "distance to target block exceeds maximum proof window"},
+             id: 3
+           }
+  end
+
+  test "transport error for a proxied request is returned as an internal error" do
+    set_extended_proxy_methods_enabled(true)
+
+    expect(EthereumJSONRPC.Mox, :json_rpc, fn [%{id: 1, jsonrpc: "2.0", method: "net_version", params: []}], _options ->
+      {:error, :timeout}
+    end)
+
+    request = %{"id" => 1, "jsonrpc" => "2.0", "method" => "net_version", "params" => []}
+
+    assert [response] = EthRPC.responses([request])
+    assert response == %{error: %{code: -32_603, message: ":timeout"}, id: 1}
+  end
+
   test "default proxy methods remain available when feature flag is disabled" do
     set_extended_proxy_methods_enabled(false)
 


### PR DESCRIPTION
## Motivation

A proxied `/api/eth-rpc` method crashed the request with a 500 whenever the node replied with a JSONRPC error object instead of a result:

```bash
curl --location 'https://optimism-sepolia.k8s-dev.blockscout.com/api/eth-rpc' \
--header 'Content-Type: application/json' \
--data '{"id": 3, "jsonrpc": "2.0", "method": "eth_getProof", "params": ["0x96f56752bde1b9f6f86393658a79dec9f7095de3", [], "0x2d69fc1"]}'
```

```
** (exit) an exception was raised:
    ** (WithClauseError) no with clause matching:

    {:proxy,
     %{
       error: %{
         code: -32602,
         message: "distance to target block exceeds maximum proof window"
       },
       id: 3,
       jsonrpc: "2.0"
     }}

        (explorer 12.0.0) lib/explorer/eth_rpc.ex:893: anonymous fn/2 in Explorer.EthRPC.responses/1
```

Root cause: proxied requests are dispatched through the **batch** path of `EthereumJSONRPC.HTTP.json_rpc/2`. Unlike the single-request path, which converts a node-side error into an `{:error, standardized_error}` tuple in `handle_response/2`, the batch path returns `{:ok, responses}` and each response keeps its `:error` key as-is (`standardize_response/1`). The `with` block in `Explorer.EthRPC.responses/1` only had `else` clauses for `{:error, %{code: code, message: message}}` tuples and `%{result: result}` maps, so a `%{error: ...}` map matched nothing.

Any node with a limited archive/proof window reproduces this for `eth_getProof`, and the same shape is returned for `eth_call`, `eth_getBalance`, `eth_estimateGas` and other proxied methods, so a plain client error resulted in a crashed connection instead of a valid JSONRPC error response.

## Changelog

### Enhancements

- Regression tests in `apps/explorer/test/explorer/eth_rpc_test.exs` covering both a node-returned JSONRPC error and a transport error for a proxied request.

### Bug Fixes

- `Explorer.EthRPC.responses/1` now handles a per-request JSONRPC error returned inside a successful batch response and passes it through verbatim, preserving the optional `data` field (useful for revert reasons on proxied `eth_call`). A new `format_error/2` clause does the pass-through.
- Added a catch-all `{:proxy, {:error, reason}}` clause. The `else` block previously handled only `:bad_response` and `%Mint.TransportError{}`, so other transport failures — `{:error, :timeout}`, `{:error, %{status_code: 413}}` from `rechunk_json_rpc/4`, `%EthereumJSONRPC.DecodeError{}` — crashed the same way. They now return `-32603` with the inspected reason.


## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON-RPC errors returned by proxied nodes.
  * Preserved detailed error information, including additional data fields.
  * Converted connection, timeout, and malformed-response failures into consistent internal-error responses.
  * Prevented node request URLs from being exposed in error messages.

* **Tests**
  * Added coverage for proxied node errors, timeouts, malformed responses, and error-detail preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->