### PR TITLE
fix: Group JSON RPC requests by url type

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/http.ex
@@ -25,7 +25,8 @@ defmodule EthereumJSONRPC.HTTP do
   def json_rpc(%{method: method} = request, options) when is_map(request) do
     json = encode_json(request)
     http = Keyword.fetch!(options, :http)
-    {url_type, url} = url(options, method)
+    url_type = url_type(options, method)
+    url = CommonHelper.get_available_url(options, url_type)
     http_options = Keyword.fetch!(options, :http_options)
 
     with {:ok, %{body: body, status_code: code}} <- http.json_rpc(url, json, headers(), http_options),
@@ -41,25 +42,75 @@ defmodule EthereumJSONRPC.HTTP do
   end
 
   def json_rpc([batch | _] = chunked_batch_request, options) when is_list(batch) do
-    chunked_json_rpc(chunked_batch_request, options, [])
+    chunked_batch_request
+    |> Enum.flat_map(&group_by_url_type(&1, options))
+    |> chunked_json_rpc(options, [])
   end
 
   def json_rpc(batch_request, options) when is_list(batch_request) do
     batch_size = Application.get_env(:ethereum_jsonrpc, __MODULE__)[:batch_size]
-    chunked_batch_request = Enum.chunk_every(batch_request, batch_size)
-    maybe_log_big_batch(chunked_batch_request)
+    maybe_log_big_batch(batch_request, batch_size)
+
+    chunked_batch_request =
+      batch_request
+      |> group_by_url_type(options)
+      |> Enum.flat_map(fn {url_type, requests} ->
+        requests |> Enum.chunk_every(batch_size) |> Enum.map(&{url_type, &1})
+      end)
+
     chunked_json_rpc(chunked_batch_request, options, [])
   end
 
-  defp maybe_log_big_batch([]), do: :ok
-  defp maybe_log_big_batch([_]), do: :ok
-
-  defp maybe_log_big_batch([first_chunk | _] = batch) do
-    Logger.warning(
-      "Big amount of node requests in batch: #{batch |> Enum.map(&length/1) |> Enum.sum()}, 1st_chunk_1st_request: #{inspect(List.first(first_chunk))}"
-    )
+  # Requests within a single batch can be mapped to different url types (e.g. `eth_call`
+  # requests are sent to `eth_call_urls`), so the batch has to be split by the url type
+  # its methods are mapped to. Url types that are configured with the same urls are kept
+  # together in order to not send redundant requests.
+  #
+  # Note that this reorders the requests, so the responses of a batch are not returned in
+  # the order of the requests and have to be matched by their id (see
+  # `t:EthereumJSONRPC.Transport.batch_response/0`).
+  @spec group_by_url_type([Transport.request()], Keyword.t()) :: [{atom(), [Transport.request()]}]
+  defp group_by_url_type(requests, options) do
+    requests
+    |> Enum.group_by(& &1[:method])
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce([], fn {method, method_requests}, acc ->
+      merge_url_type_requests(url_type(options, method), method_requests, acc, options)
+    end)
+    |> Enum.map(fn {_urls, url_type, grouped_requests} -> {url_type, grouped_requests} end)
   end
 
+  defp merge_url_type_requests(url_type, requests, acc, options) do
+    urls = {
+      CommonHelper.url_type_to_urls(url_type, options),
+      CommonHelper.url_type_to_urls(url_type, options, :fallback)
+    }
+
+    case List.keyfind(acc, urls, 0) do
+      nil ->
+        acc ++ [{urls, url_type, requests}]
+
+      {_urls, existing_url_type, existing_requests} ->
+        # `:http` is preferred as the representative of a merged group, so that endpoint
+        # availability is tracked under the type these urls are primarily configured for
+        merged_url_type = if :http in [existing_url_type, url_type], do: :http, else: existing_url_type
+
+        List.keyreplace(acc, urls, 0, {urls, merged_url_type, existing_requests ++ requests})
+    end
+  end
+
+  defp maybe_log_big_batch(batch_request, batch_size) do
+    count = Enum.count(batch_request)
+
+    if count > batch_size do
+      Logger.warning(
+        "Big amount of node requests in batch: #{count}, 1st_chunk_1st_request: #{inspect(List.first(batch_request))}"
+      )
+    end
+  end
+
+  # An empty batch produces no chunks, which matches the JSONRPC 2.0 standard saying that an empty batch (`[]`) returns
+  # an empty response (`""`): an empty response isn't valid JSON, so instead act like it returns an empty list (`[]`)
   defp chunked_json_rpc([], _options, decoded_response_bodies) when is_list(decoded_response_bodies) do
     list =
       decoded_response_bodies
