### PR TITLE
feat: add market source requests metric with endpoint type labels

### DIFF
--- a/apps/explorer/lib/explorer/market/AGENTS.md
+++ b/apps/explorer/lib/explorer/market/AGENTS.md
@@ -11,3 +11,22 @@ on_exit(fn ->
   :persistent_term.put(:market_token_fetcher_enabled, false)
 end)
 ```
+
+## Market source request metric
+
+All market source requests go through `Explorer.Market.Source.http_request/4`, which increments the
+`market_source_requests_count` counter (`Explorer.Prometheus.Instrumenter`, exposed on `/metrics`)
+with the `source`, `endpoint` and `status` labels.
+
+When adding a request to a market source, pass `__MODULE__` and a new endpoint atom:
+
+```elixir
+Source.http_request(url, headers(), __MODULE__, :coins_details)
+```
+
+The endpoint atom is the *endpoint type*, not the URL: requests differing only in variable parts
+(token address hash, coin id, pagination offset, date range) must share one atom, so that e.g. all
+per-token DIA calls land in a single `asset_quotation_token` series. Conversely, when one path serves
+two purposes, use two atoms (`coins_market_chart_price` vs `coins_market_chart_market_cap`) so the
+driving fetcher is distinguishable. Never interpolate a variable into the atom — that would blow up
+the metric cardinality.

--- a/apps/explorer/lib/explorer/market/source.ex
+++ b/apps/explorer/lib/explorer/market/source.ex
@@ -48,6 +48,7 @@ defmodule Explorer.Market.Source do
   }
 
   alias Explorer.Market.Token
+  alias Explorer.Prometheus.Instrumenter
 
   # Native coin processing
   @callback native_coin_fetching_enabled?() :: boolean() | :ignore
@@ -113,10 +114,18 @@ defmodule Explorer.Market.Source do
   handling for NFT-related responses. Error responses are formatted into descriptive
   error messages.
 
+  Every request is counted in the `market_source_requests_count` metric, labeled with
+  the source, the endpoint type and the request outcome.
+
   ## Parameters
   - `source_url`: The URL to send the GET request to
   - `additional_headers`: Extra HTTP headers to be added to the default JSON
     content-type header
+  - `source_module`: The module of the market data source performing the request, used
+    as the `source` label of the metric
+  - `endpoint`: The endpoint type of the request, used as the `endpoint` label of the
+    metric. Requests to the same endpoint with different variable parts (token address
+    hash, coin id, pagination offset, etc.) must share the same endpoint type
 
   ## Returns
   - `{:ok, decoded_data}` if the request succeeds with status 200 and valid JSON
@@ -128,9 +137,18 @@ defmodule Explorer.Market.Source do
     - HTTP client errors: reason will be the underlying error
     - JSON decoding errors: reason will be the raw response body
   """
-  @spec http_request(String.t(), [{atom() | binary(), binary()}]) :: {:ok, any()} | {:error, any()}
-  def http_request(source_url, additional_headers) do
-    case HttpClient.get(source_url, headers() ++ additional_headers) do
+  @spec http_request(String.t(), [{atom() | binary(), binary()}], module(), atom()) ::
+          {:ok, any()} | {:error, any()}
+  def http_request(source_url, additional_headers, source_module, endpoint) do
+    response = HttpClient.get(source_url, headers() ++ additional_headers)
+
+    Instrumenter.market_source_request(source_label(source_module), endpoint, request_status(response))
+
+    handle_http_response(response)
+  end
+
+  defp handle_http_response(response) do
+    case response do
       {:ok, %{body: body, status_code: 200}} ->
         parse_http_success_response(body)
 
@@ -147,6 +165,23 @@ defmodule Explorer.Market.Source do
         {:error, reason}
     end
   end
+
+  # Converts a source module into the `source` label of the
+  # `market_source_requests_count` metric, e.g. `Explorer.Market.Source.CoinGecko`
+  # becomes `"coin_gecko"`.
+  @spec source_label(module()) :: String.t()
+  defp source_label(source_module) do
+    source_module |> Module.split() |> List.last() |> Macro.underscore()
+  end
+
+  # Converts an HTTP response into the `status` label of the
+  # `market_source_requests_count` metric. Error reasons of failed requests are not
+  # used as label values since they are unbounded.
+  @spec request_status({:ok, map()} | {:error, any()}) :: String.t()
+  defp request_status({:ok, %{status_code: 200}}), do: "ok"
+  defp request_status({:ok, %{status_code: status_code}}) when status_code in 300..526, do: to_string(status_code)
+  defp request_status({:ok, %{status_code: _status_code}}), do: "unexpected_status"
+  defp request_status({:error, _reason}), do: "transport_error"
 
   defp parse_http_success_response(body) do
     case Helper.decode_json(body, true) do

--- a/apps/explorer/lib/explorer/market/source/coin_gecko.ex
+++ b/apps/explorer/lib/explorer/market/source/coin_gecko.ex
@@ -53,7 +53,9 @@ defmodule Explorer.Market.Source.CoinGecko do
            |> URI.append_query("include_24hr_vol=true")
            |> URI.append_query("ids=#{joined_token_ids}")
            |> URI.to_string(),
-           headers()
+           headers(),
+           __MODULE__,
+           :simple_price
          ) do
       {:ok, data} ->
         to_import = put_market_data_to_tokens(to_fetch, data)
@@ -89,7 +91,9 @@ defmodule Explorer.Market.Source.CoinGecko do
              |> URI.append_query("vs_currency=#{config(:currency)}")
              |> URI.append_query("days=#{previous_days}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :coins_market_chart_market_cap
            ) do
       market_caps =
         case market_caps_dates do
@@ -133,7 +137,9 @@ defmodule Explorer.Market.Source.CoinGecko do
              |> URI.append_query("developer_data=false")
              |> URI.append_query("sparkline=false")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :coins_details
            ) do
       {:ok,
        %Token{
@@ -166,7 +172,9 @@ defmodule Explorer.Market.Source.CoinGecko do
              |> URI.append_path("/coins/list")
              |> URI.append_query("include_platform=true")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :coins_list
            ) do
       tokens
       |> Enum.reduce([], &reduce_coingecko_token(&1, &2, platform))
@@ -247,7 +255,9 @@ defmodule Explorer.Market.Source.CoinGecko do
              |> URI.append_query("vs_currency=#{config(:currency)}")
              |> URI.append_query("days=#{previous_days}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :coins_market_chart_price
            ) do
       closings =
         case prices do

--- a/apps/explorer/lib/explorer/market/source/coin_market_cap.ex
+++ b/apps/explorer/lib/explorer/market/source/coin_market_cap.ex
@@ -57,7 +57,9 @@ defmodule Explorer.Market.Source.CoinMarketCap do
              |> URI.append_query("convert_id=#{currency_id}")
              |> URI.append_query("aux=market_cap")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :cryptocurrency_quotes_historical_market_cap
            ) do
       quotes = market_data["quotes"]
 
@@ -101,7 +103,9 @@ defmodule Explorer.Market.Source.CoinMarketCap do
              |> URI.append_query("convert_id=#{convert_id}")
              |> URI.append_query("aux=circulating_supply,total_supply")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :cryptocurrency_quotes_latest
            ) do
       token_properties = market_data |> Map.values() |> List.first() || %{}
       currency_id = token_properties["quote"][config(:currency_id)]
@@ -150,7 +154,9 @@ defmodule Explorer.Market.Source.CoinMarketCap do
              |> URI.append_query("convert_id=#{currency_id}")
              |> URI.append_query("aux=price")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :cryptocurrency_quotes_historical_price
            ) do
       closing_quotes =
         case quotes do

--- a/apps/explorer/lib/explorer/market/source/crypto_compare.ex
+++ b/apps/explorer/lib/explorer/market/source/crypto_compare.ex
@@ -65,7 +65,9 @@ defmodule Explorer.Market.Source.CryptoCompare do
              |> URI.append_query("tsym=#{config(:currency)}")
              |> URI.append_query("extraParams=Blockscout/#{Application.spec(:explorer)[:vsn]}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :data_histoday
            ) do
       result =
         for item <- data do

--- a/apps/explorer/lib/explorer/market/source/crypto_rank.ex
+++ b/apps/explorer/lib/explorer/market/source/crypto_rank.ex
@@ -37,7 +37,9 @@ defmodule Explorer.Market.Source.CryptoRank do
              |> URI.append_query("limit=#{batch_size}")
              |> URI.append_query("skip=#{skip}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :currencies_contracts
            ) do
       {tokens_to_import, initial_tokens_len} =
         tokens |> Enum.reduce({[], 0}, &reduce_token(platform_id, &1, &2))
@@ -114,7 +116,12 @@ defmodule Explorer.Market.Source.CryptoRank do
   defp do_fetch_coin(coin_id, coin_id_not_specified_error) do
     with coin_id when not is_nil(coin_id) <- coin_id,
          {:ok, %{"data" => coin}} <-
-           Source.http_request(base_url() |> URI.append_path("/currencies/#{coin_id}") |> URI.to_string(), headers()) do
+           Source.http_request(
+             base_url() |> URI.append_path("/currencies/#{coin_id}") |> URI.to_string(),
+             headers(),
+             __MODULE__,
+             :currencies_details
+           ) do
       coin_data = coin["values"][config(:currency)]
 
       {:ok,
@@ -152,7 +159,9 @@ defmodule Explorer.Market.Source.CryptoRank do
              |> URI.append_query("from=#{from}")
              |> URI.append_query("to=#{to}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :currencies_sparkline
            ) do
       closing_prices =
         case opening_prices do

--- a/apps/explorer/lib/explorer/market/source/defillama.ex
+++ b/apps/explorer/lib/explorer/market/source/defillama.ex
@@ -54,7 +54,9 @@ defmodule Explorer.Market.Source.DefiLlama do
          {:ok, data} when is_list(data) <-
            Source.http_request(
              base_url() |> URI.append_path("/historicalChainTvl/#{URI.encode(coin_id)}") |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :historical_chain_tvl
            ) do
       result =
         Enum.map(data, fn %{"date" => date, "tvl" => tvl} ->

--- a/apps/explorer/lib/explorer/market/source/dia.ex
+++ b/apps/explorer/lib/explorer/market/source/dia.ex
@@ -58,7 +58,9 @@ defmodule Explorer.Market.Source.DIA do
                  |> URI.append_path("/#{blockchain}")
                  |> URI.append_path("/#{token.contract_address_hash}")
                  |> URI.to_string(),
-                 []
+                 [],
+                 __MODULE__,
+                 :asset_quotation_token
                ) do
             {:ok, data} ->
               token_to_import =
@@ -142,7 +144,9 @@ defmodule Explorer.Market.Source.DIA do
              base_url()
              |> URI.append_path("/assetQuotation/#{blockchain}/#{coin_address_hash}")
              |> URI.to_string(),
-             []
+             [],
+             __MODULE__,
+             :asset_quotation_coin
            ) do
       {:ok,
        %Token{
@@ -176,7 +180,9 @@ defmodule Explorer.Market.Source.DIA do
              |> URI.append_path("/quotedAssets")
              |> URI.append_query("blockchain=#{blockchain}")
              |> URI.to_string(),
-             []
+             [],
+             __MODULE__,
+             :quoted_assets
            ) do
       tokens
       |> Enum.reduce([], &reduce_dia_token(&1, &2, coin_address_hash))
@@ -234,7 +240,9 @@ defmodule Explorer.Market.Source.DIA do
              |> URI.append_query("starttime=#{unix_from}")
              |> URI.append_query("endtime=#{unix_now}")
              |> URI.to_string(),
-             []
+             [],
+             __MODULE__,
+             :asset_chart_points
            ) do
       values
       |> Enum.reduce_while(%{}, fn value, acc ->

--- a/apps/explorer/lib/explorer/market/source/mobula.ex
+++ b/apps/explorer/lib/explorer/market/source/mobula.ex
@@ -41,7 +41,9 @@ defmodule Explorer.Market.Source.Mobula do
              |> URI.append_query("limit=#{batch_size}")
              |> URI.append_query("offset=#{offset}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :market_query
            ) do
       {tokens_to_import, initial_tokens_len} =
         Enum.reduce(tokens, {[], 0}, &reduce_mobula_token/2)
@@ -115,7 +117,9 @@ defmodule Explorer.Market.Source.Mobula do
              |> URI.append_path("/market/data")
              |> URI.append_query("asset=#{coin_id}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :market_data
            ) do
       {:ok,
        %Token{
@@ -155,7 +159,9 @@ defmodule Explorer.Market.Source.Mobula do
              |> URI.append_query("asset=#{coin_id}")
              |> URI.append_query("from=#{timestamp_ms}")
              |> URI.to_string(),
-             headers()
+             headers(),
+             __MODULE__,
+             :market_history
            ) do
       result =
         for [date_ms, price] <- price_history do

--- a/apps/explorer/lib/explorer/prometheus/instrumenter.ex
+++ b/apps/explorer/lib/explorer/prometheus/instrumenter.ex
@@ -88,6 +88,14 @@ defmodule Explorer.Prometheus.Instrumenter do
     registry: :public
   ]
 
+  # metrics of market data sources
+
+  @counter [
+    name: :market_source_requests_count,
+    labels: [:source, :endpoint, :status],
+    help: "Number of HTTP requests sent to market data sources by source, endpoint type and outcome"
+  ]
+
   @gauge [name: :average_block_time, help: "Average block time in milliseconds"]
 
   @gauge [name: :batch_average_time, help: "L2 average batch time"]
@@ -218,6 +226,21 @@ defmodule Explorer.Prometheus.Instrumenter do
   @spec increment_failed_uploading_media_number() :: :ok
   def increment_failed_uploading_media_number do
     Counter.inc(name: :failed_uploading_media_number, registry: :public)
+  end
+
+  @doc """
+  Increments the counter of HTTP requests sent to a market data source.
+
+  ## Parameters
+  - `source`: The market data source name, e.g. `"coin_gecko"`
+  - `endpoint`: The endpoint type of the request. Requests to the same endpoint with
+    different variable parts (token address hash, coin id, pagination offset, etc.)
+    share the same endpoint type
+  - `status`: The outcome of the request, e.g. `"ok"` or `"429"`
+  """
+  @spec market_source_request(String.t(), atom(), String.t()) :: :ok
+  def market_source_request(source, endpoint, status) do
+    Counter.inc(name: :market_source_requests_count, labels: [source, endpoint, status])
   end
 
   @doc """

--- a/apps/explorer/test/explorer/market/source_metrics_test.exs
+++ b/apps/explorer/test/explorer/market/source_metrics_test.exs
@@ -11,10 +11,15 @@ defmodule Explorer.Market.SourceMetricsTest do
   setup do
     bypass = Bypass.open()
 
+    initial_tesla_adapter = Application.fetch_env(:tesla, :adapter)
+
     Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
 
     on_exit(fn ->
-      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+      case initial_tesla_adapter do
+        {:ok, adapter} -> Application.put_env(:tesla, :adapter, adapter)
+        :error -> Application.delete_env(:tesla, :adapter)
+      end
     end)
 
     {:ok, bypass: bypass}

--- a/apps/explorer/test/explorer/market/source_metrics_test.exs
+++ b/apps/explorer/test/explorer/market/source_metrics_test.exs
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Market.SourceMetricsTest do
+  use ExUnit.Case
+
+  use Prometheus.Metric
+
+  alias Explorer.Market.Source
+  alias Explorer.Market.Source.CoinGecko
+  alias Plug.Conn
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(:tesla, :adapter, Tesla.Adapter.Mint)
+
+    on_exit(fn ->
+      Application.put_env(:tesla, :adapter, Explorer.Mock.TeslaAdapter)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "market_source_requests_count metric" do
+    test "counts a successful request with the source and endpoint labels", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/test", fn conn ->
+        Conn.resp(conn, 200, ~s({"result": "ok"}))
+      end)
+
+      labels = ["coin_gecko", :test_endpoint, "ok"]
+      value_before = counter_value(labels)
+
+      assert {:ok, %{"result" => "ok"}} =
+               Source.http_request("http://localhost:#{bypass.port}/test", [], CoinGecko, :test_endpoint)
+
+      assert counter_value(labels) == value_before + 1
+    end
+
+    test "counts requests to the same endpoint with different variable parts in one series", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/test/0x1", fn conn -> Conn.resp(conn, 200, ~s({})) end)
+      Bypass.expect(bypass, "GET", "/test/0x2", fn conn -> Conn.resp(conn, 200, ~s({})) end)
+
+      labels = ["dia", :test_shared_endpoint, "ok"]
+      value_before = counter_value(labels)
+
+      Enum.each(["0x1", "0x2"], fn address_hash ->
+        assert {:ok, _} =
+                 Source.http_request(
+                   "http://localhost:#{bypass.port}/test/#{address_hash}",
+                   [],
+                   Source.DIA,
+                   :test_shared_endpoint
+                 )
+      end)
+
+      assert counter_value(labels) == value_before + 2
+    end
+
+    test "counts an error response with the status code as the status label", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/test", fn conn ->
+        Conn.resp(conn, 429, "Too many requests")
+      end)
+
+      labels = ["coin_gecko", :test_endpoint, "429"]
+      value_before = counter_value(labels)
+
+      assert {:error, "429: Too many requests"} =
+               Source.http_request("http://localhost:#{bypass.port}/test", [], CoinGecko, :test_endpoint)
+
+      assert counter_value(labels) == value_before + 1
+    end
+
+    test "counts a transport error", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      labels = ["coin_gecko", :test_endpoint, "transport_error"]
+      value_before = counter_value(labels)
+
+      assert {:error, _reason} =
+               Source.http_request("http://localhost:#{bypass.port}/test", [], CoinGecko, :test_endpoint)
+
+      assert counter_value(labels) == value_before + 1
+    end
+  end
+
+  defp counter_value(labels) do
+    case Counter.value(name: :market_source_requests_count, labels: labels) do
+      :undefined -> 0
+      value -> value
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Market data (coin price, token prices, price/market cap/TVL history) is fetched from 7 external providers in `apps/explorer/lib/explorer/market/source/`, and until now there was zero observability on that traffic: we could not tell how many requests go to which provider endpoint, nor how often they fail. These are paid, rate-limited third-party APIs — e.g. `DIA` issues **one request per token** (`Task.async_stream`, `max_concurrency: 5`), so a large token list silently turns into thousands of calls.

This PR adds a Prometheus counter of market source requests, labeled by provider, endpoint type and outcome. "Endpoint type" collapses the variable parts of the URL, so per-endpoint request volume is readable regardless of how many different tokens, coins or pages were requested.

## Changelog

### Enhancements

- New Prometheus counter `market_source_requests_count` with the `source`, `endpoint` and `status` labels, declared in `Explorer.Prometheus.Instrumenter` alongside the setter `market_source_request/3`. It uses the default registry, so it is exposed on the existing `/metrics` endpoint together with the indexer metrics. No new wiring is needed — `Explorer.Prometheus.Instrumenter.setup/0` is already called from `Explorer.Application`.
- `Explorer.Market.Source.http_request/2` is now `http_request/4`, taking the calling source module and an endpoint type atom, and increments the counter for every request. All market source traffic funnels through this single function, so all 19 call sites across the 7 providers are covered.
  - The `source` label is derived from the source module, e.g. `Explorer.Market.Source.CoinGecko` becomes `coin_gecko`.
  - The `status` label is `ok` for `200`, the exact status code for `300..526` (so `401`/`429` quota and rate-limit problems are visible per endpoint), `unexpected_status` for any other code, and `transport_error` for HTTP client failures. Error reasons are deliberately not used as label values, since they are unbounded.
  - Response handling was moved unchanged into a private `handle_http_response/1`, so return values and error strings are byte-identical to before.
- 20 endpoint types are now distinguishable (17 distinct URL paths):

  | source | endpoints |
  | --- | --- |
  | `coin_gecko` | `simple_price`, `coins_details`, `coins_list`, `coins_market_chart_price`, `coins_market_chart_market_cap` |
  | `coin_market_cap` | `cryptocurrency_quotes_latest`, `cryptocurrency_quotes_historical_price`, `cryptocurrency_quotes_historical_market_cap` |
  | `crypto_compare` | `data_histoday` |
  | `crypto_rank` | `currencies_contracts`, `currencies_details`, `currencies_sparkline` |
  | `defi_llama` | `historical_chain_tvl` |
  | `mobula` | `market_query`, `market_data`, `market_history` |
  | `dia` | `asset_quotation_token`, `asset_quotation_coin`, `quoted_assets`, `asset_chart_points` |

  Variable URL parts — token address hash, coin id, coin symbol, platform/chain id, pagination `skip`/`offset`, date and timestamp windows — all collapse into one series per endpoint type. Where one path serves two purposes it gets two labels (`coins_market_chart_price` vs `coins_market_chart_market_cap`, `cryptocurrency_quotes_historical_price` vs `cryptocurrency_quotes_historical_market_cap`, `asset_quotation_token` vs `asset_quotation_coin`), so the driving fetcher stays distinguishable.
- New tests in `apps/explorer/test/explorer/market/source_metrics_test.exs` covering successful request counting, two different token address hashes collapsing into a single series, a `429` response landing on `status="429"`, and a transport error.
- Documented the convention for adding new market source endpoints in `apps/explorer/lib/explorer/market/AGENTS.md`.

Sample scrape output:

```
market_source_requests_count{source="dia",endpoint="asset_quotation_token",status="ok"} 2
market_source_requests_count{source="dia",endpoint="asset_quotation_token",status="429"} 1
market_source_requests_count{source="coin_gecko",endpoint="coins_details",status="ok"} 1
```

Out of scope: `Explorer.Market.Fetcher.TokenList` calls `HttpClient.get/1` directly with the operator-supplied `TOKEN_LIST_URL` and does not go through `Explorer.Market.Source`, so it is not instrumented.

### Incompatible Changes

- `Explorer.Market.Source.http_request/2` is replaced by `http_request/4`. This is an internal helper used only by the market source modules within `apps/explorer`; no public API, contract or interface changes.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for market-data requests.
  * Metrics track the data source, endpoint type, and request status.
  * Requests with variable URL values are grouped consistently for clearer reporting.

* **Documentation**
  * Documented market-data request instrumentation and endpoint-labeling guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->