### PR TITLE
refactor: switch TAC operations in search to Read API v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ dump.rdb
 .cursorrules
 .elixir_ls
 .claude/settings.local.json
+.claude/commands/review-pr.md
 
 **.dec**
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/search_controller.ex
@@ -107,7 +107,7 @@ defmodule BlockScoutWeb.API.V2.SearchController do
     responses: [
       ok:
         {"Quick search results.", "application/json",
-         %Schema{type: :array, items: %Schema{type: :object}, nullable: false}},
+         %Schema{type: :array, items: Schemas.Search.ResultItem, nullable: false}},
       unprocessable_entity: JsonErrorResponse.response()
     ]
 

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/result_item.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/result_item.ex
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.Schemas.API.V2.Search.ResultItem do
+  @moduledoc """
+  This module defines the schema for a single item of the search results.
+
+  Only `tac_operation` is typed so far. The other result types (address, block, transaction,
+  token, etc.) are not described individually yet, so additional properties are deliberately
+  allowed and this schema only constrains an item that carries a TAC operation.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.Search.TacOperation
+
+  OpenApiSpex.schema(%{
+    title: "SearchResultItem",
+    description: "Single search result. The shape depends on `type`; only `tac_operation` results are fully described.",
+    type: :object,
+    properties: %{
+      tac_operation: TacOperation
+    },
+    required: []
+  })
+end

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/results.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/results.ex
@@ -5,6 +5,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Search.Results do
   """
   require OpenApiSpex
 
+  alias BlockScoutWeb.Schemas.API.V2.Search.ResultItem
   alias OpenApiSpex.Schema
 
   OpenApiSpex.schema(%{
@@ -12,7 +13,7 @@ defmodule BlockScoutWeb.Schemas.API.V2.Search.Results do
     description: "Search results containing blocks, transactions, and addresses",
     type: :object,
     properties: %{
-      items: %Schema{type: :array, items: %Schema{type: :object}},
+      items: %Schema{type: :array, items: ResultItem},
       next_page_params: %Schema{type: :object, nullable: true, additionalProperties: true}
     },
     required: []

--- a/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/tac_operation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/schemas/api/v2/search/tac_operation.ex
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule BlockScoutWeb.Schemas.API.V2.Search.TacOperation do
+  @moduledoc """
+  This module defines the schema for a TAC operation in the search results.
+
+  The object is returned by the `tac-operation-lifecycle` microservice (Read API v2) and is
+  proxied verbatim, so this schema mirrors the microservice contract rather than describing a
+  Blockscout-owned struct.
+  """
+  require OpenApiSpex
+
+  alias BlockScoutWeb.Schemas.API.V2.General
+  alias OpenApiSpex.Schema
+
+  @type_enum [
+    "UNKNOWN",
+    "TON_TAC_TON",
+    "TAC_TON",
+    "TON_TAC"
+  ]
+
+  @status_enum [
+    "pending",
+    "success",
+    "failed"
+  ]
+
+  @blockchain_enum [
+    "TAC",
+    "TON",
+    "UNKNOWN_BLOCKCHAIN"
+  ]
+
+  @sender_schema %Schema{
+    type: :object,
+    properties: %{
+      address: %Schema{
+        type: :string,
+        nullable: false,
+        description: "TAC (EVM) or TON address, depending on `blockchain`",
+        example: "EQDoF2OkxsI3gc5jAuxlqozN9H/SgEOUCopMa1yU4djLaXuL"
+      },
+      blockchain: %Schema{type: :string, enum: @blockchain_enum, nullable: false, example: "TON"}
+    },
+    required: [:address, :blockchain],
+    additionalProperties: false,
+    nullable: true
+  }
+
+  OpenApiSpex.schema(%{
+    title: "TacOperationSearchResult",
+    description: "TAC operation as returned by the tac-operation-lifecycle service Read API v2.",
+    type: :object,
+    properties: %{
+      operation_id: %Schema{
+        type: :string,
+        nullable: false,
+        example: "0xf01646ac36cbbcebd8a5ff09c300d5f3bebdd2fbe0135a377eaa485d9edcc670"
+      },
+      type: %Schema{
+        type: :string,
+        enum: @type_enum,
+        nullable: false,
+        description: "Transfer route. Never carries a lifecycle outcome — see `status` and `rollback`.",
+        example: "TAC_TON"
+      },
+      status: %Schema{
+        type: :string,
+        enum: @status_enum,
+        nullable: false,
+        description: "Business outcome of the operation.",
+        example: "success"
+      },
+      rollback: %Schema{
+        type: :boolean,
+        nullable: false,
+        description: "Whether a rollback occurred.",
+        example: false
+      },
+      timestamp: General.Timestamp,
+      sender: @sender_schema,
+      error_reason: %Schema{
+        type: :string,
+        nullable: true,
+        description:
+          "Short failure label. It is published only when the stored reason is short enough to be a label, so it is legitimately `null` on a failed operation — its absence does not imply success.",
+        example: "Insufficient Fee"
+      }
+    },
+    required: [:operation_id, :type, :status, :rollback, :timestamp],
+    additionalProperties: false
+  })
+end

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -7,6 +7,8 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
   alias Explorer.Tags.AddressTag
   alias Plug.Conn.Query
 
+  @tac_operations_path "/api/v2/tac/operations"
+
   describe "/search" do
     setup do
       initial_value = :persistent_term.get(:market_token_fetcher_enabled, false)
@@ -1236,9 +1238,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
+              "type": "TON_TAC_TON",
+              "status": "success",
+              "rollback": false,
               "timestamp": "2025-05-14T19:16:38.000Z",
-              "type": "TON_TAC_TON"
+              "sender": null,
+              "error_reason": null
           }
         ],
         "next_page_params": null