@@ -70,16 +121,10 @@ defmodule EthereumJSONRPC.HTTP do
     {:ok, list}
   end
 
-  # JSONRPC 2.0 standard says that an empty batch (`[]`) returns an empty response (`""`), but an empty response isn't
-  # valid JSON, so instead act like it returns an empty list (`[]`)
-  defp chunked_json_rpc([[] | tail], options, decoded_response_bodies) do
-    chunked_json_rpc(tail, options, decoded_response_bodies)
-  end
-
-  defp chunked_json_rpc([[%{method: method} | _] = batch | tail] = chunks, options, decoded_response_bodies)
+  defp chunked_json_rpc([{url_type, batch} | tail] = chunks, options, decoded_response_bodies)
        when is_list(tail) and is_list(decoded_response_bodies) do
     http = Keyword.fetch!(options, :http)
-    {url_type, url} = url(options, method)
+    url = CommonHelper.get_available_url(options, url_type)
     http_options = Keyword.fetch!(options, :http_options)
 
     json = encode_json(batch)
@@ -110,7 +155,7 @@ defmodule EthereumJSONRPC.HTTP do
     end
   end
 
-  defp rechunk_json_rpc([batch | tail], options, response, decoded_response_bodies) do
+  defp rechunk_json_rpc([{url_type, batch} | tail], options, response, decoded_response_bodies) do
     case length(batch) do
       # it can't be made any smaller
       1 ->
@@ -134,7 +179,7 @@ defmodule EthereumJSONRPC.HTTP do
       batch_size ->
         split_size = div(batch_size, 2)
         {first_chunk, second_chunk} = Enum.split(batch, split_size)
-        new_chunks = [first_chunk, second_chunk | tail]
+        new_chunks = [{url_type, first_chunk}, {url_type, second_chunk} | tail]
         chunked_json_rpc(new_chunks, options, decoded_response_bodies)
     end
   end
@@ -260,16 +305,18 @@ defmodule EthereumJSONRPC.HTTP do
     end
   end
 
-  defp url(options, method) when is_list(options) and is_binary(method) do
+  @spec url_type(Keyword.t(), String.t() | nil) :: atom()
+  defp url_type(options, method) when is_list(options) and is_binary(method) do
     with {:ok, method_to_url} <- Keyword.fetch(options, :method_to_url),
          {:ok, method_atom} <- to_existing_atom(method),
          {:ok, url_type} <- Keyword.fetch(method_to_url, method_atom) do
-      {url_type, CommonHelper.get_available_url(options, url_type)}
+      url_type
     else
-      _ ->
-        {:http, CommonHelper.get_available_url(options, :http)}
+      _ -> :http
     end
   end
+
+  defp url_type(_options, _method), do: :http
 
   defp to_existing_atom(string) do
     {:ok, String.to_existing_atom(string)}

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/request_coordinator.ex
@@ -74,9 +74,9 @@ defmodule EthereumJSONRPC.RequestCoordinator do
   @spec perform(Transport.batch_request(), Transport.t(), Transport.options(), non_neg_integer()) ::
           {:ok, Transport.batch_response()} | {:error, term()}
   def perform(request, transport, transport_options, throttle_timeout) do
-    request_method = request_method(request)
+    request_methods = request_methods(request)
 
-    sleep_time = sleep_time(request_method)
+    sleep_time = sleep_time(request_methods)
 
     if sleep_time <= throttle_timeout do
       :timer.sleep(sleep_time)
@@ -88,7 +88,7 @@ defmodule EthereumJSONRPC.RequestCoordinator do
           trace_request(request, fn ->
             request
             |> transport.json_rpc(transport_options)
-            |> handle_transport_response(request_method)
+            |> handle_transport_response(request_methods)
           end)
 
         :error ->
@@ -113,24 +113,29 @@ defmodule EthereumJSONRPC.RequestCoordinator do
 
   defp trace_request(_, fun), do: fun.()
 
-  defp request_method([request | _]), do: request_method(request)
-  defp request_method(%{method: method}), do: method
-  defp request_method(_), do: nil
+  defp request_methods(requests) when is_list(requests) do
+    requests
+    |> Enum.flat_map(&request_methods/1)
+    |> Enum.uniq()
+  end
 
