### PR TITLE
perf: Deduplicate preloads

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -27,19 +27,31 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
       @chain_type_transaction_necessity_by_association %{}
   end
 
+  # Address-info preloads for the `from`/`to`/`created_contract` participants are
+  # intentionally absent: `preload_transaction_participants/1` loads them for the
+  # whole page in a single deduplicated pass.
   @transactions_options [
     necessity_by_association:
-      %{
-        :block => :required,
-        [created_contract_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] =>
-          :optional,
-        [from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional,
-        [to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()]] => :optional
-      }
+      %{:block => :required}
       |> Map.merge(@chain_type_transaction_necessity_by_association),
     paging_options: %PagingOptions{page_size: 6},
     api?: true
   ]
+
+  @transaction_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address},
+    {:created_contract_address_hash, :created_contract_address}
+  ]
+
+  @transaction_participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :smart_contract => :optional,
+    proxy_implementations_association() => :optional
+  }
+
+  @api_true [api?: true]
 
   action_fallback(BlockScoutWeb.API.V2.FallbackController)
 
@@ -107,8 +119,22 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
     |> put_status(200)
     |> put_view(TransactionView)
     |> render(:transactions, %{
-      transactions: recent_transactions |> maybe_preload_ens_and_metadata(:transactions)
+      transactions: recent_transactions |> preload_transaction_participants()
     })
+  end
+
+  # Loads the address info of every participant on the page in one pass,
+  # deduplicating addresses shared between items and between roles of the same
+  # item. Runs before `maybe_preload_ens_and_metadata/2`, which writes ENS and
+  # metadata into the very address structs assigned here.
+  defp preload_transaction_participants(transactions) do
+    transactions
+    |> Chain.preload_address_participants(
+      @transaction_address_fields,
+      @transaction_participant_necessity_by_association,
+      @api_true
+    )
+    |> maybe_preload_ens_and_metadata(:transactions)
   end
 
   operation :watchlist_transactions,
@@ -139,7 +165,7 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
       |> put_status(200)
       |> put_view(TransactionView)
       |> render(:transactions_watchlist, %{
-        transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+        transactions: transactions |> preload_transaction_participants(),
         watchlist_names: watchlist_names
       })
     end

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/main_page_controller.ex
@@ -47,7 +47,6 @@ defmodule BlockScoutWeb.API.V2.MainPageController do
   @transaction_participant_necessity_by_association %{
     :scam_badge => :optional,
     :names => :optional,
-    :smart_contract => :optional,
     proxy_implementations_association() => :optional
   }
 

--- a/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/api/v2/transaction_controller.ex
@@ -91,8 +91,8 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   # Address-info preloads for the transaction participants (from/to/created and
   # token transfer addresses) are intentionally absent here: the `transaction`
   # action loads them all in a single deduplicated pass via
-  # `Chain.preload_transaction_participants/3` using
-  # `@transaction_participants_necessity_by_association`.
+  # `Chain.preload_transaction_participants/3`, and the list actions via
+  # `Chain.preload_address_participants/4`.
   @transaction_necessity_by_association %{:block => :optional}
                                         |> Map.merge(@chain_type_transaction_necessity_by_association)
 
@@ -103,6 +103,23 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     SmartContract.association_without_abi() => :optional,
     proxy_implementations_association() => :optional
   }
