### PR TITLE
perf: Remove redundant preloads in api/v2/addresses/*

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_coin_balance_controller.ex
@@ -18,11 +18,11 @@ defmodule BlockScoutWeb.AddressCoinBalanceController do
 
   def index(conn, %{"address_id" => address_hash_string, "type" => "JSON"} = params) do
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
-         {:ok, address} <- Chain.hash_to_address(address_hash, []),
+         {:ok, _address} <- Chain.hash_to_address(address_hash, []),
          {:ok, false} <- AccessHelper.restricted_access?(address_hash_string, params) do
       full_options = paging_options(params)
 
-      coin_balances_plus_one = CoinBalance.address_to_coin_balances(address, full_options)
+      coin_balances_plus_one = CoinBalance.address_hash_to_coin_balances(address_hash, full_options)
 
       {coin_balances, next_page} = split_list_by_page(coin_balances_plus_one)
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -250,8 +250,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec counters(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def counters(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      # TODO: check if @address_options is needed here
-      case Chain.hash_to_address(address_hash, @address_options) do
+      case Chain.hash_to_address(address_hash, @api_true) do
         {:ok, address} ->
           {validation_count} = Counters.address_counters(address, @api_true)
 
@@ -314,8 +313,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           token_balances =
             address_hash
             |> Chain.fetch_last_token_balances(
@@ -395,8 +394,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           options =
             [necessity_by_association: address_transactions_necessity_by_association()]
             |> Keyword.merge(@api_true)
@@ -519,8 +518,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, token_address_hash} <- validate_optional_address_hash(params[:token], params),
          token_address_exists <- (token_address_hash && Token.check_token_exists(token_address_hash)) || :ok do
-      case {Chain.hash_to_address(address_hash, @address_options), token_address_exists} do
-        {{:ok, _address}, :ok} ->
+      case {Chain.check_address_exists(address_hash, @api_true), token_address_exists} do
+        {{:ok, _address_hash}, :ok} ->
           paging_options = paging_options(params)
 
           options =
@@ -607,8 +606,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec internal_transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def internal_transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           full_options =
             [
               address_preloads: [
@@ -682,8 +681,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def logs(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, topic} <- validate_optional_topic(params[:topic]) do
-      case Chain.hash_to_address(address_hash, @api_true) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           options =
             params
             |> paging_options()
@@ -755,8 +754,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec blocks_validated(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def blocks_validated(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           full_options =
             [
               necessity_by_association: %{
@@ -884,8 +883,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def coin_balance_history_by_day(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           balances_by_day =
             address_hash
             |> Chain.address_to_balances_by_day(@api_true)
@@ -945,8 +944,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           results_plus_one =
             address_hash
             |> Chain.fetch_paginated_last_token_balances(
@@ -1017,8 +1016,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec withdrawals(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def withdrawals(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           options = @api_true |> Keyword.merge(paging_options(params))
           withdrawals_plus_one = address_hash |> Chain.address_hash_to_withdrawals(options)
           {withdrawals, next_page} = split_list_by_page(withdrawals_plus_one)
@@ -1150,8 +1149,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         beacon_deposits: :beacon_deposits_count
       }
 
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           counters_json =
             address_hash
             |> Counters.address_limited_counters(@api_true)
@@ -1227,8 +1226,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_list(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_list(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           results_plus_one =
             Instance.nft_list(
               address_hash,
@@ -1303,8 +1302,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_collections(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_collections(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, _address} ->
+      case Chain.check_address_exists(address_hash, @api_true) do
+        {:ok, _address_hash} ->
           results_plus_one =
             Instance.nft_collections(
               address_hash,
@@ -1369,7 +1368,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec celo_election_rewards(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def celo_election_rewards(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
-         {:ok, _address} <- Chain.hash_to_address(address_hash, api?: true) do
+         {:ok, _address_hash} <- Chain.check_address_exists(address_hash, api?: true) do
       full_options =
         @celo_election_rewards_options
         |> Keyword.put(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -250,7 +250,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec counters(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def counters(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @api_true) do
+      case Chain.hash_to_address(address_hash, Keyword.merge(@api_true, necessity_by_association: %{})) do
         {:ok, address} ->
           {validation_count} = Counters.address_counters(address, @api_true)
 
@@ -313,8 +313,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           token_balances =
             address_hash
             |> Chain.fetch_last_token_balances(
@@ -394,8 +394,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           options =
             [necessity_by_association: address_transactions_necessity_by_association()]
             |> Keyword.merge(@api_true)
@@ -518,8 +518,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, token_address_hash} <- validate_optional_address_hash(params[:token], params),
          token_address_exists <- (token_address_hash && Token.check_token_exists(token_address_hash)) || :ok do
-      case {Chain.check_address_exists(address_hash, @api_true), token_address_exists} do
-        {{:ok, _address_hash}, :ok} ->
+      case {Address.check_address_exists(address_hash, @api_true), token_address_exists} do
+        {:ok, :ok} ->
           paging_options = paging_options(params)
 
           options =
@@ -606,8 +606,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec internal_transactions(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def internal_transactions(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           full_options =
             [
               address_preloads: [
@@ -681,8 +681,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   def logs(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
          {:ok, topic} <- validate_optional_topic(params[:topic]) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           options =
             params
             |> paging_options()
@@ -754,8 +754,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec blocks_validated(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def blocks_validated(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           full_options =
             [
               necessity_by_association: %{
@@ -821,11 +821,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec coin_balance_history(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def coin_balance_history(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.hash_to_address(address_hash, @address_options) do
-        {:ok, address} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           full_options = params |> paging_options() |> Keyword.merge(@api_true)
 
-          results_plus_one = CoinBalance.address_to_coin_balances(address, full_options)
+          results_plus_one = CoinBalance.address_hash_to_coin_balances(address_hash, full_options)
 
           {coin_balances, next_page} = split_list_by_page(results_plus_one)
 
@@ -883,8 +883,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def coin_balance_history_by_day(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           balances_by_day =
             address_hash
             |> Chain.address_to_balances_by_day(@api_true)
@@ -944,8 +944,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     ip = AccessHelper.conn_to_ip_string(conn)
 
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           results_plus_one =
             address_hash
             |> Chain.fetch_paginated_last_token_balances(
@@ -1016,8 +1016,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec withdrawals(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def withdrawals(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           options = @api_true |> Keyword.merge(paging_options(params))
           withdrawals_plus_one = address_hash |> Chain.address_hash_to_withdrawals(options)
           {withdrawals, next_page} = split_list_by_page(withdrawals_plus_one)
@@ -1149,8 +1149,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
         beacon_deposits: :beacon_deposits_count
       }
 
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           counters_json =
             address_hash
             |> Counters.address_limited_counters(@api_true)
@@ -1226,8 +1226,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_list(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_list(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           results_plus_one =
             Instance.nft_list(
               address_hash,
@@ -1302,8 +1302,8 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec nft_collections(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def nft_collections(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params) do
-      case Chain.check_address_exists(address_hash, @api_true) do
-        {:ok, _address_hash} ->
+      case Address.check_address_exists(address_hash, @api_true) do
+        :ok ->
           results_plus_one =
             Instance.nft_collections(
               address_hash,
@@ -1368,7 +1368,7 @@ defmodule BlockScoutWeb.API.V2.AddressController do
   @spec celo_election_rewards(Plug.Conn.t(), map()) :: {:format, :error} | {:restricted_access, true} | Plug.Conn.t()
   def celo_election_rewards(conn, %{address_hash_param: address_hash_string} = params) do
     with {:ok, address_hash} <- validate_address_hash(address_hash_string, params),
-         {:ok, _address_hash} <- Chain.check_address_exists(address_hash, api?: true) do
+         :ok <- Address.check_address_exists(address_hash, api?: true) do
       full_options =
         @celo_election_rewards_options
         |> Keyword.put(

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/fallback_controller.ex
@@ -128,6 +128,15 @@ defmodule BlockScoutWeb.API.V2.FallbackController do
     |> call({:not_found, nil})
   end
 
+  def call(conn, :not_found) do
+    Logger.debug(fn ->
+      [":not_found"]
+    end)
+
+    conn
+    |> call({:not_found, nil})
+  end
+
   def call(conn, {:error, %Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -894,6 +894,27 @@ defmodule Explorer.Chain do
     end
   end
 
+  @doc """
+  Checks if an address with the given `hash` exists in the database.
+
+  ## Parameters
+    - `hash` - the address hash to check.
+    - `options` - keyword list with optional `api?: true` for replica selection.
+
+  ## Returns
+    - `{:ok, address_hash}` if the address exists.
+    - `{:error, :not_found}` if the address does not exist.
+  """
+  @spec check_address_exists(Hash.Address.t(), keyword()) :: {:ok, Hash.Address.t()} | {:error, :not_found}
+  def check_address_exists(hash, options \\ []) do
+    query = from(address in Address, where: address.hash == ^hash, select: address.hash)
+
+    case select_repo(options).one(query) do
+      nil -> {:error, :not_found}
+      address_hash -> {:ok, address_hash}
+    end
+  end
+
   defp default_hash_to_address_necessity_by_association do
     %{
       :names => :optional,

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -907,11 +907,11 @@ defmodule Explorer.Chain do
   """
   @spec check_address_exists(Hash.Address.t(), keyword()) :: {:ok, Hash.Address.t()} | {:error, :not_found}
   def check_address_exists(hash, options \\ []) do
-    query = from(address in Address, where: address.hash == ^hash, select: address.hash)
+    query = from(address in Address, where: address.hash == ^hash)
 
-    case select_repo(options).one(query) do
-      nil -> {:error, :not_found}
-      address_hash -> {:ok, address_hash}
+    case select_repo(options).exists?(query) do
+      false -> {:error, :not_found}
+      true -> {:ok, hash}
     end
   end
 

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -894,27 +894,6 @@ defmodule Explorer.Chain do
     end
   end
 
-  @doc """
-  Checks if an address with the given `hash` exists in the database.
-
-  ## Parameters
-    - `hash` - the address hash to check.
-    - `options` - keyword list with optional `api?: true` for replica selection.
-
-  ## Returns
-    - `{:ok, address_hash}` if the address exists.
-    - `{:error, :not_found}` if the address does not exist.
-  """
-  @spec check_address_exists(Hash.Address.t(), keyword()) :: {:ok, Hash.Address.t()} | {:error, :not_found}
-  def check_address_exists(hash, options \\ []) do
-    query = from(address in Address, where: address.hash == ^hash)
-
-    case select_repo(options).exists?(query) do
-      false -> {:error, :not_found}
-      true -> {:ok, hash}
-    end
-  end
-
   defp default_hash_to_address_necessity_by_association do
     %{
       :names => :optional,

--- a/apps/explorer/lib/explorer/chain/address/coin_balance.ex
+++ b/apps/explorer/lib/explorer/chain/address/coin_balance.ex
@@ -167,28 +167,23 @@ defmodule Explorer.Chain.Address.CoinBalance do
   end
 
   @doc """
-  Retrieves paginated coin balance records for a given address with timestamp interpolation.
+  Retrieves paginated coin balance records for a given address hash with timestamp interpolation.
 
-  This function fetches coin balance history for an address, applying pagination
-  and performing timestamp calculations for blocks. It includes an optimization
-  that returns an empty list immediately when the paging key is `{0}`, avoiding
-  unnecessary database queries. For other cases, it processes balances by
-  filtering records with values, calculating block timestamp ranges, and
-  interpolating timestamps for intermediate blocks when multiple blocks are
-  present.
+  Fetches coin balance history for an address, applying pagination and performing
+  timestamp calculations for blocks. Returns an empty list immediately when the
+  paging key is `{0}`, avoiding unnecessary database queries.
 
   ## Parameters
-  - `address`: Address.t() - The address record to fetch coin balances for
-  - `options`: [Chain.paging_options() | Chain.api?()] - Query options including
-    paging configuration and API mode selection
+  - `address_hash`: `Hash.Address.t()` - The address hash to fetch coin balances for.
+  - `options`: keyword list with paging and API mode options.
 
   ## Returns
   - `[t()]` - List of coin balance records sorted by block number in descending
     order, with interpolated timestamps, or empty list if paging key is `{0}` or
-    no balances exist
+    no balances exist.
   """
-  @spec address_to_coin_balances(Address.t(), [Chain.paging_options() | Chain.api?()]) :: [t()]
-  def address_to_coin_balances(address, options) do
+  @spec address_hash_to_coin_balances(Hash.Address.t(), [Chain.paging_options() | Chain.api?()]) :: [t()]
+  def address_hash_to_coin_balances(address_hash, options) do
     paging_options = Keyword.get(options, :paging_options, PagingOptions.default_paging_options())
 
     case paging_options do
@@ -196,13 +191,13 @@ defmodule Explorer.Chain.Address.CoinBalance do
         []
 
       _ ->
-        address_to_coin_balances_internal(address, options, paging_options)
+        address_hash_to_coin_balances_internal(address_hash, options, paging_options)
     end
   end
 
-  defp address_to_coin_balances_internal(address, options, paging_options) do
+  defp address_hash_to_coin_balances_internal(address_hash, options, paging_options) do
     balances_raw =
-      address.hash
+      address_hash
       |> fetch_coin_balances(paging_options)
       |> page_coin_balances(paging_options)
       |> Chain.select_repo(options).all()


### PR DESCRIPTION
## Motivation
useless preloads
## Changelog

Remove redundant preloads in api/v2/addresses/*
## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address validation across address-related API endpoints.
  * Standardized not-found responses for missing addresses.
  * Improved coin balance history handling using validated address information.
  * Preserved successful empty responses when requested addresses do not exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->