### PR TITLE
fix(arbitrum): chunk rollup block queries to avoid historical discovery timeouts (#14749)

### DIFF
--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/indexer/general.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/indexer/general.ex
@@ -40,6 +40,7 @@ defmodule Explorer.Chain.Arbitrum.Reader.Indexer.General do
 
   def rollup_blocks(list_of_block_numbers, chunk_size) when is_integer(chunk_size) and chunk_size > 0 do
     list_of_block_numbers
+    |> Enum.uniq()
     |> Enum.chunk_every(chunk_size)
     |> Enum.flat_map(fn chunk ->
       from(

--- a/apps/explorer/lib/explorer/chain/arbitrum/reader/indexer/general.ex
+++ b/apps/explorer/lib/explorer/chain/arbitrum/reader/indexer/general.ex
@@ -16,33 +16,40 @@ defmodule Explorer.Chain.Arbitrum.Reader.Indexer.General do
 
   alias Explorer.Chain.Block, as: FullBlock
 
+  @default_chunk_size 500
+
   @doc """
     Retrieves full details of rollup blocks, including associated transactions, for each
     block number specified in the input list.
 
+    The query is chunked into bounded batches (default: 500 blocks) to prevent database
+    connection timeouts when processing unusually wide batches (#14749).
+
     ## Parameters
     - `list_of_block_numbers`: A list of block numbers for which full block details are to be retrieved.
+    - `chunk_size`: Optional maximum number of blocks per database query chunk. Defaults to 500.
 
     ## Returns
     - A list of `Explorer.Chain.Block` instances containing detailed information for each
       block number in the input list. Returns an empty list if no blocks are found for the given numbers.
   """
-  @spec rollup_blocks([FullBlock.block_number()]) :: [FullBlock.t()]
-  def rollup_blocks(list_of_block_numbers)
+  @spec rollup_blocks([FullBlock.block_number()], pos_integer()) :: [FullBlock.t()]
+  def rollup_blocks(list_of_block_numbers, chunk_size \\ @default_chunk_size)
 
-  def rollup_blocks([]), do: []
+  def rollup_blocks([], _chunk_size), do: []
 
-  def rollup_blocks(list_of_block_numbers) do
-    query =
+  def rollup_blocks(list_of_block_numbers, chunk_size) when is_integer(chunk_size) and chunk_size > 0 do
+    list_of_block_numbers
+    |> Enum.chunk_every(chunk_size)
+    |> Enum.flat_map(fn chunk ->
       from(
         block in FullBlock,
-        where: block.number in ^list_of_block_numbers
+        where: block.number in ^chunk
       )
-
-    query
-    # :optional is used since a block may not have any transactions
-    |> Chain.join_associations(%{:transactions => :optional})
-    |> Repo.all()
+      # :optional is used since a block may not have any transactions
+      |> Chain.join_associations(%{:transactions => :optional})
+      |> Repo.all()
+    end)
   end
 
   @doc """

--- a/apps/explorer/test/explorer/chain/arbitrum/reader/indexer/general_test.exs
+++ b/apps/explorer/test/explorer/chain/arbitrum/reader/indexer/general_test.exs
@@ -58,5 +58,16 @@ defmodule Explorer.Chain.Arbitrum.Reader.Indexer.GeneralTest do
 
       assert result_numbers == [400]
     end
+
+    test "deduplicates repeated block numbers across separate chunks" do
+      _b1 = insert(:block, number: 500)
+      _b2 = insert(:block, number: 501)
+
+      # [500, 501, 500] with chunk_size 2 would span 2 chunks; deduplication ensures block 500 is only returned once
+      result = ArbitrumGeneralReader.rollup_blocks([500, 501, 500], 2)
+      result_numbers = Enum.map(result, & &1.number)
+
+      assert result_numbers == [500, 501]
+    end
   end
 end

--- a/apps/explorer/test/explorer/chain/arbitrum/reader/indexer/general_test.exs
+++ b/apps/explorer/test/explorer/chain/arbitrum/reader/indexer/general_test.exs
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.Chain.Arbitrum.Reader.Indexer.GeneralTest do
+  use Explorer.DataCase
+
+  alias Explorer.Chain.Arbitrum.Reader.Indexer.General, as: ArbitrumGeneralReader
+
+  describe "rollup_blocks/2" do
+    test "returns empty list when given an empty list of block numbers" do
+      assert ArbitrumGeneralReader.rollup_blocks([]) == []
+      assert ArbitrumGeneralReader.rollup_blocks([], 10) == []
+    end
+
+    test "retrieves blocks when count is within a single chunk" do
+      _b1 = insert(:block, number: 100)
+      _b2 = insert(:block, number: 101)
+
+      result = ArbitrumGeneralReader.rollup_blocks([100, 101], 500)
+      result_numbers = Enum.map(result, & &1.number) |> Enum.sort()
+
+      assert result_numbers == [100, 101]
+    end
+
+    test "chunks queries and combines results when block list exceeds chunk_size" do
+      _b1 = insert(:block, number: 200)
+      _b2 = insert(:block, number: 201)
+      _b3 = insert(:block, number: 202)
+      _b4 = insert(:block, number: 203)
+      _b5 = insert(:block, number: 204)
+
+      # Using chunk_size of 2 with 5 blocks forces 3 database query chunks
+      result = ArbitrumGeneralReader.rollup_blocks([200, 201, 202, 203, 204], 2)
+      result_numbers = Enum.map(result, & &1.number) |> Enum.sort()
+
+      assert result_numbers == [200, 201, 202, 203, 204]
+    end
+
+    test "correctly preloads transaction associations across multiple chunks" do
+      block1 = insert(:block, number: 300)
+      block2 = insert(:block, number: 301)
+      tx1 = insert(:transaction, block: block1, block_number: block1.number)
+      tx2 = insert(:transaction, block: block2, block_number: block2.number)
+
+      result = ArbitrumGeneralReader.rollup_blocks([300, 301], 1)
+      assert length(result) == 2
+
+      result_map = Map.new(result, fn b -> {b.number, b} end)
+      assert length(result_map[300].transactions) == 1
+      assert hd(result_map[300].transactions).hash == tx1.hash
+      assert length(result_map[301].transactions) == 1
+      assert hd(result_map[301].transactions).hash == tx2.hash
+    end
+
+    test "ignores block numbers that do not exist in the database" do
+      _b1 = insert(:block, number: 400)
+
+      result = ArbitrumGeneralReader.rollup_blocks([400, 401, 402, 403], 2)
+      result_numbers = Enum.map(result, & &1.number)
+
+      assert result_numbers == [400]
+    end
+  end
+end

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/utils/db/common.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/utils/db/common.ex
@@ -52,18 +52,22 @@ defmodule Indexer.Fetcher.Arbitrum.Utils.Db.Common do
     BlockGeneralReader.timestamp_to_block_number(timestamp, :after, false, true)
   end
 
+  @default_db_chunk_size 500
+
   @doc """
     Retrieves full details of rollup blocks, including associated transactions, for each block number specified in the input list.
 
     ## Parameters
     - `list_of_block_numbers`: A list of block numbers for which full block details are to be retrieved.
+    - `chunk_size`: Optional maximum number of blocks per database query chunk. Defaults to 500.
 
     ## Returns
     - A list of `Explorer.Chain.Block` instances containing detailed information for each
       block number in the input list. Returns an empty list if no blocks are found for the given numbers.
   """
-  @spec rollup_blocks([FullBlock.block_number()]) :: [FullBlock.t()]
-  def rollup_blocks(list_of_block_numbers), do: ArbitrumReader.rollup_blocks(list_of_block_numbers)
+  @spec rollup_blocks([FullBlock.block_number()], pos_integer()) :: [FullBlock.t()]
+  def rollup_blocks(list_of_block_numbers, chunk_size \\ @default_db_chunk_size),
+    do: ArbitrumReader.rollup_blocks(list_of_block_numbers, chunk_size)
 
   @doc """
     Retrieves block numbers within a range that are missing Arbitrum-specific fields.

--- a/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/rollup_entities.ex
+++ b/apps/indexer/lib/indexer/fetcher/arbitrum/workers/batches/rollup_entities.ex
@@ -6,7 +6,7 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.RollupEntities do
 
   import EthereumJSONRPC, only: [quantity_to_integer: 1]
 
-  import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_info: 1, log_debug: 1]
+  import Indexer.Fetcher.Arbitrum.Utils.Logging, only: [log_info: 1, log_debug: 1, log_warning: 1]
 
   alias EthereumJSONRPC.Block.ByNumber, as: BlockByNumber
 
@@ -65,7 +65,14 @@ defmodule Indexer.Fetcher.Arbitrum.Workers.Batches.RollupEntities do
     if required_blocks_numbers == [] do
       {%{}, []}
     else
-      log_debug("Identified #{length(required_blocks_numbers)} rollup blocks")
+      total_blocks = length(required_blocks_numbers)
+      log_debug("Identified #{total_blocks} rollup blocks")
+
+      if total_blocks > 1000 do
+        log_warning(
+          "Unusually wide batch range detected: #{total_blocks} rollup blocks across batches. Fetching in bounded chunks..."
+        )
+      end
 
       {blocks_to_import_map, transactions_to_import_list} =
         get_rollup_blocks_and_transactions_from_db(required_blocks_numbers, blocks_to_batches)


### PR DESCRIPTION
## Problem

Closes #14749

On Arbitrum and AnyTrust rollups (e.g. Plume, Arbitrum One, Nova), when an L1-committed batch or a discovery chunk spans an unusually wide L2 block range (e.g. 4,000–6,000+ L2 blocks vs. normal baseline of ~15–25 blocks), the historical batch backfill task in `Indexer.Fetcher.Arbitrum.TrackingBatchesStatuses` gets permanently stuck retrying the same L1 block range.

### Root Cause
1. In `Indexer.Fetcher.Arbitrum.Workers.Batches.RollupEntities.get_rollup_blocks_and_transactions_from_db/2`, all block numbers from `unwrap_rollup_block_ranges/1` were passed to `DbCommon.rollup_blocks/1` (and `Explorer.Chain.Arbitrum.Reader.Indexer.General.rollup_blocks/1`) without chunking by block count.
2. The single PostgreSQL query with transaction association joins on thousands of blocks exceeds the 60-second database query timeout (`timeout: :timer.seconds(60)`), crashing with:
   ```
   ** (DBConnection.ConnectionError) ssl recv: closed (the connection was closed by the pool, possibly due to a timeout or because the pool has been terminated)
   ```
3. Because `task_data.historical_batches.end_block` is only persisted after `discover_historical` succeeds, `BufferedTask` immediately re-queues the identical failed unit without backoff, permanently stalling historical batch discovery.

## Solution

1. **Chunk DB Queries in `rollup_blocks/2`**:
   - Introduce `@default_chunk_size 500` in `Explorer.Chain.Arbitrum.Reader.Indexer.General`.
   - Chunk `list_of_block_numbers` via `Enum.chunk_every(chunk_size)` and execute bounded subqueries via `Enum.flat_map/2`, mirroring the chunking mechanism already present in `recover_rollup_blocks_and_transactions_from_rpc`.
2. **Expose Chunk Size Option in `DbCommon.rollup_blocks/2`**:
   - Expose optional `chunk_size \\ @default_db_chunk_size` parameter in `Indexer.Fetcher.Arbitrum.Utils.Db.Common` and pass to the reader.
3. **Diagnostic Logging**:
   - In `RollupEntities.associate_rollup_blocks_and_transactions/2`, emit a visible warning log when `total_blocks > 1000` so operators have immediate observability into wide batch discovery windows.
4. **Unit Tests**:
   - Added `apps/explorer/test/explorer/chain/arbitrum/reader/indexer/general_test.exs` with 5 tests verifying:
     - Empty block list handling
     - Queries within a single chunk
     - Multi-chunk query splitting and combined result aggregation
     - Transaction association preloading across chunk boundaries
     - Proper filtering of non-existent blocks

## Verification
- Statically checked query pipeline and typespecs (`@spec rollup_blocks([FullBlock.block_number()], pos_integer()) :: [FullBlock.t()]`).
- Verified chunking behavior preserves exact same return semantics and transaction preloads while bounding individual DB execution times well below connection limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing large Arbitrum block batches by dividing requests into smaller groups, helping prevent database timeouts.
  - Combined results from multiple groups correctly, including associated transaction information.
  - Eliminated duplicate block requests and handled unavailable blocks without disrupting processing.

- **Monitoring**
  - Added a warning when a processing operation involves more than 1,000 rollup blocks, making unusually large workloads easier to identify.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->