@@ -1248,7 +1253,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect_once(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -1263,9 +1268,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                      "priority" => 0,
                      "tac_operation" => %{
                        "operation_id" => operation_id,
-                       "sender" => nil,
+                       "type" => "TON_TAC_TON",
+                       "status" => "success",
+                       "rollback" => false,
                        "timestamp" => "2025-05-14T19:16:38.000Z",
-                       "type" => "TON_TAC_TON"
+                       "sender" => nil,
+                       "error_reason" => nil
                      },
                      "type" => "tac_operation"
                    }
@@ -1303,7 +1311,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -1344,9 +1352,10 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
-              "timestamp": "2025-05-14T19:16:38.000Z",
-              "type": "TON_TAC_TON"
+              "type": "TAC_TON",
+              "status": "pending",
+              "rollback": false,
+              "timestamp": "2025-05-14T19:16:38.000Z"
           }
         ],
         "next_page_params": null
@@ -1356,7 +1365,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -1371,9 +1380,10 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                  "priority" => 0,
                  "tac_operation" => %{
                    "operation_id" => operation_id,
-                   "sender" => nil,
-                   "timestamp" => "2025-05-14T19:16:38.000Z",
-                   "type" => "TON_TAC_TON"
+                   "type" => "TAC_TON",
+                   "status" => "pending",
+                   "rollback" => false,
+                   "timestamp" => "2025-05-14T19:16:38.000Z"
                  },
                  "type" => "tac_operation"
                } in tl(response["items"])
@@ -1413,9 +1423,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
+              "type": "TON_TAC",
+              "status": "failed",
+              "rollback": false,
               "timestamp": "2025-05-14T19:16:38.000Z",
-              "type": "TON_TAC_TON"
+              "sender": null,
+              "error_reason": "Insufficient Fee"
           }
         ],
         "next_page_params": null
@@ -1425,7 +1438,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -1440,9 +1453,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                  "priority" => 0,
                  "tac_operation" => %{
                    "operation_id" => operation_id,
-                   "sender" => nil,
+                   "type" => "TON_TAC",
+                   "status" => "failed",
+                   "rollback" => false,
                    "timestamp" => "2025-05-14T19:16:38.000Z",
-                   "type" => "TON_TAC_TON"
+                   "sender" => nil,
+                   "error_reason" => "Insufficient Fee"
                  },
                  "type" => "tac_operation"
                } in tl(response["items"])
