### PR TITLE
fix: resolve bzz:// image_url to Swarm gateway URL in token instance API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Migrate Sourcify integration from API v1 to v2 ([#14584](https://github.com/blockscout/blockscout/pull/14584))
 - Add universal merged API types, operation shorthands, and API v2 schema correctness improvements ([#14515](https://github.com/blockscout/blockscout/pull/14515))
 - Add an option to disable core proxy methods in the Ethereum JSON-RPC API ([#14495](https://github.com/blockscout/blockscout/pull/14495))
-- Add ETH Swarm (bzz://) support for token metadata ([#14446](https://github.com/blockscout/blockscout/pull/14446))
+- Add ETH Swarm (bzz://) support for token metadata ([#14446](https://github.com/blockscout/blockscout/pull/14446), [#14744](https://github.com/blockscout/blockscout/pull/14744))
 - Add ENS and metadata preloads to advanced filters and NFT owner output ([#14443](https://github.com/blockscout/blockscout/issues/14443), [#14428](https://github.com/blockscout/blockscout/pull/14428))
 - Add an include_zero_value flag for filtering zero-value internal transactions in REST endpoints ([#14400](https://github.com/blockscout/blockscout/issues/14400))
 - Add transaction log input decoding in ABI-like format ([#13783](https://github.com/blockscout/blockscout/issues/13783))

--- a/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
@@ -102,6 +102,11 @@ defmodule BlockScoutWeb.NFTHelper do
         resource_id = image_url |> String.slice(5..-1//1)
         MetadataRetriever.arweave_link(resource_id)
 
+      image_url_downcase =~ ~r/^bzz:\/\// ->
+        # take resource id after "bzz://" prefix
+        resource_id = image_url |> String.slice(6..-1//1)
+        MetadataRetriever.swarm_link(resource_id)
+
       true ->
         image_url
     end

--- a/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/nft_helper.ex
@@ -62,20 +62,30 @@ defmodule BlockScoutWeb.NFTHelper do
   end
 
   @doc """
-  Composes a full IPFS URL from the given image URL.
+  Composes a full gateway URL from the given resource URL.
+
+  Supports IPFS (`ipfs://`), Arweave (`ar://`), and Swarm (`bzz://`) resource
+  URLs, resolving them against the corresponding configured gateway. Any other
+  URL is returned unchanged.
 
   ## Parameters
 
-    - image_url: The URL of the image to be composed into an IPFS URL. It can be nil.
+    - image_url: The URL of the resource to be resolved to a gateway URL. It can be nil.
 
   ## Returns
 
-    - A string representing the full IPFS URL or nil.
+    - A string representing the full gateway URL, the original URL, or nil.
 
   ## Examples
 
       iex> compose_resource_url("ipfs://QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1")
       "https://ipfs.io/ipfs/QmTzQ1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1e1Y1"
+
+      iex> compose_resource_url("ar://Ah3vCrgV-9hEkA2Zl4Yq0iL5wGuMD5-Zr9EAF9zjHDU")
+      "https://arweave.net/Ah3vCrgV-9hEkA2Zl4Yq0iL5wGuMD5-Zr9EAF9zjHDU"
+
+      iex> compose_resource_url("bzz://swarm-devrel.eth/assets/swarm-logo.svg")
+      "https://gateway.ethswarm.org/bzz/swarm-devrel.eth/assets/swarm-logo.svg"
 
   """
   @spec compose_resource_url(String.t() | nil) :: String.t() | nil

--- a/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/views/nft_helper_test.exs
@@ -106,5 +106,26 @@ defmodule BlockScoutWeb.NFTHelperTest do
       assert "https://ipfs.io/ipfs/baFybeid4ed2ua7fwupv4nx2ziczr3edhygl7ws3yx6y2juon7xakgj6cfm/51.json" ==
                NFTHelper.compose_resource_url(url)
     end
+
+    test "transforms bzz link with host and path" do
+      url = "bzz://swarm-devrel.eth/assets/swarm-logo.svg"
+
+      assert "https://gateway.ethswarm.org/bzz/swarm-devrel.eth/assets/swarm-logo.svg" ==
+               NFTHelper.compose_resource_url(url)
+    end
+
+    test "transforms bzz link with bare hash" do
+      hash = "1234abcd" <> String.duplicate("0", 56)
+      url = "bzz://" <> hash
+
+      assert "https://gateway.ethswarm.org/bzz/#{hash}/" == NFTHelper.compose_resource_url(url)
+    end
+
+    test "transforms bzz link in different case" do
+      url = "BzZ://swarm-devrel.eth/assets/swarm-logo.svg"
+
+      assert "https://gateway.ethswarm.org/bzz/swarm-devrel.eth/assets/swarm-logo.svg" ==
+               NFTHelper.compose_resource_url(url)
+    end
   end
 end

--- a/bin/install_chrome_headless.sh
+++ b/bin/install_chrome_headless.sh
@@ -2,7 +2,7 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
 #export CHROMEDRIVER_VERSION=$(curl -s "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json" | jq -r '.channels' | jq -r '.Stable' | jq -r '.version')
-export CHROMEDRIVER_VERSION=150.0.7871.125
+export CHROMEDRIVER_VERSION=152.0.7977.65
 curl -L -O "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip"
 unzip -j chromedriver-linux64.zip
 sudo chmod +x chromedriver

--- a/cspell.json
+++ b/cspell.json
@@ -227,6 +227,7 @@
         "describedby",
         "dets",
         "devcontainer",
+        "devrel",
         "dfda",
         "dialyxir",
         "differenceby",


### PR DESCRIPTION
## Motivation

#14446 added ETH Swarm (`bzz://`) support for token metadata fetching in `Explorer.Token.MetadataRetriever`, but the display URL rewriting in `BlockScoutWeb.NFTHelper.compose_resource_url/1` only handled `ipfs://` and `ar://` schemes. As a result, the API v2 token instance endpoint returned the raw unfetchable `bzz://` URI in `image_url` (and `animation_url`) instead of a resolvable Swarm gateway URL, e.g.:

`https://optimism-sepolia.k8s-dev.blockscout.com/api/v2/tokens/0xDf51577Fb8aE5f3DDCf052F345FB89DC6994A7D8/instances/0` returned `"image_url": "bzz://swarm-devrel.eth/assets/swarm-logo.svg"`.

## Changelog

### Bug Fixes

- Added a `bzz://` branch to `NFTHelper.compose_resource_url/1`, mirroring the existing `ipfs://` and `ar://` handling: the resource id after the `bzz://` prefix is passed to `MetadataRetriever.swarm_link/1`, which builds the URL against the configured Swarm gateway (`https://gateway.ethswarm.org` by default). The scheme match is case-insensitive, consistent with IPFS handling. This fixes both `image_url` and `animation_url` in the API v2 token instance response, which now return e.g. `https://gateway.ethswarm.org/bzz/swarm-devrel.eth/assets/swarm-logo.svg`.
- Added regression tests for `compose_resource_url/1` covering the `bzz://host/path` form, a bare 64-char Swarm hash (trailing slash appended), and a mixed-case `BzZ://` scheme.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NFT metadata and resource support for `bzz://` Swarm URLs.
  * Swarm URLs are converted to accessible EthSwarm gateway links, including URLs with hosts, paths, or bare content hashes.
  * Bare content hashes receive the required trailing slash.
  * Scheme matching is case-insensitive, so uppercase and mixed-case `bzz://` URLs are supported.
  * Improved compatibility for retrieving NFT resources hosted through Swarm gateways.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->