+
+  # The same associations for an item of a transaction *list*, where nothing
+  # renders the contract source, so the smart contract itself is not loaded.
+  # `:token` stays: `TransactionView.transaction_types/3` reports
+  # `token_creation` off `created_contract_address.token`.
+  @transaction_list_participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :token => :optional,
+    proxy_implementations_association() => :optional
+  }
+
+  @transaction_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address},
+    {:created_contract_address_hash, :created_contract_address}
+  ]
 
   @token_transfers_necessity_by_association %{
     [token: reputation_association()] => :optional
@@ -255,7 +272,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
 
     full_options =
       [
-        necessity_by_association: transactions_necessity_by_association()
+        necessity_by_association: @transaction_necessity_by_association
       ]
       |> Keyword.merge(paging_options(params, filter_options))
       |> Keyword.merge(method_filter_options(params))
@@ -271,38 +288,27 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     conn
     |> put_status(200)
     |> render(:transactions, %{
-      transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+      transactions: transactions |> preload_transaction_list_participants(),
       next_page_params: next_page_params
     })
   end
 
-  defp transactions_necessity_by_association do
-    %{
-      :block => :optional,
-      [
-        created_contract_address: [
-          :scam_badge,
-          :names,
-          :token,
-          proxy_implementations_association()
-        ]
-      ] => :optional,
-      [
-        from_address: [
-          :scam_badge,
-          :names,
-          proxy_implementations_association()
-        ]
-      ] => :optional,
-      [
-        to_address: [
-          :scam_badge,
-          :names,
-          proxy_implementations_association()
-        ]
-      ] => :optional
-    }
-    |> Map.merge(@chain_type_transaction_necessity_by_association)
+  # Loads the address info of every `from`/`to`/`created_contract` participant on
+  # the page in one pass, deduplicating addresses shared between items and
+  # between roles of the same item. Preloading it per role through
+  # `necessity_by_association` instead repeats the `address_names`, scam badge
+  # and proxy implementation queries once per role.
+  #
+  # Runs before `maybe_preload_ens_and_metadata/2`, which writes ENS and metadata
+  # into the very address structs assigned here.
+  defp preload_transaction_list_participants(transactions) do
+    transactions
+    |> Chain.preload_address_participants(
+      @transaction_address_fields,
+      @transaction_list_participant_necessity_by_association,
+      @api_true
+    )
+    |> maybe_preload_ens_and_metadata(:transactions)
   end
 
   operation :zksync_batch,
@@ -504,7 +510,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
           end
 
         query
-        |> Chain.join_associations(transactions_necessity_by_association())
+        |> Chain.join_associations(@transaction_necessity_by_association)
         |> preload([{:token_transfers, [:token, :from_address, :to_address]}])
         |> Repo.replica().all()
       end
@@ -515,7 +521,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     conn
     |> put_status(200)
     |> render(:transactions, %{
-      transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+      transactions: transactions |> preload_transaction_list_participants(),
       next_page_params: next_page_params
     })
   end
@@ -538,7 +544,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   defp handle_batch_transactions(conn, %{batch_number_param: batch_number} = params, batch_transactions_fun) do
     full_options =
       [
-        necessity_by_association: transactions_necessity_by_association()
+        necessity_by_association: @transaction_necessity_by_association
       ]
       |> Keyword.merge(paging_options(params))
       |> Keyword.merge(@api_true)
@@ -559,7 +565,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     conn
     |> put_status(200)
     |> render(:transactions, %{
-      transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+      transactions: transactions |> preload_transaction_list_participants(),
       next_page_params: next_page_params
     })
   end
@@ -591,7 +597,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
   def execution_node(conn, %{execution_node_hash_param: execution_node_hash_string} = params) do
     with {:format, {:ok, execution_node_hash}} <- {:format, Chain.string_to_address_hash(execution_node_hash_string)} do
       full_options =
-        [necessity_by_association: transactions_necessity_by_association()]
+        [necessity_by_association: @transaction_necessity_by_association]
         |> Keyword.merge(put_key_value_to_paging_options(paging_options(params), :is_index_in_asc_order, true))
         |> Keyword.merge(@api_true)
 
@@ -606,7 +612,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       conn
       |> put_status(200)
       |> render(:transactions, %{
-        transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+        transactions: transactions |> preload_transaction_list_participants(),
         next_page_params: next_page_params
       })
     end
@@ -955,7 +961,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
     with {:auth, %{watchlist_id: watchlist_id}} <- {:auth, current_user(conn)} do
       full_options =
         [
-          necessity_by_association: transactions_necessity_by_association()
+          necessity_by_association: @transaction_necessity_by_association
         ]
         |> Keyword.merge(paging_options(params, [:validated]))
         |> Keyword.merge(@api_true)
@@ -970,7 +976,7 @@ defmodule BlockScoutWeb.API.V2.TransactionController do
       conn
       |> put_status(200)
       |> render(:transactions_watchlist, %{
-        transactions: transactions |> maybe_preload_ens_and_metadata(:transactions),
+        transactions: transactions |> preload_transaction_list_participants(),
         next_page_params: next_page_params,
         watchlist_names: watchlist_names
       })

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -89,22 +89,27 @@ defmodule BlockScoutWeb.Notifier do
       @chain_type_transaction_associations []
   end
 
-  @transaction_associations [
-                              from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-                              to_address: [
-                                :scam_badge,
-                                :names,
-                                :smart_contract,
-                                proxy_implementations_association()
-                              ],
-                              created_contract_address: [
-                                :scam_badge,
-                                :names,
-                                :smart_contract,
-                                proxy_implementations_association()
-                              ]
-                            ] ++
-                              @chain_type_transaction_associations
+  # Address-info associations shared by every participant role of a broadcast
+  # item. Loaded once per broadcast batch by
+  # `Chain.preload_address_participants/4` rather than per role, which repeats
+  # each of these queries once per role.
+  @participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :smart_contract => :optional,
+    proxy_implementations_association() => :optional
+  }
+
+  @transaction_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address},
+    {:created_contract_address_hash, :created_contract_address}
+  ]
+
+  @token_transfer_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address}
+  ]
 
   def handle_event({:chain_event, :addresses, type, addresses}) when type in [:realtime, :on_demand] do
     addresses_count = AddressesCount.fetch()
