### PR TITLE
perf: Remove unconditional contract_address preload for tokens

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -52,12 +52,6 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
   @api_true [api?: true]
 
-  @token_options [
-    api?: true,
-    necessity_by_association:
-      Map.merge(%{reputation_association() => :optional}, @chain_type_token_necessity_by_association)
-  ]
-
   case @chain_type do
     :filecoin ->
       @chain_type_token_necessity_by_association %{contract_address: :optional}
@@ -68,6 +62,12 @@ defmodule BlockScoutWeb.API.V2.TokenController do
     _ ->
       @chain_type_token_necessity_by_association %{}
   end
+
+  @token_options [
+    api?: true,
+    necessity_by_association:
+      Map.merge(%{reputation_association() => :optional}, @chain_type_token_necessity_by_association)
+  ]
 
   operation :token,
     summary: "Retrieve detailed information about a specific token",

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/token_controller.ex
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: LicenseRef-Blockscout
 defmodule BlockScoutWeb.API.V2.TokenController do
   use BlockScoutWeb, :controller
-  use Utils.CompileTimeEnvHelper, bridged_tokens_enabled: [:explorer, [Explorer.Chain.BridgedToken, :enabled]]
+
+  use Utils.CompileTimeEnvHelper,
+    bridged_tokens_enabled: [:explorer, [Explorer.Chain.BridgedToken, :enabled]],
+    chain_type: [:explorer, :chain_type]
+
   use OpenApiSpex.ControllerSpecs
 
   alias BlockScoutWeb.{AccessHelper, AuthenticationHelper}
@@ -48,7 +52,22 @@ defmodule BlockScoutWeb.API.V2.TokenController do
 
   @api_true [api?: true]
 
-  @token_options [api?: true, necessity_by_association: %{reputation_association() => :optional}]
+  @token_options [
+    api?: true,
+    necessity_by_association:
+      Map.merge(%{reputation_association() => :optional}, @chain_type_token_necessity_by_association)
+  ]
+
+  case @chain_type do
+    :filecoin ->
+      @chain_type_token_necessity_by_association %{contract_address: :optional}
+
+    :zilliqa ->
+      @chain_type_token_necessity_by_association %{contract_address: :optional}
+
+    _ ->
+      @chain_type_token_necessity_by_association %{}
+  end
 
   operation :token,
     summary: "Retrieve detailed information about a specific token",

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -27,16 +27,6 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   @request_error_msg "Error while sending request to Transaction Interpretation Service"
   @api_true api?: true
   @items_limit 50
-  @token_options [
-    api?: true,
-    necessity_by_association:
-      Map.merge(
-        %{
-          reputation_association() => :optional
-        },
-        @chain_type_token_necessity_by_association
-      )
-  ]
 
   case @chain_type do
     :filecoin ->
@@ -48,6 +38,17 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
     _ ->
       @chain_type_token_necessity_by_association %{}
   end
+
+  @token_options [
+    api?: true,
+    necessity_by_association:
+      Map.merge(
+        %{
+          reputation_association() => :optional
+        },
+        @chain_type_token_necessity_by_association
+      )
+  ]
 
   @internal_transaction_address_preloads [
     address_preloads: [

--- a/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
+++ b/apps/block_scout_web/lib/block_scout_web/microservice_interfaces/transaction_interpretation.ex
@@ -29,10 +29,26 @@ defmodule BlockScoutWeb.MicroserviceInterfaces.TransactionInterpretation do
   @items_limit 50
   @token_options [
     api?: true,
-    necessity_by_association: %{
-      reputation_association() => :optional
-    }
+    necessity_by_association:
+      Map.merge(
+        %{
+          reputation_association() => :optional
+        },
+        @chain_type_token_necessity_by_association
+      )
   ]
+
+  case @chain_type do
+    :filecoin ->
+      @chain_type_token_necessity_by_association %{contract_address: :optional}
+
+    :zilliqa ->
+      @chain_type_token_necessity_by_association %{contract_address: :optional}
+
+    _ ->
+      @chain_type_token_necessity_by_association %{}
+  end
+
   @internal_transaction_address_preloads [
     address_preloads: [
       created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2475,7 +2475,6 @@ defmodule Explorer.Chain do
 
     query
     |> join_associations(necessity_by_association)
-    |> preload(:contract_address)
     |> select_repo(options).one()
     |> case do
       nil ->


### PR DESCRIPTION
## Motivation
- contract_address is not used in API v2 except zilliqa and filecoin chain_types 
## Changelog
- Preload contract_address, only where needed
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token data retrieval for Filecoin and Zilliqa networks.
  - Token information can now be resolved when contract address details are available but not required.
  - Updated token interpretation and display flows to load relevant address information based on the network.
  - Preserved existing token lookup behavior for other supported networks.
  - Improved consistency when displaying token details across supported networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->