### PR TITLE
fix: Arbitrum missing origination chunking

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
@@ -264,6 +264,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
       - JSON RPC arguments for L1
       - L1 bridge address
       - L1 rollup initialization block
+      - L1 RPC block range for chunking `eth_getLogs` requests
       - L1 RPC chunk size for batch requests
       - Message ID range window size
     - `task_data`: Contains:
@@ -288,6 +289,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
             :json_l1_rpc_named_arguments => EthereumJSONRPC.json_rpc_named_arguments(),
             :l1_bridge_address => binary(),
             :l1_rollup_init_block => non_neg_integer(),
+            :l1_rpc_block_range => non_neg_integer(),
             :l1_rpc_chunk_size => non_neg_integer(),
             :missed_message_ids_range => non_neg_integer(),
             optional(any()) => any()
@@ -308,6 +310,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
           config: %{
             json_l1_rpc_named_arguments: json_rpc_named_arguments,
             l1_rpc_chunk_size: chunk_size,
+            l1_rpc_block_range: rpc_block_range,
             l1_bridge_address: bridge_address,
             l1_rollup_init_block: l1_rollup_init_block,
             missed_message_ids_range: missed_message_ids_range
@@ -357,7 +360,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
           safe_l1_block,
           bridge_address,
           json_rpc_named_arguments,
-          chunk_size
+          chunk_size,
+          rpc_block_range
         )
       end)
     end
@@ -408,6 +412,9 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
   # - `bridge_address`: L1 bridge contract address for log filtering
   # - `json_rpc_named_arguments`: RPC configuration
   # - `chunk_size`: Batch size for RPC requests
+  # - `rpc_block_range`: Maximum width of a single `eth_getLogs` request; the
+  #   discovered L1 block range is split into chunks of at most this width so
+  #   that the node's per-request block-range limit is never exceeded
   #
   # ## Returns
   # - `:ok` after attempting to discover and import the message
@@ -417,7 +424,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
          safe_l1_block,
          bridge_address,
          json_rpc_named_arguments,
-         chunk_size
+         chunk_size,
+         rpc_block_range
        ) do
     log_debug("Discovering origination for message ID #{message_id}")
 
@@ -442,15 +450,26 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
       lower_than: higher_bound.message_id
     }
 
-    # Discover messages in the L1 block range, filtering to only messages
-    # within the discovered bounds (exclusive)
-    discover(
-      bridge_address,
+    # Since the L1 block range to search could be wider than `rpc_block_range`
+    # it is required to divide it into smaller chunks so that a single
+    # `eth_getLogs` request never exceeds the node's per-request block-range
+    # limit. `filter_range` is computed once above and reused for every chunk,
+    # so chunking does not change which messages end up imported.
+    # credo:disable-for-lines:9 Credo.Check.Refactor.PipeChainStart
+    ArbitrumHelper.execute_for_block_range_in_chunks(
       l1_start_block,
       l1_end_block,
-      json_rpc_named_arguments,
-      chunk_size,
-      filter_range
+      rpc_block_range,
+      fn chunk_start, chunk_end ->
+        discover(
+          bridge_address,
+          chunk_start,
+          chunk_end,
+          json_rpc_named_arguments,
+          chunk_size,
+          filter_range
+        )
+      end
     )
 
     :ok

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
@@ -245,9 +245,11 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
   newly discovered messages as range delimiters.
 
   Note: When consecutive messages are missing (no fully indexed message between
-  them), processing one may also import others in the same L1 block range. This
-  results in some messages being imported multiple times, which is harmless due
-  to Chain.import's upsert behavior.
+  them), processing one may also import others in the same L1 block range as a
+  side effect. Before processing each message, its origination status is
+  re-checked against the database so that messages already back-filled by an
+  earlier iteration of this same loop are skipped instead of triggering a
+  redundant L1 scan.
 
   The cursor advances by the configured range size with each iteration. The
   task completes and stops when the next iteration's range would extend below
@@ -342,19 +344,24 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
 
       # Process each missing message (already in descending order from highest to lowest ID).
       #
-      # Note on duplicate imports: When consecutive messages are missing (no fully indexed
-      # message between them), processing the higher-ID message may also discover and import
-      # lower-ID messages within the same L1 block range. For example:
+      # Note on co-import side effect: When consecutive messages are missing (no fully
+      # indexed message between them), processing the higher-ID message may also discover
+      # and import lower-ID messages within the same L1 block range. For example:
       #   - Messages A(indexed), B(missing), C(missing), D(indexed)
       #   - Processing C: L1 range spans A..D, both B and C are discovered and imported
-      #   - Processing B: B is imported again (already has origination from previous step)
+      #   - Processing B: origination is already present from the previous step, so the
+      #     skip check below avoids re-scanning L1 for it
       #