@@ -304,21 +309,10 @@ defmodule BlockScoutWeb.Notifier do
         |> Repo.preload(
           DenormalizationHelper.extend_transaction_preload([
             [token: Reputation.reputation_association()],
-            :transaction,
-            from_address: [
-              :scam_badge,
-              :names,
-              :smart_contract,
-              proxy_implementations_association()
-            ],
-            to_address: [
-              :scam_badge,
-              :names,
-              :smart_contract,
-              proxy_implementations_association()
-            ]
+            :transaction
           ])
         )
+        |> preload_participants(@token_transfer_address_fields)
         |> Instance.preload_nft(@api_true)
 
       broadcast_token_transfers_websocket_v2(all_token_transfers_full)
@@ -796,7 +790,10 @@ defmodule BlockScoutWeb.Notifier do
       relevant_transactions ->
         prepared_transactions =
           TransactionView.render("transactions.json", %{
-            transactions: Repo.preload(relevant_transactions, transaction_broadcast_associations()),
+            transactions:
+              relevant_transactions
+              |> Repo.preload(transaction_broadcast_associations())
+              |> preload_participants(@transaction_address_fields),
             conn: nil
           })
 
@@ -818,7 +815,8 @@ defmodule BlockScoutWeb.Notifier do
 
     if relevant_transactions != [] do
       relevant_transactions
-      |> Repo.preload([:block | @transaction_associations])
+      |> Repo.preload([:block | @chain_type_transaction_associations])
+      |> preload_participants(@transaction_address_fields)
       |> Enum.map(fn transaction ->
         Map.put(transaction, :token_transfers, [])
       end)
@@ -828,8 +826,19 @@ defmodule BlockScoutWeb.Notifier do
 
   defp transaction_broadcast_associations do
     if API_V2.enabled?(),
-      do: [:block, {:token_transfers, [token: Reputation.reputation_association()]} | @transaction_associations],
-      else: [:block | @transaction_associations]
+      do: [
+        :block,
+        {:token_transfers, [token: Reputation.reputation_association()]} | @chain_type_transaction_associations
+      ],
+      else: [:block | @chain_type_transaction_associations]
+  end
+
+  # Loads the address info of every participant of the broadcast batch in one
+  # pass, deduplicating addresses shared between items and between roles of the
+  # same item. Broadcasts run off the primary repo, as the preloads they replace
+  # did.
+  defp preload_participants(items, address_fields) do
+    Chain.preload_address_participants(items, address_fields, @participant_necessity_by_association, [])
   end
 
   defp broadcast_transaction(%Transaction{block_number: nil} = pending) do

