### PR TITLE
fix: dedup Arbitrum batch blocks in the import runner

### DIFF
--- a/apps/explorer/lib/explorer/chain/import/runner/arbitrum/batch_blocks.ex
+++ b/apps/explorer/lib/explorer/chain/import/runner/arbitrum/batch_blocks.ex
@@ -65,7 +65,10 @@ defmodule Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks do
     on_conflict = Map.get_lazy(options, :on_conflict, &default_on_conflict/0)
 
     # Enforce Arbitrum.BatchBlock ShareLocks order (see docs: sharelock.md)
-    ordered_changes_list = Enum.sort_by(changes_list, & &1.block_number)
+    ordered_changes_list =
+      changes_list
+      |> Enum.sort_by(& &1.block_number)
+      |> Enum.dedup_by(& &1.block_number)
 
     {:ok, inserted} =
       Import.insert_changes_list(

--- a/apps/explorer/test/explorer/chain/import/runner/arbitrum/batch_blocks_test.exs
+++ b/apps/explorer/test/explorer/chain/import/runner/arbitrum/batch_blocks_test.exs
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+if Application.compile_env(:explorer, :chain_type) == :arbitrum do
+  defmodule Explorer.Chain.Import.Runner.Arbitrum.BatchBlocksTest do
+    use Explorer.DataCase
+
+    alias Ecto.Multi
+    alias Explorer.Chain.Arbitrum.BatchBlock
+    alias Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks
+
+    describe "insert/3" do
+      test "deduplicates a changes list containing two entries with the same block_number, keeping the first" do
+        %{number: batch_number} = insert(:arbitrum_l1_batch)
+        %{id: first_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+        %{id: second_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+
+        block_number = 42
+
+        changes = [
+          %{
+            batch_number: batch_number,
+            block_number: block_number,
+            confirmation_id: first_confirmation_id
+          },
+          %{
+            batch_number: batch_number,
+            block_number: block_number,
+            confirmation_id: second_confirmation_id
+          }
+        ]
+
+        assert {:ok, %{insert_arbitrum_batch_blocks: inserted}} = run_changes(changes)
+
+        assert length(inserted) == 1
+
+        assert [%BatchBlock{block_number: ^block_number, confirmation_id: ^first_confirmation_id}] =
+                 Repo.all(from(bb in BatchBlock, where: bb.block_number == ^block_number))
+      end
+
+      test "imports all rows for a well-formed list without duplicates" do
+        %{number: batch_number} = insert(:arbitrum_l1_batch)
+        %{id: first_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+        %{id: second_confirmation_id} = insert(:arbitrum_lifecycle_transaction)
+
+        changes = [
+          %{
+            batch_number: batch_number,
+            block_number: 1,
+            confirmation_id: first_confirmation_id
+          },
+          %{
+            batch_number: batch_number,
+            block_number: 2,
+            confirmation_id: second_confirmation_id
+          }
+        ]
+
+        assert {:ok, %{insert_arbitrum_batch_blocks: inserted}} = run_changes(changes)
+
+        assert length(inserted) == 2
+
+        assert Repo.aggregate(from(bb in BatchBlock, where: bb.block_number in [1, 2]), :count) == 2
+      end
+    end
+
+    defp run_changes(changes) when is_list(changes) do
+      Multi.new()
+      |> BatchBlocks.run(changes, %{
+        timestamps: %{inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()}
+      })
+      |> Repo.transaction()
+    end
+  end
+end

--- a/apps/explorer/test/support/factory.ex
+++ b/apps/explorer/test/support/factory.ex
@@ -2092,9 +2092,10 @@ defmodule Explorer.Factory do
   end
 
   # Pure association factory — callers must supply `:batch_number` and `:block_number`
-  # as overrides referencing existing records. Both are required foreign keys on
-  # `Explorer.Chain.Arbitrum.BatchBlock`, so `insert(:arbitrum_batch_block)` without
-  # overrides will raise.
+  # as overrides referencing existing records. `batch_number` is a required foreign key
+  # on `Explorer.Chain.Arbitrum.BatchBlock`; `block_number` is a required standalone
+  # primary key with no foreign key to `blocks` (deliberate, so re-orgs of `blocks` don't
+  # cascade here). `insert(:arbitrum_batch_block)` without overrides will raise.
   def arbitrum_batch_block_factory do
     %ArbitrumBatchBlock{}
   end


### PR DESCRIPTION
Partially addresses #14720 

## Motivation

Two entries with the same `block_number` in one changes list stop the whole import with the Postgres `cardinality_violation` error, because `ON CONFLICT DO UPDATE` touches the same row two times. This condition occurs when one tick of the confirmations discovery builds two overlapping lists of rollup blocks.

## Changelog

### Bug Fixes

`Explorer.Chain.Import.Runner.Arbitrum.BatchBlocks.insert/3` now removes duplicate `block_number` entries after the sort. A duplicate entry degrades the data of one confirmation, and it no longer stops the whole tick with a database error. This is the same idiom that the `Blocks` and `Addresses` runners already use.

Also corrects the comment of `arbitrum_batch_block_factory`: `block_number` is a standalone primary key with no foreign key to `blocks`, and only `batch_number` is a required foreign key.

## Design notes

These points came up in review. They are deliberate:

**The code keeps an arbitrary duplicate, and the choice of which one is not specified.** `Enum.sort_by/2` is stable, so the entry that comes first in the incoming list is the one that stays. This is not a decision about which confirmation is more correct. `Confirmations.RollupBlocks.extend_confirmations/3` sorts the confirmations by rollup block number, but it gives no guarantee about the order of the related L1 transactions: a confirmation for a higher rollup block can occur in an earlier L1 block. There is therefore no "correct" entry to keep, and the code does not try to select one.

**The attribution of a rollup block to one L1 confirmation transaction is best-effort.** A confirmation declares that all rollup blocks up to the block it names are confirmed on the settlement layer. The `confirmation_id` of a single block is extra information for interested users: it shows the earliest moment at which the block became confirmed. An incorrect attribution of a duplicate block degrades this information only. It does not make the confirmation status of the block incorrect.

**The dedup does not log a warning.** It is a defensive measure. After the full fix of #14720, duplicates must not occur at all. The import runner is a write layer: it does not know the source of the changes list, and it cannot tell what a duplicate means. The diagnostics for the source belong in the fetcher. Also, no other runner in `apps/explorer/lib/explorer/chain/import/runner/` writes log messages.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

