### PR TITLE
feat(api): add tokeninfo, tokenholderlist, and tokenholdercount RPC actions (#14605)

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/rpc/token_controller.ex
@@ -23,6 +23,8 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
     end
   end
 
+  def tokeninfo(conn, params), do: gettoken(conn, params)
+
   def gettokenholders(conn, params) do
     with pagination_options <- Helper.put_pagination_options(%{}, params),
          {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
@@ -49,6 +51,26 @@ defmodule BlockScoutWeb.API.RPC.TokenController do
 
       {:format, :error} ->
         render(conn, :error, error: "Invalid contract address hash")
+    end
+  end
+
+  def tokenholderlist(conn, params), do: gettokenholders(conn, params)
+
+  def tokenholdercount(conn, params) do
+    with {:contractaddress_param, {:ok, contractaddress_param}} <- fetch_contractaddress(params),
+         {:format, {:ok, address_hash}} <- to_address_hash(contractaddress_param),
+         {:token, {:ok, _token}} <- {:token, Chain.token_from_address_hash(address_hash)} do
+      count = Chain.count_token_holders_from_token_hash(address_hash)
+      render(conn, "tokenholdercount.json", %{count: count})
+    else
+      {:contractaddress_param, :error} ->
+        render(conn, :error, error: "Query parameter contract address is required")
+
+      {:format, :error} ->
+        render(conn, :error, error: "Invalid contract address hash")
+
+      {:token, {:error, :not_found}} ->
+        render(conn, :error, error: "Contract address not found")
     end
   end
 

--- a/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
+++ b/apps/block_scout_web/lib/block_scout_web/views/api/rpc/token_view.ex
@@ -15,6 +15,10 @@ defmodule BlockScoutWeb.API.RPC.TokenView do
     RPCView.render("show.json", data: data)
   end
 
+  def render("tokenholdercount.json", %{count: count}) do
+    RPCView.render("show.json", data: to_string(count))
+  end
+
   def render("bridgedtokenlist.json", %{bridged_tokens: bridged_tokens}) do
     data = Enum.map(bridged_tokens, &prepare_bridged_token/1)
     RPCView.render("show.json", data: data)

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/token_controller_test.exs
@@ -86,25 +86,196 @@ defmodule BlockScoutWeb.API.RPC.TokenControllerTest do
     end
   end
 
-  # defp gettoken_schema do
-  #   ExJsonSchema.Schema.resolve(%{
-  #     "type" => "object",
-  #     "properties" => %{
-  #       "message" => %{"type" => "string"},
-  #       "status" => %{"type" => "string"},
-  #       "result" => %{
-  #         "type" => "object",
-  #         "properties" => %{
-  #           "name" => %{"type" => "string"},
-  #           "symbol" => %{"type" => "string"},
-  #           "totalSupply" => %{"type" => "string"},
-  #           "decimals" => %{"type" => "string"},
-  #           "type" => %{"type" => "string"},
-  #           "cataloged" => %{"type" => "string"},
-  #           "contractAddress" => %{"type" => "string"}
-  #         }
-  #       }
-  #     }
-  #   })
-  # end
+  describe "tokeninfo" do
+    test "response includes all required fields", %{conn: conn} do
+      token = insert(:token)
+
+      params = %{
+        "module" => "token",
+        "action" => "tokeninfo",
+        "contractaddress" => to_string(token.contract_address_hash)
+      }
+
+      expected_result = %{
+        "name" => token.name,
+        "symbol" => token.symbol,
+        "totalSupply" => to_string(token.total_supply),
+        "decimals" => to_string(token.decimals),
+        "type" => token.type,
+        "cataloged" => token.cataloged,
+        "contractAddress" => to_string(token.contract_address_hash)
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["result"] == expected_result
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+    end
+  end
+
+  describe "tokenholderlist" do
+    test "with missing contract address", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokenholderlist"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "contract address is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid contract address hash", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokenholderlist",
+        "contractaddress" => "badhash"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid contract address hash"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "returns token holders", %{conn: conn} do
+      token = insert(:token)
+      address = insert(:address)
+
+      insert(
+        :address_current_token_balance,
+        address: address,
+        block_number: 1000,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 5000
+      )
+
+      params = %{
+        "module" => "token",
+        "action" => "tokenholderlist",
+        "contractaddress" => to_string(token.contract_address_hash)
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert response["result"] == [
+               %{
+                 "address" => to_string(address.hash),
+                 "value" => 5000
+               }
+             ]
+    end
+  end
+
+  describe "tokenholdercount" do
+    test "with missing contract address", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokenholdercount"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "contract address is required"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with an invalid contract address hash", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokenholdercount",
+        "contractaddress" => "badhash"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Invalid contract address hash"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "with a contract address that doesn't exist", %{conn: conn} do
+      params = %{
+        "module" => "token",
+        "action" => "tokenholdercount",
+        "contractaddress" => "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["message"] =~ "Contract address not found"
+      assert response["status"] == "0"
+      assert Map.has_key?(response, "result")
+      refute response["result"]
+    end
+
+    test "returns the count of token holders", %{conn: conn} do
+      token = insert(:token)
+      address_a = insert(:address)
+      address_b = insert(:address)
+
+      insert(
+        :address_current_token_balance,
+        address: address_a,
+        block_number: 1000,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 5000
+      )
+
+      insert(
+        :address_current_token_balance,
+        address: address_b,
+        block_number: 1002,
+        token_contract_address_hash: token.contract_address_hash,
+        value: 1000
+      )
+
+      params = %{
+        "module" => "token",
+        "action" => "tokenholdercount",
+        "contractaddress" => to_string(token.contract_address_hash)
+      }
+
+      assert response =
+               conn
+               |> get("/api", params)
+               |> json_response(200)
+
+      assert response["status"] == "1"
+      assert response["message"] == "OK"
+      assert response["result"] == "2"
+    end
+  end
 end

--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -2670,6 +2670,14 @@ defmodule Explorer.Chain do
     |> select_repo(options).all()
   end
 
+  @doc """
+  Counts the distinct token holders for a given token contract address hash.
+  """
+  @spec count_token_holders_from_token_hash(Hash.Address.t()) :: non_neg_integer()
+  def count_token_holders_from_token_hash(contract_address_hash) do
+    CurrentTokenBalance.count_token_holders_from_token_hash(contract_address_hash)
+  end
+
   @spec fetch_token_holders_from_token_hash_for_csv(Hash.Address.t(), [paging_options | api? | timeout_option]) :: [
           TokenBalance.t()
         ]


### PR DESCRIPTION
## Motivation

Resolves #14605.

The custom RPC interface (`module=token`) lacked support for several standard custom actions:
- `tokeninfo` (alias for token metadata details, matching `gettoken`)
- `tokenholderlist` (alias for token holder list, matching `gettokenholders`)
- `tokenholdercount` (action returning the total distinct holder count for a given token contract address)

## Changelog

- Added `tokeninfo/2` alias to `BlockScoutWeb.API.RPC.TokenController` delegating to `gettoken/2`.
- Added `tokenholderlist/2` alias to `BlockScoutWeb.API.RPC.TokenController` delegating to `gettokenholders/2`.
- Added `tokenholdercount/2` to `BlockScoutWeb.API.RPC.TokenController` to validate contract address parameters, verify contract existence, query total distinct token holders, and render the count.
- Exposed `Explorer.Chain.count_token_holders_from_token_hash/1` delegating to `Explorer.Chain.Address.CurrentTokenBalance.count_token_holders_from_token_hash/1`.
- Added `"tokenholdercount.json"` rendering clause in `BlockScoutWeb.API.RPC.TokenView` returning the formatted count string via `RPCView.render("show.json", ...)`.
- Added test cases in `BlockScoutWeb.API.RPC.TokenControllerTest` for `tokeninfo`, `tokenholderlist`, and `tokenholdercount` including error paths (missing param, invalid hash, contract not found) and successful count/list responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPC support for retrieving token details and token holder lists.
  * Added an RPC endpoint to return the total number of holders for a token.
  * Token holder counts are returned in the standard response format.

* **Bug Fixes**
  * Added validation and clear error responses for missing, invalid, or nonexistent token contracts.

* **Tests**
  * Added coverage for successful responses and validation errors across the new token RPC actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->