### PR TITLE
fix: Route batched eth_call requests to ETHEREUM_JSONRPC_ETH_CALL_URL

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/common_helper.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/utility/common_helper.ex
@@ -34,6 +34,21 @@ defmodule EthereumJSONRPC.Utility.CommonHelper do
   end
 
   @doc """
+  Returns `json_rpc_named_arguments` with the given methods routed to the `:eth_call` url type
+  (`ETHEREUM_JSONRPC_ETH_CALL_URL`), overriding the configured `:method_to_url` routing.
+
+  The endpoint of a batched request is derived from the method of its first request, so this is
+  needed for batches that must be sent to the `eth_call` endpoint even when they contain methods
+  that are routed elsewhere by default.
+  """
+  @spec force_eth_call_url(Keyword.t(), [atom()]) :: Keyword.t()
+  def force_eth_call_url(json_rpc_named_arguments, methods) do
+    Enum.reduce(methods, json_rpc_named_arguments, fn method, acc ->
+      put_in_keyword_nested(acc, [:transport_options, :method_to_url, method], :eth_call)
+    end)
+  end
+
+  @doc """
   Get available json rpc url from `json_rpc_transport_options` (or global `json_rpc_named_arguments`) of `url_type` type
   based on `EthereumJSONRPC.Utility.EndpointAvailabilityObserver`.
   """

--- a/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract/proxy.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   import EthereumJSONRPC, only: [id_to_params: 1, json_rpc: 2]
 
   alias EthereumJSONRPC.Contract
+  alias EthereumJSONRPC.Utility.CommonHelper
   alias Explorer.Chain.{Address, Data, Hash, SmartContract}
   alias Explorer.Chain.SmartContract.Proxy
   alias Explorer.Chain.SmartContract.Proxy.Models.Implementation
@@ -301,7 +302,15 @@ defmodule Explorer.Chain.SmartContract.Proxy do
   @spec fetch_values([ResolverBehaviour.fetch_requirement()], Hash.Address.t()) ::
           {:ok, %{ResolverBehaviour.fetch_requirement() => String.t() | nil}} | :error
   def fetch_values(reqs, address_hash) do
-    json_rpc_named_arguments = Application.get_env(:explorer, :json_rpc_named_arguments)
+    # `eth_getStorageAt` requests are batched together with `eth_call` ones here, and the endpoint
+    # of a batch is derived from its first request's method, so both methods are pinned to the
+    # `eth_call` endpoint (`ETHEREUM_JSONRPC_ETH_CALL_URL`) to keep the whole batch off the main
+    # HTTP endpoint.
+    json_rpc_named_arguments =
+      CommonHelper.force_eth_call_url(
+        Application.get_env(:explorer, :json_rpc_named_arguments),
+        [:eth_call, :eth_getStorageAt]
+      )
 
     id_to_params = id_to_params(reqs)
 

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -8,6 +8,7 @@ defmodule Explorer.EthRPC do
   use Utils.CompileTimeEnvHelper, chain_type: [:explorer, :chain_type]
 
   alias Ecto.Type, as: EctoType
+  alias EthereumJSONRPC.Utility.CommonHelper
   alias Explorer.{BloomFilter, Chain, Helper, Repo}
 
   alias Explorer.Chain.{
@@ -729,7 +730,23 @@ defmodule Explorer.EthRPC do
     end)
   end
 
+  # Proxied `eth_call` requests are routed to the `eth_call` endpoint
+  # (`ETHEREUM_JSONRPC_ETH_CALL_URL`), so they are batched separately from the rest
+  # of the proxied methods, which go to the main HTTP endpoint.
   defp json_rpc(map) when is_map(map) do
+    {eth_call_requests, other_requests} =
+      Enum.split_with(map, fn
+        {_index, %{"method" => "eth_call"}} -> true
+        {_index, _request} -> false
+      end)
+
+    other_requests
+    |> Map.new()
+    |> do_json_rpc(json_rpc_named_arguments())
+    |> Map.merge(eth_call_requests |> Map.new() |> do_json_rpc(eth_call_json_rpc_named_arguments()))
+  end
+
+  defp do_json_rpc(map, json_rpc_named_arguments) when is_map(map) do
     to_request =
       Enum.flat_map(Map.values(map), fn
         {:error, _} ->
@@ -740,8 +757,7 @@ defmodule Explorer.EthRPC do
       end)
 
     with [_ | _] = to_request <- to_request,
