### PR TITLE
fix: support hexadecimal block number in eth_getBalance

### DIFF
--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -710,6 +710,32 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
       assert response["result"] == "0x2"
     end
 
+    test "with a hexadecimal block provided", %{conn: conn, api_params: api_params} do
+      address = insert(:address)
+
+      insert(:fetched_balance, block_number: 1, address_hash: address.hash, value: 1)
+      insert(:fetched_balance, block_number: 2, address_hash: address.hash, value: 2)
+      insert(:fetched_balance, block_number: 3, address_hash: address.hash, value: 3)
+
+      assert response =
+               conn
+               |> post("/api/eth-rpc", params(api_params, [to_string(address.hash), "0x2"]))
+               |> json_response(200)
+
+      assert response["result"] == "0x2"
+    end
+
+    test "with an invalid hexadecimal block provided", %{conn: conn, api_params: api_params} do
+      address = insert(:address)
+
+      assert response =
+               conn
+               |> post("/api/eth-rpc", params(api_params, [to_string(address.hash), "0xnothex"]))
+               |> json_response(200)
+
+      assert response["error"] == "Query parameter 'block' is invalid"
+    end
+
     test "with a block provided and no balance", %{conn: conn, api_params: api_params} do
       address = insert(:address)
 

--- a/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
+++ b/apps/block_scout_web/test/block_scout_web/controllers/api/rpc/eth_controller_test.exs
@@ -730,7 +730,7 @@ defmodule BlockScoutWeb.API.RPC.EthControllerTest do
 
       assert response =
                conn
-               |> post("/api/eth-rpc", params(api_params, [to_string(address.hash), "0xnothex"]))
+               |> post("/api/eth-rpc", params(api_params, [to_string(address.hash), "0xnonsense"]))
                |> json_response(200)
 
       assert response["error"] == "Query parameter 'block' is invalid"

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -1334,6 +1334,13 @@ defmodule Explorer.EthRPC do
   defp block_param("earliest"), do: {:ok, :earliest}
   defp block_param("pending"), do: {:ok, :pending}
 
+  defp block_param("0x" <> hexadecimal_digits) do
+    case Integer.parse(hexadecimal_digits, 16) do
+      {integer, ""} -> {:ok, integer}
+      _ -> :error
+    end
+  end
+
   defp block_param(string_integer) when is_bitstring(string_integer) do
     case Integer.parse(string_integer) do
       {integer, ""} -> {:ok, integer}


### PR DESCRIPTION
## Motivation

`eth_getBalance` rejected hexadecimal block numbers, which is the format mandated by the JSON-RPC spec and used by all standard Ethereum clients:

```
curl -L 'http://localhost:4000/api/eth-rpc' \
-H 'Content-Type: application/json' \
-d '{
        "jsonrpc":"2.0",
        "method":"eth_getBalance",
        "params":[
                "0x91be515287A961a8d09Fd4cA3DFb5E76Ed01575e",
                "0xb1ea8b"
        ],
        "id":1
}'
{"jsonrpc":"2.0","error": "Query parameter 'block' is invalid","id": 1}
```

`block_param/1` in `Explorer.EthRPC` only handled `"latest"`, `"earliest"`, `"pending"`, `nil` and base-10 strings. For `"0xb1ea8b"`, `Integer.parse/1` returned `{0, "xb1ea8b"}`, which fell through to `:error`.

## Changelog

### Bug Fixes

- Added a `"0x" <> hexadecimal_digits` clause to `block_param/1` in `Explorer.EthRPC`, matching the existing `cast_block/1` idiom in the same module. It is placed before the decimal clause, so hex block numbers resolve correctly, plain decimal strings (e.g. `"2"`) keep working, and malformed input (e.g. `"0xnothex"`) still returns `Query parameter 'block' is invalid`.
- Added regression tests in `eth_controller_test.exs` covering a valid hexadecimal block number and a malformed hexadecimal block number.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Account balance lookups now support hexadecimal block parameters, such as `0x2`, for more flexible block selection.
  - Invalid hexadecimal block parameters return a clear validation error instead of failing silently.

- **Tests**
  - Added coverage for successful hexadecimal block parsing and validation of malformed hexadecimal values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->