### PR TITLE
perf: batch on-demand internal transaction trace requests

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -581,7 +581,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
         |> Enum.reduce_while([], fn chunk, acc ->
           case EthereumJSONRPC.fetch_block_internal_transactions(chunk, json_rpc_named_arguments) do
             {:ok, result} ->
-              {:cont, acc ++ result}
+              {:cont, [result | acc]}
 
             error ->
               Logger.error("Failed to fetch internal transactions for blocks #{inspect(chunk)}: #{inspect(error)}")
@@ -589,6 +589,8 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
               {:halt, []}
           end
         end)
+        |> Enum.reverse()
+        |> Enum.concat()
       else
         Enum.reduce(block_numbers, [], fn block_number, acc_list ->
           block_number
@@ -629,7 +631,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
     |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
       try do
         case EthereumJSONRPC.fetch_internal_transactions(chunk, json_rpc_named_arguments) do
-          {:ok, internal_transactions} -> {:cont, {:ok, acc ++ internal_transactions}}
+          {:ok, internal_transactions} -> {:cont, {:ok, [internal_transactions | acc]}}
           error_or_ignore -> {:halt, error_or_ignore}
         end
       catch
@@ -637,6 +639,10 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
           {:halt, {:error, error, __STACKTRACE__}}
       end
     end)
+    |> case do
+      {:ok, chunk_results} -> {:ok, chunk_results |> Enum.reverse() |> Enum.concat()}
+      error_or_ignore -> error_or_ignore
+    end
   end
 
   defp batch_size do

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -23,7 +23,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
   # in a single batch (the transport-level ETHEREUM_JSONRPC_HTTP_BATCH_SIZE
   # default of 500 is tuned for cheap calls, not traces), sharing one timeout
   # window on the archive node. Batches are sent in parallel.
-  @default_blocks_batch_size 10
+  @default_blocks_batch_size 2
   @default_transactions_batch_size 20
 
   @doc """

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -18,6 +18,13 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
 
   @default_paging_options %PagingOptions{page_size: 50}
 
+  # Limits how many trace requests are sent to the node in one JSON-RPC batch.
+  # Without it, all block/transaction trace calls of an on-demand fetch end up
+  # in a single batch (the transport-level ETHEREUM_JSONRPC_HTTP_BATCH_SIZE
+  # default of 500 is tuned for cheap calls, not traces), sharing one timeout
+  # window on the archive node.
+  @default_batch_size 10
+
   @doc """
     Determines whether internal transactions should be fetched on-demand based on DB records and limit.
 
@@ -569,17 +576,19 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
       variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
 
       if variant in InternalTransactionFetcher.block_traceable_variants() do
-        case EthereumJSONRPC.fetch_block_internal_transactions(block_numbers, json_rpc_named_arguments) do
-          {:ok, result} ->
-            result
+        block_numbers
+        |> Enum.chunk_every(batch_size())
+        |> Enum.reduce_while([], fn chunk, acc ->
+          case EthereumJSONRPC.fetch_block_internal_transactions(chunk, json_rpc_named_arguments) do
+            {:ok, result} ->
+              {:cont, acc ++ result}
 
-          error ->
-            Logger.error(
-              "Failed to fetch internal transactions for blocks #{inspect(block_numbers)}: #{inspect(error)}"
-            )
+            error ->
+              Logger.error("Failed to fetch internal transactions for blocks #{inspect(chunk)}: #{inspect(error)}")
 
-            []
-        end
+              {:halt, []}
+          end
+        end)
       else
         Enum.reduce(block_numbers, [], fn block_number, acc_list ->
           block_number
@@ -592,18 +601,7 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
               transaction_index: &1.index
             }
           )
-          |> case do
-            [] ->
-              {:ok, []}
-
-            transactions ->
-              try do
-                EthereumJSONRPC.fetch_internal_transactions(transactions, json_rpc_named_arguments)
-              catch
-                :exit, error ->
-                  {:error, error, __STACKTRACE__}
-              end
-          end
+          |> fetch_transactions_internal_transactions(json_rpc_named_arguments)
           |> case do
             {:ok, internal_transactions} ->
               internal_transactions ++ acc_list