@@ -1484,15 +1500,21 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           #{for i <- 10..59, do: """
           {
             "operation_id": "#{operation_id}",
-            "sender": "#{address_hash}",
-            "timestamp": "2025-05-14T19:16:#{i}.000Z",
-            "type": "TON_TAC_TON"
+            "type": "TAC_TON",
+            "status": "success",
+            "rollback": false,
+            "timestamp": "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
+            "sender": {
+              "address": "#{address_hash}",
+              "blockchain": "TAC"
+            },
+            "error_reason": null
           }#{if i == 59, do: "", else: ","}
         """}
           ],
           "next_page_params": {
             "page_token": 1747250219,
-            "page_size": 50
+            "page_items": 50
           }
         }
         """
@@ -1503,15 +1525,21 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           #{for i <- 10..59, do: """
           {
             "operation_id": "#{operation_id}",
-            "sender": "#{address_hash}",
+            "type": "TAC_TON",
+            "status": "success",
+            "rollback": false,
             "timestamp": "#{if i == 0, do: "2025-05-14T19:16:59.000Z", else: "2025-05-14T19:17:#{i}.000Z"}",
-            "type": "TON_TAC_TON"
+            "sender": {
+              "address": "#{address_hash}",
+              "blockchain": "TAC"
+            },
+            "error_reason": null
           }#{if i == 59, do: "", else: ","}
         """}
           ],
           "next_page_params": {
             "page_token": 1747250279,
-            "page_size": 50
+            "page_items": 50
           }
         }
         """
@@ -1521,9 +1549,15 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           "items": [
           {
             "operation_id": "#{operation_id}",
-            "sender": "#{address_hash}",
+            "type": "TAC_TON",
+            "status": "success",
+            "rollback": false,
             "timestamp": "2025-05-14T19:18:01.000Z",
-            "type": "TON_TAC_TON"
+            "sender": {
+              "address": "#{address_hash}",
+              "blockchain": "TAC"
+            },
+            "error_reason": null
           }
           ],
           "next_page_params": null
@@ -1533,7 +1567,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             case conn.params["page_token"] do
               nil -> Plug.Conn.resp(conn, 200, tac_first_response)
@@ -1561,9 +1595,15 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                      "priority" => 0,
                      "tac_operation" => %{
                        "operation_id" => operation_id,
-                       "sender" => address_hash,
+                       "type" => "TAC_TON",
+                       "status" => "success",
+                       "rollback" => false,
                        "timestamp" => "2025-05-14T19:18:01.000Z",
-                       "type" => "TON_TAC_TON"
+                       "sender" => %{
+                         "address" => address_hash,
+                         "blockchain" => "TAC"
+                       },
+                       "error_reason" => nil
                      },
                      "type" => "tac_operation"
                    }
@@ -1594,12 +1634,15 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-              "type": "ROLLBACK",
+              "type": "TON_TAC_TON",
+              "status": "failed",
+              "rollback": true,
               "timestamp": "2025-06-05T12:21:11.000Z",
               "sender": {
                   "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
                   "blockchain": "TON"
-              }
+              },
+              "error_reason": null
           }
         ],
         "next_page_params": null
@@ -1609,7 +1652,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             case conn.params["q"] do
               expected_q
@@ -1629,110 +1672,59 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           end
         )
 