-  defp handle_transport_response({:error, {error_type, _}} = error, method)
+  defp request_methods(%{method: method}), do: [method]
+  defp request_methods(_), do: []
+
+  defp handle_transport_response({:error, {error_type, _}} = error, methods)
        when error_type in [:bad_gateway, :bad_response] do
-    RollingWindow.inc(table(), method_error_key(method))
+    inc_methods_error_count(methods)
     inc_throttle_table()
     error
   end
 
-  defp handle_transport_response({:error, :timeout} = error, method) do
-    RollingWindow.inc(table(), method_error_key(method))
+  defp handle_transport_response({:error, :timeout} = error, methods) do
+    inc_methods_error_count(methods)
     inc_throttle_table()
     error
   end
 
-  defp handle_transport_response(response, _method) do
+  defp handle_transport_response(response, _methods) do
     inc_throttle_table()
     response
   end
@@ -162,8 +167,16 @@ defmodule EthereumJSONRPC.RequestCoordinator do
     end
   end
 
-  defp sleep_time(request_method) do
-    wait_coefficient = RollingWindow.count(table(), method_error_key(request_method))
+  defp inc_methods_error_count(methods) do
+    Enum.each(methods, &RollingWindow.inc(table(), method_error_key(&1)))
+  end
+
+  defp sleep_time(request_methods) do
+    wait_coefficient =
+      Enum.reduce(request_methods, 0, fn request_method, acc ->
+        max(acc, RollingWindow.count(table(), method_error_key(request_method)))
+      end)
+
     jitter = :rand.uniform(config!(:max_jitter))
     wait_per_timeout = config!(:wait_per_timeout)
 

--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/transport.ex
@@ -69,6 +69,10 @@ defmodule EthereumJSONRPC.Transport do
 
   @typedoc """
   A batch of `t:response/0`.  Each `t:response/0` will have an `"id"` corresponding to the `"id"` in the `t:request/0`.
+
+  The order of the responses is **not** guaranteed to match the order of the requests: the
+  [JSONRPC specification](https://www.jsonrpc.org/specification#batch) allows a server to respond in any order and
+  `EthereumJSONRPC.HTTP` can split a batch into several requests. Callers must match responses to requests by `"id"`.
   """
   @type batch_response :: [response]
 

--- a/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/http/mox_test.exs
+++ b/apps/ethereum_jsonrpc/test/ethereum_jsonrpc/http/mox_test.exs
@@ -344,6 +344,86 @@ defmodule EthereumJSONRPC.HTTP.MoxTest do
 
       assert log =~ "Big amount of node requests in batch: 10, 1st_chunk_1st_request: %{"
     end
+
+    test "sends requests of a batch to the urls their methods are mapped to" do
+      json_rpc_named_arguments = method_to_url_named_arguments(["http://storage.url"], ["http://eth-call.url"])
+
+      expect(EthereumJSONRPC.HTTP.Mox, :json_rpc, 2, fn url, json, _headers, _options ->
+        requests = decode_requests(json)
+
+        case url do
+          "http://eth-call.url" -> assert Enum.map(requests, & &1["method"]) == ["eth_call"]
+          "http://storage.url" -> assert Enum.map(requests, & &1["method"]) == ["eth_getStorageAt", "eth_getStorageAt"]
+        end
+
+        {:ok, %{body: encode_results(requests), status_code: 200}}
+      end)
+
+      assert {:ok, responses} = EthereumJSONRPC.json_rpc(mixed_batch_request(), json_rpc_named_arguments)
+      assert_results_match_ids(responses)
+    end
+
+    test "keeps requests in a single batch when their url types are configured with the same urls" do
+      json_rpc_named_arguments = method_to_url_named_arguments([url()], [url()])
+
+      expect(EthereumJSONRPC.HTTP.Mox, :json_rpc, 1, fn _url, json, _headers, _options ->
+        requests = decode_requests(json)
+
+        assert Enum.map(requests, & &1["method"]) == ["eth_call", "eth_getStorageAt", "eth_getStorageAt"]
+
+        {:ok, %{body: encode_results(requests), status_code: 200}}
+      end)
+
+      assert {:ok, responses} = EthereumJSONRPC.json_rpc(mixed_batch_request(), json_rpc_named_arguments)
+      assert_results_match_ids(responses)
+    end
+  end
+
+  # Batch responses are not returned in the order of the requests, so the only guarantee
+  # is that every request gets its own result back under its own id
+  defp assert_results_match_ids(responses) do
+    assert Map.new(responses, &{&1.id, &1.result}) == %{
+             0 => "0x0",
+             1 => "0x1",
+             2 => "0x2"
+           }
+  end
+
+  defp method_to_url_named_arguments(urls, eth_call_urls) do
+    [
+      transport: EthereumJSONRPC.HTTP,
+      transport_options: [
+        http: EthereumJSONRPC.HTTP.Mox,
+        urls: urls,
+        eth_call_urls: eth_call_urls,
+        fallback_urls: nil,
+        fallback_eth_call_urls: nil,
+        method_to_url: [eth_call: :eth_call],
+        http_options: http_options()
+      ],
+      # Which one does not matter, so pick one
+      variant: EthereumJSONRPC.Nethermind
+    ]
+  end
+
+  defp mixed_batch_request do
+    [
+      request(%{id: 0, method: "eth_getStorageAt", params: ["0x0", "0x0", "latest"]}),
+      request(%{id: 1, method: "eth_call", params: [%{to: "0x0", data: "0x0"}, "latest"]}),
+      request(%{id: 2, method: "eth_getStorageAt", params: ["0x0", "0x1", "latest"]})
+    ]
+  end
+
+  defp decode_requests(json) do
+    json |> IO.iodata_to_binary() |> Jason.decode!()
+  end
+
+  # the result is derived from the request id, so that a response can be traced back to the
+  # request it belongs to
+  defp encode_results(requests) do
+    requests
+    |> Enum.map(&%{jsonrpc: "2.0", id: &1["id"], result: "0x#{&1["id"]}"})
+    |> Jason.encode!()
   end
 
   defp assert_payload_too_large(payload, json_rpc_named_arguments) do