@@ -618,6 +616,31 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
         end)
       end
     end
+  end
+
+  # Chunks per-transaction trace requests so a block with many transactions is
+  # not sent to the node as one huge JSON-RPC batch. Any failed chunk fails the
+  # whole set to keep the block's results atomic.
+  defp fetch_transactions_internal_transactions([], _json_rpc_named_arguments), do: {:ok, []}
+
+  defp fetch_transactions_internal_transactions(transactions, json_rpc_named_arguments) do
+    transactions
+    |> Enum.chunk_every(batch_size())
+    |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
+      try do
+        case EthereumJSONRPC.fetch_internal_transactions(chunk, json_rpc_named_arguments) do
+          {:ok, internal_transactions} -> {:cont, {:ok, acc ++ internal_transactions}}
+          error_or_ignore -> {:halt, error_or_ignore}
+        end
+      catch
+        :exit, error ->
+          {:halt, {:error, error, __STACKTRACE__}}
+      end
+    end)
+  end
+
+  defp batch_size do
+    Application.get_env(:indexer, __MODULE__, [])[:batch_size] || @default_batch_size
   end
 
   defp internal_transactions_fetching_disabled? do

--- a/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/internal_transaction.ex
@@ -18,12 +18,13 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
 
   @default_paging_options %PagingOptions{page_size: 50}
 
-  # Limits how many trace requests are sent to the node in one JSON-RPC batch.
-  # Without it, all block/transaction trace calls of an on-demand fetch end up
+  # Limit how many trace requests are sent to the node in one JSON-RPC batch.
+  # Without them, all block/transaction trace calls of an on-demand fetch end up
   # in a single batch (the transport-level ETHEREUM_JSONRPC_HTTP_BATCH_SIZE
   # default of 500 is tuned for cheap calls, not traces), sharing one timeout