+        expected_items = [
+          %{
+            "priority" => 0,
+            "tac_operation" => %{
+              "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+              "type" => "TON_TAC_TON",
+              "status" => "failed",
+              "rollback" => true,
+              "timestamp" => "2025-06-05T12:21:11.000Z",
+              "sender" => %{
+                "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                "blockchain" => "TON"
+              },
+              "error_reason" => nil
+            },
+            "type" => "tac_operation"
+          }
+        ]
+
         request =
           get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
 
         request =
           get(conn, "/api/v2/search?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
 
         request =
           get(conn, "/api/v2/search?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
 
         request =
           get(conn, "/api/v2/search?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
 
         request =
           get(conn, "/api/v2/search?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
 
         request =
           get(
@@ -1742,21 +1734,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response["items"]
+        assert expected_items == response["items"]
       end
 
       test "finds TAC operations with transaction and paginates", %{conn: conn} do
@@ -1786,15 +1764,18 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           #{for i <- 0..49, do: """
           {
             "operation_id": "#{operation_id}",
+            "type": "TON_TAC_TON",
+            "status": "success",
+            "rollback": false,
+            "timestamp": "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
             "sender": null,
-            "timestamp": "2025-05-14T19:16:#{i}.000Z",
-            "type": "TON_TAC_TON"
+            "error_reason": null
           }#{if i == 49, do: "", else: ","}
         """}
           ],
           "next_page_params": {
             "page_token": 1747250209,
-            "page_size": 50
+            "page_items": 50
           }
         }
         """
@@ -1804,9 +1785,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
+              "type": "TON_TAC_TON",
+              "status": "success",
+              "rollback": false,
               "timestamp": "2025-05-14T19:16:50.000Z",
-              "type": "TON_TAC_TON"
+              "sender": null,
+              "error_reason": null
           }
         ],
         "next_page_params": null
@@ -1816,7 +1800,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             case conn.params["page_token"] do
               nil -> Plug.Conn.resp(conn, 200, tac_first_response)
@@ -1838,9 +1822,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                      "priority" => 0,
                      "tac_operation" => %{
                        "operation_id" => operation_id,
-                       "sender" => nil,
+                       "type" => "TON_TAC_TON",
+                       "status" => "success",
+                       "rollback" => false,
                        "timestamp" => "2025-05-14T19:16:50.000Z",
-                       "type" => "TON_TAC_TON"
+                       "sender" => nil,
+                       "error_reason" => nil
                      },
                      "type" => "tac_operation"
                    }
@@ -2242,9 +2229,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
             "operation_id": "#{operation_id}",
-            "sender": null,
+            "type": "TON_TAC_TON",
+            "status": "success",
+            "rollback": false,
             "timestamp": "2025-05-14T19:16:38.000Z",
-            "type": "TON_TAC_TON"
+            "sender": null,
+            "error_reason": null
           }
         ],
         "next_page_params": null
@@ -2254,7 +2244,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -2268,9 +2258,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                    "priority" => 0,
                    "tac_operation" => %{
                      "operation_id" => operation_id,
-                     "sender" => nil,
+                     "type" => "TON_TAC_TON",
+                     "status" => "success",
+                     "rollback" => false,
                      "timestamp" => "2025-05-14T19:16:38.000Z",
-                     "type" => "TON_TAC_TON"
+                     "sender" => nil,
+                     "error_reason" => nil
                    },
                    "type" => "tac_operation"
                  }
@@ -2303,9 +2296,10 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
-              "timestamp": "2025-05-14T19:16:38.000Z",
-              "type": "TON_TAC_TON"
+              "type": "TAC_TON",
+              "status": "pending",
+              "rollback": false,
+              "timestamp": "2025-05-14T19:16:38.000Z"
           }
         ],
         "next_page_params": null
@@ -2315,7 +2309,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -2330,9 +2324,10 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                  "priority" => 0,
                  "tac_operation" => %{
                    "operation_id" => operation_id,
-                   "sender" => nil,
-                   "timestamp" => "2025-05-14T19:16:38.000Z",
-                   "type" => "TON_TAC_TON"
+                   "type" => "TAC_TON",
+                   "status" => "pending",
+                   "rollback" => false,
+                   "timestamp" => "2025-05-14T19:16:38.000Z"
                  },
                  "type" => "tac_operation"
                } in tl(response)
@@ -2372,9 +2367,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "#{operation_id}",
-              "sender": null,
+              "type": "TON_TAC",
+              "status": "failed",
+              "rollback": false,
               "timestamp": "2025-05-14T19:16:38.000Z",
-              "type": "TON_TAC_TON"
+              "sender": null,
+              "error_reason": "Insufficient Fee"
           }
         ],
         "next_page_params": null
