### PR TITLE
fix(explorer): handle race condition in create_or_update_smart_contract (#14498)

### DIFF
--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -931,7 +931,7 @@ defmodule Explorer.Chain.SmartContract do
           case __MODULE__.create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources) do
             {:error, %Changeset{} = changeset} ->
               if unique_smart_contract_conflict?(changeset) do
-                existing_contract = address_hash_to_smart_contract(address_hash, api?: true)
+                existing_contract = address_hash_to_smart_contract(address_hash)
 
                 if existing_contract && existing_contract.partially_verified &&
                      Map.get(attrs, :partially_verified, false) &&

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -928,12 +928,13 @@ defmodule Explorer.Chain.SmartContract do
     result =
       cond do
         is_nil(smart_contract) ->
-          case create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources) do
-            {:error, %Changeset{errors: errors} = changeset} ->
-              if Keyword.has_key?(errors, :address_hash) do
+          case __MODULE__.create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources) do
+            {:error, %Changeset{} = changeset} ->
+              if unique_smart_contract_conflict?(changeset) do
                 existing_contract = address_hash_to_smart_contract(address_hash, api?: true)
 
-                if existing_contract && existing_contract.partially_verified && attrs.partially_verified &&
+                if existing_contract && existing_contract.partially_verified &&
+                     Map.get(attrs, :partially_verified, false) &&
                      Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] do
                   invalid_changeset =
                     invalid_contract_changeset(
@@ -956,7 +957,7 @@ defmodule Explorer.Chain.SmartContract do
               other
           end
 
-        smart_contract.partially_verified && attrs.partially_verified &&
+        smart_contract.partially_verified && Map.get(attrs, :partially_verified, false) &&
             Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] ->
           changeset =
             invalid_contract_changeset(
@@ -983,6 +984,15 @@ defmodule Explorer.Chain.SmartContract do
 
     result
   end
+
+  defp unique_smart_contract_conflict?(%Changeset{data: %__MODULE__{}, errors: errors}) do
+    case Keyword.get(errors, :address_hash) do
+      {_msg, opts} when is_list(opts) -> opts[:constraint] == :unique
+      _ -> false
+    end
+  end
+
+  defp unique_smart_contract_conflict?(_), do: false
 
   @doc """
     Inserts a new smart contract and associated data into the database.

--- a/apps/explorer/lib/explorer/chain/smart_contract.ex
+++ b/apps/explorer/lib/explorer/chain/smart_contract.ex
@@ -928,7 +928,33 @@ defmodule Explorer.Chain.SmartContract do
     result =
       cond do
         is_nil(smart_contract) ->
-          create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
+          case create_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources) do
+            {:error, %Changeset{errors: errors} = changeset} ->
+              if Keyword.has_key?(errors, :address_hash) do
+                existing_contract = address_hash_to_smart_contract(address_hash, api?: true)
+
+                if existing_contract && existing_contract.partially_verified && attrs.partially_verified &&
+                     Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] do
+                  invalid_changeset =
+                    invalid_contract_changeset(
+                      %SmartContract{address_hash: address_hash},
+                      Helper.add_contract_code_md5(attrs),
+                      "Cannot update partially verified smart contract with another partially verified contract",
+                      nil,
+                      verification_with_files?
+                    )
+
+                  {:error, %{invalid_changeset | action: :insert}}
+                else
+                  update_smart_contract(attrs, attrs.external_libraries, attrs.secondary_sources)
+                end
+              else
+                {:error, changeset}
+              end
+
+            other ->
+              other
+          end
 
         smart_contract.partially_verified && attrs.partially_verified &&
             Application.get_env(:block_scout_web, :contract)[:partial_reverification_disabled] ->

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -198,6 +198,15 @@ defmodule Explorer.Chain.SmartContractTest do
 
       assert Repo.get_by(VerificationStatus, uid: "pending-uid").status == 0
     end
+
+    test "handles concurrent race condition when contract is inserted between check and create", %{
+      valid_attrs: valid_attrs,
+      address: address
+    } do
+      insert(:smart_contract, address_hash: address.hash, contract_code_md5: "123")
+
+      assert {:ok, %SmartContract{}} = SmartContract.create_or_update_smart_contract(address.hash, valid_attrs, false)
+    end
   end
 
   describe "update_smart_contract/1" do

--- a/apps/explorer/test/explorer/chain/smart_contract_test.exs
+++ b/apps/explorer/test/explorer/chain/smart_contract_test.exs
@@ -203,9 +203,91 @@ defmodule Explorer.Chain.SmartContractTest do
       valid_attrs: valid_attrs,
       address: address
     } do
-      insert(:smart_contract, address_hash: address.hash, contract_code_md5: "123")
+      :meck.new(SmartContract, [:passthrough])
+      on_exit(fn -> :meck.unload(SmartContract) end)
 
-      assert {:ok, %SmartContract{}} = SmartContract.create_or_update_smart_contract(address.hash, valid_attrs, false)
+      conflict_changeset =
+        %SmartContract{address_hash: address.hash}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(
+          :address_hash,
+          "has already been taken",
+          constraint: :unique,
+          constraint_name: "smart_contracts_pkey"
+        )
+
+      :meck.expect(SmartContract, :create_smart_contract, fn _attrs, _libs, _sources ->
+        insert(:smart_contract, address_hash: address.hash, contract_code_md5: "123")
+        {:error, conflict_changeset}
+      end)
+
+      # Test when attrs omits :partially_verified to verify Map.get avoids KeyError
+      attrs_without_partially_verified = Map.delete(valid_attrs, :partially_verified)
+
+      assert {:ok, %SmartContract{}} =
+               SmartContract.create_or_update_smart_contract(
+                 address.hash,
+                 attrs_without_partially_verified,
+                 false
+               )
+    end
+
+    test "rejects partial reverification on race condition when partial reverification is disabled", %{
+      valid_attrs: valid_attrs,
+      address: address
+    } do
+      initial = Application.get_env(:block_scout_web, :contract) || []
+
+      Application.put_env(
+        :block_scout_web,
+        :contract,
+        Keyword.merge(initial, partial_reverification_disabled: true)
+      )
+
+      on_exit(fn -> Application.put_env(:block_scout_web, :contract, initial) end)
+
+      :meck.new(SmartContract, [:passthrough])
+      on_exit(fn -> :meck.unload(SmartContract) end)
+
+      conflict_changeset =
+        %SmartContract{address_hash: address.hash}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(
+          :address_hash,
+          "has already been taken",
+          constraint: :unique,
+          constraint_name: "smart_contracts_pkey"
+        )
+
+      :meck.expect(SmartContract, :create_smart_contract, fn _attrs, _libs, _sources ->
+        insert(:smart_contract, address_hash: address.hash, partially_verified: true, contract_code_md5: "123")
+        {:error, conflict_changeset}
+      end)
+
+      attrs = Map.put(valid_attrs, :partially_verified, true)
+
+      assert {:error, %Ecto.Changeset{action: :insert}} =
+               SmartContract.create_or_update_smart_contract(address.hash, attrs, false)
+    end
+
+    test "does not fall back to update when secondary source has address_hash error", %{
+      valid_attrs: valid_attrs,
+      address: address
+    } do
+      :meck.new(SmartContract, [:passthrough])
+      on_exit(fn -> :meck.unload(SmartContract) end)
+
+      secondary_source_changeset =
+        %Explorer.Chain.SmartContractAdditionalSource{address_hash: address.hash}
+        |> Ecto.Changeset.change()
+        |> Ecto.Changeset.add_error(:address_hash, "is invalid")
+
+      :meck.expect(SmartContract, :create_smart_contract, fn _attrs, _libs, _sources ->
+        {:error, secondary_source_changeset}
+      end)
+
+      assert {:error, %Ecto.Changeset{data: %Explorer.Chain.SmartContractAdditionalSource{}}} =
+               SmartContract.create_or_update_smart_contract(address.hash, valid_attrs, false)
     end
   end
 


### PR DESCRIPTION
## Motivation

Resolves #14498.

In `create_or_update_smart_contract/3`, the existence check `address_hash_to_smart_contract` is performed outside of a transaction before `create_smart_contract` runs inside one. When two concurrent verification requests for the same address occur simultaneously, both can observe `nil` from the pre-check and attempt `INSERT`, causing one of them to fail with an unhandled unique constraint error on `address_hash`.

## Changelog

- In `Explorer.Chain.SmartContract.create_or_update_smart_contract/3`, when `create_smart_contract/3` fails with a unique constraint error on `:address_hash`, gracefully handle the TOCTOU race condition by re-evaluating the newly inserted contract and falling back to `update_smart_contract/3` (respecting `partial_reverification_disabled` if applicable).
- Added test in `Explorer.Chain.SmartContractTest` verifying that concurrent contract insertion race conditions are safely resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart contract verification when concurrent creation attempts occur.
  * Existing contracts are now handled correctly when they appear during verification, including when data sources are briefly out of sync.
  * Partial reverification restrictions return the appropriate validation error, including when verification details are omitted.
  * Secondary-source address validation errors remain preserved instead of being treated as existing-contract conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->