-         {:ok, responses} <-
-           EthereumJSONRPC.json_rpc(to_request, Application.get_env(:explorer, :json_rpc_named_arguments)) do
+         {:ok, responses} <- EthereumJSONRPC.json_rpc(to_request, json_rpc_named_arguments) do
       {map, []} =
         Enum.map_reduce(map, responses, fn
           {_index, {:error, _}} = elem, responses ->
@@ -771,6 +787,14 @@ defmodule Explorer.EthRPC do
 
   defp request_to_elixir(%{"jsonrpc" => json_rpc, "method" => method, "params" => params, "id" => id}) do
     %{jsonrpc: json_rpc, method: method, params: params, id: id}
+  end
+
+  defp json_rpc_named_arguments do
+    Application.get_env(:explorer, :json_rpc_named_arguments)
+  end
+
+  defp eth_call_json_rpc_named_arguments do
+    CommonHelper.force_eth_call_url(json_rpc_named_arguments(), [:eth_call])
   end
 
   @doc """


### PR DESCRIPTION
## Motivation

`EthereumJSONRPC.HTTP` derives the endpoint of a batched JSON RPC request from the method of its **first** request only ([`http.ex#L82`](https://github.com/blockscout/blockscout/blob/master/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex#L82)). Configuring `eth_call: :eth_call` in `method_to_url` is therefore not enough for mixed-method batches, and two hot paths were leaking `eth_call` load onto the main `ETHEREUM_JSONRPC_HTTP_URL` endpoint:

1. **`POST /api/eth-rpc`** — all proxied methods (`eth_call`, `eth_getCode`, `eth_getStorageAt`, `eth_estimateGas`, `eth_getTransactionCount`, `eth_getBlockByNumber`, `eth_sendRawTransaction`) were sent as one batch. A batch led by, say, `eth_getCode` sent its `eth_call` entries to `ETHEREUM_JSONRPC_HTTP_URL`.
2. **`Explorer.Chain.SmartContract.Proxy.fetch_values/2`** — proxy implementation detection batches `eth_getStorageAt` and `eth_call` requirements together. `eth_getStorageAt` is absent from `method_to_url`, so a storage-led batch went entirely to `ETHEREUM_JSONRPC_HTTP_URL`.

Both are now pinned to `ETHEREUM_JSONRPC_ETH_CALL_URL`, which keeps this traffic off the main endpoint and lets operators scale it independently.

## Changelog

### Enhancements

- Added `EthereumJSONRPC.Utility.CommonHelper.force_eth_call_url/2`, which returns `json_rpc_named_arguments` with the given methods pinned to the `:eth_call` url type, overriding the configured `:method_to_url`. It is built on the existing `put_in_keyword_nested/3`, so it also works where `transport_options` is empty (e.g. the `EthereumJSONRPC.Mox` test config).

### Bug Fixes

- `POST /api/eth-rpc`: proxied `eth_call` requests are now batched separately from the other proxied methods and always sent to `ETHEREUM_JSONRPC_ETH_CALL_URL`, regardless of the order of requests in the incoming batch. Responses are re-merged by their original index, so response ordering and ids are unchanged.
- `Explorer.Chain.SmartContract.Proxy.fetch_values/2`: both `eth_call` and `eth_getStorageAt` are pinned to `ETHEREUM_JSONRPC_ETH_CALL_URL`, so the whole proxy-resolution batch stays off the main HTTP endpoint no matter which requirement leads it.

### Incompatible Changes

None.

## Upgrading

No action required. No new ENV vars are introduced, and `ConfigHelper.parse_urls_list(:eth_call)` already falls back to `ETHEREUM_JSONRPC_HTTP_URL(S)` when `ETHEREUM_JSONRPC_ETH_CALL_URL(S)` is unset, so chains without a dedicated `eth_call` endpoint behave exactly as before.

Operators who already set `ETHEREUM_JSONRPC_ETH_CALL_URL` should note that it will now receive additional traffic that previously hit `ETHEREUM_JSONRPC_HTTP_URL`: the `eth_call` portion of `/api/eth-rpc` batches, plus all `eth_getStorageAt` and `eth_call` requests issued during proxy implementation detection. `EndpointAvailabilityObserver` error counting and `ETHEREUM_JSONRPC_FALLBACK_ETH_CALL_URL(S)` fallback now cover these requests under the `:eth_call` url type.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Proxied `eth_call` requests are now batched and routed through the configured `eth_call` endpoint.
  - Batched smart contract requests involving storage reads are routed consistently through the appropriate endpoint.
  - Other JSON-RPC methods continue using the standard endpoint, with responses combined transparently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->