@@ -2384,7 +2382,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
             Plug.Conn.resp(conn, 200, tac_response)
@@ -2399,9 +2397,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                  "priority" => 0,
                  "tac_operation" => %{
                    "operation_id" => operation_id,
-                   "sender" => nil,
+                   "type" => "TON_TAC",
+                   "status" => "failed",
+                   "rollback" => false,
                    "timestamp" => "2025-05-14T19:16:38.000Z",
-                   "type" => "TON_TAC_TON"
+                   "sender" => nil,
+                   "error_reason" => "Insufficient Fee"
                  },
                  "type" => "tac_operation"
                } in tl(response)
@@ -2444,15 +2445,21 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
             #{for i <- 0..49, do: """
             {
               "operation_id": "#{operation_id}",
-              "sender": "#{address_hash}",
-              "timestamp": "2025-05-14T19:16:#{i}.000Z",
-              "type": "TON_TAC_TON"
+              "type": "TAC_TON",
+              "status": "success",
+              "rollback": false,
+              "timestamp": "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
+              "sender": {
+                "address": "#{address_hash}",
+                "blockchain": "TAC"
+              },
+              "error_reason": null
             }#{if i == 49, do: "", else: ","}
           """}
             ],
             "next_page_params": {
               "page_token": "2025-05-14T19:16:49.000Z",
-              "page_size": 50
+              "page_items": 50
             }
           }
           """
@@ -2460,7 +2467,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == address_hash
 
@@ -2490,9 +2497,15 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                 "priority" => 0,
                 "tac_operation" => %{
                   "operation_id" => operation_id,
-                  "sender" => address_hash,
-                  "timestamp" => "2025-05-14T19:16:#{i}.000Z",
-                  "type" => "TON_TAC_TON"
+                  "type" => "TAC_TON",
+                  "status" => "success",
+                  "rollback" => false,
+                  "timestamp" => "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
+                  "sender" => %{
+                    "address" => address_hash,
+                    "blockchain" => "TAC"
+                  },
+                  "error_reason" => nil
                 },
                 "type" => "tac_operation"
               }
@@ -2524,12 +2537,15 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         "items": [
           {
               "operation_id": "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-              "type": "ROLLBACK",
+              "type": "TON_TAC_TON",
+              "status": "failed",
+              "rollback": true,
               "timestamp": "2025-06-05T12:21:11.000Z",
               "sender": {
                   "address": "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
                   "blockchain": "TON"
-              }
+              },
+              "error_reason": null
           }
         ],
         "next_page_params": null
@@ -2539,7 +2555,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             case conn.params["q"] do
               expected_q
@@ -2559,110 +2575,59 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           end
         )
 