--- a/apps/explorer/lib/explorer/eth_rpc.ex
+++ b/apps/explorer/lib/explorer/eth_rpc.ex
@@ -659,6 +659,7 @@ defmodule Explorer.EthRPC do
   }
 
   @incorrect_number_of_params "Incorrect number of params."
+  @no_result "No result"
 
   @spec responses([map()]) :: [map()]
   def responses(requests) do
@@ -729,29 +730,32 @@ defmodule Explorer.EthRPC do
     end)
   end
 
+  # Responses of a batch request are not guaranteed to be returned in the order of the
+  # requests, so they are matched by id. The index of the request is used as the id sent
+  # to the node, since the id provided by the user can be duplicated or nil. The user's
+  # id is attached to the response by `responses/1` anyway.
   defp json_rpc(map) when is_map(map) do
     to_request =
-      Enum.flat_map(Map.values(map), fn
-        {:error, _} ->
+      Enum.flat_map(map, fn
+        {_index, {:error, _}} ->
           []
 
-        map when is_map(map) ->
-          [request_to_elixir(map)]
+        {index, request} when is_map(request) ->
+          [request |> request_to_elixir() |> Map.put(:id, index)]
       end)
 
-    with [_ | _] = to_request <- to_request,
+    with [_ | _] <- to_request,
          {:ok, responses} <-
            EthereumJSONRPC.json_rpc(to_request, Application.get_env(:explorer, :json_rpc_named_arguments)) do
-      {map, []} =
-        Enum.map_reduce(map, responses, fn
-          {_index, {:error, _}} = elem, responses ->
-            {elem, responses}
+      index_to_response = Map.new(responses, &{&1.id, &1})
 
-          {index, _request}, [response | other_responses] ->
-            {{index, response}, other_responses}
-        end)
+      Map.new(map, fn
+        {_index, {:error, _}} = elem ->
+          elem
 
-      Enum.into(map, %{})
+        {index, _request} ->
+          {index, Map.get(index_to_response, index, {:error, @no_result})}
+      end)
     else
       [] ->
         map

--- a/apps/explorer/test/explorer/eth_rpc_test.exs
+++ b/apps/explorer/test/explorer/eth_rpc_test.exs
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: LicenseRef-Blockscout
+defmodule Explorer.EthRPCTest do
+  # the tested requests are proxied to the node, so no database is involved
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Explorer.EthRPC
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  @address_hash "0x1643E812aE58766192Cf7D2Cf9567dF2C37e9B7F"
+
+  describe "responses/1" do
+    test "matches responses of a batch to the requests by id, not by their order" do
+      requests = [
+        %{
+          "jsonrpc" => "2.0",
+          "id" => "storage",
+          "method" => "eth_getStorageAt",
+          "params" => [@address_hash, "0x0", "latest"]
+        },
+        %{
+          "jsonrpc" => "2.0",
+          "id" => "call",
+          "method" => "eth_call",
+          "params" => [%{"to" => @address_hash, "input" => "0xd4aae0c4"}, "latest"]
+        }
+      ]
+
+      # the node is free to respond in any order, and `EthereumJSONRPC.HTTP` splits a batch
+      # by the url type its methods are mapped to, so the responses are reversed here
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn batch, _options ->
+        assert [%{method: "eth_getStorageAt"}, %{method: "eth_call"}] = batch
+
+        responses =
+          Enum.map(batch, fn
+            %{id: id, method: "eth_getStorageAt"} -> %{jsonrpc: "2.0", id: id, result: "0x123"}
+            %{id: id, method: "eth_call"} -> %{jsonrpc: "2.0", id: id, result: "0x234"}
+          end)
+
+        {:ok, Enum.reverse(responses)}
+      end)
+
+      assert [
+               %{id: "storage", result: "0x123"},
+               %{id: "call", result: "0x234"}
+             ] = EthRPC.responses(requests)
+    end
+
+    test "matches responses of a batch with duplicated user ids" do
+      request = fn id, storage_pointer ->
+        %{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "method" => "eth_getStorageAt",
+          "params" => [@address_hash, storage_pointer, "latest"]
+        }
+      end
+
+      expect(EthereumJSONRPC.Mox, :json_rpc, fn batch, _options ->
+        responses =
+          Enum.map(batch, fn %{id: id, params: [_, storage_pointer, _]} ->
+            %{jsonrpc: "2.0", id: id, result: storage_pointer}
+          end)
+
+        {:ok, Enum.reverse(responses)}
+      end)
+
+      assert [
+               %{id: 1, result: "0x0"},
+               %{id: 1, result: "0x1"}
+             ] = EthRPC.responses([request.(1, "0x0"), request.(1, "0x1")])
+    end
+  end
+end

