### PR TITLE
fix: distinguish eth_call reverts from RPC errors in proxy fetch

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -65,6 +65,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   @zero_address_hash_string "0x0000000000000000000000000000000000000000"
   @zero_bytes32_string "0x0000000000000000000000000000000000000000000000000000000000000000"
+  @vm_execution_error "VM execution error"
 
   @type options :: [{:api?, true | false}]
 
@@ -258,8 +259,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   ## Returns
   - `{:ok, [{any(), ResolverBehaviour.fetched_values()}]}` if all of the values are fetched successfully,
-    map can contain nil values for failed/reverted eth_call requests.
-  - `:error` if the prefetching failed.
+    map can contain nil values for reverted eth_call requests.
+  - `:error` if the prefetching failed or an eth_call failed with a non-revert RPC error.
   """
   @spec prefetch_values([{any(), ResolverBehaviour.fetch_requirements()}], Hash.Address.t()) ::
           {:ok, [{any(), ResolverBehaviour.fetched_values()}]} | :error
@@ -295,8 +296,8 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   ## Returns
   - `{:ok, prefetched_values()}` if all of the values are fetched successfully,
-    map can contain nil values for failed/reverted eth_call requests.
-  - `:error` if the prefetching failed.
+    map can contain nil values for reverted eth_call requests.
+  - `:error` if the prefetching failed or an eth_call failed with a non-revert RPC error.
   """
   @spec fetch_values([ResolverBehaviour.fetch_requirement()], Hash.Address.t()) ::
           {:ok, %{ResolverBehaviour.fetch_requirement() => String.t() | nil}} | :error
@@ -333,15 +334,15 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @doc """
   Fetches value for the given eth_getStorageAt or eth_call request for a given address hash.
 
-  The eth_call request is allowed to fail/revert, nil will be returned in such case.
+  Reverted eth_call requests return nil; other RPC failures return `:error`.
 
   ## Parameters
   - `req`: The eth_getStorageAt or eth_call request to fetch the value for.
   - `address_hash`: The address hash to fetch the value for.
 
   ## Returns
-  - `{:ok, String.t() | nil}` if the value is fetched successfully.
-  - `:error` if the fetch request failed.
+  - `{:ok, String.t() | nil}` if the value is fetched successfully or the eth_call reverted.
+  - `:error` if the fetch request failed with a non-revert RPC error.
   """
   @spec fetch_value(ResolverBehaviour.fetch_requirement(), Hash.Address.t()) :: {:ok, String.t() | nil} | :error
   def fetch_value(req, address_hash) do
@@ -361,9 +362,27 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   defp handle_response({:storage, _}, %{result: result}) when is_binary(result), do: {:ok, result}
   defp handle_response({:call, _}, %{result: result}) when is_binary(result), do: {:ok, result}
-  # TODO: it'll be better to return nil only for the revert-related errors
-  defp handle_response({:call, _}, %{error: _}), do: {:ok, nil}
+  defp handle_response({:call, _}, %{error: error}) do
+    if revert_error?(error), do: {:ok, nil}, else: :error
+  end
+
   defp handle_response(_, _), do: :error