+        expected_items = [
+          %{
+            "priority" => 0,
+            "tac_operation" => %{
+              "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
+              "type" => "TON_TAC_TON",
+              "status" => "failed",
+              "rollback" => true,
+              "timestamp" => "2025-06-05T12:21:11.000Z",
+              "sender" => %{
+                "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
+                "blockchain" => "TON"
+              },
+              "error_reason" => nil
+            },
+            "type" => "tac_operation"
+          }
+        ]
+
         request =
           get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
 
         request =
           get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnXTt")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
 
         request =
           get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("UQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnSko")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
 
         request =
           get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("kQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnc9n")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
 
         request =
           get(conn, "/api/v2/search/quick?q=#{URI.encode_www_form("0QBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2-Zw8yaoxnZKi")}")
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
 
         request =
           get(
@@ -2672,21 +2637,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
         assert response = json_response(request, 200)
 
-        assert [
-                 %{
-                   "priority" => 0,
-                   "tac_operation" => %{
-                     "operation_id" => "0xcdbc69a2d42c796bb8d6c2db76f366baa93f0ce5badcf8ed766f686b0f734612",
-                     "sender" => %{
-                       "address" => "EQBnVg4x6uTCa8jlrh8YXyWpnJJ3oxxrdBQ2+Zw8yaoxnXTt",
-                       "blockchain" => "TON"
-                     },
-                     "timestamp" => "2025-06-05T12:21:11.000Z",
-                     "type" => "ROLLBACK"
-                   },
-                   "type" => "tac_operation"
-                 }
-               ] == response
+        assert expected_items == response
       end
 
       test "finds a lot if TAC operations with transaction", %{conn: conn} do
@@ -2718,15 +2669,18 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
           #{for i <- 0..49, do: """
           {
             "operation_id": "#{operation_id}",
+            "type": "TON_TAC_TON",
+            "status": "success",
+            "rollback": false,
+            "timestamp": "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
             "sender": null,
-            "timestamp": "2025-05-14T19:16:#{i}.000Z",
-            "type": "TON_TAC_TON"
+            "error_reason": null
           }#{if i == 49, do: "", else: ","}
         """}
           ],
           "next_page_params": {
             "page_token": "2025-05-14T19:16:49.000Z",
-            "page_size": 50
+            "page_items": 50
           }
         }
         """
@@ -2734,7 +2688,7 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
         Bypass.expect(
           bypass,
           "GET",
-          "/api/v1/tac/operations",
+          @tac_operations_path,
           fn conn ->
             assert conn.params["q"] == operation_id
 
@@ -2759,9 +2713,12 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                 "priority" => 0,
                 "tac_operation" => %{
                   "operation_id" => operation_id,
+                  "type" => "TON_TAC_TON",
+                  "status" => "success",
+                  "rollback" => false,
+                  "timestamp" => "2025-05-14T19:16:#{String.pad_leading(Integer.to_string(i), 2, "0")}.000Z",
                   "sender" => nil,
-                  "timestamp" => "2025-05-14T19:16:#{i}.000Z",
-                  "type" => "TON_TAC_TON"
+                  "error_reason" => nil
                 },
                 "type" => "tac_operation"
               }

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -1326,6 +1326,50 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
                } == json_response(request, 200)
       end
 
+      test "degrades gracefully on an unexpected body from TAC microservice", %{conn: conn} do
+        bypass = Bypass.open()
+        tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)
+
+        Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle,
+          service_url: "http://localhost:#{bypass.port}",
+          enabled: true
+        )
+
+        Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+        on_exit(fn ->
+          Bypass.down(bypass)
+          Application.put_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle, tac_envs)
+          Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+        end)
+
+        operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
+
+        # 200 with a body that has no `items` key, e.g. a mispointed route or an error envelope
+        tac_response = """
+        {
+          "message": "not found"
+        }
+        """
+
+        Bypass.expect(
+          bypass,
+          "GET",
+          @tac_operations_path,
+          fn conn ->
+            assert conn.params["q"] == operation_id
+            Plug.Conn.resp(conn, 200, tac_response)
+          end
+        )
+
+        request = get(conn, "/api/v2/search?q=#{operation_id}")
+
+        assert %{
+                 "items" => [],
+                 "next_page_params" => nil
+               } == json_response(request, 200)
+      end
+
       test "finds a TAC operation with transaction", %{conn: conn} do
         bypass = Bypass.open()
         tac_envs = Application.get_env(:explorer, Explorer.MicroserviceInterfaces.TACOperationLifecycle)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/search_controller_test.exs
@@ -1301,10 +1301,10 @@ defmodule BlockScoutWeb.API.V2.SearchControllerTest do
 
         operation_id = "0xd06b6d3dbefcd1e4a5bb5806d0fdad87ae963bcc7d48d9a39ed361167958c09b"
 
+        # `next_page_params` is omitted rather than null: the v2 schema does not guarantee the key
         tac_response = """
         {
-          "items": [],
-          "next_page_params": null
+          "items": []
         }
         """
 

--- a/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
@@ -27,6 +27,10 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
         {:ok, %{"items" => operations} = response} ->
           {:ok, %{items: operations, next_page_params: Map.get(response, "next_page_params")}}
 
+        {:ok, unexpected} ->
+          log_error({:unexpected_body, unexpected})
+          {:error, @request_error_msg}
+
         error ->
           error
       end

--- a/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
@@ -24,8 +24,8 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
       operations_quick_search_url()
       |> http_get_request(query_params)
       |> case do