--- a/cspell.json
+++ b/cspell.json
@@ -385,6 +385,7 @@
         "keyfind",
         "keymember",
         "keyout",
+        "keyreplace",
         "kittencream",
         "KnxbUejwY",
         "labelledby",


### PR DESCRIPTION
## Motivation

`EthereumJSONRPC.HTTP` resolved the target URL for an entire batch from the method of its **first** request: `chunked_json_rpc/3` matched on `[[%{method: method} | _] = batch | tail]` and looked that single method up in `method_to_url`. That is only correct as long as every request in a batch shares one method.

`Explorer.Chain.SmartContract.Proxy.fetch_values/2` breaks this assumption: it builds one batch mixing `eth_getStorageAt` (mapped to `:http`) and `eth_call` (mapped to `:eth_call`). Depending on the order in which proxy resolvers declare their requirements, the whole batch was sent either to `ETHEREUM_JSONRPC_HTTP_URLS` or to `ETHEREUM_JSONRPC_ETH_CALL_URLS`, so on instances where these point to different endpoints, part of every proxy detection batch went to the wrong node. The same misdetection was propagated to `EndpointAvailabilityObserver.inc_error_count/3`, which received the `url_type` of the first request and could therefore mark the wrong endpoint as unavailable.

`EthereumJSONRPC.RequestCoordinator.perform/4` made the same assumption for its per-method backoff and error counters, attributing a mixed batch entirely to the method of its first request.

## Changelog

- `EthereumJSONRPC.HTTP`: split a batch by the url type its methods are mapped to before chunking it, so every request is sent to the endpoint configured for its own method. Chunks are now carried as `{url_type, requests}` tuples, which also keeps `url_type` correct for `EndpointAvailabilityObserver` error counting and preserves it when a chunk is split in `rechunk_json_rpc/4` after a 413/504/timeout.
- `EthereumJSONRPC.RequestCoordinator`: calculate the throttling backoff from all distinct methods of a batch (the maximum of their recent error counts) and increment the rolling-window error counter for each of them instead of only the first one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Batch requests are routed accurately when methods use different endpoint URLs.
  * Requests with equivalent endpoint configurations remain efficiently grouped.
  * Retry and fallback handling preserves endpoint routing for split or empty batches.
  * Batch operations apply appropriate timeout behavior across all included methods.
  * Transport errors are tracked consistently for every affected method.
* **Bug Fixes**
  * Batch responses are matched to requests by ID, preventing incorrect results when responses arrive out of order or IDs are duplicated.
  * Missing responses are reported clearly instead of being matched incorrectly.
* **Documentation**
  * Clarified response-ordering expectations for batch requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->