-      # This is expected and harmless - Chain.import performs upserts, so reimporting
-      # the same message data is idempotent. Duplicate imports only occur with consecutive
-      # missing messages; alternating indexed/missing patterns naturally prevent this.
+      # This side effect is intentionally not short-circuited by an early exit from this
+      # loop - scanning every remaining chunk for the highest-ID message is what lets
+      # neighbouring missing messages in the same gap get co-discovered in the first
+      # place. Instead, each message is re-checked against the database immediately
+      # before it would be processed: if an earlier iteration of this same loop already
+      # filled in its origination data, the message is skipped and no RPC call is made
+      # for it at all.
       missing_origination_message_ids
       |> Enum.each(fn message_id ->
-        discover_and_import_single_missing_message(
+        discover_and_import_missing_message_unless_already_filled(
           message_id,
           l1_rollup_init_block,
           safe_l1_block,
@@ -384,6 +391,53 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
       |> set_missing_origination_completion(should_complete)
 
     {:ok, updated_state}
+  end
+
+  # Re-checks a single missing message against the database immediately before
+  # processing it, and skips the L1 scan entirely when an earlier iteration of
+  # the same `check_missing_origination/1` loop already filled in its
+  # origination info as a side effect of processing a higher message ID.
+  #
+  # ## Parameters
+  # - `message_id`: The ID of the message to discover origination for
+  # - `l1_rollup_init_block`: Fallback minimum L1 block if no preceding message
+  # - `safe_l1_block`: Fallback maximum L1 block if no following message
+  # - `bridge_address`: L1 bridge contract address for log filtering
+  # - `json_rpc_named_arguments`: RPC configuration
+  # - `chunk_size`: Batch size for RPC requests
+  # - `rpc_block_range`: Maximum width of a single `eth_getLogs` request
+  #
+  # ## Returns
+  # - `:ok` after attempting to discover and import the message, or after
+  #   skipping it because its origination info is already present
+  defp discover_and_import_missing_message_unless_already_filled(
+         message_id,
+         l1_rollup_init_block,
+         safe_l1_block,
+         bridge_address,
+         json_rpc_named_arguments,
+         chunk_size,
+         rpc_block_range
+       ) do
+    # A single-ID range (message_id, message_id) is a valid query - the guard only
+    # requires start <= end - and tells us whether this specific message still lacks
+    # origination info at this point in the loop.
+    case DbMessages.messages_to_l2_completed_but_originating_info_missed(message_id, message_id) do
+      [] ->
+        log_debug("Message ID #{message_id} already has origination info, skipping")
+        :ok
+
+      _ ->
+        discover_and_import_single_missing_message(
+          message_id,
+          l1_rollup_init_block,
+          safe_l1_block,
+          bridge_address,
+          json_rpc_named_arguments,
+          chunk_size,
+          rpc_block_range
+        )
+    end
   end
 
   # Discovers and imports origination information for a single L1-to-L2 message

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/new_messages_to_l2.ex
@@ -25,7 +25,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
 
   import Explorer.Helper, only: [decode_data: 2]
 
-  import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_info: 1, log_debug: 1]
+  import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_info: 1, log_debug: 1, log_warning: 1]
 
   alias Indexer.Fetcher.Arbitrum.Utils.Db.Messages, as: DbMessages
   alias Indexer.Fetcher.Arbitrum.Utils.Helper, as: ArbitrumHelper
@@ -341,27 +341,29 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
       log_info(
         "Found #{length(missing_origination_message_ids)} messages with missing origination in range #{start_message_id}..#{end_message_id}"
       )
+    end
 
-      # Process each missing message (already in descending order from highest to lowest ID).
-      #
-      # Note on co-import side effect: When consecutive messages are missing (no fully
-      # indexed message between them), processing the higher-ID message may also discover
-      # and import lower-ID messages within the same L1 block range. For example:
-      #   - Messages A(indexed), B(missing), C(missing), D(indexed)
-      #   - Processing C: L1 range spans A..D, both B and C are discovered and imported
-      #   - Processing B: origination is already present from the previous step, so the
-      #     skip check below avoids re-scanning L1 for it
-      #
-      # This side effect is intentionally not short-circuited by an early exit from this
-      # loop - scanning every remaining chunk for the highest-ID message is what lets
-      # neighbouring missing messages in the same gap get co-discovered in the first
-      # place. Instead, each message is re-checked against the database immediately
-      # before it would be processed: if an earlier iteration of this same loop already
-      # filled in its origination data, the message is skipped and no RPC call is made
-      # for it at all.
-      missing_origination_message_ids
-      |> Enum.each(fn message_id ->
-        discover_and_import_missing_message_unless_already_filled(
+    # Process each missing message (already in descending order from highest to lowest ID).
+    #
+    # Note on co-import side effect: When consecutive messages are missing (no fully
+    # indexed message between them), processing the higher-ID message may also discover
+    # and import lower-ID messages within the same L1 block range. For example:
+    #   - Messages A(indexed), B(missing), C(missing), D(indexed)
+    #   - Processing C: L1 range spans A..D, both B and C are discovered and imported
+    #   - Processing B: origination is already present from the previous step, so the
+    #     skip check below avoids re-scanning L1 for it
+    #
+    # This side effect is intentionally not short-circuited by an early exit from this
+    # loop - scanning every remaining chunk for the highest-ID message is what lets
+    # neighbouring missing messages in the same gap get co-discovered in the first
+    # place. Instead, each message is re-checked against the database immediately
+    # before it would be processed: if an earlier iteration of this same loop already
+    # filled in its origination data, the message is skipped and no RPC call is made
+    # for it at all.
+    missing_origination_message_ids
+    |> Enum.each(fn message_id ->
+      if origination_info_missing?(message_id) do
+        discover_and_import_single_missing_message(
           message_id,
           l1_rollup_init_block,
           safe_l1_block,
@@ -370,8 +372,10 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
           chunk_size,
           rpc_block_range
         )
-      end)
-    end
+      else
+        log_debug("Message ID #{message_id} already has originating block number, skipping")
+      end
+    end)
 
     # Move cursor backward for next iteration
     next_end_message_id = start_message_id - 1
@@ -393,51 +397,16 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
     {:ok, updated_state}
   end
 
-  # Re-checks a single missing message against the database immediately before
-  # processing it, and skips the L1 scan entirely when an earlier iteration of
-  # the same `check_missing_origination/1` loop already filled in its
-  # origination info as a side effect of processing a higher message ID.
+  # Tells whether the message still lacks its originating block number, i.e. it
+  # was not back-filled as a side effect of processing a higher message ID
+  # earlier in the same `check_missing_origination/1` loop. The check must run
+  # immediately before the message is processed - a single query ahead of the
+  # loop would not observe those side effects.
   #
-  # ## Parameters
-  # - `message_id`: The ID of the message to discover origination for
-  # - `l1_rollup_init_block`: Fallback minimum L1 block if no preceding message
-  # - `safe_l1_block`: Fallback maximum L1 block if no following message
-  # - `bridge_address`: L1 bridge contract address for log filtering
-  # - `json_rpc_named_arguments`: RPC configuration
-  # - `chunk_size`: Batch size for RPC requests
-  # - `rpc_block_range`: Maximum width of a single `eth_getLogs` request
-  #
-  # ## Returns
-  # - `:ok` after attempting to discover and import the message, or after
-  #   skipping it because its origination info is already present
-  defp discover_and_import_missing_message_unless_already_filled(
-         message_id,
-         l1_rollup_init_block,
-         safe_l1_block,
-         bridge_address,
-         json_rpc_named_arguments,
-         chunk_size,
-         rpc_block_range
-       ) do
-    # A single-ID range (message_id, message_id) is a valid query - the guard only
-    # requires start <= end - and tells us whether this specific message still lacks
-    # origination info at this point in the loop.
-    case DbMessages.messages_to_l2_completed_but_originating_info_missed(message_id, message_id) do
-      [] ->
-        log_debug("Message ID #{message_id} already has origination info, skipping")
-        :ok
-
-      _ ->
-        discover_and_import_single_missing_message(
-          message_id,
-          l1_rollup_init_block,
-          safe_l1_block,
-          bridge_address,
-          json_rpc_named_arguments,
-          chunk_size,
-          rpc_block_range
-        )
-    end
+  # A single-ID range (message_id, message_id) is a valid query - the guards
+  # only require non-negative IDs with start <= end.
+  defp origination_info_missing?(message_id) do
+    DbMessages.messages_to_l2_completed_but_originating_info_missed(message_id, message_id) != []
   end
 
   # Discovers and imports origination information for a single L1-to-L2 message
@@ -509,7 +478,6 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
     # `eth_getLogs` request never exceeds the node's per-request block-range
     # limit. `filter_range` is computed once above and reused for every chunk,
     # so chunking does not change which messages end up imported.
-    # credo:disable-for-lines:9 Credo.Check.Refactor.PipeChainStart
     ArbitrumHelper.execute_for_block_range_in_chunks(
       l1_start_block,
       l1_end_block,
@@ -641,7 +609,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
           [%{String.t() => any()}],
           EthereumJSONRPC.json_rpc_named_arguments(),
           non_neg_integer(),
-          %{higher_than: non_neg_integer(), lower_than: non_neg_integer()} | nil
+          %{higher_than: integer(), lower_than: non_neg_integer()} | nil
         ) :: [Arbitrum.Message.to_import()]
   defp get_messages_from_logs(logs, json_rpc_named_arguments, chunk_size, only_messages_in_range)
 
@@ -653,8 +621,26 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2 do
     transactions_to_from =
       Rpc.execute_transactions_requests_and_get_from(transactions_requests, json_rpc_named_arguments, chunk_size)
 
+    # A successful-but-null `eth_getTransactionByHash` response (e.g. from a
+    # lagging or pruned node behind a load balancer) leaves the originator
+    # address unknown. Such a message must not be imported at all: persisting it
+    # with the block number filled but the originator empty would make it look
+    # complete to the discovery queries keyed on the block number, so it would
+    # never be re-processed. Left unimported, it stays selectable for a retry on
+    # a later pass.
+    {messages_with_originator, messages_without_originator} =
+      Enum.split_with(messages, fn msg ->
+        not is_nil(transactions_to_from[msg.originating_transaction_hash])
+      end)
+
+    unless Enum.empty?(messages_without_originator) do
+      log_warning(
+        "Skipping import of #{length(messages_without_originator)} L1-to-L2 messages with unknown originator address"
+      )
+    end
+
     complete_messages =
-      Enum.map(messages, fn msg ->
+      Enum.map(messages_with_originator, fn msg ->
         Map.merge(msg, %{
           originator_address: transactions_to_from[msg.originating_transaction_hash],
           status: :initiated

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
@@ -13,7 +13,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
     alias Explorer.Repo
     alias Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2
 
-    @bridge_address "0xa723c008e76e379c55599d2e4d93879beafda79"
+    @bridge_address "0xa723c008e76e379c55599d2e4d93879beafda790"
 
     setup :verify_on_exit!
 
@@ -52,6 +52,27 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
       }
     end
 
+    # Inserts a `:to_l2` message that has completion information but lacks all
+    # four origination fields - the shape selected by
+    # `messages_to_l2_completed_but_originating_info_missed/2`. The factory
+    # already defaults `status` to `:relayed`; `opts` extends or overrides the
+    # attributes (e.g. `completion_transaction_hash`).
+    defp insert_message_missing_origination(message_id, opts \\ []) do
+      insert(
+        :arbitrum_message,
+        Keyword.merge(
+          [
+            message_id: message_id,
+            originator_address: nil,
+            originating_transaction_hash: nil,
+            origination_timestamp: nil,
+            originating_transaction_block_number: nil
+          ],
+          opts
+        )
+      )
+    end
+
     # Mocks both the `eth_getLogs` and `eth_getTransactionByHash` requests the
     # discovery loop can issue, in a single `expect/4` with as many clauses as
     # request shapes: since a single chunk's `eth_getTransactionByHash` lookups
@@ -64,9 +85,21 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
     # sent to the calling test process; the whole call path runs synchronously
     # in that same process, so the messages land in its mailbox in call order
     # and can be drained with `drain_get_logs_ranges/0` right after.
-    defp expect_rpc(get_logs_responses, transaction_responses \\ %{}) do
+    #
+    # An `eth_getLogs` range absent from `get_logs_responses` raises `KeyError`,
+    # so an unexpected chunk boundary fails the test loudly instead of being
+    # silently answered with no logs. A transaction hash mapped to `nil` in
+    # `transaction_responses` simulates a successful-but-null
+    # `eth_getTransactionByHash` response (the transaction is unknown to the
+    # node).
+    #
+    # By default every map entry is expected to be requested exactly once;
+    # scenarios that legitimately repeat requests (e.g. re-scanning overlapping
+    # ranges for a retried message) pass the exact call count as
+    # `expected_calls`.
+    defp expect_rpc(get_logs_responses, transaction_responses \\ %{}, expected_calls \\ nil) do
       test_pid = self()
-      total_calls = map_size(get_logs_responses) + map_size(transaction_responses)
+      total_calls = expected_calls || map_size(get_logs_responses) + map_size(transaction_responses)
 
       expect(EthereumJSONRPC.Mox, :json_rpc, total_calls, fn
         %{method: "eth_getLogs", params: [%{fromBlock: from_block_quantity, toBlock: to_block_quantity}]}, _options ->
@@ -74,12 +107,16 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
           to_block = quantity_to_integer(to_block_quantity)
           send(test_pid, {:eth_get_logs_range, from_block, to_block})
 
-          {:ok, Map.get(get_logs_responses, {from_block, to_block}, [])}
+          {:ok, Map.fetch!(get_logs_responses, {from_block, to_block})}
 
         [%{id: 0, jsonrpc: "2.0", method: "eth_getTransactionByHash", params: [transaction_hash]}], _options ->
-          from_address = Map.fetch!(transaction_responses, transaction_hash)
+          case Map.fetch!(transaction_responses, transaction_hash) do
+            nil ->
+              {:ok, [%{id: 0, jsonrpc: "2.0", result: nil}]}
 
-          {:ok, [%{id: 0, jsonrpc: "2.0", result: %{"hash" => transaction_hash, "from" => from_address}}]}
+            from_address ->
+              {:ok, [%{id: 0, jsonrpc: "2.0", result: %{"hash" => transaction_hash, "from" => from_address}}]}
+          end
       end)
     end
 
@@ -130,14 +167,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 10, originating_transaction_block_number: 100)
         insert(:arbitrum_message, message_id: 30, originating_transaction_block_number: 135)
 
-        insert(:arbitrum_message,
-          message_id: 20,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(20)
 
         expect_rpc(%{
           {100, 109} => [],
@@ -150,7 +180,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
 
         assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
 
-        assert Enum.sort(drain_get_logs_ranges()) == [{100, 109}, {110, 119}, {120, 129}, {130, 135}]
+        assert drain_get_logs_ranges() == [{100, 109}, {110, 119}, {120, 129}, {130, 135}]
       end
 
       test "issues exactly one request when the gap does not exceed l1_rpc_block_range", %{
@@ -159,14 +189,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 40, originating_transaction_block_number: 200)
         insert(:arbitrum_message, message_id: 42, originating_transaction_block_number: 205)
 
-        insert(:arbitrum_message,
-          message_id: 41,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(41)
 
         expect_rpc(%{{200, 205} => []})
 
@@ -183,14 +206,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 50, originating_transaction_block_number: 300)
         insert(:arbitrum_message, message_id: 52, originating_transaction_block_number: 300)
 
-        insert(:arbitrum_message,
-          message_id: 51,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(51)
 
         expect_rpc(%{{300, 300} => []})
 
@@ -209,15 +225,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
 
         completion_transaction_hash = transaction_hash()
 
-        insert(:arbitrum_message,
-          message_id: 61,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          completion_transaction_hash: completion_transaction_hash,
-          status: :relayed
-        )
+        insert_message_missing_origination(61, completion_transaction_hash: completion_transaction_hash)
 
         transaction_hash_string = to_string(transaction_hash())
         originator_address_string = to_string(address_hash())
@@ -239,7 +247,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
 
         assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
 
-        assert Enum.sort(drain_get_logs_ranges()) == [{400, 409}, {410, 419}, {420, 429}, {430, 435}]
+        assert drain_get_logs_ranges() == [{400, 409}, {410, 419}, {420, 429}, {430, 435}]
 
         message = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 61)
 
@@ -257,14 +265,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 70, originating_transaction_block_number: 500)
         insert(:arbitrum_message, message_id: 72, originating_transaction_block_number: 535)
 
-        insert(:arbitrum_message,
-          message_id: 71,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(71)
 
         neighbour_transaction_hash_string = to_string(transaction_hash())
         neighbour_originator_address_string = to_string(address_hash())
@@ -312,14 +313,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 80, originating_transaction_block_number: 600)
         insert(:arbitrum_message, message_id: 82, originating_transaction_block_number: 635)
 
-        insert(:arbitrum_message,
-          message_id: 81,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(81)
 
         expect_rpc(%{
           {600, 609} => [],
@@ -345,23 +339,8 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         insert(:arbitrum_message, message_id: 90, originating_transaction_block_number: 700)
         insert(:arbitrum_message, message_id: 93, originating_transaction_block_number: 735)
 
-        insert(:arbitrum_message,
-          message_id: 91,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
-
-        insert(:arbitrum_message,
-          message_id: 92,
-          originator_address: nil,
-          originating_transaction_hash: nil,
-          origination_timestamp: nil,
-          originating_transaction_block_number: nil,
-          status: :relayed
-        )
+        insert_message_missing_origination(91)
+        insert_message_missing_origination(92)
 
         transaction_hash_91_string = to_string(transaction_hash())
         originator_address_91_string = to_string(address_hash())
@@ -396,7 +375,7 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         # Only the chunks scanned while processing message ID 92 are observed;
         # processing message ID 91 afterwards issues no `eth_getLogs` request at
         # all because the skip check finds its origination already filled in.
-        assert Enum.sort(drain_get_logs_ranges()) == [{700, 709}, {710, 719}, {720, 729}, {730, 735}]
+        assert drain_get_logs_ranges() == [{700, 709}, {710, 719}, {720, 729}, {730, 735}]
 
         message_91 = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 91)
         assert to_string(message_91.originator_address) == String.downcase(originator_address_91_string)
@@ -407,6 +386,79 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         assert to_string(message_92.originator_address) == String.downcase(originator_address_92_string)
         assert to_string(message_92.originating_transaction_hash) == String.downcase(transaction_hash_92_string)
         assert message_92.originating_transaction_block_number == 715
+      end
+
+      test "does not import a message whose originating transaction lookup returns null and retries it in a later iteration (regression)",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        insert(:arbitrum_message, message_id: 100, originating_transaction_block_number: 800)
+        insert(:arbitrum_message, message_id: 103, originating_transaction_block_number: 835)
+
+        insert_message_missing_origination(101)
+        insert_message_missing_origination(102)
+
+        transaction_hash_101_string = to_string(transaction_hash())
+        transaction_hash_102_string = to_string(transaction_hash())
+        originator_address_102_string = to_string(address_hash())
+        timestamp = 1_700_000_000
+
+        log_101 = build_message_delivered_log(101, 815, transaction_hash_101_string, timestamp)
+        log_102 = build_message_delivered_log(102, 829, transaction_hash_102_string, timestamp)
+
+        # Message 101's `eth_getTransactionByHash` responds successfully but with
+        # a null result (mapped to `nil` below), so its originator address stays
+        # unknown. The message must not be imported half-filled while processing
+        # message ID 102 - otherwise the skip check (keyed on the originating
+        # block number) would consider it done and it would never be re-processed.
+        #
+        # Processing 102 scans 800..835 (4 chunks, bounded by messages 100 and
+        # 103) and imports only 102. Processing 101 afterwards is NOT skipped:
+        # it re-scans 800..829 (3 chunks, the higher bound now comes from the
+        # just-imported 102) and repeats both transaction lookups (101's log in
+        # chunk {810, 819}, 102's log in chunk {820, 829} - the latter is then
+        # dropped by the message-ID filter). Hence 7 `eth_getLogs` calls over 4
+        # distinct ranges and 4 `eth_getTransactionByHash` calls over 2 hashes,
+        # so the expected call count (11) is passed explicitly.
+        expect_rpc(
+          %{
+            {800, 809} => [],
+            {810, 819} => [log_101],
+            {820, 829} => [log_102],
+            {830, 835} => []
+          },
+          %{
+            transaction_hash_101_string => nil,
+            transaction_hash_102_string => originator_address_102_string
+          },
+          11
+        )
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 102, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert drain_get_logs_ranges() == [
+                 {800, 809},
+                 {810, 819},
+                 {820, 829},
+                 {830, 835},
+                 {800, 809},
+                 {810, 819},
+                 {820, 829}
+               ]
+
+        # Message 101 stays entirely unimported - no half-filled record with the
+        # block number set but the originator address empty - so it remains
+        # selectable for a retry on a later pass.
+        message_101 = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 101)
+        assert message_101.originator_address == nil
+        assert message_101.originating_transaction_hash == nil
+        assert message_101.origination_timestamp == nil
+        assert message_101.originating_transaction_block_number == nil
+        assert message_101.status == :relayed
+
+        message_102 = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 102)
+        assert to_string(message_102.originator_address) == String.downcase(originator_address_102_string)
+        assert message_102.originating_transaction_block_number == 829
       end
     end
   end

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+if Application.get_env(:explorer, :chain_type) == :arbitrum do
+  defmodule Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2Test do
+    use EthereumJSONRPC.Case, async: false
+    use Explorer.DataCase
+
+    import EthereumJSONRPC, only: [quantity_to_integer: 1, integer_to_quantity: 1]
+    import Mox
+
+    alias ABI.TypeEncoder
+    alias EthereumJSONRPC.Arbitrum.Constants.Events, as: ArbitrumEvents
+    alias Explorer.Chain.Arbitrum.Message, as: ArbitrumMessage
+    alias Explorer.Repo
+    alias Indexer.Fetcher.Arbitrum.Workers.NewMessagesToL2
+
+    @bridge_address "0xa723c008e76e379c55599d2e4d93879beafda79"
+
+    setup :verify_on_exit!
+
+    setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
+
+      %{json_rpc_named_arguments: mocked_json_rpc_named_arguments}
+    end
+
+    # Builds the fetcher state accepted by `check_missing_origination/1`.
+    #
+    # `end_message_id` and `missed_message_ids_range` are chosen so that the
+    # message-ID range checked by `check_missing_origination/1` always covers
+    # `end_message_id` itself, keeping every scenario's setup self-contained.
+    defp build_state(json_rpc_named_arguments, opts) do
+      end_message_id = Keyword.fetch!(opts, :end_message_id)
+      rpc_block_range = Keyword.fetch!(opts, :rpc_block_range)
+
+      %{
+        config: %{
+          json_l1_rpc_named_arguments: json_rpc_named_arguments,
+          l1_rpc_chunk_size: 50,
+          l1_rpc_block_range: rpc_block_range,
+          l1_bridge_address: @bridge_address,
+          l1_rollup_init_block: 0,
+          missed_message_ids_range: 1000
+        },
+        task_data: %{
+          check_missing_origination: %{
+            end_message_id: end_message_id,
+            earliest_discovered_message_id: 0,
+            safe_l1_block: 999_999_999
+          }
+        },
+        completed_tasks: %{}
+      }
+    end
+
+    # Mocks both the `eth_getLogs` and `eth_getTransactionByHash` requests the
+    # discovery loop can issue, in a single `expect/4` with as many clauses as
+    # request shapes: since a single chunk's `eth_getTransactionByHash` lookups
+    # are interleaved between two chunks' `eth_getLogs` calls, separate `expect`
+    # calls (each queued independently in call order, not dispatched by pattern)
+    # would need to predict that interleaving; one closure with multiple clauses
+    # dispatches purely on each call's own shape instead.
+    #
+    # Every `eth_getLogs` request's `fromBlock`/`toBlock` (as integers) is also
+    # sent to the calling test process; the whole call path runs synchronously
+    # in that same process, so the messages land in its mailbox in call order
+    # and can be drained with `drain_get_logs_ranges/0` right after.
+    defp expect_rpc(get_logs_responses, transaction_responses \\ %{}) do
+      test_pid = self()
+      total_calls = map_size(get_logs_responses) + map_size(transaction_responses)
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, total_calls, fn
+        %{method: "eth_getLogs", params: [%{fromBlock: from_block_quantity, toBlock: to_block_quantity}]}, _options ->
+          from_block = quantity_to_integer(from_block_quantity)
+          to_block = quantity_to_integer(to_block_quantity)
+          send(test_pid, {:eth_get_logs_range, from_block, to_block})
+
+          {:ok, Map.get(get_logs_responses, {from_block, to_block}, [])}
+
+        [%{id: 0, jsonrpc: "2.0", method: "eth_getTransactionByHash", params: [transaction_hash]}], _options ->
+          from_address = Map.fetch!(transaction_responses, transaction_hash)
+
+          {:ok, [%{id: 0, jsonrpc: "2.0", result: %{"hash" => transaction_hash, "from" => from_address}}]}
+      end)
+    end
+
+    defp drain_get_logs_ranges do
+      receive do
+        {:eth_get_logs_range, from_block, to_block} -> [{from_block, to_block} | drain_get_logs_ranges()]
+      after
+        0 -> []
+      end
+    end
+
+    # Builds a raw `MessageDelivered` event log (as it would arrive from an
+    # `eth_getLogs` JSON-RPC response) for the given message ID, L1 block number,
+    # originating transaction hash, and unix timestamp.
+    defp build_message_delivered_log(message_id, block_number, transaction_hash, timestamp) do
+      data =
+        "0x" <>
+          ([<<0::160>>, 3, <<0::160>>, <<0::256>>, 0, timestamp]
+           |> TypeEncoder.encode(%ABI.FunctionSelector{
+             function: nil,
+             types: ArbitrumEvents.message_delivered_unindexed_params()
+           })
+           |> Base.encode16(case: :lower))
+
+      message_id_topic =
+        "0x" <>
+          (message_id
+           |> Integer.to_string(16)
+           |> String.downcase()
+           |> String.pad_leading(64, "0"))
+
+      %{
+        "address" => @bridge_address,
+        "blockHash" => "0x" <> String.duplicate("0", 64),
+        "blockNumber" => integer_to_quantity(block_number),
+        "data" => data,
+        "logIndex" => "0x0",
+        "removed" => false,
+        "topics" => [ArbitrumEvents.message_delivered(), message_id_topic],
+        "transactionHash" => transaction_hash,
+        "transactionIndex" => "0x0"
+      }
+    end
+
+    describe "check_missing_origination/1" do
+      test "splits a gap wider than l1_rpc_block_range into exact, contiguous, non-overlapping chunks (regression)",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        insert(:arbitrum_message, message_id: 10, originating_transaction_block_number: 100)
+        insert(:arbitrum_message, message_id: 30, originating_transaction_block_number: 135)
+
+        insert(:arbitrum_message,
+          message_id: 20,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        expect_rpc(%{
+          {100, 109} => [],
+          {110, 119} => [],
+          {120, 129} => [],
+          {130, 135} => []
+        })
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 20, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert Enum.sort(drain_get_logs_ranges()) == [{100, 109}, {110, 119}, {120, 129}, {130, 135}]
+      end
+
+      test "issues exactly one request when the gap does not exceed l1_rpc_block_range", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 40, originating_transaction_block_number: 200)
+        insert(:arbitrum_message, message_id: 42, originating_transaction_block_number: 205)
+
+        insert(:arbitrum_message,
+          message_id: 41,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        expect_rpc(%{{200, 205} => []})
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 41, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert drain_get_logs_ranges() == [{200, 205}]
+      end
+
+      test "issues exactly one request for a single-block range", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 50, originating_transaction_block_number: 300)
+        insert(:arbitrum_message, message_id: 52, originating_transaction_block_number: 300)
+
+        insert(:arbitrum_message,
+          message_id: 51,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        expect_rpc(%{{300, 300} => []})
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 51, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert drain_get_logs_ranges() == [{300, 300}]
+      end
+
+      test "imports a message whose log falls in a later chunk, preserving completion data and :relayed status", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 60, originating_transaction_block_number: 400)
+        insert(:arbitrum_message, message_id: 62, originating_transaction_block_number: 435)
+
+        completion_transaction_hash = transaction_hash()
+
+        insert(:arbitrum_message,
+          message_id: 61,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          completion_transaction_hash: completion_transaction_hash,
+          status: :relayed
+        )
+
+        transaction_hash_string = to_string(transaction_hash())
+        originator_address_string = to_string(address_hash())
+        timestamp = 1_700_000_000
+
+        log = build_message_delivered_log(61, 425, transaction_hash_string, timestamp)
+
+        expect_rpc(
+          %{
+            {400, 409} => [],
+            {410, 419} => [],
+            {420, 429} => [log],
+            {430, 435} => []
+          },
+          %{transaction_hash_string => originator_address_string}
+        )
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 61, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert Enum.sort(drain_get_logs_ranges()) == [{400, 409}, {410, 419}, {420, 429}, {430, 435}]
+
+        message = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 61)
+
+        assert to_string(message.originator_address) == String.downcase(originator_address_string)
+        assert to_string(message.originating_transaction_hash) == String.downcase(transaction_hash_string)
+        assert DateTime.to_unix(message.origination_timestamp) == timestamp
+        assert message.originating_transaction_block_number == 425
+        assert to_string(message.completion_transaction_hash) == to_string(completion_transaction_hash)
+        assert message.status == :relayed
+      end
+
+      test "applies the message-ID filter per chunk, excluding an out-of-bounds neighbour found in another chunk", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 70, originating_transaction_block_number: 500)
+        insert(:arbitrum_message, message_id: 72, originating_transaction_block_number: 535)
+
+        insert(:arbitrum_message,
+          message_id: 71,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        neighbour_transaction_hash_string = to_string(transaction_hash())
+        neighbour_originator_address_string = to_string(address_hash())
+        target_transaction_hash_string = to_string(transaction_hash())
+        target_originator_address_string = to_string(address_hash())
+        timestamp = 1_700_000_000
+
+        # Out-of-bounds neighbour: shares message ID 72 with the higher bound
+        # message, which already has origination information, so it must be
+        # filtered out (the filter is exclusive of the bounds).
+        neighbour_log = build_message_delivered_log(72, 505, neighbour_transaction_hash_string, timestamp)
+        target_log = build_message_delivered_log(71, 525, target_transaction_hash_string, timestamp)
+
+        # Transaction enrichment happens before the ID filter is applied, so both
+        # logs' `eth_getTransactionByHash` lookups are issued even though the
+        # neighbour is later filtered out.
+        expect_rpc(
+          %{
+            {500, 509} => [neighbour_log],
+            {510, 519} => [],
+            {520, 529} => [target_log],
+            {530, 535} => []
+          },
+          %{
+            neighbour_transaction_hash_string => neighbour_originator_address_string,
+            target_transaction_hash_string => target_originator_address_string
+          }
+        )
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 71, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        target_message = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 71)
+        assert to_string(target_message.originating_transaction_hash) == String.downcase(target_transaction_hash_string)
+        assert target_message.originating_transaction_block_number == 525
+
+        neighbour_message = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 72)
+        assert neighbour_message.originating_transaction_block_number == 535
+      end
+
+      test "advances the cursor and completion flag as usual when all chunks return no logs", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 80, originating_transaction_block_number: 600)
+        insert(:arbitrum_message, message_id: 82, originating_transaction_block_number: 635)
+
+        insert(:arbitrum_message,
+          message_id: 81,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        expect_rpc(%{
+          {600, 609} => [],
+          {610, 619} => [],
+          {620, 629} => [],
+          {630, 635} => []
+        })
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 81, rpc_block_range: 10)
+
+        assert {:ok, updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        assert updated_state.task_data.check_missing_origination.end_message_id == -1
+        assert updated_state.completed_tasks.check_missing_origination == true
+
+        assert Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 81).originating_transaction_block_number ==
+                 nil
+      end
+    end
+  end
+end

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs
@@ -338,6 +338,76 @@ if Application.get_env(:explorer, :chain_type) == :arbitrum do
         assert Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 81).originating_transaction_block_number ==
                  nil
       end
+
+      test "skips a message already back-filled by the same loop's processing of a higher ID (regression)", %{
+        json_rpc_named_arguments: json_rpc_named_arguments
+      } do
+        insert(:arbitrum_message, message_id: 90, originating_transaction_block_number: 700)
+        insert(:arbitrum_message, message_id: 93, originating_transaction_block_number: 735)
+
+        insert(:arbitrum_message,
+          message_id: 91,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        insert(:arbitrum_message,
+          message_id: 92,
+          originator_address: nil,
+          originating_transaction_hash: nil,
+          origination_timestamp: nil,
+          originating_transaction_block_number: nil,
+          status: :relayed
+        )
+
+        transaction_hash_91_string = to_string(transaction_hash())
+        originator_address_91_string = to_string(address_hash())
+        transaction_hash_92_string = to_string(transaction_hash())
+        originator_address_92_string = to_string(address_hash())
+        timestamp = 1_700_000_000
+
+        # Both logs fall within the L1 block range scanned while processing the
+        # higher missing message ID (92); the message-ID filter for that scan
+        # allows both 91 and 92 through since it is bounded by the indexed
+        # neighbours 90 and 93.
+        log_91 = build_message_delivered_log(91, 725, transaction_hash_91_string, timestamp)
+        log_92 = build_message_delivered_log(92, 715, transaction_hash_92_string, timestamp)
+
+        expect_rpc(
+          %{
+            {700, 709} => [],
+            {710, 719} => [log_92],
+            {720, 729} => [log_91],
+            {730, 735} => []
+          },
+          %{
+            transaction_hash_91_string => originator_address_91_string,
+            transaction_hash_92_string => originator_address_92_string
+          }
+        )
+
+        state = build_state(json_rpc_named_arguments, end_message_id: 92, rpc_block_range: 10)
+
+        assert {:ok, _updated_state} = NewMessagesToL2.check_missing_origination(state)
+
+        # Only the chunks scanned while processing message ID 92 are observed;
+        # processing message ID 91 afterwards issues no `eth_getLogs` request at
+        # all because the skip check finds its origination already filled in.
+        assert Enum.sort(drain_get_logs_ranges()) == [{700, 709}, {710, 719}, {720, 729}, {730, 735}]
+
+        message_91 = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 91)
+        assert to_string(message_91.originator_address) == String.downcase(originator_address_91_string)
+        assert to_string(message_91.originating_transaction_hash) == String.downcase(transaction_hash_91_string)
+        assert message_91.originating_transaction_block_number == 725
+
+        message_92 = Repo.get_by(ArbitrumMessage, direction: :to_l2, message_id: 92)
+        assert to_string(message_92.originator_address) == String.downcase(originator_address_92_string)
+        assert to_string(message_92.originating_transaction_hash) == String.downcase(transaction_hash_92_string)
+        assert message_92.originating_transaction_block_number == 715
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #14721

## Motivation

The `:check_missing_origination` task of `Indexer.Fetcher.Arbitrum.TrackingMessagesOnL1` sent one `eth_getLogs` request for the full parent-chain block gap between two indexed messages. The database sets this gap width. No setting limits the width, so it grows with the size of the gap in message indexing.

Most parent-chain nodes limit the block range of an `eth_getLogs` request. In the reported case, the node limit was 10,000 blocks. When a gap went over this limit, the node rejected the request. Then `get_logs_for_l1_to_l2_messages/4` raised a `MatchError` on its `{:ok, logs} =` match, and the task stopped.

The task runs on a 2-second catchup interval and never finished, so the system never removed it from the schedule. The reporter saw the same block range retried about 465 times in 45 minutes, for several hours.

The two sibling tasks of the same fetcher already use `INDEXER_ARBITRUM_L1_RPC_HISTORICAL_BLOCKS_RANGE` (`l1_rpc_block_range`) to limit their range: `:check_new` splits its range into chunks, and `:check_historical` uses a window of this size. Only `:check_missing_origination` did not use this setting.

## Changelog

### Enhancements

- `:check_missing_origination` now checks if a message's origination information is already filled in by an earlier iteration of the same loop. If so, it skips new discovery requests for that message. The chunk loop still scans every remaining chunk after it finds the target message, because this also finds and imports other missing messages in the same gap. The new skip check turns this side effect into saved work on later iterations.
- Added regression tests for the fetcher: a new file, `apps/indexer/test/indexer/fetcher/arbitrum/workers/new_messages_to_l2_test.exs`, with 8 test scenarios. The scenarios cover wide-gap chunking; narrow-gap and single-block-range requests; import from a later chunk with the completion status kept; per-chunk message-ID filtering of an out-of-bounds neighbor; cursor and completion-flag updates when every chunk is empty; the skip of an already-filled message; and a null `eth_getTransactionByHash` response that leaves a message unimported for a retry in a later iteration.

### Bug Fixes

- The unbounded `eth_getLogs` request in `:check_missing_origination` is now split into chunks of the configured `l1_rpc_block_range` width. This reuses `ArbitrumHelper.execute_for_block_range_in_chunks/5`, the method `:check_new` already uses. This removes the oversized-block-range rejection that put the task into a permanent crash loop. The `filter_range` argument of `discover/6` selects messages by ID. The code computes this argument once and reuses it for every chunk, so chunking does not change which messages get imported.
- When `eth_getTransactionByHash` returns a successful but null result for an L1-to-L2 message — for example, from a lagging or pruned node behind a load balancer — the code no longer imports that message with an empty originator address. `get_messages_from_logs/4` now skips such a message and logs a warning, so the message stays available for a retry on a later pass. Before this fix, the half-filled record looked complete to the discovery queries, because they key on the originating block number. Combined with the new skip check, this problem would have blocked the message from ever being reprocessed. This fix is in shared discovery code, so it applies to all three tasks of the fetcher.

### Incompatible Changes

None. This PR does not change the schema, routes, the OpenAPI spec, environment variables, or dependencies. The fix reuses the existing `INDEXER_ARBITRUM_L1_RPC_HISTORICAL_BLOCKS_RANGE` setting.

## Upgrading

No action is necessary. A database reset or re-index is not necessary.

## Note on suggestion 2 of the issue

The issue also suggested that `get_logs_for_l1_to_l2_messages/4` replace its `{:ok, logs} =` match with explicit error handling. This PR does not include that change, for these reasons:

- The hard match followed by a crash matches the pattern at all 12 comparable `get_logs` call sites in `apps/indexer`.
- The crash path loses no data. The exception occurs inside the per-message loop, before the code recomputes the `end_message_id` cursor. `BufferedTask` replaces the handler state only after a successful return, and it re-queues a crashed batch at the end of the queue. So a crash here does not block the fetcher's other tasks. A failure streak trips the existing `failure_interval_threshold` check, which then applies a 10-minute cooldown.
- Returning an empty log list to hide the error is not a good alternative: this result looks the same as "no messages in this range". If the code did this, the cursor would advance past the gap, and the missing message would never get a re-check.
- Transient errors already get three attempts in total: the first call, plus two retries with 3-second and 6-second pauses, inside `Indexer.Helper.get_logs/7`.

Chunking removes the oversized-block-range error from the issue, as long as the configured `l1_rpc_block_range` does not go over the provider's own limit. Chunking does not remove other unrecoverable provider errors, such as a cap on the number of returned logs. Those errors still go through the existing crash/cooldown mechanism.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

This PR does not need: documentation or ENV var updates (no new, changed, or removed variables); OpenAPI schema updates (no API endpoints touched); new DB indices (none added); or chain-type matrix and label changes (none added or removed — the existing `ci:arbitrum` label already applies).