--- a/apps/block_scout_web/lib/block_scout_web/notifier.ex
+++ b/apps/block_scout_web/lib/block_scout_web/notifier.ex
@@ -96,7 +96,6 @@ defmodule BlockScoutWeb.Notifier do
   @participant_necessity_by_association %{
     :scam_badge => :optional,
     :names => :optional,
-    :smart_contract => :optional,
     proxy_implementations_association() => :optional
   }
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/v2/transaction_controller_test.exs
@@ -44,6 +44,23 @@ defmodule BlockScoutWeb.API.V2.TransactionControllerTest do
       assert response["next_page_params"] == nil
     end
 
+    # `token_creation` is reported off `created_contract_address.token`, which is
+    # only there while the participant preload keeps loading `:token`.
+    test "reports token_creation for a transaction that created a token", %{conn: conn} do
+      contract_address = insert(:contract_address)
+      insert(:token, contract_address: contract_address)
+
+      :transaction
+      |> insert()
+      |> with_block()
+      |> with_contract_creation(contract_address)
+
+      request = get(conn, "/api/v2/transactions")
+
+      assert %{"items" => [item]} = json_response(request, 200)
+      assert "token_creation" in item["transaction_types"]
+    end
+
     test "transactions with next_page_params", %{conn: conn} do
       transactions =
         51

