### PR TITLE
perf: Preload only rendered transaction fields in v1 tokentx endpoints

### DIFF
--- a/apps/explorer/lib/explorer/etherscan.ex
+++ b/apps/explorer/lib/explorer/etherscan.ex
@@ -776,13 +776,33 @@ defmodule Explorer.Etherscan do
     |> maybe_preload_entities()
   end
 
+  # Transaction fields needed to render the `tokentx`-family RPC responses (see
+  # `BlockScoutWeb.API.RPC.AddressView.prepare_common_token_transfer/3`) and to decode the method call.
+  # Token transfers are fetched in pages of up to `@default_options.page_size` items, so preloading full
+  # transaction rows for each of them was one of the top consumers of DB time on the API read replica.
+  # `hash` must stay in the list: Ecto uses it to match preloaded transactions to token transfers.
+  @token_transfer_transaction_fields [
+    :hash,
+    :block_timestamp,
+    :nonce,
+    :index,
+    :gas,
+    :gas_price,
+    :gas_used,
+    :cumulative_gas_used,
+    :input,
+    :to_address_hash,
+    :created_contract_address_hash
+  ]
+
   defp maybe_preload_entities(query) do
+    transaction_query =
+      from(transaction in Transaction, select: struct(transaction, ^@token_transfer_transaction_fields))
+
     if DenormalizationHelper.tt_denormalization_finished?() do
-      query
-      |> preload([:transaction, :token])
+      preload(query, [:token, transaction: ^transaction_query])
     else
-      query
-      |> preload([:block, :token, :transaction])
+      preload(query, [:block, :token, transaction: ^transaction_query])
     end
   end
 

--- a/apps/explorer/test/explorer/etherscan_test.exs
+++ b/apps/explorer/test/explorer/etherscan_test.exs
@@ -1277,6 +1277,37 @@ defmodule Explorer.EtherscanTest do
       assert token_transfer.to_address_hash == found_token_transfer.to_address_hash
     end
 
+    test "preloads only the transaction fields used by the RPC view" do
+      transaction =
+        :transaction
+        |> insert()
+        |> with_block()
+
+      token_transfer =
+        insert(:token_transfer,
+          transaction: transaction,
+          block: transaction.block,
+          block_number: transaction.block_number
+        )
+
+      [found_token_transfer] = Etherscan.list_token_transfers(:erc20, token_transfer.from_address_hash, nil, %{})
+
+      assert %Transaction{} = found_transaction = found_token_transfer.transaction
+      assert found_transaction.hash == transaction.hash
+      assert found_transaction.input == transaction.input
+      assert found_transaction.nonce == transaction.nonce
+      assert found_transaction.index == transaction.index
+      assert found_transaction.gas == transaction.gas
+      assert found_transaction.gas_price == transaction.gas_price
+      assert found_transaction.gas_used == transaction.gas_used
+      assert found_transaction.cumulative_gas_used == transaction.cumulative_gas_used
+
+      # signature fields are not rendered by the RPC view, so they must not be fetched
+      assert is_nil(found_transaction.r)
+      assert is_nil(found_transaction.s)
+      assert is_nil(found_transaction.v)
+    end
+
     test "with address with 0 token transfers" do
       address = insert(:address)
 


### PR DESCRIPTION
## Motivation

On a busy API read replica, `pg_stat_statements` showed that the single most expensive statement was the Ecto preload `SELECT ... FROM transactions WHERE hash = ANY($1)`, accounting for about 26% of total replica execution time (1.2M calls, 76 ms mean, ~101 rows per call). A large share of it came from the Etherscan-compatible `?module=account&action=tokentx` family (`tokentx`, `token721tx`, `token1155tx`, `token404tx`, `token7984tx`), which preloads a full `Transaction` struct for every token transfer in a page of up to 10,000 items.

The RPC view only renders a handful of transaction columns (`nonce`, `index`, `gas`, `gas_price`, `gas_used`, `cumulative_gas_used`, `input`, `block_timestamp`) and needs `hash`/`input` for method decoding. Fetching `r`, `s`, `v`, `error`, `revert_reason`, `status`, `value`, fee-cap fields, timestamps and chain-specific columns for every row is wasted work on both the database and the API node.

## Changelog

### Enhancements

- `Explorer.Etherscan.maybe_preload_entities/1` now preloads `transaction` through a query with `select: struct(transaction, ^@token_transfer_transaction_fields)`, restricted to the fields consumed by `BlockScoutWeb.API.RPC.AddressView.prepare_common_token_transfer/3` and by `Transaction.decode_transactions/3`. The statement shape stays a single `hash = ANY($1)` lookup; only the per-row payload shrinks. Applies to all token standards served by `list_token_transfers/4`, with or without an address filter, in both the pre- and post-`token_transfers` denormalization branches.
- Added a regression test in `Explorer.EtherscanTest` asserting that the rendered fields are loaded and that non-rendered fields such as `r`, `s`, `v` are not fetched.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token-transfer API responses by loading the transaction details required for method decoding and response generation.
  - Preserved transaction matching and block information where needed during token-transfer retrieval.
  - Reduced unnecessary transaction data loading, improving efficiency without changing the returned token-transfer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->