+
+  defp revert_error?(error) do
+    error
+    |> error_message()
+    |> case do
+      message when is_binary(message) ->
+        String.contains?(message, "execution reverted") or String.contains?(message, @vm_execution_error)
+
+      _ ->
+        false
+    end
+  end
+
+  defp error_message(%{message: message}), do: to_string(message)
+  defp error_message(error) when is_binary(error) or is_atom(error), do: to_string(error)
+  defp error_message(error), do: inspect(error)
 
   @doc """
   Returns combined ABI from proxy and implementation smart-contracts

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -65,7 +65,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   @zero_address_hash_string "0x0000000000000000000000000000000000000000"
   @zero_bytes32_string "0x0000000000000000000000000000000000000000000000000000000000000000"
-  @vm_execution_error "VM execution error"
+  @revert_error_message_markers ["execution reverted", "vm execution error"]
 
   @type options :: [{:api?, true | false}]
 
@@ -362,25 +362,25 @@ defmodule Explorer.Chain.SmartContract.Proxy do
 
   defp handle_response({:storage, _}, %{result: result}) when is_binary(result), do: {:ok, result}
   defp handle_response({:call, _}, %{result: result}) when is_binary(result), do: {:ok, result}
+
   defp handle_response({:call, _}, %{error: error}) do
     if revert_error?(error), do: {:ok, nil}, else: :error
   end
 
   defp handle_response(_, _), do: :error
 
-  defp revert_error?(error) do
-    error
-    |> error_message()
-    |> case do
-      message when is_binary(message) ->
-        String.contains?(message, "execution reverted") or String.contains?(message, @vm_execution_error)
+  # error code 3 is the standard EIP-1474 code for reverted execution
+  defp revert_error?(%{code: 3}), do: true
 
-      _ ->
-        false
-    end
+  defp revert_error?(error) do
+    # revert message casing differs between node clients (e.g. Geth "execution
+    # reverted" vs Besu "Execution reverted"), so match case-insensitively
+    message = error |> error_message() |> String.downcase()
+
+    Enum.any?(@revert_error_message_markers, &String.contains?(message, &1))
   end
 
-  defp error_message(%{message: message}), do: to_string(message)
+  defp error_message(%{message: message}) when is_binary(message), do: message
   defp error_message(error) when is_binary(error) or is_atom(error), do: to_string(error)
   defp error_message(error), do: inspect(error)
 

--- a/apps/explorer/lib/test_helper.ex
+++ b/apps/explorer/lib/test_helper.ex
@@ -248,7 +248,7 @@ defmodule Explorer.TestHelper do
          mocks |> Keyword.get(:eip1967, @zero_address_hash) |> encode_in_batch_response(id1),
          mocks |> Keyword.get(:eip1822, @zero_address_hash) |> encode_in_batch_response(id2),
          mocks |> Keyword.get(:eip1967_beacon, @zero_address_hash) |> encode_in_batch_response(id3),
-         %{id: id4, error: "error"},
+         %{id: id4, error: %{code: 3, message: "execution reverted"}},
          mocks |> Keyword.get(:eip1967_oz, @zero_address_hash) |> encode_in_batch_response(id5)
        ] ++
          Enum.map(rest, fn

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -305,6 +305,46 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
     assert implementation_abi == @implementation_abi
   end
 
+  describe "fetch_value/2 and fetch_values/2" do
+    setup do
+      address = insert(:address)
+      %{address: address}
+    end
+
+    test "returns nil when eth_call reverts", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, "execution reverted"}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == {:ok, nil}
+    end
+
+    test "returns error when eth_call fails with a non-revert error", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, :timeout}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == :error
+    end
+
+    test "returns error when batched eth_call fails with a non-revert error", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:ok, [%{id: 0, error: "timeout"}]}
+      end)
+
+      assert Proxy.fetch_values([{:call, "0x5c60da1b"}], address.hash) == :error
+    end
+
+    test "returns nil for reverted batched eth_call", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:ok, [%{id: 0, error: %{code: 3, message: "execution reverted"}}]}
+      end)
+
+      assert Proxy.fetch_values([{:call, "0x5c60da1b"}], address.hash) ==
+               {:ok, %{{:call, "0x5c60da1b"} => nil}}
+    end
+  end
+
   test "extract_address_hash/1" do
     assert Proxy.extract_address_hash(nil) == nil
     assert Proxy.extract_address_hash("0x") == nil

--- a/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract/proxy_test.exs
@@ -343,6 +343,30 @@ defmodule Explorer.Chain.SmartContract.ProxyTest do
       assert Proxy.fetch_values([{:call, "0x5c60da1b"}], address.hash) ==
                {:ok, %{{:call, "0x5c60da1b"} => nil}}
     end
+
+    test "returns nil when eth_call reverts with a capitalized message (Besu)", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, %{code: -32000, message: "Execution reverted"}}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == {:ok, nil}
+    end
+
+    test "returns nil when eth_call reverts with the standard revert error code", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, %{code: 3, message: "Reverted", data: "0x08c379a0"}}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == {:ok, nil}
+    end
+
+    test "returns error when eth_call fails with a non-binary error message", %{address: address} do
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn _, _ ->
+        {:error, %{message: {:closed, :timeout}}}
+      end)
+
+      assert Proxy.fetch_value({:call, "0x5c60da1b"}, address.hash) == :error
+    end
   end
 
   test "extract_address_hash/1" do


### PR DESCRIPTION
## Motivation

`Proxy.fetch_value/2` and `Proxy.fetch_values/2` treated every `eth_call` error as `{:ok, nil}` (resolving the long-standing `TODO` in `handle_response/2`). As a result, a transient RPC failure (e.g. timeout) during proxy detection produced all-`nil` values, which flowed into `save_implementation_data/2` and overwrote known proxy implementations with an empty list via the `on_conflict` upsert. Now only reverted `eth_call` requests return `nil`, while other RPC failures propagate as `:error`, leaving previously fetched implementation data untouched.

Since the prefetch batch for every verified contract includes calls that are expected to revert on non-proxies (`facetAddresses()`, `implementation()`, `getImplementation()`, `comptroller()`), revert classification must work across all supported node clients. Detection is therefore based on the standard EIP-1474 revert error code `3` and case-insensitive message matching, covering Geth/Erigon/Reth (`execution reverted`), Nethermind (`VM execution error`), and Besu (`Execution reverted`).

## Changelog

### Enhancements

- Recognize reverts by the standard EIP-1474 JSON-RPC error code `3` in addition to message matching.
- Match revert messages case-insensitively to support node clients with different casing (e.g. Besu's `Execution reverted`).
- Guard against non-binary error messages in `error_message/1` so malformed transport errors return `:error` instead of raising `Protocol.UndefinedError` inside the implementation-fetching task.
- Added regression tests for `fetch_value/2` and `fetch_values/2` covering reverted and failed `eth_call` requests (single and batched), Besu-style capitalized revert messages, code-`3` reverts, and non-binary error messages.

### Bug Fixes

- Return `{:ok, nil}` from `Proxy.fetch_value/2` / `Proxy.fetch_values/2` only for reverted `eth_call` requests; other RPC failures now return `:error`, preventing transient RPC errors from overwriting known proxy implementations with empty data.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of smart contract calls that revert, returning an empty result instead of treating them as unexpected failures.
  * Non-revert RPC errors are now reported distinctly, including for batched calls and varied error message formats.

* **Tests**
  * Added coverage for reverted calls, standard and capitalized revert messages, non-revert errors, and non-text error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->