-        {:ok, %{"items" => operations, "next_page_params" => next_page_params}} ->
-          {:ok, %{items: operations, next_page_params: next_page_params}}
+        {:ok, %{"items" => operations} = response} ->
+          {:ok, %{items: operations, next_page_params: Map.get(response, "next_page_params")}}
 
         error ->
           error
@@ -46,6 +46,14 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
         end
 
       {:ok, %{body: _body, status_code: 404}} ->
+        Logger.warning(fn ->
+          [
+            "#{@request_error_msg}: ",
+            url,
+            " returned 404, TAC operations will be omitted from search results"
+          ]
+        end)
+
         {:error, :not_found}
 
       {_, error} ->

--- a/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
+++ b/apps/explorer/lib/explorer/microservice_interfaces/tac_operation_lifecycle.ex
@@ -68,6 +68,6 @@ defmodule Explorer.MicroserviceInterfaces.TACOperationLifecycle do
   end
 
   defp base_url do
-    "#{Microservice.base_url(__MODULE__)}/api/v1"
+    "#{Microservice.base_url(__MODULE__)}/api/v2"
   end
 end

--- a/cspell.json
+++ b/cspell.json
@@ -435,6 +435,7 @@
         "millis",
         "mintings",
         "misestimates",
+        "mispointed",
         "mistmatches",
         "miterlimit",
         "Mixfile",


### PR DESCRIPTION
Resolves https://github.com/blockscout/blockscout/issues/14706

## Motivation

Blockscout's multisearch proxies TAC operations from the `tac-operation-lifecycle` microservice and returns the payload to clients **verbatim**, still calling Read API **v1**. v1 overloads a single `type` field with two orthogonal concepts — the transfer route and the lifecycle state (`PENDING`, `ROLLBACK`, `INSUFFICIENT_FEE`, `ERROR` sit in the same enum as `TON_TAC`, `TAC_TON`, `TON_TAC_TON`).

