### PR TITLE
fix: use cgroup memory limit for memory monitor in containers

### DIFF
--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -140,12 +140,20 @@ defmodule Indexer.Memory.Monitor do
   end
 
   defp read_cgroup_memory_limit(path) do
-    with {:ok, content} <- File.read(path),
-         {limit, _} <- Integer.parse(String.trim(content)),
-         true <- limit < @cgroup_no_limit_threshold do
+    case File.read(path) do
+      {:ok, content} -> parse_cgroup_memory_limit(content)
+      _ -> nil
+    end
+  end
+
+  @doc false
+  def parse_cgroup_memory_limit(content) do
+    with {limit, ""} <- Integer.parse(String.trim(content)),
+         true <- limit > 0 and limit < @cgroup_no_limit_threshold do
       limit
     else
-      # file is absent, contains "max" (cgroup v2 for "no limit"), or the limit is not set
+      # content is "max" (cgroup v2 for "no limit"), not a plain positive integer,
+      # or the limit is not set
       _ -> nil
     end
   end

--- a/apps/indexer/lib/indexer/memory/monitor.ex
+++ b/apps/indexer/lib/indexer/memory/monitor.ex
@@ -111,9 +111,42 @@ defmodule Indexer.Memory.Monitor do
         _ -> Application.get_env(:indexer, :system_memory_percentage)
       end
 
-    case :memsup.get_system_memory_data()[:total_memory] do
+    case total_memory() do
       nil -> default_limit
       total_memory -> floor(total_memory * percentage / 100)
+    end
+  end
+
+  @cgroup_memory_limit_paths [
+    # cgroup v2
+    "/sys/fs/cgroup/memory.max",
+    # cgroup v1
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  ]
+
+  # cgroup v1 reports "no limit" as a huge sentinel number (PAGE_COUNTER_MAX)
+  # rather than a keyword, so values above this threshold are treated as unset
+  @cgroup_no_limit_threshold 1 <<< 60
+
+  # When running in a container, the memory available to the pod is defined by
+  # its cgroup limit, while `:memsup` reports the host's total memory, so the
+  # cgroup limit takes precedence when it is present and set.
+  defp total_memory do
+    cgroup_memory_limit() || :memsup.get_system_memory_data()[:total_memory]
+  end
+
+  defp cgroup_memory_limit do
+    Enum.find_value(@cgroup_memory_limit_paths, &read_cgroup_memory_limit/1)
+  end
+
+  defp read_cgroup_memory_limit(path) do
+    with {:ok, content} <- File.read(path),
+         {limit, _} <- Integer.parse(String.trim(content)),
+         true <- limit < @cgroup_no_limit_threshold do
+      limit
+    else
+      # file is absent, contains "max" (cgroup v2 for "no limit"), or the limit is not set
+      _ -> nil
     end
   end
 


### PR DESCRIPTION
## Motivation

`Indexer.Memory.Monitor` derives its memory limit from `:memsup.get_system_memory_data()[:total_memory]`, which reports the **host's** total memory. When Blockscout runs in a container (e.g. a Kubernetes pod), the actual memory available to the application is defined by the pod's cgroup limit, which can be far lower than the host total. As a result, the monitor computed an inflated limit and failed to shrink queues before the pod hit its memory ceiling.

## Changelog

### Bug Fixes

- `Indexer.Memory.Monitor` now determines total memory from the container's cgroup limit instead of the host's total memory:
  - checks `/sys/fs/cgroup/memory.max` (cgroup v2) first, then `/sys/fs/cgroup/memory/memory.limit_in_bytes` (cgroup v1);
  - a cgroup file is skipped when it is absent, contains the literal `max` (cgroup v2 "no limit"), or contains the cgroup v1 "no limit" sentinel (values >= `2^60`, i.e. `PAGE_COUNTER_MAX`);
  - falls back to `:memsup.get_system_memory_data()[:total_memory]` when no usable cgroup limit is found, preserving the previous behavior outside containers.
- Existing behavior is otherwise unchanged: an explicit `INDEXER_MEMORY_LIMIT` setting still takes precedence, and the 1 GiB default still applies when no source is available.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory limit detection in containerized environments by prioritizing supported container memory limits.
  * Added safeguards for missing, malformed, non-positive, unlimited, or unsupported limit values.
  * Memory limits are now validated as complete numeric values before use.
  * Systems without a usable container limit continue using the standard system memory estimate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->