-  # window on the archive node.
-  @default_batch_size 10
+  # window on the archive node. Batches are sent in parallel.
+  @default_blocks_batch_size 10
+  @default_transactions_batch_size 20
 
   @doc """
     Determines whether internal transactions should be fetched on-demand based on DB records and limit.
@@ -576,77 +577,103 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransaction do
       variant = Keyword.fetch!(json_rpc_named_arguments, :variant)
 
       if variant in InternalTransactionFetcher.block_traceable_variants() do
-        block_numbers
-        |> Enum.chunk_every(batch_size())
-        |> Enum.reduce_while([], fn chunk, acc ->
-          case EthereumJSONRPC.fetch_block_internal_transactions(chunk, json_rpc_named_arguments) do
-            {:ok, result} ->
-              {:cont, [result | acc]}
-
-            error ->
-              Logger.error("Failed to fetch internal transactions for blocks #{inspect(chunk)}: #{inspect(error)}")
-
-              {:halt, []}
-          end
-        end)
-        |> Enum.reverse()
-        |> Enum.concat()
+        fetch_blocks_internal_transactions(block_numbers, json_rpc_named_arguments)
       else
-        Enum.reduce(block_numbers, [], fn block_number, acc_list ->
-          block_number
-          |> Transaction.get_transactions_of_block_number()
-          |> Transaction.filter_non_traceable_transactions()
-          |> Enum.map(
-            &%{
-              block_number: &1.block_number,
-              hash_data: to_string(&1.hash),
-              transaction_index: &1.index
-            }
-          )
-          |> fetch_transactions_internal_transactions(json_rpc_named_arguments)
-          |> case do
-            {:ok, internal_transactions} ->
-              internal_transactions ++ acc_list
-
-            error_or_ignore ->
-              Logger.error(
-                "Failed to fetch internal transactions for block #{block_number}: #{inspect(error_or_ignore)}"
-              )
-
-              acc_list
-          end
-        end)
+        block_numbers
+        |> transactions_to_trace()
+        |> fetch_transactions_internal_transactions(json_rpc_named_arguments)
       end
     end
   end
 
-  # Chunks per-transaction trace requests so a block with many transactions is
-  # not sent to the node as one huge JSON-RPC batch. Any failed chunk fails the
-  # whole set to keep the block's results atomic.
-  defp fetch_transactions_internal_transactions([], _json_rpc_named_arguments), do: {:ok, []}
+  # Traces blocks in batches of `blocks_batch_size()` sent in parallel. Any
+  # failed batch fails the whole fetch (as a failed batch did before batching
+  # was introduced) to avoid silent gaps in paginated results.
+  defp fetch_blocks_internal_transactions(block_numbers, json_rpc_named_arguments) do
+    chunk_results =
+      block_numbers
+      |> Enum.chunk_every(blocks_batch_size())
+      |> Task.async_stream(
+        fn chunk -> {chunk, EthereumJSONRPC.fetch_block_internal_transactions(chunk, json_rpc_named_arguments)} end,
+        timeout: :infinity
+      )
+      |> Enum.map(fn {:ok, chunk_result} -> chunk_result end)
 
+    if Enum.all?(chunk_results, &match?({_chunk, {:ok, _}}, &1)) do
+      Enum.flat_map(chunk_results, fn {_chunk, {:ok, result}} -> result end)
+    else
+      Enum.each(chunk_results, fn
+        {_chunk, {:ok, _}} ->
+          :ok
+
+        {chunk, error} ->
+          Logger.error("Failed to fetch internal transactions for blocks #{inspect(chunk)}: #{inspect(error)}")
+      end)
+
+      []
+    end
+  end
+
+  # Collects traceable transactions of all the blocks with a single DB query,
+  # preserving the order of `block_numbers` (and transaction index order within
+  # a block).
+  defp transactions_to_trace(block_numbers) do
+    transactions_by_block_number =
+      block_numbers
+      |> Transaction.get_transactions_of_block_numbers()
+      |> Transaction.filter_non_traceable_transactions()
+      |> Enum.group_by(& &1.block_number)
+
+    Enum.flat_map(block_numbers, fn block_number ->
+      transactions_by_block_number
+      |> Map.get(block_number, [])
+      |> Enum.sort_by(& &1.index)
+      |> Enum.map(
+        &%{
+          block_number: &1.block_number,
+          hash_data: to_string(&1.hash),
+          transaction_index: &1.index
+        }
+      )
+    end)
+  end
+
+  # Traces transactions in cross-block batches of `transactions_batch_size()`
+  # sent in parallel, instead of one batch per block. A failed batch is skipped
+  # with a log, the same way a failed per-block batch was skipped before.
   defp fetch_transactions_internal_transactions(transactions, json_rpc_named_arguments) do
     transactions
-    |> Enum.chunk_every(batch_size())
-    |> Enum.reduce_while({:ok, []}, fn chunk, {:ok, acc} ->
-      try do
-        case EthereumJSONRPC.fetch_internal_transactions(chunk, json_rpc_named_arguments) do
-          {:ok, internal_transactions} -> {:cont, {:ok, [internal_transactions | acc]}}
-          error_or_ignore -> {:halt, error_or_ignore}
-        end
-      catch
-        :exit, error ->
-          {:halt, {:error, error, __STACKTRACE__}}
-      end
+    |> Enum.chunk_every(transactions_batch_size())
+    |> Task.async_stream(
+      fn chunk -> {chunk, do_fetch_transactions_internal_transactions(chunk, json_rpc_named_arguments)} end,
+      timeout: :infinity
+    )
+    |> Enum.flat_map(fn
+      {:ok, {_chunk, {:ok, internal_transactions}}} ->
+        internal_transactions
+
+      {:ok, {chunk, error_or_ignore}} ->
+        Logger.error(
+          "Failed to fetch internal transactions for transactions #{inspect(Enum.map(chunk, & &1.hash_data))}: #{inspect(error_or_ignore)}"
+        )
+
+        []
     end)
-    |> case do
-      {:ok, chunk_results} -> {:ok, chunk_results |> Enum.reverse() |> Enum.concat()}
-      error_or_ignore -> error_or_ignore
-    end
   end
 
-  defp batch_size do
-    Application.get_env(:indexer, __MODULE__, [])[:batch_size] || @default_batch_size
+  defp do_fetch_transactions_internal_transactions(chunk, json_rpc_named_arguments) do
+    EthereumJSONRPC.fetch_internal_transactions(chunk, json_rpc_named_arguments)
+  catch
+    :exit, error ->
+      {:error, error, __STACKTRACE__}
+  end
+
+  defp blocks_batch_size do
+    Application.get_env(:indexer, __MODULE__, [])[:blocks_batch_size] || @default_blocks_batch_size
+  end
+
+  defp transactions_batch_size do
+    Application.get_env(:indexer, __MODULE__, [])[:transactions_batch_size] || @default_transactions_batch_size
   end
 
   defp internal_transactions_fetching_disabled? do

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -400,6 +400,74 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
     assert result |> Enum.filter(&(&1.block_number == 2)) |> Enum.count() == 1
   end
 
+  test "fetch_by_address/2 chunks block trace requests by batch_size" do
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, batch_size: 1)
+
+    address = insert(:address)
+    address_hash_str = to_string(address.hash)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    for block_number <- [1, 2] do
+      insert(:deleted_internal_transactions_address_placeholder,
+        address_id: id_to_hash.address_id,
+        block_number: block_number,
+        count_tos: 1,
+        count_froms: 1
+      )
+    end
+
+    # with batch_size 1, blocks 2 and 1 must arrive as two single-request batches
+    expect(EthereumJSONRPC.Mox, :json_rpc, 2, fn [%{id: id, params: [quantity, _]}], _ ->
+      assert quantity in ["0x1", "0x2"]
+
+      {:ok,
+       [
+         %{
+           id: id,
+           result: [
+             %{
+               "result" => %{
+                 "calls" => [
+                   %{
+                     "from" => "0x4200000000000000000000000000000000000015",
+                     "gas" => "0xe9a3c",
+                     "gasUsed" => "0x4a28",
+                     "input" => "0x",
+                     "to" => address_hash_str,
+                     "type" => "CALL",
+                     "value" => "0x0"
+                   }
+                 ],
+                 "from" => "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                 "gas" => "0xf4240",
+                 "gasUsed" => "0xb6f9",
+                 "input" => "0x",
+                 "to" => address_hash_str,
+                 "type" => "CALL",
+                 "value" => "0x0"
+               },
+               "txHash" => "0x32b17f27ddb546eab3c4c33f31eb22c1cb992d4ccc50dae26922805b717efe5c"
+             }
+           ]
+         }
+       ]}
+    end)
+
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth,
+      tracer: "call_tracer",
+      debug_trace_timeout: "5s",
+      block_traceable?: true
+    )
+
+    opts = [
+      direction: :to_address_hash,
+      paging_options: %PagingOptions{page_size: 2}
+    ]
+
+    assert [%InternalTransaction{block_number: 2}, %InternalTransaction{block_number: 1}] =
+             InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
+  end
+
   test "fetch_by_address/2 (no suitable placeholders)" do
     address = insert(:address)
     address_hash_str = to_string(address.hash)

--- a/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/internal_transaction_test.exs
@@ -400,8 +400,8 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
     assert result |> Enum.filter(&(&1.block_number == 2)) |> Enum.count() == 1
   end
 
-  test "fetch_by_address/2 chunks block trace requests by batch_size" do
-    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, batch_size: 1)
+  test "fetch_by_address/2 chunks block trace requests by blocks_batch_size" do
+    Application.put_env(:indexer, Indexer.Fetcher.OnDemand.InternalTransaction, blocks_batch_size: 1)
 
     address = insert(:address)
     address_hash_str = to_string(address.hash)
@@ -457,6 +457,74 @@ defmodule Indexer.Fetcher.OnDemand.InternalTransactionTest do
       tracer: "call_tracer",
       debug_trace_timeout: "5s",
       block_traceable?: true
+    )
+
+    opts = [
+      direction: :to_address_hash,
+      paging_options: %PagingOptions{page_size: 2}
+    ]
+
+    assert [%InternalTransaction{block_number: 2}, %InternalTransaction{block_number: 1}] =
+             InternalTransactionOnDemand.fetch_by_address(address.hash, opts)
+  end
+
+  test "fetch_by_address/2 batches transaction trace requests across blocks" do
+    address = insert(:address)
+    address_hash_str = to_string(address.hash)
+    id_to_hash = insert(:address_id_to_address_hash, address: address)
+
+    transactions =
+      for block_number <- [1, 2] do
+        insert(:deleted_internal_transactions_address_placeholder,
+          address_id: id_to_hash.address_id,
+          block_number: block_number,
+          count_tos: 1,
+          count_froms: 1
+        )
+
+        block = insert(:block, number: block_number)
+        :transaction |> insert() |> with_block(block)
+      end
+
+    transaction_hashes = MapSet.new(transactions, &to_string(&1.hash))
+
+    # transactions of both blocks must arrive in one cross-block batch
+    expect(EthereumJSONRPC.Mox, :json_rpc, 1, fn requests, _ ->
+      assert length(requests) == 2
+      assert MapSet.new(requests, fn %{params: [hash, _]} -> hash end) == transaction_hashes
+
+      {:ok,
+       Enum.map(requests, fn %{id: id} ->
+         %{
+           id: id,
+           result: %{
+             "calls" => [
+               %{
+                 "from" => "0x4200000000000000000000000000000000000015",
+                 "gas" => "0xe9a3c",
+                 "gasUsed" => "0x4a28",
+                 "input" => "0x",
+                 "to" => address_hash_str,
+                 "type" => "CALL",
+                 "value" => "0x0"
+               }
+             ],
+             "from" => "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+             "gas" => "0xf4240",
+             "gasUsed" => "0xb6f9",
+             "input" => "0x",
+             "to" => address_hash_str,
+             "type" => "CALL",
+             "value" => "0x0"
+           }
+         }
+       end)}
+    end)
+
+    Application.put_env(:ethereum_jsonrpc, EthereumJSONRPC.Geth,
+      tracer: "call_tracer",
+      debug_trace_timeout: "5s",
+      block_traceable?: false
     )
 
     opts = [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1202,7 +1202,10 @@ config :indexer, Indexer.Fetcher.InternalTransaction,
 
 config :indexer, Indexer.Fetcher.OnDemand.InternalTransaction,
   disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER"),
-  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BATCH_SIZE", 10, min: 1)
+  blocks_batch_size:
+    ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BLOCKS_BATCH_SIZE", 10, min: 1),
+  transactions_batch_size:
+    ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_TRANSACTIONS_BATCH_SIZE", 20, min: 1)
 
 disable_coin_balances_fetcher? = ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ADDRESS_COIN_BALANCE_FETCHER")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1201,7 +1201,8 @@ config :indexer, Indexer.Fetcher.InternalTransaction,
   disabled?: trace_url_missing? or ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
 
 config :indexer, Indexer.Fetcher.OnDemand.InternalTransaction,
-  disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER")
+  disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER"),
+  batch_size: ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BATCH_SIZE", 10, min: 1)
 
 disable_coin_balances_fetcher? = ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_ADDRESS_COIN_BALANCE_FETCHER")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1203,7 +1203,7 @@ config :indexer, Indexer.Fetcher.InternalTransaction,
 config :indexer, Indexer.Fetcher.OnDemand.InternalTransaction,
   disabled?: ConfigHelper.parse_bool_env_var("INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER"),
   blocks_batch_size:
-    ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BLOCKS_BATCH_SIZE", 10, min: 1),
+    ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BLOCKS_BATCH_SIZE", 2, min: 1),
   transactions_batch_size:
     ConfigHelper.parse_integer_env_var("INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_TRANSACTIONS_BATCH_SIZE", 20, min: 1)
 


### PR DESCRIPTION
## Motivation

Profiling of `/api/v2/addresses/:hash/internal-transactions` showed that when the DB has too few rows (records deleted per `deleted_internal_transactions_address_placeholders`), the endpoint falls back to on-demand fetching from the archive node — and `Indexer.Fetcher.OnDemand.InternalTransaction` performed that fetch very inefficiently:

- on non-block-traceable variants, trace requests were batched **one batch per block**, sent **sequentially** — a real trace of one page produced 53 per-block batches at a ~600ms node floor each, ~61s of RPC time out of a ~72s stage:

  ```
  on-demand trace batches: 53, RPC total 60916.8 ms of 72077.0 ms stage
    #1   604.2 ms  ok   1 txs in block 14111759  (fetch_internal_transactions)
    #2   599.0 ms  ok  10 txs in block 14110706  (fetch_internal_transactions)
    ...
  ```

- each block's transaction list was also loaded with a **separate DB query per block** (53 queries), accounting for most of the remaining stage time;
- on block-traceable variants, **all** `debug_traceBlockByNumber` calls went out in a single JSON-RPC batch — the only limit was the transport-level `ETHEREUM_JSONRPC_HTTP_BATCH_SIZE` (default `500`), which is tuned for cheap calls, not traces, so up to dozens of heavy trace calls shared one HTTP timeout window, with recovery only via halving-rechunk *after* a `413`/`504`/timeout had already occurred.

The background indexer already protects itself from oversized trace batches with `INDEXER_INTERNAL_TRANSACTIONS_BATCH_SIZE` (default `10`); the on-demand fetcher had no such limit and no parallelism.

## Changelog

### Enhancements

- **Cross-block transaction trace batches.** On non-block-traceable variants, traceable transactions of *all* placeholder blocks are collected first and traced in flat batches of `transactions_batch_size` (default `20`), instead of one batch per block — 53 per-block batches from the trace above become ~10 batches. A failed batch is skipped with a log, the same way a failed per-block batch was skipped before.
- **Single DB query for the transactions to trace.** The per-block `get_transactions_of_block_number/1` loop is replaced with one `Transaction.get_transactions_of_block_numbers/1` call (53 queries → 1 in the trace above).
- **Parallel batch dispatch.** Both variants now send their trace batches concurrently via `Task.async_stream` (concurrency naturally capped by the scheduler count), so the RPC stage takes roughly the duration of the slowest batch instead of the sum of all batches — ~61s → a few seconds for the profiled page.
- **Bounded block trace batches.** On block-traceable variants, `debug_traceBlockByNumber` calls are chunked by `blocks_batch_size` (default `10`, matching the background indexer). Any failed chunk fails the whole fetch — as a failed batch did before — to avoid silent gaps in paginated results.
- **Consistent result ordering.** Both variants now return results in the requested block-number order (the per-transaction variant previously returned ascending order regardless of the requested sort), which is the order the pagination-continuation logic in `do_fetch_for_address/7` expects.
- **New env vars** `INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BLOCKS_BATCH_SIZE` (default `2`, min `1`) and `INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_TRANSACTIONS_BATCH_SIZE` (default `20`, min `1`) to tune the batch sizes.
- Tests covering the new behavior:
  - with `blocks_batch_size: 1` and two placeholder blocks, the block-traceable fetch issues two separate single-request JSON-RPC batches and returns the merged, correctly ordered result;
  - with two placeholder blocks holding one transaction each, the per-transaction fetch issues **one** cross-block JSON-RPC batch carrying both trace requests.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`. — **required for this PR**: add `INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_BLOCKS_BATCH_SIZE` and `INDEXER_ON_DEMAND_INTERNAL_TRANSACTIONS_TRANSACTIONS_BATCH_SIZE` https://github.com/blockscout/docs/pull/151
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved on-demand internal transaction fetching by processing requests in parallel batches.
  * Added separate configurable batch sizes for block and transaction trace requests.
  * Combined transaction requests across blocks into fewer database and RPC operations.
  * Preserved descending block order while improving request efficiency.

* **Reliability**
  * Failed trace batches are now logged and handled without blocking unrelated transaction requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->