The microservice now also serves v2 ([blockscout-rs#1720](https://github.com/blockscout/blockscout-rs/pull/1720)), which splits these into `type` (route only), `status`, `rollback` and `error_reason`.

The frontend is migrating its TAC views to v2 in [frontend#3627](https://github.com/blockscout/frontend/issues/3627), whose checklist removes all handling of the v1 pseudo-statuses. That issue covers the TAC operation views, which call the microservice directly — but **not** search results, which arrive through Blockscout's own `/api/v2/search`. Once #3627 lands, a TAC operation found via search would be undisplayable while the same operation renders correctly on its own page. Multisearch is the last remaining path that produces v1 objects.

## Changelog

### Enhancements

- `Explorer.MicroserviceInterfaces.TACOperationLifecycle` now calls `/api/v2/tac/operations`. This is a one-line change: the module decodes the envelope and passes `items` through untouched, and the only operation field Blockscout reads is `timestamp` (in `Explorer.Chain.Search.paging_params/2`), whose format is identical in v2.
- **The `tac_operation` search result object now has an OpenAPI schema** — previously it was completely untyped. Two new modules:
  - `BlockScoutWeb.Schemas.API.V2.Search.TacOperation` — enum-typed `type`/`status`/`sender.blockchain`, boolean `rollback`, nullable `error_reason`, `additionalProperties: false`, reusing the existing `General.Timestamp`.
  - `BlockScoutWeb.Schemas.API.V2.Search.ResultItem` — wired into both `Search.Results.items` and the quick-search response.

  `ResultItem` declares `tac_operation` as a *property* of a permissive object rather than building a `oneOf`/`discriminator` union. Since `Cast.Object` casts only the keys actually present in the payload, this enforces the TAC shape whenever the key appears while leaving the ~9 other (still untyped) result types unconstrained — so typing the full search-result union is not a prerequisite. Verified: v2 payloads pass, the v1 shape is rejected with `Missing field: status; Missing field: rollback`, and `block`/`token` results validate unchanged.
- Test coverage now spans every `status` value, a `failed` operation with `rollback: true`, a `failed` operation with `error_reason: null` (which does **not** imply success), `error_reason: "Insufficient Fee"`, an operation with the optional keys omitted entirely, and all three route enum values. Because `ConnCase` shadows `json_response/2` with `TestApiSchemaAssertions`, all 50 search tests now validate against the new schema.
- The 13 `Bypass` stubs share a single `@tac_operations_path` attribute instead of repeating the literal path, so the next version bump is a one-line change.

### Bug Fixes

- Test fixtures built with `for i <- 0..49` were emitting `"2025-05-14T19:16:0.000Z"` — single-digit seconds, which is not valid RFC 3339. Nothing validated timestamps before, so this passed silently; the new schema surfaced it. Zero-padded via `String.pad_leading`, which is a no-op for the `10..59` fixture, so the pinned `page_token` assertions (`1747250218`, `1747250279`, `1747250208`) are unchanged. The schema assertion is itself the regression guard.
- Fixture `next_page_params` now use v2's `page_items` rather than v1's `page_size`. Inert for behaviour — Blockscout only uses the microservice's `next_page_params` as a has-more flag and derives its own `page_token` — but the fixtures now match the real envelope.

### Incompatible Changes

The `tac_operation` object in `/api/v2/search` and `/api/v2/search/quick` results changes shape. This is intentional and was agreed as acceptable; the frontend switches in lockstep via [frontend#3627](https://github.com/blockscout/frontend/issues/3627), and the object was never present in the OpenAPI schema. Any external integration reading `tac_operation.type` will break.

| Field | v1 | v2 |
|---|---|---|
| `type` | route **or** state: `ERROR`, `PENDING`, `TON_TAC_TON`, `TAC_TON`, `TON_TAC`, `ROLLBACK`, `UNKNOWN`, `INSUFFICIENT_FEE` | **route only**: `UNKNOWN`, `TON_TAC_TON`, `TAC_TON`, `TON_TAC` |
| `status` | — | **new, required**: `pending`, `success`, `failed` (lower-case) |
| `rollback` | — | **new, required**: boolean |
| `error_reason` | — | **new**: short failure label or `null` |
| `sender` | `null`, or an address string, or `{address, blockchain}` | always `null` or `{address, blockchain}` |

An operation v1 reported as `type: "PENDING"` is now reported as e.g. `type: "TON_TAC"` + `status: "pending"`.

Note that `error_reason` is serialized as `null` rather than omitted, and is legitimately `null` on a *failed* operation — it is published only when the stored value is short enough to be a label. **Do not treat its absence as success.**

## Upgrading

**Deployment ordering matters.** Blockscout must not be pointed at a `tac-operation-lifecycle` instance whose build predates [blockscout-rs#1720](https://github.com/blockscout/blockscout-rs/pull/1720). Earlier builds return 404 for `/api/v2/tac/*`, `http_get_request/2` maps 404 to `{:error, :not_found}`, and `await_task_with_paging/1` swallows that into an empty result — so TAC operations would **silently disappear** from search results rather than fail loudly.

Suggested order: confirm the target deployment serves `/api/v2/tac/operations` → merge this PR → land [frontend#3627](https://github.com/blockscout/frontend/issues/3627).

Read API v1 is unchanged and both versions are served in parallel indefinitely, so there is no cutover window to hit — only this ordering constraint. No database reset, re-index, or ENV var change is required.

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on. — **intentionally not checked**: this PR does break the `tac_operation` object in `/api/v2/search`, as detailed under Incompatible Changes.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed: not needed — no ENV vars added, removed, or renamed (`MICROSERVICE_TAC_OPERATION_LIFECYCLE_URL` is the version-agnostic service base and is unchanged).
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools. — N/A
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly. — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved API documentation for search results, including TAC operation statuses, timestamps, sender information, rollback states, and error details.
  * Search responses now provide more precise result types for easier integration.

* **Bug Fixes**
  * Updated TAC Operation Lifecycle requests to use the v2 API.
  * Improved handling of missing pagination data, unavailable results, empty responses, and malformed search data for more reliable searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->