--- a/apps/explorer/lib/explorer/chain/address/scam_badge_to_address.ex
+++ b/apps/explorer/lib/explorer/chain/address/scam_badge_to_address.ex
@@ -20,7 +20,13 @@ defmodule Explorer.Chain.Address.ScamBadgeToAddress do
   """
   @primary_key false
   typed_schema "scam_address_badge_mappings" do
-    belongs_to(:address, Address, foreign_key: :address_hash, references: :hash, type: Hash.Address, null: false)
+    belongs_to(:address, Address,
+      foreign_key: :address_hash,
+      references: :hash,
+      type: Hash.Address,
+      null: false,
+      primary_key: true
+    )
 
     timestamps()
   end

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -91,7 +91,6 @@ defmodule Explorer.Chain.AdvancedFilter do
   @participant_necessity_by_association %{
     :scam_badge => :optional,
     :names => :optional,
-    :smart_contract => :optional,
     proxy_implementations_association() => :optional
   }
 

--- a/apps/explorer/lib/explorer/chain/advanced_filter.ex
+++ b/apps/explorer/lib/explorer/chain/advanced_filter.ex
@@ -79,6 +79,22 @@ defmodule Explorer.Chain.AdvancedFilter do
     field(:token_transfer_batch_index, :integer, null: true)
   end
 
+  @address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address},
+    {:created_contract_address_hash, :created_contract_address}
+  ]
+
+  # Address-info associations shared by every participant role of a filter row.
+  # Loaded once for the whole page by `Chain.preload_address_participants/4`
+  # rather than per role, which repeats each of these queries three times.
+  @participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :smart_contract => :optional,
+    proxy_implementations_association() => :optional
+  }
+
   @typep transaction_types :: {:transaction_types, [String.t()] | nil}
   @typep methods :: {:methods, [String.t()] | nil}
   @typep age :: {:age, [{:from, DateTime.t() | nil} | {:to, DateTime.t() | nil}] | nil}
@@ -153,10 +169,10 @@ defmodule Explorer.Chain.AdvancedFilter do
     |> Enum.map(&to_advanced_filter/1)
     |> Enum.sort(&sort_function/2)
     |> take_page_size(paging_options)
-    |> Chain.select_repo(options).preload(
-      from_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      to_address: [:scam_badge, :names, :smart_contract, proxy_implementations_association()],
-      created_contract_address: [:names, :smart_contract, proxy_implementations_association()]
+    |> Chain.preload_address_participants(
+      @address_fields,
+      @participant_necessity_by_association,
+      options
     )
     |> sanitize_fee()
     |> assign_type()

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -158,6 +158,18 @@ defmodule Explorer.Chain.TokenTransfer do
 
   @default_paging_options %PagingOptions{page_size: 50}
 
+  @participant_address_fields [
+    {:from_address_hash, :from_address},
+    {:to_address_hash, :to_address}
+  ]
+
+  @participant_necessity_by_association %{
+    :scam_badge => :optional,
+    :names => :optional,
+    :smart_contract => :optional,
+    Implementation.proxy_implementations_association() => :optional
+  }
+
   @typep paging_options :: {:paging_options, PagingOptions.t()}
   @typep api? :: {:api?, true | false}
 
@@ -301,23 +313,16 @@ defmodule Explorer.Chain.TokenTransfer do
         []
 
       _ ->
-        preloads =
-          DenormalizationHelper.extend_transaction_preload([
-            :transaction,
-            [token: reputation_association()],
-            [from_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]],
-            [to_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]]
-          ])
-
         only_consensus_transfers_query()
         |> where([tt], tt.token_contract_address_hash == ^token_address_hash)
         |> where([tt], fragment("? @> ARRAY[?::decimal]", tt.token_ids, ^Decimal.new(token_id)))
         |> where([tt], not is_nil(tt.block_number))
-        |> preload(^preloads)
+        |> preload(^non_address_preloads())
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
         |> page_token_transfer(paging_options)
         |> limit(^paging_options.page_size)
         |> Chain.select_repo(options).all()
+        |> preload_participants(options)
     end
   end
 
@@ -334,23 +339,38 @@ defmodule Explorer.Chain.TokenTransfer do
         []
 
       _ ->
-        preloads =
-          DenormalizationHelper.extend_transaction_preload([
-            :transaction,
-            [token: reputation_association()],
-            [from_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]],
-            [to_address: [:scam_badge, :names, :smart_contract, Implementation.proxy_implementations_association()]]
-          ])
-
         only_consensus_transfers_query()
-        |> preload(^preloads)
+        |> preload(^non_address_preloads())
         |> order_by([tt], desc: tt.block_number, desc: tt.log_index)
         |> maybe_filter_by_token_type(token_type)
         |> ExplorerHelper.maybe_hide_scam_addresses_for_token_transfers(options)
         |> page_token_transfer(paging_options)
         |> limit(^paging_options.page_size)
         |> Chain.select_repo(options).all()
+        |> preload_participants(options)
     end
+  end
+
+  # Everything but the `from`/`to` addresses, which `preload_participants/2`
+  # loads afterwards.
+  defp non_address_preloads do
+    DenormalizationHelper.extend_transaction_preload([
+      :transaction,
+      [token: reputation_association()]
+    ])
+  end
+
+  # Loads the address info of every `from`/`to` participant of the page in one
+  # pass, deduplicating addresses shared between transfers and between the two
+  # roles of the same transfer. Preloading it per role instead repeats the
+  # `addresses` query and every one of these associations twice.
+  defp preload_participants(token_transfers, options) do
+    Chain.preload_address_participants(
+      token_transfers,
+      @participant_address_fields,
+      @participant_necessity_by_association,
+      options
+    )
   end
 
   @doc """

--- a/apps/explorer/lib/explorer/chain/token_transfer.ex
+++ b/apps/explorer/lib/explorer/chain/token_transfer.ex
@@ -166,7 +166,6 @@ defmodule Explorer.Chain.TokenTransfer do
   @participant_necessity_by_association %{
     :scam_badge => :optional,
     :names => :optional,
-    :smart_contract => :optional,
     Implementation.proxy_implementations_association() => :optional
   }
 


### PR DESCRIPTION
Continuation of https://github.com/blockscout/blockscout/pull/14758

Applied to:

- `/api/v2/transactions`
- `/api/v2/advanced-filters`
- `/api/v2/main-page/transactions`
- `/api/v2/token-transfers`
- token transfers by instance
- realtime events for transactions and token transfers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance
- Improved response efficiency for transactions, token transfers, advanced filters, watchlists, and notifications by loading participant address details in a consolidated pass.
- Improved consistency of displayed names, scam badges, and proxy implementation information across relevant results.

## Bug Fixes
- Transaction API results now correctly report `token_creation` for transactions that create tokens.

## Tests
- Added coverage for token creation transaction types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->