### PR TITLE
perf: Reduce addresses preload queries count

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/address_controller.ex
@@ -73,13 +73,38 @@ defmodule BlockScoutWeb.API.V2.AddressController do
 
   @token_transfer_necessity_by_association [
     necessity_by_association: %{
-      [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-      [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
       :block => :optional,
       :transaction => :optional,
       [token: reputation_association()] => :optional
     },
     api?: true
+  ]
+
+  # Address-info associations shared by every participant role of a list item.
+  # Loaded once for the whole page by `Chain.preload_address_participants/4`
+  # rather than per role through `necessity_by_association`.
+  @transaction_participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    proxy_implementations_association() => :optional
+  }
+
+  @token_transfer_participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :smart_contract => :optional,
+    proxy_implementations_association() => :optional
+  }
+
+  @transaction_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address},
+    {:created_contract_address_hash, :created_contract_address}
+  ]
+
+  @token_transfer_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address}
   ]
 
   case @chain_identity do
@@ -419,7 +444,14 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           |> put_status(200)
           |> put_view(TransactionView)
           |> render(:transactions, %{
-            transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+            transactions:
+              transactions
+              |> Chain.preload_address_participants(
+                @transaction_address_fields,
+                @transaction_participant_necessity_by_association,
+                @api_true
+              )
+              |> maybe_preload_ens_and_metadata(:transactions),
             next_page_params: next_page_params
           })
 
@@ -435,31 +467,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
     end
   end
 
+  # Address participants are loaded separately by
+  # `Chain.preload_address_participants/4`, which shares one query pass between
+  # `from`/`to`/`created_contract` instead of repeating it per role.
   defp address_transactions_necessity_by_association do
-    %{
-      [
-        created_contract_address: [
-          :scam_badge,
-          :names,
-          proxy_implementations_association()
-        ]
-      ] => :optional,
-      [
-        from_address: [
-          :scam_badge,
-          :names,
-          proxy_implementations_association()
-        ]
-      ] => :optional,
-      [
-        to_address: [
-          :scam_badge,
-          :names,
-          proxy_implementations_association()
-        ]
-      ] => :optional,
-      :block => :optional
-    }
+    %{:block => :optional}
     |> Map.merge(@chain_type_transaction_necessity_by_association)
   end
 
@@ -548,6 +560,11 @@ defmodule BlockScoutWeb.API.V2.AddressController do
           |> render(:token_transfers, %{
             token_transfers:
               token_transfers
+              |> Chain.preload_address_participants(
+                @token_transfer_address_fields,
+                @token_transfer_participant_necessity_by_association,
+                @api_true
+              )
               |> Instance.preload_nft(@api_true)
               |> maybe_preload_ens_and_metadata(:token_transfers),
             next_page_params: next_page_params

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1174,12 +1174,7 @@ defmodule Explorer.Chain do
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
-    addresses =
-      Address
-      |> where([address], address.hash in ^participant_hashes)
-      |> join_associations(address_necessity_by_association)
-      |> select_repo(options).all()
-      |> Map.new(&{&1.hash, &1})
+    addresses = addresses_by_hash(participant_hashes, address_necessity_by_association, options)
 
     to_address =
       addresses
@@ -1200,6 +1195,68 @@ defmodule Explorer.Chain do
             }
           end)
     }
+  end
+
+  @doc """
+    Loads address-info associations for every address referenced by a list of items in a single query pass.
+
+    Addresses shared between items, and between roles of the same item, are
+    deduplicated. Preloading the same associations per role instead — as
+    `necessity_by_association` does — repeats both the `addresses` query and
+    every nested association query once per role. This issues one `addresses`
+    query and one query per entry in `address_necessity_by_association`,
+    regardless of how many roles are populated.
+
+    Must run before `Explorer.Chain.Address.MetadataPreloader`, which writes ENS
+    and metadata into the very address structs assigned here.
+
+    ## Parameters
+    - `items`: The list of structs whose address associations are populated.
+    - `address_fields`: The `{hash_field, association_field}` pairs to populate, for
+      example `[{:from_address_hash, :from_address}, {:to_address_hash, :to_address}]`.
+    - `address_necessity_by_association`: A map of address associations to load,
+      shared by every role.
+    - `options`: An optional keyword list of options, such as selecting a specific repository.
+
+    ## Returns
+    - The list of items with every association named in `address_fields` set to the
+      matching `t:Explorer.Chain.Address.t/0`, or to `nil` when the hash field is
+      `nil` or no address row exists.
+  """
+  @spec preload_address_participants([struct()], [{atom(), atom()}], %{any() => :optional | :required}, [api?]) ::
+          [struct()]
+  def preload_address_participants(items, address_fields, address_necessity_by_association, options)
+
+  def preload_address_participants([], _address_fields, _address_necessity_by_association, _options), do: []
+
+  def preload_address_participants(items, address_fields, address_necessity_by_association, options) do
+    addresses =
+      items
+      |> Enum.flat_map(fn item ->
+        Enum.map(address_fields, fn {hash_field, _association_field} -> Map.fetch!(item, hash_field) end)
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> addresses_by_hash(address_necessity_by_association, options)
+
+    Enum.map(items, fn item ->
+      Enum.reduce(address_fields, item, fn {hash_field, association_field}, item_acc ->
+        Map.replace!(item_acc, association_field, Map.get(addresses, Map.fetch!(item_acc, hash_field)))
+      end)
+    end)
+  end
+
+  @spec addresses_by_hash([Hash.Address.t()], %{any() => :optional | :required}, [api?]) :: %{
+          Hash.Address.t() => Address.t()
+        }
+  defp addresses_by_hash([], _address_necessity_by_association, _options), do: %{}
+
+  defp addresses_by_hash(hashes, address_necessity_by_association, options) do
+    Address
+    |> where([address], address.hash in ^hashes)
+    |> join_associations(address_necessity_by_association)
+    |> select_repo(options).all()
+    |> Map.new(&{&1.hash, &1})
   end
 
   defp preload_full_smart_contract(%Address{contract_code: contract_code} = address, options)


### PR DESCRIPTION
Similar performance upgrade as in https://github.com/blockscout/blockscout/pull/14705 for transactions, but for `/api/v2/addresses/:address_hash_param/transactions` and `/api/v2/addresses/:address_hash_param/token-transfers` endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading of address details across transaction and token-transfer views.
  * Reduced redundant data lookups while preserving names, scam indicators, smart-contract status, and proxy details.
  * Improved handling of results with no address participants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->