### PR TITLE
perf: Limit logs before joining transactions in topic-only getLogs

### DIFF
--- a/apps/explorer/lib/explorer/etherscan/logs.ex
+++ b/apps/explorer/lib/explorer/etherscan/logs.ex
@@ -6,7 +6,8 @@ defmodule Explorer.Etherscan.Logs do
 
   """
 
-  import Ecto.Query, only: [dynamic: 2, from: 2, where: 2, where: 3, subquery: 1, order_by: 3, union_all: 2]
+  import Ecto.Query,
+    only: [dynamic: 2, from: 2, join: 5, limit: 2, where: 2, where: 3, subquery: 1, order_by: 3, union_all: 2]
 
   alias Explorer.{Chain, Repo}
   alias Explorer.Chain.{DenormalizationHelper, Log, Transaction}
@@ -87,62 +88,24 @@ defmodule Explorer.Etherscan.Logs do
       |> page_logs(paging_options)
       |> where_topic_match(prepared_filter, union_multiple_values: true)
 
-    if DenormalizationHelper.transactions_denormalization_finished?() do
-      all_transaction_logs_query =
-        from(log in subquery(logs_query),
-          join: transaction in Transaction,
-          on: log.transaction_hash == transaction.hash and log.block_hash == transaction.block_hash,
-          where: transaction.block_consensus == true,
-          select: map(log, ^@log_fields),
-          select_merge: %{
-            gas_price: transaction.gas_price,
-            gas_used: transaction.gas_used,
-            transaction_index: transaction.index,
-            block_hash: transaction.block_hash,
-            block_number: transaction.block_number,
-            block_timestamp: transaction.block_timestamp,
-            block_consensus: transaction.block_consensus
-          },
-          order_by: [asc: log.block_number, asc: log.index],
-          limit: 1000
-        )
-
-      all_transaction_logs_query
-      |> Chain.wrapped_union_subquery()
-      |> order_by([log], asc: log.block_number, asc: log.index)
-      |> Repo.replica().all()
-    else
-      all_transaction_logs_query =
-        from(log in subquery(logs_query),
-          join: transaction in Transaction,
-          on: log.transaction_hash == transaction.hash and log.block_hash == transaction.block_hash,
-          inner_join: block in assoc(transaction, :block),
-          where: block.consensus == true,
-          select: map(log, ^@log_fields),
-          select_merge: %{
-            gas_price: transaction.gas_price,
-            gas_used: transaction.gas_used,
-            transaction_index: transaction.index,
-            block_hash: transaction.block_hash,
-            block_number: transaction.block_number,
-            block_timestamp: block.timestamp,
-            block_consensus: block.consensus
-          },
-          order_by: [asc: log.block_number, asc: log.index],
-          limit: 1000
-        )
-
-      all_transaction_logs_query
-      |> Chain.wrapped_union_subquery()
-      |> order_by([log], asc: log.block_number, asc: log.index)
-      |> Repo.replica().all()
-    end
+    logs_query
+    |> join_transaction_data()
+    |> limit(1000)
+    |> fetch_ordered()
   end
 
-  # Since address_hash was not present, we know that a
-  # topic filter has been applied, so we use a different
-  # query that is optimized for a logs filter over an
-  # address_hash
+  # Since address_hash was not present, we know that a topic filter has been
+  # applied. Ordering, paging and the LIMIT are applied inside a subquery over
+  # `logs` alone, so the planner has to produce at most 1000 logs before
+  # joining `transactions`. Joining first and limiting afterwards lets the
+  # planner scan the whole `transactions` block range up front, which is
+  # prohibitively slow for wide ranges.
+  #
+  # Logs of non-consensus blocks are never deleted, so consensus has to be
+  # checked before the LIMIT: otherwise a page could come back short, or empty
+  # with no cursor to continue from, while later consensus logs still exist.
+  # The check uses the same predicate as `join_transaction_data/1`, so no row
+  # that makes it into the page is dropped by the outer join afterwards.
   def list_logs(filter, paging_options) do
     paging_options = if is_nil(paging_options), do: @default_paging_options, else: paging_options
     prepared_filter = Map.merge(@base_filter, filter)
@@ -152,74 +115,83 @@ defmodule Explorer.Etherscan.Logs do
       |> where_topic_match(prepared_filter)
       |> where([log], log.block_number >= ^prepared_filter.from_block)
       |> where([log], log.block_number <= ^prepared_filter.to_block)
+      |> where_consensus()
+      |> page_logs(paging_options)
+      |> order_by([log], asc: log.block_number, asc: log.index)
+      |> limit(1000)
 
+    logs_query
+    |> join_transaction_data()
+    |> fetch_ordered()
+  end
+
+  # Keeps only logs whose consensus predicate matches the one applied by
+  # `join_transaction_data/1` in the current denormalization state. Each check
+  # is a primary-key lookup per candidate log. `transactions.block_consensus`
+  # can diverge from `blocks.consensus` (see
+  # `Explorer.Migrator.TransactionBlockConsensus`), which is why the predicate
+  # is not simply `blocks.consensus` in both states.
+  defp where_consensus(logs_query) do
     if DenormalizationHelper.transactions_denormalization_finished?() do
-      block_transaction_query =
-        from(transaction in Transaction,
-          where: transaction.block_number >= ^prepared_filter.from_block,
-          where: transaction.block_number <= ^prepared_filter.to_block,
-          where: transaction.block_consensus == true,
-          select: %{
-            transaction_hash: transaction.hash,
-            gas_price: transaction.gas_price,
-            gas_used: transaction.gas_used,
-            transaction_index: transaction.index,
-            block_hash: transaction.block_hash,
-            block_number: transaction.block_number,
-            block_timestamp: transaction.block_timestamp,
-            block_consensus: transaction.block_consensus
-          }
-        )
-
-      query_with_block_transaction_data =
-        from(log in logs_query,
-          join: block_transaction_data in subquery(block_transaction_query),
-          on:
-            block_transaction_data.transaction_hash == log.transaction_hash and
-              block_transaction_data.block_hash == log.block_hash,
-          order_by: log.block_number,
-          limit: 1000,
-          select: block_transaction_data,
-          select_merge: map(log, ^@log_fields)
-        )
-
-      query_with_block_transaction_data
-      |> order_by([log], asc: log.index)
-      |> page_logs(paging_options)
-      |> Repo.replica().all()
+      join(logs_query, :inner, [log], transaction in Transaction,
+        on:
+          log.transaction_hash == transaction.hash and log.block_hash == transaction.block_hash and
+            transaction.block_consensus == true
+      )
     else
-      block_transaction_query =
-        from(transaction in Transaction,
-          join: block in assoc(transaction, :block),
-          where: block.number >= ^prepared_filter.from_block,
-          where: block.number <= ^prepared_filter.to_block,
-          where: block.consensus == true,
-          select: %{
-            transaction_hash: transaction.hash,
-            gas_price: transaction.gas_price,
-            gas_used: transaction.gas_used,
-            transaction_index: transaction.index,
-            block_hash: block.hash,
-            block_number: block.number,
-            block_timestamp: block.timestamp,
-            block_consensus: block.consensus
-          }
-        )
+      join(logs_query, :inner, [log], block in assoc(log, :block), on: block.consensus == true)
+    end
+  end
 
-      query_with_block_transaction_data =
-        from(log in logs_query,
-          join: block_transaction_data in subquery(block_transaction_query),
-          on: block_transaction_data.transaction_hash == log.transaction_hash,
-          order_by: log.block_number,
-          limit: 1000,
-          select: block_transaction_data,
-          select_merge: map(log, ^@log_fields)
-        )
+  # Re-selects the joined query through an outer subquery so that fields
+  # taken from the `logs` subquery are loaded with their schema types (`Hash`
+  # structs instead of raw binaries), then applies the final ordering.
+  defp fetch_ordered(query) do
+    query
+    |> Chain.wrapped_union_subquery()
+    |> order_by([log], asc: log.block_number, asc: log.index)
+    |> Repo.replica().all()
+  end
 
-      query_with_block_transaction_data
-      |> order_by([log], asc: log.index)
-      |> page_logs(paging_options)
-      |> Repo.replica().all()
+  # Wraps `logs_query` in a subquery and joins each log to its consensus
+  # transaction by `(hash, block_hash)`, a primary-key lookup per log. The
+  # selected shape is identical in both denormalization states.
+  defp join_transaction_data(logs_query) do
+    if DenormalizationHelper.transactions_denormalization_finished?() do
+      from(log in subquery(logs_query),
+        join: transaction in Transaction,
+        on: log.transaction_hash == transaction.hash and log.block_hash == transaction.block_hash,
+        where: transaction.block_consensus == true,
+        select: map(log, ^@log_fields),
+        select_merge: %{
+          gas_price: transaction.gas_price,
+          gas_used: transaction.gas_used,
+          transaction_index: transaction.index,
+          block_hash: transaction.block_hash,
+          block_number: transaction.block_number,
+          block_timestamp: transaction.block_timestamp,
+          block_consensus: transaction.block_consensus
+        },
+        order_by: [asc: log.block_number, asc: log.index]
+      )
+    else
+      from(log in subquery(logs_query),
+        join: transaction in Transaction,
+        on: log.transaction_hash == transaction.hash and log.block_hash == transaction.block_hash,
+        inner_join: block in assoc(transaction, :block),
+        where: block.consensus == true,
+        select: map(log, ^@log_fields),
+        select_merge: %{
+          gas_price: transaction.gas_price,
+          gas_used: transaction.gas_used,
+          transaction_index: transaction.index,
+          block_hash: transaction.block_hash,
+          block_number: transaction.block_number,
+          block_timestamp: block.timestamp,
+          block_consensus: block.consensus
+        },
+        order_by: [asc: log.block_number, asc: log.index]
+      )
     end
   end
 

--- a/apps/explorer/test/explorer/etherscan/logs_test.exs
+++ b/apps/explorer/test/explorer/etherscan/logs_test.exs
@@ -2,10 +2,13 @@
 defmodule Explorer.Etherscan.LogsTest do
   use Explorer.DataCase
 
+  import Ecto.Query, only: [from: 2]
   import Explorer.Factory
 
   alias Explorer.Etherscan.Logs
-  alias Explorer.Chain.Transaction
+  alias Explorer.Chain.{Block, Transaction}
+  alias Explorer.Chain.Cache.BackgroundMigrations
+  alias Explorer.Repo
 
   @first_topic_hex_string_1 "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"
   @first_topic_hex_string_2 "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
@@ -859,6 +862,258 @@ defmodule Explorer.Etherscan.LogsTest do
       block_number_order = Enum.map(found_logs, & &1.block_number)
 
       assert block_number_order == Enum.sort(block_number_order)
+    end
+
+    test "paginates topic-only logs" do
+      contract_address = insert(:contract_address)
+      first_topic = topic(@first_topic_hex_string_1)
+
+      transaction_a =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      transaction_b =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      transaction_c =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block()
+
+      inserted_records =
+        for {transaction, count} <- [{transaction_a, 700}, {transaction_b, 700}, {transaction_c, 600}],
+            i <- 1..count do
+          insert(:log,
+            address: contract_address,
+            transaction: transaction,
+            block_number: transaction.block.number,
+            block: transaction.block,
+            index: i,
+            first_topic: first_topic
+          )
+        end
+
+      # A log with a different topic in the same range must not be returned.
+      insert(:log,
+        address: contract_address,
+        transaction: transaction_a,
+        block_number: transaction_a.block.number,
+        block: transaction_a.block,
+        index: 701,
+        first_topic: topic(@first_topic_hex_string_2)
+      )
+
+      filter = %{
+        from_block: transaction_a.block.number,
+        to_block: transaction_c.block.number,
+        first_topic: first_topic
+      }
+
+      first_found_logs = Logs.list_logs(filter)
+
+      assert Enum.count(first_found_logs) == 1_000
+
+      last_record = List.last(first_found_logs)
+
+      next_page_params = %{
+        log_index: last_record.index,
+        block_number: last_record.block_number
+      }
+
+      second_found_logs = Logs.list_logs(filter, next_page_params)
+
+      assert Enum.count(second_found_logs) == 1_000
+
+      all_found_logs = first_found_logs ++ second_found_logs
+
+      assert Enum.all?(all_found_logs, &(&1.first_topic == first_topic))
+
+      found_keys = MapSet.new(all_found_logs, &{&1.block_number, &1.index})
+      inserted_keys = MapSet.new(inserted_records, &{&1.block_number, &1.index})
+
+      assert MapSet.equal?(found_keys, inserted_keys)
+    end
+
+    test "topic-only logs are sorted by block and index" do
+      first_block = insert(:block)
+      second_block = insert(:block)
+      third_block = insert(:block)
+
+      contract_address = insert(:contract_address)
+      first_topic = topic(@first_topic_hex_string_1)
+
+      transaction_block1 =
+        %Transaction{} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(first_block)
+
+      transaction_block2 =
+        %Transaction{} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(second_block)
+
+      transaction_block3 =
+        %Transaction{} =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(third_block)
+
+      for {transaction, block, index} <- [
+            {transaction_block3, third_block, 1},
+            {transaction_block1, first_block, 2},
+            {transaction_block2, second_block, 1},
+            {transaction_block1, first_block, 1}
+          ] do
+        insert(:log,
+          address: contract_address,
+          transaction: transaction,
+          block: block,
+          block_number: block.number,
+          index: index,
+          first_topic: first_topic
+        )
+      end
+
+      filter = %{
+        from_block: first_block.number,
+        to_block: third_block.number,
+        first_topic: first_topic
+      }
+
+      found_logs = Logs.list_logs(filter)
+
+      assert length(found_logs) == 4
+
+      order = Enum.map(found_logs, &{&1.block_number, &1.index})
+
+      assert order == Enum.sort(order)
+    end
+
+    test "topic-only logs skip a full page of non-consensus logs and still return later consensus logs" do
+      contract_address = insert(:contract_address)
+      first_topic = topic(@first_topic_hex_string_1)
+
+      non_consensus_block = insert(:block)
+      consensus_block = insert(:block, number: non_consensus_block.number + 1)
+
+      non_consensus_transaction =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(non_consensus_block)
+
+      consensus_transaction =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(consensus_block)
+
+      for i <- 1..1_000 do
+        insert(:log,
+          address: contract_address,
+          transaction: non_consensus_transaction,
+          block: non_consensus_block,
+          block_number: non_consensus_block.number,
+          index: i,
+          first_topic: first_topic
+        )
+      end
+
+      consensus_log =
+        insert(:log,
+          address: contract_address,
+          transaction: consensus_transaction,
+          block: consensus_block,
+          block_number: consensus_block.number,
+          index: 1,
+          first_topic: first_topic
+        )
+
+      # The factory only attaches transactions to consensus blocks, so the
+      # reorg is simulated after the fact.
+      Repo.update_all(from(b in Block, where: b.hash == ^non_consensus_block.hash), set: [consensus: false])
+
+      Repo.update_all(from(t in Transaction, where: t.hash == ^non_consensus_transaction.hash),
+        set: [block_consensus: false]
+      )
+
+      filter = %{
+        from_block: non_consensus_block.number,
+        to_block: consensus_block.number,
+        first_topic: first_topic
+      }
+
+      [found_log] = Logs.list_logs(filter)
+
+      assert found_log.block_number == consensus_log.block_number
+      assert found_log.index == consensus_log.index
+      assert found_log.block_consensus == true
+    end
+
+    test "topic-only logs skip a full page of logs whose transactions lost consensus while their block did not" do
+      old_denormalization_finished = BackgroundMigrations.get_transactions_denormalization_finished()
+      BackgroundMigrations.set_transactions_denormalization_finished(true)
+
+      on_exit(fn ->
+        BackgroundMigrations.set_transactions_denormalization_finished(old_denormalization_finished)
+      end)
+
+      contract_address = insert(:contract_address)
+      first_topic = topic(@first_topic_hex_string_1)
+
+      stale_block = insert(:block)
+      consensus_block = insert(:block, number: stale_block.number + 1)
+
+      stale_transaction =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(stale_block)
+
+      consensus_transaction =
+        :transaction
+        |> insert(to_address: contract_address)
+        |> with_block(consensus_block)
+
+      for i <- 1..1_000 do
+        insert(:log,
+          address: contract_address,
+          transaction: stale_transaction,
+          block: stale_block,
+          block_number: stale_block.number,
+          index: i,
+          first_topic: first_topic
+        )
+      end
+
+      consensus_log =
+        insert(:log,
+          address: contract_address,
+          transaction: consensus_transaction,
+          block: consensus_block,
+          block_number: consensus_block.number,
+          index: 1,
+          first_topic: first_topic
+        )
+
+      # `transactions.block_consensus` and `blocks.consensus` can diverge; the
+      # block keeps consensus here while the denormalized flag says otherwise.
+      Repo.update_all(from(t in Transaction, where: t.hash == ^stale_transaction.hash),
+        set: [block_consensus: false]
+      )
+
+      filter = %{
+        from_block: stale_block.number,
+        to_block: consensus_block.number,
+        first_topic: first_topic
+      }
+
+      [found_log] = Logs.list_logs(filter)
+
+      assert found_log.block_number == consensus_log.block_number
+      assert found_log.index == consensus_log.index
     end
   end
 end


### PR DESCRIPTION
## Motivation

The Etherscan-compatible `?module=logs&action=getLogs` endpoint without an `address` parameter (topic-only filter) was observed running for 40+ seconds on `robinhood_mainnet`, stuck in `DataFileRead`:

```sql
SELECT ... FROM "logs" AS l0
INNER JOIN (SELECT ... FROM "transactions" AS st0
            WHERE st0."block_number" >= $1 AND st0."block_number" <= $2
              AND st0."block_consensus" = TRUE) AS s1
  ON s1."transaction_hash" = l0."transaction_hash" AND s1."block_hash" = l0."block_hash"
WHERE l0."first_topic" = $3 AND l0."third_topic" = $4
  AND l0."block_number" >= $5 AND l0."block_number" <= $6
ORDER BY l0."block_number", l0."index" LIMIT 1000
```

The topic-only clause of `Explorer.Etherscan.Logs.list_logs/2` joined `logs` to a `transactions` subquery filtered only by block range and applied `ORDER BY ... LIMIT 1000` on the outer query. For a wide block range (`fromBlock`/`toBlock` are optional and uncapped) the planner is free to hash the whole `transactions` slice before emitting a single row, and cannot stop early on the `logs` side.

The address clause already had the right shape: select logs in a subquery, then join `transactions` by `(hash, block_hash)`. This PR gives the topic-only clause the same shape and shares the join code between both clauses.

## Changelog

### Enhancements

- `Explorer.Etherscan.Logs.list_logs/2` (topic-only clause): paging, `ORDER BY block_number, index` and `LIMIT 1000` are now applied inside a subquery over `logs`, so the planner must produce at most 1000 logs before joining `transactions`. The join is a primary-key lookup per log on `(hash, block_hash)`; the block-range subquery over `transactions` is removed entirely.
- Logs of non-consensus blocks are never deleted, so the consensus check happens inside the limited subquery via an inner join on `blocks` (a primary-key lookup per candidate log). Otherwise a page could come back short, or empty with no cursor to continue from, while later consensus logs still exist. The check works in both `transactions` denormalization states.
- Extracted `join_transaction_data/1` and `fetch_ordered/1` private helpers shared by the address and topic-only clauses. The address clause's SQL is unchanged.
- Added tests for topic-only pagination (two pages of 1000 with a non-matching topic in range), topic-only `(block_number, index)` ordering, and a regression test where 1000 non-consensus topic matches are followed by a single consensus log that must still be returned.

Resulting SQL for the topic-only path:

```sql
SELECT ... FROM (
  SELECT ... FROM (
    SELECT l0.* FROM logs AS l0
    INNER JOIN blocks AS b1 ON b1.hash = l0.block_hash AND b1.consensus = TRUE
    WHERE l0.first_topic = $1 AND l0.block_number >= $2 AND l0.block_number <= $3
    ORDER BY l0.block_number, l0.index LIMIT 1000
  ) AS ss0
  INNER JOIN transactions AS st1
    ON ss0.transaction_hash = st1.hash AND ss0.block_hash = st1.block_hash
  WHERE st1.block_consensus = TRUE
  ORDER BY ss0.block_number, ss0.index
) AS s0 ORDER BY s0.block_number, s0.index
```

Note: fields selected straight from the `logs` subquery come back as raw binaries instead of `Hash` structs, so the joined query is re-selected through `Chain.wrapped_union_subquery/1`, the same way the address clause already did.

Follow-ups (not in this PR): composite `(first_topic, third_topic, block_number, index)` / `(first_topic, second_topic, block_number, index)` indexes as heavy-index migrators, and a configurable block-range cap for topic-only requests.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Etherscan-compatible log queries for more consistent results.
  - Fixed topic-filtered log retrieval so consensus logs are found even when earlier results include non-consensus entries.
  - Ensured consensus checks remain consistent across data states while preserving ordering and 1,000-log request limits.

- **Tests**
  - Added regression coverage for topic-filtered requests spanning more than 1,000 logs.
  - Expanded verification for consensus filtering when block and transaction status values differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->