### PR TITLE
fix: Arbitrum inverted confirmations order

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/arbitrum/batch_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/arbitrum/batch_blocks.ex
@@ -65,7 +65,10 @@ defmodule Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Arbitrum.BatchBlock ShareLocks order (see docs: sharelock.md)
-    ordered_changes_list = Enum.sort_by(changes_list, & &1.block_number)
+    ordered_changes_list =
+      changes_list
+      |> Enum.sort_by(& &1.block_number)
+      |> Enum.dedup_by(& &1.block_number)
 
     {:ok, inserted} =
       Import.insert_changes_list(

--- a/apps/explorer/test/explorer/chain/import/runner/arbitrum/batch_blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/arbitrum/batch_blocks_test.exs
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+if Application.compile_env(:explorer, :chain_type) == :arbitrum do
+  defmodule Explorer.Chain.Import.Runner.Arbitrum.BatchBlocksTest do
+    use Explorer.DataCase
+
+    alias Ecto.Multi
+    alias Explorer.Chain.Arbitrum.BatchBlock
+    alias Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks
+
+    describe "insert/3" do
+      test "deduplicates a changes list containing two entries with the same block_number, keeping the first" do
+        %{number: batch_number} = insert(:arbitrum_l1_batch)
+        %{id: first_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+        %{id: second_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+
+        block_number = 42
+
+        changes = [
+          %{
+            batch_number: batch_number,
+            block_number: block_number,
+            confirmation_id: first_confirmation_id
+          },
+          %{
+            batch_number: batch_number,
+            block_number: block_number,
+            confirmation_id: second_confirmation_id
+          }
+        ]
+
+        assert {:ok, %{insert_arbitrum_batch_blocks: inserted}} = run_changes(changes)
+
+        assert length(inserted) == 1
+
+        assert [%BatchBlock{block_number: ^block_number, confirmation_id: ^first_confirmation_id}] =
+                 Repo.all(from(bb in BatchBlock, where: bb.block_number == ^block_number))
+      end
+
+      test "imports all rows for a well-formed list without duplicates" do
+        %{number: batch_number} = insert(:arbitrum_l1_batch)
+        %{id: first_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+        %{id: second_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+
+        changes = [
+          %{
+            batch_number: batch_number,
+            block_number: 1,
+            confirmation_id: first_confirmation_id
+          },
+          %{
+            batch_number: batch_number,
+            block_number: 2,
+            confirmation_id: second_confirmation_id
+          }
+        ]
+
+        assert {:ok, %{insert_arbitrum_batch_blocks: inserted}} = run_changes(changes)
+
+        assert length(inserted) == 2
+
+        assert Repo.aggregate(from(bb in BatchBlock, where: bb.block_number in [1, 2]), :count) == 2
+      end
+    end
+
+    defp run_changes(changes) when is_list(changes) do
+      Multi.new()
+      |> BatchBlocks.run(changes, %{
+        timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+      })
+      |> Repo.transaction()
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -2092,9 +2092,10 @@ defmodule Explorer.Factory do
   end
 
   # Pure association factory — callers must supply `:batch_number` and `:block_number`
-  # as overrides referencing existing records. Both are required foreign keys on
-  # `Explorer.Chain.Arbitrum.BatchBlock`, so `insert(:arbitrum_batch_block)` without
-  # overrides will raise.
+  # as overrides referencing existing records. `batch_number` is a required foreign key
+  # on `Explorer.Chain.Arbitrum.BatchBlock`; `block_number` is a required standalone
+  # primary key with no foreign key to `blocks` (deliberate, so re-orgs of `blocks` don't
+  # cascade here). `insert(:arbitrum_batch_block)` without overrides will raise.
   def arbitrum_batch_block_factory do
     %ArbitrumBatchBlock{}
   end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/discovery.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/discovery.ex
@@ -182,9 +182,9 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.Discovery do
 
     # This step must be run only if there are hashes of the confirmed rollup blocks
     # in rollup_blocks_to_l1_transactions - when there are newly discovered confirmations.
-    rollup_blocks =
+    {rollup_blocks, confirmation_outcomes} =
       if Enum.empty?(rollup_blocks_to_l1_transactions) do
-        []
+        {[], %{}}
       else
         RollupBlocks.extend_confirmations(
           rollup_blocks_to_l1_transactions,
@@ -199,7 +199,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.Discovery do
 
     # Will return %{} if there are no new confirmations
     applicable_lifecycle_transactions =
-      take_lifecycle_transactions_for_confirmed_blocks(rollup_blocks, lifecycle_transactions_basic)
+      take_lifecycle_transactions_for_handled_confirmations(confirmation_outcomes, lifecycle_transactions_basic)
 
     # Will contain :ok if no new confirmations are found
     retcode =
@@ -338,21 +338,32 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.Discovery do
      Map.values(existing_lifecycle_transactions)}
   end
 
-  # Selects lifecycle transaction descriptions used for confirming a given list of rollup blocks.
-  @spec take_lifecycle_transactions_for_confirmed_blocks(
-          [Arbitrum.BatchBlock.to_import()],
+  # Selects lifecycle transaction descriptions for confirmations that were handled -
+  # either claimed at least one rollup block or were found fully covered by blocks
+  # already claimed (`:claimed` or `:covered` outcome).
+  #
+  # A `:covered` confirmation is imported as a lifecycle transaction with no
+  # referencing `arbitrum_batch_blocks` row: this is safe because gap detection in
+  # `DbSettlement.l1_blocks_to_expect_rollup_blocks_confirmation/1` is derived from
+  # `arbitrum_batch_blocks`, not from the lifecycle-transaction table, and no API
+  # path reaches a confirmation except through a block row.
+  #
+  # A confirmation with an `:error` outcome, or with no outcome at all (its top hash
+  # failed to resolve to a block number, or it was never reached because an earlier
+  # descent in the same tick halted processing), is excluded here and therefore
+  # counted as missed by the caller's retcode derivation.
+  @spec take_lifecycle_transactions_for_handled_confirmations(
+          %{binary() => RollupBlocks.confirmation_outcome()},
           %{binary() => %{hash: binary(), block_number: non_neg_integer()}}
         ) :: %{binary() => %{hash: binary(), block_number: non_neg_integer()}}
-  defp take_lifecycle_transactions_for_confirmed_blocks(confirmed_rollup_blocks, lifecycle_transactions) do
-    confirmed_rollup_blocks
-    |> Enum.reduce(%{}, fn block_descr, updated_transactions ->
-      confirmation_transaction_hash = block_descr.confirmation_transaction
-
-      Map.put_new(
-        updated_transactions,
-        confirmation_transaction_hash,
-        lifecycle_transactions[confirmation_transaction_hash]
-      )
+  defp take_lifecycle_transactions_for_handled_confirmations(confirmation_outcomes, lifecycle_transactions) do
+    confirmation_outcomes
+    |> Enum.reduce(%{}, fn {l1_transaction_hash, outcome}, updated_transactions ->
+      if outcome in [:claimed, :covered] do
+        Map.put_new(updated_transactions, l1_transaction_hash, lifecycle_transactions[l1_transaction_hash])
+      else
+        updated_transactions
+      end
     end)
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks.ex
@@ -206,7 +206,14 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
          # If it returns `{:ok, []}` it will be passed as the return value of
          # discover_rollup_blocks_belonging_to_one_confirmation function.
          {:ok, {first_unconfirmed_block, new_cache}} <-
-           check_confirmed_blocks_of_batch(rollup_block_num, batch, confirmation_desc, outbox_config, cache),
+           check_confirmed_blocks_of_batch(
+             rollup_block_num,
+             batch,
+             confirmation_desc,
+             outbox_config,
+             raw_unconfirmed_rollup_blocks,
+             cache
+           ),
          {:ok, unconfirmed_rollup_blocks} <-
            check_consecutive_rollup_blocks(
              raw_unconfirmed_rollup_blocks,
@@ -349,10 +356,22 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   #
   # This function attempts to find a `SendRootUpdated` event between the already
   # discovered confirmation and the L1 block where the batch was committed, that
-  # mentions any block of the batch as the top of the confirmed blocks. Depending
-  # on the lookup result, it either considers the found block or the very
-  # first block of the batch as the start of the range of unconfirmed blocks ending
-  # with `rollup_block_num`.
+  # mentions any block of the batch as the top of the confirmed blocks. When such
+  # an event is found, the block right after it starts the range of unconfirmed
+  # blocks ending with `rollup_block_num`.
+  #
+  # When no such event is found in the scanned logs, the lower boundary already
+  # known to the database is used instead of unconditionally falling back to the
+  # start of the batch: `raw_unconfirmed_rollup_blocks` (fetched by the caller from
+  # `DbSettlement.unconfirmed_rollup_blocks/2`) reflects a boundary recorded by an
+  # earlier discovery pass at a higher parent-chain block than the current log
+  # scan window can see. Its minimum block number is accepted as the boundary only
+  # when it is proven safe: either it equals `batch.start_block` (the ordinary
+  # case, behavior unchanged), or the immediately preceding rollup block is
+  # already confirmed in the database. Otherwise the minimum is ambiguous - it may
+  # mean "confirmed" or "batch not fully synced below this point" - so the
+  # confirmation is postponed as before.
+  #
   # To optimize `eth_getLogs` calls required for the `SendRootUpdated` event lookup,
   # it uses a cache.
   # Since this function only discovers the number of the unconfirmed block, it does
@@ -363,6 +382,10 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   # - `batch`: The batch containing the rollup blocks.
   # - `confirmation_desc`: Details of the latest confirmation.
   # - `outbox_config`: Configuration for the Arbitrum outbox contract.
+  # - `raw_unconfirmed_rollup_blocks`: The list of unconfirmed (and potentially
+  #   re-confirmation) rollup blocks of the batch already read from the database,
+  #   used to derive a database-backed lower boundary when no boundary event is
+  #   found in the scanned logs.
   # - `cache`: A cache to minimize `eth_getLogs` calls.
   #
   # ## Returns
@@ -381,6 +404,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
             :json_rpc_named_arguments => EthereumJSONRPC.json_rpc_named_arguments(),
             optional(any()) => any()
           },
+          [Arbitrum.BatchBlock.to_import()],
           EventsUtils.cached_logs()
         ) :: {:ok, {non_neg_integer(), EventsUtils.cached_logs()}} | {:ok, []} | {:error, []}
   defp check_confirmed_blocks_of_batch(
@@ -388,6 +412,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
          batch,
          confirmation_desc,
          outbox_config,
+         raw_unconfirmed_rollup_blocks,
          cache
        ) do
     # This function might look like over-engineered, but confirmations are not always
@@ -407,17 +432,70 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
         {:ok, []}
 
       {_, false} ->
-        first_unconfirmed_block_in_batch =
-          case block? do
-            nil ->
-              batch.start_block
+        case block? do
+          nil ->
+            database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, new_cache)
 
-            value ->
-              log_info("Blocks up to ##{value} of the batch have been already confirmed by another transaction")
-              value + 1
-          end
+          value ->
+            log_info("Blocks up to ##{value} of the batch have been already confirmed by another transaction")
+            {:ok, {value + 1, new_cache}}
+        end
+    end
+  end
 
-        {:ok, {first_unconfirmed_block_in_batch, new_cache}}
+  # Derives the lower boundary of the unconfirmed range from the database when no
+  # boundary event was found in the scanned `SendRootUpdated` logs.
+  #
+  # The minimum block number of `raw_unconfirmed_rollup_blocks` (as returned by
+  # `DbSettlement.unconfirmed_rollup_blocks/2`, which can append already-confirmed
+  # "re-confirmation" blocks at the top of the range, but never lowers the true
+  # minimum) is accepted as the boundary only when it is provably safe:
+  # - it equals `batch.start_block`, the ordinary case where nothing in the batch
+  #   is confirmed yet, or
+  # - the immediately preceding rollup block is confirmed in the database, proving
+  #   the row exists and carries a valid confirmation.
+  # Otherwise the minimum is ambiguous between "confirmed" and "batch not fully
+  # synced below this point", so the confirmation is postponed, preserving the
+  # module's existing defense against partially-synced batches.
+  #
+  # ## Parameters
+  # - `batch`: The batch containing the rollup blocks.
+  # - `raw_unconfirmed_rollup_blocks`: The list of unconfirmed rollup blocks of the
+  #   batch already read from the database.
+  # - `cache`: The current logs cache to thread through unchanged.
+  #
+  # ## Returns
+  # - `{:ok, {first_unconfirmed_block_in_batch, cache}}` when the boundary is
+  #   proven safe.
+  # - `{:error, []}` when the boundary is ambiguous.
+  @spec database_derived_boundary(
+          Arbitrum.L1Batch.t(),
+          [Arbitrum.BatchBlock.to_import()],
+          EventsUtils.cached_logs()
+        ) :: {:ok, {non_neg_integer(), EventsUtils.cached_logs()}} | {:error, []}
+  defp database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, cache) do
+    minimum_unconfirmed_block =
+      raw_unconfirmed_rollup_blocks
+      |> List.first()
+      |> Map.fetch!(:block_number)
+
+    cond do
+      minimum_unconfirmed_block == batch.start_block ->
+        {:ok, {minimum_unconfirmed_block, cache}}
+
+      not is_nil(DbSettlement.l1_block_of_confirmation_for_rollup_block(minimum_unconfirmed_block - 1)) ->
+        log_info(
+          "Block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is confirmed according to the database, using ##{minimum_unconfirmed_block} as the lower boundary"
+        )
+
+        {:ok, {minimum_unconfirmed_block, cache}}
+
+      true ->
+        log_warning(
+          "Could not confirm that block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is confirmed, postponing the confirmation"
+        )
+
+        {:error, []}
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks.ex
@@ -18,6 +18,23 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   processing is postponed. The module also verifies block continuity to detect and handle
   potential database inconsistencies, ensuring that no gaps exist in the confirmed blocks
   sequence.
+
+  Confirmations of a single discovery tick are processed in ascending parent-chain
+  (L1) block order rather than ascending rollup block order. In the ordinary case the
+  two orders coincide, but a `SendRootUpdated` event whose parent-chain position is
+  inverted relative to the rollup range it confirms is possible; ascending parent-chain
+  order guarantees that every confirmation processed earlier in the tick is visible to
+  later confirmations' log scans (which only cover L1 blocks up to `l1_block_num - 1`).
+  A "highest rollup block already claimed in this tick" watermark is carried through the
+  processing: it lets a confirmation whose top block was already claimed by an
+  earlier-on-parent-chain confirmation be skipped entirely (attribution rule: on overlap,
+  the confirmation earlier on the parent chain owns the overlapping blocks), and it acts
+  as a floor under the database-derived lower boundary so that two confirmations of the
+  same tick never produce overlapping rollup block ranges - even when their events share
+  the same L1 block and are therefore mutually invisible to each other's log scan. A
+  descent that errors halts the remaining confirmations of the tick; every confirmation
+  actually processed - whether it claimed blocks, was found fully covered, or failed - is
+  reported back through a per-confirmation outcome.
   """
 
   import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_warning: 1, log_info: 1, log_debug: 1]
@@ -32,15 +49,39 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   @logs_per_report 10
   @zero_counters %{pairs_counter: 1, capped_logs_counter: 0, report?: false}
 
+  @typedoc """
+  The outcome of processing a single confirmation within a discovery tick:
+    * `:claimed` - the confirmation was processed and claimed at least one rollup block.
+    * `:covered` - the confirmation was processed successfully but claimed zero rollup
+      blocks, because everything it could have claimed was already claimed either by a
+      confirmation earlier on the parent chain within the same tick, or by a previous
+      tick.
+    * `:error` - the confirmation's descent failed (for example, a batch that is not
+      yet fully synced, or a database inconsistency).
+  """
+  @type confirmation_outcome :: :claimed | :covered | :error
+
   @doc """
     Discovers and marks all rollup blocks associated with provided confirmations.
 
     First, converts the input map of rollup block hashes to a map keyed by block numbers,
     transforming confirmation descriptions to use block numbers instead of hashes. Then
-    processes these confirmations sequentially starting from the lowest rollup block
-    number, ensuring that each block is associated with the correct confirmation. This
-    sequential handling preserves the confirmation history, allowing future processing
-    to accurately associate blocks with their respective confirmations.
+    processes these confirmations in ascending parent-chain (L1) block order, carrying a
+    running watermark of the highest rollup block already claimed in this tick.
+
+    A confirmation whose top block does not exceed the watermark is skipped - every block
+    it could claim was already claimed by a confirmation earlier on the parent chain (the
+    attribution rule). Otherwise the confirmation's descent is attempted with the watermark
+    passed down as a floor under the database-derived lower boundary, which guarantees that
+    no rollup block is claimed by two confirmations of the same tick even when two
+    `SendRootUpdated` events share the same L1 block. The watermark is raised to a
+    confirmation's top block only once that confirmation actually claims at least one
+    block; a covered (zero-block) or failed confirmation never raises it.
+
+    A descent that fails halts processing of the remaining confirmations in the tick:
+    confirmations already processed keep their claimed blocks, while the failed
+    confirmation and every later-on-parent-chain confirmation are left with no outcome and
+    are deferred to a following tick.
 
     ## Parameters
     - `rollup_blocks_to_l1_transactions`: A map linking rollup block hashes (the "top" blocks
@@ -50,8 +91,13 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
       the chain
 
     ## Returns
-    - A list of rollup blocks each associated with the transaction's hash that
-      confirms the block
+    - `{blocks, outcomes}` where
+      - `blocks` is a list of rollup blocks each associated with the transaction's hash
+        that confirms the block
+      - `outcomes` maps a confirmation's L1 transaction hash to its `confirmation_outcome()`.
+        A confirmation whose top block hash failed to resolve to a rollup block number, or
+        that was never reached because an earlier descent in the same tick failed, has no
+        entry in this map.
   """
   @spec extend_confirmations(
           %{binary() => %{l1_transaction_hash: binary(), l1_block_num: non_neg_integer()}},
@@ -62,7 +108,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
             optional(any()) => any()
           },
           non_neg_integer()
-        ) :: [Arbitrum.BatchBlock.to_import()]
+        ) :: {[Arbitrum.BatchBlock.to_import()], %{binary() => confirmation_outcome()}}
   def extend_confirmations(rollup_blocks_to_l1_transactions, outbox_config, rollup_first_block) do
     block_to_l1_transactions =
       rollup_blocks_to_l1_transactions
@@ -83,35 +129,165 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
       end)
 
     if Enum.empty?(block_to_l1_transactions) do
-      []
+      {[], %{}}
     else
-      # Oldest (with the lowest number) block is first
-      rollup_block_numbers = Enum.sort(Map.keys(block_to_l1_transactions), :asc)
+      # Confirmations of this tick are processed in ascending parent-chain (L1) block
+      # order so that an earlier-processed confirmation is always visible to a later
+      # confirmation's log scan.
+      confirmations_in_parent_chain_order =
+        block_to_l1_transactions
+        |> Enum.sort_by(fn {_block_number, confirmation_desc} -> confirmation_desc.l1_block_num end, :asc)
 
-      rollup_block_numbers
-      |> Enum.reduce([], fn block_number, updated_rollup_blocks ->
-        log_info("Attempting to mark all rollup blocks including ##{block_number} and lower as confirmed")
+      {blocks, outcomes, _high_watermark} =
+        Enum.reduce_while(confirmations_in_parent_chain_order, {[], %{}, 0}, fn confirmation,
+                                                                                {updated_blocks, outcomes,
+                                                                                 high_watermark} ->
+          {block_number, confirmation_desc} = confirmation
 
-        {_, confirmed_blocks} =
-          discover_rollup_blocks_belonging_to_one_confirmation(
+          process_one_confirmation_in_tick(
             block_number,
-            block_to_l1_transactions[block_number],
+            confirmation_desc,
             outbox_config,
-            rollup_first_block
+            rollup_first_block,
+            high_watermark,
+            updated_blocks,
+            outcomes
           )
+        end)
 
-        # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-        if Enum.empty?(confirmed_blocks) do
-          log_info("Either no unconfirmed blocks found or DB inconsistency error discovered")
-          []
-        else
-          log_info("Found #{length(confirmed_blocks)} confirmed blocks")
-
-          add_confirmation_transaction(confirmed_blocks, block_to_l1_transactions[block_number].l1_transaction_hash) ++
-            updated_rollup_blocks
-        end
-      end)
+      {blocks, outcomes}
     end
+  end
+
+  # Processes a single confirmation within a discovery tick's reduce_while.
+  #
+  # If the confirmation's top block does not exceed the watermark, every block it could
+  # claim was already claimed by a confirmation earlier on the parent chain in this same
+  # tick, so it is marked `:covered` without attempting a descent. Otherwise the descent
+  # is attempted with the current watermark passed down as a floor.
+  @spec process_one_confirmation_in_tick(
+          non_neg_integer(),
+          %{:l1_transaction_hash => binary(), :l1_block_num => non_neg_integer(), optional(any()) => any()},
+          %{
+            :logs_block_range => non_neg_integer(),
+            :outbox_address => binary(),
+            :json_rpc_named_arguments => EthereumJSONRPC.json_rpc_named_arguments(),
+            optional(any()) => any()
+          },
+          non_neg_integer(),
+          non_neg_integer(),
+          [Arbitrum.BatchBlock.to_import()],
+          %{binary() => confirmation_outcome()}
+        ) ::
+          {:cont | :halt, {[Arbitrum.BatchBlock.to_import()], %{binary() => confirmation_outcome()}, non_neg_integer()}}
+  defp process_one_confirmation_in_tick(
+         block_number,
+         confirmation_desc,
+         outbox_config,
+         rollup_first_block,
+         high_watermark,
+         updated_blocks,
+         outcomes
+       ) do
+    if block_number <= high_watermark do
+      log_info(
+        "Rollup block ##{block_number} and lower are already claimed by a confirmation processed earlier in this tick, skipping"
+      )
+
+      {:cont, {updated_blocks, Map.put(outcomes, confirmation_desc.l1_transaction_hash, :covered), high_watermark}}
+    else
+      log_info("Attempting to mark all rollup blocks including ##{block_number} and lower as confirmed")
+
+      {status, confirmed_blocks} =
+        discover_rollup_blocks_belonging_to_one_confirmation(
+          block_number,
+          confirmation_desc,
+          outbox_config,
+          rollup_first_block,
+          high_watermark
+        )
+
+      handle_confirmation_descent_result(
+        status,
+        confirmed_blocks,
+        block_number,
+        confirmation_desc,
+        high_watermark,
+        updated_blocks,
+        outcomes
+      )
+    end
+  end
+
+  # Folds the result of a single confirmation's descent into the tick's accumulator.
+  #
+  # An `:error` status halts the remaining confirmations of the tick: blocks accumulated
+  # by confirmations already processed successfully are kept, the failed confirmation is
+  # marked `:error`, and the watermark is not raised so a following tick retries from the
+  # same point.
+  #
+  # An `:ok` status with an empty block list means the confirmation is fully covered by
+  # blocks already confirmed (in the database, from a previous tick) - it is marked
+  # `:covered` and the watermark is not raised, since nothing new was claimed in this
+  # tick.
+  #
+  # An `:ok` status with a non-empty block list means the confirmation claimed new
+  # blocks - it is marked `:claimed` and the watermark is raised to the confirmation's top
+  # block.
+  @spec handle_confirmation_descent_result(
+          :ok | :error,
+          [Arbitrum.BatchBlock.to_import()],
+          non_neg_integer(),
+          %{:l1_transaction_hash => binary(), optional(any()) => any()},
+          non_neg_integer(),
+          [Arbitrum.BatchBlock.to_import()],
+          %{binary() => confirmation_outcome()}
+        ) ::
+          {:cont | :halt, {[Arbitrum.BatchBlock.to_import()], %{binary() => confirmation_outcome()}, non_neg_integer()}}
+  defp handle_confirmation_descent_result(
+         :error,
+         _confirmed_blocks,
+         _block_number,
+         confirmation_desc,
+         high_watermark,
+         updated_blocks,
+         outcomes
+       ) do
+    log_info("Either no unconfirmed blocks found or DB inconsistency error discovered")
+
+    {:halt, {updated_blocks, Map.put(outcomes, confirmation_desc.l1_transaction_hash, :error), high_watermark}}
+  end
+
+  defp handle_confirmation_descent_result(
+         :ok,
+         [],
+         _block_number,
+         confirmation_desc,
+         high_watermark,
+         updated_blocks,
+         outcomes
+       ) do
+    log_info("The confirmation is fully covered by blocks already claimed, no new blocks to add")
+
+    {:cont, {updated_blocks, Map.put(outcomes, confirmation_desc.l1_transaction_hash, :covered), high_watermark}}
+  end
+
+  defp handle_confirmation_descent_result(
+         :ok,
+         confirmed_blocks,
+         block_number,
+         confirmation_desc,
+         high_watermark,
+         updated_blocks,
+         outcomes
+       ) do
+    log_info("Found #{length(confirmed_blocks)} confirmed blocks")
+
+    new_blocks =
+      add_confirmation_transaction(confirmed_blocks, confirmation_desc.l1_transaction_hash) ++ updated_blocks
+
+    {:cont,
+     {new_blocks, Map.put(outcomes, confirmation_desc.l1_transaction_hash, :claimed), max(high_watermark, block_number)}}
   end
 
   # Takes first 6 and last 6 nibbles of the hash
@@ -130,8 +306,9 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   #    are covered by the current confirmation and those that a going to be covered
   #    by the predecessor confirmation.
   # 3. Determine the first unconfirmed block in the batch. It could be the first
-  #    block in the batch or a block the next after the last confirmed block in the
-  #    predecessor confirmation.
+  #    block in the batch, a block the next after the last confirmed block in the
+  #    predecessor confirmation, or the block right above the in-tick watermark when
+  #    that watermark is higher than what the database or the log scan can prove.
   # 4. Verify the continuity of the unconfirmed blocks to be covered by the current
   #    confirmation to ensure there are no database inconsistencies or unindexed
   #    blocks.
@@ -168,6 +345,9 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   # - `outbox_config`: Configuration for the Arbitrum outbox contract.
   # - `rollup_first_block`: The block number limiting the lowest indexed block of
   #   the chain.
+  # - `high_watermark`: The highest rollup block number already claimed by a
+  #   confirmation earlier on the parent chain within the current tick. Used as a
+  #   floor under the database-derived lower boundary.
   # - `cache`: A cache to minimize repetitive `eth_getLogs` calls.
   #
   # ## Returns
@@ -185,6 +365,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
             optional(any()) => any()
           },
           non_neg_integer(),
+          non_neg_integer(),
           EventsUtils.cached_logs()
         ) :: {:ok, [Arbitrum.BatchBlock.to_import()]} | {:error, []}
   defp discover_rollup_blocks_belonging_to_one_confirmation(
@@ -192,6 +373,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
          confirmation_desc,
          outbox_config,
          rollup_first_block,
+         high_watermark,
          cache \\ %{}
        ) do
     # The following batch fields are required in the further processing:
@@ -212,6 +394,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
              confirmation_desc,
              outbox_config,
              raw_unconfirmed_rollup_blocks,
+             high_watermark,
              cache
            ),
          {:ok, unconfirmed_rollup_blocks} <-
@@ -233,6 +416,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
           confirmation_desc,
           outbox_config,
           rollup_first_block,
+          high_watermark,
           new_cache,
           unconfirmed_rollup_blocks,
           raw_unconfirmed_rollup_blocks
@@ -254,6 +438,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
          confirmation_desc,
          outbox_config,
          rollup_first_block,
+         high_watermark,
          new_cache,
          unconfirmed_rollup_blocks,
          _raw_unconfirmed_rollup_blocks
@@ -264,6 +449,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
         confirmation_desc,
         outbox_config,
         rollup_first_block,
+        high_watermark,
         new_cache
       )
 
@@ -366,11 +552,12 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   # `DbSettlement.unconfirmed_rollup_blocks/2`) reflects a boundary recorded by an
   # earlier discovery pass at a higher parent-chain block than the current log
   # scan window can see. Its minimum block number is accepted as the boundary only
-  # when it is proven safe: either it equals `batch.start_block` (the ordinary
-  # case, behavior unchanged), or the immediately preceding rollup block is
-  # already confirmed in the database. Otherwise the minimum is ambiguous - it may
-  # mean "confirmed" or "batch not fully synced below this point" - so the
-  # confirmation is postponed as before.
+  # when it is proven safe (see `boundary_proven?/3`); otherwise the minimum is
+  # ambiguous - it may mean "confirmed" or "batch not fully synced below this
+  # point" - so the confirmation is postponed as before. Once a boundary is
+  # accepted, it is raised to `high_watermark + 1` if that is higher, so that a
+  # confirmation processed earlier in the same tick can never have its claimed
+  # blocks claimed again by this confirmation.
   #
   # To optimize `eth_getLogs` calls required for the `SendRootUpdated` event lookup,
   # it uses a cache.
@@ -386,6 +573,8 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   #   re-confirmation) rollup blocks of the batch already read from the database,
   #   used to derive a database-backed lower boundary when no boundary event is
   #   found in the scanned logs.
+  # - `high_watermark`: The highest rollup block number already claimed by a
+  #   confirmation earlier on the parent chain within the current tick.
   # - `cache`: A cache to minimize `eth_getLogs` calls.
   #
   # ## Returns
@@ -405,6 +594,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
             optional(any()) => any()
           },
           [Arbitrum.BatchBlock.to_import()],
+          non_neg_integer(),
           EventsUtils.cached_logs()
         ) :: {:ok, {non_neg_integer(), EventsUtils.cached_logs()}} | {:ok, []} | {:error, []}
   defp check_confirmed_blocks_of_batch(
@@ -413,6 +603,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
          confirmation_desc,
          outbox_config,
          raw_unconfirmed_rollup_blocks,
+         high_watermark,
          cache
        ) do
     # This function might look like over-engineered, but confirmations are not always
@@ -434,7 +625,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
       {_, false} ->
         case block? do
           nil ->
-            database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, new_cache)
+            database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, high_watermark, new_cache)
 
           value ->
             log_info("Blocks up to ##{value} of the batch have been already confirmed by another transaction")
@@ -449,19 +640,21 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   # The minimum block number of `raw_unconfirmed_rollup_blocks` (as returned by
   # `DbSettlement.unconfirmed_rollup_blocks/2`, which can append already-confirmed
   # "re-confirmation" blocks at the top of the range, but never lowers the true
-  # minimum) is accepted as the boundary only when it is provably safe:
-  # - it equals `batch.start_block`, the ordinary case where nothing in the batch
-  #   is confirmed yet, or
-  # - the immediately preceding rollup block is confirmed in the database, proving
-  #   the row exists and carries a valid confirmation.
+  # minimum) is accepted as the boundary only when `boundary_proven?/3` holds.
   # Otherwise the minimum is ambiguous between "confirmed" and "batch not fully
   # synced below this point", so the confirmation is postponed, preserving the
   # module's existing defense against partially-synced batches.
+  #
+  # Once accepted, the boundary is raised to `high_watermark + 1` if that is
+  # higher, so that blocks already claimed earlier in the same tick can never be
+  # claimed again by this confirmation.
   #
   # ## Parameters
   # - `batch`: The batch containing the rollup blocks.
   # - `raw_unconfirmed_rollup_blocks`: The list of unconfirmed rollup blocks of the
   #   batch already read from the database.
+  # - `high_watermark`: The highest rollup block number already claimed by a
+  #   confirmation earlier on the parent chain within the current tick.
   # - `cache`: The current logs cache to thread through unchanged.
   #
   # ## Returns
@@ -471,31 +664,57 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks do
   @spec database_derived_boundary(
           Arbitrum.L1Batch.t(),
           [Arbitrum.BatchBlock.to_import()],
+          non_neg_integer(),
           EventsUtils.cached_logs()
         ) :: {:ok, {non_neg_integer(), EventsUtils.cached_logs()}} | {:error, []}
-  defp database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, cache) do
+  defp database_derived_boundary(batch, raw_unconfirmed_rollup_blocks, high_watermark, cache) do
     minimum_unconfirmed_block =
       raw_unconfirmed_rollup_blocks
       |> List.first()
       |> Map.fetch!(:block_number)
 
+    if boundary_proven?(batch, minimum_unconfirmed_block, high_watermark) do
+      {:ok, {max(minimum_unconfirmed_block, high_watermark + 1), cache}}
+    else
+      log_warning(
+        "Could not confirm that block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is confirmed, postponing the confirmation"
+      )
+
+      {:error, []}
+    end
+  end
+
+  # Checks whether `minimum_unconfirmed_block` is provably safe to use as the lower
+  # boundary of the unconfirmed range, considering three independent proofs:
+  # - it equals `batch.start_block`, the ordinary case where nothing in the batch
+  #   is confirmed yet;
+  # - the in-tick watermark already covers everything below it, i.e. blocks below
+  #   it were claimed earlier in this same tick and are simply not yet imported
+  #   into the database; or
+  # - the immediately preceding rollup block is confirmed in the database, proving
+  #   the row exists and carries a valid confirmation.
+  @spec boundary_proven?(Arbitrum.L1Batch.t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp boundary_proven?(batch, minimum_unconfirmed_block, high_watermark) do
     cond do
       minimum_unconfirmed_block == batch.start_block ->
-        {:ok, {minimum_unconfirmed_block, cache}}
+        true
+
+      high_watermark >= minimum_unconfirmed_block - 1 ->
+        log_info(
+          "Block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is claimed by a confirmation processed earlier in this tick, using ##{minimum_unconfirmed_block} as the lower boundary"
+        )
+
+        true
 
       not is_nil(DbSettlement.l1_block_of_confirmation_for_rollup_block(minimum_unconfirmed_block - 1)) ->
         log_info(
           "Block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is confirmed according to the database, using ##{minimum_unconfirmed_block} as the lower boundary"
         )
 
-        {:ok, {minimum_unconfirmed_block, cache}}
+        true
 
       true ->
-        log_warning(
-          "Could not confirm that block ##{minimum_unconfirmed_block - 1} of the batch ##{batch.number} is confirmed, postponing the confirmation"
-        )
-
-        {:error, []}
+        false
     end
   end
 

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/tasks.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/confirmations/tasks.ex
@@ -452,7 +452,15 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.Tasks do
       when not is_nil(end_block) do
     {lowest_l1_block, _} = get_lowest_l1_block_for_confirmations(state)
 
-    end_block < lowest_l1_block
+    if end_block < lowest_l1_block do
+      log_info(
+        "Historical confirmations discovery completed: reached the lowest L1 block for confirmations (#{lowest_l1_block})"
+      )
+
+      true
+    else
+      false
+    end
   end
 
   def historical_confirmations_discovery_completed?(_), do: false

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks_test.exs
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+if Application.compile_env(:explorer, :chain_type) == :arbitrum do
+  defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocksTest do
+    use EthereumJSONRPC.Case, async: false
+    use Explorer.DataCase
+
+    import Mox
+
+    alias Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks
+
+    setup :verify_on_exit!
+
+    setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+      mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
+
+      %{json_rpc_named_arguments: mocked_json_rpc_named_arguments}
+    end
+
+    describe "extend_confirmations/3" do
+      test "returns all unconfirmed blocks down to batch.start_block when the batch has no earlier boundary anywhere",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 100)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 15, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        top_block = insert(:block, number: batch.end_block)
+
+        confirmation_l1_transaction_hash = to_string(transaction_hash())
+
+        expect_no_boundary_logs()
+
+        result =
+          RollupBlocks.extend_confirmations(
+            confirmation_desc(top_block, confirmation_l1_transaction_hash),
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        assert Enum.map(result, & &1.block_number) |> Enum.sort() ==
+                 Enum.to_list(batch.start_block..batch.end_block)
+
+        assert Enum.all?(result, &(&1.confirmation_transaction == confirmation_l1_transaction_hash))
+      end
+
+      test "derives the lower boundary from the database when the boundary is recorded only there and rows below it are confirmed",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        confirmed_boundary_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 50)
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 100)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 20, commitment_id: commitment_transaction.id)
+
+        # Rows below the boundary (K = 15) are already confirmed in the database, proving the
+        # boundary safe to use even though no SendRootUpdated event for it appears in the
+        # scanned logs (it was recorded at a higher parent-chain block in an earlier pass).
+        Enum.each(batch.start_block..14, fn block_number ->
+          insert(:arbitrum_batch_block,
+            batch_number: batch.number,
+            block_number: block_number,
+            confirmation_id: confirmed_boundary_transaction.id
+          )
+        end)
+
+        Enum.each(15..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        top_block = insert(:block, number: batch.end_block)
+
+        confirmation_l1_transaction_hash = to_string(transaction_hash())
+
+        expect_no_boundary_logs()
+
+        result =
+          RollupBlocks.extend_confirmations(
+            confirmation_desc(top_block, confirmation_l1_transaction_hash),
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        assert Enum.map(result, & &1.block_number) |> Enum.sort() == Enum.to_list(15..batch.end_block)
+        assert Enum.all?(result, &(&1.confirmation_transaction == confirmation_l1_transaction_hash))
+      end
+
+      test "postpones the confirmation when the rows below the candidate boundary are missing entirely",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 100)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 20, commitment_id: commitment_transaction.id)
+
+        # Rows below the candidate boundary (K = 15) are missing entirely (batch.start_block..14
+        # have no arbitrum_batch_l2_blocks rows at all), unlike the confirmed-predecessor case:
+        # this must NOT be mistaken for "confirmed", so the confirmation stays postponed.
+        Enum.each(15..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        top_block = insert(:block, number: batch.end_block)
+
+        confirmation_l1_transaction_hash = to_string(transaction_hash())
+
+        expect_no_boundary_logs()
+
+        result =
+          RollupBlocks.extend_confirmations(
+            confirmation_desc(top_block, confirmation_l1_transaction_hash),
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        assert result == []
+      end
+    end
+
+    defp confirmation_desc(top_block, confirmation_l1_transaction_hash) do
+      %{
+        to_string(top_block.hash) => %{
+          l1_transaction_hash: confirmation_l1_transaction_hash,
+          l1_block_num: 200
+        }
+      }
+    end
+
+    defp outbox_config(json_rpc_named_arguments) do
+      %{
+        logs_block_range: 1000,
+        outbox_address: "0x0000000000000000000000000000000000000064",
+        json_rpc_named_arguments: json_rpc_named_arguments
+      }
+    end
+
+    # No SendRootUpdated event is found for the requested L1 block range, mimicking a
+    # confirmation recorded at a higher parent-chain block in an earlier discovery pass.
+    defp expect_no_boundary_logs do
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn %{method: "eth_getLogs"}, _options -> {:ok, []} end)
+    end
+  end
+end

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/rollup_blocks_test.exs
@@ -5,8 +5,15 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
     use Explorer.DataCase
 
     import Mox
+    import Ecto.Query, only: [from: 2]
 
+    import EthereumJSONRPC, only: [integer_to_quantity: 1, quantity_to_integer: 1]
+
+    alias Explorer.Chain.Arbitrum.{BatchBlock, LifecycleTransaction}
+
+    alias Indexer.Fetcher.Arbitrum.Workers.Confirmations.Discovery, as: ConfirmationsDiscovery
     alias Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks
+    alias Indexer.Fetcher.Arbitrum.Workers.Confirmations.Tasks, as: ConfirmationsTasks
 
     setup :verify_on_exit!
 
@@ -34,7 +41,7 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
 
         expect_no_boundary_logs()
 
-        result =
+        {result, outcomes} =
           RollupBlocks.extend_confirmations(
             confirmation_desc(top_block, confirmation_l1_transaction_hash),
             outbox_config(json_rpc_named_arguments),
@@ -45,6 +52,7 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
                  Enum.to_list(batch.start_block..batch.end_block)
 
         assert Enum.all?(result, &(&1.confirmation_transaction == confirmation_l1_transaction_hash))
+        assert outcomes == %{confirmation_l1_transaction_hash => :claimed}
       end
 
       test "derives the lower boundary from the database when the boundary is recorded only there and rows below it are confirmed",
@@ -76,7 +84,7 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
 
         expect_no_boundary_logs()
 
-        result =
+        {result, outcomes} =
           RollupBlocks.extend_confirmations(
             confirmation_desc(top_block, confirmation_l1_transaction_hash),
             outbox_config(json_rpc_named_arguments),
@@ -85,6 +93,7 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
 
         assert Enum.map(result, & &1.block_number) |> Enum.sort() == Enum.to_list(15..batch.end_block)
         assert Enum.all?(result, &(&1.confirmation_transaction == confirmation_l1_transaction_hash))
+        assert outcomes == %{confirmation_l1_transaction_hash => :claimed}
       end
 
       test "postpones the confirmation when the rows below the candidate boundary are missing entirely",
@@ -107,7 +116,7 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
 
         expect_no_boundary_logs()
 
-        result =
+        {result, outcomes} =
           RollupBlocks.extend_confirmations(
             confirmation_desc(top_block, confirmation_l1_transaction_hash),
             outbox_config(json_rpc_named_arguments),
@@ -115,6 +124,372 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
           )
 
         assert result == []
+        assert outcomes == %{confirmation_l1_transaction_hash => :error}
+      end
+
+      test "processes two confirmations in agreeing parent-chain/rollup order: each claims exactly its own range",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 1)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 30, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        lower_top_block = insert(:block, number: 20)
+        higher_top_block = insert(:block, number: 30)
+
+        lower_hash = to_string(transaction_hash())
+        higher_hash = to_string(transaction_hash())
+
+        # Two separate log scans: one for the lower (earlier on the parent chain) confirmation's
+        # descent, one for the higher (later on the parent chain) confirmation's descent.
+        expect_no_boundary_logs()
+        expect_no_boundary_logs()
+
+        {result, outcomes} =
+          RollupBlocks.extend_confirmations(
+            %{
+              to_string(lower_top_block.hash) => %{l1_transaction_hash: lower_hash, l1_block_num: 100},
+              to_string(higher_top_block.hash) => %{l1_transaction_hash: higher_hash, l1_block_num: 200}
+            },
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        block_numbers = Enum.map(result, & &1.block_number) |> Enum.sort()
+        assert block_numbers == Enum.to_list(10..30)
+        assert length(block_numbers) == length(Enum.uniq(block_numbers))
+
+        assert Enum.all?(result, fn block ->
+                 (block.block_number <= 20 and block.confirmation_transaction == lower_hash) or
+                   (block.block_number > 20 and block.confirmation_transaction == higher_hash)
+               end)
+
+        assert outcomes == %{lower_hash => :claimed, higher_hash => :claimed}
+      end
+
+      test "processes two confirmations in inverted parent-chain order (issue #14720): the earlier-on-parent-chain confirmation owns the overlap",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 1)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 30, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        # Analogous (scaled down) to the issue's concrete pair: the confirmation earlier on the
+        # parent chain (L1 25373587) tops a higher rollup range (877285) than the confirmation
+        # later on the parent chain (L1 25373590, rollup top 873589).
+        higher_top_block = insert(:block, number: 30)
+        lower_top_block = insert(:block, number: 20)
+
+        earlier_hash = to_string(transaction_hash())
+        later_hash = to_string(transaction_hash())
+
+        # Only one descent is attempted: the earlier confirmation's. The later one is skipped
+        # entirely once its top block is found to be at or below the watermark.
+        expect_no_boundary_logs()
+
+        {result, outcomes} =
+          RollupBlocks.extend_confirmations(
+            %{
+              to_string(higher_top_block.hash) => %{l1_transaction_hash: earlier_hash, l1_block_num: 100},
+              to_string(lower_top_block.hash) => %{l1_transaction_hash: later_hash, l1_block_num: 200}
+            },
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        block_numbers = Enum.map(result, & &1.block_number) |> Enum.sort()
+        assert block_numbers == Enum.to_list(10..30)
+        assert length(block_numbers) == length(Enum.uniq(block_numbers))
+        refute Enum.empty?(result)
+        assert Enum.all?(result, &(&1.confirmation_transaction == earlier_hash))
+
+        assert outcomes == %{earlier_hash => :claimed, later_hash => :covered}
+      end
+
+      test "processes two confirmations sharing the same L1 block (tie): the floor prevents any duplicate attribution",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 1)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 30, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        low_top_block = insert(:block, number: 15)
+        high_top_block = insert(:block, number: 25)
+
+        low_hash = to_string(transaction_hash())
+        high_hash = to_string(transaction_hash())
+
+        # Both events share the same L1 block, so they are mutually invisible to each other's
+        # log scan. Depending on map-iteration order, either one or two descents are attempted
+        # (the second is skipped outright when the higher-top confirmation is processed first),
+        # so the number of `eth_getLogs` calls is not fixed - a stub tolerates either.
+        stub_no_boundary_logs()
+
+        {result, outcomes} =
+          RollupBlocks.extend_confirmations(
+            %{
+              to_string(low_top_block.hash) => %{l1_transaction_hash: low_hash, l1_block_num: 150},
+              to_string(high_top_block.hash) => %{l1_transaction_hash: high_hash, l1_block_num: 150}
+            },
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        block_numbers = Enum.map(result, & &1.block_number) |> Enum.sort()
+        assert block_numbers == Enum.to_list(10..25)
+        assert length(block_numbers) == length(Enum.uniq(block_numbers))
+
+        assert Enum.all?(result, fn block ->
+                 Enum.count(result, &(&1.block_number == block.block_number)) == 1
+               end)
+
+        refute :error in Map.values(outcomes)
+        assert map_size(outcomes) == 2
+
+        assert Enum.sort(Map.values(outcomes)) == [:claimed, :claimed] or
+                 Enum.sort(Map.values(outcomes)) == [:claimed, :covered]
+      end
+
+      test "halts on a descent error and, after the database prerequisite is restored, correctly attributes the overlap on retry",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 1)
+
+        # A placeholder confirmation for the batch's boundary rows only, so that the top-block
+        # hashes can resolve to rollup block numbers (`rollup_block_hash_to_num/1` inner-joins on
+        # `arbitrum_batch_l2_blocks`). The rest of the batch's rows do not exist at all yet (the
+        # block fetcher has not caught up), which is the reachable `{:error, []}` path in
+        # `get_unconfirmed_rollup_blocks/2`: no unconfirmed blocks are found in range while the
+        # confirmed count is below the batch size.
+        placeholder_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 5)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 30, commitment_id: commitment_transaction.id)
+
+        higher_top_block = insert(:block, number: 30)
+        lower_top_block = insert(:block, number: 20)
+
+        insert(:arbitrum_batch_block,
+          batch_number: batch.number,
+          block_number: 30,
+          confirmation_id: placeholder_transaction.id
+        )
+
+        insert(:arbitrum_batch_block,
+          batch_number: batch.number,
+          block_number: 20,
+          confirmation_id: placeholder_transaction.id
+        )
+
+        earlier_hash = to_string(transaction_hash())
+        later_hash = to_string(transaction_hash())
+
+        confirmations = %{
+          to_string(higher_top_block.hash) => %{l1_transaction_hash: earlier_hash, l1_block_num: 100},
+          to_string(lower_top_block.hash) => %{l1_transaction_hash: later_hash, l1_block_num: 200}
+        }
+
+        # First call: the earlier confirmation's descent fails immediately (no unconfirmed
+        # blocks found in the database at all), before any `eth_getLogs` call is made. The halt
+        # means the later confirmation is never reached.
+        {result, outcomes} =
+          RollupBlocks.extend_confirmations(
+            confirmations,
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        assert result == []
+        assert outcomes == %{earlier_hash => :error}
+
+        # Restore the database prerequisite: the block fetcher has now associated the batch's
+        # rollup blocks (including re-opening the two boundary rows used above only to make the
+        # hashes resolvable).
+        Explorer.Repo.update_all(
+          from(b in BatchBlock, where: b.block_number in [20, 30]),
+          set: [confirmation_id: nil]
+        )
+
+        Enum.each(10..19, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        Enum.each(21..29, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        expect_no_boundary_logs()
+
+        {retry_result, retry_outcomes} =
+          RollupBlocks.extend_confirmations(
+            confirmations,
+            outbox_config(json_rpc_named_arguments),
+            batch.start_block
+          )
+
+        block_numbers = Enum.map(retry_result, & &1.block_number) |> Enum.sort()
+        assert block_numbers == Enum.to_list(10..30)
+        assert length(block_numbers) == length(Enum.uniq(block_numbers))
+        assert Enum.all?(retry_result, &(&1.confirmation_transaction == earlier_hash))
+
+        assert retry_outcomes == %{earlier_hash => :claimed, later_hash => :covered}
+      end
+    end
+
+    describe "convergence through Discovery.perform/5 and Tasks.check_unprocessed/2" do
+      test "an inverted pair converges (:ok) in one historical window, importing the covered confirmation as a lifecycle transaction with no block attribution",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 100)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 10, end_block: 20, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        top_block_a = insert(:block, number: 20)
+        top_block_b = insert(:block, number: 15)
+
+        transaction_hash_a = to_string(transaction_hash())
+        transaction_hash_b = to_string(transaction_hash())
+
+        outbox_address = "0x0000000000000000000000000000000000000064"
+        l1_rpc_config = l1_rpc_config(json_rpc_named_arguments)
+
+        state = %{
+          config: %{
+            l1_outbox_address: outbox_address,
+            l1_rollup_init_block: 1,
+            l1_rpc: l1_rpc_config,
+            l1_start_block: 1,
+            rollup_first_block: batch.start_block
+          },
+          task_data: %{
+            historical_confirmations: %{start_block: 250, end_block: 320}
+          }
+        }
+
+        expect_send_root_updated_logs([
+          send_root_updated_log(to_string(top_block_a.hash), transaction_hash_a, 300),
+          send_root_updated_log(to_string(top_block_b.hash), transaction_hash_b, 310)
+        ])
+
+        # The earlier (on parent chain) confirmation's descent scan.
+        expect_no_boundary_logs()
+
+        expect_block_timestamps([300, 310])
+
+        {retcode, new_state} = ConfirmationsTasks.check_unprocessed(state, false)
+
+        assert retcode == :ok
+        assert new_state.task_data.historical_confirmations == %{start_block: nil, end_block: nil}
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          assert %BatchBlock{confirmation_id: confirmation_id} = Repo.get(BatchBlock, block_number)
+          refute is_nil(confirmation_id)
+
+          lifecycle_transaction = Repo.get(LifecycleTransaction, confirmation_id)
+          assert lifecycle_transaction.hash == hash_from_string(transaction_hash_a)
+        end)
+
+        covered_lifecycle_transaction =
+          Repo.get_by!(LifecycleTransaction, hash: hash_from_string(transaction_hash_b))
+
+        refute Repo.get_by(BatchBlock, confirmation_id: covered_lifecycle_transaction.id)
+
+        # A second run over the same window (now that both confirmations are already imported)
+        # converges instead of re-processing: no new blocks are claimed, and the result is `:ok`.
+        expect_send_root_updated_logs([
+          send_root_updated_log(to_string(top_block_a.hash), transaction_hash_a, 300),
+          send_root_updated_log(to_string(top_block_b.hash), transaction_hash_b, 310)
+        ])
+
+        expect_block_timestamps([300, 310])
+
+        assert ConfirmationsDiscovery.perform(outbox_address, 250, 320, l1_rpc_config, batch.start_block) == :ok
+      end
+
+      test "an unresolved top hash keeps the tick at :confirmation_missed without advancing, while the resolved confirmation's work is still imported",
+           %{json_rpc_named_arguments: json_rpc_named_arguments} do
+        commitment_transaction = insert(:arbitrum_lifecycle_transaction, block_number: 100)
+
+        batch =
+          insert(:arbitrum_l1_batch, start_block: 30, end_block: 40, commitment_id: commitment_transaction.id)
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          insert(:arbitrum_batch_block, batch_number: batch.number, block_number: block_number, confirmation_id: nil)
+        end)
+
+        resolved_top_block = insert(:block, number: 40)
+        # No `Explorer.Chain.Block` is inserted for this hash: it can never resolve to a rollup
+        # block number, mimicking a block the block fetcher has not indexed yet.
+        unresolved_top_hash = to_string(block_hash())
+
+        resolved_transaction_hash = to_string(transaction_hash())
+        unresolved_transaction_hash = to_string(transaction_hash())
+
+        outbox_address = "0x0000000000000000000000000000000000000064"
+        l1_rpc_config = l1_rpc_config(json_rpc_named_arguments)
+
+        state = %{
+          config: %{
+            l1_outbox_address: outbox_address,
+            l1_rollup_init_block: 1,
+            l1_rpc: l1_rpc_config,
+            l1_start_block: 1,
+            rollup_first_block: batch.start_block
+          },
+          task_data: %{
+            historical_confirmations: %{start_block: 480, end_block: 520}
+          }
+        }
+
+        expect_send_root_updated_logs([
+          send_root_updated_log(to_string(resolved_top_block.hash), resolved_transaction_hash, 500),
+          send_root_updated_log(unresolved_top_hash, unresolved_transaction_hash, 510)
+        ])
+
+        expect_no_boundary_logs()
+        expect_block_timestamps([500, 510])
+
+        {retcode, new_state} = ConfirmationsTasks.check_unprocessed(state, false)
+
+        assert retcode == :confirmation_missed
+        assert new_state.task_data.historical_confirmations == %{start_block: 480, end_block: 520}
+
+        Enum.each(batch.start_block..batch.end_block, fn block_number ->
+          assert %BatchBlock{confirmation_id: confirmation_id} = Repo.get(BatchBlock, block_number)
+          refute is_nil(confirmation_id)
+        end)
+
+        assert Repo.get_by(LifecycleTransaction, hash: hash_from_string(resolved_transaction_hash))
+        refute Repo.get_by(LifecycleTransaction, hash: hash_from_string(unresolved_transaction_hash))
+
+        # A second run over the same (unchanged) database state must return :confirmation_missed
+        # again - this is the intended "wait for the block fetcher" behavior, not the issue
+        # #14720 loop, so it is not "fixed" here.
+        expect_send_root_updated_logs([
+          send_root_updated_log(to_string(resolved_top_block.hash), resolved_transaction_hash, 500),
+          send_root_updated_log(unresolved_top_hash, unresolved_transaction_hash, 510)
+        ])
+
+        expect_block_timestamps([500, 510])
+
+        {second_retcode, _second_state} = ConfirmationsTasks.check_unprocessed(new_state, false)
+
+        assert second_retcode == :confirmation_missed
       end
     end
 
@@ -135,11 +510,65 @@ if Application.compile_env(:explorer, :chain_type) == :arbitrum do
       }
     end
 
+    defp l1_rpc_config(json_rpc_named_arguments) do
+      %{
+        json_rpc_named_arguments: json_rpc_named_arguments,
+        logs_block_range: 100_000,
+        chunk_size: 10,
+        track_finalization: false
+      }
+    end
+
+    defp hash_from_string(string_hash) do
+      {:ok, hash} = Explorer.Chain.Hash.Full.cast(string_hash)
+      hash
+    end
+
     # No SendRootUpdated event is found for the requested L1 block range, mimicking a
     # confirmation recorded at a higher parent-chain block in an earlier discovery pass.
     defp expect_no_boundary_logs do
       EthereumJSONRPC.Mox
       |> expect(:json_rpc, fn %{method: "eth_getLogs"}, _options -> {:ok, []} end)
+    end
+
+    # Same as `expect_no_boundary_logs/0`, but tolerates being called zero, one, or more times -
+    # for scenarios where the number of descent-level log scans depends on a nondeterministic
+    # (map iteration order dependent) processing order.
+    defp stub_no_boundary_logs do
+      EthereumJSONRPC.Mox
+      |> stub(:json_rpc, fn %{method: "eth_getLogs"}, _options -> {:ok, []} end)
+    end
+
+    defp expect_send_root_updated_logs(events) do
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn %{method: "eth_getLogs"}, _options -> {:ok, events} end)
+    end
+
+    defp send_root_updated_log(top_rollup_block_hash, l1_transaction_hash, l1_block_num) do
+      %{
+        "topics" => [to_string(block_hash()), to_string(block_hash()), top_rollup_block_hash],
+        "transactionHash" => l1_transaction_hash,
+        "blockNumber" => integer_to_quantity(l1_block_num)
+      }
+    end
+
+    defp expect_block_timestamps(l1_block_numbers) do
+      EthereumJSONRPC.Mox
+      |> expect(:json_rpc, fn request_list, _options when is_list(request_list) ->
+        {:ok,
+         Enum.map(request_list, fn %{id: id, params: [quantity, false]} ->
+           block_number = quantity_to_integer(quantity)
+           true = block_number in l1_block_numbers
+
+           %{
+             id: id,
+             result: %{
+               "number" => quantity,
+               "timestamp" => integer_to_quantity(1_700_000_000)
+             }
+           }
+         end)}
+      end)
     end
   end
 end

--- a/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/tasks_test.exs
+++ b/apps/indexer/test/indexer/fetcher/arbitrum/workers/confirmations/tasks_test.exs
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+if Application.compile_env(:explorer, :chain_type) == :arbitrum do
+  defmodule Indexer.Fetcher.Arbitrum.Workers.Confirmations.TasksTest do
+    use Explorer.DataCase
+
+    import ExUnit.CaptureLog
+
+    alias Indexer.Fetcher.Arbitrum.Workers.Confirmations.Tasks, as: ConfirmationsTasks
+
+    describe "historical_confirmations_discovery_completed?/1" do
+      test "returns true and logs completion when end_block is below the lowest L1 block" do
+        state = state_with(end_block: 9, lowest_l1_block_for_confirmations: 10)
+
+        log =
+          capture_log(fn ->
+            assert ConfirmationsTasks.historical_confirmations_discovery_completed?(state) == true
+          end)
+
+        assert log =~ "Historical confirmations discovery completed"
+        assert log =~ "10"
+      end
+
+      test "returns false and logs nothing when end_block is at the lowest L1 block" do
+        state = state_with(end_block: 10, lowest_l1_block_for_confirmations: 10)
+
+        log =
+          capture_log(fn ->
+            assert ConfirmationsTasks.historical_confirmations_discovery_completed?(state) == false
+          end)
+
+        assert log == ""
+      end
+
+      test "returns false and logs nothing when end_block is above the lowest L1 block" do
+        state = state_with(end_block: 11, lowest_l1_block_for_confirmations: 10)
+
+        log =
+          capture_log(fn ->
+            assert ConfirmationsTasks.historical_confirmations_discovery_completed?(state) == false
+          end)
+
+        assert log == ""
+      end
+
+      test "returns false and logs nothing when end_block is nil" do
+        state = state_with(end_block: nil, lowest_l1_block_for_confirmations: 10)
+
+        log =
+          capture_log(fn ->
+            assert ConfirmationsTasks.historical_confirmations_discovery_completed?(state) == false
+          end)
+
+        assert log == ""
+      end
+    end
+
+    defp state_with(end_block: end_block, lowest_l1_block_for_confirmations: lowest_l1_block_for_confirmations) do
+      %{
+        config: %{
+          l1_rollup_init_block: 1,
+          rollup_first_block: 1
+        },
+        task_data: %{
+          historical_confirmations: %{
+            end_block: end_block,
+            start_block: nil,
+            lowest_l1_block_for_confirmations: lowest_l1_block_for_confirmations
+          }
+        }
+      }
+    end
+  end
+end


### PR DESCRIPTION
Fixes #14720

## Motivation

Historical rollup confirmations discovery stops permanently in one condition. The condition occurs when one L1 scan window holds two `SendRootUpdated` events in inverted order. The later event on the parent chain confirms the older rollup range.

In this condition the fetcher builds two lists of rollup blocks in one tick, and these lists overlap. The import then stops with the Postgres error `cardinality_violation`, because `ON CONFLICT DO UPDATE` touches the same `block_number` two times. The database cancels the transaction, and the tick saves no progress. The fetcher repeats the same L1 window at each recheck interval, and this repeats forever.

On HPP mainnet (chain id 190415) the same window repeated for more than 5 hours. This is 427 ticks. All rollup blocks below that window stay unconfirmed.

## Changelog

### Enhancements

- `Indexer.Fetcher.Arbitrum.Workers.Confirmations.RollupBlocks.extend_confirmations/3` now reports a per-confirmation outcome (`:claimed`, `:covered`, or `:error`). `Confirmations.Discovery` derives the return code of the tick from these outcomes. A confirmation with zero blocks counts as handled, and the tick no longer repeats with the status `:confirmation_missed`.
- A new log line records the completion of the historical confirmations discovery, together with the lowest parent-chain block of the range.
- New regression tests cover the import runner (2 tests), the confirmations worker (9 tests), and the completion of the discovery task (4 tests). The worker tests cover the inverted order of this issue, an agreeing order, and a same-L1-block tie. They also cover a halt after an error and two scenarios through `Discovery.perform/5`.

### Bug Fixes

- `Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks.insert/3` now removes duplicate `block_number` entries after the sort. A duplicate entry degrades the data of one confirmation, and it no longer stops the whole tick with a database error.
- The descent of one confirmation now takes its lower boundary from the database when the L1 log scan finds no earlier confirmation. Before this change the code always used the start block of the batch. The code accepts a database-derived boundary only when the rollup block before it is confirmed, so partially synced batches stay protected.
- `extend_confirmations/3` now processes the confirmations of one tick in ascending parent-chain block order. It carries a watermark of the highest rollup block that a confirmation of the same tick claimed. The watermark skips a confirmation that is already covered, and it is also a floor for each descent. As a result, two confirmations of one tick cannot claim the same rollup block.
- An error in one descent now stops the remaining confirmations of the tick. The confirmations before it keep their blocks. The failed confirmation and each later confirmation move to a following tick. This prevents a later confirmation from taking the blocks of the failed one.

### Incompatible Changes

None.

## Upgrading

No database reset and no re-index are necessary. This change adds no environment variable, no migration, and no API change.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed: — not applicable, this change adds no user-facing option.
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description. — not applicable, no API endpoint changes.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools. — not applicable, no new indices.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly. — not applicable, no chain type changes.
